### PR TITLE
feat(api): Slack chat-history brain source — fork the ingest core, reuse the ADR-0030 engine (#4770)

### DIFF
--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -56334,7 +56334,8 @@
                               "intercom",
                               "front",
                               "helpscout",
-                              "freshdesk"
+                              "freshdesk",
+                              "slack-history"
                             ]
                           },
                           "description": {
@@ -56388,12 +56389,23 @@
                                   "string",
                                   "null"
                                 ]
+                              },
+                              "coverageIncomplete": {
+                                "type": "boolean"
+                              },
+                              "coverageDetail": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
                               }
                             },
                             "required": [
                               "lastSyncAt",
                               "status",
-                              "error"
+                              "error",
+                              "coverageIncomplete",
+                              "coverageDetail"
                             ]
                           },
                           "documents": {

--- a/docs/development/brain-slack-history.md
+++ b/docs/development/brain-slack-history.md
@@ -1,0 +1,270 @@
+# The Slack chat-history brain source (#4770)
+
+The first ingest source for the company brain (ADR-0036 §Ingestion &
+connectors). It reads history from chosen Slack channels into `brain_episodes`
+as immutable tier-3 evidence. Nothing it writes is a fact and nothing it writes
+is published — the claims drawn from these episodes are #4771's, and they go
+through the #4769 review gate before anything becomes authoritative.
+
+## What is reused, and what is forked
+
+ADR-0036 §T6 is a two-part instruction and both halves are load-bearing.
+
+**Reused verbatim** — the ADR-0030 connector engine:
+
+| Concern | Where it lives | Notes |
+|---|---|---|
+| Scheduling | `scheduler/knowledge-bundle-sync.ts` | The one fiber. There is no second scheduler. |
+| Cycle walk + dispatch | `lib/knowledge/sync.ts` | Lists installs of every registered catalog id; routes each to its engine. |
+| Incremental vs reconcile cadence | `connector-sync.ts::getKnowledgeSyncReconcileIntervalMs` | `ATLAS_KNOWLEDGE_SYNC_RECONCILE_INTERVAL_HOURS`, default weekly. ADR-0036 repurposes the cadence to re-run **extraction** (#4771); this source fetches identically in both modes — see below. |
+| Overlap window | `connector-sync.ts::SYNC_OVERLAP_WINDOW_MS` | Reused by the Slack client as its safety lag. |
+| 429 backoff | `connector-sync.ts::withRateLimitBackoff` | Client throws `ConnectorRateLimitError`; the engine waits and retries. |
+| Per-sync caps | `billing/knowledge-limits::resolveIngestCaps` | Episodes count against the same `maxDocs` as documents. |
+| Bookkeeping | `knowledge_sync_state` via `read/upsertConnectorSyncState` | Same table, same COALESCE-forward semantics. |
+
+**Forked** — the ingest core only (`lib/brain/ingest/`):
+
+| Knowledge documents | Brain episodes |
+|---|---|
+| identified by PATH | identified by SOURCE-ID |
+| mutable — upsert-by-path | immutable — `ON CONFLICT DO NOTHING` |
+| absent path on a full crawl → **archived** | absent record → simply absent; **nothing is ever archived** |
+| content-mode registered (`draft`/`published`) | deliberately NOT registered — evidence is not review-gated |
+
+The dispatch that chooses between them is `dispatchInstall` in
+`lib/knowledge/sync.ts`, keyed on which registry owns the catalog id. Because
+the brain arm never calls `ingestDocuments`, the subtractive-archive path is
+structurally unreachable from it rather than merely switched off — pinned by
+`__tests__/episode-sync-archive.test.ts`.
+
+## The source-id contract
+
+```
+source_id = `<channelId>:<ts>`
+```
+
+Freshness for chat is "poll + reconcile, plus a webhook fast-path" (M3), and
+the fast-path is **an alternate writer into the same idempotent episode
+store**. Two writers that disagree about the id duplicate every message they
+race on, and an append-only store has no upsert that would converge them later.
+So the id is a contract, not an implementation detail:
+
+- Slack's `ts` is the message's identity within a channel.
+- It is channel-scoped, because Slack's `ts` is not globally unique.
+- Thread replies carry their own `ts`, so a reply is its own episode.
+- It survives an edit: `conversations.history` returns the message's original
+  `ts` with the edit recorded in an `edited` sub-object, so an edited message
+  re-ingests as a no-op.
+
+⚠️ **The two writers read `ts` from different field paths.** "Just use `ts`" is
+the trap this section exists for:
+
+| writer | field |
+|---|---|
+| poll (`conversations.history`) | `message.ts` |
+| webhook, plain `message` event | `event.ts` |
+| webhook, `subtype: "message_changed"` | **`event.message.ts`** |
+
+On a `message_changed` event, top-level `event.ts` is the *event's* timestamp
+and `event.message.edited.ts` is the *edit's* — using either mints a new id for
+a message already stored and duplicates every edited message. `message_changed`
+never appears on the poll path; `conversations.history` serves a message's
+current state, not its edit events.
+
+**The format must never change.** It is a stored key: a reformat re-ingests
+every message in every workspace as a new episode, and #4771 would re-extract
+facts from all of them.
+
+## Grants
+
+Derived at ingest (ADR-0036 §T5), by `lib/brain/ingest/grant.ts`:
+
+- **public channel → `[org]`** — everyone in the workspace can already read it
+  at the source. The grant is explicit, never implicit, so a forgotten grant
+  can't read as public.
+- **private channel → `[audience:chat-channel:slack:<channelId>]`** —
+  membership lives in `fact_audience_member` and is the live revocation path.
+
+Membership population is #4771's, so **until it lands, a private channel's
+episodes are visible to nobody.** That is the fail-closed direction and it is
+repairable with no rewrite: the grant names the audience, and filling the
+membership table makes the existing rows visible.
+
+The deriver emits only tokens `parseGrant` finds usable, and `episodes.ts`
+re-checks with `isUsableGrant` before the INSERT. This matters more than it
+looks: `chk_brain_episodes_grant_nonempty` admits `['everyone']`, which grants
+nobody anything and — once episodes become facts — would be refused at every
+publish forever by #4769's `GRANT_UNUSABLE` classifier, with no repair UI until
+#4772. That refusal is meant to be defence in depth, not a live trap.
+
+## The per-channel cursor
+
+Slack pages `conversations.history` newest → oldest. A pass that runs out of
+budget has covered the *top* of its window and left a hole at the *bottom* — and
+in an append-only store "absent" and "not yet fetched" look identical. So the
+per-channel mark (persisted opaquely in `knowledge_sync_state.sync_cursor`) is a
+**discriminated union**, not a bag of optional fields:
+
+```json
+{"v":1,"channels":{
+  "C01ABCDEF": {"ts":"…"},                          // contiguous
+  "C02GHIJKL": {"ts":"…","top":"…","resume":"…"}    // backfilling
+}}
+```
+
+- `ts` — covered contiguously up to here. Advances only when a window is
+  covered end to end.
+- `top` — the ceiling of an in-progress backfill, set when a pass truncates.
+- `resume` — where the next pass continues walking downward.
+
+That makes truncation **convergent** (each cycle fills more of the same window)
+and **gapless** (the mark never jumps over an unfetched range). A single value
+can have one property or the other, not both.
+
+Gaplessness is a property of the whole pass, not just the mark, so two more
+rules hold it up:
+
+- **A channel the pass never reached keeps the mark it came in with.** The
+  cursor is written as a whole-object replacement and the state upsert only
+  COALESCEs a *null* cursor forward, so a channel missing from the new cursor is
+  a channel whose mark is deleted — which restarts it at the floor. This is
+  handled once, after the channel loop, so no future early exit can reintroduce
+  it. (An early cut handled it per-branch and the rate-limit `break` lost every
+  channel after the throttled one.)
+- **A truncated pass with no resumable window keeps its incoming mark too.**
+  Degrading an in-flight backfill to `contiguous` would discard a window whose
+  bottom is unfetched, and since the next pass would then walk from `now`, hit
+  the same obstacle and degrade again, that is a fixed point rather than a
+  delay.
+
+The union matters because `resume` **without** `top` is unsound in a silent way:
+the pass would walk `[ts, resume]`, complete, take the ordinary completion
+branch, and advance the mark to `now` — claiming coverage of `(resume, now]` it
+never fetched. Both the parser and the walk refuse to construct a half or
+out-of-order pair (`ts < resume ≤ top`), degrading to `contiguous`, which
+over-crawls: more work, no gap.
+
+A channel whose window is covered end to end advances to
+`max(its old mark, the newest message seen, now − SAFETY_LAG)`
+(= the engine's overlap window, reused because five minutes is the right order
+of magnitude for both — not because they are the same mechanism). That is what
+keeps a quiet channel's window from growing without bound while still not racing
+messages in flight.
+
+### Two budgets
+
+`maxEpisodes` (the workspace's effective per-sync ingest cap) is a **hard
+contract**: the engine refuses any batch over it, and because an error attempt
+COALESCEs the old cursor forward, an over-cap batch would be recomputed and
+refused identically every cycle, forever. So the walk checks the budget before
+keeping each record and records `resume` at the last message it **walked**
+(kept or skipped — resuming above a skipped one would re-read it forever), so an
+over-large window becomes an ordinary truncation instead of a wedge. (The
+250-record trial/starter tiers are where a between-pages-only check bit.)
+
+A page budget (`HISTORY_MAX_PAGES_PER_PASS`) bounds vendor calls separately,
+because kept episodes are not the only cost: a channel of pure join/leave noise
+keeps zero episodes while still spending a Slack call per page. The
+"not read this cycle" warning names whichever budget actually ran out — blaming
+the record cap when the page budget bound would send an operator to raise a plan
+limit that was never the constraint.
+
+**The starting channel rotates each pass**, and the offset rides in the cursor.
+A fixed order plus one shared budget is deterministic starvation: on the
+250-record tiers one busy channel takes the whole cap every cycle and the
+channels after it are never read — not slowly, never.
+
+### `mode` does not change what this source fetches
+
+ADR-0036 repurposes the reconcile cadence to **re-run extraction** (#4771), not
+to re-crawl the source. There is nothing for a re-crawl to accomplish here:
+episodes are append-only, so a reconciliation cannot archive absences, and a
+channel added since the last pass has no mark and already backfills from the
+floor on an ordinary cycle. An earlier cut had reconciliation rewind every
+channel to the floor; combined with "an incomplete pass holds the reconcile
+clock", that re-walked the same week every cycle and could not converge.
+
+## Operating it
+
+**Scopes are a staging-first change.** Reading history needs `channels:history`
+and `groups:history`. Two places must agree:
+
+1. `SLACK_SCOPES` in `lib/integrations/install/slack-oauth-handler.ts` — that
+   string *is* the OAuth `scope=` param, so without both scopes listed there no
+   reconnect could ever grant them and the source would be uninstallable
+   everywhere. #4770 adds them.
+2. The **Slack app manifest**, which per CLAUDE.md's operational rule is changed
+   on the **staging** app first and soaked there. Until an app's manifest
+   carries the scopes, Slack refuses the consent screen for the *whole* install,
+   not just this source — so manifest first, then a re-install.
+
+A workspace whose token predates them fails `missing_scope`, surfaced at install
+as a field error and at sync time as the source's error row; reconnecting is
+what grants them.
+
+**Installing.** Admin → Integrations → *Company Brain (Slack history)*. It
+collects channel IDs and no secret: the connector reuses the workspace's
+existing Slack OAuth install (`chat_cache`), exactly as `salesforce-knowledge`
+reuses the Salesforce one (ADR-0030 amendment #4397).
+
+Install-time verification probes every channel **twice**, and the second probe
+is not redundant: `conversations.info` is gated on `channels:read`/`groups:read`
+— which the chat adapter's token already has — so a one-message
+`conversations.history` read is the only thing that can tell whether the token
+carries the *history* scopes. Between them, "the bot isn't in that channel",
+"that id doesn't exist" and "the token can't read history" are all 400s on the
+form rather than a sync error a week later.
+
+**Backfill.** `ATLAS_BRAIN_CHAT_BACKFILL_DAYS` (settings registry, default 7)
+is how far back a channel with no stored mark reads. It is the lever when a
+first sync reports that a channel has more history than one cycle can read.
+
+**Known warts, and why they are not bugs.** The install is a
+`pillar='knowledge'` row — that is what lets it reuse the install spine, the
+bookkeeping, and the one cycle walk verbatim — so it appears on
+/admin/knowledge as a collection with **zero documents** (its rows land in
+`brain_episodes`) and it **consumes one of the workspace's plan-capped
+knowledge-collection slots**. "Sync now" works and routes to the episode engine;
+the sync row is where this source reports itself until the brain's own surface
+lands in #4772.
+
+A sync that succeeded but deferred work reports `coverageIncomplete` on the
+collection list and renders as an amber **"Partially synced"** rather than the
+green "Synced", so a source that is quietly achieving nothing — a channel the
+bot was removed from, a budget that never clears — is visibly different from one
+that is working.
+
+**Re-adding a removed channel starts from the backfill floor.** The cursor keeps
+marks only for currently-configured channels, so removing a channel and adding
+it back later skips anything older than the floor at that moment. Widen
+`ATLAS_BRAIN_CHAT_BACKFILL_DAYS` before re-adding if that history matters.
+
+## Not ingested
+
+Bot/app messages (`bot_id`) and membership noise (`channel_join`, topic
+changes, …). Atlas's own Slack answers carry a `bot_id`, and ingesting them
+would make the brain cite itself as evidence — the self-echo ADR-0036 §T9
+neutralises on the write-back path for the same reason. The subtype filter is a
+**denylist**: an unknown subtype is a message Slack added that probably does
+carry content, and defaulting those to "drop" would silently lose evidence.
+
+Messages with empty `text` are also skipped, because
+`chk_brain_episodes_body_xor_locator` refuses `''` outright. That drops
+attachment- and blocks-only posts whose content lives outside `text` — richer
+extraction is M3's. Every skip is **counted**, and a pass that read messages but
+stored none says so in its warnings, so "read 500, stored 0" never looks like an
+empty channel.
+
+1:1 DMs (`D…` ids) are refused at install: their audience is two people, and
+ADR-0036 puts source-principal-resolution failure on the block side. Legacy
+multi-person DMs carry `G…` ids and *are* admitted, ingested as private channels
+with a channel-scoped `audience:` grant — fail-closed, just broader than "no
+DMs" suggests.
+
+**Thread replies are not fetched at all.** `conversations.history` returns
+top-level messages and `thread_broadcast` copies; replies need
+`conversations.replies`, which M1 does not call. So a thread-heavy channel
+ingests only its top-level posts, and — unlike every other omission here —
+replies are absent from the skip tallies too, because they are never read. The
+source-id contract states the reply rule anyway, so the writer that does fetch
+them agrees with this one.

--- a/packages/api/src/api/routes/__tests__/admin-knowledge.test.ts
+++ b/packages/api/src/api/routes/__tests__/admin-knowledge.test.ts
@@ -218,6 +218,37 @@ void mock.module("@atlas/api/lib/knowledge/connectors", () => ({
   ConnectorRateLimitError,
   toIsoInstant: (value: unknown) => (typeof value === "string" ? value : null),
 }));
+// The brain ingest seam (#4770) — the cycle walk and the "Sync now" route both
+// consult this registry BEFORE the knowledge one, so the router must be able to
+// find a brain source here for the third dispatch arm to be reachable at all.
+let BRAIN_SOURCE: { catalogId: string; source: string; createClient: () => unknown } | undefined;
+const getBrainSourceConnector = mock((_id: string) => BRAIN_SOURCE);
+void mock.module("@atlas/api/lib/brain/ingest/types", () => ({
+  getBrainSourceConnector,
+  registerBrainSourceConnector: () => {},
+  listBrainSourceCatalogIds: () => (BRAIN_SOURCE ? [BRAIN_SOURCE.catalogId] : []),
+  _resetBrainSourceConnectors: () => {},
+}));
+const syncBrainEpisodeSource = mock(async (params: { installId: string }) => ({
+  installId: params.installId,
+  status: "success" as const,
+  mode: "reconciliation" as const,
+  syncedAt: "2026-07-02T02:00:00.000Z",
+  error: null,
+  episodes: {
+    inserted: 4,
+    duplicate: 1,
+    refused: { blank_source_id: 0, blank_body: 0, unusable_grant: 0, invalid_occurred_at: 0 },
+    batchDuplicate: 0,
+  },
+  coverageIncomplete: false,
+  warnings: [],
+  highWaterMark: "2026-07-01T00:00:00.000Z",
+}));
+void mock.module("@atlas/api/lib/brain/ingest/episode-sync", () => ({
+  syncBrainEpisodeSource,
+}));
+
 const syncConnectorCollection = mock(async (params: { collectionSlug: string }) => ({
   collection: params.collectionSlug,
   status: "success" as const,
@@ -344,6 +375,8 @@ beforeEach(() => {
   internalQuery.mockClear();
   syncCollection.mockClear();
   syncConnectorCollection.mockClear();
+  syncBrainEpisodeSource.mockClear();
+  BRAIN_SOURCE = undefined;
   getKnowledgeSyncConnector.mockClear();
   NOTION_CONNECTOR = { catalogId: "catalog:notion-knowledge", vendor: "notion", createClient: () => ({}) };
 });
@@ -817,6 +850,93 @@ describe("POST /{collectionSlug}/sync — connector collections (#4378)", () => 
     expect(sf?.source).toBe("salesforce-knowledge");
     expect(sf?.endpointUrl).toBeNull();
     expect(sf?.sync).not.toBeNull();
+  });
+
+  it("dispatches a Slack history collection to the EPISODE engine and lists it as source 'slack-history' (#4770)", async () => {
+    // The third dispatch arm. Without it the knowledge-connector lookup misses
+    // (brain sources live in their own registry) and a perfectly healthy
+    // install answers 500 "contact your operator" — the failure the arm's own
+    // comment claims to prevent.
+    BRAIN_SOURCE = {
+      catalogId: "catalog:slack-history",
+      source: "slack",
+      createClient: () => ({}),
+    };
+    COLLECTION = {
+      install_id: "slack-brain",
+      catalog_id: "catalog:slack-history",
+      status: "published",
+      config: { channels: ["C01ABCDEF"] },
+    };
+    SYNC_STATES = [
+      {
+        collection_id: "slack-brain",
+        last_sync_at: "2026-07-02T02:00:00.000Z",
+        status: "success",
+        error: null,
+        coverage_incomplete: false,
+      },
+    ];
+    const syncRes = await adminKnowledge.request("/slack-brain/sync", { method: "POST" });
+    expect(syncRes.status).toBe(200);
+    expect(syncBrainEpisodeSource).toHaveBeenCalledTimes(1);
+    expect(syncConnectorCollection).not.toHaveBeenCalled();
+    expect(syncCollection).not.toHaveBeenCalled();
+    // Episodes are not documents: the document counters stay null rather than
+    // reporting episode counts in a field the UI labels "documents".
+    const syncBody = (await syncRes.json()) as { documents: unknown; archivedAbsent: unknown };
+    expect(syncBody.documents).toBeNull();
+    expect(syncBody.archivedAbsent).toBeNull();
+
+    const listRes = await adminKnowledge.request("/", { method: "GET" });
+    const body = (await listRes.json()) as {
+      collections: Array<{ slug: string; source: string; sync: { coverageIncomplete: boolean } | null }>;
+    };
+    const brain = body.collections.find((c) => c.slug === "slack-brain");
+    expect(brain?.source).toBe("slack-history");
+    // It carries sync bookkeeping like any other synced collection…
+    expect(brain?.sync).not.toBeNull();
+    expect(brain?.sync?.coverageIncomplete).toBe(false);
+  });
+
+  it("surfaces a coverage-incomplete sync so deferred work is not a plain green tick (#4770)", async () => {
+    // The whole point of putting the flag on the wire. Delete the projection
+    // and this goes red; without it the route would emit `false` for every
+    // collection and an operator could never learn a sync deferred work.
+    BRAIN_SOURCE = {
+      catalogId: "catalog:slack-history",
+      source: "slack",
+      createClient: () => ({}),
+    };
+    COLLECTION = {
+      install_id: "slack-brain",
+      catalog_id: "catalog:slack-history",
+      status: "published",
+      config: { channels: ["C01ABCDEF"] },
+    };
+    SYNC_STATES = [
+      {
+        collection_id: "slack-brain",
+        last_sync_at: "2026-07-02T02:00:00.000Z",
+        status: "success",
+        error: null,
+        coverage_incomplete: true,
+        coverage_detail: "Channel C2 was not read this cycle.",
+      },
+    ];
+    const listRes = await adminKnowledge.request("/", { method: "GET" });
+    const body = (await listRes.json()) as {
+      collections: Array<{
+        slug: string;
+        sync: { status: string; coverageIncomplete: boolean; coverageDetail: string | null } | null;
+      }>;
+    };
+    const brain = body.collections.find((c) => c.slug === "slack-brain");
+    expect(brain?.sync?.status).toBe("success");
+    expect(brain?.sync?.coverageIncomplete).toBe(true);
+    // A flag with no reason is a flag nobody can act on — the three causes
+    // need three different fixes.
+    expect(brain?.sync?.coverageDetail).toBe("Channel C2 was not read this cycle.");
   });
 
   it("dispatches an Intercom collection to the connector engine and lists it as source 'intercom' (#4399)", async () => {

--- a/packages/api/src/api/routes/admin-knowledge.ts
+++ b/packages/api/src/api/routes/admin-knowledge.ts
@@ -63,6 +63,9 @@ import { CONFLUENCE_DC_CATALOG_ID } from "@atlas/api/lib/knowledge/confluence/co
 import { GITBOOK_CATALOG_ID } from "@atlas/api/lib/knowledge/gitbook/config";
 import { ZENDESK_CATALOG_ID } from "@atlas/api/lib/knowledge/zendesk/config";
 import { SALESFORCE_KNOWLEDGE_CATALOG_ID } from "@atlas/api/lib/knowledge/salesforce/config";
+import { SLACK_HISTORY_CATALOG_ID } from "@atlas/api/lib/brain/ingest/slack/config";
+import { getBrainSourceConnector } from "@atlas/api/lib/brain/ingest/types";
+import { syncBrainEpisodeSource } from "@atlas/api/lib/brain/ingest/episode-sync";
 import { INTERCOM_CATALOG_ID } from "@atlas/api/lib/knowledge/intercom/config";
 import { FRONT_CATALOG_ID } from "@atlas/api/lib/knowledge/front/config";
 import { HELPSCOUT_CATALOG_ID } from "@atlas/api/lib/knowledge/helpscout/config";
@@ -140,6 +143,7 @@ function sourceOf(catalogId: string): KnowledgeSource {
   if (catalogId === FRONT_CATALOG_ID) return "front";
   if (catalogId === HELPSCOUT_CATALOG_ID) return "helpscout";
   if (catalogId === FRESHDESK_CATALOG_ID) return "freshdesk";
+  if (catalogId === SLACK_HISTORY_CATALOG_ID) return "slack-history";
   return "unknown";
 }
 
@@ -156,7 +160,11 @@ function isSyncedSource(source: KnowledgeSource): boolean {
     source === "intercom" ||
     source === "front" ||
     source === "helpscout" ||
-    source === "freshdesk"
+    source === "freshdesk" ||
+    // #4770: a brain source has no documents, but it DOES have sync
+    // bookkeeping in the same `knowledge_sync_state` row, so the list's sync
+    // column and "Sync now" apply to it unchanged.
+    source === "slack-history"
   );
 }
 
@@ -171,13 +179,24 @@ const CollectionSyncStatusSchema = z.object({
   lastSyncAt: z.string(),
   status: z.enum(["success", "error"]),
   error: z.string().nullable(),
+  /**
+   * True when the last sync SUCCEEDED but knowingly left part of its window
+   * uncovered — a per-cycle budget ran out, a channel was unreadable, a vendor
+   * enumeration was partial. Both CONNECTOR engines persist this in the state
+   * row's JSONB `report` (bundle-sync has no coverage concept and reads as
+   * `false`); carrying it on the wire is what lets a caller tell a clean sync
+   * from one that is quietly achieving nothing.
+   */
+  coverageIncomplete: z.boolean(),
+  /** Why, when `coverageIncomplete` — the first of the engine's warnings. */
+  coverageDetail: z.string().nullable(),
 });
 
 const CollectionListResponseSchema = z.object({
   collections: z.array(
     z.object({
       slug: z.string(),
-      source: z.enum(["upload", "bundle-sync", "notion", "confluence", "confluence-datacenter", "gitbook", "zendesk", "salesforce-knowledge", "intercom", "front", "helpscout", "freshdesk"]),
+      source: z.enum(["upload", "bundle-sync", "notion", "confluence", "confluence-datacenter", "gitbook", "zendesk", "salesforce-knowledge", "intercom", "front", "helpscout", "freshdesk", "slack-history"]),
       description: z.string().nullable(),
       installedAt: z.string().nullable(),
       endpointUrl: z.string().nullable(),
@@ -444,11 +463,26 @@ adminKnowledge.openapi(listRoute, async (c) =>
         countsQuery.text,
         countsQuery.params,
       ),
-      internalQuery<{ collection_id: string; last_sync_at: string; status: string; error: string | null }>(
+      internalQuery<{
+        collection_id: string;
+        last_sync_at: string;
+        status: string;
+        error: string | null;
+        coverage_incomplete: boolean | null;
+        coverage_detail: string | null;
+      }>(
         `SELECT collection_id,
                 to_char(last_sync_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') AS last_sync_at,
                 status,
-                error
+                error,
+                -- Compared IN JSON SPACE rather than cast to boolean. The
+                -- report column is free-form JSONB written by more than one
+                -- engine, and a ->>'k'::boolean cast raises on any value
+                -- outside Postgres's boolean vocabulary, faulting the ENTIRE
+                -- collection list for the workspace off one malformed row with
+                -- no per-row isolation. This degrades to false instead.
+                (report -> 'coverageIncomplete') = 'true'::jsonb AS coverage_incomplete,
+                report -> 'warnings' ->> 0                        AS coverage_detail
            FROM knowledge_sync_state
           WHERE workspace_id = $1`,
         [orgId],
@@ -466,11 +500,24 @@ adminKnowledge.openapi(listRoute, async (c) =>
 
     const syncBySlug = new Map<
       string,
-      { lastSyncAt: string; status: "success" | "error"; error: string | null }
+      {
+        lastSyncAt: string;
+        status: "success" | "error";
+        error: string | null;
+        coverageIncomplete: boolean;
+        coverageDetail: string | null;
+      }
     >();
     for (const row of syncStates) {
       syncBySlug.set(row.collection_id, {
         lastSyncAt: row.last_sync_at,
+        // Three cases read as `false`, and it is the honest answer for all
+        // three: a report predating this field, an error attempt (whose report
+        // carries no coverage field), and a bundle-sync row (that engine has
+        // no partial-coverage concept). "No evidence of deferred work" —
+        // never "we checked and there is none".
+        coverageIncomplete: row.coverage_incomplete === true,
+        coverageDetail: row.coverage_detail,
         // The table CHECK pins success|error; if something unexpected slips
         // through, fail toward "error" — never report a sync healthy on a
         // value we don't recognize.
@@ -833,6 +880,7 @@ adminKnowledge.openapi(syncRoute, async (c) =>
     // schema's inferred (mutable) shape; the module-level producer-drift guard
     // keeps it assignable to `KnowledgeSyncRunResponse`.
     let wire: z.infer<typeof SyncRunResponseSchema>;
+    const brainSource = getBrainSourceConnector(collection.catalog_id);
     if (source === "bundle-sync") {
       const outcome = await syncCollection({
         workspaceId: orgId,
@@ -849,6 +897,33 @@ adminKnowledge.openapi(syncRoute, async (c) =>
         archivedAbsent: outcome.archivedAbsent,
         linksWritten: outcome.linksWritten,
         rejected: [...outcome.rejected],
+      };
+    } else if (brainSource !== undefined) {
+      // A brain SOURCE (#4770): same install spine and same sync bookkeeping,
+      // different ingest target — so "Sync now" has to route to the episode
+      // engine. Without this arm the knowledge-connector lookup below misses
+      // (brain sources register in their own registry), and a perfectly
+      // healthy install answers 500 "contact your operator".
+      const outcome = await syncBrainEpisodeSource({
+        connector: brainSource,
+        workspaceId: orgId,
+        installId: collectionSlug,
+        config: collection.config,
+      });
+      wire = {
+        collection: outcome.installId,
+        status: outcome.status,
+        syncedAt: outcome.syncedAt,
+        error: outcome.error,
+        format: null,
+        // A brain source writes episodes, not knowledge documents. The
+        // document counters stay null rather than reporting episode counts in
+        // a field the UI labels "documents" — the episode report lives in the
+        // sync state row until #4772 gives the brain its own surface.
+        documents: null,
+        archivedAbsent: null,
+        linksWritten: null,
+        rejected: [],
       };
     } else {
       const connector = getKnowledgeSyncConnector(collection.catalog_id);

--- a/packages/api/src/lib/brain/ingest/__tests__/episode-sync-archive.test.ts
+++ b/packages/api/src/lib/brain/ingest/__tests__/episode-sync-archive.test.ts
@@ -1,0 +1,162 @@
+/**
+ * "The engine's subtractive-archive path is provably untouched for episodes"
+ * (#4770 acceptance criterion), plus the seam registration rules.
+ *
+ * The claim is STRUCTURAL, so the test is too. A behavioural test ("we called
+ * the engine with `archiveAbsent: false`") would prove the opposite of what is
+ * wanted — it would prove the archive path is a flag away. What is wanted is
+ * that the brain arm cannot reach it at all:
+ *
+ *   - nothing under `lib/brain/ingest/` imports `ingest-bundle` (which owns
+ *     `ingestDocuments`, `archiveAbsent`, and upsert-by-path);
+ *   - nothing under `lib/brain/ingest/` names `archiveAbsent` or writes an
+ *     UPDATE/DELETE against `brain_episodes`;
+ *   - the ONE write is `ON CONFLICT … DO NOTHING`.
+ *
+ * Source-text pins are the same instrument `connector-sync.test.ts` uses to
+ * pin "no publish path exists here", for the same reason: a future refactor
+ * that reintroduces the coupling has to delete a test that says why it
+ * shouldn't.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { readdirSync, readFileSync, statSync } from "fs";
+import { join } from "path";
+import { INSERT_EPISODES_SQL } from "@atlas/api/lib/brain/ingest/episodes";
+import {
+  _resetBrainSourceConnectors,
+  getBrainSourceConnector,
+  listBrainSourceCatalogIds,
+  registerBrainSourceConnector,
+  type BrainSourceConnector,
+} from "@atlas/api/lib/brain/ingest/types";
+
+const INGEST_DIR = join(import.meta.dir, "..");
+
+/**
+ * Strip comments before matching.
+ *
+ * These modules explain AT LENGTH why they don't archive and don't call
+ * `ingestDocuments` — that prose is the point, and a guard that tripped on it
+ * would force the explanation to be deleted to stay green, which is exactly
+ * backwards. The rule is about CODE, so the scan reads code.
+ */
+function codeOf(file: string): string {
+  return readFileSync(file, "utf8")
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/(^|[^:])\/\/.*$/gm, "$1");
+}
+
+/** Every non-test source file under `lib/brain/ingest/`, recursively. */
+function ingestSources(dir: string = INGEST_DIR): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      if (entry === "__tests__") continue;
+      out.push(...ingestSources(full));
+      continue;
+    }
+    if (entry.endsWith(".ts") && !entry.endsWith(".test.ts")) out.push(full);
+  }
+  return out;
+}
+
+describe("the episode path cannot reach the engine's archive/upsert half", () => {
+  const sources = ingestSources();
+
+  it("finds the modules it is meant to be guarding (the guard is not vacuous)", () => {
+    // A recursion or path bug that returned [] would make every assertion
+    // below pass while checking nothing.
+    const names = sources.map((f) => f.replace(`${INGEST_DIR}/`, ""));
+    expect(names).toContain("episodes.ts");
+    expect(names).toContain("episode-sync.ts");
+    expect(names).toContain("slack/client.ts");
+    expect(sources.length).toBeGreaterThanOrEqual(6);
+  });
+
+  it("never imports the document ingest seam that owns archiveAbsent", () => {
+    for (const file of sources) {
+      const text = codeOf(file);
+      expect({ file, hit: /from\s+["'][^"']*ingest-bundle["']/.test(text) }).toEqual({
+        file,
+        hit: false,
+      });
+      expect({ file, hit: text.includes("ingestDocuments") }).toEqual({ file, hit: false });
+    }
+  });
+
+  it("never names archiveAbsent at all", () => {
+    for (const file of sources) {
+      expect({ file, hit: codeOf(file).includes("archiveAbsent") }).toEqual({
+        file,
+        hit: false,
+      });
+    }
+  });
+
+  it("never issues an UPDATE or DELETE against brain_episodes", () => {
+    // Append-only is the point, not an optimization: evidence that can be
+    // edited after the fact cannot back a provenance claim (migration 0180).
+    for (const file of sources) {
+      const text = codeOf(file);
+      expect({ file, hit: /UPDATE\s+brain_episodes/i.test(text) }).toEqual({ file, hit: false });
+      expect({ file, hit: /DELETE\s+FROM\s+brain_episodes/i.test(text) }).toEqual({
+        file,
+        hit: false,
+      });
+    }
+  });
+
+  it("writes with DO NOTHING — not DO UPDATE", () => {
+    expect(INSERT_EPISODES_SQL).toContain(
+      "ON CONFLICT (workspace_id, source, source_id) DO NOTHING",
+    );
+    expect(INSERT_EPISODES_SQL).not.toContain("DO UPDATE");
+  });
+
+  it("never writes extracted_at — the extraction queue stays #4771's", () => {
+    expect(INSERT_EPISODES_SQL).not.toContain("extracted_at");
+  });
+
+  it("never writes a status column — episodes are evidence, not review-gated", () => {
+    // `brain_episodes` is deliberately NOT content-mode registered (#4769); a
+    // status write here would be staging evidence as a draft.
+    expect(INSERT_EPISODES_SQL).not.toContain("status");
+  });
+});
+
+describe("the brain source registry", () => {
+  function connector(overrides: Partial<BrainSourceConnector> = {}): BrainSourceConnector {
+    return {
+      catalogId: "catalog:fixture",
+      source: "fixture",
+      createClient: () => ({ fetchEpisodes: async () => ({ episodes: [], highWaterMark: null }) }),
+      ...overrides,
+    };
+  }
+
+  it("registers, resolves, and lists a source", () => {
+    _resetBrainSourceConnectors();
+    registerBrainSourceConnector(connector());
+    expect(getBrainSourceConnector("catalog:fixture")?.source).toBe("fixture");
+    expect(listBrainSourceCatalogIds()).toEqual(["catalog:fixture"]);
+    _resetBrainSourceConnectors();
+  });
+
+  it("refuses a duplicate catalog id rather than shadowing an install", () => {
+    _resetBrainSourceConnectors();
+    registerBrainSourceConnector(connector());
+    expect(() => registerBrainSourceConnector(connector())).toThrow(/already registered/);
+    _resetBrainSourceConnectors();
+  });
+
+  it("refuses a malformed source slug — it is stored verbatim in the table", () => {
+    _resetBrainSourceConnectors();
+    expect(() => registerBrainSourceConnector(connector({ source: "Slack History" }))).toThrow(
+      /invalid/,
+    );
+    expect(() => registerBrainSourceConnector(connector({ source: "" }))).toThrow(/invalid/);
+    _resetBrainSourceConnectors();
+  });
+});

--- a/packages/api/src/lib/brain/ingest/__tests__/episode-sync.test.ts
+++ b/packages/api/src/lib/brain/ingest/__tests__/episode-sync.test.ts
@@ -1,0 +1,401 @@
+/**
+ * The brain episode sync engine (#4770) — the fork's attempt shape.
+ *
+ * What is worth testing here is precisely what the module does NOT own:
+ * ADR-0036 reuses the ADR-0030 engine verbatim, so the tests assert that the
+ * reused pieces are actually driving (cadence decides the mode, the shared
+ * backoff sees the 429, the shared cap bounds the fetch, the shared
+ * bookkeeping records the attempt) rather than re-testing them.
+ *
+ * The layering rule this suite lives under: `episode-sync.ts` never touches a
+ * database handle directly — it reaches storage through
+ * `connector-sync.ts`'s bookkeeping helpers and through `ingestEpisodes`, and
+ * both of those modules (plus `knowledge-limits`) are `mock.module()`d here
+ * with EVERY export stubbed (CLAUDE.md). The point is the control flow; the SQL
+ * has its own real-Postgres suite in `episodes-pg.test.ts`.
+ */
+
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import { ConnectorRateLimitError } from "@atlas/api/lib/knowledge/connectors";
+import type { EpisodeIngestReport } from "@atlas/api/lib/brain/ingest/episodes";
+import type {
+  BrainEpisodeRecord,
+  BrainSourceConnector,
+  BrainSourceFetchParams,
+} from "@atlas/api/lib/brain/ingest/types";
+
+// ── Stubs ──────────────────────────────────────────────────────────────────
+// Recorded per test; the mocks below close over these.
+
+let syncStateRow: {
+  highWaterMark: string | null;
+  cursor: string | null;
+  lastReconciledAt: string | null;
+} = { highWaterMark: null, cursor: null, lastReconciledAt: null };
+let stateWrites: Record<string, unknown>[] = [];
+let ingested: { workspaceId: string; source: string; episodes: readonly BrainEpisodeRecord[] }[] = [];
+let ingestThrows: Error | null = null;
+let maxDocs = 1000;
+let capsThrow: Error | null = null;
+
+void mock.module("@atlas/api/lib/knowledge/connector-sync", () => ({
+  // Reused engine surface, faithfully shaped.
+  SYNC_OVERLAP_WINDOW_MS: 5 * 60 * 1000,
+  RATE_LIMIT_MAX_ATTEMPTS: 3,
+  RATE_LIMIT_DEFAULT_WAIT_MS: 2_000,
+  RATE_LIMIT_MAX_WAIT_MS: 60_000,
+  DEFAULT_SYNC_RECONCILE_INTERVAL_HOURS: 168,
+  CONNECTOR_SYNC_STATE_SELECT_SQL: "select",
+  CONNECTOR_SYNC_STATE_UPSERT_SQL: "upsert",
+  getKnowledgeSyncReconcileIntervalMs: () => 168 * 3_600_000,
+  readConnectorSyncState: async () => syncStateRow,
+  upsertConnectorSyncState: async (
+    _workspaceId: string,
+    _installId: string,
+    write: Record<string, unknown>,
+  ) => {
+    stateWrites.push(write);
+  },
+  // A FAITHFUL REIMPLEMENTATION of the engine's backoff, not the real function
+  // (mock.module replaces the whole module). It is shaped this way so that
+  // REMOVING the backoff wrapper from `episode-sync.ts` is caught — the attempt
+  // count drops to 1 — which is the regression that matters here. It does NOT
+  // pin the engine's constants: `RATE_LIMIT_MAX_ATTEMPTS` is a literal below,
+  // so a change to the real one would not surface in this suite.
+  withRateLimitBackoff: async <T>(
+    fn: () => Promise<T>,
+    opts?: { sleep?: (ms: number) => Promise<void>; maxAttempts?: number },
+  ): Promise<T> => {
+    const maxAttempts = opts?.maxAttempts ?? 3;
+    for (let attempt = 1; ; attempt++) {
+      try {
+        return await fn();
+      } catch (err) {
+        if (!(err instanceof ConnectorRateLimitError) || attempt >= maxAttempts) throw err;
+        await (opts?.sleep ?? (async () => {}))(1);
+      }
+    }
+  },
+  syncConnectorCollection: async () => {
+    throw new Error("the brain arm must never call the document engine");
+  },
+}));
+
+void mock.module("@atlas/api/lib/billing/knowledge-limits", () => ({
+  resolveIngestCaps: async () => {
+    if (capsThrow) throw capsThrow;
+    return {
+      maxDocs: { value: maxDocs, boundBy: "platform" },
+      maxBundleBytes: { value: 1, boundBy: "platform" },
+      maxDocBytes: { value: 1, boundBy: "platform" },
+    };
+  },
+  capIsOperatorTunable: () => true,
+  lowestTierAdmitting: () => null,
+  // CLAUDE.md: mock ALL exports. A partial factory is what produces
+  // "Export named 'X' not found" in an unrelated file the moment someone adds
+  // an import — the failure lands nowhere near this file.
+  resolveKnowledgeTierLimits: () => ({}),
+  assertNotTierBound: () => {},
+  minKnowledgeCap: (a: number) => a,
+  assertIngestCapsFor: async () => {},
+}));
+
+void mock.module("@atlas/api/lib/brain/ingest/episodes", () => ({
+  INSERT_EPISODES_SQL: "insert",
+  ingestEpisodes: async (params: {
+    workspaceId: string;
+    source: string;
+    episodes: readonly BrainEpisodeRecord[];
+  }) => {
+    if (ingestThrows) throw ingestThrows;
+    ingested.push(params);
+    return {
+      inserted: params.episodes.length,
+      duplicate: 0,
+      refused: {
+        blank_source_id: 0,
+        blank_body: 0,
+        unusable_grant: 0,
+        invalid_occurred_at: 0,
+      },
+      batchDuplicate: 0,
+    } satisfies EpisodeIngestReport;
+  },
+}));
+
+const { syncBrainEpisodeSource } = await import("@atlas/api/lib/brain/ingest/episode-sync");
+
+// ── Fixtures ───────────────────────────────────────────────────────────────
+
+const NOW = new Date("2026-07-01T12:00:00.000Z");
+
+function episode(sourceId: string): BrainEpisodeRecord {
+  return {
+    sourceId,
+    sourceActor: "U1",
+    body: "evidence",
+    occurredAt: new Date("2026-06-30T00:00:00.000Z"),
+    visibleTo: ["org"],
+  };
+}
+
+function connectorReturning(
+  fetchEpisodes: (params: BrainSourceFetchParams) => Promise<{
+    episodes: readonly BrainEpisodeRecord[];
+    highWaterMark: string | null;
+    cursor?: string | null;
+    coverageIncomplete?: boolean;
+    warnings?: readonly string[];
+  }>,
+): BrainSourceConnector {
+  return { catalogId: "catalog:fixture", source: "fixture", createClient: () => ({ fetchEpisodes }) };
+}
+
+function run(connector: BrainSourceConnector) {
+  return syncBrainEpisodeSource({
+    connector,
+    workspaceId: "ws-1",
+    installId: "install-1",
+    config: {},
+    now: () => NOW,
+    sleep: async () => {},
+  });
+}
+
+beforeEach(() => {
+  syncStateRow = { highWaterMark: null, cursor: null, lastReconciledAt: null };
+  stateWrites = [];
+  ingested = [];
+  ingestThrows = null;
+  capsThrow = null;
+  maxDocs = 1000;
+});
+
+// ══════════════════════════════════════════════════════════════════
+// The reused cadence decides the mode
+// ══════════════════════════════════════════════════════════════════
+
+describe("cadence (reused from the ADR-0030 engine)", () => {
+  it("reconciles a source that has never synced", async () => {
+    let seen: BrainSourceFetchParams | null = null;
+    const outcome = await run(
+      connectorReturning(async (params) => {
+        seen = params;
+        return { episodes: [], highWaterMark: null };
+      }),
+    );
+    expect(seen!.mode).toBe("reconciliation");
+    expect(outcome.mode).toBe("reconciliation");
+  });
+
+  it("runs incrementally once a mark exists and the reconcile clock is fresh", async () => {
+    syncStateRow = {
+      highWaterMark: "2026-07-01T11:00:00.000Z",
+      cursor: "{}",
+      lastReconciledAt: "2026-07-01T00:00:00.000Z",
+    };
+    let seen: BrainSourceFetchParams | null = null;
+    await run(
+      connectorReturning(async (params) => {
+        seen = params;
+        return { episodes: [], highWaterMark: null };
+      }),
+    );
+    expect(seen!.mode).toBe("incremental");
+    // The engine's overlap window rewinds the mark by 5 minutes.
+    expect(seen!.since).toBe("2026-07-01T10:55:00.000Z");
+    expect(seen!.cursor).toBe("{}");
+  });
+
+  it("reconciles again once the clock is due", async () => {
+    syncStateRow = {
+      highWaterMark: "2026-07-01T11:00:00.000Z",
+      cursor: null,
+      lastReconciledAt: "2026-01-01T00:00:00.000Z",
+    };
+    let seen: BrainSourceFetchParams | null = null;
+    await run(
+      connectorReturning(async (params) => {
+        seen = params;
+        return { episodes: [], highWaterMark: null };
+      }),
+    );
+    expect(seen!.mode).toBe("reconciliation");
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════
+// Caps and backoff come from the engine, not from the source
+// ══════════════════════════════════════════════════════════════════
+
+describe("caps and backoff", () => {
+  it("hands the client the workspace's effective per-sync cap", async () => {
+    maxDocs = 42;
+    let seen: BrainSourceFetchParams | null = null;
+    await run(
+      connectorReturning(async (params) => {
+        seen = params;
+        return { episodes: [], highWaterMark: null };
+      }),
+    );
+    expect(seen!.maxEpisodes).toBe(42);
+  });
+
+  it("refuses the whole batch when a client overshoots the cap it was given", async () => {
+    // A partial store whose high-water mark claimed to cover the dropped
+    // records would be worse than storing nothing — the gap would be
+    // permanent and invisible.
+    maxDocs = 2;
+    const outcome = await run(
+      connectorReturning(async () => ({
+        episodes: [episode("a"), episode("b"), episode("c")],
+        highWaterMark: "2026-06-30T00:00:00.000Z",
+      })),
+    );
+    expect(outcome.status).toBe("error");
+    expect(outcome.error).toContain("over the 2-record per-sync limit");
+    expect(ingested).toHaveLength(0);
+  });
+
+  it("retries through the shared 429 backoff, then reports exhaustion actionably", async () => {
+    let attempts = 0;
+    const outcome = await run(
+      connectorReturning(async () => {
+        attempts++;
+        throw new ConnectorRateLimitError("throttled", 7);
+      }),
+    );
+    expect(attempts).toBe(3);
+    expect(outcome.status).toBe("error");
+    expect(outcome.error).toContain("rate limiting");
+    expect(outcome.error).toContain("Retry-After 7s");
+  });
+
+  it("succeeds when the retry succeeds", async () => {
+    let attempts = 0;
+    const outcome = await run(
+      connectorReturning(async () => {
+        if (++attempts === 1) throw new ConnectorRateLimitError("throttled", null);
+        return { episodes: [episode("a")], highWaterMark: "2026-06-30T00:00:00.000Z" };
+      }),
+    );
+    expect(outcome.status).toBe("success");
+    expect(outcome.episodes?.inserted).toBe(1);
+  });
+
+  it("reports a caps lookup failure as itself, not as a cap refusal", async () => {
+    capsThrow = new Error("tier lookup timed out");
+    const outcome = await run(connectorReturning(async () => ({ episodes: [], highWaterMark: null })));
+    expect(outcome.status).toBe("error");
+    expect(outcome.error).toContain("tier lookup timed out");
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════
+// Bookkeeping — the shared state row, with the fork's report shape
+// ══════════════════════════════════════════════════════════════════
+
+describe("bookkeeping", () => {
+  it("advances the mark, cursor, and reconcile clock on a complete pass", async () => {
+    const outcome = await run(
+      connectorReturning(async () => ({
+        episodes: [episode("a")],
+        highWaterMark: "2026-06-30T00:00:00.000Z",
+        cursor: '{"v":1}',
+      })),
+    );
+    expect(outcome.status).toBe("success");
+    const write = stateWrites[0]!;
+    expect(write.highWaterMark).toBe("2026-06-30T00:00:00.000Z");
+    expect(write.cursor).toBe('{"v":1}');
+    expect(write.reconciledAt).toBe(NOW.toISOString());
+  });
+
+  it("holds the reconcile clock when coverage was incomplete", async () => {
+    // A partially-covered pass must stay DUE, so the uncovered window gets a
+    // wide re-crawl soon rather than in a week.
+    await run(
+      connectorReturning(async () => ({
+        episodes: [episode("a")],
+        highWaterMark: "2026-06-30T00:00:00.000Z",
+        coverageIncomplete: true,
+        warnings: ["C2 was not read this cycle"],
+      })),
+    );
+    const write = stateWrites[0]!;
+    expect(write.reconciledAt).toBeNull();
+    const report = write.report as { coverageIncomplete: boolean; warnings: string[] };
+    // Persisted so a coverage-incomplete "success" is never silently green.
+    expect(report.coverageIncomplete).toBe(true);
+    expect(report.warnings).toEqual(["C2 was not read this cycle"]);
+  });
+
+  it("passes NULLs on an error so the engine COALESCEs the old mark forward", async () => {
+    ingestThrows = new Error("connection reset");
+    const outcome = await run(
+      connectorReturning(async () => ({
+        episodes: [episode("a")],
+        highWaterMark: "2026-06-30T00:00:00.000Z",
+        cursor: '{"v":1}',
+      })),
+    );
+    expect(outcome.status).toBe("error");
+    const write = stateWrites[0]!;
+    // A failed cycle must never skip the records it failed to ingest.
+    expect(write.highWaterMark).toBeNull();
+    expect(write.cursor).toBeNull();
+    expect(write.reconciledAt).toBeNull();
+  });
+
+  it("drops an unparseable high-water mark instead of failing the sync on it", async () => {
+    const outcome = await run(
+      connectorReturning(async () => ({ episodes: [episode("a")], highWaterMark: "not-a-date" })),
+    );
+    expect(outcome.status).toBe("success");
+    expect(stateWrites[0]!.highWaterMark).toBeNull();
+  });
+
+  it("records the REAL mode when the failure came after the mode was decided", async () => {
+    const outcome = await syncBrainEpisodeSource({
+      connector: {
+        catalogId: "catalog:fixture",
+        source: "fixture",
+        createClient: () => {
+          throw new Error("unreachable");
+        },
+      },
+      workspaceId: "ws-1",
+      installId: "install-1",
+      config: {},
+      now: () => NOW,
+    });
+    // `createClient` runs AFTER the mode decision, so this one is honest about
+    // knowing the mode — the `unknown` arm is for failures before it.
+    expect(outcome.mode).toBe("reconciliation");
+    expect(outcome.status).toBe("error");
+    expect(outcome.error).toBe("unreachable");
+  });
+});
+
+describe("never throws", () => {
+  it("turns a client that rejects with a non-Error into an error outcome", async () => {
+    const outcome = await run(
+      connectorReturning(async () => {
+        // A non-Error rejection: the outcome must still be a recorded error,
+        // not an unhandled rejection out of a scheduler tick.
+        throw "boom";
+      }),
+    );
+    expect(outcome.status).toBe("error");
+    expect(outcome.error).toBe("boom");
+  });
+
+  it("stamps the source into every ingest call", async () => {
+    await run(
+      connectorReturning(async () => ({ episodes: [episode("a")], highWaterMark: null })),
+    );
+    expect(ingested[0]!.source).toBe("fixture");
+    expect(ingested[0]!.workspaceId).toBe("ws-1");
+  });
+});

--- a/packages/api/src/lib/brain/ingest/__tests__/episodes-pg.test.ts
+++ b/packages/api/src/lib/brain/ingest/__tests__/episodes-pg.test.ts
@@ -1,0 +1,342 @@
+/**
+ * Real-Postgres coverage for the brain ingest core (#4770, ADR-0036
+ * §Ingestion & connectors).
+ *
+ * The whole slice rests on claims only a live schema can settle, and every one
+ * of them would pass vacuously against a mock:
+ *
+ *   1. **Is re-ingest genuinely a no-op?** The acceptance criterion is "a
+ *      re-poll of the same window writes zero new rows". That is a property of
+ *      `uq_brain_episodes_source_id` + `ON CONFLICT DO NOTHING`, not of the
+ *      TypeScript around it — a mock would report whatever it was told.
+ *   2. **Is re-ingest a no-op rather than an UPSERT?** Different claim, and
+ *      the one that matters for evidence: a second write with the same
+ *      source-id and DIFFERENT body must leave the first body untouched.
+ *   3. **Do the screens match the CHECKs they stand in for?** Blank body and
+ *      unusable grant are dropped BEFORE the INSERT so one bad record can't
+ *      abort a batch; the test also asserts the CHECK would in fact have
+ *      rejected them, so the screen can never quietly diverge from it.
+ *   4. **Does `extracted_at` stay NULL?** It is #4771's work-queue marker and
+ *      the partial index is what makes the backlog visible; an ingest that
+ *      stamped it would silently drop every episode off the queue.
+ *
+ * Opt in locally with:
+ *   bun run db:up && export TEST_DATABASE_URL=postgresql://atlas:atlas@localhost:5433/brain_4770_scratch
+ */
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
+import { Pool } from "pg";
+import { runMigrations } from "@atlas/api/lib/db/migrate";
+import { MANAGED_AUTH_MIGRATIONS, _resetPool } from "@atlas/api/lib/db/internal";
+import { ingestEpisodes } from "@atlas/api/lib/brain/ingest/episodes";
+import type { BrainEpisodeRecord } from "@atlas/api/lib/brain/ingest/types";
+
+const TEST_DB_URL = process.env.TEST_DATABASE_URL;
+const describeIfPg = TEST_DB_URL ? describe : describe.skip;
+const PG_TEST_TIMEOUT_MS = 60_000;
+
+const WORKSPACE = "ws-brain-ingest";
+const SOURCE = "slack";
+
+function record(overrides: Partial<BrainEpisodeRecord> = {}): BrainEpisodeRecord {
+  return {
+    sourceId: "C01ABCDEF:1719000000.000100",
+    sourceActor: "U123",
+    body: "the deploy window is Thursdays",
+    occurredAt: new Date("2026-06-21T00:00:00.000Z"),
+    visibleTo: ["org"],
+    ...overrides,
+  };
+}
+
+describeIfPg("brain episode ingest core (real Postgres)", () => {
+  let pool: Pool;
+  const schemaName = `brain_ingest_${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
+
+  beforeAll(async () => {
+    // `search_path` baked into the connection string, not SET from an unawaited
+    // `pool.on("connect")` handler — the pattern `promotion-pg.test.ts` and
+    // `acl-visibility-pg.test.ts` established.
+    pool = new Pool({
+      connectionString: TEST_DB_URL,
+      options: `-c search_path="${schemaName}",public`,
+    });
+    const bootstrap = new Pool({ connectionString: TEST_DB_URL });
+    try {
+      await bootstrap.query(`CREATE SCHEMA IF NOT EXISTS "${schemaName}"`);
+    } finally {
+      await bootstrap.end();
+    }
+    await runMigrations(pool, { skip: MANAGED_AUTH_MIGRATIONS });
+    // `ingestEpisodes` writes through `internalQuery`, so the module-level pool
+    // has to BE this schema-scoped one for the test to exercise the real SQL.
+    _resetPool(pool);
+  }, PG_TEST_TIMEOUT_MS);
+
+  afterAll(async () => {
+    _resetPool(null);
+    if (pool) {
+      await pool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+      await pool.end();
+    }
+  }, PG_TEST_TIMEOUT_MS);
+
+  afterEach(async () => {
+    await pool.query(`DELETE FROM brain_episodes WHERE workspace_id = $1`, [WORKSPACE]);
+  });
+
+  async function countEpisodes(): Promise<number> {
+    const { rows } = await pool.query<{ n: string }>(
+      `SELECT count(*)::text AS n FROM brain_episodes WHERE workspace_id = $1`,
+      [WORKSPACE],
+    );
+    return Number(rows[0]!.n);
+  }
+
+  // ══════════════════════════════════════════════════════════════════
+  // 1 + 2. Re-ingest is a NO-OP, not an upsert — the acceptance criterion
+  // ══════════════════════════════════════════════════════════════════
+
+  it("a re-poll of the same window inserts zero new rows", async () => {
+    const window = [
+      record({ sourceId: "C1:1.000001" }),
+      record({ sourceId: "C1:1.000002" }),
+      record({ sourceId: "C1:1.000003" }),
+    ];
+
+    const first = await ingestEpisodes({ workspaceId: WORKSPACE, source: SOURCE, episodes: window });
+    expect(first.inserted).toBe(3);
+    expect(first.duplicate).toBe(0);
+
+    const second = await ingestEpisodes({ workspaceId: WORKSPACE, source: SOURCE, episodes: window });
+    expect(second.inserted).toBe(0);
+    expect(second.duplicate).toBe(3);
+    expect(await countEpisodes()).toBe(3);
+  });
+
+  it("re-ingest with a CHANGED body leaves the stored evidence untouched", async () => {
+    // The difference between DO NOTHING and DO UPDATE, and the reason 0180 has
+    // no `updated_at`: an upstream edit is a new episode's business, never a
+    // rewrite of evidence already cited.
+    await ingestEpisodes({
+      workspaceId: WORKSPACE,
+      source: SOURCE,
+      episodes: [record({ sourceId: "C1:9.000001", body: "original" })],
+    });
+    const again = await ingestEpisodes({
+      workspaceId: WORKSPACE,
+      source: SOURCE,
+      episodes: [record({ sourceId: "C1:9.000001", body: "edited upstream" })],
+    });
+
+    expect(again.inserted).toBe(0);
+    const { rows } = await pool.query<{ body: string }>(
+      `SELECT body FROM brain_episodes WHERE workspace_id = $1 AND source_id = $2`,
+      [WORKSPACE, "C1:9.000001"],
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.body).toBe("original");
+  });
+
+  it("dedupes per (workspace, source, source_id) — not across sources or tenants", async () => {
+    const shared = record({ sourceId: "SAME:1.000001" });
+    await ingestEpisodes({ workspaceId: WORKSPACE, source: SOURCE, episodes: [shared] });
+    const otherSource = await ingestEpisodes({
+      workspaceId: WORKSPACE,
+      source: "teams",
+      episodes: [shared],
+    });
+    const otherWorkspace = await ingestEpisodes({
+      workspaceId: "ws-other",
+      source: SOURCE,
+      episodes: [shared],
+    });
+
+    expect(otherSource.inserted).toBe(1);
+    expect(otherWorkspace.inserted).toBe(1);
+    await pool.query(`DELETE FROM brain_episodes WHERE workspace_id = 'ws-other'`);
+  });
+
+  it("collapses a source that emitted the same record twice in one batch", async () => {
+    const report = await ingestEpisodes({
+      workspaceId: WORKSPACE,
+      source: SOURCE,
+      episodes: [record({ sourceId: "C1:2.000001" }), record({ sourceId: "C1:2.000001" })],
+    });
+    // Reported as a BATCH duplicate, not a storage duplicate: "the source
+    // repeated itself" and "we already had it" are different facts about the
+    // world and point at different bugs.
+    expect(report.inserted).toBe(1);
+    expect(report.batchDuplicate).toBe(1);
+    expect(report.duplicate).toBe(0);
+  });
+
+  // ══════════════════════════════════════════════════════════════════
+  // 3. The screens stand in for CHECKs that WOULD have fired
+  // ══════════════════════════════════════════════════════════════════
+
+  it("drops a blank body before the INSERT — and the CHECK would have refused it", async () => {
+    const report = await ingestEpisodes({
+      workspaceId: WORKSPACE,
+      source: SOURCE,
+      episodes: [record({ sourceId: "C1:3.000001", body: "   " }), record({ sourceId: "C1:3.000002" })],
+    });
+    // One bad record must not abort the batch — the good one still lands.
+    expect(report.refused.blank_body).toBe(1);
+    expect(report.inserted).toBe(1);
+
+    await expect(
+      pool.query(
+        `INSERT INTO brain_episodes (workspace_id, source, source_id, body, visible_to)
+         VALUES ($1, $2, 'direct-blank', '', ARRAY['org'])`,
+        [WORKSPACE, SOURCE],
+      ),
+    ).rejects.toThrow(/chk_brain_episodes_body_xor_locator/);
+  });
+
+  it("drops an unusable grant that the CHECK would have ADMITTED", async () => {
+    // The asymmetry this whole module exists for: `['everyone']` is legal at
+    // rest and grants nobody anything. The screen is stricter than the CHECK on
+    // the WRITE side, which `grant.ts` explains is legitimate precisely because
+    // it is not a rejection at rest or at import.
+    const report = await ingestEpisodes({
+      workspaceId: WORKSPACE,
+      source: SOURCE,
+      episodes: [record({ sourceId: "C1:4.000001", visibleTo: ["everyone"] })],
+    });
+    expect(report.refused.unusable_grant).toBe(1);
+    expect(report.inserted).toBe(0);
+
+    const direct = await pool.query<{ id: string }>(
+      `INSERT INTO brain_episodes (workspace_id, source, source_id, body, visible_to)
+       VALUES ($1, $2, 'direct-everyone', 'x', ARRAY['everyone']) RETURNING id`,
+      [WORKSPACE, SOURCE],
+    );
+    expect(direct.rows).toHaveLength(1);
+  });
+
+  it("drops an Invalid Date rather than letting it abort the whole batch", async () => {
+    // `new Date(NaN).toISOString()` throws RangeError synchronously, so without
+    // a screen one poison record kills the batch — and because the engine
+    // leaves the mark unmoved on an error, the same record would be re-fetched
+    // and re-thrown every cycle forever.
+    const report = await ingestEpisodes({
+      workspaceId: WORKSPACE,
+      source: SOURCE,
+      episodes: [
+        record({ sourceId: "C1:bad.000001", occurredAt: new Date("nonsense") }),
+        record({ sourceId: "C1:good.000001" }),
+      ],
+    });
+    expect(report.refused.invalid_occurred_at).toBe(1);
+    expect(report.inserted).toBe(1);
+  });
+
+  it("drops a blank source id — a blank dedupe key would collapse the source", async () => {
+    const report = await ingestEpisodes({
+      workspaceId: WORKSPACE,
+      source: SOURCE,
+      episodes: [record({ sourceId: "  " })],
+    });
+    expect(report.refused.blank_source_id).toBe(1);
+    expect(await countEpisodes()).toBe(0);
+  });
+
+  // ══════════════════════════════════════════════════════════════════
+  // 4. The stored row's shape
+  // ══════════════════════════════════════════════════════════════════
+
+  it("stores by value, leaves locator NULL, and leaves extracted_at on the queue", async () => {
+    await ingestEpisodes({
+      workspaceId: WORKSPACE,
+      source: SOURCE,
+      episodes: [record({ sourceId: "C1:5.000001" })],
+    });
+    const { rows } = await pool.query<{
+      body: string;
+      locator: string | null;
+      extracted_at: Date | null;
+      source_actor: string | null;
+      occurred_at: Date | null;
+      visible_to: string[];
+    }>(
+      `SELECT body, locator, extracted_at, source_actor, occurred_at, visible_to
+         FROM brain_episodes WHERE workspace_id = $1 AND source_id = $2`,
+      [WORKSPACE, "C1:5.000001"],
+    );
+    const row = rows[0]!;
+    expect(row.body).toBe("the deploy window is Thursdays");
+    expect(row.locator).toBeNull();
+    // NULL forever is a VISIBLE BACKLOG. A stamped value here is a silent drop.
+    expect(row.extracted_at).toBeNull();
+    expect(row.source_actor).toBe("U123");
+    expect(row.occurred_at?.toISOString()).toBe("2026-06-21T00:00:00.000Z");
+    expect(row.visible_to).toEqual(["org"]);
+  });
+
+  it("keeps the episode on #4771's extraction-queue index", async () => {
+    await ingestEpisodes({
+      workspaceId: WORKSPACE,
+      source: SOURCE,
+      episodes: [record({ sourceId: "C1:6.000001" })],
+    });
+    // The exact predicate the extraction fiber drains
+    // (`idx_brain_episodes_extraction_queue`).
+    const { rows } = await pool.query<{ n: string }>(
+      `SELECT count(*)::text AS n FROM brain_episodes
+        WHERE workspace_id = $1 AND extracted_at IS NULL`,
+      [WORKSPACE],
+    );
+    expect(Number(rows[0]!.n)).toBe(1);
+  });
+
+  it("stores a null actor and a null event time without coercing them", async () => {
+    await ingestEpisodes({
+      workspaceId: WORKSPACE,
+      source: SOURCE,
+      episodes: [record({ sourceId: "C1:7.000001", sourceActor: null, occurredAt: null })],
+    });
+    const { rows } = await pool.query<{ source_actor: string | null; occurred_at: Date | null }>(
+      `SELECT source_actor, occurred_at FROM brain_episodes
+        WHERE workspace_id = $1 AND source_id = $2`,
+      [WORKSPACE, "C1:7.000001"],
+    );
+    expect(rows[0]!.source_actor).toBeNull();
+    expect(rows[0]!.occurred_at).toBeNull();
+  });
+
+  it("stores a multi-principal grant without flattening it", async () => {
+    await ingestEpisodes({
+      workspaceId: WORKSPACE,
+      source: SOURCE,
+      episodes: [
+        record({ sourceId: "C1:8.000001", visibleTo: ["audience:chat-channel:slack:C1"] }),
+        record({ sourceId: "C1:8.000002", visibleTo: ["role:admin", "user:u-9"] }),
+      ],
+    });
+    const { rows } = await pool.query<{ source_id: string; visible_to: string[] }>(
+      `SELECT source_id, visible_to FROM brain_episodes
+        WHERE workspace_id = $1 AND source_id LIKE 'C1:8.%' ORDER BY source_id`,
+      [WORKSPACE],
+    );
+    // Mixed grant arities in ONE batch — the case a parallel-`unnest` binding
+    // could not express at all (Postgres requires `text[][]` to be rectangular).
+    expect(rows[0]!.visible_to).toEqual(["audience:chat-channel:slack:C1"]);
+    expect(rows[1]!.visible_to).toEqual(["role:admin", "user:u-9"]);
+  });
+
+  it("is a no-op on an empty batch and never touches the database", async () => {
+    const report = await ingestEpisodes({ workspaceId: WORKSPACE, source: SOURCE, episodes: [] });
+    expect(report).toEqual({
+      inserted: 0,
+      duplicate: 0,
+      refused: {
+        blank_source_id: 0,
+        blank_body: 0,
+        unusable_grant: 0,
+        invalid_occurred_at: 0,
+      },
+      batchDuplicate: 0,
+    });
+  });
+});

--- a/packages/api/src/lib/brain/ingest/__tests__/grant.test.ts
+++ b/packages/api/src/lib/brain/ingest/__tests__/grant.test.ts
@@ -1,0 +1,122 @@
+/**
+ * The grant deriver (#4770) — the write side of ADR-0036 §T5.
+ *
+ * The property under test is narrow and the whole slice leans on it: every
+ * grant this module mints must be USABLE by `parseGrant`. A grant that passes
+ * migration 0180's CHECK but names no principal is legal, invisible, and — once
+ * #4771 turns episodes into facts — refused at every publish forever with no
+ * repair UI until #4772. So the tests assert against `parseGrant` itself rather
+ * than against expected strings: an assertion on the literal `"org"` would
+ * still pass if the grammar moved underneath it.
+ */
+
+import { describe, expect, it } from "bun:test";
+import {
+  AUDIENCE_PREFIX,
+  ORG_PRINCIPAL,
+  parseGrant,
+} from "@atlas/api/lib/brain/acl";
+import {
+  chatChannelAudienceId,
+  deriveChatChannelGrant,
+  isUsableGrant,
+} from "@atlas/api/lib/brain/ingest/grant";
+
+describe("deriveChatChannelGrant", () => {
+  it("maps a public channel to the explicit org principal", () => {
+    const grant = deriveChatChannelGrant({
+      source: "slack",
+      channelId: "C01ABCDEF",
+      isPrivate: false,
+    });
+    expect(grant).toEqual([ORG_PRINCIPAL]);
+    // ADR-0036: "visible to everyone" is a STATED grant, so a forgotten grant
+    // can never read as public.
+    expect(parseGrant(grant ?? []).principals).toEqual([{ kind: "org" }]);
+  });
+
+  it("maps a private channel to a channel-scoped audience", () => {
+    const grant = deriveChatChannelGrant({
+      source: "slack",
+      channelId: "G01SECRET",
+      isPrivate: true,
+    });
+    const parsed = parseGrant(grant ?? []);
+    expect(parsed.principals).toEqual([
+      { kind: "audience", audienceId: chatChannelAudienceId("slack", "G01SECRET") },
+    ]);
+    expect(parsed.malformed).toEqual([]);
+  });
+
+  it("namespaces the audience id by SOURCE, so two vendors' channels can't merge", () => {
+    // `fact_audience_member` has no column that tells vendors apart, so the
+    // namespace has to live in the id itself.
+    const slack = deriveChatChannelGrant({ source: "slack", channelId: "C1", isPrivate: true });
+    const teams = deriveChatChannelGrant({ source: "teams", channelId: "C1", isPrivate: true });
+    expect(slack).not.toEqual(teams);
+  });
+
+  it("builds tokens from the exported prefixes, never a literal", () => {
+    const grant = deriveChatChannelGrant({ source: "slack", channelId: "C1", isPrivate: true });
+    expect(grant?.[0]?.startsWith(AUDIENCE_PREFIX)).toBe(true);
+  });
+
+  it("refuses rather than widening when the channel id is blank", () => {
+    // ADR-0036 §T6 puts grant-derivation failure on the BLOCK side. There is no
+    // safe default: `[org]` would publish content whose audience Atlas failed
+    // to establish.
+    expect(deriveChatChannelGrant({ source: "slack", channelId: "   ", isPrivate: true })).toBeNull();
+    expect(deriveChatChannelGrant({ source: "", channelId: "C1", isPrivate: true })).toBeNull();
+  });
+
+  it("treats unknown visibility as PRIVATE at every call site that can pass it", () => {
+    // The contract `ChatChannelVisibility.isPrivate` states: a vendor that
+    // cannot determine visibility passes `true`. This pins the consequence —
+    // `true` never produces the org-wide grant.
+    const grant = deriveChatChannelGrant({ source: "slack", channelId: "C1", isPrivate: true });
+    expect(grant).not.toContain(ORG_PRINCIPAL);
+  });
+
+  it("never mints a grant parseGrant finds unusable", () => {
+    for (const isPrivate of [true, false]) {
+      for (const channelId of ["C1", "G0123456789", "CABCDEFGHIJ"]) {
+        const grant = deriveChatChannelGrant({ source: "slack", channelId, isPrivate });
+        expect(grant).not.toBeNull();
+        expect(isUsableGrant(grant ?? [])).toBe(true);
+      }
+    }
+  });
+});
+
+describe("isUsableGrant", () => {
+  it("rejects the grants the 0180 CHECK admits but nobody can match", () => {
+    // Each of these has cardinality ≥ 1 and would be stored happily.
+    expect(isUsableGrant(["everyone"])).toBe(false);
+    expect(isUsableGrant(["team:eng"])).toBe(false);
+    expect(isUsableGrant(["ROLE:admin"])).toBe(false);
+    expect(isUsableGrant(["role:platform_admin"])).toBe(false);
+    expect(isUsableGrant(["user:"])).toBe(false);
+    expect(isUsableGrant([`${AUDIENCE_PREFIX}`])).toBe(false);
+  });
+
+  it("accepts a grant with at least ONE usable principal among malformed ones", () => {
+    // The `['user:abc', 'everyone']` case `logGrantAnomalies` exists for: the
+    // row IS reachable, so refusing it here would drop evidence over a stray
+    // token.
+    expect(isUsableGrant(["user:abc", "everyone"])).toBe(true);
+  });
+
+  it("rejects an empty grant and one made only of NULL/empty elements", () => {
+    expect(isUsableGrant([])).toBe(false);
+    expect(isUsableGrant([null, ""])).toBe(false);
+  });
+
+  it("accepts every arm of the grammar", () => {
+    expect(isUsableGrant([ORG_PRINCIPAL])).toBe(true);
+    expect(isUsableGrant(["role:owner"])).toBe(true);
+    expect(isUsableGrant(["role:admin"])).toBe(true);
+    expect(isUsableGrant(["role:member"])).toBe(true);
+    expect(isUsableGrant(["user:u-1"])).toBe(true);
+    expect(isUsableGrant([`${AUDIENCE_PREFIX}x`])).toBe(true);
+  });
+});

--- a/packages/api/src/lib/brain/ingest/__tests__/slack-client.test.ts
+++ b/packages/api/src/lib/brain/ingest/__tests__/slack-client.test.ts
@@ -1,0 +1,841 @@
+/**
+ * The Slack chat-history vendor client (#4770).
+ *
+ * Two things here are contracts rather than implementation, and both are tested
+ * against their stated property rather than a golden string:
+ *
+ *   - the SOURCE-ID FORMAT, which a future webhook writer (M3) must reproduce
+ *     byte-for-byte or the two writers duplicate every message they race on;
+ *   - the CURSOR's gapless-and-convergent behaviour under truncation, resume,
+ *     budget exhaustion and channel-set changes — the only thing standing
+ *     between a budget-limited pass and permanently lost history.
+ *
+ * The budget cases in particular are written so the branch under test actually
+ * RUNS: an earlier cut of this file scripted every channel with
+ * `nextCursor: null`, which short-circuits before the budget check, so it
+ * certified an overshoot bug as safe. Any fixture here that means to exercise
+ * truncation carries a non-null cursor.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { ConnectorRateLimitError } from "@atlas/api/lib/knowledge/connectors";
+import type {
+  SlackConversationInfo,
+  SlackHistoryMessage,
+  SlackHistoryPageParams,
+} from "@atlas/api/lib/slack/api";
+import {
+  HISTORY_MAX_PAGES_PER_CHANNEL,
+  HISTORY_MAX_PAGES_PER_PASS,
+  HISTORY_PAGE_LIMIT,
+  SAFETY_LAG_MS,
+  createSlackHistoryClient,
+  msToSlackTs,
+  parseSlackHistoryCursor,
+  serialiseSlackHistoryCursor,
+  toEpisode,
+  type SlackChannelMark,
+  type SlackHistoryApi,
+} from "@atlas/api/lib/brain/ingest/slack/client";
+import { slackEpisodeSourceId } from "@atlas/api/lib/brain/ingest/slack/config";
+
+const NOW = new Date("2026-07-01T12:00:00.000Z");
+/** Inside the 7-day backfill window, so fixtures exercise real comparisons. */
+const RECENT = Math.floor(NOW.getTime() / 1000) - 3600;
+
+function message(overrides: Partial<SlackHistoryMessage> = {}): SlackHistoryMessage {
+  return { ts: "1750000000.000100", text: "hello", user: "U1", subtype: null, botId: null, ...overrides };
+}
+
+function channel(overrides: Partial<SlackConversationInfo> = {}): SlackConversationInfo {
+  return { id: "C1", name: "general", isPrivate: false, isMember: true, isArchived: false, ...overrides };
+}
+
+/** `n` messages, newest first — the order Slack pages them in. */
+function page(n: number, startSeconds: number, nextCursor: string | null) {
+  return {
+    messages: Array.from({ length: n }, (_, i) =>
+      message({ ts: `${startSeconds - i}.000000` }),
+    ),
+    nextCursor,
+  };
+}
+
+function cursorOf(entries: Record<string, SlackChannelMark>): string {
+  return serialiseSlackHistoryCursor(new Map(Object.entries(entries)));
+}
+
+function marksOf(raw: string | null | undefined): Map<string, SlackChannelMark> {
+  return parseSlackHistoryCursor(raw ?? null).marks;
+}
+
+/** A fake Slack surface: one scripted page list per channel. */
+function fakeApi(opts: {
+  channels?: Record<string, SlackConversationInfo>;
+  pages?: Record<string, { messages: SlackHistoryMessage[]; nextCursor: string | null }[]>;
+  dropped?: Record<string, number>;
+  onInfo?: (channelId: string) => ReturnType<SlackHistoryApi["getConversationInfo"]> | undefined;
+  calls?: SlackHistoryPageParams[];
+}): SlackHistoryApi {
+  const pageIndex = new Map<string, number>();
+  return {
+    async getConversationInfo(_token, channelId) {
+      const override = opts.onInfo?.(channelId);
+      if (override !== undefined) return override;
+      const info = opts.channels?.[channelId];
+      if (info === undefined) {
+        return { ok: false, error: "channel_not_found", retryAfterSeconds: null };
+      }
+      return { ok: true, channel: info };
+    },
+    async fetchConversationHistoryPage(_token, params) {
+      opts.calls?.push(params);
+      const pages = opts.pages?.[params.channel] ?? [];
+      const index = pageIndex.get(params.channel) ?? 0;
+      pageIndex.set(params.channel, index + 1);
+      const scripted = pages[index];
+      const dropped = index === 0 ? (opts.dropped?.[params.channel] ?? 0) : 0;
+      if (scripted === undefined) return { ok: true, messages: [], nextCursor: null, dropped };
+      return { ok: true, messages: scripted.messages, nextCursor: scripted.nextCursor, dropped };
+    },
+  };
+}
+
+function client(api: SlackHistoryApi, channels: string[] = ["C1"]) {
+  return createSlackHistoryClient({
+    token: "xoxb-test",
+    channels,
+    backfillWindowMs: 7 * 86_400_000,
+    api,
+    now: () => NOW,
+  });
+}
+
+function fetchWith(
+  api: SlackHistoryApi,
+  channels: string[],
+  overrides: Partial<Parameters<ReturnType<typeof client>["fetchEpisodes"]>[0]> = {},
+) {
+  return client(api, channels).fetchEpisodes({
+    mode: "incremental",
+    since: null,
+    cursor: null,
+    maxEpisodes: 1000,
+    ...overrides,
+  });
+}
+
+// ══════════════════════════════════════════════════════════════════
+// The source-id contract
+// ══════════════════════════════════════════════════════════════════
+
+describe("the source-id contract", () => {
+  it("is `<channelId>:<ts>` — the format a webhook writer must reproduce", () => {
+    const episode = toEpisode("C01ABCDEF", message({ ts: "1750000000.000100" }), ["org"]);
+    expect(episode?.sourceId).toBe("C01ABCDEF:1750000000.000100");
+    expect(episode?.sourceId).toBe(slackEpisodeSourceId("C01ABCDEF", "1750000000.000100"));
+  });
+
+  it("is channel-scoped — the same ts in two channels is two episodes", () => {
+    const a = toEpisode("C1", message({ ts: "1.000001" }), ["org"]);
+    const b = toEpisode("C2", message({ ts: "1.000001" }), ["org"]);
+    expect(a?.sourceId).not.toBe(b?.sourceId);
+  });
+
+  it("gives a thread reply its own id rather than folding it into its parent", () => {
+    const parent = toEpisode("C1", message({ ts: "1.000001" }), ["org"]);
+    const reply = toEpisode("C1", message({ ts: "1.000002" }), ["org"]);
+    expect(parent?.sourceId).not.toBe(reply?.sourceId);
+  });
+});
+
+describe("toEpisode", () => {
+  it("carries the message text by value and the Slack author as the actor", () => {
+    const episode = toEpisode("C1", message({ text: "we ship Thursdays", user: "U9" }), ["org"]);
+    expect(episode?.body).toBe("we ship Thursdays");
+    expect(episode?.sourceActor).toBe("U9");
+  });
+
+  it("converts the Slack ts to an event time", () => {
+    const episode = toEpisode("C1", message({ ts: "1750000000.000100" }), ["org"]);
+    expect(episode?.occurredAt?.toISOString()).toBe(new Date(1750000000000.1).toISOString());
+  });
+
+  it("skips bot messages — the brain must not cite itself as evidence", () => {
+    expect(toEpisode("C1", message({ botId: "B123" }), ["org"])).toBeNull();
+  });
+
+  it("skips membership noise", () => {
+    expect(toEpisode("C1", message({ subtype: "channel_join" }), ["org"])).toBeNull();
+    expect(toEpisode("C1", message({ subtype: "channel_topic" }), ["org"])).toBeNull();
+  });
+
+  it("KEEPS an unknown subtype — the filter is a denylist on purpose", () => {
+    expect(toEpisode("C1", message({ subtype: "thread_broadcast" }), ["org"])).not.toBeNull();
+    expect(toEpisode("C1", message({ subtype: "file_share" }), ["org"])).not.toBeNull();
+  });
+
+  it("skips a blank message rather than letting the CHECK abort the batch", () => {
+    expect(toEpisode("C1", message({ text: "   " }), ["org"])).toBeNull();
+  });
+
+  it("counts every skip by reason — 'stored 0' must be distinguishable from 'empty'", () => {
+    const skips = { bot: 0, subtype: 0, emptyText: 0 };
+    toEpisode("C1", message({ botId: "B1" }), ["org"], skips);
+    toEpisode("C1", message({ subtype: "channel_join" }), ["org"], skips);
+    toEpisode("C1", message({ text: "" }), ["org"], skips);
+    toEpisode("C1", message(), ["org"], skips);
+    expect(skips).toEqual({ bot: 1, subtype: 1, emptyText: 1 });
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════
+// Grant derivation flows from channel visibility
+// ══════════════════════════════════════════════════════════════════
+
+describe("grants", () => {
+  it("stamps org on a public channel's episodes", async () => {
+    const api = fakeApi({
+      channels: { C1: channel({ isPrivate: false }) },
+      pages: { C1: [{ messages: [message()], nextCursor: null }] },
+    });
+    const changes = await fetchWith(api, ["C1"]);
+    expect(changes.episodes[0]?.visibleTo).toEqual(["org"]);
+  });
+
+  it("stamps a channel audience on a private channel's episodes", async () => {
+    const api = fakeApi({
+      channels: { C1: channel({ isPrivate: true }) },
+      pages: { C1: [{ messages: [message()], nextCursor: null }] },
+    });
+    const changes = await fetchWith(api, ["C1"]);
+    expect(changes.episodes[0]?.visibleTo).toEqual(["audience:chat-channel:slack:C1"]);
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════
+// The per-channel cursor: gapless AND convergent
+// ══════════════════════════════════════════════════════════════════
+
+describe("the per-channel cursor", () => {
+  it("round-trips both arms of the mark union", () => {
+    const marks = new Map<string, SlackChannelMark>([
+      ["C1", { kind: "backfilling", ts: "1.000001", top: "9.000009", resume: "5.000005" }],
+      ["C2", { kind: "contiguous", ts: "3.000003" }],
+    ]);
+    expect(marksOf(serialiseSlackHistoryCursor(marks))).toEqual(marks);
+  });
+
+  it("treats an unreadable cursor as ABSENT rather than fatal", () => {
+    expect(parseSlackHistoryCursor("{not json").marks.size).toBe(0);
+    expect(parseSlackHistoryCursor('{"v":99,"channels":{"C1":{"ts":"1"}}}').marks.size).toBe(0);
+    expect(parseSlackHistoryCursor(null).marks.size).toBe(0);
+    expect(parseSlackHistoryCursor('["C1"]').marks.size).toBe(0);
+    expect(parseSlackHistoryCursor('{"v":1,"channels":["C1"]}').marks.size).toBe(0);
+  });
+
+  it("NAMES the channels whose marks it had to drop", () => {
+    // Dropping a mark restarts that channel at the backfill FLOOR, and when the
+    // lost mark was older than the floor that is a forward jump over history
+    // nobody will ever fetch. Silent would be the wrong shape of failure.
+    const parsed = parseSlackHistoryCursor('{"v":1,"channels":{"C1":{"ts":""},"C2":{"ts":"5.0"}}}');
+    expect(parsed.dropped).toEqual(["C1"]);
+    expect(parsed.marks.get("C2")).toEqual({ kind: "contiguous", ts: "5.0" });
+  });
+
+  it("refuses a `resume` with no `top` — the pair is what stops a false completion", () => {
+    // Half a pair would let a `latest`-bounded pass complete, take the ordinary
+    // completion branch, and claim coverage of everything above `resume`.
+    const parsed = parseSlackHistoryCursor(
+      '{"v":1,"channels":{"C1":{"ts":"1.0","resume":"5.0"}}}',
+    );
+    expect(parsed.marks.get("C1")).toEqual({ kind: "contiguous", ts: "1.0" });
+  });
+
+  it("refuses an out-of-order backfill pair", () => {
+    // `ts < resume ≤ top` or it is not a window this walk can fill.
+    const parsed = parseSlackHistoryCursor(
+      '{"v":1,"channels":{"C1":{"ts":"9.0","resume":"5.0","top":"7.0"}}}',
+    );
+    expect(parsed.marks.get("C1")?.kind).toBe("contiguous");
+  });
+
+  it("starts a never-synced channel at the backfill floor, not at epoch", async () => {
+    const calls: SlackHistoryPageParams[] = [];
+    const api = fakeApi({ channels: { C1: channel() }, pages: {}, calls });
+    await fetchWith(api, ["C1"]);
+    expect(calls[0]?.oldest).toBe(msToSlackTs(NOW.getTime() - 7 * 86_400_000));
+  });
+
+  it("advances a fully-covered EMPTY window to now-minus-the-safety-lag", async () => {
+    const api = fakeApi({ channels: { C1: channel() }, pages: {} });
+    const changes = await fetchWith(api, ["C1"], {
+      cursor: cursorOf({ C1: { kind: "contiguous", ts: "1.000000" } }),
+    });
+    // EXACT, not a range: a range passes for a 1 ms lag, a 1 week lag, and for
+    // replacing the floor with any arbitrary forward jump. The lag is what
+    // stops a quiet channel's re-scan window from growing until it exceeds the
+    // budget, so it is worth pinning to the constant.
+    expect(marksOf(changes.cursor).get("C1")!.ts).toBe(
+      msToSlackTs(NOW.getTime() - SAFETY_LAG_MS),
+    );
+  });
+
+  it("does NOT advance the mark when a pass is truncated — no gap is skipped", async () => {
+    const api = fakeApi({
+      channels: { C1: channel() },
+      pages: {
+        C1: Array.from({ length: 6 }, (_, i) => page(HISTORY_PAGE_LIMIT, RECENT - i * 250, "more")),
+      },
+    });
+    const changes = await fetchWith(api, ["C1"], {
+      cursor: cursorOf({ C1: { kind: "contiguous", ts: `${RECENT - 10_000}.000000` } }),
+      maxEpisodes: 2 * HISTORY_PAGE_LIMIT,
+    });
+
+    expect(changes.coverageIncomplete).toBe(true);
+    const mark = marksOf(changes.cursor).get("C1")!;
+    expect(mark.kind).toBe("backfilling");
+    // The frontier is untouched: the BOTTOM of the window is still unfetched.
+    expect(mark.ts).toBe(`${RECENT - 10_000}.000000`);
+    if (mark.kind !== "backfilling") throw new Error("expected a backfilling mark");
+    expect(Number.parseFloat(mark.resume)).toBeLessThan(Number.parseFloat(mark.top));
+  });
+
+  it("resumes a truncated backfill downward, then advances to the recorded ceiling", async () => {
+    const calls: SlackHistoryPageParams[] = [];
+    const api = fakeApi({
+      channels: { C1: channel() },
+      pages: { C1: [{ messages: [message({ ts: `${RECENT - 500}.000000` })], nextCursor: null }] },
+      calls,
+    });
+    const changes = await fetchWith(api, ["C1"], {
+      cursor: cursorOf({
+        C1: {
+          kind: "backfilling",
+          ts: `${RECENT - 1000}.000000`,
+          top: `${RECENT}.000000`,
+          resume: `${RECENT - 400}.000000`,
+        },
+      }),
+    });
+
+    expect(calls[0]?.latest).toBe(`${RECENT - 400}.000000`);
+    expect(calls[0]?.oldest).toBe(`${RECENT - 1000}.000000`);
+
+    const mark = marksOf(changes.cursor).get("C1")!;
+    // Window complete → the frontier jumps to the ceiling the truncated pass
+    // recorded, NOT to the newest message this pass happened to see, and NOT
+    // to `now` (everything above `top` was never fetched).
+    expect(mark).toEqual({ kind: "contiguous", ts: `${RECENT}.000000` });
+  });
+
+  it("fetches identically in reconciliation mode — the cadence is #4771's, not a re-crawl", async () => {
+    // An earlier cut rewound every channel to the floor on a reconciliation.
+    // Combined with "an incomplete pass holds the reconcile clock", that
+    // re-walked the same week every cycle and could not converge.
+    const calls: SlackHistoryPageParams[] = [];
+    const api = fakeApi({ channels: { C1: channel() }, pages: {}, calls });
+    await fetchWith(api, ["C1"], {
+      mode: "reconciliation",
+      cursor: cursorOf({ C1: { kind: "contiguous", ts: msToSlackTs(NOW.getTime() - 3600_000) } }),
+    });
+    expect(calls[0]?.oldest).toBe(msToSlackTs(NOW.getTime() - 3600_000));
+  });
+
+  it("makes forward progress across consecutive cycles instead of re-walking", async () => {
+    // The convergence claim, driven for two cycles: cycle 2 is fed cycle 1's
+    // cursor and must ask for a strictly narrower window.
+    const calls: SlackHistoryPageParams[] = [];
+    const api1 = fakeApi({
+      channels: { C1: channel() },
+      pages: {
+        C1: [page(HISTORY_PAGE_LIMIT, RECENT, "more"), page(HISTORY_PAGE_LIMIT, RECENT - 250, "more")],
+      },
+      calls,
+    });
+    const first = await fetchWith(api1, ["C1"], {
+      cursor: cursorOf({ C1: { kind: "contiguous", ts: `${RECENT - 10_000}.000000` } }),
+      maxEpisodes: HISTORY_PAGE_LIMIT,
+    });
+    const firstMark = marksOf(first.cursor).get("C1")!;
+    if (firstMark.kind !== "backfilling") throw new Error("expected truncation");
+
+    const calls2: SlackHistoryPageParams[] = [];
+    const api2 = fakeApi({ channels: { C1: channel() }, pages: {}, calls: calls2 });
+    await fetchWith(api2, ["C1"], {
+      cursor: first.cursor,
+      maxEpisodes: HISTORY_PAGE_LIMIT,
+    });
+    // Cycle 2 resumes strictly below cycle 1's ceiling.
+    expect(Number.parseFloat(calls2[0]!.latest!)).toBeLessThan(Number.parseFloat(firstMark.top));
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════
+// Channel-set changes
+// ══════════════════════════════════════════════════════════════════
+
+describe("channel-set changes", () => {
+  it("drops the mark of a channel removed from the config", async () => {
+    const api = fakeApi({ channels: { C1: channel() }, pages: {} });
+    const changes = await fetchWith(api, ["C1"], {
+      cursor: cursorOf({
+        C1: { kind: "contiguous", ts: "5.000000" },
+        C2: { kind: "contiguous", ts: "6.000000" },
+      }),
+    });
+    const marks = marksOf(changes.cursor);
+    expect(marks.has("C2")).toBe(false);
+    expect(marks.has("C1")).toBe(true);
+  });
+
+  it("starts a channel newly added to the config at the backfill floor", async () => {
+    const calls: SlackHistoryPageParams[] = [];
+    const api = fakeApi({
+      channels: { C1: channel(), C2: channel({ id: "C2" }) },
+      pages: {},
+      calls,
+    });
+    await fetchWith(api, ["C1", "C2"], {
+      cursor: cursorOf({ C1: { kind: "contiguous", ts: "1500.000000" } }),
+    });
+    expect(calls.find((c) => c.channel === "C1")?.oldest).toBe("1500.000000");
+    expect(calls.find((c) => c.channel === "C2")?.oldest).toBe(
+      msToSlackTs(NOW.getTime() - 7 * 86_400_000),
+    );
+  });
+
+  it("reports a channel whose stored mark was unreadable", async () => {
+    const api = fakeApi({ channels: { C1: channel() }, pages: {} });
+    const changes = await fetchWith(api, ["C1"], {
+      cursor: '{"v":1,"channels":{"C1":{"ts":""}}}',
+    });
+    expect(changes.coverageIncomplete).toBe(true);
+    expect(changes.warnings?.join(" ")).toContain("unreadable sync mark");
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════
+// Budget — the contract the engine refuses a batch over
+// ══════════════════════════════════════════════════════════════════
+
+describe("budget", () => {
+  it("never returns more episodes than the budget, even mid-page", async () => {
+    // The regression that made the source unusable on the 250-record plan
+    // tiers: the walk used to check the budget only BETWEEN pages, so a
+    // 250-budget returned 400 and the engine refused the whole batch — every
+    // cycle, forever, because the error path leaves the cursor untouched.
+    const api = fakeApi({
+      channels: { C1: channel() },
+      pages: {
+        C1: [page(HISTORY_PAGE_LIMIT, RECENT, "more"), page(HISTORY_PAGE_LIMIT, RECENT - 250, "more")],
+      },
+    });
+    const changes = await fetchWith(api, ["C1"], { maxEpisodes: 250 });
+    expect(changes.episodes).toHaveLength(250);
+    expect(changes.coverageIncomplete).toBe(true);
+  });
+
+  it("resumes exactly below the last WALKED message after a mid-page stop", async () => {
+    const api = fakeApi({
+      channels: { C1: channel() },
+      pages: { C1: [page(HISTORY_PAGE_LIMIT, RECENT, "more")] },
+    });
+    const changes = await fetchWith(api, ["C1"], { maxEpisodes: 10 });
+    const mark = marksOf(changes.cursor).get("C1")!;
+    if (mark.kind !== "backfilling") throw new Error("expected truncation");
+    // 10 walked, newest first → the last walked is RECENT − 9.
+    expect(mark.resume).toBe(`${RECENT - 9}.000000`);
+    expect(mark.top).toBe(`${RECENT}.000000`);
+  });
+
+  it("resumes below a SKIPPED message — `resume` tracks what was WALKED, not what was kept", async () => {
+    // A channel deeper than the page cap whose messages are ALL noise. The pass
+    // truncates on pages, having kept nothing.
+    //
+    // Tracking KEPT records instead would leave `coveredDownTo` null here, the
+    // pair would be judged unresumable, the incoming mark would be preserved,
+    // and the channel would re-walk the same 50 pages every cycle forever. The
+    // distinction is invisible on the episode-budget path — there the last
+    // walked message is also the last kept one — so this is the fixture that
+    // separates them.
+    const noisePage = (start: number) => ({
+      messages: Array.from({ length: HISTORY_PAGE_LIMIT }, (_, i) =>
+        message({ ts: `${start - i}.000000`, subtype: "channel_join" }),
+      ),
+      nextCursor: "more" as const,
+    });
+    const api = fakeApi({
+      channels: { C1: channel() },
+      pages: {
+        C1: Array.from({ length: HISTORY_MAX_PAGES_PER_CHANNEL + 5 }, (_, p) =>
+          noisePage(RECENT - p * HISTORY_PAGE_LIMIT),
+        ),
+      },
+    });
+    const changes = await fetchWith(api, ["C1"], {
+      cursor: cursorOf({ C1: { kind: "contiguous", ts: `${RECENT - 1_000_000}.000000` } }),
+      maxEpisodes: 5000,
+    });
+
+    // Nothing was worth keeping…
+    expect(changes.episodes).toHaveLength(0);
+    const mark = marksOf(changes.cursor).get("C1")!;
+    // …and the pass STILL recorded where to resume, because it walked plenty.
+    expect(mark.kind).toBe("backfilling");
+    if (mark.kind !== "backfilling") throw new Error("expected a resumable backfill");
+    expect(mark.top).toBe(`${RECENT}.000000`);
+    expect(mark.resume).toBe(
+      `${RECENT - HISTORY_MAX_PAGES_PER_CHANNEL * HISTORY_PAGE_LIMIT + 1}.000000`,
+    );
+  });
+
+  it("splits the budget across channels without overshooting the total", async () => {
+    const api = fakeApi({
+      channels: { C1: channel(), C2: channel({ id: "C2" }) },
+      pages: {
+        C1: [page(HISTORY_PAGE_LIMIT, RECENT, "more")],
+        C2: [page(HISTORY_PAGE_LIMIT, RECENT - 1000, "more")],
+      },
+    });
+    const changes = await fetchWith(api, ["C1", "C2"], { maxEpisodes: 300 });
+    // EXACT: C1 completes its 200, C2 truncates at the remaining 100. A
+    // regression where C2 contributes nothing still satisfies `<= 300`.
+    expect(changes.episodes).toHaveLength(300);
+    expect(changes.coverageIncomplete).toBe(true);
+    expect(marksOf(changes.cursor).size).toBe(2);
+  });
+
+  it("leaves an unread channel's mark untouched so nothing is silently passed over", async () => {
+    const api = fakeApi({
+      channels: { C1: channel(), C2: channel({ id: "C2" }) },
+      pages: { C1: [page(HISTORY_PAGE_LIMIT, RECENT, "more")] },
+    });
+    const changes = await fetchWith(api, ["C1", "C2"], {
+      cursor: cursorOf({ C2: { kind: "contiguous", ts: "77.000000" } }),
+      maxEpisodes: HISTORY_PAGE_LIMIT,
+    });
+    expect(marksOf(changes.cursor).get("C2")).toEqual({ kind: "contiguous", ts: "77.000000" });
+  });
+
+  it("bounds vendor calls with a PAGE budget, which noise cannot evade", async () => {
+    // A channel of pure join-noise keeps zero episodes, so it spends none of
+    // `maxEpisodes` while spending a Slack call per page. Without a separate
+    // page budget that is an unbounded walk on a Tier-3 method.
+    const calls: SlackHistoryPageParams[] = [];
+    const noise = () => ({
+      messages: Array.from({ length: HISTORY_PAGE_LIMIT }, (_, i) =>
+        message({ ts: `${9000 - i}.000000`, subtype: "channel_join" }),
+      ),
+      nextCursor: "more" as const,
+    });
+    const api = fakeApi({
+      channels: Object.fromEntries(
+        ["C1", "C2", "C3"].map((id) => [id, channel({ id })]),
+      ),
+      pages: Object.fromEntries(
+        ["C1", "C2", "C3"].map((id) => [id, Array.from({ length: 200 }, noise)]),
+      ),
+      calls,
+    });
+    const changes = await fetchWith(api, ["C1", "C2", "C3"], { maxEpisodes: 5000 });
+    expect(changes.episodes).toHaveLength(0);
+    expect(calls.length).toBeLessThanOrEqual(HISTORY_MAX_PAGES_PER_PASS);
+    expect(changes.warnings?.join(" ")).toContain("stored none");
+  });
+
+  it("caps one channel's walk so it cannot hog the whole pass", async () => {
+    const calls: SlackHistoryPageParams[] = [];
+    const api = fakeApi({
+      channels: { C1: channel() },
+      pages: {
+        C1: Array.from({ length: 200 }, (_, i) => page(1, 9000 - i, "more")),
+      },
+      calls,
+    });
+    await fetchWith(api, ["C1"], { maxEpisodes: 5000 });
+    expect(calls.length).toBeLessThanOrEqual(HISTORY_MAX_PAGES_PER_CHANNEL);
+  });
+
+  it("KEEPS an in-flight backfill pair when a pass cannot resume", async () => {
+    // The non-convergence case. A pass that covers nothing resumable must not
+    // degrade a `backfilling` mark to `contiguous`: doing so discards a window
+    // whose bottom is unfetched, and since the next pass then walks from `now`,
+    // hits the same obstacle and degrades again, it is a fixed point rather
+    // than a delay — the channel never converges and burns the shared budget
+    // forever trying.
+    const api = fakeApi({
+      channels: { C1: channel() },
+      // First page is entirely unidentifiable, so nothing is covered and there
+      // is no `resume` to record from this pass.
+      pages: { C1: [{ messages: [], nextCursor: "more" }] },
+      dropped: { C1: 3 },
+    });
+    const before = {
+      kind: "backfilling" as const,
+      ts: `${RECENT - 1000}.000000`,
+      top: `${RECENT}.000000`,
+      resume: `${RECENT - 400}.000000`,
+    };
+    const changes = await fetchWith(api, ["C1"], { cursor: cursorOf({ C1: before }) });
+    expect(changes.coverageIncomplete).toBe(true);
+    expect(marksOf(changes.cursor).get("C1")).toEqual(before);
+  });
+
+  it("stops rather than marking a window covered when Slack returns unidentifiable messages", async () => {
+    // Those entries sit INSIDE the window this pass would otherwise mark
+    // covered, so advancing past them would be the silent skip the walk exists
+    // to prevent.
+    const api = fakeApi({
+      channels: { C1: channel() },
+      pages: { C1: [{ messages: [message({ ts: "5.000001" })], nextCursor: null }] },
+      dropped: { C1: 3 },
+    });
+    const changes = await fetchWith(api, ["C1"], {
+      cursor: cursorOf({ C1: { kind: "contiguous", ts: "1.000000" } }),
+    });
+    expect(changes.coverageIncomplete).toBe(true);
+    expect(changes.warnings?.join(" ")).toContain("no usable identity");
+    expect(marksOf(changes.cursor).get("C1")?.ts).toBe("1.000000");
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════
+// Failure isolation
+// ══════════════════════════════════════════════════════════════════
+
+describe("failures", () => {
+  it("isolates a per-channel failure instead of failing the whole pass", async () => {
+    const api = fakeApi({
+      channels: { C2: channel({ id: "C2" }) },
+      pages: { C2: [{ messages: [message({ ts: "5.000001" })], nextCursor: null }] },
+      onInfo: (channelId) =>
+        channelId === "C1"
+          ? Promise.resolve({ ok: false as const, error: "not_in_channel", retryAfterSeconds: null })
+          : undefined,
+    });
+    const changes = await fetchWith(api, ["C1", "C2"]);
+    expect(changes.episodes).toHaveLength(1);
+    expect(changes.coverageIncomplete).toBe(true);
+    expect(changes.warnings?.join(" ")).toContain("invite the Atlas bot");
+  });
+
+  it("propagates a rate limit when there is nothing banked, so the engine backs off", async () => {
+    const api = fakeApi({
+      onInfo: () => Promise.resolve({ ok: false as const, error: "ratelimited", retryAfterSeconds: 30 }),
+    });
+    await expect(fetchWith(api, ["C1"])).rejects.toBeInstanceOf(ConnectorRateLimitError);
+  });
+
+  it("BANKS partial progress when a rate limit hits mid-pass", async () => {
+    // Throwing here would discard the episodes and marks the earlier channels
+    // already earned — and because a throttled multi-channel crawl is the
+    // steady state rather than an exception, the same prefix would be re-walked
+    // and re-lost every cycle, starving every channel after it forever.
+    const api = fakeApi({
+      channels: { C1: channel() },
+      pages: { C1: [{ messages: [message({ ts: "5.000001" })], nextCursor: null }] },
+      onInfo: (channelId) =>
+        channelId === "C2"
+          ? Promise.resolve({ ok: false as const, error: "ratelimited", retryAfterSeconds: 30 })
+          : undefined,
+    });
+    const changes = await fetchWith(api, ["C1", "C2", "C3"], {
+      cursor: cursorOf({ C3: { kind: "contiguous", ts: "77.000000" } }),
+    });
+    expect(changes.episodes).toHaveLength(1);
+    expect(changes.coverageIncomplete).toBe(true);
+    expect(changes.warnings?.join(" ")).toContain("rate limiting");
+    expect(marksOf(changes.cursor).has("C1")).toBe(true);
+    // The pass STOPPED at the throttled channel — C3 was never probed, so it
+    // contributes no warning. Without this, deleting the `break` still passes.
+    expect(changes.warnings?.join(" ")).not.toContain("C3");
+    // …and C3's existing mark survived. Reconstructing the cursor from only the
+    // channels this pass VISITED would silently delete it, restarting C3 at the
+    // backfill floor — a forward jump over history nothing re-fetches.
+    expect(marksOf(changes.cursor).get("C3")).toEqual({ kind: "contiguous", ts: "77.000000" });
+  });
+
+  it("keeps the mark of a channel the pass never reached", async () => {
+    // Same invariant as above, reached through the budget path instead of the
+    // throttle path: whichever way a pass ends early, an unvisited channel must
+    // not lose its place.
+    const api = fakeApi({
+      channels: { C1: channel() },
+      pages: { C1: [page(HISTORY_PAGE_LIMIT, RECENT, "more")] },
+    });
+    const changes = await fetchWith(api, ["C1", "C2"], {
+      cursor: cursorOf({
+        C2: { kind: "backfilling", ts: "10.000000", top: "90.000000", resume: "50.000000" },
+      }),
+      maxEpisodes: HISTORY_PAGE_LIMIT,
+    });
+    expect(marksOf(changes.cursor).get("C2")).toEqual({
+      kind: "backfilling",
+      ts: "10.000000",
+      top: "90.000000",
+      resume: "50.000000",
+    });
+  });
+
+  it("surfaces a missing history scope as an actionable reconnect message", async () => {
+    const api = fakeApi({
+      onInfo: () => Promise.resolve({ ok: false as const, error: "missing_scope", retryAfterSeconds: null }),
+    });
+    const changes = await fetchWith(api, ["C1"]);
+    expect(changes.warnings?.join(" ")).toContain("channels:history");
+  });
+
+  it("names the fix for a revoked token rather than echoing the raw code", async () => {
+    const api = fakeApi({
+      onInfo: () => Promise.resolve({ ok: false as const, error: "token_revoked", retryAfterSeconds: null }),
+    });
+    const changes = await fetchWith(api, ["C1"]);
+    expect(changes.warnings?.join(" ")).toContain("reconnect Slack");
+  });
+
+  it("reports no high-water mark when coverage was incomplete", async () => {
+    // The interface requires the mark to cover only the CONTIGUOUS part of the
+    // window; a truncated pass's newest episode is the top of a window whose
+    // bottom is unfetched. Null is lossless — the state upsert COALESCEs.
+    const api = fakeApi({
+      channels: { C1: channel() },
+      pages: { C1: [page(HISTORY_PAGE_LIMIT, RECENT, "more")] },
+    });
+    const changes = await fetchWith(api, ["C1"], { maxEpisodes: 10 });
+    expect(changes.highWaterMark).toBeNull();
+  });
+
+  it("reports the newest covered event time on a complete pass", async () => {
+    const api = fakeApi({
+      channels: { C1: channel() },
+      pages: {
+        C1: [
+          {
+            messages: [message({ ts: "1750000000.000100" }), message({ ts: "1740000000.000100" })],
+            nextCursor: null,
+          },
+        ],
+      },
+    });
+    const changes = await fetchWith(api, ["C1"]);
+    expect(changes.highWaterMark).toBe(new Date(1750000000000.1).toISOString());
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════
+// The property the whole cursor design exists for
+// ══════════════════════════════════════════════════════════════════
+
+describe("gaplessness across cycles (end to end)", () => {
+  it("collects EVERY message across a budget-limited multi-cycle walk", async () => {
+    // The one test that would have caught the round-1 overshoot by
+    // CONSTRUCTION rather than by fixture inspection: script a channel with N
+    // messages, run cycles at a quarter of that budget, and assert the union of
+    // everything ingested equals the full set — and that it terminates.
+    const TOTAL = 400;
+    const all = Array.from({ length: TOTAL }, (_, i) =>
+      message({ ts: `${RECENT - i}.000000` }),
+    );
+    /** Serve `[oldest, latest]` from the full set, newest-first, 200 per page. */
+    function windowApi(calls: SlackHistoryPageParams[]): SlackHistoryApi {
+      const cursors = new Map<string, number>();
+      return {
+        async getConversationInfo() {
+          return { ok: true, channel: channel() };
+        },
+        async fetchConversationHistoryPage(_token, params) {
+          calls.push(params);
+          const oldest = Number.parseFloat(params.oldest ?? "0");
+          const latest = params.latest === undefined ? Infinity : Number.parseFloat(params.latest);
+          const inWindow = all.filter((m) => {
+            const ts = Number.parseFloat(m.ts);
+            return ts > oldest && ts <= latest;
+          });
+          const offset = params.cursor === undefined ? 0 : (cursors.get(params.cursor) ?? 0);
+          const slice = inWindow.slice(offset, offset + HISTORY_PAGE_LIMIT);
+          const nextOffset = offset + slice.length;
+          const more = nextOffset < inWindow.length;
+          const nextCursor = more ? `off:${nextOffset}:${oldest}:${latest}` : null;
+          if (nextCursor !== null) cursors.set(nextCursor, nextOffset);
+          return { ok: true, messages: slice, nextCursor, dropped: 0 };
+        },
+      };
+    }
+
+    const seen = new Set<string>();
+    let cursor: string | null = cursorOf({
+      C1: { kind: "contiguous", ts: `${RECENT - TOTAL}.000000` },
+    });
+    let cycles = 0;
+    for (; cycles < 20; cycles++) {
+      const calls: SlackHistoryPageParams[] = [];
+      const changes = await fetchWith(windowApi(calls), ["C1"], {
+        cursor,
+        maxEpisodes: TOTAL / 4,
+      });
+      // The budget is a HARD contract every cycle, not just at the end: without
+      // this the loop passes even with the round-1 between-pages-only check,
+      // because an over-budget cycle still terminates and still covers the set.
+      expect(changes.episodes.length).toBeLessThanOrEqual(TOTAL / 4);
+      for (const e of changes.episodes) seen.add(e.sourceId);
+      cursor = changes.cursor ?? null;
+      if (!changes.coverageIncomplete) break;
+    }
+
+    // Terminated…
+    expect(cycles).toBeLessThan(20);
+    // …and lost nothing.
+    expect(seen.size).toBe(TOTAL);
+    for (const m of all) expect(seen.has(`C1:${m.ts}`)).toBe(true);
+    // …and settled on a contiguous mark, so steady state is cheap.
+    expect(marksOf(cursor).get("C1")?.kind).toBe("contiguous");
+  });
+
+  it("rotates the starting channel so a busy first channel cannot starve the rest", async () => {
+    // Static order + one shared budget is deterministic starvation: on the
+    // 250-record tiers one busy channel takes the whole cap every cycle and the
+    // channels after it are never read — not slowly, never.
+    const busy = () => [page(HISTORY_PAGE_LIMIT, RECENT, "more")];
+    const api = fakeApi({
+      channels: Object.fromEntries(["C1", "C2"].map((id) => [id, channel({ id })])),
+      pages: { C1: busy(), C2: busy() },
+    });
+    const first = await fetchWith(api, ["C1", "C2"], { maxEpisodes: HISTORY_PAGE_LIMIT });
+    expect(first.warnings?.join(" ")).toContain("C2");
+
+    const calls: SlackHistoryPageParams[] = [];
+    const api2 = fakeApi({
+      channels: Object.fromEntries(["C1", "C2"].map((id) => [id, channel({ id })])),
+      pages: { C1: busy(), C2: busy() },
+      calls,
+    });
+    await fetchWith(api2, ["C1", "C2"], {
+      cursor: first.cursor,
+      maxEpisodes: HISTORY_PAGE_LIMIT,
+    });
+    // Cycle 2 starts where cycle 1 stopped, so C2 is read first this time.
+    expect(calls[0]?.channel).toBe("C2");
+  });
+
+  it("names the budget that actually ran out", async () => {
+    // Blaming the record cap when the PAGE budget bound sends the operator to
+    // raise a plan limit that was never the constraint.
+    const noise = () => ({
+      messages: Array.from({ length: HISTORY_PAGE_LIMIT }, (_, i) =>
+        message({ ts: `${RECENT - i}.000000`, subtype: "channel_join" }),
+      ),
+      nextCursor: "more" as const,
+    });
+    const ids = ["C1", "C2", "C3", "C4"];
+    const api = fakeApi({
+      channels: Object.fromEntries(ids.map((id) => [id, channel({ id })])),
+      pages: Object.fromEntries(ids.map((id) => [id, Array.from({ length: 200 }, noise)])),
+    });
+    const changes = await fetchWith(api, ids, { maxEpisodes: 5000 });
+    const text = changes.warnings?.join(" ") ?? "";
+    expect(text).toContain("page budget");
+    expect(text).not.toContain("record budget");
+  });
+});

--- a/packages/api/src/lib/brain/ingest/__tests__/slack-config.test.ts
+++ b/packages/api/src/lib/brain/ingest/__tests__/slack-config.test.ts
@@ -1,0 +1,97 @@
+/**
+ * The Slack brain source's stored-config contract (#4770).
+ *
+ * `parseSlackHistoryConfig` is the READ side — it runs per cycle against a row
+ * the install handler wrote, which means it also runs against a row somebody
+ * edited by hand. Its errors land in `knowledge_sync_state.error`, so each one
+ * has to say what to do about it.
+ */
+
+import { describe, expect, it } from "bun:test";
+import {
+  SLACK_CHANNEL_ID_PATTERN,
+  SLACK_HISTORY_CATALOG_ID,
+  SLACK_HISTORY_MAX_CHANNELS,
+  SLACK_HISTORY_SLUG,
+  SLACK_HISTORY_SOURCE,
+  parseSlackHistoryConfig,
+  slackEpisodeSourceId,
+} from "@atlas/api/lib/brain/ingest/slack/config";
+
+describe("identity constants", () => {
+  it("keeps the catalog id and slug in lockstep", () => {
+    expect(SLACK_HISTORY_CATALOG_ID).toBe(`catalog:${SLACK_HISTORY_SLUG}`);
+  });
+
+  it("uses the class name, not the vendor-qualified one, as the stored source", () => {
+    // ADR-0036 is class-major, vendor-minor; `brain_episodes.source` carries
+    // the vendor within the chat class.
+    expect(SLACK_HISTORY_SOURCE).toBe("slack");
+  });
+});
+
+describe("SLACK_CHANNEL_ID_PATTERN", () => {
+  it("admits public and legacy-private channel ids", () => {
+    expect(SLACK_CHANNEL_ID_PATTERN.test("C01ABCDEF")).toBe(true);
+    expect(SLACK_CHANNEL_ID_PATTERN.test("G0123456789")).toBe(true);
+  });
+
+  it("refuses DM ids — a DM's audience is two people", () => {
+    // ADR-0036 puts source-principal-resolution failure on the BLOCK side, and
+    // DM membership is #4771's work.
+    expect(SLACK_CHANNEL_ID_PATTERN.test("D01ABCDEF")).toBe(false);
+  });
+
+  it("refuses names, urls, and lowercase", () => {
+    expect(SLACK_CHANNEL_ID_PATTERN.test("#general")).toBe(false);
+    expect(SLACK_CHANNEL_ID_PATTERN.test("c01abcdef")).toBe(false);
+    expect(SLACK_CHANNEL_ID_PATTERN.test("https://slack.com/C1")).toBe(false);
+  });
+});
+
+describe("parseSlackHistoryConfig", () => {
+  it("parses a normal config", () => {
+    const parsed = parseSlackHistoryConfig({ channels: ["C01ABCDEF", "G0123456789"] });
+    expect(parsed).toEqual({ ok: true, channels: ["C01ABCDEF", "G0123456789"] });
+  });
+
+  it("normalises case and drops duplicates", () => {
+    const parsed = parseSlackHistoryConfig({ channels: ["c01abcdef", "C01ABCDEF"] });
+    expect(parsed.ok && parsed.channels).toEqual(["C01ABCDEF"]);
+  });
+
+  it("refuses a missing or non-array channel list with a repair instruction", () => {
+    for (const config of [null, {}, { channels: "C1" }]) {
+      const parsed = parseSlackHistoryConfig(config as Record<string, unknown> | null);
+      expect(parsed.ok).toBe(false);
+      expect(parsed.ok === false && parsed.error).toMatch(/re-install/i);
+    }
+  });
+
+  it("refuses an out-of-band-edited channel id rather than silently skipping it", () => {
+    // Silently dropping it would mean a source that reports success while
+    // never reading a channel the admin believes is connected.
+    const parsed = parseSlackHistoryConfig({ channels: ["C01ABCDEF", "D01DIRECT"] });
+    expect(parsed.ok).toBe(false);
+  });
+
+  it("refuses an empty usable set", () => {
+    expect(parseSlackHistoryConfig({ channels: [] }).ok).toBe(false);
+    expect(parseSlackHistoryConfig({ channels: [42, null] }).ok).toBe(false);
+  });
+
+  it("refuses more channels than one source may scope", () => {
+    const many = Array.from({ length: SLACK_HISTORY_MAX_CHANNELS + 1 }, (_, i) =>
+      `C${String(i).padStart(8, "0")}`,
+    );
+    const parsed = parseSlackHistoryConfig({ channels: many });
+    expect(parsed.ok).toBe(false);
+    expect(parsed.ok === false && parsed.error).toContain(String(SLACK_HISTORY_MAX_CHANNELS));
+  });
+});
+
+describe("slackEpisodeSourceId", () => {
+  it("is the documented `<channelId>:<ts>` format", () => {
+    expect(slackEpisodeSourceId("C1", "1.000001")).toBe("C1:1.000001");
+  });
+});

--- a/packages/api/src/lib/brain/ingest/__tests__/slack-connector.test.ts
+++ b/packages/api/src/lib/brain/ingest/__tests__/slack-connector.test.ts
@@ -1,0 +1,173 @@
+/**
+ * The Slack chat-history connector's factory contract (#4770).
+ *
+ * Small surface, two things on it that fail SILENTLY if they regress:
+ *
+ *   - `getChatBackfillWindowMs` guards against a non-positive window. A `0`
+ *     makes `floorTs === now`, so every never-synced channel walks an empty
+ *     window, returns nothing, and reports `status: "success"` with
+ *     `coverageIncomplete: false` — a source that ingests nothing forever while
+ *     rendering green. The guard is the only thing between a fat-fingered
+ *     platform setting and that state.
+ *   - `resolveSlackHistoryToken` is shared BY DESIGN between the install
+ *     handler's pre-write verification and the per-cycle sync, so the two
+ *     cannot disagree about whether Slack is connected. Its two arms say
+ *     different things ("connect Slack" vs "reconnect Slack"), and they are
+ *     different fixes.
+ */
+
+import { afterEach, describe, expect, it, mock } from "bun:test";
+import type { SlackInstallationWithSecret } from "@atlas/api/lib/slack/store";
+
+let SETTING: string | undefined;
+// Mock-all-exports (CLAUDE.md): every VALUE export of `lib/settings.ts`. The
+// module is imported for one getter, but a partial factory surfaces as
+// "Export named 'X' not found" in whatever unrelated file happens to import
+// the missing symbol next.
+void mock.module("@atlas/api/lib/settings", () => ({
+  getSettingAuto: (key: string) =>
+    key === "ATLAS_BRAIN_CHAT_BACKFILL_DAYS" ? SETTING : undefined,
+  getSetting: (key: string) =>
+    key === "ATLAS_BRAIN_CHAT_BACKFILL_DAYS" ? SETTING : undefined,
+  getSettingLive: async (key: string) =>
+    key === "ATLAS_BRAIN_CHAT_BACKFILL_DAYS" ? SETTING : undefined,
+  getSettingOverride: () => undefined,
+  setSetting: async () => {},
+  deleteSetting: async () => {},
+  loadSettings: async () => 0,
+  getAllSettingOverrides: async () => [],
+  getSettingsForAdmin: () => [],
+  getSettingsRegistry: () => [],
+  getSettingDefinition: () => undefined,
+  refreshSettingsTick: async () => {},
+  isHotReloadedKey: () => false,
+  isSaasModeForGuard: () => false,
+  securitySensitiveAuditFields: () => ({}),
+  _resetSettingsCache: () => {},
+  HOT_RELOADED_KEYS: new Set<string>(),
+  SECURITY_SENSITIVE_KEYS: new Set<string>(),
+}));
+
+const {
+  DEFAULT_CHAT_BACKFILL_DAYS,
+  createSlackHistoryConnector,
+  getChatBackfillWindowMs,
+  registerSlackHistoryConnector,
+  resolveSlackHistoryToken,
+} = await import("@atlas/api/lib/brain/ingest/slack/connector");
+const { _resetBrainSourceConnectors, getBrainSourceConnector } = await import(
+  "@atlas/api/lib/brain/ingest/types"
+);
+const { SLACK_HISTORY_CATALOG_ID } = await import(
+  "@atlas/api/lib/brain/ingest/slack/config"
+);
+
+const DEFAULT_MS = DEFAULT_CHAT_BACKFILL_DAYS * 86_400_000;
+
+function store(opts: { installation?: boolean; token?: string | null } = {}) {
+  return {
+    getInstallationByOrg: async () =>
+      opts.installation === false
+        ? null
+        : ({
+            team_id: "T1",
+            org_id: "ws-1",
+            workspace_name: "w",
+            installed_at: "now",
+          } as SlackInstallationWithSecret),
+    getBotToken: async () => (opts.token === undefined ? "xoxb-test" : opts.token),
+  };
+}
+
+afterEach(() => {
+  SETTING = undefined;
+  _resetBrainSourceConnectors();
+});
+
+describe("getChatBackfillWindowMs", () => {
+  it("uses the default when unset or empty", () => {
+    SETTING = undefined;
+    expect(getChatBackfillWindowMs()).toBe(DEFAULT_MS);
+    SETTING = "";
+    expect(getChatBackfillWindowMs()).toBe(DEFAULT_MS);
+  });
+
+  it("honours a configured window, including a fractional one", () => {
+    SETTING = "14";
+    expect(getChatBackfillWindowMs()).toBe(14 * 86_400_000);
+    SETTING = "0.5";
+    expect(getChatBackfillWindowMs()).toBe(0.5 * 86_400_000);
+  });
+
+  it("falls back to the default rather than a ZERO window", () => {
+    // A zero window is the silent-green failure: floor == now, every channel
+    // reads an empty range, and the source reports success forever.
+    for (const raw of ["0", "-1", "abc", "NaN"]) {
+      SETTING = raw;
+      expect({ raw, ms: getChatBackfillWindowMs() }).toEqual({ raw, ms: DEFAULT_MS });
+    }
+  });
+});
+
+describe("resolveSlackHistoryToken", () => {
+  it("returns the workspace's bot token", async () => {
+    expect(await resolveSlackHistoryToken(store(), "ws-1")).toBe("xoxb-test");
+  });
+
+  it("says CONNECT when there is no Slack install", async () => {
+    await expect(resolveSlackHistoryToken(store({ installation: false }), "ws-1")).rejects.toThrow(
+      /connect Slack/i,
+    );
+  });
+
+  it("says RECONNECT when the install exists but its token cannot be read", async () => {
+    // The decrypt-failure path — `getInstallation` hides a row whose token will
+    // not decrypt. Re-running OAuth is the fix; re-inviting the bot is not, so
+    // the two arms must not share a message.
+    for (const token of [null, ""]) {
+      await expect(resolveSlackHistoryToken(store({ token }), "ws-1")).rejects.toThrow(
+        /reconnect Slack/i,
+      );
+    }
+  });
+});
+
+describe("createClient", () => {
+  it("refuses a stored config with no usable channels, actionably", async () => {
+    const connector = createSlackHistoryConnector({ store: store() });
+    await expect(
+      connector.createClient({ workspaceId: "ws-1", installId: "i", config: {} }),
+    ).rejects.toThrow(/re-install/i);
+  });
+
+  it("surfaces the token failure rather than building a client that cannot fetch", async () => {
+    const connector = createSlackHistoryConnector({ store: store({ installation: false }) });
+    await expect(
+      connector.createClient({
+        workspaceId: "ws-1",
+        installId: "i",
+        config: { channels: ["C01ABCDEF"] },
+      }),
+    ).rejects.toThrow(/connect Slack/i);
+  });
+
+  it("builds a client for a valid config", async () => {
+    const connector = createSlackHistoryConnector({ store: store() });
+    const client = await connector.createClient({
+      workspaceId: "ws-1",
+      installId: "i",
+      config: { channels: ["C01ABCDEF"] },
+    });
+    expect(typeof client.fetchEpisodes).toBe("function");
+  });
+});
+
+describe("registerSlackHistoryConnector", () => {
+  it("registers once and is idempotent", () => {
+    // `registerBuiltinInstallHandlers()` runs repeatedly across suites, and
+    // `registerBrainSourceConnector` throws on a duplicate catalog id.
+    registerSlackHistoryConnector();
+    registerSlackHistoryConnector();
+    expect(getBrainSourceConnector(SLACK_HISTORY_CATALOG_ID)?.source).toBe("slack");
+  });
+});

--- a/packages/api/src/lib/brain/ingest/episode-sync.ts
+++ b/packages/api/src/lib/brain/ingest/episode-sync.ts
@@ -1,0 +1,371 @@
+/**
+ * The brain episode sync engine (#4770, ADR-0036 §Ingestion & connectors).
+ *
+ * ## Read this before assuming it duplicates `connector-sync.ts`
+ *
+ * ADR-0036 §T6 reuses the ADR-0030 engine VERBATIM and forks only the ingest
+ * core. Every schedulable/retryable/cap-bearing decision below is IMPORTED
+ * from that engine, not restated:
+ *
+ *   - the cycle that calls this lives in `lib/knowledge/sync.ts`, driven by the
+ *     one existing scheduler fiber (`scheduler/knowledge-bundle-sync.ts`).
+ *     There is no second scheduler;
+ *   - `SYNC_OVERLAP_WINDOW_MS` — the incremental rewind;
+ *   - `getKnowledgeSyncReconcileIntervalMs` — the reconcile cadence knob;
+ *   - `withRateLimitBackoff` + `ConnectorRateLimitError` — the 429 policy;
+ *   - `resolveIngestCaps` (from `lib/billing/knowledge-limits`, the same cap
+ *     source the document engine reads) — the effective per-sync cap
+ *     (`min(platform ceiling, plan tier)`), resolved ONCE and shared by the
+ *     fetch bound and the ingest;
+ *   - `readConnectorSyncState` / `upsertConnectorSyncState` — the
+ *     `knowledge_sync_state` bookkeeping, including its COALESCE-forward
+ *     semantics (an error attempt records its status WITHOUT regressing the
+ *     high-water mark, so a failed cycle can never skip what it failed to
+ *     ingest).
+ *
+ * What this module owns is the shape of an attempt around a DIFFERENT ingest
+ * core, plus the outcome vocabulary that core produces (`inserted` /
+ * `duplicate` / `refused`, not `created` / `updated` / `demoted`).
+ *
+ * ## The archive path is not "skipped" — it is unreachable
+ *
+ * There is no `archiveAbsent` parameter to pass `false` to, because
+ * `ingestDocuments` is never called: an episode is identified by source-id and
+ * an absent record is simply absent. A flag would have made "don't archive" a
+ * call-site convention one edit away from being wrong.
+ * `episode-sync-archive.test.ts` pins the structural version (no import, no
+ * call).
+ *
+ * ## What `reconciliation` means here
+ *
+ * Not "enumerate the full set so absences can be archived" — nothing is
+ * archived. ADR-0036 §Ingestion repurposes the cadence to **re-run extraction**
+ * (#4771) over a wider window; the fetch side may or may not do anything
+ * different, and the Slack source deliberately does not (see its client's
+ * header). The mode is still decided and recorded here, because it is the
+ * engine's decision to make and #4771 reads the same clock. A pass the client
+ * flags `coverageIncomplete` does NOT advance that clock, so whatever is due
+ * stays due.
+ *
+ * Like the engine it forks, `syncBrainEpisodeSource` NEVER throws: every
+ * failure becomes a `status: "error"` outcome so one bad source can't sink the
+ * cycle's remaining installs.
+ */
+
+import { createLogger } from "@atlas/api/lib/logger";
+import {
+  resolveIngestCaps,
+  type EffectiveIngestCaps,
+} from "@atlas/api/lib/billing/knowledge-limits";
+import { ConnectorRateLimitError } from "@atlas/api/lib/knowledge/connectors";
+import {
+  RATE_LIMIT_MAX_ATTEMPTS,
+  SYNC_OVERLAP_WINDOW_MS,
+  getKnowledgeSyncReconcileIntervalMs,
+  readConnectorSyncState,
+  upsertConnectorSyncState,
+  withRateLimitBackoff,
+} from "@atlas/api/lib/knowledge/connector-sync";
+import { ingestEpisodes, type EpisodeIngestReport } from "./episodes";
+import type {
+  BrainSourceChanges,
+  BrainSourceConnector,
+  BrainSourceFetchMode,
+  BrainSourceVendorClient,
+} from "./types";
+
+const log = createLogger("brain.ingest.episode-sync");
+
+/** Bound the warning list persisted in the state report. */
+const REPORT_WARNINGS_CAP = 20;
+
+/** Outcome of one brain source sync attempt. */
+export interface BrainEpisodeSyncOutcome {
+  /** The install id (= the sync-state row's `collection_id`). */
+  readonly installId: string;
+  readonly status: "success" | "error";
+  /** `"unknown"` only when the attempt failed before the mode was decided. */
+  readonly mode: BrainSourceFetchMode | "unknown";
+  readonly syncedAt: string;
+  readonly error: string | null;
+  /** Null when the attempt failed before (or during) ingest. */
+  readonly episodes: EpisodeIngestReport | null;
+  readonly coverageIncomplete: boolean;
+  readonly warnings: readonly string[];
+  /** The high-water mark persisted by this attempt (null = unchanged). */
+  readonly highWaterMark: string | null;
+}
+
+export interface SyncBrainEpisodeSourceParams {
+  readonly connector: BrainSourceConnector;
+  readonly workspaceId: string;
+  readonly installId: string;
+  readonly config: Record<string, unknown> | null;
+  /** Test-only clock. */
+  readonly now?: () => Date;
+  /** Test-only backoff sleep. */
+  readonly sleep?: (ms: number) => Promise<void>;
+}
+
+/**
+ * A source timestamp is persisted only when it actually parses — a garbage
+ * high-water mark must be caught visibly (warn) here rather than surface as an
+ * opaque state-row INSERT error. Same rule, same reason, as the engine's
+ * `validVendorTimestamp`.
+ */
+function validSourceTimestamp(
+  value: string | null,
+  context: { workspaceId: string; installId: string },
+): string | null {
+  if (value === null) return null;
+  const ms = Date.parse(value);
+  if (Number.isNaN(ms)) {
+    log.warn(
+      { ...context, value },
+      "Brain source returned an unparseable high-water mark — not persisting it (the previous mark, if any, carries forward via COALESCE)",
+    );
+    return null;
+  }
+  return new Date(ms).toISOString();
+}
+
+type BrainAttempt =
+  | {
+      readonly kind: "ok";
+      readonly mode: BrainSourceFetchMode;
+      readonly episodes: EpisodeIngestReport;
+      readonly coverageIncomplete: boolean;
+      readonly warnings: readonly string[];
+      readonly highWaterMark: string | null;
+      readonly cursor: string | null;
+    }
+  | {
+      readonly kind: "error";
+      readonly mode: BrainSourceFetchMode | "unknown";
+      readonly error: string;
+    };
+
+/**
+ * Sync one brain source end-to-end and record the attempt in
+ * `knowledge_sync_state`.
+ */
+export async function syncBrainEpisodeSource(
+  params: SyncBrainEpisodeSourceParams,
+): Promise<BrainEpisodeSyncOutcome> {
+  const { connector, workspaceId, installId } = params;
+  const now = params.now ?? (() => new Date());
+
+  // The attempt reports its mode as soon as it is decided so the catch-all can
+  // record the REAL mode — or an honest "unknown" when the failure happened
+  // before the decision (e.g. the state read threw).
+  let decidedMode: BrainSourceFetchMode | "unknown" = "unknown";
+  let attempt: BrainAttempt;
+  try {
+    attempt = await runBrainAttempt(params, now, (mode) => {
+      decidedMode = mode;
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log.error(
+      { workspaceId, installId, catalogId: connector.catalogId, err: msg },
+      "Brain episode sync attempt threw past its internal handling — recording an error state",
+    );
+    attempt = {
+      kind: "error",
+      mode: decidedMode,
+      error: `Sync failed unexpectedly: ${msg}. Retry the sync; if it persists, check the API logs.`,
+    };
+  }
+
+  const syncedAt = now().toISOString();
+  const outcome: BrainEpisodeSyncOutcome =
+    attempt.kind === "ok"
+      ? {
+          installId,
+          status: "success",
+          mode: attempt.mode,
+          syncedAt,
+          error: null,
+          episodes: attempt.episodes,
+          coverageIncomplete: attempt.coverageIncomplete,
+          warnings: attempt.warnings,
+          highWaterMark: attempt.highWaterMark,
+        }
+      : {
+          installId,
+          status: "error",
+          mode: attempt.mode,
+          syncedAt,
+          error: attempt.error,
+          episodes: null,
+          coverageIncomplete: false,
+          warnings: [],
+          highWaterMark: null,
+        };
+
+  await upsertConnectorSyncState(workspaceId, installId, {
+    status: outcome.status,
+    error: outcome.error,
+    report:
+      outcome.status === "success"
+        ? {
+            mode: outcome.mode,
+            target: "brain-episodes",
+            episodes: outcome.episodes,
+            // Persisted so the admin surface can show that part of the window
+            // was deferred — a coverage-incomplete "success" is not silently
+            // green.
+            coverageIncomplete: outcome.coverageIncomplete,
+            warnings: outcome.warnings.slice(0, REPORT_WARNINGS_CAP),
+          }
+        : { mode: outcome.mode, target: "brain-episodes" },
+    highWaterMark: outcome.highWaterMark,
+    cursor: attempt.kind === "ok" ? attempt.cursor : null,
+    // An incomplete pass must not satisfy the reconcile clock — the next cycle
+    // stays due, so the uncovered window gets a wide re-crawl soon.
+    reconciledAt:
+      attempt.kind === "ok" && attempt.mode === "reconciliation" && !attempt.coverageIncomplete
+        ? syncedAt
+        : null,
+  });
+
+  if (outcome.status === "success") {
+    log.info(
+      {
+        workspaceId,
+        installId,
+        source: connector.source,
+        mode: outcome.mode,
+        ...outcome.episodes,
+        coverageIncomplete: outcome.coverageIncomplete,
+        warnings: outcome.warnings.length,
+        highWaterMark: outcome.highWaterMark,
+      },
+      "Brain episode sync succeeded",
+    );
+  } else {
+    log.warn(
+      { workspaceId, installId, source: connector.source, mode: outcome.mode, error: outcome.error },
+      "Brain episode sync failed",
+    );
+  }
+  return outcome;
+}
+
+async function runBrainAttempt(
+  params: SyncBrainEpisodeSourceParams,
+  now: () => Date,
+  onModeDecided: (mode: BrainSourceFetchMode) => void,
+): Promise<BrainAttempt> {
+  const { connector, workspaceId, installId, config } = params;
+
+  // ── Bookkeeping → mode decision (the engine's rule, unchanged) ────────────
+  const state = await readConnectorSyncState(workspaceId, installId);
+  const reconcileIntervalMs = getKnowledgeSyncReconcileIntervalMs();
+  const due =
+    state.lastReconciledAt === null ||
+    now().getTime() - Date.parse(state.lastReconciledAt) >= reconcileIntervalMs;
+  const sinceIso =
+    state.highWaterMark === null
+      ? null
+      : new Date(Date.parse(state.highWaterMark) - SYNC_OVERLAP_WINDOW_MS).toISOString();
+  const mode: BrainSourceFetchMode = due || sinceIso === null ? "reconciliation" : "incremental";
+  onModeDecided(mode);
+
+  // ── Effective caps ────────────────────────────────────────────────────────
+  // Episodes count against the SAME per-sync ingest cap as documents: they are
+  // the unit this workspace's plan bounds, and a second cap would let the
+  // brain path pull past what the knowledge path is refused.
+  let caps: EffectiveIngestCaps;
+  try {
+    caps = await resolveIngestCaps(workspaceId);
+  } catch (err) {
+    return {
+      kind: "error",
+      mode,
+      error: `Could not verify this workspace's ingest limits: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  // ── Client ────────────────────────────────────────────────────────────────
+  let client: BrainSourceVendorClient;
+  try {
+    client = await connector.createClient({ workspaceId, installId, config });
+  } catch (err) {
+    return { kind: "error", mode, error: err instanceof Error ? err.message : String(err) };
+  }
+
+  // ── Fetch (bounded 429 backoff — the engine's, imported) ──────────────────
+  const backoffOpts = params.sleep ? { sleep: params.sleep } : undefined;
+  let changes: BrainSourceChanges;
+  try {
+    changes = await withRateLimitBackoff(
+      () =>
+        client.fetchEpisodes({
+          mode,
+          since: sinceIso,
+          cursor: state.cursor,
+          maxEpisodes: caps.maxDocs.value,
+        }),
+      backoffOpts,
+    );
+  } catch (err) {
+    if (err instanceof ConnectorRateLimitError) {
+      return {
+        kind: "error",
+        mode,
+        error: `The source is rate limiting this workspace (backoff exhausted after ${RATE_LIMIT_MAX_ATTEMPTS} attempts${err.retryAfterSeconds !== null ? `; last Retry-After ${err.retryAfterSeconds}s` : ""}) — the next scheduled cycle will retry.`,
+      };
+    }
+    return { kind: "error", mode, error: err instanceof Error ? err.message : String(err) };
+  }
+
+  const highWaterMark = validSourceTimestamp(changes.highWaterMark, { workspaceId, installId });
+  const cursor = changes.cursor ?? null;
+  const coverageIncomplete = changes.coverageIncomplete === true;
+  const warnings = changes.warnings ?? [];
+
+  // A source returning MORE than the cap is a client bug, not a cap refusal:
+  // the cap was handed to it as `maxEpisodes` precisely so it could bound its
+  // own fetch. Refuse the batch rather than store a partial window whose
+  // high-water mark would claim to cover records that were dropped.
+  if (changes.episodes.length > caps.maxDocs.value) {
+    log.error(
+      {
+        workspaceId,
+        installId,
+        source: connector.source,
+        returned: changes.episodes.length,
+        maxEpisodes: caps.maxDocs.value,
+      },
+      "Brain source returned more episodes than the per-sync cap it was given — refusing the batch",
+    );
+    return {
+      kind: "error",
+      mode,
+      error: `The source returned ${changes.episodes.length} records, over the ${caps.maxDocs.value}-record per-sync limit it was given — nothing was ingested. This is a connector defect; check the API logs.`,
+    };
+  }
+
+  // ── Ingest through the FORKED core (append-only; no upsert, no archive) ───
+  let report: EpisodeIngestReport;
+  try {
+    report = await ingestEpisodes({
+      workspaceId,
+      source: connector.source,
+      episodes: changes.episodes,
+    });
+  } catch (err) {
+    log.error(
+      { workspaceId, installId, err: err instanceof Error ? err.message : String(err) },
+      "Brain episode ingest failed after a successful source fetch",
+    );
+    return {
+      kind: "error",
+      mode,
+      error: `Ingest failed after a successful fetch: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  return { kind: "ok", mode, episodes: report, coverageIncomplete, warnings, highWaterMark, cursor };
+}

--- a/packages/api/src/lib/brain/ingest/episodes.ts
+++ b/packages/api/src/lib/brain/ingest/episodes.ts
@@ -1,0 +1,265 @@
+/**
+ * The brain ingest core (#4770, ADR-0036 §Ingestion & connectors) — the one
+ * INGEST write path onto `brain_episodes`.
+ *
+ * ("Ingest" is load-bearing: `api/routes/admin-migrate.ts` also inserts, when a
+ * region-migration bundle is imported, and deliberately preserves the
+ * `extracted_at` and `locator` this module never sets. That is the import path,
+ * not an ingest path, and it must stay exactly as permissive as the CHECKs —
+ * see `acl.ts`'s header on why an importer stricter than the schema makes a
+ * workspace unmigratable.)
+ *
+ * This is the forked half of ADR-0030. Everything the connector engine does
+ * around it (scheduling, high-water marks, cadence, 429 backoff, caps) is
+ * reused verbatim; the write itself is not, because episodes are immutable
+ * append-only evidence and knowledge documents are mutable path-identified
+ * content. Concretely, this module has:
+ *
+ *   - **no upsert.** `ON CONFLICT (workspace_id, source, source_id) DO NOTHING`
+ *     — re-ingest is a NO-OP, not an update. A chat message edited upstream is
+ *     a NEW episode (a new `source_id` is the source's business); mutating the
+ *     old row would rewrite evidence after the fact, which is the one thing
+ *     migration 0180's "there is deliberately NO `updated_at` column" is
+ *     stating. The UNIQUE index is what makes that the only AVAILABLE
+ *     behaviour rather than a call-site convention.
+ *   - **no archive.** Nothing here (or anywhere under `lib/brain/ingest/`)
+ *     imports `ingestDocuments`, so the engine's subtractive-archive path is
+ *     unreachable from the episode path — an absent record is simply absent,
+ *     never a deletion. `episode-sync-archive.test.ts` pins that structurally.
+ *   - **no `extracted_at` write.** It stays NULL so the episode lands on
+ *     #4771's extraction queue (`idx_brain_episodes_extraction_queue`). NULL
+ *     forever is a VISIBLE BACKLOG; a stamped-at-ingest value would be a
+ *     silent drop.
+ *   - **no `status` column to write.** `brain_episodes` is deliberately NOT
+ *     content-mode registered (#4769): episodes are evidence and are not
+ *     review-gated — only the claims drawn from them are.
+ *
+ * ## Refusals happen HERE, before the batch, not at the CHECK
+ *
+ * A statement-fatal rejection anywhere in the batch aborts the whole INSERT and
+ * loses a cycle's worth of good evidence. So each record is screened first and
+ * the bad ones are dropped with a counted, logged reason — per-record
+ * isolation, the same posture the ingest seam takes toward per-file rejections.
+ *
+ * FOUR screens run, and only two of them mirror one of `brain_episodes`'s two
+ * CHECKs:
+ *
+ *   - blank `body` → mirrors `chk_brain_episodes_body_xor_locator`, which
+ *     refuses `''` outright (evidence that is empty backs a provenance claim
+ *     with nothing);
+ *   - unusable grant → DELIBERATELY STRICTER than
+ *     `chk_brain_episodes_grant_nonempty`, which catches the empty and
+ *     all-NULL/`''` cases but admits `['everyone']`. `grant.ts`'s header
+ *     explains why being stricter is legitimate on the write side and
+ *     forbidden at rest or at import;
+ *   - blank `source_id` → no CHECK covers it, but a blank dedupe key collapses
+ *     every record from that source into one row;
+ *   - invalid `occurred_at` → no CHECK can cover it, because
+ *     `new Date(NaN).toISOString()` throws in JS BEFORE any SQL is sent. That
+ *     one is the reason this list is a screen and not a `try` around the
+ *     INSERT: a thrown record would take the batch with it, and the engine
+ *     leaves the mark unmoved on an error, so the same poison record would be
+ *     re-fetched and re-thrown every cycle forever.
+ */
+
+import { createLogger } from "@atlas/api/lib/logger";
+import { internalQuery } from "@atlas/api/lib/db/internal";
+import { isUsableGrant } from "./grant";
+import type { BrainEpisodeRecord } from "./types";
+
+const log = createLogger("brain.ingest.episodes");
+
+/** Bound the refused-id list in the log line — a whole bad batch must not flood it. */
+const REFUSED_ID_LOG_CAP = 20;
+
+/**
+ * The append-only episode insert. Exported so the real-Postgres test executes
+ * this exact string against the live schema rather than asserting a paraphrase.
+ *
+ * Records travel as ONE jsonb array rather than parallel `unnest` arrays
+ * because `visible_to` is itself an array — parallel arrays would need
+ * `text[][]`, which Postgres requires to be rectangular, so a batch mixing a
+ * 1-principal and a 2-principal grant could not be bound at all.
+ *
+ * `->>` yields SQL NULL for a JSON `null`, so `source_actor` and `occurred_at`
+ * need no coalescing; `locator` is a literal NULL because a connector record
+ * is always by-value (see `BrainEpisodeRecord`), and `extracted_at` is absent
+ * so the column's NULL default puts the row on the extraction queue.
+ *
+ * `RETURNING source_id` returns ONLY genuinely inserted rows — `DO NOTHING`
+ * suppresses the conflicting ones — which is what makes the dedupe count
+ * observed rather than inferred.
+ */
+export const INSERT_EPISODES_SQL = `INSERT INTO brain_episodes
+         (workspace_id, source, source_id, source_actor, body, locator, occurred_at, visible_to)
+       SELECT $1,
+              $2,
+              rec->>'sourceId',
+              rec->>'sourceActor',
+              rec->>'body',
+              NULL,
+              (rec->>'occurredAt')::timestamptz,
+              ARRAY(SELECT jsonb_array_elements_text(rec->'visibleTo'))
+         FROM jsonb_array_elements($3::jsonb) AS rec
+       ON CONFLICT (workspace_id, source, source_id) DO NOTHING
+       RETURNING source_id`;
+
+/** Why a record never reached the INSERT. Counted, logged, never silent. */
+export type EpisodeRefusalReason =
+  | "blank_source_id"
+  | "blank_body"
+  | "unusable_grant"
+  | "invalid_occurred_at";
+
+export interface EpisodeIngestReport {
+  /** Rows the INSERT actually created. */
+  readonly inserted: number;
+  /**
+   * Records the source produced that were ALREADY stored — the dedupe hit
+   * count. This is the number an acceptance test reads to prove a re-poll of
+   * the same window writes zero new rows.
+   */
+  readonly duplicate: number;
+  /** Records dropped before the INSERT, by reason. */
+  readonly refused: Readonly<Record<EpisodeRefusalReason, number>>;
+  /**
+   * Records the source emitted twice in ONE batch. Collapsed before the
+   * INSERT: `ON CONFLICT DO NOTHING` tolerates a self-conflict, but it would
+   * report the second copy as a `duplicate` against storage, which is a
+   * different fact about the world (the SOURCE repeated itself) and points at
+   * a different bug.
+   */
+  readonly batchDuplicate: number;
+}
+
+const NO_REFUSALS: Readonly<Record<EpisodeRefusalReason, number>> = Object.freeze({
+  blank_source_id: 0,
+  blank_body: 0,
+  unusable_grant: 0,
+  invalid_occurred_at: 0,
+});
+
+export interface IngestEpisodesParams {
+  readonly workspaceId: string;
+  /** The connector class stamped into `brain_episodes.source`. */
+  readonly source: string;
+  readonly episodes: readonly BrainEpisodeRecord[];
+}
+
+/**
+ * Append a batch of episodes. Idempotent by `(workspace_id, source,
+ * source_id)`: re-ingesting the same window inserts nothing and reports every
+ * record as a duplicate.
+ *
+ * Throws on a database failure — the caller (`episode-sync.ts`) turns that
+ * into the source's error outcome, which leaves the high-water mark unmoved so
+ * the next cycle re-fetches exactly what this one failed to store. Swallowing
+ * it here would advance the mark past evidence that never landed.
+ */
+export async function ingestEpisodes(
+  params: IngestEpisodesParams,
+): Promise<EpisodeIngestReport> {
+  const { workspaceId, source, episodes } = params;
+  if (episodes.length === 0) {
+    return { inserted: 0, duplicate: 0, refused: NO_REFUSALS, batchDuplicate: 0 };
+  }
+
+  const refused: Record<EpisodeRefusalReason, number> = { ...NO_REFUSALS };
+  const refusedIds: string[] = [];
+  const seen = new Set<string>();
+  let batchDuplicate = 0;
+  const payload: {
+    sourceId: string;
+    sourceActor: string | null;
+    body: string;
+    occurredAt: string | null;
+    visibleTo: readonly string[];
+  }[] = [];
+
+  for (const record of episodes) {
+    const sourceId = record.sourceId.trim();
+    if (sourceId === "") {
+      refused.blank_source_id++;
+      refusedIds.push("<blank>");
+      continue;
+    }
+    // Screened on the TRIMMED value but STORED verbatim: the CHECK only
+    // refuses `''`, and silently trimming evidence would edit it.
+    if (record.body.trim() === "") {
+      refused.blank_body++;
+      refusedIds.push(sourceId);
+      continue;
+    }
+    if (!isUsableGrant(record.visibleTo)) {
+      refused.unusable_grant++;
+      refusedIds.push(sourceId);
+      continue;
+    }
+    // `Date | null` admits an INVALID Date, and `new Date(NaN).toISOString()`
+    // throws `RangeError` — synchronously, before any SQL runs. One such record
+    // would therefore abort the whole batch and, because the engine leaves the
+    // mark unmoved on an error, the same poison record would be re-fetched and
+    // re-thrown every cycle forever. Screened here with the others so
+    // per-record isolation actually covers every field.
+    if (record.occurredAt !== null && Number.isNaN(record.occurredAt.getTime())) {
+      refused.invalid_occurred_at++;
+      refusedIds.push(sourceId);
+      continue;
+    }
+    if (seen.has(sourceId)) {
+      batchDuplicate++;
+      continue;
+    }
+    seen.add(sourceId);
+    payload.push({
+      sourceId,
+      sourceActor: record.sourceActor,
+      body: record.body,
+      // Explicit rather than leaning on `JSON.stringify`'s Date handling: that
+      // turns an Invalid Date into `null`, which would silently lose the event
+      // time instead of refusing the record. The screen above guarantees this
+      // call cannot throw.
+      occurredAt: record.occurredAt === null ? null : record.occurredAt.toISOString(),
+      visibleTo: [...record.visibleTo],
+    });
+  }
+
+  // Summed over the record rather than hand-listed: a fifth reason that only
+  // ever fired alone would otherwise leave `totalRefused` at 0, so the
+  // operator-facing warn (with the refused ids) would never emit — making a
+  // refused record both unrecoverable AND invisible, which is exactly the state
+  // this module's header says must not exist.
+  const totalRefused = Object.values(refused).reduce((sum, n) => sum + n, 0);
+  if (totalRefused > 0) {
+    log.warn(
+      {
+        workspaceId,
+        source,
+        ...refused,
+        candidates: episodes.length,
+        // A refused record is unrecoverable — the mark advances past it — so
+        // "3 records refused" with no identity gives an operator nothing to
+        // act on. Ids only; the bodies are the sensitive half.
+        refusedSourceIds: refusedIds.slice(0, REFUSED_ID_LOG_CAP),
+      },
+      "brain ingest: dropped source records that could not be stored as episodes",
+    );
+  }
+
+  if (payload.length === 0) {
+    return { inserted: 0, duplicate: 0, refused, batchDuplicate };
+  }
+
+  const rows = await internalQuery<{ source_id: string }>(INSERT_EPISODES_SQL, [
+    workspaceId,
+    source,
+    JSON.stringify(payload),
+  ]);
+  const inserted = rows.length;
+  return {
+    inserted,
+    duplicate: payload.length - inserted,
+    refused,
+    batchDuplicate,
+  };
+}

--- a/packages/api/src/lib/brain/ingest/grant.ts
+++ b/packages/api/src/lib/brain/ingest/grant.ts
@@ -1,0 +1,136 @@
+/**
+ * Grant derivation at ingest (#4770, ADR-0036 §Access control & residency).
+ *
+ * ADR-0036 derives a grant AT INGEST and evaluates it read-time-local: the
+ * grant is a self-contained principal set frozen onto the row, and the LIVE
+ * half — the revocation path — is `audience:` membership. This module is where
+ * a chat source's visibility becomes that principal set.
+ *
+ * ## The one rule that is easy to get subtly, permanently wrong
+ *
+ * `chk_brain_episodes_grant_nonempty` admits any grant with one non-NULL,
+ * non-`''` element. `['everyone']` passes it. It also grants NOBODY anything,
+ * because enforcement is Postgres array overlap against reader tokens and no
+ * reader token is ever malformed (`acl.ts`'s load-bearing invariant). So a
+ * deriver that emits `['everyone']` writes a row that is legal, invisible, and
+ * — once #4771 turns episodes into facts — refused at EVERY publish forever by
+ * #4769's `GRANT_UNUSABLE` classifier, with no repair UI until #4772.
+ *
+ * That is why this module builds every grant token from `acl.ts`'s exported
+ * constants — `ORG_PRINCIPAL` and `AUDIENCE_PREFIX` are the two arms a chat
+ * source mints; `ROLE_PREFIX`/`USER_PREFIX` exist there for the entry points
+ * that need them — never from a literal, and why {@link isUsableGrant} is
+ * applied at the ingest seam as defence in depth. #4769's promotion refusal is
+ * meant to be the second line, not the first — a refusal that fires in
+ * practice is a live trap, not defence in depth. (#4797 tracks the
+ * observability half: a fully-malformed grant is invisible to every reader, so
+ * nobody is holding the row to log about it.)
+ *
+ * ## What this module deliberately does NOT do
+ *
+ * It never REJECTS a grant read from storage, and it is never called on the
+ * import path. `acl.ts`'s header forbids being stricter than the CHECK at rest
+ * or at import, because a row Postgres legally stores but Atlas refuses is a
+ * workspace that cannot be migrated between regions. This is a WRITE-SIDE
+ * constructor: it chooses what to mint. Choosing well is unconstrained;
+ * refusing what already landed is not.
+ */
+
+import {
+  AUDIENCE_PREFIX,
+  ORG_PRINCIPAL,
+  parseGrant,
+} from "@atlas/api/lib/brain/acl";
+import type { BrainGrant } from "@atlas/api/lib/brain/types";
+
+/**
+ * The `audience:` id prefix for a source-derived chat channel — the stored
+ * form is `audience:chat-channel:<source>:<channelId>`.
+ *
+ * Namespaced by SOURCE because `audience_id` is workspace-scoped but NOT
+ * source-scoped: a Slack channel `C123` and a (future) Teams channel `C123`
+ * would otherwise mint the same audience and merge two unrelated membership
+ * sets. `fact_audience_member` has no column to tell them apart, so the
+ * namespace has to live in the id.
+ */
+export const CHAT_CHANNEL_AUDIENCE_NAMESPACE = "chat-channel" as const;
+
+/** Build the audience id (WITHOUT the `audience:` prefix — that is grammar). */
+export function chatChannelAudienceId(source: string, channelId: string): string {
+  return `${CHAT_CHANNEL_AUDIENCE_NAMESPACE}:${source}:${channelId}`;
+}
+
+/** The visibility facts a chat channel exposes, normalised across vendors. */
+export interface ChatChannelVisibility {
+  /** The connector class (`brain_episodes.source`), e.g. `slack`. */
+  readonly source: string;
+  /** The vendor's channel identifier. */
+  readonly channelId: string;
+  /**
+   * True when the channel is private / invite-only at the source.
+   *
+   * A vendor that cannot determine this must pass `true`. "Unknown visibility"
+   * and "public" are opposite situations and must not share a branch: guessing
+   * public publishes an invite-only channel's contents to the whole org, and
+   * that is a leak no review gate downstream can catch, because the reviewer
+   * is shown the grant Atlas derived rather than the one Slack had.
+   */
+  readonly isPrivate: boolean;
+}
+
+/**
+ * Derive the grant for one chat channel's episodes.
+ *
+ * - **Public channel → `[org]`.** Everybody in the workspace can already read
+ *   it at the source, so the org-wide principal is the faithful mapping — and
+ *   ADR-0036 requires the public majority to carry an EXPLICIT `org`, never an
+ *   implicit one, so a forgotten grant can never READ as public.
+ * - **Private channel → `[audience:chat-channel:<source>:<id>]`.** The grant
+ *   names an Atlas-owned audience whose membership `fact_audience_member`
+ *   carries; ADR-0036 routes sensitive facts to a synced `audience:` precisely
+ *   so revocation flows through membership live rather than waiting for
+ *   re-ingest.
+ *
+ *   Membership population is #4771's (the issue's "channel-membership read for
+ *   #4771's grant derivation"), so until it lands a private channel's episodes
+ *   are visible to NOBODY. That is the fail-closed direction and it is
+ *   REPAIRABLE — populating membership makes existing rows visible with no
+ *   rewrite, because the grant names the audience and the membership is the
+ *   live half. Contrast the failure this module exists to prevent: a
+ *   structurally malformed token is unrepairable without editing every row.
+ *
+ * Returns `null` when no usable grant can be derived — a blank channel id or a
+ * blank source, either of which would make the audience id ambiguous.
+ * ADR-0036 §T6's block-vs-flag asymmetry puts grant-derivation failure on the
+ * BLOCK side: the caller abandons that channel's whole pass (its mark
+ * preserved, a warning surfaced) and never falls back to a wider grant. There is no safe default here — `[org]` would publish content
+ * whose audience Atlas failed to establish.
+ */
+export function deriveChatChannelGrant(visibility: ChatChannelVisibility): BrainGrant | null {
+  if (!visibility.isPrivate) return [ORG_PRINCIPAL];
+
+  const channelId = visibility.channelId.trim();
+  const source = visibility.source.trim();
+  if (channelId === "" || source === "") return null;
+
+  const grant: BrainGrant = [
+    `${AUDIENCE_PREFIX}${chatChannelAudienceId(source, channelId)}`,
+  ];
+  // Belt-and-braces: the arm above cannot construct an unusable token today
+  // (both halves are non-empty by the guard), but a future edit to the id
+  // builder could, and this is the one place that mistake is cheap to catch.
+  return isUsableGrant(grant) ? grant : null;
+}
+
+/**
+ * Does this grant name at least one principal a reader could ever match?
+ *
+ * The write-side gate that keeps #4769's `GRANT_UNUSABLE` promotion refusal a
+ * genuine second line of defence. Uses `parseGrant` — the SAME parser the
+ * refusal classifier uses — so the two can never disagree about what "usable"
+ * means; a hand-rolled shape check here would drift the first time the grammar
+ * gained an arm.
+ */
+export function isUsableGrant(grant: readonly unknown[]): boolean {
+  return parseGrant(grant).principals.length > 0;
+}

--- a/packages/api/src/lib/brain/ingest/slack/client.ts
+++ b/packages/api/src/lib/brain/ingest/slack/client.ts
@@ -1,0 +1,880 @@
+/**
+ * The Slack chat-history vendor client (#4770, ADR-0036 §Ingestion &
+ * connectors) — the thin half of the seam. It enumerates
+ * `conversations.history` and converts messages to
+ * {@link BrainEpisodeRecord}s. It owns NO scheduling and NO backoff policy:
+ * cadence and 429 retry are the shared engine's. It DOES own bounding its own
+ * fetch, because the engine hands it the per-sync budget as `maxEpisodes` and
+ * refuses any batch that exceeds it.
+ *
+ * ## The walk, and why it is shaped this way
+ *
+ * Slack pages `conversations.history` NEWEST → oldest within `[oldest,
+ * latest]`. That direction is the whole difficulty: if a pass runs out of
+ * budget partway, it has covered the TOP of its window and left a hole at the
+ * bottom — and an append-only store has no later pass that would notice the
+ * hole, because "absent" and "not yet fetched" look identical.
+ *
+ * So the per-channel mark is a DISCRIMINATED UNION, not a bag of optionals:
+ *
+ *   - `contiguous` — covered end to end up to `ts` (the exclusive `oldest`
+ *     bound of the next pass).
+ *   - `backfilling` — a truncated window is being filled downward. `top` is
+ *     the ceiling the truncated pass reached, `resume` is where the next pass
+ *     continues walking down, and `ts` is still the untouched frontier. When
+ *     the fill completes, the mark becomes `contiguous` at `top`.
+ *
+ * The union is what makes truncation both CONVERGENT (each cycle fills more of
+ * the same window until it meets `ts`) and GAPLESS (the mark never jumps over
+ * an unfetched range). It is a union rather than three optional fields because
+ * `resume` WITHOUT `top` is unsound in a specific, silent way: the pass would
+ * walk `[ts, resume]`, complete, take the ordinary completion branch, and
+ * advance the mark to `now`, claiming coverage of `(resume, now]` it never
+ * fetched. Optional fields made that state constructible from a hand-edited or
+ * partially-written cursor; the union does not (`parseSlackHistoryCursor`
+ * degrades such a cursor to `contiguous`, which over-crawls — a deduped no-op).
+ *
+ * ## Two budgets, because there are two costs
+ *
+ * `maxEpisodes` is a HARD contract: returning more makes the engine refuse the
+ * whole batch (`episode-sync.ts`), and — because an error attempt COALESCEs the
+ * old cursor forward — the next cycle would compute the identical over-cap
+ * batch and fail identically, forever. So the walk trims to the budget and
+ * records `resume` at the last message it WALKED, which turns an over-large
+ * window into a normal truncation instead of a wedge. (Walked, not kept: a
+ * message this pass skipped as noise is still a message this pass covered, and
+ * resuming above it would re-read it forever.)
+ *
+ * That alone is not enough, because kept episodes are not the only cost: a
+ * channel of pure join/leave noise keeps ZERO episodes while still costing a
+ * Slack call per page. So the pass also carries a PAGE budget
+ * ({@link HISTORY_MAX_PAGES_PER_PASS}), which bounds vendor calls regardless of
+ * how much of what it reads is worth storing.
+ *
+ * ## Why `mode` does not change what this client fetches
+ *
+ * ADR-0036 repurposes ADR-0030's reconcile cadence to **re-run extraction**
+ * (#4771) over a wider window — not to re-crawl the source. There is nothing
+ * for a re-crawl to accomplish here: episodes are append-only, so a
+ * reconciliation cannot archive absences, and a channel added since the last
+ * pass has no mark and already backfills from the floor on an ordinary cycle.
+ * An earlier cut had reconciliation rewind every channel to the floor; that
+ * re-walked the same week every cycle, and — since an incomplete pass holds the
+ * reconcile clock — it could not converge. `mode` stays on the seam because a
+ * future source may need it; the ENGINE records it (in the sync report and its
+ * log line) and this client never reads it.
+ *
+ * ## Why the engine's `since` is not used
+ *
+ * The engine's high-water mark is one timestamp per INSTALL; this cursor is one
+ * per CHANNEL, which is strictly finer — a channel invited yesterday must
+ * backfill from its own floor, not from the install's mark.
+ *
+ * ## What is deliberately not ingested
+ *
+ * Bot/app messages (`bot_id`) and membership noise (`channel_join`, topic
+ * changes, …). Atlas's own Slack answers carry a `bot_id`, and ingesting them
+ * would make the brain cite itself as evidence — the self-echo ADR-0036 §T9
+ * neutralises on the write-back path for the same reason. Every skip is
+ * COUNTED and surfaced, because "read 500 messages, stored 0" and "the channel
+ * is empty" must not look the same to an operator.
+ */
+
+import { createLogger } from "@atlas/api/lib/logger";
+import { SYNC_OVERLAP_WINDOW_MS } from "@atlas/api/lib/knowledge/connector-sync";
+import { ConnectorRateLimitError } from "@atlas/api/lib/knowledge/connectors";
+import {
+  fetchConversationHistoryPage,
+  getConversationInfo,
+  type SlackHistoryMessage,
+  type SlackReadError,
+} from "@atlas/api/lib/slack/api";
+import { deriveChatChannelGrant } from "../grant";
+import type {
+  BrainEpisodeRecord,
+  BrainSourceChanges,
+  BrainSourceFetchParams,
+  BrainSourceVendorClient,
+} from "../types";
+import { SLACK_HISTORY_SOURCE, slackEpisodeSourceId } from "./config";
+
+const log = createLogger("brain.ingest.slack.client");
+
+/**
+ * Slack's RECOMMENDED page size for `conversations.history`. The documented
+ * `limit` maximum is far higher (~1000), but Slack advises ≤200 and reserves
+ * the right to return fewer; treating 200 as a hard vendor ceiling would be
+ * wrong, and treating whatever it returns as "the page" is why the walk counts
+ * actual messages rather than `pages * limit`.
+ */
+export const HISTORY_PAGE_LIMIT = 200;
+
+/** Hard bound on pages per channel per pass — one bad channel can't hog the pass. */
+export const HISTORY_MAX_PAGES_PER_CHANNEL = 50;
+
+/**
+ * Hard bound on Slack calls per PASS, across all channels.
+ *
+ * The episode budget cannot serve this purpose: a channel of pure join/leave
+ * noise keeps zero episodes, so it spends none of `maxEpisodes` while spending
+ * a Slack call per page. Without a separate page budget, 50 configured
+ * channels × 50 pages is 2,500 calls in one cycle against a Tier-3 method —
+ * i.e. the client burning the rate limit the engine's backoff then has to
+ * absorb.
+ */
+export const HISTORY_MAX_PAGES_PER_PASS = 120;
+
+/**
+ * How far a channel's mark may be advanced past the newest message it actually
+ * saw, when a window was covered end to end.
+ *
+ * Without it, a channel whose mark is old and which then goes quiet would
+ * re-scan `[mark, now]` every cycle, and that window grows without bound until
+ * it exceeds the budget. Advancing all the way to `now` would race messages in
+ * flight: `ts` is stamped by SLACK's clock and the walk's `now` is ATLAS's, so
+ * a message stamped just before our `now` can still arrive after we read the
+ * last page.
+ *
+ * It is set to the engine's overlap window because five minutes is the right
+ * order of magnitude for both and one number is cheaper to reason about than
+ * two — NOT because they are the same mechanism. `SYNC_OVERLAP_WINDOW_MS`
+ * rewinds a query's LOWER bound so a re-fetch can no-op in an upsert; this
+ * holds back a mark's FORWARD advance. If either ever needs tuning
+ * independently, split them rather than compromising on one value.
+ */
+export const SAFETY_LAG_MS = SYNC_OVERLAP_WINDOW_MS;
+
+/**
+ * Message subtypes that are not something a person said in the channel —
+ * membership and channel bookkeeping (`channel_join`, topic/purpose/name
+ * changes), app output (`bot_message`, which `bot_id` usually catches first),
+ * and deleted-message placeholders (`tombstone`). Skipped as noise: each would
+ * otherwise become an episode, and #4771 would spend an LLM call deciding that
+ * "X joined the channel" contains no claim.
+ *
+ * A DENYLIST, not an allowlist: an unknown subtype is a message Slack added
+ * that probably does carry content (`thread_broadcast`, `file_share`, …), and
+ * defaulting those to "drop" would silently lose evidence, which is the one
+ * failure mode an evidence store must not have.
+ */
+export const SKIPPED_MESSAGE_SUBTYPES: ReadonlySet<string> = new Set([
+  "channel_join",
+  "channel_leave",
+  "group_join",
+  "group_leave",
+  "channel_topic",
+  "channel_purpose",
+  "channel_name",
+  "channel_archive",
+  "channel_unarchive",
+  "bot_message",
+  "tombstone",
+]);
+
+/**
+ * Per-channel bookkeeping. See the module header for why this is a union.
+ *
+ * `ts` is the contiguous frontier in both arms. The `backfilling` arm adds the
+ * pair — never one without the other — that a resumed walk needs.
+ */
+export type SlackChannelMark =
+  | { readonly kind: "contiguous"; readonly ts: string }
+  | {
+      readonly kind: "backfilling";
+      readonly ts: string;
+      readonly top: string;
+      readonly resume: string;
+    };
+
+/** The opaque cursor persisted in `knowledge_sync_state.sync_cursor`. */
+export interface SlackHistoryCursor {
+  readonly v: 1;
+  readonly channels: Readonly<Record<string, { ts: string; top?: string; resume?: string }>>;
+  /**
+   * Index into the install's channel list where the NEXT pass starts walking.
+   * Persisted so budget pressure circulates instead of always falling on the
+   * same tail of the list.
+   */
+  readonly nextStart?: number;
+}
+
+/** What a cursor parse found — the marks plus anything it had to discard. */
+export interface ParsedSlackHistoryCursor {
+  readonly marks: Map<string, SlackChannelMark>;
+  /** Where the next pass starts walking; 0 when absent or unusable. */
+  readonly nextStart: number;
+  /**
+   * Channel ids whose stored mark was unusable and was dropped. NOT merely a
+   * log line: dropping a mark makes that channel restart at the backfill
+   * FLOOR, and when the lost mark was OLDER than the floor that is a forward
+   * jump over history nobody will ever fetch. The caller reports these so the
+   * loss lands in the sync state row rather than only in a log nobody tails.
+   */
+  readonly dropped: readonly string[];
+}
+
+/**
+ * Parse the stored cursor. An unreadable cursor degrades rather than throwing:
+ * throwing would wedge the source permanently on one bad row with no
+ * operator-reachable repair, whereas re-crawling is a deduped no-op WRITE.
+ *
+ * Two things it will not do:
+ *   - keep a `resume` without a `top` (see the module header — that pair is
+ *     what stops a completing pass from claiming coverage it never fetched);
+ *   - discard a mark silently. Every drop is named in {@link
+ *     ParsedSlackHistoryCursor.dropped}.
+ */
+export function parseSlackHistoryCursor(raw: string | null): ParsedSlackHistoryCursor {
+  const marks = new Map<string, SlackChannelMark>();
+  const dropped: string[] = [];
+  const empty = { marks, dropped, nextStart: 0 };
+  if (raw === null || raw === "") return empty;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err) },
+      "Slack history cursor is not valid JSON — every channel restarts at the backfill floor",
+    );
+    return empty;
+  }
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    log.warn({}, "Slack history cursor is not an object — every channel restarts at the backfill floor");
+    return empty;
+  }
+  const outer = parsed as Record<string, unknown>;
+  if (outer.v !== 1) {
+    log.warn(
+      { version: outer.v },
+      "Slack history cursor has an unrecognised version — every channel restarts at the backfill floor",
+    );
+    return empty;
+  }
+  const channels = outer.channels;
+  if (channels === null || typeof channels !== "object" || Array.isArray(channels)) {
+    log.warn({}, "Slack history cursor carries no channel map — every channel restarts at the backfill floor");
+    return empty;
+  }
+
+  for (const [channelId, value] of Object.entries(channels as Record<string, unknown>)) {
+    if (value === null || typeof value !== "object" || Array.isArray(value)) {
+      dropped.push(channelId);
+      continue;
+    }
+    const entry = value as Record<string, unknown>;
+    if (typeof entry.ts !== "string" || entry.ts === "" || !isNumericTs(entry.ts)) {
+      dropped.push(channelId);
+      continue;
+    }
+    const top = typeof entry.top === "string" && isNumericTs(entry.top) ? entry.top : null;
+    const resume = typeof entry.resume === "string" && isNumericTs(entry.resume) ? entry.resume : null;
+    // The pair is kept only when it is INTERNALLY CONSISTENT: `ts < resume ≤
+    // top`. A half-pair or an out-of-order one degrades to `contiguous`, which
+    // re-crawls `[ts, now]` — more work, no gap. Keeping half of it would
+    // instead advance the mark over a range never fetched.
+    if (
+      top !== null &&
+      resume !== null &&
+      tsGreater(resume, entry.ts) &&
+      !tsGreater(resume, top)
+    ) {
+      marks.set(channelId, { kind: "backfilling", ts: entry.ts, top, resume });
+      continue;
+    }
+    if (top !== null || resume !== null) {
+      log.warn(
+        { channelId },
+        "Slack history cursor has an inconsistent backfill pair — restarting that channel's window from its frontier",
+      );
+    }
+    marks.set(channelId, { kind: "contiguous", ts: entry.ts });
+  }
+
+  if (dropped.length > 0) {
+    log.warn(
+      { channels: dropped },
+      "Slack history cursor entries were unusable — those channels restart at the backfill floor, which skips anything older than it",
+    );
+  }
+  const nextStart =
+    typeof outer.nextStart === "number" && Number.isInteger(outer.nextStart) && outer.nextStart >= 0
+      ? outer.nextStart
+      : 0;
+  return { marks, dropped, nextStart };
+}
+
+/**
+ * Serialise whatever marks it is given — pruning REMOVED channels is the
+ * CALLER's, and falls out of `fetchEpisodes` building its map exclusively from
+ * `options.channels`. Stated here because a future caller passing an unfiltered
+ * map would get no pruning and no warning.
+ *
+ * The cost of that pruning, stated because it is invisible otherwise: removing
+ * a channel and RE-ADDING it later restarts it at the backfill floor, so
+ * anything older than the floor at that moment is never ingested. Widening the
+ * floor before re-adding is the workaround.
+ */
+export function serialiseSlackHistoryCursor(
+  marks: ReadonlyMap<string, SlackChannelMark>,
+  nextStart = 0,
+): string {
+  const channels: Record<string, { ts: string; top?: string; resume?: string }> = {};
+  for (const [channelId, mark] of marks) {
+    channels[channelId] =
+      mark.kind === "backfilling"
+        ? { ts: mark.ts, top: mark.top, resume: mark.resume }
+        : { ts: mark.ts };
+  }
+  return JSON.stringify({ v: 1, channels, nextStart } satisfies SlackHistoryCursor);
+}
+
+/** Milliseconds → a Slack `ts` bound. Slack compares these numerically. */
+export function msToSlackTs(ms: number): string {
+  return (ms / 1000).toFixed(6);
+}
+
+/** A Slack `ts` → milliseconds, or null when it is not a finite number. */
+export function slackTsToMs(ts: string): number | null {
+  const seconds = Number.parseFloat(ts);
+  return Number.isFinite(seconds) ? seconds * 1000 : null;
+}
+
+/**
+ * A Slack `ts` is `<seconds>.<microseconds>`. FULL-STRING matched, because
+ * `parseFloat` prefix-parses — `"12abc"` would otherwise pass validation and be
+ * sent to Slack verbatim as an `oldest` bound, turning a clean degrade-to-floor
+ * into a per-cycle vendor rejection.
+ */
+function isNumericTs(value: string): boolean {
+  return /^\d+(\.\d+)?$/.test(value) && Number.isFinite(Number.parseFloat(value));
+}
+
+/**
+ * Numeric comparison. Today's Slack `ts` values are fixed-width (`10.6`) and
+ * would in fact sort lexicographically, but they ARE numbers — Slack compares
+ * them numerically, and a width change (or a hand-written bound like `"1.0"`
+ * from a repaired cursor) would silently reorder a text sort.
+ */
+function tsGreater(a: string, b: string): boolean {
+  return Number.parseFloat(a) > Number.parseFloat(b);
+}
+
+/** The Slack surface this client needs — injectable so tests need no HTTP. */
+export interface SlackHistoryApi {
+  readonly getConversationInfo: typeof getConversationInfo;
+  readonly fetchConversationHistoryPage: typeof fetchConversationHistoryPage;
+}
+
+export interface SlackHistoryClientOptions {
+  readonly token: string;
+  readonly channels: readonly string[];
+  /** How far back a never-synced channel backfills. */
+  readonly backfillWindowMs: number;
+  /** Test-only injection. */
+  readonly api?: SlackHistoryApi;
+  /** Test-only clock. */
+  readonly now?: () => Date;
+}
+
+/**
+ * Turn a Slack read failure into the shared throttle vocabulary, or a plain
+ * `Error`. `ratelimited` becomes {@link ConnectorRateLimitError} so the
+ * ENGINE's bounded backoff applies unchanged — a client that retried on its
+ * own would be exactly the per-vendor backoff ADR-0030 forbids.
+ *
+ * The non-throttle arms mirror the install handler's table on purpose: an
+ * admin who saw "invite the Atlas bot" at install time should see the same
+ * sentence if the bot is later removed, not a raw Slack error code.
+ */
+function toClientError(context: string, failure: SlackReadError): Error {
+  switch (failure.error) {
+    case "ratelimited":
+      return new ConnectorRateLimitError(
+        `Slack is rate limiting ${context}`,
+        failure.retryAfterSeconds,
+      );
+    case "missing_scope":
+      return new Error(
+        `The Slack connection is missing the history scopes (channels:history / groups:history) needed to read ${context} — reconnect Slack under Admin → Integrations to grant them.`,
+      );
+    case "not_in_channel":
+      return new Error(
+        `Atlas is not a member of ${context} — invite the Atlas bot to the channel, then sync again.`,
+      );
+    case "channel_not_found":
+      return new Error(
+        `Slack no longer recognises ${context} — it may have been deleted, or the id may have changed. Re-install this source with the current channel list.`,
+      );
+    case "invalid_auth":
+    case "token_revoked":
+    case "account_inactive":
+      return new Error(
+        `The workspace's Slack connection is no longer valid (${failure.error}) — reconnect Slack under Admin → Integrations, then sync again.`,
+      );
+    default:
+      return new Error(`Slack rejected the request for ${context}: ${failure.error}`);
+  }
+}
+
+/** Per-channel drop tally — every message read but not stored, by reason. */
+interface ChannelSkips {
+  bot: number;
+  subtype: number;
+  emptyText: number;
+}
+
+/** One channel's pass result. */
+interface ChannelPass {
+  readonly episodes: readonly BrainEpisodeRecord[];
+  readonly mark: SlackChannelMark;
+  /** True when the pass ran out of budget/pages before covering its window. */
+  readonly truncated: boolean;
+  /** Raw messages read from Slack, whether or not they were kept. */
+  readonly walked: number;
+  readonly pages: number;
+  /** Entries Slack returned that carried no usable identity (see the walk). */
+  readonly unidentifiable: number;
+  /**
+   * True when the pass truncated with NO resumable window — it made no progress
+   * and will not on its own. Distinct from an ordinary truncation, because the
+   * two need different words: a backlog continues next cycle, a stall does not.
+   */
+  readonly stalled: boolean;
+  readonly skips: ChannelSkips;
+}
+
+export function createSlackHistoryClient(
+  options: SlackHistoryClientOptions,
+): BrainSourceVendorClient {
+  const api: SlackHistoryApi = options.api ?? {
+    getConversationInfo,
+    fetchConversationHistoryPage,
+  };
+  const now = options.now ?? (() => new Date());
+
+  async function runChannel(
+    channelId: string,
+    existing: SlackChannelMark | undefined,
+    floorTs: string,
+    budget: { episodes: number; pages: number },
+  ): Promise<ChannelPass> {
+    // Visibility first: the grant is derived from it, and ADR-0036 §T6 puts
+    // source-principal-resolution failure on the BLOCK side — so a channel we
+    // cannot classify contributes nothing rather than defaulting to `org`.
+    const info = await api.getConversationInfo(options.token, channelId);
+    if (!info.ok) throw toClientError(`channel ${channelId}`, info);
+    const grant = deriveChatChannelGrant({
+      source: SLACK_HISTORY_SOURCE,
+      channelId,
+      isPrivate: info.channel.isPrivate,
+    });
+    if (grant === null) {
+      throw new Error(
+        `Could not derive an access grant for Slack channel ${channelId} — nothing was ingested from it.`,
+      );
+    }
+
+    const oldest = existing?.ts ?? floorTs;
+    const windowTop = existing?.kind === "backfilling" ? existing.top : null;
+    const resume = existing?.kind === "backfilling" ? existing.resume : null;
+
+    const episodes: BrainEpisodeRecord[] = [];
+    const skips: ChannelSkips = { bot: 0, subtype: 0, emptyText: 0 };
+    let newestSeen: string | null = null;
+    /** The oldest ts the pass covered CONTIGUOUSLY from its ceiling downward. */
+    let coveredDownTo: string | null = null;
+    let cursor: string | undefined;
+    let pages = 0;
+    let walked = 0;
+    let unidentifiable = 0;
+    let truncated = false;
+    const maxPages = Math.min(HISTORY_MAX_PAGES_PER_CHANNEL, budget.pages);
+
+    for (;;) {
+      if (pages >= maxPages) {
+        truncated = true;
+        break;
+      }
+      const page = await api.fetchConversationHistoryPage(options.token, {
+        channel: channelId,
+        oldest,
+        ...(pages === 0 && resume !== null ? { latest: resume } : {}),
+        ...(cursor !== undefined ? { cursor } : {}),
+        limit: HISTORY_PAGE_LIMIT,
+      });
+      if (!page.ok) throw toClientError(`channel ${channelId}`, page);
+      pages++;
+      if (page.dropped > 0) {
+        // Messages Slack returned that carry no usable identity. They sit
+        // INSIDE the window this pass is about to mark covered, so advancing
+        // the mark past them would be the silent skip this walk exists to
+        // prevent. Truncating instead re-reads them next cycle.
+        //
+        // NOTE this does not by itself get PAST a persistently-malformed page:
+        // the mark is preserved, so the next cycle walks the same window and
+        // stops in the same place. That is a VISIBLE stall — the warning and
+        // `coverageIncomplete` fire every cycle — never a silent skip, which is
+        // the trade this store makes everywhere.
+        unidentifiable += page.dropped;
+        truncated = true;
+        break;
+      }
+
+      let budgetHit = false;
+      for (const message of page.messages) {
+        // The episode budget is a HARD contract with the engine, so it is
+        // checked BEFORE each record is kept, not once per page. Stopping here
+        // leaves `coveredDownTo` at the last message we actually kept, which is
+        // exactly the `resume` the next pass needs — an over-large window
+        // becomes an ordinary truncation instead of a refused batch.
+        if (episodes.length >= budget.episodes) {
+          budgetHit = true;
+          truncated = true;
+          break;
+        }
+        walked++;
+        if (newestSeen === null || tsGreater(message.ts, newestSeen)) newestSeen = message.ts;
+        coveredDownTo = message.ts;
+        const record = toEpisode(channelId, message, grant, skips);
+        if (record !== null) episodes.push(record);
+      }
+      if (budgetHit) break;
+
+      if (page.nextCursor === null) break;
+      cursor = page.nextCursor;
+    }
+
+    if (!truncated) {
+      // Window covered end to end. WHERE the mark lands depends on where the
+      // window ENDED, and conflating the two cases loses history:
+      //
+      //   - completing a backfill (`windowTop` set) — the window ends at `top`,
+      //     NOT at now. Anything above `top` has never been fetched, so
+      //     advancing past it would skip that range permanently.
+      //   - an ordinary pass — the walk had no `latest` bound, so it ran to
+      //     now. The mark takes `max(newest seen, now − SAFETY_LAG)`. The lag
+      //     floor applies whether or not the window was empty: the window was
+      //     PROVEN covered, so a quiet stretch is genuinely covered too, and
+      //     without the floor a channel that goes quiet would re-scan an
+      //     ever-growing window until it exceeded the budget.
+      if (windowTop !== null) {
+        return {
+          episodes,
+          mark: { kind: "contiguous", ts: windowTop },
+          truncated: false,
+          walked,
+          pages,
+          unidentifiable,
+          stalled: false,
+          skips,
+        };
+      }
+      const lagTs = msToSlackTs(now().getTime() - SAFETY_LAG_MS);
+      let next = oldest;
+      for (const candidate of [newestSeen, lagTs]) {
+        if (candidate !== null && tsGreater(candidate, next)) next = candidate;
+      }
+      return {
+        episodes,
+        mark: { kind: "contiguous", ts: next },
+        truncated: false,
+        walked,
+        pages,
+        unidentifiable,
+        stalled: false,
+        skips,
+      };
+    }
+
+    // Truncated: keep what was fetched (episodes are idempotent, so landing the
+    // top of the window early is pure gain) but do NOT advance `ts` — the
+    // bottom of the window is still unfetched. `top` remembers the ceiling so
+    // the completing pass knows where to advance to; `resume` is where the next
+    // pass continues downward.
+    //
+    // A truncated pass with no resumable window — it covered nothing, or what
+    // it covered is not consistently below its own ceiling — KEEPS the mark it
+    // came in with, so the next cycle picks up exactly where this one did. It is
+    // logged as its own condition because the generic "more history than one
+    // cycle can read" message would misdiagnose a stall as a backlog.
+    // The pair must satisfy the same `ts < resume ≤ top` the parser enforces.
+    // Emitting a half-consistent one would be the producer creating the state
+    // the parser exists to reject — and the parser would then silently degrade
+    // it, quietly discarding the backfill this pass just earned.
+    // Frozen into `const`s so the guard below NARROWS them — a `let` would
+    // force a non-null assertion at the construction site, which is the one
+    // place this module cannot afford to assert rather than prove.
+    const covered = coveredDownTo;
+    const ceiling = windowTop ?? newestSeen;
+    const consistent =
+      covered !== null &&
+      ceiling !== null &&
+      tsGreater(covered, oldest) &&
+      !tsGreater(covered, ceiling);
+    if (!consistent) {
+      // No resumable window: the pass covered nothing, or what it covered does
+      // not sit consistently below its own ceiling. KEEP THE INCOMING MARK.
+      // Degrading an in-flight `backfilling` mark to `contiguous` would throw
+      // away a window whose bottom is unfetched — and because the next pass
+      // then walks from `now` again, hits the same obstacle, and degrades
+      // again, that is a fixed point rather than a delay: the channel never
+      // converges and consumes the shared budget forever trying.
+      log.warn(
+        { channelId, pages, oldest, coveredDownTo: covered, ceiling, kept: existing?.kind ?? "none" },
+        "Slack history pass was truncated with no resumable window — the channel makes no progress this cycle and will not on its own",
+      );
+      return {
+        episodes,
+        mark: existing ?? { kind: "contiguous", ts: oldest },
+        truncated: true,
+        walked,
+        pages,
+        unidentifiable,
+        stalled: true,
+        skips,
+      };
+    }
+    return {
+      episodes,
+      mark: { kind: "backfilling", ts: oldest, top: ceiling, resume: covered },
+      truncated: true,
+      walked,
+      pages,
+      unidentifiable,
+      stalled: false,
+      skips,
+    };
+  }
+
+  return {
+    async fetchEpisodes(params: BrainSourceFetchParams): Promise<BrainSourceChanges> {
+      const { marks, dropped, nextStart } = parseSlackHistoryCursor(params.cursor);
+      const floorTs = msToSlackTs(now().getTime() - options.backfillWindowMs);
+
+      const nextMarks = new Map<string, SlackChannelMark>();
+      const episodes: BrainEpisodeRecord[] = [];
+      const warnings: string[] = [];
+      let coverageIncomplete = false;
+      let remainingEpisodes = params.maxEpisodes;
+      let remainingPages = HISTORY_MAX_PAGES_PER_PASS;
+      const totals: ChannelSkips = { bot: 0, subtype: 0, emptyText: 0 };
+      let walked = 0;
+
+      for (const channelId of dropped) {
+        if (!options.channels.includes(channelId)) continue;
+        coverageIncomplete = true;
+        warnings.push(
+          `Channel ${channelId} had an unreadable sync mark — it restarts at the backfill window, so anything older than that is not ingested.`,
+        );
+      }
+
+      // ROTATE the starting channel each pass. A fixed order plus one shared
+      // budget is deterministic starvation: on the 250-record tiers a single
+      // busy channel takes the whole cap every cycle, and channels after it are
+      // never read — not slowly, never. Rotating makes the budget circulate, so
+      // "not read this cycle" is genuinely this cycle.
+      const start = options.channels.length === 0 ? 0 : nextStart % options.channels.length;
+      const ordered = [...options.channels.slice(start), ...options.channels.slice(0, start)];
+      let advancedTo = start;
+
+      for (const channelId of ordered) {
+        const existing = marks.get(channelId);
+
+        if (remainingEpisodes <= 0 || remainingPages <= 0) {
+          // Out of budget: leave this channel's mark untouched so the next
+          // cycle picks it up exactly where it was.
+          if (existing !== undefined) nextMarks.set(channelId, existing);
+          coverageIncomplete = true;
+          // Name the budget that ACTUALLY ran out. Blaming the record cap when
+          // the page budget bound sends the operator to raise a plan limit that
+          // was never the constraint — the noisy-channel case the page budget
+          // exists for is exactly when the two diverge.
+          warnings.push(
+            remainingEpisodes <= 0
+              ? `Channel ${channelId} was not read this cycle — the per-sync record budget (${params.maxEpisodes}) was reached first. It resumes next cycle.`
+              : `Channel ${channelId} was not read this cycle — the per-pass Slack page budget (${HISTORY_MAX_PAGES_PER_PASS}) was spent on earlier channels. It resumes next cycle.`,
+          );
+          continue;
+        }
+
+        let pass: ChannelPass;
+        try {
+          pass = await runChannel(channelId, existing, floorTs, {
+            episodes: remainingEpisodes,
+            pages: remainingPages,
+          });
+        } catch (err) {
+          // Per-channel isolation, matching the engine's per-collection
+          // posture: one misconfigured channel must not cost the others their
+          // cycle. Its mark stays put, so nothing is skipped.
+          //
+          // A rate limit is the one failure that also stops the PASS: Slack is
+          // telling us to stop talking, and the remaining channels would each
+          // earn their own 429. But the pass still RETURNS rather than throwing
+          // once anything has been collected — throwing would discard the
+          // episodes and marks earned by the channels that already succeeded,
+          // and (because a throttled multi-channel crawl is the steady state,
+          // not an exception) the same prefix would be re-walked and re-lost on
+          // every cycle. Only a pass that has nothing to bank rethrows, so the
+          // ENGINE's backoff still owns the retry.
+          const throttled = err instanceof ConnectorRateLimitError;
+          if (throttled && episodes.length === 0 && nextMarks.size === 0) throw err;
+          if (existing !== undefined) nextMarks.set(channelId, existing);
+          coverageIncomplete = true;
+          const message = err instanceof Error ? err.message : String(err);
+          warnings.push(
+            throttled
+              ? `Channel ${channelId} and any channels after it were not read — Slack is rate limiting this workspace. They resume on the next cycle.`
+              : `Channel ${channelId} was skipped: ${message}`,
+          );
+          log.warn(
+            { channelId, err: message, throttled },
+            throttled
+              ? "Slack rate limit mid-pass — banking the channels already read and stopping"
+              : "Slack history channel pass failed — continuing with the remaining channels",
+          );
+          if (throttled) break;
+          continue;
+        }
+
+        nextMarks.set(channelId, pass.mark);
+        advancedTo = (options.channels.indexOf(channelId) + 1) % options.channels.length;
+        episodes.push(...pass.episodes);
+        remainingEpisodes -= pass.episodes.length;
+        remainingPages -= pass.pages;
+        walked += pass.walked;
+        totals.bot += pass.skips.bot;
+        totals.subtype += pass.skips.subtype;
+        totals.emptyText += pass.skips.emptyText;
+        if (pass.unidentifiable > 0) {
+          coverageIncomplete = true;
+          warnings.push(
+            `Channel ${channelId}: Slack returned ${pass.unidentifiable} message(s) with no usable identity — that part of the window was not marked covered and is re-read next cycle.`,
+          );
+        } else if (pass.stalled) {
+          // A stall is NOT a backlog. Telling the operator to narrow the
+          // backfill window would be the same misdiagnosis the log line at the
+          // stall site is careful to avoid — the window is not too big, the
+          // channel is not moving.
+          coverageIncomplete = true;
+          warnings.push(
+            `Channel ${channelId} made no progress this cycle and will not on its own — Slack returned nothing this pass could resume from. Check the API logs for that channel.`,
+          );
+        } else if (pass.truncated) {
+          coverageIncomplete = true;
+          warnings.push(
+            `Channel ${channelId} has more history than one cycle can read — the backlog continues on the next cycle. Lower ATLAS_BRAIN_CHAT_BACKFILL_DAYS to narrow a first sync.`,
+          );
+        }
+      }
+
+      if (walked > 0 && episodes.length === 0) {
+        // "Read 500 messages, stored 0" and "the channel is empty" must not
+        // look the same. Most often this is a channel of bot output or of
+        // attachment-only posts (Slack puts their content in `files`/`blocks`,
+        // leaving `text` empty — richer extraction is M3's).
+        warnings.push(
+          `Read ${walked} Slack messages but stored none: ${totals.bot} from bots/apps, ${totals.subtype} channel-membership events, ${totals.emptyText} with no message text.`,
+        );
+      }
+      if (totals.bot + totals.subtype + totals.emptyText > 0) {
+        log.info(
+          { walked, kept: episodes.length, ...totals },
+          "Slack history pass complete — messages read but not stored, by reason",
+        );
+      }
+
+      // Any channel this pass never REACHED keeps the mark it came in with.
+      //
+      // This is structural on purpose. `serialiseSlackHistoryCursor` writes a
+      // whole-cursor REPLACEMENT and the state upsert only COALESCEs a NULL
+      // cursor forward — so a channel missing from `nextMarks` is a channel
+      // whose mark is deleted, which restarts it at the backfill floor and, if
+      // its frontier was older than the floor, jumps forward over history
+      // nothing will ever re-fetch. Handling that per-branch is how the
+      // rate-limit `break` above lost every channel after the throttled one;
+      // doing it once, here, means no future `break`/`return` can reintroduce
+      // it. Iterating `options.channels` keeps REMOVED channels pruned.
+      for (const channelId of options.channels) {
+        if (nextMarks.has(channelId)) continue;
+        const existing = marks.get(channelId);
+        if (existing !== undefined) nextMarks.set(channelId, existing);
+      }
+
+      // The mark the ENGINE persists is coarse (one per install) and this
+      // source's real bookkeeping is the per-channel cursor. It is still
+      // reported honestly: `null` whenever coverage was incomplete, because
+      // `BrainSourceChanges` requires a high-water mark to cover only the
+      // CONTIGUOUS part of the window, and a truncated pass's newest episode is
+      // the top of a window whose bottom is unfetched. The state upsert
+      // COALESCEs the previous mark forward, so null loses nothing.
+      let highWaterMark: string | null = null;
+      if (!coverageIncomplete) {
+        for (const record of episodes) {
+          if (record.occurredAt === null) continue;
+          const iso = record.occurredAt.toISOString();
+          if (highWaterMark === null || iso > highWaterMark) highWaterMark = iso;
+        }
+      }
+
+      return {
+        episodes,
+        highWaterMark,
+        cursor: serialiseSlackHistoryCursor(nextMarks, advancedTo),
+        coverageIncomplete,
+        warnings,
+      };
+    },
+  };
+}
+
+/**
+ * One Slack message → an episode record, or null when it is not evidence.
+ * Increments `skips` by reason, so a channel that yields nothing can say why.
+ *
+ * SCOPE: only what `conversations.history` returns — top-level channel posts
+ * and `thread_broadcast` copies. THREAD REPLIES ARE NOT FETCHED AT ALL (that
+ * needs `conversations.replies`, which M1 does not call), so they never reach
+ * this function and are absent from every skip tally. A thread-heavy channel
+ * therefore ingests only its top-level messages; see
+ * `docs/development/brain-slack-history.md`.
+ *
+ * Exported for the client's own tests: the source-id contract and the skip
+ * rules are the two things a future webhook writer (M3) must match exactly,
+ * and a test that can call this directly can pin them without a fake HTTP
+ * layer in between.
+ */
+export function toEpisode(
+  channelId: string,
+  message: SlackHistoryMessage,
+  grant: readonly string[],
+  skips: ChannelSkips = { bot: 0, subtype: 0, emptyText: 0 },
+): BrainEpisodeRecord | null {
+  if (message.botId !== null) {
+    skips.bot++;
+    return null;
+  }
+  if (message.subtype !== null && SKIPPED_MESSAGE_SUBTYPES.has(message.subtype)) {
+    skips.subtype++;
+    return null;
+  }
+  if (message.text.trim() === "") {
+    // `chk_brain_episodes_body_xor_locator` refuses `''` outright, so there is
+    // nothing to store. This DOES drop attachment/blocks-only posts whose
+    // content lives outside `text` — counted rather than silent, and richer
+    // extraction is M3's (see docs/development/brain-slack-history.md).
+    skips.emptyText++;
+    return null;
+  }
+
+  const occurredMs = slackTsToMs(message.ts);
+  return {
+    sourceId: slackEpisodeSourceId(channelId, message.ts),
+    sourceActor: message.user,
+    body: message.text,
+    occurredAt: occurredMs === null ? null : new Date(occurredMs),
+    visibleTo: grant,
+  };
+}

--- a/packages/api/src/lib/brain/ingest/slack/config.ts
+++ b/packages/api/src/lib/brain/ingest/slack/config.ts
@@ -1,0 +1,168 @@
+/**
+ * Slack chat-history brain source identity + stored-config contract (#4770,
+ * ADR-0036 §Ingestion & connectors).
+ *
+ * A leaf module: the catalog id / slug / source constants and the non-secret
+ * install config shape live here so the install handler (writes the config),
+ * the connector (reads it back in `createClient`), and the catalog seed share
+ * ONE definition.
+ *
+ * Like `salesforce-knowledge` (ADR-0030 amendment #4397), this source stores
+ * NO credential of its own. It reuses the workspace's EXISTING Slack OAuth
+ * install (`chat_cache`, `lib/slack/store.ts`), so installing it registers no
+ * new Slack app and opens no new secret path. The config is pure scope: which
+ * channels to read.
+ *
+ * ══════════════════════════════════════════════════════════════════════
+ * ██  THE SOURCE-ID CONTRACT
+ * ══════════════════════════════════════════════════════════════════════
+ *
+ *     source_id = `<channelId>:<ts>`      (see {@link slackEpisodeSourceId})
+ *
+ * ADR-0036 §Ingestion makes a stable source-id a per-connector OBLIGATION,
+ * not a nicety: freshness is "poll + reconcile universally, PLUS a webhook
+ * fast-path for event-native chat" (M3), and the fast-path is *an alternate
+ * writer into the same idempotent episode store*. Two writers that disagree
+ * about the id duplicate every message they race on — and because episodes are
+ * append-only there is no upsert to converge them afterwards.
+ *
+ * Why THIS id satisfies the contract:
+ *
+ *   - Slack's `ts` is the message's identity within a channel, and is what
+ *     every Slack surface uses as the message key.
+ *   - It is CHANNEL-SCOPED, so the same `ts` value in two channels is two
+ *     episodes. Slack's `ts` is NOT globally unique; without the channel
+ *     prefix two channels' messages could collide and one would be silently
+ *     dropped by the dedupe.
+ *   - Thread replies carry their OWN `ts`, so a reply WOULD be its own episode
+ *     rather than a mutation of its parent. (M1's poll path does not fetch
+ *     replies — `conversations.history` returns only top-level messages and
+ *     `thread_broadcast` copies. The id rule is stated here so the writer that
+ *     does fetch them agrees with this one.)
+ *   - It survives an edit: `conversations.history` returns the message's
+ *     ORIGINAL `ts` with the edit recorded in an `edited` sub-object. So an
+ *     edited message re-ingests as a no-op — right for evidence, since the
+ *     episode records what was said when Atlas saw it and 0180 keeps the row
+ *     immutable. A future slice that wants the revision as NEW evidence must
+ *     mint a different id from `edited.ts`, deliberately.
+ *
+ * ⚠️ WHERE THE WEBHOOK WRITER MUST READ IT FROM (the trap this section exists
+ * for). The two writers read `ts` from DIFFERENT FIELD PATHS, so "just use
+ * `ts`" is wrong:
+ *
+ *   - poll (`conversations.history`)        → `message.ts`
+ *   - webhook, plain `message` event        → `event.ts`
+ *   - webhook, `subtype: "message_changed"` → **`event.message.ts`**
+ *     (top-level `event.ts` is the EVENT's timestamp, and `event.message.edited.ts`
+ *     is the edit's — using either mints a new id for a message already stored
+ *     and duplicates every edited message)
+ *
+ * Note `message_changed` never appears on the poll path: `conversations.history`
+ * serves a message's current state, not its edit events.
+ *
+ * The one thing that must never change is the FORMAT. It is a stored key; a
+ * reformat re-ingests every message in every workspace as a new episode, and
+ * #4771 would then re-extract facts from all of them.
+ */
+
+/** The built-in catalog slug + row id for the Slack chat-history brain source. */
+export const SLACK_HISTORY_SLUG = "slack-history";
+export const SLACK_HISTORY_CATALOG_ID = "catalog:slack-history";
+
+/**
+ * The value stamped into `brain_episodes.source`. ADR-0036 orders SOURCES
+ * class-major, vendor-minor (chat → transcripts → email → docs); the column
+ * stores the VENDOR within that class, so the chat class will hold `slack`
+ * today and `teams`/`discord`/… as M3 adds them.
+ */
+export const SLACK_HISTORY_SOURCE = "slack";
+
+/**
+ * Slack channel ids are `[A-Z0-9]` after a leading letter (`C…` public, `G…`
+ * legacy private / multi-person DM, `D…` 1:1 DM). Validated because the id is
+ * interpolated into a `source_id` and into an `audience:` grant token — both
+ * stored keys — and because a typo'd id should be a form error at install time
+ * rather than a per-cycle Slack `channel_not_found`.
+ *
+ * 1:1 DMs (`D…`) are deliberately NOT admitted: their audience is two people,
+ * and ADR-0036 puts source-principal-resolution failure on the BLOCK side. M1
+ * ingests channels the bot was invited to; DM ingestion needs the membership
+ * work #4771 owns. NOTE this does not exclude every kind of DM — legacy
+ * multi-person DMs (mpim) carry `G…` ids and are admitted, ingested as private
+ * channels with a channel-scoped `audience:` grant. That is fail-closed and
+ * correct, just broader than "no DMs" would suggest.
+ */
+export const SLACK_CHANNEL_ID_PATTERN = /^[CG][A-Z0-9]{2,}$/;
+
+/** Defensive bound on the configured channel set (one install, one scope). */
+export const SLACK_HISTORY_MAX_CHANNELS = 50;
+
+/** Build the episode `source_id`. THE contract — see the module header. */
+export function slackEpisodeSourceId(channelId: string, ts: string): string {
+  return `${channelId}:${ts}`;
+}
+
+/** The non-secret config persisted on the install's `workspace_plugins` row. */
+export interface SlackHistoryInstallConfig {
+  /** Channel ids to read history from. Non-empty. */
+  readonly channels: readonly string[];
+  readonly description?: string;
+}
+
+export type ParsedSlackHistoryConfig =
+  | { readonly ok: true; readonly channels: readonly string[] }
+  | { readonly ok: false; readonly error: string };
+
+/**
+ * Parse a stored install config back into the connector's inputs. Actionable,
+ * admin-facing errors (they land in `knowledge_sync_state.error`) — a missing
+ * or invalid field means someone edited the row out of band; re-installing
+ * repairs it.
+ */
+export function parseSlackHistoryConfig(
+  config: Record<string, unknown> | null,
+): ParsedSlackHistoryConfig {
+  const raw = config?.channels;
+  if (!Array.isArray(raw)) {
+    return {
+      ok: false,
+      error:
+        "This Slack history source has no channel list configured — re-install it and pick at least one channel.",
+    };
+  }
+  const channels: string[] = [];
+  for (const entry of raw) {
+    // A non-string entry is refused, not skipped: silently narrowing the
+    // configured scope produces a source that reports success while never
+    // reading a channel the admin believes is connected.
+    if (typeof entry !== "string") {
+      return {
+        ok: false,
+        error:
+          "This Slack history source has a malformed channel list configured — re-install it and pick channels from the list.",
+      };
+    }
+    const trimmed = entry.trim().toUpperCase();
+    if (!SLACK_CHANNEL_ID_PATTERN.test(trimmed)) {
+      return {
+        ok: false,
+        error: `This Slack history source has an invalid channel id configured ("${String(entry).slice(0, 40)}") — re-install it and pick channels from the list.`,
+      };
+    }
+    if (!channels.includes(trimmed)) channels.push(trimmed);
+  }
+  if (channels.length === 0) {
+    return {
+      ok: false,
+      error:
+        "This Slack history source has no usable channel ids configured — re-install it and pick at least one channel.",
+    };
+  }
+  if (channels.length > SLACK_HISTORY_MAX_CHANNELS) {
+    return {
+      ok: false,
+      error: `This Slack history source has ${channels.length} channels configured, over the ${SLACK_HISTORY_MAX_CHANNELS}-channel limit — re-install it with a narrower scope.`,
+    };
+  }
+  return { ok: true, channels };
+}

--- a/packages/api/src/lib/brain/ingest/slack/connector.ts
+++ b/packages/api/src/lib/brain/ingest/slack/connector.ts
@@ -1,0 +1,161 @@
+/**
+ * The Slack chat-history {@link BrainSourceConnector} (#4770, ADR-0036
+ * §Ingestion & connectors) — the catalog-id-keyed adapter the shared sync
+ * cycle dispatches on. It owns only the factory contract: bind the stored
+ * channel scope + the workspace's EXISTING Slack OAuth install into a vendor
+ * client. Scheduling, backoff, caps, and the episode ingest are elsewhere.
+ *
+ * ## Credentials: reuse, never register
+ *
+ * This follows ADR-0030's amendment #4397 (Salesforce Knowledge) exactly: no
+ * `knowledge_sync_credentials` row, no new secret path, no new OAuth app.
+ * `createClient` resolves the workspace's Slack bot token from the same
+ * `chat_cache` install the chat adapter uses (`lib/slack/store.ts`), so
+ * "Slack is live" — which is true of the chat ADAPTER — is what makes this
+ * connector installable at all. Disconnecting Slack breaks this source's sync,
+ * surfaced per cycle as an actionable error outcome, never a silent no-op.
+ *
+ * Token resolution is DB-only, per CLAUDE.md's per-tenant credential rule: the
+ * store's `SLACK_BOT_TOKEN` env fallback is for single-workspace deploys with
+ * no internal DB, and this connector cannot run without an internal DB anyway
+ * (the episodes it writes live there).
+ *
+ * ## Scopes are a STAGING-FIRST change
+ *
+ * Reading history needs `channels:history` (public) and `groups:history`
+ * (private) on top of the scopes the chat adapter already requested. #4770 adds
+ * both to `SLACK_SCOPES` in `slack-oauth-handler.ts` — that string IS the OAuth
+ * `scope=` param, so without the edit no reconnect could ever grant them and
+ * the source would be uninstallable everywhere.
+ *
+ * Per CLAUDE.md's operational rule the matching Slack APP MANIFEST change lands
+ * on STAGING first and soaks there; until an app's manifest carries the scopes,
+ * Slack refuses the consent screen for the whole install, not just this source.
+ * A workspace whose token predates them fails `missing_scope` — surfaced at
+ * install as a field error and at sync time as "reconnect Slack to grant them",
+ * and reconnecting is what actually grants them. See
+ * `docs/development/brain-slack-history.md`.
+ */
+
+import { createLogger } from "@atlas/api/lib/logger";
+import { getSettingAuto } from "@atlas/api/lib/settings";
+import { getBotToken, getInstallationByOrg } from "@atlas/api/lib/slack/store";
+import { createSlackHistoryClient } from "./client";
+import {
+  SLACK_HISTORY_CATALOG_ID,
+  SLACK_HISTORY_SOURCE,
+  parseSlackHistoryConfig,
+} from "./config";
+import {
+  getBrainSourceConnector,
+  registerBrainSourceConnector,
+  type BrainSourceConnector,
+  type BrainSourceInstallContext,
+  type BrainSourceVendorClient,
+} from "../types";
+
+const log = createLogger("brain.ingest.slack.connector");
+
+/** Default backfill window for a channel with no stored mark: one week. */
+export const DEFAULT_CHAT_BACKFILL_DAYS = 7;
+
+/**
+ * How far back a never-synced channel reads (ms), from the settings-registry
+ * knob `ATLAS_BRAIN_CHAT_BACKFILL_DAYS`.
+ *
+ * A knob rather than a constant because it is the operator's lever when a first
+ * sync reports that a channel has more history than one cycle can read — the
+ * truncation warning names it. Fractional days are legal (soak-testing);
+ * non-positive / unparseable values fall back to the default WITH A WARN rather
+ * than backfilling nothing, because a zero window would produce a sync that
+ * succeeds, finds no history, and reports itself green forever.
+ */
+export function getChatBackfillWindowMs(): number {
+  const raw = getSettingAuto("ATLAS_BRAIN_CHAT_BACKFILL_DAYS");
+  if (raw === undefined || raw === "") return DEFAULT_CHAT_BACKFILL_DAYS * 86_400_000;
+  const days = Number.parseFloat(raw);
+  if (!Number.isFinite(days) || days <= 0) {
+    log.warn(
+      { raw },
+      "ATLAS_BRAIN_CHAT_BACKFILL_DAYS is non-positive or unparseable — using the default",
+    );
+    return DEFAULT_CHAT_BACKFILL_DAYS * 86_400_000;
+  }
+  return days * 86_400_000;
+}
+
+/** The store slice the connector needs — injectable for tests. */
+export interface SlackInstallationReader {
+  getInstallationByOrg: typeof getInstallationByOrg;
+  getBotToken: typeof getBotToken;
+}
+
+/**
+ * Resolve the workspace's Slack bot token, mapping absence to an actionable,
+ * admin-facing error (it lands in the sync state row). Exported so the install
+ * handler runs the SAME resolution as its loud pre-write verification —
+ * install-time and sync-time must not be able to disagree about whether Slack
+ * is connected.
+ */
+export async function resolveSlackHistoryToken(
+  store: SlackInstallationReader,
+  workspaceId: string,
+): Promise<string> {
+  const installation = await store.getInstallationByOrg(workspaceId);
+  if (installation === null) {
+    throw new Error(
+      "This workspace has no Slack connection — connect Slack under Admin → Integrations, then sync again.",
+    );
+  }
+  const token = await store.getBotToken(installation.team_id);
+  if (token === null || token === "") {
+    // Reached when the ORG lookup found an install but the per-team lookup no
+    // longer resolves a token — the row was removed or expired between the two
+    // reads, or the stored token decrypts to empty. (An undecryptable row is
+    // hidden from BOTH lookups by `decryptOrHide`, so it surfaces as the
+    // no-connection arm above, not here.) Re-running the OAuth flow is the
+    // repair either way; re-inviting the bot is not.
+    throw new Error(
+      "The workspace's Slack credential could not be read — reconnect Slack under Admin → Integrations, then sync again.",
+    );
+  }
+  return token;
+}
+
+export interface SlackHistoryConnectorDeps {
+  /** Injected installation store for tests; defaults to the real one. */
+  readonly store?: SlackInstallationReader;
+}
+
+/** Build the Slack chat-history brain source. `deps` is test-only injection. */
+export function createSlackHistoryConnector(
+  deps: SlackHistoryConnectorDeps = {},
+): BrainSourceConnector {
+  const store: SlackInstallationReader = deps.store ?? { getInstallationByOrg, getBotToken };
+  return {
+    catalogId: SLACK_HISTORY_CATALOG_ID,
+    source: SLACK_HISTORY_SOURCE,
+    async createClient(ctx: BrainSourceInstallContext): Promise<BrainSourceVendorClient> {
+      const parsed = parseSlackHistoryConfig(ctx.config);
+      if (!parsed.ok) throw new Error(parsed.error);
+      const token = await resolveSlackHistoryToken(store, ctx.workspaceId);
+      return createSlackHistoryClient({
+        token,
+        channels: parsed.channels,
+        backfillWindowMs: getChatBackfillWindowMs(),
+      });
+    },
+  };
+}
+
+/**
+ * Register the Slack chat-history source idempotently — called from the boot
+ * seam that also registers install handlers, and from tests.
+ * `registerBrainSourceConnector` throws on a duplicate catalog id, so gate on
+ * the registry first.
+ */
+export function registerSlackHistoryConnector(): void {
+  if (getBrainSourceConnector(SLACK_HISTORY_CATALOG_ID) !== undefined) return;
+  registerBrainSourceConnector(createSlackHistoryConnector());
+  log.info({ catalogId: SLACK_HISTORY_CATALOG_ID }, "Registered Slack chat-history brain source");
+}

--- a/packages/api/src/lib/brain/ingest/types.ts
+++ b/packages/api/src/lib/brain/ingest/types.ts
@@ -1,0 +1,257 @@
+/**
+ * The brain ingest seam (#4770, ADR-0036 §Ingestion & connectors) — the
+ * FORKED half of the ADR-0030 connector architecture.
+ *
+ * ## What is reused and what is forked
+ *
+ * ADR-0036 §T6 is explicit: **reuse the ADR-0030 connector engine verbatim**
+ * (scheduling / high-water marks / incremental-vs-reconcile cadence / 429
+ * backoff / caps) and **fork the ingest core**. This module is the fork's
+ * vocabulary; `episode-sync.ts` is the fork's engine, and it imports the
+ * reused halves (`withRateLimitBackoff`, `SYNC_OVERLAP_WINDOW_MS`,
+ * `getKnowledgeSyncReconcileIntervalMs`, the `knowledge_sync_state`
+ * bookkeeping) from `lib/knowledge/connector-sync.ts` rather than
+ * reimplementing them. Dispatch onto one engine or the other happens in
+ * `lib/knowledge/sync.ts`'s cycle walk, keyed on which registry a catalog id
+ * belongs to — that is the "engine dispatch on ingest-target" fork point.
+ *
+ * The ingest core is forked because the two targets are structurally
+ * different, not merely differently-shaped:
+ *
+ *   - a knowledge document is IDENTIFIED BY PATH and is MUTABLE — the engine's
+ *     `ingestDocuments` upserts by path and, on a coverage-complete
+ *     reconciliation crawl, ARCHIVES paths absent from the vendor's full set;
+ *   - an episode is IDENTIFIED BY SOURCE-ID and is IMMUTABLE — a Slack message
+ *     edited upstream is a NEW episode, not a mutation of the old one, because
+ *     an episode is EVIDENCE and evidence that can be edited after the fact
+ *     cannot back a provenance claim (migration 0180's header).
+ *
+ * So the episode path deliberately has **no upsert and no archive**. The only
+ * write is `INSERT … ON CONFLICT (workspace_id, source, source_id) DO NOTHING`
+ * (`episodes.ts`), and nothing in `lib/brain/ingest/` imports
+ * `ingestDocuments` — `episode-sync-archive.test.ts` pins both.
+ *
+ * ## Why there is no `fetchChanges` / `fetchAll` pair
+ *
+ * ADR-0030's client interface splits enumeration in two because the
+ * reconciliation crawl is the CORRECTNESS ANCHOR for subtractive archiving:
+ * `fetchAll` promises a full set, and paths missing from it get archived. An
+ * episode source archives nothing, so a "full set" contract would promise
+ * something no caller consumes — and a contract nobody enforces is a contract
+ * that quietly rots. One method takes the mode instead. What `reconciliation`
+ * then means is the source's business: ADR-0036 §Ingestion repurposes the
+ * cadence to **re-run extraction** (#4771), and a source may additionally widen
+ * its own fetch window — but it never means "enumerate everything so absences
+ * can be deleted".
+ */
+
+import {
+  claimCatalogIngestTarget,
+  _resetCatalogIngestClaims,
+} from "@atlas/api/lib/knowledge/catalog-claims";
+import type { BrainGrant } from "@atlas/api/lib/brain/types";
+
+/**
+ * One record a source produced, ready to become a tier-3 episode row.
+ *
+ * Deliberately NOT `BrainEpisode` from `lib/brain/types.ts`: that type is the
+ * stored row (it carries `id`, `ingestedAt`, `createdAt`, `extractedAt`), and
+ * a connector must not be able to name any of them. `extractedAt` in
+ * particular is #4771's work-queue marker and MUST stay NULL at ingest — a
+ * connector that could set it would take episodes off the extraction queue
+ * before anything extracted them, and the design's "NULL forever is a visible
+ * backlog, not a silent drop" would become a silent drop.
+ */
+export interface BrainEpisodeRecord {
+  /**
+   * The source's own stable identifier. THE dedupe key, and a per-connector
+   * CONTRACT: it must be byte-identical from the polling path and from the
+   * webhook fast-path (M3), or the two writers duplicate every record they
+   * race on. Each connector documents its construction next to its client —
+   * see `slack/config.ts` for the Slack chat contract.
+   */
+  readonly sourceId: string;
+  /** Source-side author principal (e.g. a Slack user id); null when none. */
+  readonly sourceActor: string | null;
+  /**
+   * The record's content, stored BY VALUE. Chat is by-value on purpose: Slack
+   * may delete the message out from under us and the evidence must survive
+   * (migration 0180). Never `''` — `chk_brain_episodes_body_xor_locator`
+   * refuses an empty string outright rather than treating it as absent, so
+   * the ingest core drops blank records rather than letting the CHECK reject
+   * a whole batch.
+   *
+   * There is no `locator` field here. Episodes stored BY REFERENCE
+   * (warehouse-derived, KB-derived) come from entry points that are not
+   * connectors, and admitting both halves of the XOR into a chat connector's
+   * record type would make "which one backs the provenance claim" a per-call
+   * question instead of a per-source one.
+   */
+  readonly body: string;
+  /** Event time at the source. Null when the source exposes none. */
+  readonly occurredAt: Date | null;
+  /**
+   * The derived ACL grant (ADR-0036 §T5). Must contain at least one principal
+   * that `parseGrant` finds USABLE — see `grant.ts` for why a grant the 0180
+   * CHECK admits can still be a permanent trap.
+   */
+  readonly visibleTo: BrainGrant;
+}
+
+/** The two cadences, carried through to the client. */
+export type BrainSourceFetchMode = "incremental" | "reconciliation";
+
+/** What the engine hands a client for one fetch. */
+export interface BrainSourceFetchParams {
+  /**
+   * `incremental` — fetch what changed since `since`.
+   * `reconciliation` — the wider-window cadence. It is NOT a full enumeration
+   * and NOTHING is archived from its absences; a source that has nothing wider
+   * to fetch may treat it identically to `incremental` (the Slack source
+   * does — see its client's header for why).
+   */
+  readonly mode: BrainSourceFetchMode;
+  /**
+   * The persisted high-water mark minus the engine's overlap window, or null
+   * when the source has never synced successfully. Re-fetched records no-op in
+   * the source-id dedupe, so the overlap costs bandwidth and never correctness
+   * — the same property that lets ADR-0030 rewind its incremental window.
+   */
+  readonly since: string | null;
+  /** The opaque per-source cursor from the last successful sync, or null. */
+  readonly cursor: string | null;
+  /**
+   * The maximum number of episodes this fetch may return — the engine's
+   * EFFECTIVE per-sync cap (`min(platform ceiling, plan tier)`), resolved once
+   * per cycle and shared with the ingest stage. Required, not optional, for
+   * the same reason ADR-0030 made it required: a client that silently fell
+   * back to the raw platform ceiling would burn a Starter workspace's vendor
+   * rate limit pulling 20× what it can ever ingest.
+   */
+  readonly maxEpisodes: number;
+}
+
+/** One fetch's result — records plus the bookkeeping to persist on success. */
+export interface BrainSourceChanges {
+  readonly episodes: readonly BrainEpisodeRecord[];
+  /**
+   * The newest source-side event time this fetch covered (ISO-8601), or null
+   * when the fetch covered nothing new. Persisted on success as the source's
+   * high-water mark. Return the SOURCE's clock, never the local one.
+   */
+  readonly highWaterMark: string | null;
+  /** Opaque per-source continuation, persisted verbatim and echoed back. */
+  readonly cursor?: string | null;
+  /**
+   * True when the client KNOWS this pass left part of its window uncovered
+   * (a per-cycle budget ran out, a sub-source errored) while the records it
+   * DID return are sound. The engine still ingests them and still advances the
+   * high-water mark the client returned — but it does NOT advance the
+   * reconcile clock, so the wider re-crawl stays due. Omit / false on a
+   * complete pass.
+   *
+   * Correctness rests on the CLIENT, not the engine: a client that reports
+   * incomplete coverage must return a high-water mark (and cursor) that covers
+   * only the CONTIGUOUS part of the window it actually enumerated, or it will
+   * skip the gap forever. `slack/client.ts` does that per channel.
+   */
+  readonly coverageIncomplete?: boolean;
+  /**
+   * Human-readable, non-fatal notes from the pass (a channel that exceeded the
+   * budget, a sub-source the source refused). Surfaced in the sync state
+   * report so a partially-covered "success" is never silently green.
+   */
+  readonly warnings?: readonly string[];
+}
+
+/**
+ * The per-source client the engine drives. May throw — a
+ * `ConnectorRateLimitError` (imported from the ADR-0030 seam
+ * `lib/knowledge/connectors.ts`, so both halves speak ONE throttle vocabulary
+ * and the shared backoff applies unchanged) gets the engine's bounded backoff;
+ * anything else becomes that source's error outcome, isolated and never
+ * cycle-fatal.
+ */
+export interface BrainSourceVendorClient {
+  fetchEpisodes(params: BrainSourceFetchParams): Promise<BrainSourceChanges>;
+}
+
+/** What a connector gets to build a client from — the install row, no more. */
+export interface BrainSourceInstallContext {
+  readonly workspaceId: string;
+  /** The install's `workspace_plugins.install_id`. */
+  readonly installId: string;
+  /** The install row's config (scope fields; never secrets). */
+  readonly config: Record<string, unknown> | null;
+}
+
+/**
+ * A registered brain ingest source: one catalog row → one client factory.
+ *
+ * `createClient` may throw (bad config, a disconnected upstream OAuth install)
+ * — the engine turns that into the source's error outcome with the message
+ * surfaced to the admin, so make it actionable.
+ */
+export interface BrainSourceConnector {
+  /** The catalog row this connector serves — the cycle-walk dispatch key. */
+  readonly catalogId: string;
+  /**
+   * The connector class stamped into `brain_episodes.source` (`slack`,
+   * `warehouse`, `human` — ADR-0036 is class-major, vendor-minor). Constrained
+   * to `[a-z0-9-]+` for the same reason ADR-0030 constrains its vendor slug:
+   * it is a stored discriminator, and a stored discriminator with free-form
+   * text in it stops being one.
+   */
+  readonly source: string;
+  createClient(
+    ctx: BrainSourceInstallContext,
+  ): Promise<BrainSourceVendorClient> | BrainSourceVendorClient;
+}
+
+// ---------------------------------------------------------------------------
+// Registry — catalog id → connector, read by the shared sync cycle walk
+// ---------------------------------------------------------------------------
+
+const SOURCE_SLUG = /^[a-z0-9][a-z0-9-]*$/;
+
+const registry = new Map<string, BrainSourceConnector>();
+
+/**
+ * Register a brain source for its catalog row. Called once per source at
+ * wiring time. Duplicate catalog ids and malformed source slugs fail loudly —
+ * a silent overwrite would let one source shadow another's installs, and a
+ * malformed slug would land unqueryable garbage in `brain_episodes.source`.
+ */
+export function registerBrainSourceConnector(connector: BrainSourceConnector): void {
+  if (!SOURCE_SLUG.test(connector.source)) {
+    throw new Error(
+      `Brain source slug "${connector.source}" is invalid — expected a lowercase alphanumeric slug matching ${SOURCE_SLUG.source} (it is stored verbatim in brain_episodes.source)`,
+    );
+  }
+  if (registry.has(connector.catalogId)) {
+    throw new Error(
+      `Brain source connector for catalog id "${connector.catalogId}" is already registered`,
+    );
+  }
+  // One catalog id, one ingest target. Both registries claim through the same
+  // module so the check is ORDER-INDEPENDENT — an earlier one-sided peek at the
+  // knowledge registry only covered the direction that cannot happen (brain
+  // sources register last today) and missed the one that can.
+  claimCatalogIngestTarget(connector.catalogId, "brain-episodes");
+  registry.set(connector.catalogId, connector);
+}
+
+export function getBrainSourceConnector(catalogId: string): BrainSourceConnector | undefined {
+  return registry.get(catalogId);
+}
+
+/** The catalog ids with a registered brain source — the cycle walk's filter. */
+export function listBrainSourceCatalogIds(): string[] {
+  return [...registry.keys()];
+}
+
+/** Test-only: clear the registry (tests register fixtures per-suite). */
+export function _resetBrainSourceConnectors(): void {
+  registry.clear();
+  _resetCatalogIngestClaims("brain-episodes");
+}

--- a/packages/api/src/lib/db/__tests__/seed-builtin-knowledge-catalog.test.ts
+++ b/packages/api/src/lib/db/__tests__/seed-builtin-knowledge-catalog.test.ts
@@ -329,6 +329,7 @@ describe("seedBuiltinKnowledgeCatalog (idempotent boot seed)", () => {
       "front",
       "helpscout",
       "freshdesk",
+      "slack-history",
     ]);
   });
 
@@ -361,6 +362,7 @@ describe("seedBuiltinKnowledgeCatalog (idempotent boot seed)", () => {
       "front",
       "helpscout",
       "freshdesk",
+      "slack-history",
     ]);
     // Empty RETURNING = rows already existed (ON CONFLICT DO NOTHING path).
     const reboot = await seedBuiltinKnowledgeCatalog(captureDb(false).db);

--- a/packages/api/src/lib/db/seed-builtin-knowledge-catalog.ts
+++ b/packages/api/src/lib/db/seed-builtin-knowledge-catalog.ts
@@ -49,6 +49,10 @@ import {
 import { FRONT_CATALOG_ID, FRONT_SLUG } from "@atlas/api/lib/knowledge/front/config";
 import { HELPSCOUT_CATALOG_ID, HELPSCOUT_SLUG } from "@atlas/api/lib/knowledge/helpscout/config";
 import { FRESHDESK_CATALOG_ID, FRESHDESK_SLUG } from "@atlas/api/lib/knowledge/freshdesk/config";
+import {
+  SLACK_HISTORY_CATALOG_ID,
+  SLACK_HISTORY_SLUG,
+} from "@atlas/api/lib/brain/ingest/slack/config";
 import type { ConfigSchemaField } from "@atlas/api/lib/plugins/registry";
 import { assertOperatorCatalogWrite } from "@atlas/api/lib/plugins/catalog-provenance";
 
@@ -658,6 +662,58 @@ export const BUILTIN_FRESHDESK_CATALOG_ROW: BuiltinKnowledgeCatalogRow = {
   ],
 };
 
+/**
+ * The Slack chat-history BRAIN SOURCE catalog row (#4770, ADR-0036 §Ingestion
+ * & connectors).
+ *
+ * The odd one out in this list, deliberately: it is a `pillar='knowledge'`
+ * install like its neighbours — which is what lets it reuse the collection
+ * install spine, the `knowledge_sync_state` bookkeeping, and the ONE sync
+ * cycle walk verbatim (ADR-0036 §T6's "reuse the engine, fork the ingest
+ * core") — but what it ingests is tier-3 EPISODES into `brain_episodes`, not
+ * knowledge documents. The cycle walk routes it on that ingest target
+ * (`lib/knowledge/sync.ts::dispatchInstall`).
+ *
+ * Two visible consequences, both worth stating because they will look like
+ * bugs: an installed Slack history source appears on /admin/knowledge as a
+ * collection with ZERO documents (its rows land in `brain_episodes`), and it
+ * CONSUMES one of the workspace's plan-capped knowledge-collection slots. Both
+ * are the price of reusing the collection spine verbatim. The brain's own
+ * surface is #4772; until it lands, the sync status row is where this source
+ * reports itself.
+ *
+ * No secret field: the connector reuses the workspace's existing Slack OAuth
+ * install (`chat_cache`), so installing this row registers no new Slack app
+ * and writes no `knowledge_sync_credentials` row. The id/slug are the config
+ * SSOT (`SLACK_HISTORY_CATALOG_ID` / `SLACK_HISTORY_SLUG`).
+ */
+export const BUILTIN_SLACK_HISTORY_CATALOG_ROW: BuiltinKnowledgeCatalogRow = {
+  id: SLACK_HISTORY_CATALOG_ID,
+  slug: SLACK_HISTORY_SLUG,
+  name: "Company Brain (Slack history)",
+  description:
+    "Read history from chosen Slack channels into the company brain as immutable, deduped episodes using the workspace's existing Slack connection — no extra credentials. Episodes are raw evidence; the claims drawn from them go through review before anything becomes an authoritative fact.",
+  installModel: "form",
+  autoInstall: false,
+  saasEligible: true,
+  configSchema: [
+    {
+      key: "channels",
+      type: "string",
+      label: "Channels",
+      required: true,
+      description:
+        "Comma-separated Slack channel IDs (e.g. C01ABCDEF, C02GHIJKL) that Atlas should read history from. Invite the Atlas bot to each channel first. Private channels are ingested with an access grant scoped to that channel.",
+    },
+    {
+      key: "description",
+      type: "string",
+      label: "Description",
+      description: "Optional. A human description of this brain source.",
+    },
+  ],
+};
+
 /** Every built-in Knowledge Base catalog row, in seed order. */
 export const BUILTIN_KNOWLEDGE_CATALOG_ROWS: ReadonlyArray<BuiltinKnowledgeCatalogRow> = [
   BUILTIN_KNOWLEDGE_CATALOG_ROW,
@@ -672,6 +728,7 @@ export const BUILTIN_KNOWLEDGE_CATALOG_ROWS: ReadonlyArray<BuiltinKnowledgeCatal
   BUILTIN_FRONT_CATALOG_ROW,
   BUILTIN_HELPSCOUT_CATALOG_ROW,
   BUILTIN_FRESHDESK_CATALOG_ROW,
+  BUILTIN_SLACK_HISTORY_CATALOG_ROW,
 ];
 
 /**

--- a/packages/api/src/lib/integrations/install/__tests__/slack-history-form-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/slack-history-form-handler.test.ts
@@ -1,0 +1,246 @@
+/**
+ * The Slack chat-history install handler (#4770).
+ *
+ * The handler's whole claim is that it verifies LOUDLY BEFORE PERSISTING — it
+ * collects no credential, so pre-write verification is what replaces the
+ * credential check its siblings run. So the highest-value test here is not
+ * "does a good install work" but **"does a failed probe leave the database
+ * untouched"**: a `workspace_plugins` row written against a channel the bot was
+ * never invited to is a source that errors every cycle forever, discovered a
+ * week later in a log instead of immediately on the form.
+ *
+ * The second-highest is the ROUND TRIP: `validateChannels` (here) and
+ * `parseSlackHistoryConfig` (in the connector) are two hand-written statements
+ * of the same rule in different files. A divergence means an install that
+ * succeeds and then fails every single sync with "re-install it".
+ */
+
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import type { WorkspaceId } from "@useatlas/types";
+import type { SlackConversationInfo } from "@atlas/api/lib/slack/api";
+import {
+  SLACK_HISTORY_MAX_CHANNELS,
+  parseSlackHistoryConfig,
+} from "@atlas/api/lib/brain/ingest/slack/config";
+import { buildInternalDbMockDefaults } from "@atlas/api/testing/api-test-mocks";
+
+const catalogRows: { id: string }[] = [{ id: "catalog:slack-history" }];
+let upserts: { sql: string; params: unknown[] }[] = [];
+
+void mock.module("@atlas/api/lib/db/internal", () => ({
+  ...buildInternalDbMockDefaults({ internalQuery: async () => catalogRows }),
+  hasInternalDB: () => true,
+  getInternalDB: () => ({ query: async () => ({ rows: [] }) }),
+}));
+
+void mock.module("@atlas/api/lib/integrations/install/knowledge-collection-install", () => ({
+  assertCollectionInstallable: async () => {},
+  // Mock-all-exports (CLAUDE.md) — unused here, but a missing symbol surfaces
+  // as "Export named X not found" in an unrelated file, not this one.
+  assertCollectionBatchInstallable: async () => {},
+  upsertKnowledgeCollectionRow: async (params: { sql: string; params: unknown[] }) => {
+    upserts.push({ sql: params.sql, params: params.params });
+    return "row-id";
+  },
+}));
+
+const { SlackHistoryFormInstallHandler } = await import(
+  "@atlas/api/lib/integrations/install/slack-history-form-handler"
+);
+const { FormInstallValidationError } = await import(
+  "@atlas/api/lib/integrations/install/persist-form-install"
+);
+
+const WORKSPACE = "ws-1" as WorkspaceId;
+
+function channel(overrides: Partial<SlackConversationInfo> = {}): SlackConversationInfo {
+  return { id: "C01ABCDEF", name: "general", isPrivate: false, isMember: true, isArchived: false, ...overrides };
+}
+
+function handler(opts: {
+  info?: (channelId: string) => Promise<
+    { ok: true; channel: SlackConversationInfo } | { ok: false; error: string; retryAfterSeconds: number | null }
+  >;
+  history?: () => Promise<
+    | { ok: true; messages: []; nextCursor: null; dropped: number }
+    | { ok: false; error: string; retryAfterSeconds: number | null }
+  >;
+  token?: string | null;
+} = {}) {
+  return new SlackHistoryFormInstallHandler({
+    idGenerator: () => "fixed-id",
+    store: {
+      getInstallationByOrg: async () =>
+        opts.token === null
+          ? null
+          : ({ team_id: "T1", org_id: WORKSPACE, workspace_name: "w", installed_at: "now" } as never),
+      getBotToken: async () => opts.token ?? "xoxb-test",
+    },
+    getConversationInfo: (async (_token: string, channelId: string) =>
+      (opts.info ?? (async () => ({ ok: true as const, channel: channel({ id: channelId }) })))(
+        channelId,
+      )) as never,
+    fetchConversationHistoryPage: (async () =>
+      (opts.history ?? (async () => ({ ok: true as const, messages: [], nextCursor: null, dropped: 0 })))()) as never,
+  });
+}
+
+beforeEach(() => {
+  upserts = [];
+});
+
+/**
+ * `FormInstallValidationError`'s own `.message` is the generic "Form install
+ * validation failed" — the ACTIONABLE text lives in `fieldErrors`/`formErrors`,
+ * which is what the admin form renders. Asserting on `.message` would pass for
+ * any validation failure at all, so every assertion here reads the payload.
+ */
+async function refusalText(promise: Promise<unknown>): Promise<string> {
+  try {
+    await promise;
+  } catch (err) {
+    if (err instanceof FormInstallValidationError) {
+      return [...Object.values(err.fieldErrors).flat(), ...err.formErrors].join(" | ");
+    }
+    return err instanceof Error ? err.message : String(err);
+  }
+  throw new Error("expected the install to be refused");
+}
+
+describe("pre-write verification", () => {
+  it("persists nothing when a channel probe fails", async () => {
+    const h = handler({
+      info: async () => ({ ok: false, error: "channel_not_found", retryAfterSeconds: null }),
+    });
+    await expect(
+      h.validateConfig(WORKSPACE, { channels: "C01ABCDEF" }),
+    ).rejects.toBeInstanceOf(FormInstallValidationError);
+    // The whole point of the handler's shape.
+    expect(upserts).toHaveLength(0);
+  });
+
+  it("persists nothing when Slack is not connected", async () => {
+    const h = handler({ token: null });
+    expect(await refusalText(h.validateConfig(WORKSPACE, { channels: "C01ABCDEF" }))).toMatch(
+      /connect Slack/i,
+    );
+    expect(upserts).toHaveLength(0);
+  });
+
+  it("refuses a channel the Atlas bot has not been invited to, naming the fix", async () => {
+    const h = handler({
+      info: async (channelId) => ({ ok: true, channel: channel({ id: channelId, isMember: false }) }),
+    });
+    expect(await refusalText(h.validateConfig(WORKSPACE, { channels: "C01ABCDEF" }))).toMatch(
+      /invite the Atlas bot/i,
+    );
+    expect(upserts).toHaveLength(0);
+  });
+
+  it("probes HISTORY too — conversations.info alone cannot see the history scopes", async () => {
+    // `conversations.info` is gated on channels:read/groups:read, which the
+    // chat adapter's token already has. Without the history probe a token
+    // missing channels:history passes every install check and then fails
+    // `missing_scope` on the first sync — the per-cycle error nobody reads.
+    const h = handler({
+      history: async () => ({ ok: false, error: "missing_scope", retryAfterSeconds: null }),
+    });
+    expect(await refusalText(h.validateConfig(WORKSPACE, { channels: "C01ABCDEF" }))).toMatch(
+      /channels:history/,
+    );
+    expect(upserts).toHaveLength(0);
+  });
+
+  it("ADMITS an archived channel — its history is still evidence", async () => {
+    const h = handler({
+      info: async (channelId) => ({ ok: true, channel: channel({ id: channelId, isArchived: true }) }),
+    });
+    await h.validateConfig(WORKSPACE, { channels: "C01ABCDEF" });
+    expect(upserts).toHaveLength(1);
+  });
+});
+
+describe("persisted install", () => {
+  it("writes a knowledge-pillar row, normalised channels, and no credential", async () => {
+    const h = handler();
+    const result = await h.validateConfig(WORKSPACE, {
+      channels: "c01abcdef, C02GHIJKL",
+      description: "  eng chatter  ",
+    });
+    expect(result.credentialWritten).toBe(false);
+    expect(upserts).toHaveLength(1);
+    const config = JSON.parse(String(upserts[0]!.params[4])) as {
+      channels: string[];
+      description?: string;
+    };
+    expect(config.channels).toEqual(["C01ABCDEF", "C02GHIJKL"]);
+    expect(config.description).toBe("eng chatter");
+    expect(upserts[0]!.sql).toContain("'knowledge'");
+    // No secret field anywhere in the persisted config.
+    expect(JSON.stringify(config)).not.toContain("xoxb");
+  });
+
+  it("dedupes a repeated channel", async () => {
+    const h = handler();
+    await h.validateConfig(WORKSPACE, { channels: "C01ABCDEF,c01abcdef" });
+    const config = JSON.parse(String(upserts[0]!.params[4])) as { channels: string[] };
+    expect(config.channels).toEqual(["C01ABCDEF"]);
+  });
+});
+
+describe("channel validation", () => {
+  const cases: ReadonlyArray<[string, unknown, RegExp]> = [
+    ["a 1:1 DM id", "D01ABCDEF", /Direct messages cannot be ingested/],
+    ["a channel name", "#general", /not a Slack channel ID/],
+    ["an empty list", "   ", /at least one Slack channel ID/],
+    ["a non-string entry in an array", ["C01ABCDEF", 42], /must be a Slack channel ID string/],
+    ["a non-list value", 42, /separated by commas/],
+  ];
+  for (const [label, input, pattern] of cases) {
+    it(`refuses ${label}`, async () => {
+      expect(await refusalText(handler().validateConfig(WORKSPACE, { channels: input }))).toMatch(
+        pattern,
+      );
+      expect(upserts).toHaveLength(0);
+    });
+  }
+
+  it("refuses more channels than one source may scope", async () => {
+    const many = Array.from({ length: 51 }, (_, i) => `C${String(i).padStart(8, "0")}`);
+    expect(await refusalText(handler().validateConfig(WORKSPACE, { channels: many }))).toMatch(
+      /at most 50/,
+    );
+  });
+
+  it("accepts a whitespace-separated list as well as a comma-separated one", async () => {
+    await handler().validateConfig(WORKSPACE, { channels: "C01ABCDEF C02GHIJKL" });
+    const config = JSON.parse(String(upserts[0]!.params[4])) as { channels: string[] };
+    expect(config.channels).toEqual(["C01ABCDEF", "C02GHIJKL"]);
+  });
+});
+
+describe("the install ⇄ sync round trip", () => {
+  it("everything the handler accepts, the connector's config parser also accepts", async () => {
+    // Two hand-written statements of one rule in two files. A divergence is an
+    // install that succeeds and then fails EVERY sync with "re-install it".
+    const atCap = Array.from({ length: SLACK_HISTORY_MAX_CHANNELS }, (_, i) =>
+      `C${String(i).padStart(8, "0")}`,
+    );
+    for (const input of [
+      "C01ABCDEF",
+      "c01abcdef, C02GHIJKL",
+      "C01ABCDEF C02GHIJKL",
+      ["C01ABCDEF", "G0123456789"],
+      // The CAP BOUNDARY is the only real divergence surface: both sides
+      // hand-write the same rule, and a `>=` on one side silently makes every
+      // sync of a full-capacity install fail with "re-install it".
+      atCap,
+    ]) {
+      upserts = [];
+      await handler().validateConfig(WORKSPACE, { channels: input });
+      const config = JSON.parse(String(upserts[0]!.params[4])) as Record<string, unknown>;
+      const parsed = parseSlackHistoryConfig(config);
+      expect({ input, ok: parsed.ok }).toEqual({ input, ok: true });
+    }
+  });
+});

--- a/packages/api/src/lib/integrations/install/__tests__/slack-oauth-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/slack-oauth-handler.test.ts
@@ -215,10 +215,19 @@ describe("SlackOAuthInstallHandler.startInstall", () => {
     expect(parsed.origin + parsed.pathname).toBe("https://slack.com/oauth/v2/authorize");
     expect(parsed.searchParams.get("client_id")).toBe(SLACK_CONFIG.clientId);
     expect(parsed.searchParams.get("state")).toBe(stateToken);
-    // Legacy slack.ts scopes (preserved by lift) + the conversation-read
-    // pair powering the admin channel picker.
+    // Legacy slack.ts scopes (preserved by lift) + the conversation-read pair
+    // powering the admin channel picker + the history pair the company-brain
+    // chat source needs (#4770).
+    //
+    // Pinned as an EXACT string on purpose: this list IS the `scope=` param, so
+    // a scope Atlas does not request here is a scope no workspace can ever
+    // hold — dropping one silently makes a downstream feature uninstallable for
+    // everybody, with the failure surfacing as a vendor error much later. It
+    // also means ADDING one is a live-system change: the Slack app manifest
+    // must carry the scope first (staging, then every prod region) or Slack
+    // rejects the consent screen for the WHOLE install.
     expect(parsed.searchParams.get("scope")).toBe(
-      "commands,chat:write,app_mentions:read,channels:read,groups:read",
+      "commands,chat:write,app_mentions:read,channels:read,groups:read,channels:history,groups:history",
     );
     expect(parsed.searchParams.get("redirect_uri")).toBe(SLACK_CONFIG.redirectUri);
   });

--- a/packages/api/src/lib/integrations/install/register.ts
+++ b/packages/api/src/lib/integrations/install/register.ts
@@ -63,6 +63,11 @@ import { HelpScoutFormInstallHandler, HELPSCOUT_SLUG } from "./helpscout-form-ha
 import { registerHelpScoutKnowledgeConnector } from "@atlas/api/lib/knowledge/helpscout/connector";
 import { FreshdeskFormInstallHandler, FRESHDESK_SLUG } from "./freshdesk-form-handler";
 import { registerFreshdeskKnowledgeConnector } from "@atlas/api/lib/knowledge/freshdesk/connector";
+import {
+  SlackHistoryFormInstallHandler,
+  SLACK_HISTORY_SLUG,
+} from "./slack-history-form-handler";
+import { registerSlackHistoryConnector } from "@atlas/api/lib/brain/ingest/slack/connector";
 import { OpenApiGenericFormInstallHandler } from "./openapi-generic-form-handler";
 import { OPENAPI_GENERIC_SLUG } from "@atlas/api/lib/openapi/catalog";
 import { DataCandidateFormInstallHandler } from "./data-candidate-form-handler";
@@ -382,6 +387,21 @@ export function registerBuiltinInstallHandlers(): void {
   registerFormHandler(FRESHDESK_SLUG, new FreshdeskFormInstallHandler());
   registerFreshdeskKnowledgeConnector();
   log.info("Registered FreshdeskFormInstallHandler + knowledge sync connector");
+  // Company Brain (Slack history) — the built-in `slack-history` BRAIN SOURCE
+  // install (#4770, ADR-0036 §Ingestion & connectors). Knowledge-pillar like
+  // its neighbours (which is what lets it reuse the collection install spine,
+  // the sync bookkeeping, and the one cycle walk verbatim), but it ingests
+  // tier-3 EPISODES rather than knowledge documents — the cycle walk routes it
+  // on that ingest target. Like `salesforce-knowledge` it collects NO secret:
+  // the connector reuses the workspace's existing Slack OAuth install
+  // (`chat_cache`), so no new Slack app is registered. Registering the FORM
+  // handler + the SOURCE together keeps a half-wired deploy from having an
+  // installable card whose scheduled sync has no registered client. No env
+  // gate: the install fails loudly and actionably ("connect Slack first",
+  // "invite the bot to the channel") on a workspace that isn't ready.
+  registerFormHandler(SLACK_HISTORY_SLUG, new SlackHistoryFormInstallHandler());
+  registerSlackHistoryConnector();
+  log.info("Registered SlackHistoryFormInstallHandler + brain source connector");
   // Generic OpenAPI REST datasource (#2926). Datasource-pillar, multi-instance
   // (a workspace installs Twenty, Stripe, an internal service side by side).
   // No env gate — the customer admin supplies the spec URL + credential at

--- a/packages/api/src/lib/integrations/install/slack-history-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/slack-history-form-handler.ts
@@ -1,0 +1,310 @@
+/**
+ * `SlackHistoryFormInstallHandler` — the {@link FormBasedInstallHandler} for
+ * the built-in `slack-history` brain-source catalog row (#4770, ADR-0036
+ * §Ingestion & connectors).
+ *
+ * Installing it creates one `pillar='knowledge'` install scoped to a set of
+ * Slack channels; the Scheduler dispatches the registered brain source per
+ * install on the SAME cadence as the knowledge connectors
+ * (`lib/knowledge/sync.ts` routes it to `lib/brain/ingest/episode-sync.ts` on
+ * its ingest target), and every message lands as an immutable tier-3 episode.
+ *
+ * Credentials: this handler collects NO secret. The connector reuses the
+ * workspace's EXISTING Slack OAuth install, so there is no
+ * `knowledge_sync_credentials` write, no rollback pairing, and no new Slack
+ * app registration — the same posture `salesforce-knowledge` takes toward the
+ * Salesforce OAuth install (ADR-0030 amendment #4397). What replaces the
+ * credential check is the loud pre-write verification that tier demands: the
+ * handler resolves the live Slack token, then probes every configured channel
+ * TWICE — `conversations.info` for existence/membership/visibility, and a
+ * one-message `conversations.history` read for the history scopes, which
+ * `conversations.info` structurally CANNOT see (it is gated on
+ * `channels:read`/`groups:read`, which the chat adapter's token already has, so
+ * it returns fine for a token that cannot read a single message). All of it
+ * happens BEFORE anything is persisted, so "the bot isn't in that channel",
+ * "that channel id doesn't exist", and "the token can't read history" are
+ * field-level 400s at install time rather than a per-cycle error nobody
+ * reads.
+ */
+
+import crypto from "crypto";
+import { createLogger } from "@atlas/api/lib/logger";
+import { internalQuery } from "@atlas/api/lib/db/internal";
+import type { WorkspaceId } from "@useatlas/types";
+import {
+  resolveSlackHistoryToken,
+  type SlackInstallationReader,
+} from "@atlas/api/lib/brain/ingest/slack/connector";
+import {
+  SLACK_CHANNEL_ID_PATTERN,
+  SLACK_HISTORY_CATALOG_ID,
+  SLACK_HISTORY_MAX_CHANNELS,
+  SLACK_HISTORY_SLUG,
+  type SlackHistoryInstallConfig,
+} from "@atlas/api/lib/brain/ingest/slack/config";
+import { fetchConversationHistoryPage, getConversationInfo } from "@atlas/api/lib/slack/api";
+import { getBotToken, getInstallationByOrg } from "@atlas/api/lib/slack/store";
+import { FormInstallValidationError } from "./persist-form-install";
+import {
+  assertCollectionInstallable,
+  upsertKnowledgeCollectionRow,
+} from "./knowledge-collection-install";
+import {
+  KNOWLEDGE_INSTALL_ID_FIELD,
+  resolveCollectionSlug,
+} from "./knowledge-collection-slug";
+import type { FormBasedInstallHandler, InstallRecord } from "./types";
+
+// Re-exported for the register.ts boot wiring; both are single-homed in config.ts.
+export { SLACK_HISTORY_SLUG, SLACK_HISTORY_CATALOG_ID };
+
+/**
+ * The brain-source install upsert. Identical shape to the knowledge
+ * connectors': `status='published'` because the install CONTAINER is live
+ * immediately — the review gate is on the FACTS drawn from the episodes
+ * (#4769), never on the episodes themselves, which are evidence and are
+ * deliberately not content-mode registered. Exported so the real-Postgres test
+ * executes this exact string against the live schema.
+ */
+export const SLACK_HISTORY_INSTALL_UPSERT_SQL = `INSERT INTO workspace_plugins
+           (id, workspace_id, catalog_id, install_id, pillar, config, enabled, status, installed_at, updated_at)
+         VALUES ($1, $2, $3, $4, 'knowledge', $5::jsonb, true, 'published', NOW(), NOW())
+         ON CONFLICT (workspace_id, catalog_id, install_id) DO UPDATE
+           SET config = EXCLUDED.config,
+               enabled = true,
+               status = 'published',
+               updated_at = NOW()
+         RETURNING id`;
+
+export interface SlackHistoryFormInstallHandlerOptions {
+  /** Test-only injection of the row-id generator. */
+  readonly idGenerator?: () => string;
+  /** Test-only injection of the installation store (no real Slack call). */
+  readonly store?: SlackInstallationReader;
+  /** Test-only injection of the channel probes. */
+  readonly getConversationInfo?: typeof getConversationInfo;
+  readonly fetchConversationHistoryPage?: typeof fetchConversationHistoryPage;
+}
+
+export class SlackHistoryFormInstallHandler implements FormBasedInstallHandler {
+  readonly kind = "form" as const;
+
+  private readonly newId: () => string;
+  private readonly store: SlackInstallationReader;
+  private readonly probeChannel: typeof getConversationInfo;
+  private readonly probeHistory: typeof fetchConversationHistoryPage;
+  private readonly log = createLogger("integrations.install.slack-history");
+
+  constructor(options: SlackHistoryFormInstallHandlerOptions = {}) {
+    this.newId = options.idGenerator ?? (() => crypto.randomUUID());
+    this.store = options.store ?? { getInstallationByOrg, getBotToken };
+    this.probeChannel = options.getConversationInfo ?? getConversationInfo;
+    this.probeHistory = options.fetchConversationHistoryPage ?? fetchConversationHistoryPage;
+  }
+
+  async validateConfig(
+    workspaceId: WorkspaceId,
+    formData: unknown,
+  ): Promise<{ readonly installRecord: InstallRecord; readonly credentialWritten: boolean }> {
+    if (formData === null || typeof formData !== "object" || Array.isArray(formData)) {
+      throw new FormInstallValidationError({
+        fieldErrors: {},
+        formErrors: ["Request body must be a JSON object of config fields."],
+      });
+    }
+    const rawForm = formData as Record<string, unknown>;
+
+    const slug = resolveCollectionSlug(rawForm[KNOWLEDGE_INSTALL_ID_FIELD], SLACK_HISTORY_SLUG);
+    const channels = validateChannels(rawForm.channels);
+    const description = validateDescription(rawForm.description);
+
+    // Confirm the catalog row exists + is enabled.
+    const catalogRows = await internalQuery<{ id: string }>(
+      `SELECT id FROM plugin_catalog WHERE slug = $1 AND enabled = true LIMIT 1`,
+      [SLACK_HISTORY_SLUG],
+    );
+    if (catalogRows.length === 0) {
+      this.log.error(
+        { workspaceId },
+        "slack-history catalog row missing or disabled — cannot install (built-in knowledge catalog seed has not run)",
+      );
+      throw new Error(
+        `Catalog row "${SLACK_HISTORY_SLUG}" not found or disabled — the built-in Knowledge Base catalog seed has not run.`,
+      );
+    }
+    const catalogId = catalogRows[0].id;
+
+    await assertCollectionInstallable(workspaceId, slug, catalogId, this.log);
+
+    // ── Verify the reused Slack connection loudly BEFORE persisting ─────────
+    let token: string;
+    try {
+      token = await resolveSlackHistoryToken(this.store, workspaceId);
+    } catch (err) {
+      // Surfaced to the admin AND logged. "The install keeps failing" is a
+      // support question, and the decrypt-failure arm in particular is an
+      // operator-relevant event that would otherwise exist only in an HTTP
+      // response body nobody keeps.
+      const message = err instanceof Error ? err.message : String(err);
+      this.log.warn(
+        { workspaceId, err: message },
+        "Slack history install blocked — no usable Slack connection for this workspace",
+      );
+      throw new FormInstallValidationError({ fieldErrors: {}, formErrors: [message] });
+    }
+    await this.verifyChannels(token, channels);
+
+    // ── Persist (no credential — the Slack OAuth install owns it) ───────────
+    const config: SlackHistoryInstallConfig = {
+      channels,
+      ...(description !== null ? { description } : {}),
+    };
+    const candidateId = this.newId();
+    const returned = await upsertKnowledgeCollectionRow({
+      workspaceId,
+      collectionSlug: slug,
+      sql: SLACK_HISTORY_INSTALL_UPSERT_SQL,
+      params: [candidateId, workspaceId, catalogId, slug, JSON.stringify(config)],
+      candidateId,
+      log: this.log,
+    });
+
+    this.log.info(
+      { workspaceId, installId: slug, channels: channels.length },
+      "Slack chat-history brain source install completed",
+    );
+    return {
+      installRecord: { id: returned, workspaceId, catalogId: SLACK_HISTORY_SLUG },
+      credentialWritten: false,
+    };
+  }
+
+  /**
+   * Probe every configured channel TWICE — `conversations.info` for existence,
+   * membership and visibility, then a one-message `conversations.history` read
+   * for the history scopes. Each failure blames the `channels` field and names
+   * the fix: a channel the bot was never invited to, and a token without the
+   * history scopes, are the two most likely install mistakes, and discovering
+   * either a cycle later (as a sync error) is discovering it in the wrong
+   * place.
+   *
+   * An ARCHIVED channel is admitted with a warning rather than refused: its
+   * history is still readable and still evidence, it just will not grow.
+   */
+  private async verifyChannels(token: string, channels: readonly string[]): Promise<void> {
+    for (const channelId of channels) {
+      const info = await this.probeChannel(token, channelId);
+      if (!info.ok) {
+        throw fieldError("channels", channelProbeMessage(channelId, info.error));
+      }
+      if (!info.channel.isMember) {
+        throw fieldError(
+          "channels",
+          `Atlas is not a member of #${info.channel.name} (${channelId}) — invite the Atlas bot to the channel, then install again.`,
+        );
+      }
+      if (info.channel.isArchived) {
+        this.log.warn(
+          { channelId, name: info.channel.name },
+          "Slack history source configured with an archived channel — its history is read once and never grows",
+        );
+      }
+      // A ONE-MESSAGE history read, and it is not redundant with the check
+      // above. `conversations.info` is gated on `channels:read`/`groups:read`,
+      // which the chat adapter's existing token already has — so without this
+      // probe a token missing `channels:history`/`groups:history` passes every
+      // install check and then fails `missing_scope` on the first sync, which
+      // is exactly the "per-cycle error nobody reads" this handler exists to
+      // prevent. Cheap: `limit: 1`, once per channel, at install only.
+      const history = await this.probeHistory(token, { channel: channelId, limit: 1 });
+      if (!history.ok) {
+        throw fieldError("channels", historyProbeMessage(channelId, history.error));
+      }
+    }
+  }
+}
+
+/** Map a `conversations.history` probe error to an actionable install message. */
+function historyProbeMessage(channelId: string, error: string): string {
+  switch (error) {
+    case "missing_scope":
+      return `The workspace's Slack connection cannot read message history — reconnect Slack under Admin → Integrations to grant the channels:history and groups:history scopes, then install again.`;
+    case "not_in_channel":
+      return `Atlas is not a member of ${channelId} — invite the Atlas bot to the channel, then install again.`;
+    case "ratelimited":
+      return `Slack is rate limiting this workspace right now — wait a minute and install again.`;
+    default:
+      return `Slack refused to return history for ${channelId}: ${error}.`;
+  }
+}
+
+/** Map a `conversations.info` error to an actionable install-time message. */
+function channelProbeMessage(channelId: string, error: string): string {
+  switch (error) {
+    case "channel_not_found":
+      return `Slack does not recognise the channel id ${channelId} — copy it from the channel's "View channel details" panel.`;
+    case "missing_scope":
+      return `The workspace's Slack connection cannot look this channel up — reconnect Slack under Admin → Integrations to grant the channels:read and groups:read scopes, then install again.`;
+    case "ratelimited":
+      return `Slack is rate limiting this workspace right now — wait a minute and install again.`;
+    default:
+      return `Slack rejected the check for channel ${channelId}: ${error}.`;
+  }
+}
+
+/**
+ * Validate the channel list. Accepts the comma/whitespace-separated string the
+ * form field produces, and an array (an API caller posting JSON directly).
+ */
+function validateChannels(raw: unknown): readonly string[] {
+  if (typeof raw !== "string" && !Array.isArray(raw)) {
+    throw fieldError("channels", "Enter one or more Slack channel IDs, separated by commas.");
+  }
+  // A non-string entry is a LOUD error, not a silent skip. Every other
+  // malformed input here is a field error, and quietly narrowing the requested
+  // scope is invisible until someone wonders why a channel never appears.
+  const parts: string[] = Array.isArray(raw)
+    ? raw.map((entry) => {
+        if (typeof entry !== "string") {
+          throw fieldError("channels", "Every channel must be a Slack channel ID string.");
+        }
+        return entry;
+      })
+    : raw.split(/[,\s]+/);
+
+  const channels: string[] = [];
+  for (const part of parts) {
+    const trimmed = part.trim().toUpperCase();
+    if (trimmed === "") continue;
+    if (!SLACK_CHANNEL_ID_PATTERN.test(trimmed)) {
+      throw fieldError(
+        "channels",
+        `"${part.trim().slice(0, 40)}" is not a Slack channel ID — IDs start with C or G (e.g. C01ABCDEF). Direct messages cannot be ingested.`,
+      );
+    }
+    if (!channels.includes(trimmed)) channels.push(trimmed);
+  }
+  if (channels.length === 0) {
+    throw fieldError("channels", "Enter at least one Slack channel ID (e.g. C01ABCDEF).");
+  }
+  if (channels.length > SLACK_HISTORY_MAX_CHANNELS) {
+    throw fieldError(
+      "channels",
+      `Enter at most ${SLACK_HISTORY_MAX_CHANNELS} channels — split a wider scope across several sources.`,
+    );
+  }
+  return channels;
+}
+
+function validateDescription(raw: unknown): string | null {
+  if (raw === undefined || raw === null) return null;
+  if (typeof raw !== "string") {
+    throw fieldError("description", "Description must be a string.");
+  }
+  const trimmed = raw.trim();
+  return trimmed === "" ? null : trimmed;
+}
+
+function fieldError(field: string, message: string): FormInstallValidationError {
+  return new FormInstallValidationError({ fieldErrors: { [field]: [message] }, formErrors: [] });
+}

--- a/packages/api/src/lib/integrations/install/slack-oauth-handler.ts
+++ b/packages/api/src/lib/integrations/install/slack-oauth-handler.ts
@@ -75,8 +75,23 @@ const SLACK_SLUG: CatalogId = "slack";
  * admin channel picker (`GET /admin/proactive/channels/available` →
  * `conversations.list`); installs predating them soft-degrade to manual
  * channel-id entry until the workspace re-installs.
+ *
+ * `channels:history` + `groups:history` (#4770) power the company-brain chat
+ * source, which reads `conversations.history` into `brain_episodes`. THIS
+ * STRING IS THE `scope=` PARAM, so a workspace can only hold a scope this list
+ * requests — an install predating them fails the source's install probe with
+ * "reconnect Slack to grant them", and reconnecting is what actually grants
+ * them. Read scopes cannot substitute: `conversations.info` is gated on
+ * `channels:read`/`groups:read` and returns fine without any history scope,
+ * which is why the install handler probes history separately.
+ *
+ * OPERATIONAL: the scopes must also be added to the Slack app manifest, and per
+ * CLAUDE.md's operational rule that happens on the STAGING app first. Until an
+ * app's manifest carries them, Slack refuses the consent screen for the whole
+ * install, not just the brain source — so manifest first, then this list.
  */
-const SLACK_SCOPES = "commands,chat:write,app_mentions:read,channels:read,groups:read";
+const SLACK_SCOPES =
+  "commands,chat:write,app_mentions:read,channels:read,groups:read,channels:history,groups:history";
 
 /**
  * Per-deploy operator config — Slack app client credentials registered

--- a/packages/api/src/lib/knowledge/__tests__/catalog-claims.test.ts
+++ b/packages/api/src/lib/knowledge/__tests__/catalog-claims.test.ts
@@ -1,0 +1,124 @@
+/**
+ * One catalog id, one ingest target (#4770).
+ *
+ * This guard exists BECAUSE of a review finding, and it is the kind of code
+ * that can be deleted without anything going red — the cycle walk would simply
+ * start silently misrouting. So the tests are written as the mutations they
+ * must catch:
+ *
+ *   - remove either registry's claim call → a collision registers cleanly;
+ *   - make the duplicate check unreachable → same;
+ *   - go back to a blanket `clear()` in the reset → the check is defeated
+ *     inside CI, which is the only place it is ever exercised.
+ */
+
+import { afterEach, describe, expect, it } from "bun:test";
+import {
+  _resetCatalogIngestClaims,
+  claimCatalogIngestTarget,
+  getCatalogIngestTarget,
+} from "@atlas/api/lib/knowledge/catalog-claims";
+import {
+  _resetKnowledgeSyncConnectors,
+  registerKnowledgeSyncConnector,
+} from "@atlas/api/lib/knowledge/connectors";
+import {
+  _resetBrainSourceConnectors,
+  registerBrainSourceConnector,
+} from "@atlas/api/lib/brain/ingest/types";
+
+const CATALOG = "catalog:collision";
+
+function knowledgeConnector(catalogId = CATALOG) {
+  return {
+    catalogId,
+    vendor: "fixture",
+    createClient: () => ({
+      fetchChanges: async () => ({ documents: [], highWaterMark: null }),
+      fetchAll: async () => ({ documents: [], highWaterMark: null }),
+    }),
+  };
+}
+
+function brainConnector(catalogId = CATALOG) {
+  return {
+    catalogId,
+    source: "fixture",
+    createClient: () => ({ fetchEpisodes: async () => ({ episodes: [], highWaterMark: null }) }),
+  };
+}
+
+afterEach(() => {
+  _resetKnowledgeSyncConnectors();
+  _resetBrainSourceConnectors();
+});
+
+describe("claimCatalogIngestTarget", () => {
+  it("records the holder", () => {
+    claimCatalogIngestTarget(CATALOG, "brain-episodes");
+    expect(getCatalogIngestTarget(CATALOG)).toBe("brain-episodes");
+  });
+
+  it("is idempotent for the same target — a double boot registration is a no-op", () => {
+    claimCatalogIngestTarget(CATALOG, "knowledge-documents");
+    expect(() => claimCatalogIngestTarget(CATALOG, "knowledge-documents")).not.toThrow();
+  });
+
+  it("refuses a second target, naming why the routing depends on it", () => {
+    claimCatalogIngestTarget(CATALOG, "knowledge-documents");
+    expect(() => claimCatalogIngestTarget(CATALOG, "brain-episodes")).toThrow(
+      /exactly one ingest target/,
+    );
+  });
+});
+
+describe("the two registries are disjoint IN BOTH DIRECTIONS", () => {
+  it("refuses a brain source on an id a knowledge connector already holds", () => {
+    registerKnowledgeSyncConnector(knowledgeConnector());
+    expect(() => registerBrainSourceConnector(brainConnector())).toThrow(
+      /exactly one ingest target/,
+    );
+  });
+
+  it("refuses a knowledge connector on an id a brain source already holds", () => {
+    // The direction the first, one-sided guard missed — and the one that can
+    // actually happen, since brain sources register LAST in `register.ts`.
+    registerBrainSourceConnector(brainConnector());
+    expect(() => registerKnowledgeSyncConnector(knowledgeConnector())).toThrow(
+      /exactly one ingest target/,
+    );
+  });
+
+  it("leaves distinct catalog ids alone", () => {
+    registerKnowledgeSyncConnector(knowledgeConnector("catalog:docs"));
+    expect(() => registerBrainSourceConnector(brainConnector("catalog:chat"))).not.toThrow();
+  });
+});
+
+describe("the test-only reset is target-scoped", () => {
+  it("resetting ONE registry does not release the other's claims", () => {
+    // A blanket `clear()` here would let a colliding id register cleanly right
+    // after — defeating the guard in the only environment that runs it.
+    registerBrainSourceConnector(brainConnector());
+    _resetKnowledgeSyncConnectors();
+    expect(getCatalogIngestTarget(CATALOG)).toBe("brain-episodes");
+    expect(() => registerKnowledgeSyncConnector(knowledgeConnector())).toThrow(
+      /exactly one ingest target/,
+    );
+  });
+
+  it("releases its own, so a suite can re-register the same fixture id", () => {
+    registerKnowledgeSyncConnector(knowledgeConnector());
+    _resetKnowledgeSyncConnectors();
+    expect(getCatalogIngestTarget(CATALOG)).toBeUndefined();
+    expect(() => registerKnowledgeSyncConnector(knowledgeConnector())).not.toThrow();
+  });
+
+  it("only clears the named target", () => {
+    claimCatalogIngestTarget("catalog:docs", "knowledge-documents");
+    claimCatalogIngestTarget("catalog:chat", "brain-episodes");
+    _resetCatalogIngestClaims("knowledge-documents");
+    expect(getCatalogIngestTarget("catalog:docs")).toBeUndefined();
+    expect(getCatalogIngestTarget("catalog:chat")).toBe("brain-episodes");
+  });
+});

--- a/packages/api/src/lib/knowledge/__tests__/knowledge-lifecycle-pg.test.ts
+++ b/packages/api/src/lib/knowledge/__tests__/knowledge-lifecycle-pg.test.ts
@@ -450,11 +450,15 @@ describeIfPg("knowledge ingest lifecycle against the live schema", () => {
       last_sync_at: string;
       status: string;
       error: string | null;
+      coverage_incomplete: boolean;
+      coverage_detail: string | null;
     }>(
       `SELECT collection_id,
               to_char(last_sync_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') AS last_sync_at,
               status,
-              error
+              error,
+              (report -> 'coverageIncomplete') = 'true'::jsonb AS coverage_incomplete,
+              report -> 'warnings' ->> 0                        AS coverage_detail
          FROM knowledge_sync_state
         WHERE workspace_id = $1`,
       [ws],
@@ -462,6 +466,40 @@ describeIfPg("knowledge ingest lifecycle against the live schema", () => {
     expect(projection.rows).toHaveLength(1);
     expect(projection.rows[0]?.collection_id).toBe("synced-docs");
     expect(projection.rows[0]?.last_sync_at).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+    // The #4770 coverage flag, read against the live schema. `report` is
+    // free-form JSONB written by more than one engine, so the comparison must
+    // survive whatever else lands in it — a `::boolean` CAST would raise on any
+    // value outside Postgres's boolean vocabulary and fault the ENTIRE
+    // collection list for the workspace off one malformed row.
+    // A bundle-sync row carries `report = NULL`, so the comparison yields SQL
+    // NULL rather than false — which the route maps with `=== true`. Asserting
+    // the NULL rather than papering over it is the point: it is the shape the
+    // route's mapping has to survive.
+    expect(projection.rows[0]?.coverage_incomplete).toBeNull();
+    expect(projection.rows[0]?.coverage_detail).toBeNull();
+    for (const report of [
+      `'{"coverageIncomplete": true}'`,
+      `'{"coverageIncomplete": "partial"}'`,
+      `'{"coverageIncomplete": {"nested": 1}}'`,
+      `'{}'`,
+      `NULL`,
+    ]) {
+      await pool.query(
+        `UPDATE knowledge_sync_state SET report = ${report}::jsonb
+          WHERE workspace_id = $1 AND collection_id = 'synced-docs'`,
+        [ws],
+      );
+      const row = await pool.query<{ coverage_incomplete: boolean | null }>(
+        `SELECT (report -> 'coverageIncomplete') = 'true'::jsonb AS coverage_incomplete
+           FROM knowledge_sync_state
+          WHERE workspace_id = $1 AND collection_id = 'synced-docs'`,
+        [ws],
+      );
+      // Never throws; anything that is not literal JSON `true` reads as
+      // not-incomplete (and a NULL report yields SQL NULL, which the route maps
+      // to false).
+      expect(row.rows[0]?.coverage_incomplete ?? false).toBe(report.includes("true"));
+    }
   }, PG_TEST_TIMEOUT_MS);
 
   it("installs a notion-knowledge connector collection against the live schema (#4378)", async () => {

--- a/packages/api/src/lib/knowledge/__tests__/sync.test.ts
+++ b/packages/api/src/lib/knowledge/__tests__/sync.test.ts
@@ -12,7 +12,7 @@
  * references the content-mode publish machinery).
  */
 
-import { beforeEach, describe, expect, it, mock } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 import { zipSync, strToU8 } from "fflate";
 import { buildInternalDbMockDefaults } from "@atlas/api/testing/api-test-mocks";
 
@@ -230,7 +230,40 @@ void mock.module("@atlas/api/lib/semantic/sync", () => ({
   },
 }));
 
+// The brain episode engine (#4770) — stubbed so the cycle's THIRD dispatch arm
+// is observable here. Mock-all-exports: `episode-sync.ts` exports exactly this.
+const brainSyncCalls: { workspaceId: string; installId: string; source: string }[] = [];
+let BRAIN_SYNC_STATUS: "success" | "error" = "success";
+void mock.module("@atlas/api/lib/brain/ingest/episode-sync", () => ({
+  syncBrainEpisodeSource: async (params: {
+    connector: { source: string };
+    workspaceId: string;
+    installId: string;
+  }) => {
+    brainSyncCalls.push({
+      workspaceId: params.workspaceId,
+      installId: params.installId,
+      source: params.connector.source,
+    });
+    return {
+      installId: params.installId,
+      status: BRAIN_SYNC_STATUS,
+      mode: "reconciliation" as const,
+      syncedAt: "2026-07-01T00:00:00.000Z",
+      error: null,
+      episodes: null,
+      coverageIncomplete: false,
+      warnings: [],
+      highWaterMark: null,
+    };
+  },
+}));
+
 const { syncCollection, runKnowledgeSyncCycle } = await import("@atlas/api/lib/knowledge/sync");
+const {
+  _resetBrainSourceConnectors,
+  registerBrainSourceConnector,
+} = await import("@atlas/api/lib/brain/ingest/types");
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -795,6 +828,15 @@ describe("syncCollection — endpoint auth", () => {
 // ── Cycle ────────────────────────────────────────────────────────────────────
 
 describe("runKnowledgeSyncCycle", () => {
+  // Cleanup in `afterEach`, never at the end of an `it`: a failing assertion
+  // would otherwise leave the brain registry populated and `BRAIN_SYNC_STATUS`
+  // pinned to "error" for every later test in the file, turning one real
+  // failure into a cascade that misdirects the debugging.
+  afterEach(() => {
+    _resetBrainSourceConnectors();
+    BRAIN_SYNC_STATUS = "success";
+  });
+
   it("walks every enabled install, isolating per-collection failures", async () => {
     INSTALL_ROWS = [
       { workspace_id: ORG, install_id: "good", catalog_id: "catalog:bundle-sync", config: baseConfig() },
@@ -820,6 +862,71 @@ describe("runKnowledgeSyncCycle", () => {
     const result = await runKnowledgeSyncCycle();
     expect(result).toEqual({ inspected: 0, succeeded: 0, failed: 0, queryFailed: true });
     expect(stateWrites).toHaveLength(0);
+  });
+
+  // ── The ingest-target fork point (#4770, ADR-0036 §Ingestion) ─────────────
+  //
+  // The brain arm is the only thing that makes the Slack source run at all. If
+  // its catalog id never reached the install query, or the walk routed it to
+  // the DOCUMENT engine, the source would silently never sync and the cycle
+  // would report a clean `inspected: 0` — a green, silent no-op.
+
+  it("routes a registered brain source to the episode engine, not the document one", async () => {
+    _resetBrainSourceConnectors();
+    registerBrainSourceConnector({
+      catalogId: "catalog:fixture-brain",
+      source: "fixture",
+      createClient: () => ({ fetchEpisodes: async () => ({ episodes: [], highWaterMark: null }) }),
+    });
+    brainSyncCalls.length = 0;
+    INSTALL_ROWS = [
+      { workspace_id: ORG, install_id: "chat", catalog_id: "catalog:fixture-brain", config: {} },
+    ];
+
+    const result = await runKnowledgeSyncCycle();
+    expect(result).toEqual({ inspected: 1, succeeded: 1, failed: 0, queryFailed: false });
+    expect(brainSyncCalls).toEqual([
+      { workspaceId: ORG, installId: "chat", source: "fixture" },
+    ]);
+    // The document engine writes its own state row; the brain engine's stub
+    // does not, so an empty state-write list proves the document arm was not
+    // taken as well.
+    expect(stateWrites).toHaveLength(0);
+  });
+
+  it("includes brain-source catalog ids in the install query", async () => {
+    _resetBrainSourceConnectors();
+    registerBrainSourceConnector({
+      catalogId: "catalog:fixture-brain",
+      source: "fixture",
+      createClient: () => ({ fetchEpisodes: async () => ({ episodes: [], highWaterMark: null }) }),
+    });
+    INSTALL_ROWS = [];
+    internalQuery.mockClear();
+    await runKnowledgeSyncCycle();
+    const installsCall = internalQuery.mock.calls.find((call) =>
+      String(call[0]).includes("SELECT workspace_id, install_id"),
+    );
+    expect(installsCall?.[1]?.[0]).toContain("catalog:fixture-brain");
+    _resetBrainSourceConnectors();
+  });
+
+  it("counts a failing brain source without sinking the rest of the cycle", async () => {
+    _resetBrainSourceConnectors();
+    registerBrainSourceConnector({
+      catalogId: "catalog:fixture-brain",
+      source: "fixture",
+      createClient: () => ({ fetchEpisodes: async () => ({ episodes: [], highWaterMark: null }) }),
+    });
+    BRAIN_SYNC_STATUS = "error";
+    INSTALL_ROWS = [
+      { workspace_id: ORG, install_id: "chat", catalog_id: "catalog:fixture-brain", config: {} },
+      { workspace_id: ORG, install_id: "good", catalog_id: "catalog:bundle-sync", config: baseConfig() },
+    ];
+    const { impl } = fetchReturning(fakeResponse({ bytes: zipBundle({ "a.md": "# a" }) }));
+
+    const result = await runKnowledgeSyncCycle({ fetchImpl: impl });
+    expect(result).toEqual({ inspected: 2, succeeded: 1, failed: 1, queryFailed: false });
   });
 });
 

--- a/packages/api/src/lib/knowledge/catalog-claims.ts
+++ b/packages/api/src/lib/knowledge/catalog-claims.ts
@@ -1,0 +1,60 @@
+/**
+ * One catalog id, one ingest target (#4770, ADR-0036 §Ingestion & connectors).
+ *
+ * The sync cycle walk (`lib/knowledge/sync.ts::dispatchInstall`) routes an
+ * install by asking each registry whether it owns the catalog id, and it asks
+ * the BRAIN registry first. That ordering is only safe if a catalog id can
+ * never be in both — otherwise a duplicate would silently take the brain arm
+ * and its knowledge connector would stop syncing with no error anywhere, which
+ * reads as "the connector just quietly stopped".
+ *
+ * This module is that guarantee, and it is a SEPARATE module for a concrete
+ * reason: both registries must claim through the SAME map, or the check is
+ * order-dependent again. Homing the map in either registry makes the other's
+ * call a peek into a sibling — which is exactly the first attempt, a one-sided
+ * check in `registerBrainSourceConnector` that guarded the wrong direction
+ * (brain sources register last today, so the case it caught cannot happen while
+ * the case it missed can).
+ */
+
+/** Which engine's ingest core a catalog id's installs are routed to. */
+export type CatalogIngestTarget = "knowledge-documents" | "brain-episodes";
+
+const claims = new Map<string, CatalogIngestTarget>();
+
+/**
+ * Claim a catalog id for one ingest target, or throw if another already holds
+ * it. Called by BOTH registries at registration time, so the check is
+ * order-independent — which is the whole point, since registration order is a
+ * property of one function in `register.ts` and not an invariant anyone
+ * maintains deliberately.
+ */
+export function claimCatalogIngestTarget(catalogId: string, target: CatalogIngestTarget): void {
+  const existing = claims.get(catalogId);
+  if (existing !== undefined && existing !== target) {
+    throw new Error(
+      `Catalog id "${catalogId}" is already registered as ${existing} — a catalog row must belong to exactly one ingest target, because the sync cycle routes installs by asking one registry before the other`,
+    );
+  }
+  claims.set(catalogId, target);
+}
+
+/** The claimed target for a catalog id, if any. Read by tests. */
+export function getCatalogIngestTarget(catalogId: string): CatalogIngestTarget | undefined {
+  return claims.get(catalogId);
+}
+
+/**
+ * Test-only: release the claims held by ONE target.
+ *
+ * Scoped, not a blanket `clear()`. Each registry's `_reset*` helper calls this,
+ * and a blanket clear would have one registry release the OTHER's claims while
+ * that registry's own map still held them — after which a colliding id could be
+ * registered with no error, and the check would be silently defeated inside CI,
+ * which is the only place it is ever exercised.
+ */
+export function _resetCatalogIngestClaims(target: CatalogIngestTarget): void {
+  for (const [catalogId, held] of claims) {
+    if (held === target) claims.delete(catalogId);
+  }
+}

--- a/packages/api/src/lib/knowledge/connector-sync.ts
+++ b/packages/api/src/lib/knowledge/connector-sync.ts
@@ -160,7 +160,16 @@ function isoOrNull(value: Date | string | null): string | null {
   return Number.isNaN(d.getTime()) ? null : d.toISOString();
 }
 
-async function readConnectorSyncState(
+/**
+ * Read one collection's connector bookkeeping.
+ *
+ * Exported because the brain episode engine (`lib/brain/ingest/episode-sync.ts`,
+ * #4770) reuses this bookkeeping VERBATIM — ADR-0036 forks the ingest core, not
+ * the engine, and a second high-water-mark store would be exactly the
+ * per-vendor duplication ADR-0030 §"Per-vendor backoff / scheduling (rejected)"
+ * exists to prevent.
+ */
+export async function readConnectorSyncState(
   workspaceId: string,
   collectionSlug: string,
 ): Promise<ConnectorSyncState> {
@@ -599,11 +608,52 @@ async function runConnectorAttempt(
   }
 }
 
+/** One attempt's bookkeeping, as {@link upsertConnectorSyncState} binds it. */
+export interface ConnectorSyncStateWrite {
+  readonly status: "success" | "error";
+  readonly error: string | null;
+  /** Persisted verbatim as the state row's JSONB `report`. */
+  readonly report: unknown;
+  /** Non-null ONLY on success — an error attempt COALESCEs the old one forward. */
+  readonly highWaterMark: string | null;
+  readonly cursor: string | null;
+  readonly reconciledAt: string | null;
+}
+
 /**
- * Upsert the per-collection connector bookkeeping row. Never throws — a
- * state-write failure must not fail a sync that already committed (logged at
- * error so a persistently broken state table is visible).
+ * Upsert one collection's bookkeeping row. Never throws — a state-write
+ * failure must not fail a sync that already committed (logged at error so a
+ * persistently broken state table is visible).
+ *
+ * Exported alongside {@link readConnectorSyncState} for the brain episode
+ * engine (#4770); see that function's comment for why the bookkeeping is
+ * shared rather than forked.
  */
+export async function upsertConnectorSyncState(
+  workspaceId: string,
+  collectionSlug: string,
+  write: ConnectorSyncStateWrite,
+): Promise<void> {
+  try {
+    await internalQuery(CONNECTOR_SYNC_STATE_UPSERT_SQL, [
+      workspaceId,
+      collectionSlug,
+      write.status,
+      write.error,
+      JSON.stringify(write.report),
+      write.highWaterMark,
+      write.cursor,
+      write.reconciledAt,
+    ]);
+  } catch (err) {
+    log.error(
+      { workspaceId, collectionSlug, err: err instanceof Error ? err.message : String(err) },
+      "Failed to record knowledge connector sync state — the sync outcome itself is unaffected",
+    );
+  }
+}
+
+/** Shape this engine's report, then hand it to the shared upsert. */
 async function recordConnectorSyncState(
   workspaceId: string,
   collectionSlug: string,
@@ -624,21 +674,12 @@ async function recordConnectorSyncState(
       : outcome.rejected.length > 0
         ? { mode: outcome.mode, rejected: outcome.rejected.slice(0, REPORT_REJECTED_CAP) }
         : { mode: outcome.mode };
-  try {
-    await internalQuery(CONNECTOR_SYNC_STATE_UPSERT_SQL, [
-      workspaceId,
-      collectionSlug,
-      outcome.status,
-      outcome.error,
-      JSON.stringify(report),
-      outcome.highWaterMark,
-      bookkeeping.cursor,
-      bookkeeping.reconciledAt,
-    ]);
-  } catch (err) {
-    log.error(
-      { workspaceId, collectionSlug, err: err instanceof Error ? err.message : String(err) },
-      "Failed to record knowledge connector sync state — the sync outcome itself is unaffected",
-    );
-  }
+  await upsertConnectorSyncState(workspaceId, collectionSlug, {
+    status: outcome.status,
+    error: outcome.error,
+    report,
+    highWaterMark: outcome.highWaterMark,
+    cursor: bookkeeping.cursor,
+    reconciledAt: bookkeeping.reconciledAt,
+  });
 }

--- a/packages/api/src/lib/knowledge/connectors.ts
+++ b/packages/api/src/lib/knowledge/connectors.ts
@@ -174,6 +174,8 @@ export class ConnectorRateLimitError extends Error {
 // Registry — catalog id → connector, read by the sync cycle walk
 // ---------------------------------------------------------------------------
 
+import { claimCatalogIngestTarget, _resetCatalogIngestClaims } from "./catalog-claims";
+
 const VENDOR_SLUG = /^[a-z0-9][a-z0-9-]*$/;
 
 const registry = new Map<string, KnowledgeSyncConnector>();
@@ -195,6 +197,9 @@ export function registerKnowledgeSyncConnector(connector: KnowledgeSyncConnector
       `Knowledge sync connector for catalog id "${connector.catalogId}" is already registered`,
     );
   }
+  // One catalog id, one ingest target — see `catalog-claims.ts` for why the
+  // check lives there and not as a peek into the brain registry.
+  claimCatalogIngestTarget(connector.catalogId, "knowledge-documents");
   registry.set(connector.catalogId, connector);
 }
 
@@ -210,4 +215,5 @@ export function listKnowledgeSyncConnectorCatalogIds(): string[] {
 /** Test-only: clear the registry (tests register fixtures per-suite, never at module top-level). */
 export function _resetKnowledgeSyncConnectors(): void {
   registry.clear();
+  _resetCatalogIngestClaims("knowledge-documents");
 }

--- a/packages/api/src/lib/knowledge/sync.ts
+++ b/packages/api/src/lib/knowledge/sync.ts
@@ -77,6 +77,11 @@ import {
 } from "./connectors";
 import { syncConnectorCollection } from "./connector-sync";
 import {
+  getBrainSourceConnector,
+  listBrainSourceCatalogIds,
+} from "@atlas/api/lib/brain/ingest/types";
+import { syncBrainEpisodeSource } from "@atlas/api/lib/brain/ingest/episode-sync";
+import {
   BUNDLE_SYNC_CATALOG_ID,
   parseBundleSyncConfig,
   type BundleSyncAuthScheme,
@@ -532,13 +537,25 @@ async function recordSyncState(
 }
 
 // ---------------------------------------------------------------------------
-// Cycle — walk every enabled synced collection (the scheduler tick body).
+// Cycle — walk every enabled synced install (the scheduler tick body).
+//
 // Dispatch is keyed on catalog id (#4376): `bundle-sync` installs pull their
 // endpoint through this module's fetch path; installs of a REGISTERED
 // Knowledge Sync Connector catalog row go through the connector engine
 // (`connector-sync.ts` — incremental/reconciliation cadence, high-water
-// marks, 429 backoff). Both engines isolate per-collection failures, so one
-// bad endpoint/vendor never blocks the cycle's remaining collections.
+// marks, 429 backoff).
+//
+// #4770 (ADR-0036 §Ingestion & connectors) adds the third arm, and it is THE
+// FORK POINT the ADR documents: installs of a registered BRAIN SOURCE catalog
+// row run the same cadence/backoff/caps machinery but a different INGEST CORE
+// (`lib/brain/ingest/episode-sync.ts` → append-only episodes, no upsert, no
+// subtractive archive). The dispatch is keyed on which registry owns the
+// catalog id — an ingest-target discriminator — rather than on a flag inside
+// the engine, so `connector-sync.ts` keeps knowing nothing about episodes and
+// the archive path stays structurally unreachable from the brain arm.
+//
+// All three engines isolate per-install failures, so one bad
+// endpoint/vendor/source never blocks the cycle's remaining installs.
 // ---------------------------------------------------------------------------
 
 export interface KnowledgeSyncCycleResult {
@@ -586,7 +603,11 @@ export async function runKnowledgeSyncCycle(options?: {
     return { inspected: 0, succeeded: 0, failed: 0, queryFailed: false };
   }
 
-  const catalogIds = [BUNDLE_SYNC_CATALOG_ID, ...listKnowledgeSyncConnectorCatalogIds()];
+  const catalogIds = [
+    BUNDLE_SYNC_CATALOG_ID,
+    ...listKnowledgeSyncConnectorCatalogIds(),
+    ...listBrainSourceCatalogIds(),
+  ];
   let installs: SyncInstallRow[];
   try {
     installs = await internalQuery<SyncInstallRow>(SYNC_CYCLE_INSTALLS_SQL, [catalogIds]);
@@ -627,11 +648,32 @@ export async function runKnowledgeSyncCycle(options?: {
   return { inspected: installs.length, succeeded, failed, queryFailed: false };
 }
 
-/** Route one install to its engine by catalog id. */
+/**
+ * Route one install to its engine by catalog id — the ingest-target fork point.
+ *
+ * The brain arm is checked first, and the order is safe because the registries
+ * are ENFORCED disjoint in BOTH directions: each one claims its catalog ids
+ * through `catalog-claims.ts` at registration, so whichever registers second
+ * throws. An earlier cut claimed disjointness "by construction" while nothing
+ * constructed it, and the cut after that checked only one direction — the one
+ * that cannot happen given today's registration order. A duplicate id would
+ * otherwise silently take the brain arm and the knowledge connector would stop
+ * syncing with no error anywhere.
+ */
 async function dispatchInstall(
   install: SyncInstallRow,
   options?: { readonly fetchImpl?: typeof globalThis.fetch },
 ): Promise<"success" | "error"> {
+  const brainSource = getBrainSourceConnector(install.catalog_id);
+  if (brainSource !== undefined) {
+    const outcome = await syncBrainEpisodeSource({
+      connector: brainSource,
+      workspaceId: install.workspace_id,
+      installId: install.install_id,
+      config: install.config,
+    });
+    return outcome.status;
+  }
   if (install.catalog_id === BUNDLE_SYNC_CATALOG_ID) {
     const outcome = await syncCollection({
       workspaceId: install.workspace_id,

--- a/packages/api/src/lib/settings.ts
+++ b/packages/api/src/lib/settings.ts
@@ -1708,6 +1708,23 @@ const SETTINGS_REGISTRY: SettingDefinition[] = [
     scope: "platform",
     saasVisible: false,
   },
+  {
+    // Company-brain chat ingest backfill window (#4770, ADR-0036 §Ingestion) —
+    // how far back a chat channel with no stored mark reads on its first pass.
+    // The operator's lever when a first sync hits the per-sync record cap: the
+    // cap warning names this knob. Read per cycle by
+    // `lib/brain/ingest/slack/connector.ts::getChatBackfillWindowMs`.
+    key: "ATLAS_BRAIN_CHAT_BACKFILL_DAYS",
+    section: "Knowledge Base",
+    label: "Chat History Backfill (days)",
+    description:
+      "How much history a newly-connected chat channel reads on its first sync (default 7). Lower it when a first sync reports that a channel has more history than one cycle can read; already-synced channels are unaffected. Hot-reloaded; non-positive values fall back to the default.",
+    type: "number",
+    default: "7",
+    envVar: "ATLAS_BRAIN_CHAT_BACKFILL_DAYS",
+    scope: "platform",
+    saasVisible: false,
+  },
 ];
 
 // ---------------------------------------------------------------------------

--- a/packages/api/src/lib/slack/__tests__/api-read-methods.test.ts
+++ b/packages/api/src/lib/slack/__tests__/api-read-methods.test.ts
@@ -1,0 +1,182 @@
+/**
+ * The Slack read methods the brain chat-history source drives (#4770).
+ *
+ * Three of these branches are load-bearing in ways their size hides:
+ *
+ *   - **`missing_visibility` is a SECURITY branch.** Defaulting a missing
+ *     `is_private` to `false` would publish an invite-only channel's contents
+ *     org-wide, and no review gate downstream can catch it — the reviewer sees
+ *     the grant Atlas derived, not the one Slack had.
+ *   - **`malformed_history_page` is an EVIDENCE branch.** Reading a non-array
+ *     `messages` as "empty channel" lets the caller mark a window covered and
+ *     advance past everything in it, permanently, in a store where nothing
+ *     later notices.
+ *   - **`Retry-After` parsing drives the shared engine's backoff.** Losing it
+ *     makes every throttled cycle sleep the default instead of what Slack
+ *     asked for.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import {
+  fetchConversationHistoryPage,
+  getConversationInfo,
+} from "@atlas/api/lib/slack/api";
+
+const realFetch = globalThis.fetch;
+
+/** Script one response. `headers` are merged into the Response's own. */
+function respondWith(
+  body: unknown,
+  init: { status?: number; headers?: Record<string, string> } = {},
+): void {
+  globalThis.fetch = (async () =>
+    new Response(typeof body === "string" ? body : JSON.stringify(body), {
+      status: init.status ?? 200,
+      headers: { "content-type": "application/json", ...(init.headers ?? {}) },
+    })) as unknown as typeof globalThis.fetch;
+}
+
+beforeEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+describe("getConversationInfo", () => {
+  it("returns the channel's visibility and membership", async () => {
+    respondWith({
+      ok: true,
+      channel: { id: "C1", name: "general", is_private: false, is_member: true },
+    });
+    const result = await getConversationInfo("t", "C1");
+    expect(result).toEqual({
+      ok: true,
+      channel: { id: "C1", name: "general", isPrivate: false, isMember: true, isArchived: false },
+    });
+  });
+
+  it("REFUSES a channel payload with no is_private rather than assuming public", async () => {
+    respondWith({ ok: true, channel: { id: "C1", name: "general" } });
+    const result = await getConversationInfo("t", "C1");
+    expect(result).toEqual({ ok: false, error: "missing_visibility", retryAfterSeconds: null });
+  });
+
+  it("refuses a response with no channel object", async () => {
+    respondWith({ ok: true });
+    const result = await getConversationInfo("t", "C1");
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.error).toBe("malformed_channel");
+  });
+
+  it("passes Slack's own error code through", async () => {
+    respondWith({ ok: false, error: "channel_not_found" });
+    const result = await getConversationInfo("t", "C1");
+    expect(result).toEqual({ ok: false, error: "channel_not_found", retryAfterSeconds: null });
+  });
+});
+
+describe("rate-limit signalling", () => {
+  it("parses Retry-After from a 429", async () => {
+    respondWith({}, { status: 429, headers: { "retry-after": "42" } });
+    const result = await getConversationInfo("t", "C1");
+    expect(result).toEqual({ ok: false, error: "ratelimited", retryAfterSeconds: 42 });
+  });
+
+  it("reports a 429 with no usable Retry-After as null, not zero", async () => {
+    // Null means "the engine picks its default wait"; zero would mean "retry
+    // immediately", which is the opposite instruction.
+    const headerSets: Record<string, string>[] = [{}, { "retry-after": "soon" }, { "retry-after": "-5" }];
+    for (const headers of headerSets) {
+      respondWith({}, { status: 429, headers });
+      const result = await getConversationInfo("t", "C1");
+      expect(result).toEqual({ ok: false, error: "ratelimited", retryAfterSeconds: null });
+    }
+  });
+
+  it("treats an in-body `ratelimited` as throttling too", async () => {
+    // Some Slack tiers signal in-body on a 200. Counting it as a hard failure
+    // would skip the engine's backoff entirely.
+    respondWith({ ok: false, error: "ratelimited" }, { headers: { "retry-after": "7" } });
+    const result = await getConversationInfo("t", "C1");
+    expect(result).toEqual({ ok: false, error: "ratelimited", retryAfterSeconds: 7 });
+  });
+});
+
+describe("fetchConversationHistoryPage", () => {
+  it("narrows a page and reports the pagination cursor", async () => {
+    respondWith({
+      ok: true,
+      messages: [
+        { ts: "1.000001", text: "hi", user: "U1" },
+        { ts: "1.000002", text: "there", user: "U2", subtype: "thread_broadcast", bot_id: "B1" },
+      ],
+      response_metadata: { next_cursor: "abc" },
+    });
+    const result = await fetchConversationHistoryPage("t", { channel: "C1", limit: 200 });
+    expect(result).toEqual({
+      ok: true,
+      messages: [
+        { ts: "1.000001", text: "hi", user: "U1", subtype: null, botId: null },
+        { ts: "1.000002", text: "there", user: "U2", subtype: "thread_broadcast", botId: "B1" },
+      ],
+      nextCursor: "abc",
+      dropped: 0,
+    });
+  });
+
+  it("REFUSES an ok:true response whose messages is not an array", async () => {
+    // Reading this as an empty page would let the caller mark the whole window
+    // covered and advance past it — silent, permanent evidence loss.
+    respondWith({ ok: true, messages: { "0": { ts: "1.0" } } });
+    const result = await fetchConversationHistoryPage("t", { channel: "C1", limit: 200 });
+    expect(result).toEqual({ ok: false, error: "malformed_history_page", retryAfterSeconds: null });
+  });
+
+  it("counts messages with no usable identity instead of dropping them silently", async () => {
+    respondWith({
+      ok: true,
+      messages: [{ ts: "1.000001", text: "kept" }, { text: "no ts" }, null, { ts: "", text: "blank ts" }],
+    });
+    const result = await fetchConversationHistoryPage("t", { channel: "C1", limit: 200 });
+    expect(result.ok && result.messages).toHaveLength(1);
+    expect(result.ok && result.dropped).toBe(3);
+  });
+
+  it("treats an empty next_cursor as the last page", async () => {
+    // An empty-string cursor read as a page would loop forever.
+    respondWith({ ok: true, messages: [], response_metadata: { next_cursor: "" } });
+    const result = await fetchConversationHistoryPage("t", { channel: "C1", limit: 200 });
+    expect(result.ok && result.nextCursor).toBeNull();
+  });
+
+  it("sends oldest / latest / cursor only when given", async () => {
+    let seen = "";
+    globalThis.fetch = (async (url: string | URL) => {
+      seen = String(url);
+      return new Response(JSON.stringify({ ok: true, messages: [] }), {
+        headers: { "content-type": "application/json" },
+      });
+    }) as unknown as typeof globalThis.fetch;
+    await fetchConversationHistoryPage("t", { channel: "C1", limit: 200, oldest: "1.0" });
+    expect(seen).toContain("oldest=1.0");
+    expect(seen).not.toContain("latest=");
+    expect(seen).not.toContain("cursor=");
+  });
+
+  it("reports a transport failure rather than an empty page", async () => {
+    globalThis.fetch = (async () => {
+      throw new Error("ECONNRESET");
+    }) as unknown as typeof globalThis.fetch;
+    const result = await fetchConversationHistoryPage("t", { channel: "C1", limit: 200 });
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.error).toContain("request_failed");
+  });
+
+  it("reports a non-2xx as an HTTP error", async () => {
+    respondWith("nope", { status: 503 });
+    const result = await fetchConversationHistoryPage("t", { channel: "C1", limit: 200 });
+    expect(result.ok === false && result.error).toBe("HTTP 503");
+  });
+});

--- a/packages/api/src/lib/slack/api.ts
+++ b/packages/api/src/lib/slack/api.ts
@@ -199,6 +199,286 @@ async function fetchChannelPages(
   return { ok: true, channels };
 }
 
+// ---------------------------------------------------------------------------
+// Read methods for the brain chat-history source (#4770)
+// ---------------------------------------------------------------------------
+
+/**
+ * A read-method failure. `retryAfterSeconds` is Slack's parsed `Retry-After`
+ * on a 429 and `null` otherwise.
+ *
+ * The existing {@link slackAPI} collapses a 429 into `HTTP 429` and DROPS the
+ * header, which is fine for the fire-and-forget `chat.*` writes it serves but
+ * not for a scheduled crawl: the shared connector engine's bounded backoff is
+ * driven by `Retry-After`, and without it every throttled cycle would sleep
+ * the default 2s regardless of what Slack asked for. Hence the separate read
+ * path rather than a widened `slackAPI` return type — the write callers have
+ * no use for the field and would all have to grow a branch for it.
+ */
+/**
+ * The failure codes that CARRY BEHAVIOUR — each one is branched on by the brain
+ * client (`brain/ingest/slack/client.ts`) or the install handler to produce a
+ * specific, actionable message. Slack's own error vocabulary is open, so the
+ * type stays open (`string & {}`); naming these keeps a typo on either side of
+ * the branch from silently falling through to the generic arm, which for
+ * `"ratelimited"` would turn a backoff into a hard cycle failure.
+ */
+export type SlackReadErrorCode =
+  | "ratelimited"
+  | "missing_scope"
+  | "not_in_channel"
+  | "channel_not_found"
+  | "invalid_auth"
+  | "token_revoked"
+  | "account_inactive"
+  | "malformed_channel"
+  | "missing_visibility"
+  | "malformed_history_page";
+
+export interface SlackReadError {
+  readonly ok: false;
+  // `string & {}` keeps the union open (Slack's vocabulary is) while preserving
+  // autocomplete + typo-checking on the arms above that carry behaviour.
+  readonly error: SlackReadErrorCode | (string & {});
+  readonly retryAfterSeconds: number | null;
+}
+
+/** Per-request timeout for the scheduled read methods. */
+const READ_TIMEOUT_MS = 15_000;
+
+/** Parse Slack's `Retry-After` (delta-seconds) — null when absent/unusable. */
+function parseRetryAfter(headers: Headers): number | null {
+  const raw = headers.get("retry-after");
+  if (raw === null) return null;
+  const seconds = Number.parseInt(raw.trim(), 10);
+  return Number.isFinite(seconds) && seconds >= 0 ? seconds : null;
+}
+
+/**
+ * GET a Slack read method. Unlike `chat.*`, the read namespace takes
+ * query-string args (a JSON body is rejected), which is also why this does not
+ * route through {@link slackAPI}'s POST path.
+ */
+async function slackReadGet(
+  method: string,
+  token: string,
+  params: URLSearchParams,
+): Promise<{ ok: true; data: Record<string, unknown> } | SlackReadError> {
+  try {
+    const resp = await fetch(`${SLACK_API_BASE}/${method}?${params.toString()}`, {
+      method: "GET",
+      headers: { Authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(READ_TIMEOUT_MS),
+    });
+    if (resp.status === 429) {
+      const retryAfterSeconds = parseRetryAfter(resp.headers);
+      log.warn({ method, retryAfterSeconds }, "Slack API rate limited");
+      return { ok: false, error: "ratelimited", retryAfterSeconds };
+    }
+    if (!resp.ok) {
+      log.error({ method, status: resp.status }, "Slack API HTTP error");
+      return { ok: false, error: `HTTP ${resp.status}`, retryAfterSeconds: null };
+    }
+    const data = (await resp.json()) as Record<string, unknown>;
+    if (!data.ok) {
+      const error = String((data.error as string | undefined) ?? "unknown_error");
+      log.warn({ method, error }, "Slack API returned error");
+      // Slack also signals throttling in-body on some tiers; treat it the same
+      // so the engine backs off instead of counting it as a hard failure.
+      return {
+        ok: false,
+        error,
+        retryAfterSeconds: error === "ratelimited" ? parseRetryAfter(resp.headers) : null,
+      };
+    }
+    return { ok: true, data };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error({ method, err: message }, "Slack API request failed");
+    return { ok: false, error: `request_failed: ${message}`, retryAfterSeconds: null };
+  }
+}
+
+/** One channel's metadata, projected to what grant derivation needs. */
+export interface SlackConversationInfo {
+  readonly id: string;
+  readonly name: string;
+  readonly isPrivate: boolean;
+  readonly isMember: boolean;
+  readonly isArchived: boolean;
+}
+
+/**
+ * `conversations.info` for one channel.
+ *
+ * The brain source reads this per configured channel per cycle rather than
+ * reusing `listChannels`: the listing is page-capped (1000 channels) and
+ * excludes archived conversations, so a channel outside it would come back
+ * with UNKNOWN visibility — and unknown visibility has to be treated as
+ * private, which would silently hide a public channel's episodes from
+ * everyone. One authoritative call per channel removes the ambiguity.
+ *
+ * `is_private` is REQUIRED to be present: Slack always sends it, and defaulting
+ * a missing field to `false` would publish an invite-only channel's contents
+ * org-wide on a malformed response.
+ */
+export async function getConversationInfo(
+  token: string,
+  channelId: string,
+): Promise<{ ok: true; channel: SlackConversationInfo } | SlackReadError> {
+  const result = await slackReadGet(
+    "conversations.info",
+    token,
+    new URLSearchParams({ channel: channelId }),
+  );
+  if (!result.ok) return result;
+  const raw = result.data.channel;
+  if (raw === null || typeof raw !== "object") {
+    // `slackReadGet` logged nothing — `data.ok` was true — so a Slack
+    // response-shape change would otherwise surface only as an opaque string in
+    // a JSONB state column.
+    log.error(
+      { method: "conversations.info", channel: channelId },
+      "Slack returned ok:true with no channel object — the response shape changed",
+    );
+    return { ok: false, error: "malformed_channel", retryAfterSeconds: null };
+  }
+  const channel = raw as Record<string, unknown>;
+  if (typeof channel.is_private !== "boolean") {
+    log.error(
+      { method: "conversations.info", channel: channelId },
+      "Slack channel payload carries no is_private flag — refusing to assume the channel is public",
+    );
+    return { ok: false, error: "missing_visibility", retryAfterSeconds: null };
+  }
+  return {
+    ok: true,
+    channel: {
+      id: typeof channel.id === "string" ? channel.id : channelId,
+      name: typeof channel.name === "string" ? channel.name : channelId,
+      isPrivate: channel.is_private,
+      isMember: channel.is_member === true,
+      isArchived: channel.is_archived === true,
+    },
+  };
+}
+
+/** One raw message from `conversations.history`, narrowed to what we store. */
+export interface SlackHistoryMessage {
+  /** The per-channel message identity — the episode source-id's second half. */
+  readonly ts: string;
+  readonly text: string;
+  readonly user: string | null;
+  /**
+   * Present on non-plain messages (`channel_join`, `thread_broadcast`,
+   * `file_share`, …). NOT `message_changed` — that is an Events API subtype and
+   * `conversations.history` never returns it (history serves the message's
+   * current state, with the edit recorded in an `edited` sub-object).
+   */
+  readonly subtype: string | null;
+  /** Set when the message was posted by a bot/app rather than a human. */
+  readonly botId: string | null;
+}
+
+export interface SlackHistoryPage {
+  readonly ok: true;
+  readonly messages: readonly SlackHistoryMessage[];
+  /** Slack's pagination cursor; null when the page was the last one. */
+  readonly nextCursor: string | null;
+  /**
+   * Entries Slack returned that carry no usable identity (not an object, or no
+   * `ts`). Reported rather than swallowed: they occupy the window the caller is
+   * about to mark covered, so a caller that cares about gaplessness must treat
+   * a non-zero count as incomplete coverage.
+   */
+  readonly dropped: number;
+}
+
+export interface SlackHistoryPageParams {
+  readonly channel: string;
+  /** Only messages AFTER this Slack ts (exclusive — `inclusive` is not set). */
+  readonly oldest?: string;
+  /** Only messages up to this Slack ts. */
+  readonly latest?: string;
+  readonly cursor?: string;
+  readonly limit: number;
+}
+
+/**
+ * One page of `conversations.history`.
+ *
+ * Pagination is Slack's cursor, walking NEWEST → oldest within
+ * `[oldest, latest]`. The caller owns the walk (and the budget); this function
+ * owns only the request shape and the narrowing.
+ *
+ * Requires the `channels:history` / `groups:history` scopes — a token without
+ * them fails `missing_scope`, which the caller surfaces as an actionable
+ * "re-run the Slack consent flow", never a silent empty page.
+ */
+export async function fetchConversationHistoryPage(
+  token: string,
+  params: SlackHistoryPageParams,
+): Promise<SlackHistoryPage | SlackReadError> {
+  const query = new URLSearchParams({
+    channel: params.channel,
+    limit: String(params.limit),
+  });
+  if (params.oldest !== undefined) query.set("oldest", params.oldest);
+  if (params.latest !== undefined) query.set("latest", params.latest);
+  if (params.cursor !== undefined) query.set("cursor", params.cursor);
+
+  const result = await slackReadGet("conversations.history", token, query);
+  if (!result.ok) return result;
+
+  // An `ok:true` response whose `messages` is not an array is a PROTOCOL
+  // VIOLATION, not an empty channel. Treating it as `[]` would let the caller
+  // conclude the window was covered and advance its mark past everything in it
+  // — permanent, silent evidence loss in a store where nothing later notices.
+  if (!Array.isArray(result.data.messages)) {
+    log.error(
+      { method: "conversations.history", channel: params.channel },
+      "Slack returned ok:true with a non-array `messages` — refusing to read it as an empty page",
+    );
+    return { ok: false, error: "malformed_history_page", retryAfterSeconds: null };
+  }
+  const messages: SlackHistoryMessage[] = [];
+  let dropped = 0;
+  for (const entry of result.data.messages) {
+    if (entry === null || typeof entry !== "object") {
+      dropped++;
+      continue;
+    }
+    const m = entry as Record<string, unknown>;
+    // A message with no `ts` has no identity — it cannot be deduped, so it is
+    // skipped rather than stored under a fabricated key. Counted, never silent:
+    // the caller must not advance a mark past a message it could not identify.
+    if (typeof m.ts !== "string" || m.ts === "") {
+      dropped++;
+      continue;
+    }
+    messages.push({
+      ts: m.ts,
+      text: typeof m.text === "string" ? m.text : "",
+      user: typeof m.user === "string" && m.user !== "" ? m.user : null,
+      subtype: typeof m.subtype === "string" && m.subtype !== "" ? m.subtype : null,
+      botId: typeof m.bot_id === "string" && m.bot_id !== "" ? m.bot_id : null,
+    });
+  }
+
+  const meta = result.data.response_metadata as { next_cursor?: unknown } | undefined;
+  const nextCursor =
+    typeof meta?.next_cursor === "string" && meta.next_cursor.length > 0
+      ? meta.next_cursor
+      : null;
+  if (dropped > 0) {
+    log.warn(
+      { method: "conversations.history", channel: params.channel, dropped },
+      "Slack history page contained messages with no usable identity — they cannot be stored",
+    );
+  }
+  return { ok: true, messages, nextCursor, dropped };
+}
+
 /**
  * Post a message to a Slack channel.
  */

--- a/packages/types/src/knowledge.ts
+++ b/packages/types/src/knowledge.ts
@@ -50,6 +50,13 @@ export interface KnowledgeDocumentCounts {
  *     Help Scout Docs API via a single Docs API key; one collection per Docs
  *     site, one document per published article).
  *
+ *   - `slack-history` — the #4770 company-brain CHAT SOURCE (ADR-0036). The one
+ *     member that does not mirror DOCUMENTS: it reads Slack channel history
+ *     into `brain_episodes` as immutable tier-3 evidence, so its collection
+ *     always reports zero documents. It is listed here because it installs and
+ *     syncs through the same knowledge-pillar spine; the brain's own review
+ *     surface is #4772.
+ *
  * Every value except `upload` is a "synced" collection: its content is owned by
  * an external source, it has last-sync bookkeeping, and it can be re-pulled with
  * "Sync now". Only `bundle-sync` additionally exposes an `endpointUrl` /
@@ -70,7 +77,8 @@ export type KnowledgeCollectionSource =
   | "intercom"
   | "front"
   | "helpscout"
-  | "freshdesk";
+  | "freshdesk"
+  | "slack-history";
 
 /**
  * Bundle-endpoint auth schemes for `bundle-sync` collections — the one wire
@@ -89,6 +97,26 @@ export interface KnowledgeCollectionSyncStatus {
   readonly status: "success" | "error";
   /** Actionable failure message when the last attempt errored. */
   readonly error: string | null;
+  /**
+   * True when the last attempt SUCCEEDED but knowingly left part of its window
+   * uncovered — a per-sync budget ran out, a sub-source was unreadable, a
+   * vendor enumeration was partial (#4770). A green row with deferred work is
+   * how a source that is achieving nothing goes unnoticed, so the deferral is
+   * reported rather than left in the state row's JSONB report.
+   */
+  readonly coverageIncomplete: boolean;
+  /**
+   * Why the last sync deferred work, when it did — the first of the engine's
+   * warnings ("channel C2 was not read this cycle", "Atlas is not a member of
+   * C3", "the Slack connection is missing the history scopes"). `null` on a
+   * clean sync.
+   *
+   * A flag with no reason is a flag an operator cannot act on: "the record
+   * budget ran out", "the bot was removed from a channel" and "Slack returned
+   * unidentifiable messages" need different fixes and would otherwise be
+   * indistinguishable.
+   */
+  readonly coverageDetail: string | null;
 }
 
 /**

--- a/packages/web/src/app/admin/knowledge/__tests__/knowledge-page.test.tsx
+++ b/packages/web/src/app/admin/knowledge/__tests__/knowledge-page.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, test, mock, beforeEach, afterEach } from "bun:test";
 import { useState } from "react";
 import { render, cleanup, screen } from "@testing-library/react";
 import type { KnowledgeCollection, KnowledgeCollectionListResponse } from "@/ui/lib/types";
+import { KnowledgeCollectionSchema } from "@/ui/lib/admin-schemas";
 
 // --- Mocks (declared before importing the page so it binds to them) --------
 
@@ -54,7 +55,7 @@ function syncedCollection(partial: Partial<KnowledgeCollection> = {}): Knowledge
     slug: "synced-docs",
     source: "bundle-sync",
     endpointUrl: "https://kb.example.com/bundle.tar.gz",
-    sync: { lastSyncAt: "2026-07-02T01:00:00.000Z", status: "success", error: null },
+    sync: { lastSyncAt: "2026-07-02T01:00:00.000Z", status: "success", error: null, coverageIncomplete: false, coverageDetail: null },
     ...partial,
   });
 }
@@ -66,7 +67,7 @@ function connectorCollection(partial: Partial<KnowledgeCollection> = {}): Knowle
     // Connectors carry no bundle endpoint / auth scheme.
     endpointUrl: null,
     authScheme: null,
-    sync: { lastSyncAt: "2026-07-02T02:00:00.000Z", status: "success", error: null },
+    sync: { lastSyncAt: "2026-07-02T02:00:00.000Z", status: "success", error: null, coverageIncomplete: false, coverageDetail: null },
     ...partial,
   });
 }
@@ -135,6 +136,7 @@ describe("KnowledgePage", () => {
               lastSyncAt: "2026-07-02T01:00:00.000Z",
               status: "error",
               error: 'Bundle endpoint "kb.example.com" responded HTTP 403',
+              coverageIncomplete: false, coverageDetail: null,
             },
           }),
         ],
@@ -158,7 +160,7 @@ describe("KnowledgePage", () => {
       data: {
         collections: [
           connectorCollection({
-            sync: { lastSyncAt: "2026-07-02T02:00:00.000Z", status: "success", error: null },
+            sync: { lastSyncAt: "2026-07-02T02:00:00.000Z", status: "success", error: null, coverageIncomplete: false, coverageDetail: null },
           }),
         ],
       },
@@ -187,7 +189,7 @@ describe("describeSync", () => {
     expect(
       describeSync(
         syncedCollection({
-          sync: { lastSyncAt: "2026-07-02T01:00:00.000Z", status: "error", error: "boom" },
+          sync: { lastSyncAt: "2026-07-02T01:00:00.000Z", status: "error", error: "boom", coverageIncomplete: false, coverageDetail: null },
         }),
       ),
     ).toBe("sync-failed");
@@ -195,5 +197,78 @@ describe("describeSync", () => {
   test("classifies connector collections too (#4377)", () => {
     expect(describeSync(connectorCollection())).toBe("synced");
     expect(describeSync(connectorCollection({ sync: null }))).toBe("never-synced");
+  });
+});
+
+describe("a partially-covered sync is visibly different from a clean one (#4770)", () => {
+  test("describeSync distinguishes deferred work from a clean success", () => {
+    // The whole point of the API-side coverage plumbing. Collapsing this to
+    // "synced" makes a source quietly achieving nothing — a channel the bot was
+    // removed from, a budget that never clears — indistinguishable from one
+    // that is working, which is how a broken ingest goes unnoticed for weeks.
+    const clean = syncedCollection({
+      sync: {
+        lastSyncAt: "2026-07-02T02:00:00.000Z",
+        status: "success",
+        error: null,
+        coverageIncomplete: false, coverageDetail: null,
+      },
+    });
+    const partial = syncedCollection({
+      sync: {
+        lastSyncAt: "2026-07-02T02:00:00.000Z",
+        status: "success",
+        error: null,
+        coverageIncomplete: true,
+        coverageDetail: "Channel C2 was not read this cycle — the per-sync record budget (250) was reached first. It resumes next cycle.",
+      },
+    });
+    expect(describeSync(clean)).toBe("synced");
+    expect(describeSync(partial)).toBe("partially-synced");
+  });
+
+  test("the card renders the partial state rather than a plain green tick", () => {
+    fetchState = {
+      data: {
+        collections: [
+          syncedCollection({
+            sync: {
+              lastSyncAt: "2026-07-02T02:00:00.000Z",
+              status: "success",
+              error: null,
+              coverageIncomplete: true,
+        coverageDetail: "Channel C2 was not read this cycle — the per-sync record budget (250) was reached first. It resumes next cycle.",
+            },
+          }),
+        ],
+      },
+      loading: false,
+      error: null,
+    };
+    render(<KnowledgePage />);
+    expect(screen.getByText(/Partially synced/)).toBeDefined();
+  });
+});
+
+describe("the collection schema tolerates an older API (#4770)", () => {
+  test("a sync object without coverageIncomplete parses, defaulting to false", () => {
+    // `useAdminFetch` THROWS on a parse failure, so a required field here would
+    // error the whole Knowledge page for every workspace with a sync row during
+    // an api↔web deploy-overlap window.
+    const parsed = KnowledgeCollectionSchema.parse({
+      slug: "docs",
+      source: "bundle-sync",
+      description: null,
+      installedAt: null,
+      endpointUrl: null,
+      authScheme: null,
+      sync: {
+        lastSyncAt: "2026-07-02T02:00:00.000Z",
+        status: "success",
+        error: null,
+      },
+      documents: { draft: 0, published: 0, archived: 0 },
+    });
+    expect(parsed.sync?.coverageIncomplete).toBe(false);
   });
 });

--- a/packages/web/src/app/admin/knowledge/knowledge-connectors.ts
+++ b/packages/web/src/app/admin/knowledge/knowledge-connectors.ts
@@ -1,6 +1,7 @@
 import {
   BookMarked,
   BookText,
+  Brain,
   Cloud,
   FileUp,
   Globe,
@@ -50,6 +51,7 @@ const SLUG_TO_SOURCE: Readonly<Record<string, KnowledgeCollectionSource>> = {
   front: "front",
   helpscout: "helpscout",
   freshdesk: "freshdesk",
+  "slack-history": "slack-history",
 };
 
 /**
@@ -79,6 +81,7 @@ const CONNECTOR_ICONS: Readonly<Record<string, LucideIcon>> = {
   front: Inbox,
   helpscout: LifeBuoy,
   freshdesk: Headset,
+  "slack-history": Brain,
 };
 
 /** Tile icon for a slug; a future connector falls back to the generic glyph. */
@@ -124,4 +127,8 @@ export const KNOWLEDGE_DISPLAY_ORDER: readonly string[] = [
   "front",
   "helpscout",
   "freshdesk",
+  // #4770: a brain SOURCE, not a document mirror. Last in the picker because
+  // it is the odd one out — its collection reports zero documents, since its
+  // rows land in `brain_episodes` rather than `knowledge_documents`.
+  "slack-history",
 ];

--- a/packages/web/src/app/admin/knowledge/page.tsx
+++ b/packages/web/src/app/admin/knowledge/page.tsx
@@ -304,13 +304,23 @@ export function describeArchive(collection: KnowledgeCollection): string {
  * Classify a synced collection's footer state (the card renders the actual
  * line): `null` for upload collections, `"never-synced"` before the first
  * attempt, else the last attempt's outcome. Exported for tests.
+ *
+ * `"partially-synced"` (#4770) is a SUCCESS that knowingly deferred part of its
+ * window — a per-sync budget that ran out, a chat channel the bot was removed
+ * from, a vendor enumeration that came back partial. It is distinguished from
+ * `"synced"` because a source quietly achieving nothing and a source working
+ * correctly must not render the same; that indistinguishability is how a
+ * broken ingest goes unnoticed for weeks.
  */
-export function describeSync(collection: KnowledgeCollection): "synced" | "sync-failed" | "never-synced" | null {
+export function describeSync(
+  collection: KnowledgeCollection,
+): "synced" | "partially-synced" | "sync-failed" | "never-synced" | null {
   // Every non-upload source is synced (endpoint or connector) and carries
   // last-sync bookkeeping; only upload collections have no sync footer.
   if (collection.source === "upload") return null;
   if (!collection.sync) return "never-synced";
-  return collection.sync.status === "success" ? "synced" : "sync-failed";
+  if (collection.sync.status !== "success") return "sync-failed";
+  return collection.sync.coverageIncomplete ? "partially-synced" : "synced";
 }
 
 function CollectionCard({
@@ -367,6 +377,18 @@ function CollectionCard({
             <>
               Synced <RelativeTimestamp iso={collection.sync.lastSyncAt} />
             </>
+          ) : syncState === "partially-synced" && collection.sync ? (
+            // Amber, not green and not red: the attempt succeeded, but it left
+            // work undone and will keep doing so until someone looks.
+            <span
+              className="text-amber-600 dark:text-amber-500"
+              title={
+                collection.sync.coverageDetail ??
+                "The last sync succeeded but did not cover its whole window."
+              }
+            >
+              Partially synced <RelativeTimestamp iso={collection.sync.lastSyncAt} />
+            </span>
           ) : syncState === "sync-failed" && collection.sync ? (
             <span
               className="text-destructive"

--- a/packages/web/src/ui/lib/admin-schemas.ts
+++ b/packages/web/src/ui/lib/admin-schemas.ts
@@ -677,11 +677,24 @@ const KnowledgeCollectionSyncStatusSchema = z.object({
   lastSyncAt: z.string(),
   status: z.enum(["success", "error"]),
   error: z.string().nullable(),
+  /**
+   * Last sync succeeded but knowingly deferred part of its window (#4770).
+   *
+   * `.default(false)`: added in v0.2.0 — an older API omits it during an
+   * api↔web deploy-overlap window, and `useAdminFetch` THROWS on a parse
+   * failure, so a required field here would error the whole Knowledge page for
+   * every workspace with a sync row until both services land. Same rule as
+   * `skippedNonMarkdown`'s `.default(0)` below. Tighten in a later release once
+   * no deployed API can omit it.
+   */
+  coverageIncomplete: z.boolean().default(false),
+  /** Why, when `coverageIncomplete`. `.default(null)` for the same reason. */
+  coverageDetail: z.string().nullable().default(null),
 });
 
 export const KnowledgeCollectionSchema = z.object({
   slug: z.string(),
-  source: z.enum(["upload", "bundle-sync", "notion", "confluence", "confluence-datacenter", "gitbook", "zendesk", "salesforce-knowledge", "intercom", "front", "helpscout", "freshdesk"]),
+  source: z.enum(["upload", "bundle-sync", "notion", "confluence", "confluence-datacenter", "gitbook", "zendesk", "salesforce-knowledge", "intercom", "front", "helpscout", "freshdesk", "slack-history"]),
   description: z.string().nullable(),
   installedAt: z.string().nullable(),
   endpointUrl: z.string().nullable(),


### PR DESCRIPTION
The first ingest source for the company brain (ADR-0036 §Ingestion & connectors). Reads history from chosen Slack channels into `brain_episodes` as immutable tier-3 evidence. Nothing here writes a fact and nothing here publishes — the claims drawn from these episodes are #4771's, and they pass #4769's review gate before anything becomes authoritative.

Part of **v0.2.0 — Brain M1** (issue 4 of 9). Targets `milestone/v0.2.0-brain-m1`, not `main`.

## What is reused, and what is forked

ADR-0036 §T6 is a two-part instruction and both halves are honoured.

**Reused verbatim — the ADR-0030 connector engine.** One scheduler fiber, one cycle walk, the incremental-vs-reconcile cadence knob, the overlap window, `withRateLimitBackoff`, `resolveIngestCaps`, and the `knowledge_sync_state` bookkeeping (whose COALESCE-forward semantics mean a failed cycle can never skip what it failed to ingest). `connector-sync.ts` gains only additive exports; its behaviour is unchanged.

**Forked — the ingest core only** (`lib/brain/ingest/`):

| Knowledge documents | Brain episodes |
|---|---|
| identified by PATH | identified by SOURCE-ID |
| mutable — upsert-by-path | immutable — `ON CONFLICT … DO NOTHING` |
| absent path on a full crawl → **archived** | absent record → simply absent; **nothing is ever archived** |
| content-mode registered | deliberately NOT registered — evidence is not review-gated |

The dispatch is `dispatchInstall`, keyed on which registry owns the catalog id. Because the brain arm never calls `ingestDocuments`, the subtractive-archive path is **structurally unreachable** rather than switched off — pinned by `episode-sync-archive.test.ts`.

## Decisions worth reviewing

- **Source-id contract** `<channelId>:<ts>`, documented with the per-writer field paths a future webhook writer (M3) must use — `event.message.ts` on a `message_changed` event, **not** `event.ts`, or every edited message duplicates.
- **Grants** derived at ingest: public → `[org]`, private → `[audience:chat-channel:slack:<id>]`. The deriver emits only tokens `parseGrant` finds usable and the ingest core re-checks, keeping #4769's `GRANT_UNUSABLE` refusal defence-in-depth rather than a live trap (`['everyone']` passes the 0180 CHECK and grants nobody). Private-channel membership is #4771's, so those episodes are visible to nobody until it lands — fail-closed and repairable with no rewrite.
- **A per-channel cursor as a discriminated union** (`contiguous` | `backfilling`). Slack pages newest→oldest, so a budget-limited pass covers the top of its window and leaves a hole at the bottom — and in an append-only store "absent" and "not yet fetched" look identical. The union plus two rules (an unreached channel keeps its mark; an unresumable truncation keeps its mark) make truncation **convergent AND gapless**.
- **Two budgets.** `maxEpisodes` is a hard contract checked per record: an over-cap batch is refused by the engine, and the error path carries the old cursor forward, so it would fail identically *forever*. A separate page budget bounds vendor calls, which kept episodes cannot.
- **Credentials reuse the existing Slack OAuth install**, as `salesforce-knowledge` reuses Salesforce (ADR-0030 amendment #4397). No new Slack app, no new secret path.

## ⚠️ Operational gate before deploy

`SLACK_SCOPES` gains `channels:history,groups:history`. That string **is** the OAuth `scope=` param, so without it no reconnect could ever grant them. The Slack app **manifest** must carry both scopes first — **staging, then every prod region** — or Slack rejects the consent screen for the *whole* install, including the live chat adapter. The failure is invisible to Atlas (the user never returns to the callback). See `docs/development/brain-slack-history.md`.

## Known, deliberate warts

The install is a `pillar='knowledge'` row — which is exactly what buys the verbatim engine reuse — so it appears on /admin/knowledge with **zero documents** and **consumes a collection slot**. Both are stated in the code and the doc. "Sync now" routes to the episode engine. A sync that deferred work reports `coverageIncomplete` plus a reason, rendered as an amber **"Partially synced"**, so a source quietly achieving nothing is visibly different from one that works.

Thread replies are not fetched at all (needs `conversations.replies`, M3's).

## Acceptance criteria

- [x] Channel history lands as immutable episodes; a re-poll writes zero new rows — proven against real Postgres, including the stronger claim that re-ingest is a **no-op, not an upsert** (a changed body leaves the stored evidence untouched)
- [x] Engine's subtractive-archive path provably untouched — structural pin, not a flag
- [x] Scheduling/backoff/caps from the existing engine; no second scheduler
- [x] Per-connector source-id contract documented, including the webhook/poll field-path divergence
- [x] Staging-first credentials — no new OAuth app; the scope/manifest sequence is documented and called out above

## Testing

~180 new/changed assertions across 8 suites, plus a real-Postgres suite and an end-to-end multi-cycle gaplessness property test (400 messages at a quarter budget: asserts the union equals the full set *and* that it terminates).

**Three review-panel rounds, each mutation-verified** — every guard was broken deliberately to confirm its test goes red:
- **Round 1** caught a budget overshoot that wedged the 250-record trial/starter tiers *permanently* (the engine refuses an over-cap batch; the error path carries the cursor forward, so it recomputes and fails identically forever).
- **Round 2** caught round 1's own fix deleting cursor marks for every channel after a mid-pass rate limit, and a truncation that discarded an in-flight backfill into a non-convergent loop.
- **Round 3** caught a red `SLACK_SCOPES` assertion and four round-2 fixes that no test pinned.

`/ci`: 30/32 gates green. `openapi-drift` was a false positive from uncommitted staging (the gate reads `git status --porcelain`) and passes post-commit. The `test` gate's only failures are the documented WSL2 shared-PG contention set — a different 6–8 files each run, all green when re-run serially; GitHub's sharded `api-tests` with a dedicated PG per shard is the arbiter.

`Analyze (javascript-typescript)` (CodeQL) is default-setup and main-only, so it will not run here — **deferred to the milestone→main PR, not waived**.

Closes #4770

https://claude.ai/code/session_01UZrPRTASkFqSGfytKuPfRA