### PR TITLE
feat(api): async extraction fiber + entry-point-agnostic reconcile stage (#4771)

### DIFF
--- a/packages/api/src/lib/audit/actions.ts
+++ b/packages/api/src/lib/audit/actions.ts
@@ -612,6 +612,17 @@ export const ADMIN_ACTIONS = {
     uninstall: "knowledge.uninstall",
   },
   /**
+   * Company brain (#4771, ADR-0036). `extractionCycle` is the per-tick row the
+   * async extraction fiber emits on EVERY terminal path — including the
+   * nothing-to-do one — so the ABSENCE of a row over a window is the "the fiber
+   * stopped" signal, the same forensic invariant
+   * `model_config.catalog_refresh_cycle` carries. Platform-scoped: one tick
+   * drains episodes across workspaces, so no single org owns the row.
+   */
+  brain: {
+    extractionCycle: "brain.extraction_cycle",
+  },
+  /**
    * Without these entries a compromised admin could shrink retentionDays
    * and hard-delete the audit trail leaving zero forensic record.
    *

--- a/packages/api/src/lib/billing/enforcement.ts
+++ b/packages/api/src/lib/billing/enforcement.ts
@@ -953,7 +953,8 @@ const CHAT_CAP_CHECK_FAILED_MSG = "Unable to verify plan limits. Please try agai
  * `hashtext('atlas_migrations')`, `rotate-encryption-key` `0x1f47`,
  * `backfill-plugin-config` `0x1f42`). Its peers in the two-arg space are
  * `lead-outbox` (2870), `last-admin` (3158), `stripe-subscription` (3445),
- * `demo-seed` (3683), and `knowledge-install` (4235) — all pairwise distinct.
+ * `demo-seed` (3683), `knowledge-install` (4235), and `brain-reconcile` (4771)
+ * — all pairwise distinct.
  * Value is this issue's number.
  */
 const CHAT_INSTALL_LOCK_NAMESPACE = 3001;
@@ -1409,7 +1410,8 @@ export function checkChatIntegrationLimitAndInstall<
  * the `classkey` arg of the two-arg `pg_advisory_xact_lock(int4, int4)`. Value
  * is this issue's number, and is distinct from every other two-arg user
  * (`lead-outbox` 2870, chat-install 3001, last-admin 3158, stripe-subscription
- * 3445, demo-seed 3683) so knowledge installs never serialize behind them.
+ * 3445, demo-seed 3683, brain-reconcile 4771) so knowledge installs never
+ * serialize behind them.
  */
 const KNOWLEDGE_INSTALL_LOCK_NAMESPACE = 4235;
 

--- a/packages/api/src/lib/brain/__tests__/extract-reconcile-pg.test.ts
+++ b/packages/api/src/lib/brain/__tests__/extract-reconcile-pg.test.ts
@@ -1,0 +1,421 @@
+/**
+ * Real-Postgres coverage for the extraction fiber + reconcile stage (#4771,
+ * ADR-0036 §Ingestion & connectors).
+ *
+ * The unit suites pin the DECISIONS (which failure blocks, which flags) against
+ * an in-memory executor. Everything below is a claim only a live schema can
+ * settle, and every one of them would pass vacuously against a mock:
+ *
+ *   1. **Does a reconciled fact actually land `draft`?** The insert omits
+ *      `status` entirely, because migration 0180's default IS the review gate
+ *      applying itself (#4769). A mock cannot tell that apart from a writer
+ *      that forgot the column — only the stored row can.
+ *   2. **Is the episode's batch genuinely atomic?** "One transaction, no
+ *      half-formed rows" is a property of BEGIN/ROLLBACK, not of the
+ *      TypeScript around it. A failure part-way through a multi-candidate
+ *      episode must leave NOTHING behind — including the facts that had
+ *      already succeeded.
+ *   3. **Does re-running extraction over an already-extracted window no-op?**
+ *      Acceptance criterion 5, and the thing that makes work-then-stamp safe.
+ *      It rests on the corroboration lookup + the edge's `NOT EXISTS` guard
+ *      running against real rows.
+ *   4. **Do the queue mechanics hold?** The drain reads
+ *      `idx_brain_episodes_extraction_queue`'s predicate, a completed pass
+ *      stamps `extracted_at`, and a FAILED pass does not — the difference
+ *      between "retried next cycle" and "silently dropped".
+ *   5. **Do the CHECKs the block-stage stands in front of actually fire?** The
+ *      blocked cases assert both that the stage refused AND that nothing
+ *      reached the table.
+ *
+ * Opt in locally with:
+ *   bun run db:up && export TEST_DATABASE_URL=postgresql://atlas:atlas@localhost:5433/brain_4771_scratch
+ */
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
+import { Effect } from "effect";
+import { Pool } from "pg";
+import { runMigrations } from "@atlas/api/lib/db/migrate";
+import { MANAGED_AUTH_MIGRATIONS, _resetPool } from "@atlas/api/lib/db/internal";
+import {
+  reconcileFacts,
+  type FactCandidate,
+  type ReconcileEpisodeRef,
+} from "@atlas/api/lib/brain/reconcile";
+import {
+  runBrainExtractionCycle,
+  type FactExtractor,
+  type ResolvedExtractionModel,
+} from "@atlas/api/lib/brain/extract";
+
+const TEST_DB_URL = process.env.TEST_DATABASE_URL;
+const describeIfPg = TEST_DB_URL ? describe : describe.skip;
+const PG_TEST_TIMEOUT_MS = 60_000;
+
+const WORKSPACE = "ws-brain-4771";
+
+/** A model handle the fiber only ever passes through to the injected extractor. */
+const FAKE_MODEL = {
+  model: "fake-model" as unknown as ResolvedExtractionModel["model"],
+  modelId: "fake-model",
+} satisfies ResolvedExtractionModel;
+
+describeIfPg("brain extraction + reconcile (real Postgres)", () => {
+  let pool: Pool;
+  let priorDatabaseUrl: string | undefined;
+  const schemaName = `brain_4771_${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
+
+  beforeAll(async () => {
+    // `runPeriodicDbCycle` guards on `hasInternalDB()`, which reads
+    // `DATABASE_URL` rather than the pool — so without this the cycle takes its
+    // "nothing to do, no database" path and every fiber assertion below would
+    // pass vacuously against an empty result. Set inside the hook (never at
+    // module top level, per the test-discipline rule) and restored after.
+    priorDatabaseUrl = process.env.DATABASE_URL;
+    process.env.DATABASE_URL = TEST_DB_URL;
+    // `search_path` baked into the connection string, not SET from an unawaited
+    // `pool.on("connect")` handler — the pattern the sibling brain -pg suites
+    // established.
+    pool = new Pool({
+      connectionString: TEST_DB_URL,
+      options: `-c search_path="${schemaName}",public`,
+    });
+    const bootstrap = new Pool({ connectionString: TEST_DB_URL });
+    try {
+      await bootstrap.query(`CREATE SCHEMA IF NOT EXISTS "${schemaName}"`);
+    } finally {
+      await bootstrap.end();
+    }
+    await runMigrations(pool, { skip: MANAGED_AUTH_MIGRATIONS });
+    // The stage and the fiber both write through the module-level pool, so it
+    // has to BE this schema-scoped one for the test to exercise the real SQL.
+    _resetPool(pool);
+  }, PG_TEST_TIMEOUT_MS);
+
+  afterAll(async () => {
+    _resetPool(null);
+    if (priorDatabaseUrl === undefined) delete process.env.DATABASE_URL;
+    else process.env.DATABASE_URL = priorDatabaseUrl;
+    if (pool) {
+      await pool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+      await pool.end();
+    }
+  });
+
+  afterEach(async () => {
+    await pool.query("DELETE FROM brain_edges");
+    await pool.query("DELETE FROM brain_facts");
+    await pool.query("DELETE FROM brain_episodes");
+  });
+
+  // ── helpers ─────────────────────────────────────────────────────────────
+
+  async function insertEpisode(
+    overrides: {
+      sourceId?: string;
+      sourceActor?: string | null;
+      body?: string | null;
+      locator?: string | null;
+      visibleTo?: readonly (string | null)[];
+      extractedAt?: string | null;
+    } = {},
+  ): Promise<ReconcileEpisodeRef> {
+    const {
+      sourceId = `C01:${Date.now()}.${Math.floor(Math.random() * 1e6)}`,
+      sourceActor = "U123",
+      body = "the deploy window is Thursdays",
+      locator = null,
+      visibleTo = ["org"],
+      extractedAt = null,
+    } = overrides;
+    const { rows } = await pool.query<{ id: string }>(
+      `INSERT INTO brain_episodes
+         (workspace_id, source, source_id, source_actor, body, locator, occurred_at, visible_to, extracted_at)
+       VALUES ($1, 'slack', $2, $3, $4, $5, now(), $6::text[], $7::timestamptz)
+       RETURNING id`,
+      [WORKSPACE, sourceId, sourceActor, body, locator, visibleTo, extractedAt],
+    );
+    return {
+      id: rows[0]!.id,
+      workspaceId: WORKSPACE,
+      source: "slack",
+      sourceId,
+      sourceActor,
+      occurredAt: new Date("2026-06-21T09:00:00.000Z"),
+      visibleTo,
+    };
+  }
+
+  function candidate(overrides: Partial<FactCandidate> = {}): FactCandidate {
+    return { subject: "deploy window", predicate: "is", object: "Thursdays", ...overrides };
+  }
+
+  async function facts(): Promise<
+    { id: string; subject: string; object: string; status: string; provenance: Record<string, unknown>; visible_to: string[] }[]
+  > {
+    const { rows } = await pool.query(
+      `SELECT id, subject, object, status, provenance, visible_to FROM brain_facts ORDER BY ingested_at, id`,
+    );
+    return rows;
+  }
+
+  async function edges(): Promise<{ edge_type: string; from_fact_id: string | null; to_episode_id: string | null; to_fact_id: string | null }[]> {
+    const { rows } = await pool.query(
+      `SELECT edge_type, from_fact_id, to_episode_id, to_fact_id FROM brain_edges ORDER BY created_at, id`,
+    );
+    return rows;
+  }
+
+  async function extractedAtOf(episodeId: string): Promise<Date | null> {
+    const { rows } = await pool.query<{ extracted_at: Date | null }>(
+      `SELECT extracted_at FROM brain_episodes WHERE id = $1`,
+      [episodeId],
+    );
+    return rows[0]?.extracted_at ?? null;
+  }
+
+  // ── the stage ───────────────────────────────────────────────────────────
+
+  it("lands a fully-formed candidate as a DRAFT it never asked for", async () => {
+    const episode = await insertEpisode();
+    const report = await reconcileFacts({
+      episode,
+      candidates: [candidate()],
+      producer: "extraction:v1",
+      extractedAt: new Date(),
+    });
+
+    expect(report.created).toBe(1);
+    const stored = await facts();
+    expect(stored).toHaveLength(1);
+    // The whole point of omitting the column: the review gate applies itself.
+    expect(stored[0]!.status).toBe("draft");
+    expect(stored[0]!.visible_to).toEqual(["org"]);
+    expect(stored[0]!.provenance).toMatchObject({
+      source: "slack",
+      episodeId: episode.id,
+      actor: "slack:U123",
+      producer: "extraction:v1",
+    });
+    // The evidence pointer exists in the SAME breath as the claim.
+    expect(await edges()).toEqual([
+      {
+        edge_type: "provenance",
+        from_fact_id: stored[0]!.id,
+        to_episode_id: episode.id,
+        to_fact_id: null,
+      },
+    ]);
+  });
+
+  it("rolls the WHOLE episode back when one candidate's write fails", async () => {
+    // The invariant is "no half-formed rows", which means half-formed BATCHES
+    // too: a reviewer must never inherit two of three claims from a pass that
+    // did not finish. Forced by a subject long enough to be fine and an object
+    // that violates nothing — so instead we break the write itself by aiming
+    // the second candidate at a cardinality the CHECK refuses.
+    const episode = await insertEpisode();
+    await expect(
+      reconcileFacts({
+        episode,
+        candidates: [
+          candidate(),
+          // `chk_brain_facts_predicate_cardinality` refuses this.
+          candidate({
+            object: "Fridays",
+            predicateCardinality: "sometimes" as FactCandidate["predicateCardinality"],
+          }),
+          candidate({ object: "Mondays" }),
+        ],
+        producer: "extraction:v1",
+        extractedAt: new Date(),
+      }),
+    ).rejects.toThrow();
+
+    expect(await facts()).toHaveLength(0);
+    expect(await edges()).toHaveLength(0);
+  });
+
+  it("blocks an episode whose grant no reader can match, and writes nothing", async () => {
+    // `['everyone']` satisfies `chk_brain_episodes_grant_nonempty` — it is a
+    // legally storable episode — and grants nobody. Blocking here is what keeps
+    // #4769's promotion refusal from becoming a permanent trap.
+    const episode = await insertEpisode({ visibleTo: ["everyone"] });
+    const report = await reconcileFacts({
+      episode,
+      candidates: [candidate()],
+      producer: "extraction:v1",
+      extractedAt: new Date(),
+    });
+
+    expect(report.blocked.NO_GRANT).toBe(1);
+    expect(await facts()).toHaveLength(0);
+  });
+
+  it("stores a provisional flag that survives the jsonb round-trip", async () => {
+    const episode = await insertEpisode();
+    await reconcileFacts({
+      episode,
+      candidates: [candidate()],
+      producer: "extraction:v1",
+      extractedAt: new Date(),
+      resolveEntity: (surface, { role }) => (role === "object" ? null : { canonical: surface }),
+    });
+
+    const stored = await facts();
+    expect(stored[0]!.provenance).toMatchObject({ provisional: true, unresolved: ["object"] });
+    // Still a draft, still reviewable — flagged, not dropped.
+    expect(stored[0]!.status).toBe("draft");
+  });
+
+  it("corroborates a re-observed claim instead of duplicating it", async () => {
+    const first = await insertEpisode({ sourceId: "C01:1" });
+    const second = await insertEpisode({ sourceId: "C01:2" });
+
+    await reconcileFacts({ episode: first, candidates: [candidate()], producer: "p", extractedAt: new Date() });
+    const report = await reconcileFacts({
+      episode: second,
+      candidates: [candidate()],
+      producer: "p",
+      extractedAt: new Date(),
+    });
+
+    expect(report.corroborated).toBe(1);
+    expect(await facts()).toHaveLength(1);
+    const provenanceEdges = (await edges()).filter((e) => e.edge_type === "provenance");
+    expect(provenanceEdges.map((e) => e.to_episode_id).toSorted()).toEqual(
+      [first.id, second.id].toSorted(),
+    );
+  });
+
+  it("records an advisory in-tension-with edge without invalidating anything", async () => {
+    const first = await insertEpisode({ sourceId: "C01:3" });
+    const second = await insertEpisode({ sourceId: "C01:4" });
+    const single: Partial<FactCandidate> = {
+      subject: "Ada",
+      predicate: "reports to",
+      predicateCardinality: "single",
+    };
+
+    await reconcileFacts({
+      episode: first,
+      candidates: [candidate({ ...single, object: "Grace" })],
+      producer: "p",
+      extractedAt: new Date(),
+    });
+    await reconcileFacts({
+      episode: second,
+      candidates: [candidate({ ...single, object: "Alan" })],
+      producer: "p",
+      extractedAt: new Date(),
+    });
+
+    const stored = await facts();
+    expect(stored).toHaveLength(2);
+    const tension = (await edges()).filter((e) => e.edge_type === "in-tension-with");
+    expect(tension).toHaveLength(1);
+    // Supersession is not deletion, and this stage does not supersede at all.
+    const { rows } = await pool.query<{ n: string }>(
+      `SELECT count(*)::text AS n FROM brain_facts WHERE invalidated_at IS NOT NULL`,
+    );
+    expect(rows[0]!.n).toBe("0");
+  });
+
+  // ── the fiber ───────────────────────────────────────────────────────────
+
+  function cycleWith(extract: FactExtractor) {
+    return Effect.runPromise(
+      runBrainExtractionCycle({
+        extract,
+        resolveModel: async () => FAKE_MODEL,
+      }),
+    );
+  }
+
+  const oneFact: FactExtractor = () => Promise.resolve([candidate()]);
+
+  it("drains the queue, stages drafts, and stamps the episode", async () => {
+    const episode = await insertEpisode();
+    const result = await cycleWith(oneFact);
+
+    expect(result).toMatchObject({ status: "success", inspected: 1, extracted: 1, factsCreated: 1 });
+    expect(await extractedAtOf(episode.id)).not.toBeNull();
+    expect(await facts()).toHaveLength(1);
+  });
+
+  it("re-running over an already-extracted window is a no-op", async () => {
+    // Acceptance criterion 5, both halves: the stamped episode leaves the
+    // drain's partial index, and even a forced re-run corroborates rather than
+    // duplicating — which is what makes the crash window between the reconcile
+    // commit and the stamp affordable.
+    const episode = await insertEpisode();
+    await cycleWith(oneFact);
+    const second = await cycleWith(oneFact);
+
+    expect(second).toMatchObject({ inspected: 0, extracted: 0, factsCreated: 0 });
+    expect(await facts()).toHaveLength(1);
+
+    // Force the episode back onto the queue, as a crash before the stamp would.
+    await pool.query(`UPDATE brain_episodes SET extracted_at = NULL WHERE id = $1`, [episode.id]);
+    const replay = await cycleWith(oneFact);
+
+    expect(replay).toMatchObject({ inspected: 1, extracted: 1, factsCreated: 0, factsCorroborated: 1 });
+    expect(await facts()).toHaveLength(1);
+    expect((await edges()).filter((e) => e.edge_type === "provenance")).toHaveLength(1);
+  });
+
+  it("leaves a failed episode on the queue and keeps draining the rest", async () => {
+    const poison = await insertEpisode({ sourceId: "C01:poison", body: "explode" });
+    const healthy = await insertEpisode({ sourceId: "C01:healthy" });
+
+    const result = await cycleWith((input) =>
+      input.body === "explode"
+        ? Promise.reject(new Error("model refused"))
+        : Promise.resolve([candidate()]),
+    );
+
+    expect(result).toMatchObject({ inspected: 2, extracted: 1, failed: 1, status: "success" });
+    // Not stamped ⇒ retried next cycle. A stamp here would be a silent drop.
+    expect(await extractedAtOf(poison.id)).toBeNull();
+    expect(await extractedAtOf(healthy.id)).not.toBeNull();
+  });
+
+  it("stamps a by-reference episode it can never extract, so it cannot block the queue head", async () => {
+    const byRef = await insertEpisode({ body: null, locator: "warehouse://snapshot/1" });
+    const result = await cycleWith(oneFact);
+
+    expect(result).toMatchObject({ inspected: 1, extracted: 0, skippedNoBody: 1 });
+    expect(await extractedAtOf(byRef.id)).not.toBeNull();
+    expect(await facts()).toHaveLength(0);
+  });
+
+  it("leaves episodes queued when the workspace's model cannot be resolved", async () => {
+    // A rotated-and-broken BYO key must not fall back to the platform model
+    // (that would bill Atlas for a workspace that chose its own provider) and
+    // must not stamp — re-entering the key is the whole repair.
+    const episode = await insertEpisode();
+    const result = await Effect.runPromise(
+      runBrainExtractionCycle({ extract: oneFact, resolveModel: async () => null }),
+    );
+
+    expect(result).toMatchObject({ inspected: 1, extracted: 0, skippedModelUnavailable: 1 });
+    expect(await extractedAtOf(episode.id)).toBeNull();
+    expect(await facts()).toHaveLength(0);
+  });
+
+  it("stamps an episode whose candidates were all blocked", async () => {
+    // Blocking is a DECISION, not a failure: retrying it forever would re-log
+    // the same refusal every cycle and burn a queue slot. The episode itself is
+    // never deleted, so the evidence survives for a later, smarter pass.
+    const episode = await insertEpisode({ visibleTo: ["everyone"] });
+    const result = await cycleWith(oneFact);
+
+    expect(result).toMatchObject({ extracted: 1, factsCreated: 0, factsBlocked: 1 });
+    expect(await extractedAtOf(episode.id)).not.toBeNull();
+    expect(await facts()).toHaveLength(0);
+  });
+
+  it("an empty queue is a clean success", async () => {
+    const result = await cycleWith(oneFact);
+    expect(result).toMatchObject({ status: "success", inspected: 0, extracted: 0 });
+  });
+});

--- a/packages/api/src/lib/brain/__tests__/extract-reconcile-pg.test.ts
+++ b/packages/api/src/lib/brain/__tests__/extract-reconcile-pg.test.ts
@@ -19,13 +19,15 @@
  *      Acceptance criterion 5, and the thing that makes work-then-stamp safe.
  *      It rests on the corroboration lookup + the edge's `NOT EXISTS` guard
  *      running against real rows.
- *   4. **Do the queue mechanics hold?** The drain reads
- *      `idx_brain_episodes_extraction_queue`'s predicate, a completed pass
- *      stamps `extracted_at`, and a FAILED pass does not — the difference
- *      between "retried next cycle" and "silently dropped".
- *   5. **Do the CHECKs the block-stage stands in front of actually fire?** The
- *      blocked cases assert both that the stage refused AND that nothing
- *      reached the table.
+ *   4. **Do the queue mechanics hold?** A completed pass stamps `extracted_at`
+ *      and a FAILED pass does not — the difference between "retried next cycle"
+ *      and "silently dropped". (What the drain's index does for the query is a
+ *      planner question no test here asks.)
+ *   5. **Does the stage refuse BEFORE the row reaches a table whose CHECKs
+ *      would happily accept it?** `['everyone']` is precisely the grant the
+ *      0180 CHECK does not catch, which is why the stage blocks upstream — so
+ *      the blocked cases assert both that it refused AND that nothing reached
+ *      the table.
  *
  * Opt in locally with:
  *   bun run db:up && export TEST_DATABASE_URL=postgresql://atlas:atlas@localhost:5433/brain_4771_scratch
@@ -490,16 +492,66 @@ describeIfPg("brain extraction + reconcile (real Postgres)", () => {
       return Promise.reject(new Error("model refused"));
     };
 
-    for (let i = 0; i < 3; i++) await cycleWith(exploding);
-    expect(calls).toBe(3);
+    // FOUR ticks, not three: the first all-failed tick is forgiven as a possible
+    // outage (one free pass per episode, see the refund cap), so the three
+    // strikes that reach the threshold start on tick 2.
+    for (let i = 0; i < 4; i++) await cycleWith(exploding);
+    expect(calls).toBe(4);
 
     const quarantined = await cycleWith(exploding);
     expect(quarantined).toMatchObject({ inspected: 1, failed: 0 });
     expect(quarantined.skipped.quarantined).toBe(1);
-    // No fourth model call…
-    expect(calls).toBe(3);
+    // No fifth model call…
+    expect(calls).toBe(4);
     // …and still queued, so a restart (or a fix) picks it back up.
     expect(await extractedAtOf(poison.id)).toBeNull();
+  });
+
+  it("still quarantines when the WHOLE batch is poisoned", async () => {
+    // The regression the single-episode test above structurally cannot catch.
+    // A failing episode is never stamped, so it stays at the head of the drain —
+    // and once the healthy episodes ahead of it have gone, "every episode this
+    // tick failed" is just what a poisoned queue looks like, on every tick. An
+    // uncapped outage refund therefore un-charges the strikes it just charged
+    // and quarantine becomes unreachable: measured over a simulated day, two
+    // poisoned episodes went from 25 model calls total to 576 and climbing.
+    await insertEpisode({ sourceId: "C01:poison-a", body: "explode" });
+    await insertEpisode({ sourceId: "C01:poison-b", body: "explode" });
+    let calls = 0;
+    const exploding: FactExtractor = () => {
+      calls++;
+      return Promise.reject(new Error("model refused"));
+    };
+
+    // Tick 1 charges a strike each and refunds both (a genuine outage looks
+    // exactly like this, and costs nothing). Ticks 2-4 charge again; the
+    // per-episode cap means those strikes STAY.
+    for (let i = 0; i < 4; i++) await cycleWith(exploding);
+    const quiet = await cycleWith(exploding);
+
+    expect(quiet.skipped.quarantined).toBe(2);
+    const callsBefore = calls;
+    await cycleWith(exploding);
+    // …and no further model calls while the backoff holds.
+    expect(calls).toBe(callsBefore);
+  });
+
+  it("forgives one strike each when a whole tick fails, so an outage costs nothing", async () => {
+    // The other half of the same rule. Two episodes, one bad tick, then a good
+    // one: neither may carry a strike out of the outage.
+    await insertEpisode({ sourceId: "C01:outage-a" });
+    await insertEpisode({ sourceId: "C01:outage-b" });
+    let failNext = true;
+    const flaky: FactExtractor = () =>
+      failNext ? Promise.reject(new Error("provider 503")) : Promise.resolve([candidate()]);
+
+    const outage = await cycleWith(flaky);
+    expect(outage).toMatchObject({ failed: 2, outageRefunded: 2 });
+
+    failNext = false;
+    const recovered = await cycleWith(flaky);
+    expect(recovered).toMatchObject({ extracted: 2, failed: 0 });
+    expect(recovered.skipped.quarantined).toBe(0);
   });
 
   it("stamps an episode whose extraction found nothing to claim", async () => {

--- a/packages/api/src/lib/brain/__tests__/extract-reconcile-pg.test.ts
+++ b/packages/api/src/lib/brain/__tests__/extract-reconcile-pg.test.ts
@@ -598,6 +598,85 @@ describeIfPg("brain extraction + reconcile (real Postgres)", () => {
     expect(await facts()).toHaveLength(2);
   });
 
+  it("keeps corroboration inside the tenant, in the SQL and not just the caller", async () => {
+    // Three predicates ride on this: the corroboration lookup, the tension
+    // lookup, and the stamp. Dropping `workspace_id =` from the first turns a
+    // dedupe into a cross-tenant read — tenant B's re-observation attaches a
+    // provenance edge to tenant A's fact, and A's fact then cites evidence A
+    // cannot see. The unit suite's fake implements the filter in TypeScript, so
+    // it proves the parameter is PASSED and says nothing about the SQL text.
+    const mine = await insertEpisode({ sourceId: "C01:tenant-a" });
+    const { rows } = await pool.query<{ id: string }>(
+      `INSERT INTO brain_episodes
+         (workspace_id, source, source_id, source_actor, body, occurred_at, visible_to)
+       VALUES ('ws-other-tenant', 'slack', 'C01:tenant-b', 'U999', 'same claim', now(), ARRAY['org'])
+       RETURNING id`,
+    );
+    const theirs: ReconcileEpisodeRef = {
+      id: rows[0]!.id,
+      workspaceId: "ws-other-tenant",
+      source: "slack",
+      sourceId: "C01:tenant-b",
+      sourceActor: "U999",
+      occurredAt: new Date("2026-06-21T09:00:00.000Z"),
+      visibleTo: ["org"],
+    };
+
+    await reconcileFacts({ episode: mine, candidates: [candidate()], producer: "p", extractedAt: new Date() });
+    const other = await reconcileFacts({
+      episode: theirs,
+      candidates: [candidate()],
+      producer: "p",
+      extractedAt: new Date(),
+    });
+
+    expect(other.created).toBe(1);
+    const stored = await facts();
+    expect(stored).toHaveLength(2);
+    // Each fact cites only its OWN tenant's evidence.
+    const all = await edges();
+    for (const fact of stored) {
+      const evidence = all.filter((e) => e.from_fact_id === fact.id);
+      expect(evidence).toHaveLength(1);
+    }
+
+    await pool.query(`DELETE FROM brain_facts WHERE workspace_id = 'ws-other-tenant'`);
+    await pool.query(`DELETE FROM brain_episodes WHERE workspace_id = 'ws-other-tenant'`);
+  });
+
+  it("counts CONSECUTIVE failures, so a success between them clears the ledger", async () => {
+    // Without the `delete` on the success path this counts TOTAL failures, and
+    // an episode that 429s twice, succeeds, then 429s once more would be
+    // quarantined — exactly the transient-vs-deterministic conflation the
+    // ledger exists to avoid.
+    const episode = await insertEpisode();
+    let calls = 0;
+    const flaky: FactExtractor = () => {
+      calls++;
+      return calls === 3
+        ? Promise.resolve([candidate()])
+        : Promise.reject(new Error("transient"));
+    };
+
+    await cycleWith(flaky); // fail 1
+    await cycleWith(flaky); // fail 2
+    await cycleWith(flaky); // success — clears the ledger AND stamps
+    expect(await extractedAtOf(episode.id)).not.toBeNull();
+
+    // Re-queue and fail twice more; a TOTAL counter would quarantine on the
+    // second of these, a consecutive one keeps calling the model.
+    await pool.query(`UPDATE brain_episodes SET extracted_at = NULL WHERE id = $1`, [episode.id]);
+    const failAgain: FactExtractor = () => {
+      calls++;
+      return Promise.reject(new Error("transient"));
+    };
+    await cycleWith(failAgain);
+    const second = await cycleWith(failAgain);
+
+    expect(second.skipped.quarantined).toBe(0);
+    expect(second.failed).toBe(1);
+  });
+
   it("two reconciles racing on one claim produce ONE fact", async () => {
     // What the per-workspace advisory lock is FOR. The unit suite proves the
     // statement is issued; only a real transaction proves it serializes a

--- a/packages/api/src/lib/brain/__tests__/extract-reconcile-pg.test.ts
+++ b/packages/api/src/lib/brain/__tests__/extract-reconcile-pg.test.ts
@@ -322,8 +322,12 @@ describeIfPg("brain extraction + reconcile (real Postgres)", () => {
     expect(report.corroborated).toBe(1);
     expect(await facts()).toHaveLength(1);
     const provenanceEdges = (await edges()).filter((e) => e.edge_type === "provenance");
-    expect(provenanceEdges.map((e) => e.to_episode_id).toSorted()).toEqual(
-      [first.id, second.id].toSorted(),
+    // Explicit comparator: these are uuid strings, and `toSorted()` with no
+    // argument sorts by UTF-16 code unit, which `require-array-sort-compare`
+    // refuses precisely because that is a different order than a reader assumes.
+    const byId = (a: string | null, b: string | null) => (a ?? "").localeCompare(b ?? "");
+    expect(provenanceEdges.map((e) => e.to_episode_id).toSorted(byId)).toEqual(
+      [first.id, second.id].toSorted(byId),
     );
   });
 

--- a/packages/api/src/lib/brain/__tests__/extract-reconcile-pg.test.ts
+++ b/packages/api/src/lib/brain/__tests__/extract-reconcile-pg.test.ts
@@ -42,6 +42,7 @@ import {
   type ReconcileEpisodeRef,
 } from "@atlas/api/lib/brain/reconcile";
 import {
+  _resetBrainExtractionFailures,
   runBrainExtractionCycle,
   type FactExtractor,
   type ResolvedExtractionModel,
@@ -105,6 +106,11 @@ describeIfPg("brain extraction + reconcile (real Postgres)", () => {
     await pool.query("DELETE FROM brain_edges");
     await pool.query("DELETE FROM brain_facts");
     await pool.query("DELETE FROM brain_episodes");
+    await pool.query("DELETE FROM admin_action_log");
+    // The quarantine ledger is module-level and survives between tests; a
+    // process restart is what clears it in production, and this is the test's
+    // equivalent. Without it, a later test inherits an earlier one's failures.
+    _resetBrainExtractionFailures();
   });
 
   // ── helpers ─────────────────────────────────────────────────────────────
@@ -127,12 +133,16 @@ describeIfPg("brain extraction + reconcile (real Postgres)", () => {
       visibleTo = ["org"],
       extractedAt = null,
     } = overrides;
+    // The stored `occurred_at` is the SAME value the returned ref carries — a
+    // `now()` here would make the ref a near-miss of the row it describes, and
+    // any assertion about provenance `occurredAt` silently wrong.
+    const occurredAt = new Date("2026-06-21T09:00:00.000Z");
     const { rows } = await pool.query<{ id: string }>(
       `INSERT INTO brain_episodes
          (workspace_id, source, source_id, source_actor, body, locator, occurred_at, visible_to, extracted_at)
-       VALUES ($1, 'slack', $2, $3, $4, $5, now(), $6::text[], $7::timestamptz)
+       VALUES ($1, 'slack', $2, $3, $4, $5, $6::timestamptz, $7::text[], $8::timestamptz)
        RETURNING id`,
-      [WORKSPACE, sourceId, sourceActor, body, locator, visibleTo, extractedAt],
+      [WORKSPACE, sourceId, sourceActor, body, locator, occurredAt.toISOString(), visibleTo, extractedAt],
     );
     return {
       id: rows[0]!.id,
@@ -140,7 +150,7 @@ describeIfPg("brain extraction + reconcile (real Postgres)", () => {
       source: "slack",
       sourceId,
       sourceActor,
-      occurredAt: new Date("2026-06-21T09:00:00.000Z"),
+      occurredAt,
       visibleTo,
     };
   }
@@ -163,6 +173,21 @@ describeIfPg("brain extraction + reconcile (real Postgres)", () => {
       `SELECT edge_type, from_fact_id, to_episode_id, to_fact_id FROM brain_edges ORDER BY created_at, id`,
     );
     return rows;
+  }
+
+  /** Poll for the fire-and-forget audit row. See the audit test for why. */
+  async function waitForAuditRows(
+    actionType: string,
+  ): Promise<{ status: string; actor_id: string | null }[]> {
+    for (let attempt = 0; attempt < 40; attempt++) {
+      const { rows } = await pool.query<{ status: string; actor_id: string | null }>(
+        `SELECT status, actor_id FROM admin_action_log WHERE action_type = $1`,
+        [actionType],
+      );
+      if (rows.length > 0) return rows;
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+    return [];
   }
 
   async function extractedAtOf(episodeId: string): Promise<Date | null> {
@@ -210,16 +235,16 @@ describeIfPg("brain extraction + reconcile (real Postgres)", () => {
   it("rolls the WHOLE episode back when one candidate's write fails", async () => {
     // The invariant is "no half-formed rows", which means half-formed BATCHES
     // too: a reviewer must never inherit two of three claims from a pass that
-    // did not finish. Forced by a subject long enough to be fine and an object
-    // that violates nothing — so instead we break the write itself by aiming
-    // the second candidate at a cardinality the CHECK refuses.
+    // did not finish. The failure is induced by aiming the SECOND candidate at
+    // a cardinality `chk_brain_facts_predicate_cardinality` refuses, so what is
+    // proven is that the FIRST candidate's already-succeeded write is undone.
     const episode = await insertEpisode();
+    const first = candidate();
     await expect(
       reconcileFacts({
         episode,
         candidates: [
-          candidate(),
-          // `chk_brain_facts_predicate_cardinality` refuses this.
+          first,
           candidate({
             object: "Fridays",
             predicateCardinality: "sometimes" as FactCandidate["predicateCardinality"],
@@ -229,10 +254,23 @@ describeIfPg("brain extraction + reconcile (real Postgres)", () => {
         producer: "extraction:v1",
         extractedAt: new Date(),
       }),
-    ).rejects.toThrow();
+      // Anchored: an unanchored `toThrow()` would also pass if the FIRST
+      // candidate started failing for an unrelated reason, in which case
+      // nothing was ever written and the rollback claim is untested.
+    ).rejects.toThrow(/predicate_cardinality/);
 
     expect(await facts()).toHaveLength(0);
     expect(await edges()).toHaveLength(0);
+
+    // Control: that same first candidate on its own DOES land, so the empty
+    // table above is a rollback and not a candidate that never worked.
+    await reconcileFacts({
+      episode,
+      candidates: [first],
+      producer: "extraction:v1",
+      extractedAt: new Date(),
+    });
+    expect(await facts()).toHaveLength(1);
   });
 
   it("blocks an episode whose grant no reader can match, and writes nothing", async () => {
@@ -335,11 +373,25 @@ describeIfPg("brain extraction + reconcile (real Postgres)", () => {
 
   it("drains the queue, stages drafts, and stamps the episode", async () => {
     const episode = await insertEpisode();
-    const result = await cycleWith(oneFact);
+    const seen: { modelId: string; body: string; episodeId: string }[] = [];
+    const result = await cycleWith((input) => {
+      seen.push({ modelId: input.modelId, body: input.body, episodeId: input.episode.id });
+      return Promise.resolve([candidate()]);
+    });
 
     expect(result).toMatchObject({ status: "success", inspected: 1, extracted: 1, factsCreated: 1 });
     expect(await extractedAtOf(episode.id)).not.toBeNull();
     expect(await facts()).toHaveLength(1);
+    // The resolved model reaches the extractor — the piece every other fiber
+    // test injects past, and the reason `detail.model` in provenance is
+    // trustworthy at all.
+    expect(seen).toEqual([
+      { modelId: "fake-model", body: "the deploy window is Thursdays", episodeId: episode.id },
+    ]);
+    // The event time round-trips into provenance rather than being re-derived.
+    expect((await facts())[0]!.provenance).toMatchObject({
+      occurredAt: "2026-06-21T09:00:00.000Z",
+    });
   });
 
   it("re-running over an already-extracted window is a no-op", async () => {
@@ -383,7 +435,8 @@ describeIfPg("brain extraction + reconcile (real Postgres)", () => {
     const byRef = await insertEpisode({ body: null, locator: "warehouse://snapshot/1" });
     const result = await cycleWith(oneFact);
 
-    expect(result).toMatchObject({ inspected: 1, extracted: 0, skippedNoBody: 1 });
+    expect(result).toMatchObject({ inspected: 1, extracted: 0 });
+    expect(result.skipped.no_body).toBe(1);
     expect(await extractedAtOf(byRef.id)).not.toBeNull();
     expect(await facts()).toHaveLength(0);
   });
@@ -397,21 +450,168 @@ describeIfPg("brain extraction + reconcile (real Postgres)", () => {
       runBrainExtractionCycle({ extract: oneFact, resolveModel: async () => null }),
     );
 
-    expect(result).toMatchObject({ inspected: 1, extracted: 0, skippedModelUnavailable: 1 });
+    expect(result).toMatchObject({ inspected: 1, extracted: 0 });
+    expect(result.skipped.model_unavailable).toBe(1);
     expect(await extractedAtOf(episode.id)).toBeNull();
     expect(await facts()).toHaveLength(0);
   });
 
-  it("stamps an episode whose candidates were all blocked", async () => {
-    // Blocking is a DECISION, not a failure: retrying it forever would re-log
-    // the same refusal every cycle and burn a queue slot. The episode itself is
-    // never deleted, so the evidence survives for a later, smarter pass.
+  it("refuses an unsafe episode BEFORE calling a model, and stamps it", async () => {
+    // Two claims in one. Blocking is a DECISION, not a failure: retrying it
+    // forever would re-log the same refusal every cycle and hold a queue slot,
+    // so it is stamped (the evidence itself is never deleted). And the refusal
+    // is pre-flighted, so an episode from which no safe fact can be drawn costs
+    // ZERO model calls rather than one per pass — `extractorCalls` is the
+    // assertion, since a post-hoc block would look identical in the database.
     const episode = await insertEpisode({ visibleTo: ["everyone"] });
-    const result = await cycleWith(oneFact);
+    let extractorCalls = 0;
+    const result = await cycleWith(() => {
+      extractorCalls++;
+      return Promise.resolve([candidate()]);
+    });
 
-    expect(result).toMatchObject({ extracted: 1, factsCreated: 0, factsBlocked: 1 });
+    expect(extractorCalls).toBe(0);
+    expect(result).toMatchObject({ blockedEpisodes: 1, extracted: 0, factsCreated: 0 });
     expect(await extractedAtOf(episode.id)).not.toBeNull();
     expect(await facts()).toHaveLength(0);
+  });
+
+  it("stops calling a model for an episode that fails every attempt", async () => {
+    // The spend bound. Retry-forever is right for a 429 and wrong for a body
+    // that deterministically trips a content filter — and nothing in the
+    // failure itself distinguishes them, so the ledger counts consecutive
+    // failures instead of guessing. Deliberately NOT a stamp: three failures in
+    // one process is not proof of "unextractable forever", and stamping on that
+    // guess is the silent drop the whole ordering avoids.
+    const poison = await insertEpisode({ body: "explode" });
+    let calls = 0;
+    const exploding: FactExtractor = () => {
+      calls++;
+      return Promise.reject(new Error("model refused"));
+    };
+
+    for (let i = 0; i < 3; i++) await cycleWith(exploding);
+    expect(calls).toBe(3);
+
+    const quarantined = await cycleWith(exploding);
+    expect(quarantined).toMatchObject({ inspected: 1, failed: 0 });
+    expect(quarantined.skipped.quarantined).toBe(1);
+    // No fourth model call…
+    expect(calls).toBe(3);
+    // …and still queued, so a restart (or a fix) picks it back up.
+    expect(await extractedAtOf(poison.id)).toBeNull();
+  });
+
+  it("stamps an episode whose extraction found nothing to claim", async () => {
+    // The modal case in production: most chat contains no durable fact. If an
+    // empty-candidate short-circuit ever landed before the stamp, the drain
+    // would head-of-line block on small talk forever.
+    const episode = await insertEpisode({ body: "morning all" });
+    const result = await cycleWith(() => Promise.resolve([]));
+
+    expect(result).toMatchObject({ extracted: 1, factsCreated: 0, blockedEpisodes: 0 });
+    expect(await extractedAtOf(episode.id)).not.toBeNull();
+  });
+
+  it("emits a cycle audit row on every terminal path", async () => {
+    // The row's ABSENCE over a window is the "the fiber stopped" signal, so it
+    // has to be emitted even when there was nothing to do — and the system
+    // actor has to pass `assertSystemActor`, which validates at RUNTIME and
+    // silently drops the row when it does not.
+    await cycleWith(oneFact);
+    // `logAdminAction` is fire-and-forget by contract, so the row lands just
+    // after the cycle resolves. Polling here is not only how the assertion
+    // works — it is also what keeps the suite's `DROP SCHEMA … CASCADE` from
+    // racing an in-flight INSERT and logging a spurious failure.
+    const rows = await waitForAuditRows("brain.extraction_cycle");
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.status).toBe("success");
+    // The system actor is validated at RUNTIME by `assertSystemActor`, which
+    // drops the row (with a warn) when it does not match — so a malformed
+    // actor would destroy the "absence means the fiber stopped" invariant
+    // while every other test stayed green.
+    expect(rows[0]!.actor_id).toBe("system:brain-extraction");
+  });
+
+  it("leaves the episode queued when the reconcile transaction itself fails", async () => {
+    // The stamp is the LAST thing that happens, and this is what that ordering
+    // buys: a database fault during reconcile must leave the queue marker
+    // untouched so the claim is re-derived, rather than stamping past evidence
+    // whose facts never committed.
+    const episode = await insertEpisode();
+    const result = await Effect.runPromise(
+      runBrainExtractionCycle({
+        extract: oneFact,
+        resolveModel: async () => FAKE_MODEL,
+        reconcile: () => Promise.reject(new Error("deadlock detected")),
+      }),
+    );
+
+    expect(result).toMatchObject({ inspected: 1, extracted: 0, failed: 1 });
+    expect(await extractedAtOf(episode.id)).toBeNull();
+    expect(await facts()).toHaveLength(0);
+  });
+
+  it("corroborates a PUBLISHED fact rather than minting a fresh draft duplicate", async () => {
+    // The corroboration lookup is deliberately not filtered by review state.
+    // Adding `AND status = 'draft'` to it would leave every test above green
+    // while every re-observation of an already-reviewed claim queued a new
+    // draft for a human to re-approve — the review queue would fill with work
+    // somebody already did.
+    const first = await insertEpisode({ sourceId: "C01:pub-1" });
+    const second = await insertEpisode({ sourceId: "C01:pub-2" });
+    await reconcileFacts({ episode: first, candidates: [candidate()], producer: "p", extractedAt: new Date() });
+    await pool.query(`UPDATE brain_facts SET status = 'published'`);
+
+    const report = await reconcileFacts({
+      episode: second,
+      candidates: [candidate()],
+      producer: "p",
+      extractedAt: new Date(),
+    });
+
+    expect(report.corroborated).toBe(1);
+    const stored = await facts();
+    expect(stored).toHaveLength(1);
+    expect(stored[0]!.status).toBe("published");
+    expect((await edges()).filter((e) => e.edge_type === "provenance")).toHaveLength(2);
+  });
+
+  it("does not let a RETRACTED fact absorb a re-observation", async () => {
+    // `invalidated_at IS NULL` in the lookup. A tombstoned claim corroborating
+    // a fresh observation would resurrect a belief by side-effect — and, worse,
+    // silently: the new evidence would attach to a fact no reader can see.
+    const first = await insertEpisode({ sourceId: "C01:ret-1" });
+    const second = await insertEpisode({ sourceId: "C01:ret-2" });
+    await reconcileFacts({ episode: first, candidates: [candidate()], producer: "p", extractedAt: new Date() });
+    await pool.query(`UPDATE brain_facts SET invalidated_at = now()`);
+
+    const report = await reconcileFacts({
+      episode: second,
+      candidates: [candidate()],
+      producer: "p",
+      extractedAt: new Date(),
+    });
+
+    expect(report.created).toBe(1);
+    expect(await facts()).toHaveLength(2);
+  });
+
+  it("two reconciles racing on one claim produce ONE fact", async () => {
+    // What the per-workspace advisory lock is FOR. The unit suite proves the
+    // statement is issued; only a real transaction proves it serializes a
+    // read-then-insert that would otherwise interleave into two rows.
+    const a = await insertEpisode({ sourceId: "C01:race-a" });
+    const b = await insertEpisode({ sourceId: "C01:race-b" });
+
+    await Promise.all([
+      reconcileFacts({ episode: a, candidates: [candidate()], producer: "p", extractedAt: new Date() }),
+      reconcileFacts({ episode: b, candidates: [candidate()], producer: "p", extractedAt: new Date() }),
+    ]);
+
+    expect(await facts()).toHaveLength(1);
+    expect((await edges()).filter((e) => e.edge_type === "provenance")).toHaveLength(2);
   });
 
   it("an empty queue is a clean success", async () => {

--- a/packages/api/src/lib/brain/__tests__/extract.test.ts
+++ b/packages/api/src/lib/brain/__tests__/extract.test.ts
@@ -1,0 +1,313 @@
+/**
+ * The extraction fiber's DB-free surface (#4771, ADR-0036 §Ingestion).
+ *
+ * The `-pg` sibling drives whole cycles against a live schema. What lives here
+ * is everything that needs no database and would otherwise be tested nowhere:
+ *
+ *   1. **`resolveExtractionModel`** — the BYO-key seam. It is the control that
+ *      keeps Atlas from silently billing its own key for a workspace that chose
+ *      its own provider, and every fiber test injects PAST it, so without this
+ *      file it executes in no test at all.
+ *   2. **`llmFactExtractor`** — the caps and the prompt contract. `MAX_CANDIDATES`
+ *      is a spend bound on a model that will not stop; the truncation marker is
+ *      what keeps a cut-off transcript from being extracted as if complete.
+ *   3. **The decoupling itself** (acceptance criterion 1). It holds structurally
+ *      today — nothing under `lib/brain/ingest/` imports this module — and the
+ *      only thing that would notice someone adding the synchronous
+ *      ingest→extract fast-path the header rejects is a source scan.
+ */
+
+import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { Effect, Layer } from "effect";
+import { MockLanguageModelV3 } from "ai/test";
+import type { LanguageModel } from "ai";
+import type { LanguageModelV3GenerateResult } from "@ai-sdk/provider";
+import type { RawWorkspaceModelConfig } from "@atlas/api/lib/auth/credentials";
+import type { ModelRouterShape } from "@atlas/api/lib/effect/services";
+
+// Module-top env, read at import time by `enterprise-config.ts` — forces
+// `ConditionalEELayer` to lazy-import the mocked `@atlas/ee/layers` aggregator
+// below. Without it the no-op default fires, every test sees `available: false`,
+// and the EE-unavailable assertion would pass for the wrong reason. `??=` per
+// the test-discipline rule (the module-load contract, not teardown).
+process.env.ATLAS_ENTERPRISE_ENABLED ??= "true";
+
+// ---------------------------------------------------------------------------
+// A controllable ModelRouter, reached the way production reaches it
+// ---------------------------------------------------------------------------
+
+/** What the stub router should do for the next call. */
+let routerAvailable = true;
+let routerConfig: RawWorkspaceModelConfig | null = null;
+let routerFailure: Error | null = null;
+
+void mock.module("@atlas/ee/layers", () => ({
+  EELayer: Layer.unwrapEffect(
+    Effect.sync(() => {
+      // oxlint-disable-next-line @typescript-eslint/no-require-imports -- the Layer is built lazily inside the mock factory, which must stay synchronous (bun:test deadlocks on an async factory).
+      const services = require("@atlas/api/lib/effect/services") as typeof import("@atlas/api/lib/effect/services");
+      return Layer.succeed(services.ModelRouter, {
+        // A GETTER, not a captured value: `runEnterprise` memoizes this Layer
+        // into a process-lifetime runtime, so the object is built once on the
+        // first call and a later `routerAvailable = false` would never be seen.
+        get available() {
+          return routerAvailable;
+        },
+        getWorkspaceModelConfig: () => Effect.die("not stubbed"),
+        getWorkspaceModelConfigRaw: () =>
+          routerFailure ? Effect.fail(routerFailure) : Effect.succeed(routerConfig),
+        setWorkspaceModelConfig: () => Effect.die("not stubbed"),
+        deleteWorkspaceModelConfig: () => Effect.die("not stubbed"),
+        testModelConfig: () => Effect.die("not stubbed"),
+        reconcileModelDeprecation: () =>
+          Effect.succeed({ status: "healthy" as const, suggestion: null }),
+        parseBedrockCredentialBundle: () => null,
+      } satisfies ModelRouterShape);
+    }),
+  ),
+}));
+
+const { resolveExtractionModel, llmFactExtractor, isBrainExtractionEnabled } = await import(
+  "@atlas/api/lib/brain/extract"
+);
+
+const WORKSPACE = "ws-brain-extract";
+
+function anthropicConfig(overrides: Partial<RawWorkspaceModelConfig> = {}): RawWorkspaceModelConfig {
+  return {
+    provider: "anthropic",
+    model: "claude-test-model",
+    baseUrl: null,
+    bedrockRegion: null,
+    credentials: { provider: "anthropic", apiKey: "sk-ant-test" },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  routerAvailable = true;
+  routerConfig = null;
+  routerFailure = null;
+});
+
+// ---------------------------------------------------------------------------
+// The BYO-key seam
+// ---------------------------------------------------------------------------
+
+describe("resolveExtractionModel", () => {
+  test("uses the workspace's own configuration when it has one", async () => {
+    routerConfig = anthropicConfig();
+    const resolved = await resolveExtractionModel(WORKSPACE);
+
+    expect(resolved).not.toBeNull();
+    // The model id is what lands in provenance — a reviewer has to be able to
+    // tell which model asserted a claim.
+    expect(resolved?.modelId).toBe("claude-test-model");
+  });
+
+  test("refuses when model routing is unavailable on an enterprise deployment", async () => {
+    // The defect this pins: the no-op router returns `null` for every
+    // workspace, which is INDISTINGUISHABLE from "this workspace has no BYO
+    // config". An EE module that failed to load would therefore have moved
+    // every BYO workspace's entire backlog onto Atlas's own key, unattended.
+    routerAvailable = false;
+    expect(await resolveExtractionModel(WORKSPACE)).toBeNull();
+  });
+
+  test("refuses when the configuration cannot be read", async () => {
+    routerFailure = new Error("workspace key could not be decrypted");
+    expect(await resolveExtractionModel(WORKSPACE)).toBeNull();
+  });
+
+  test("refuses a configuration that reads but cannot be built into a model", async () => {
+    // `custom` with no base URL throws inside `getModelFromWorkspaceConfig`.
+    // Left outside the guard this escaped as a per-episode throw, was counted
+    // as a TRANSIENT failure, and was retried every five minutes forever — the
+    // wrong verdict for a fault only an admin can clear.
+    routerConfig = anthropicConfig({
+      provider: "custom",
+      baseUrl: null,
+      credentials: { provider: "custom", apiKey: "key" },
+    });
+    expect(await resolveExtractionModel(WORKSPACE)).toBeNull();
+  });
+
+  test("refuses a bedrock configuration whose credential bundle is malformed", async () => {
+    // `bundle: null` is the union's post-decrypt malformed signal — precisely
+    // the "key that no longer decrypts" case, and it arrives as DATA rather
+    // than as a thrown error, so it bypasses the read guard entirely.
+    routerConfig = anthropicConfig({
+      provider: "bedrock",
+      bedrockRegion: "us-east-1",
+      credentials: { provider: "bedrock", bundle: null },
+    });
+    expect(await resolveExtractionModel(WORKSPACE)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The extractor's caps and prompt contract
+// ---------------------------------------------------------------------------
+
+describe("llmFactExtractor", () => {
+  const episode = {
+    id: "ep-1",
+    workspaceId: WORKSPACE,
+    source: "slack",
+    sourceId: "C01:1",
+    sourceActor: "U1",
+    occurredAt: new Date("2026-06-21T09:00:00.000Z"),
+    visibleTo: ["org"],
+  };
+
+  /** A model that answers with `facts` and records the call it was given. */
+  function modelReturning(facts: unknown[]): {
+    model: LanguageModel;
+    calls: { prompt: string; temperature: number | undefined }[];
+  } {
+    const calls: { prompt: string; temperature: number | undefined }[] = [];
+    const model = new MockLanguageModelV3({
+      doGenerate: async (options): Promise<LanguageModelV3GenerateResult> => {
+        const text = options.prompt
+          .flatMap((m) =>
+            Array.isArray(m.content)
+              ? m.content.flatMap((part) => (part.type === "text" ? [part.text] : []))
+              : [],
+          )
+          .join("\n");
+        calls.push({ prompt: text, temperature: options.temperature });
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify({ facts }) }],
+          finishReason: { unified: "stop" as const, raw: "end_turn" },
+          usage: {
+            inputTokens: { total: 10, noCache: 10, cacheRead: 0, cacheWrite: 0 },
+            outputTokens: { total: 10, text: 10, reasoning: 0 },
+          },
+          warnings: [],
+        };
+      },
+    });
+    return { model: model as unknown as LanguageModel, calls };
+  }
+
+  const oneFact = [
+    { subject: "deploy window", predicate: "is", object: "Thursdays", cardinality: "multi" },
+  ];
+
+  test("pins temperature to 0 — the dedupe it feeds is byte-exact", async () => {
+    // Not a quality preference: the reconcile stage collapses a re-extraction
+    // only when the model reproduces its own output verbatim, and re-extraction
+    // after a crash is the whole idempotence story.
+    const { model, calls } = modelReturning(oneFact);
+    await llmFactExtractor({ episode, body: "hello", model, modelId: "m" });
+    expect(calls[0]?.temperature).toBe(0);
+  });
+
+  test("caps how many claims one episode may produce", async () => {
+    const many = Array.from({ length: 25 }, (_, i) => ({
+      subject: `s${i}`,
+      predicate: "is",
+      object: `o${i}`,
+      cardinality: "multi",
+    }));
+    const { model } = modelReturning(many);
+    const candidates = await llmFactExtractor({ episode, body: "hello", model, modelId: "m" });
+
+    expect(candidates).toHaveLength(10);
+  });
+
+  test("marks a truncated body so the model is not extracting from a severed clause", async () => {
+    const { model, calls } = modelReturning(oneFact);
+    await llmFactExtractor({
+      episode,
+      body: "x".repeat(9_000),
+      model,
+      modelId: "m",
+    });
+
+    expect(calls[0]?.prompt).toContain("[truncated at 8000 characters]");
+  });
+
+  test("leaves a body under the cap unmarked", async () => {
+    const { model, calls } = modelReturning(oneFact);
+    await llmFactExtractor({ episode, body: "the deploy window is Thursdays", model, modelId: "m" });
+
+    expect(calls[0]?.prompt).not.toContain("truncated");
+    expect(calls[0]?.prompt).toContain("the deploy window is Thursdays");
+  });
+
+  test("records the model id in provenance detail", async () => {
+    const { model } = modelReturning(oneFact);
+    const candidates = await llmFactExtractor({
+      episode,
+      body: "hello",
+      model,
+      modelId: "claude-test-model",
+    });
+
+    expect(candidates[0]?.detail).toMatchObject({ model: "claude-test-model" });
+    expect(candidates[0]?.predicateCardinality).toBe("multi");
+  });
+
+  test("an episode with no durable claim yields no candidates", async () => {
+    // The modal production case by a wide margin — most chat is not a fact.
+    const { model } = modelReturning([]);
+    expect(await llmFactExtractor({ episode, body: "morning all", model, modelId: "m" })).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The enablement gate
+// ---------------------------------------------------------------------------
+
+describe("isBrainExtractionEnabled", () => {
+  const prior = process.env.ATLAS_BRAIN_EXTRACTION_ENABLED;
+  afterEach(() => {
+    if (prior === undefined) delete process.env.ATLAS_BRAIN_EXTRACTION_ENABLED;
+    else process.env.ATLAS_BRAIN_EXTRACTION_ENABLED = prior;
+  });
+
+  test("is OFF unless explicitly switched on", () => {
+    // Default-OFF is load-bearing while the milestone is in flight: the review
+    // surface (#4772) is what makes an extracted fact usable, so a `default:
+    // "true"` slip would spend every workspace's model budget filling a queue
+    // no UI can read.
+    delete process.env.ATLAS_BRAIN_EXTRACTION_ENABLED;
+    expect(isBrainExtractionEnabled()).toBe(false);
+  });
+
+  test("only the exact string `true` enables it", () => {
+    process.env.ATLAS_BRAIN_EXTRACTION_ENABLED = "yes";
+    expect(isBrainExtractionEnabled()).toBe(false);
+    process.env.ATLAS_BRAIN_EXTRACTION_ENABLED = "true";
+    expect(isBrainExtractionEnabled()).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Acceptance criterion 1, structurally
+// ---------------------------------------------------------------------------
+
+describe("fetch and extraction stay decoupled", () => {
+  test("nothing in the ingest path imports the extraction fiber", async () => {
+    // The criterion is "episode freshness never blocks on LLM latency/429s".
+    // Today that holds because the ONLY consumer of this module is the
+    // scheduler registration — but the synchronous ingest→extract fast-path the
+    // header rejects would be a three-line change that no behavioural test
+    // notices, because it would still produce correct facts. It would just
+    // couple the connector's cycle time to a model's.
+    const { Glob } = await import("bun");
+    const root = new URL("../ingest/", import.meta.url).pathname;
+    const offenders: string[] = [];
+    for await (const file of new Glob("**/*.ts").scan({ cwd: root, absolute: true })) {
+      if (file.includes("__tests__")) continue;
+      const source = await Bun.file(file).text();
+      if (/from\s+["'][^"']*brain\/extract["']/.test(source)) offenders.push(file);
+    }
+    expect(offenders).toEqual([]);
+  });
+});
+
+afterAll(() => {
+  mock.restore();
+});

--- a/packages/api/src/lib/brain/__tests__/extract.test.ts
+++ b/packages/api/src/lib/brain/__tests__/extract.test.ts
@@ -25,11 +25,13 @@ import type { LanguageModelV3GenerateResult } from "@ai-sdk/provider";
 import type { RawWorkspaceModelConfig } from "@atlas/api/lib/auth/credentials";
 import type { ModelRouterShape } from "@atlas/api/lib/effect/services";
 
-// Module-top env, read at import time by `enterprise-config.ts` — forces
-// `ConditionalEELayer` to lazy-import the mocked `@atlas/ee/layers` aggregator
-// below. Without it the no-op default fires, every test sees `available: false`,
-// and the EE-unavailable assertion would pass for the wrong reason. `??=` per
-// the test-discipline rule (the module-load contract, not teardown).
+// Set before the first `runEnterprise` call, because `getEnterpriseRuntime()`
+// memoizes `ConditionalEELayer` for the process lifetime and that layer decides
+// ONCE — at first build — whether to import `@atlas/ee/layers` at all. Without
+// it the no-op default wins forever, every test sees `available: false`, and the
+// EE-unavailable assertion below would pass for the wrong reason.
+// (`enterprise-config.ts::isEnterpriseEnabled`, which gates the probe under
+// test, reads the same var per call.) `??=` per the test-discipline rule.
 process.env.ATLAS_ENTERPRISE_ENABLED ??= "true";
 
 // ---------------------------------------------------------------------------
@@ -112,6 +114,31 @@ describe("resolveExtractionModel", () => {
     // every BYO workspace's entire backlog onto Atlas's own key, unattended.
     routerAvailable = false;
     expect(await resolveExtractionModel(WORKSPACE)).toBeNull();
+
+    // The control, in the same test so the two branches are shown to DIFFER:
+    // identical inputs but an available router falls through to the platform
+    // default. Without it, `toBeNull()` alone could be satisfied by any of the
+    // function's other three null paths.
+    routerAvailable = true;
+    expect(await resolveExtractionModel(WORKSPACE)).not.toBeNull();
+  });
+
+  test("a self-hosted install still gets the platform default", async () => {
+    // The complementary arm, and the reason the probe is gated rather than
+    // unconditional: on self-hosted there IS no EE layer, so `available: false`
+    // is correct and expected. Refusing there would stall every self-hosted
+    // drain forever, under an ERROR line claiming it was an enterprise
+    // deployment.
+    const prior = process.env.ATLAS_ENTERPRISE_ENABLED;
+    delete process.env.ATLAS_ENTERPRISE_ENABLED;
+    try {
+      routerAvailable = false;
+      routerConfig = null;
+      expect(await resolveExtractionModel(WORKSPACE)).not.toBeNull();
+    } finally {
+      if (prior === undefined) delete process.env.ATLAS_ENTERPRISE_ENABLED;
+      else process.env.ATLAS_ENTERPRISE_ENABLED = prior;
+    }
   });
 
   test("refuses when the configuration cannot be read", async () => {
@@ -226,6 +253,9 @@ describe("llmFactExtractor", () => {
     });
 
     expect(calls[0]?.prompt).toContain("[truncated at 8000 characters]");
+    // The marker alone would pass if the `slice` were dropped — then the model
+    // would receive the whole 9,000 characters AND a claim that it did not.
+    expect(calls[0]?.prompt.length).toBeLessThan(9_000);
   });
 
   test("leaves a body under the cap unmarked", async () => {
@@ -299,12 +329,22 @@ describe("fetch and extraction stay decoupled", () => {
     const { Glob } = await import("bun");
     const root = new URL("../ingest/", import.meta.url).pathname;
     const offenders: string[] = [];
+    let scanned = 0;
+    // All three import forms. A `from "…"` -only pattern would miss
+    // `await import(...)` and `require(...)` — which is how the PRODUCTION
+    // consumer imports this module (`layers.ts`), and therefore the idiom
+    // whoever added the fast-path would reach for first.
+    const importsExtract = /(from\s+|import\(\s*|require\(\s*)["'][^"']*brain\/extract["']/;
     for await (const file of new Glob("**/*.ts").scan({ cwd: root, absolute: true })) {
       if (file.includes("__tests__")) continue;
+      scanned++;
       const source = await Bun.file(file).text();
-      if (/from\s+["'][^"']*brain\/extract["']/.test(source)) offenders.push(file);
+      if (importsExtract.test(source)) offenders.push(file);
     }
     expect(offenders).toEqual([]);
+    // A moved or renamed directory would otherwise make this pass having read
+    // nothing at all.
+    expect(scanned).toBeGreaterThan(0);
   });
 });
 

--- a/packages/api/src/lib/brain/__tests__/reconcile.test.ts
+++ b/packages/api/src/lib/brain/__tests__/reconcile.test.ts
@@ -6,8 +6,8 @@
  * `mock.module()`, no database. What they pin is the part a real-Postgres test
  * cannot make legible: which failure BLOCKS, which failure FLAGS, and exactly
  * what a reviewer ends up holding. The storage-level claims (the CHECKs, the
- * FKs, real transaction rollback, two overlapping reconciles racing for one
- * claim) live in the `-pg` sibling.
+ * real transaction rollback, two overlapping reconciles racing for one claim,
+ * cross-tenant scoping) live in the `-pg` sibling.
  *
  * The block-vs-flag asymmetry is the reason this file exists at all. Both
  * directions are failure modes with names:

--- a/packages/api/src/lib/brain/__tests__/reconcile.test.ts
+++ b/packages/api/src/lib/brain/__tests__/reconcile.test.ts
@@ -1,0 +1,561 @@
+/**
+ * The reconcile stage's decision matrix (#4771, ADR-0036 §T6).
+ *
+ * These tests drive `reconcileFacts` against an in-memory executor that
+ * dispatches on the module's EXPORTED SQL constants — no string parsing, no
+ * `mock.module()`, no database. What they pin is the part a real-Postgres test
+ * cannot make legible: which failure BLOCKS, which failure FLAGS, and exactly
+ * what a reviewer ends up holding. The storage-level claims (the CHECKs, the
+ * FKs, real transaction rollback, real concurrency) live in the `-pg` sibling.
+ *
+ * The block-vs-flag asymmetry is the reason this file exists at all. Both
+ * directions are failure modes with names:
+ *   - a SAFETY failure that flags is a leak (a fact nobody can see, or one
+ *     nobody can attribute, reaching the review queue as if it were fine);
+ *   - a QUALITY failure that blocks is a silent fact-dropper.
+ * So every failure class gets a test on the arm it is supposed to take.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  CORROBORATION_LOOKUP_SQL,
+  INSERT_FACT_SQL,
+  INSERT_PROVENANCE_EDGE_SQL,
+  INSERT_TENSION_EDGE_SQL,
+  RECONCILE_BLOCK_REASONS,
+  RECONCILE_LOCK_SQL,
+  TENSION_CANDIDATES_SQL,
+  reconcileFacts,
+  type EntityResolver,
+  type FactCandidate,
+  type ReconcileEpisodeRef,
+  type ReconcileExecutor,
+  type ReconcileTransactionRunner,
+} from "@atlas/api/lib/brain/reconcile";
+
+// ---------------------------------------------------------------------------
+// A store that answers exactly the six statements the stage issues
+// ---------------------------------------------------------------------------
+
+interface StoredFact {
+  id: string;
+  workspaceId: string;
+  subject: string;
+  predicate: string;
+  object: string;
+  provenance: Record<string, unknown>;
+  visibleTo: string[];
+  cardinality: string;
+  validFrom: string | null;
+  extractedAt: string | null;
+}
+
+interface StoredEdge {
+  workspaceId: string;
+  edgeType: string;
+  fromFactId: string;
+  toFactId: string | null;
+  toEpisodeId: string | null;
+}
+
+class FakeBrainStore {
+  readonly facts: StoredFact[] = [];
+  readonly edges: StoredEdge[] = [];
+  readonly locks: string[] = [];
+  transactions = 0;
+  private seq = 0;
+
+  /** A runner shaped like the real one, so "did anything open a tx?" is testable. */
+  readonly runner: ReconcileTransactionRunner = async <T>(
+    fn: (tx: ReconcileExecutor) => Promise<T>,
+  ): Promise<T> => {
+    this.transactions++;
+    return fn({ query: (sql, params) => this.query(sql, params ?? []) });
+  };
+
+  private async query(
+    sql: string,
+    params: unknown[],
+  ): Promise<{ rows: readonly unknown[] }> {
+    switch (sql) {
+      case RECONCILE_LOCK_SQL: {
+        this.locks.push(String(params[1]));
+        return { rows: [] };
+      }
+      case CORROBORATION_LOOKUP_SQL: {
+        const [workspaceId, subject, predicate, object] = params.map(String);
+        const hit = this.facts.find(
+          (f) =>
+            f.workspaceId === workspaceId &&
+            f.subject === subject &&
+            f.predicate === predicate &&
+            f.object === object,
+        );
+        return { rows: hit ? [{ id: hit.id }] : [] };
+      }
+      case INSERT_FACT_SQL: {
+        const id = `fact-${++this.seq}`;
+        this.facts.push({
+          id,
+          workspaceId: String(params[0]),
+          subject: String(params[1]),
+          predicate: String(params[2]),
+          object: String(params[3]),
+          validFrom: params[4] === null ? null : String(params[4]),
+          extractedAt: params[5] === null ? null : String(params[5]),
+          provenance: JSON.parse(String(params[7])) as Record<string, unknown>,
+          visibleTo: JSON.parse(String(params[8])) as string[],
+          cardinality: String(params[9]),
+        });
+        return { rows: [{ id }] };
+      }
+      case INSERT_PROVENANCE_EDGE_SQL: {
+        const [workspaceId, fromFactId, toEpisodeId] = params.map(String);
+        const exists = this.edges.some(
+          (e) =>
+            e.edgeType === "provenance" &&
+            e.workspaceId === workspaceId &&
+            e.fromFactId === fromFactId &&
+            e.toEpisodeId === toEpisodeId,
+        );
+        if (exists) return { rows: [] };
+        this.edges.push({
+          workspaceId,
+          edgeType: "provenance",
+          fromFactId,
+          toFactId: null,
+          toEpisodeId,
+        });
+        return { rows: [{ id: `edge-${++this.seq}` }] };
+      }
+      case TENSION_CANDIDATES_SQL: {
+        const [workspaceId, subject, predicate, object, selfId] = params.map(String);
+        const rivals = this.facts.filter(
+          (f) =>
+            f.workspaceId === workspaceId &&
+            f.subject === subject &&
+            f.predicate === predicate &&
+            f.object !== object &&
+            f.id !== selfId,
+        );
+        return { rows: rivals.map((f) => ({ id: f.id })) };
+      }
+      case INSERT_TENSION_EDGE_SQL: {
+        const [workspaceId, fromFactId, toFactId] = params.map(String);
+        const exists = this.edges.some(
+          (e) =>
+            e.edgeType === "in-tension-with" &&
+            e.fromFactId === fromFactId &&
+            e.toFactId === toFactId,
+        );
+        if (exists) return { rows: [] };
+        this.edges.push({
+          workspaceId,
+          edgeType: "in-tension-with",
+          fromFactId,
+          toFactId,
+          toEpisodeId: null,
+        });
+        return { rows: [{ id: `edge-${++this.seq}` }] };
+      }
+      default:
+        throw new Error(`FakeBrainStore received an unexpected statement: ${sql}`);
+    }
+  }
+}
+
+const WORKSPACE = "ws-brain";
+
+function episode(overrides: Partial<ReconcileEpisodeRef> = {}): ReconcileEpisodeRef {
+  return {
+    id: "ep-1",
+    workspaceId: WORKSPACE,
+    source: "slack",
+    sourceId: "C01:1719000000.000100",
+    sourceActor: "U123",
+    occurredAt: new Date("2026-06-21T09:00:00.000Z"),
+    visibleTo: ["org"],
+    ...overrides,
+  };
+}
+
+function candidate(overrides: Partial<FactCandidate> = {}): FactCandidate {
+  return {
+    subject: "deploy window",
+    predicate: "is",
+    object: "Thursdays",
+    ...overrides,
+  };
+}
+
+function run(
+  store: FakeBrainStore,
+  request: Partial<Parameters<typeof reconcileFacts>[0]> = {},
+) {
+  return reconcileFacts(
+    {
+      episode: episode(),
+      candidates: [candidate()],
+      producer: "extraction:v1",
+      extractedAt: new Date("2026-06-21T10:00:00.000Z"),
+      ...request,
+    },
+    { withTransaction: store.runner, now: () => new Date("2026-06-21T10:00:01.000Z") },
+  );
+}
+
+// ---------------------------------------------------------------------------
+// BLOCK — safety failures
+// ---------------------------------------------------------------------------
+
+describe("block: no usable grant", () => {
+  // The load-bearing case. `['everyone']` satisfies
+  // `chk_brain_facts_grant_nonempty` (cardinality 1) and grants NOBODY, because
+  // enforcement is array overlap against reader tokens. Written as a draft it
+  // would be legal, invisible, refused at every publish forever by #4769's
+  // GRANT_UNUSABLE classifier, and unrepairable until #4772 ships a repair UI.
+  test("blocks a grant the 0180 CHECK admits but no reader can ever match", async () => {
+    const store = new FakeBrainStore();
+    const report = await run(store, { episode: episode({ visibleTo: ["everyone"] }) });
+
+    expect(report.blocked.NO_GRANT).toBe(1);
+    expect(report.created).toBe(0);
+    expect(report.outcomes[0]).toEqual({
+      kind: "blocked",
+      reason: RECONCILE_BLOCK_REASONS.noGrant,
+    });
+    expect(store.facts).toHaveLength(0);
+    // Not merely "wrote nothing" — it must not even open a transaction, since
+    // no candidate on this episode can produce a safe row.
+    expect(store.transactions).toBe(0);
+  });
+
+  test("blocks an empty grant", async () => {
+    const store = new FakeBrainStore();
+    const report = await run(store, { episode: episode({ visibleTo: [] }) });
+    expect(report.blocked.NO_GRANT).toBe(1);
+    expect(store.facts).toHaveLength(0);
+  });
+
+  test("blocks a grant of only null / empty elements", async () => {
+    // Legal at rest per the CHECK's `array_remove` test? No — but `pg` can hand
+    // these back on a hand-edited import bundle, and `parseGrant` counts them
+    // as malformed rather than throwing. Either way: nobody can read it.
+    const store = new FakeBrainStore();
+    const report = await run(store, { episode: episode({ visibleTo: [null, ""] }) });
+    expect(report.blocked.NO_GRANT).toBe(1);
+  });
+
+  test("proceeds when one usable principal sits beside a malformed one", async () => {
+    // The rule is "at least one principal a reader could match", not "every
+    // token is well-formed" — the inert token is carried through verbatim and
+    // simply matches nothing.
+    const store = new FakeBrainStore();
+    const report = await run(store, {
+      episode: episode({ visibleTo: ["everyone", "user:u-1"] }),
+    });
+    expect(report.created).toBe(1);
+    expect(store.facts[0]?.visibleTo).toEqual(["everyone", "user:u-1"]);
+  });
+});
+
+describe("block: unattributable claim", () => {
+  test("blocks when neither the caller nor the episode names a source principal", async () => {
+    const store = new FakeBrainStore();
+    const report = await run(store, { episode: episode({ sourceActor: null }) });
+
+    expect(report.blocked.SOURCE_PRINCIPAL_UNRESOLVED).toBe(1);
+    expect(store.transactions).toBe(0);
+  });
+
+  test("blocks on a whitespace-only source actor", async () => {
+    const store = new FakeBrainStore();
+    const report = await run(store, { episode: episode({ sourceActor: "   " }) });
+    expect(report.blocked.SOURCE_PRINCIPAL_UNRESOLVED).toBe(1);
+  });
+
+  test("an explicit sourcePrincipal covers an actorless episode", async () => {
+    // The entry-point-agnostic half: a warehouse snapshot has no `source_actor`
+    // (0180) and its caller supplies the system principal instead. Without this
+    // arm, every non-chat entry point would be permanently blocked.
+    const store = new FakeBrainStore();
+    const report = await run(store, {
+      episode: episode({ sourceActor: null, source: "warehouse" }),
+      sourcePrincipal: "system:warehouse",
+    });
+
+    expect(report.created).toBe(1);
+    expect(store.facts[0]?.provenance.actor).toBe("system:warehouse");
+  });
+
+  test("the episode's actor is namespaced by source", async () => {
+    // `U123` is only meaningful next to the source that minted it — two
+    // vendors can both hand out `U123`.
+    const store = new FakeBrainStore();
+    await run(store);
+    expect(store.facts[0]?.provenance.actor).toBe("slack:U123");
+  });
+});
+
+describe("block: no provenance", () => {
+  test("blocks an episode with no id", async () => {
+    const store = new FakeBrainStore();
+    const report = await run(store, { episode: episode({ id: "  " }) });
+    expect(report.blocked.NO_PROVENANCE).toBe(1);
+    expect(store.transactions).toBe(0);
+  });
+});
+
+describe("block: malformed claim", () => {
+  test("blocks a candidate with a blank column and still writes its siblings", async () => {
+    // Per-candidate, not per-episode: one bad triple from a producer must not
+    // cost the good ones, which is the same per-record isolation the ingest
+    // core applies to episodes.
+    const store = new FakeBrainStore();
+    const report = await run(store, {
+      candidates: [
+        candidate({ object: "   " }),
+        candidate({ subject: "release train", object: "weekly" }),
+      ],
+    });
+
+    expect(report.blocked.MALFORMED_CLAIM).toBe(1);
+    expect(report.created).toBe(1);
+    expect(store.facts).toHaveLength(1);
+    expect(store.facts[0]?.subject).toBe("release train");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FLAG — quality failures
+// ---------------------------------------------------------------------------
+
+describe("flag: entity resolution", () => {
+  const failingResolver: EntityResolver = (surface, { role }) =>
+    role === "object" ? null : { canonical: surface };
+
+  test("an unresolved object is written as a provisional draft, never dropped", async () => {
+    const store = new FakeBrainStore();
+    const report = await run(store, { resolveEntity: failingResolver });
+
+    expect(report.created).toBe(1);
+    expect(report.provisional).toBe(1);
+    expect(report.outcomes[0]).toMatchObject({ kind: "created", provisional: true });
+
+    const fact = store.facts[0];
+    expect(fact).toBeDefined();
+    // The reviewer needs to know WHICH side is unsettled — "provisional" alone
+    // would send them re-reading both.
+    expect(fact?.provenance.provisional).toBe(true);
+    expect(fact?.provenance.unresolved).toEqual(["object"]);
+    // And the unresolved surface form is preserved, so there is something to
+    // resolve rather than a hole.
+    expect(fact?.object).toBe("Thursdays");
+  });
+
+  test("a resolver that THROWS flags rather than blocking the episode", async () => {
+    // A resolver is injected code — a future one will call a store and can time
+    // out. Letting the throw escape would turn a quality failure into a block
+    // for every candidate on the episode, inverting the asymmetry.
+    const store = new FakeBrainStore();
+    const report = await run(store, {
+      resolveEntity: () => {
+        throw new Error("entity store unreachable");
+      },
+    });
+
+    expect(report.created).toBe(1);
+    expect(report.provisional).toBe(1);
+    expect(store.facts[0]?.provenance.unresolved).toEqual(["subject", "object"]);
+  });
+
+  test("the default resolver marks nothing provisional", async () => {
+    const store = new FakeBrainStore();
+    const report = await run(store);
+    expect(report.provisional).toBe(0);
+    expect(store.facts[0]?.provenance.provisional).toBeUndefined();
+  });
+
+  test("a resolver's canonical form is what lands in the fact", async () => {
+    const store = new FakeBrainStore();
+    await run(store, {
+      resolveEntity: (surface, { role }) =>
+        role === "subject" ? { canonical: "Deploy Window", entityId: "e-7" } : { canonical: surface },
+    });
+
+    expect(store.facts[0]?.subject).toBe("Deploy Window");
+    expect(store.facts[0]?.provenance.entityIds).toEqual({ subject: "e-7" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Corroboration
+// ---------------------------------------------------------------------------
+
+describe("corroboration", () => {
+  test("re-observing a claim strengthens it instead of duplicating it", async () => {
+    const store = new FakeBrainStore();
+    await run(store);
+    const second = await run(store, {
+      episode: episode({ id: "ep-2", sourceId: "C01:1719000900.000200" }),
+    });
+
+    expect(second.created).toBe(0);
+    expect(second.corroborated).toBe(1);
+    expect(second.outcomes[0]).toMatchObject({ kind: "corroborated", evidenceAdded: true });
+    // One belief…
+    expect(store.facts).toHaveLength(1);
+    // …with two pieces of evidence behind it.
+    expect(store.edges.filter((e) => e.edgeType === "provenance")).toHaveLength(2);
+  });
+
+  test("re-running the SAME episode adds no second evidence edge", async () => {
+    // This is what makes `extract.ts`'s work-then-stamp ordering safe: a crash
+    // between the reconcile commit and the queue stamp costs a repeated model
+    // call and nothing else.
+    const store = new FakeBrainStore();
+    await run(store);
+    const again = await run(store);
+
+    expect(again.corroborated).toBe(1);
+    expect(again.outcomes[0]).toMatchObject({ evidenceAdded: false });
+    expect(store.facts).toHaveLength(1);
+    expect(store.edges.filter((e) => e.edgeType === "provenance")).toHaveLength(1);
+  });
+
+  test("corroboration never rewrites the existing fact's grant", async () => {
+    // Grants are immutable per fact version (0180): a wider re-observation is
+    // evidence, not a promotion to a wider audience.
+    const store = new FakeBrainStore();
+    await run(store, { episode: episode({ visibleTo: ["audience:chat-channel:slack:C1"] }) });
+    await run(store, { episode: episode({ id: "ep-2", visibleTo: ["org"] }) });
+
+    expect(store.facts).toHaveLength(1);
+    expect(store.facts[0]?.visibleTo).toEqual(["audience:chat-channel:slack:C1"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Advisory contradiction
+// ---------------------------------------------------------------------------
+
+describe("advisory contradiction edges", () => {
+  test("a single-cardinality predicate with a rival object earns an in-tension-with edge", async () => {
+    const store = new FakeBrainStore();
+    await run(store, {
+      candidates: [
+        candidate({ subject: "Ada", predicate: "reports to", object: "Grace", predicateCardinality: "single" }),
+      ],
+    });
+    const second = await run(store, {
+      episode: episode({ id: "ep-2" }),
+      candidates: [
+        candidate({ subject: "Ada", predicate: "reports to", object: "Alan", predicateCardinality: "single" }),
+      ],
+    });
+
+    expect(second.outcomes[0]).toMatchObject({ kind: "created", tensionEdges: 1 });
+    // Both beliefs survive — nothing is superseded, invalidated, or ranked.
+    // M2 owns arbitration; this edge only makes the conflict visible.
+    expect(store.facts).toHaveLength(2);
+    expect(store.edges.filter((e) => e.edgeType === "in-tension-with")).toHaveLength(1);
+  });
+
+  test("multi-cardinality values coexist with no tension edge", async () => {
+    const store = new FakeBrainStore();
+    await run(store, { candidates: [candidate({ subject: "Ada", predicate: "knows", object: "Ada-lang" })] });
+    await run(store, {
+      episode: episode({ id: "ep-2" }),
+      candidates: [candidate({ subject: "Ada", predicate: "knows", object: "Fortran" })],
+    });
+
+    expect(store.edges.filter((e) => e.edgeType === "in-tension-with")).toHaveLength(0);
+  });
+
+  test("cardinality defaults to the conservative arm", async () => {
+    const store = new FakeBrainStore();
+    await run(store);
+    expect(store.facts[0]?.cardinality).toBe("multi");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The candidate a reviewer receives
+// ---------------------------------------------------------------------------
+
+describe("the draft candidate", () => {
+  test("carries provenance, grant, evidence edge, and validity in one pass", async () => {
+    const store = new FakeBrainStore();
+    await run(store, {
+      candidates: [candidate({ validFrom: new Date("2026-06-01T00:00:00.000Z") })],
+    });
+
+    const fact = store.facts[0];
+    expect(fact?.provenance).toMatchObject({
+      source: "slack",
+      sourceId: "C01:1719000000.000100",
+      episodeId: "ep-1",
+      actor: "slack:U123",
+      producer: "extraction:v1",
+      occurredAt: "2026-06-21T09:00:00.000Z",
+      extractedAt: "2026-06-21T10:00:00.000Z",
+    });
+    expect(fact?.visibleTo).toEqual(["org"]);
+    expect(fact?.validFrom).toBe("2026-06-01T00:00:00.000Z");
+    expect(store.edges).toEqual([
+      {
+        workspaceId: WORKSPACE,
+        edgeType: "provenance",
+        fromFactId: fact?.id ?? "",
+        toFactId: null,
+        toEpisodeId: "ep-1",
+      },
+    ]);
+  });
+
+  test("a producer's detail enriches provenance but cannot overwrite it", async () => {
+    // Producer detail is merged UNDER the structural keys on purpose: a
+    // confused (or hostile) producer must not be able to restate where the
+    // claim came from.
+    const store = new FakeBrainStore();
+    await run(store, {
+      candidates: [
+        candidate({ detail: { model: "some-model", confidence: 0.4, actor: "spoofed", episodeId: "elsewhere" } }),
+      ],
+    });
+
+    expect(store.facts[0]?.provenance).toMatchObject({
+      model: "some-model",
+      confidence: 0.4,
+      actor: "slack:U123",
+      episodeId: "ep-1",
+    });
+  });
+
+  test("an invalid validFrom degrades to null rather than throwing mid-transaction", async () => {
+    const store = new FakeBrainStore();
+    const report = await run(store, { candidates: [candidate({ validFrom: new Date("nonsense") })] });
+
+    expect(report.created).toBe(1);
+    expect(store.facts[0]?.validFrom).toBeNull();
+  });
+
+  test("every write for one episode happens inside a single transaction, under the workspace lock", async () => {
+    const store = new FakeBrainStore();
+    await run(store, {
+      candidates: [candidate(), candidate({ object: "Fridays" }), candidate({ object: "Mondays" })],
+    });
+
+    expect(store.transactions).toBe(1);
+    expect(store.locks).toEqual([WORKSPACE]);
+    expect(store.facts).toHaveLength(3);
+  });
+
+  test("no candidates is a no-op, not an empty transaction", async () => {
+    const store = new FakeBrainStore();
+    const report = await run(store, { candidates: [] });
+
+    expect(report).toMatchObject({ created: 0, corroborated: 0, provisional: 0 });
+    expect(store.transactions).toBe(0);
+  });
+});

--- a/packages/api/src/lib/brain/__tests__/reconcile.test.ts
+++ b/packages/api/src/lib/brain/__tests__/reconcile.test.ts
@@ -6,7 +6,8 @@
  * `mock.module()`, no database. What they pin is the part a real-Postgres test
  * cannot make legible: which failure BLOCKS, which failure FLAGS, and exactly
  * what a reviewer ends up holding. The storage-level claims (the CHECKs, the
- * FKs, real transaction rollback, real concurrency) live in the `-pg` sibling.
+ * FKs, real transaction rollback, two overlapping reconciles racing for one
+ * claim) live in the `-pg` sibling.
  *
  * The block-vs-flag asymmetry is the reason this file exists at all. Both
  * directions are failure modes with names:
@@ -238,9 +239,12 @@ describe("block: no usable grant", () => {
   });
 
   test("blocks a grant of only null / empty elements", async () => {
-    // Legal at rest per the CHECK's `array_remove` test? No — but `pg` can hand
-    // these back on a hand-edited import bundle, and `parseGrant` counts them
-    // as malformed rather than throwing. Either way: nobody can read it.
+    // `chk_brain_episodes_grant_nonempty` refuses this AT REST, so it cannot
+    // arrive from the database. It can arrive from an entry point that has not
+    // stored anything yet — a write-back proposal, a human correction being
+    // pre-flighted — which is exactly the caller class this stage is built to
+    // be agnostic about. `parseGrant` counts the elements as malformed rather
+    // than throwing; either way nobody can read the result.
     const store = new FakeBrainStore();
     const report = await run(store, { episode: episode({ visibleTo: [null, ""] }) });
     expect(report.blocked.NO_GRANT).toBe(1);
@@ -549,6 +553,84 @@ describe("the draft candidate", () => {
     expect(store.transactions).toBe(1);
     expect(store.locks).toEqual([WORKSPACE]);
     expect(store.facts).toHaveLength(3);
+  });
+
+  test("outcomes come back in input order, one per candidate", async () => {
+    // #4772's review surface will zip this against what it submitted; a report
+    // that silently compacted the blocked entries would misattribute every
+    // verdict after the first refusal.
+    const store = new FakeBrainStore();
+    const report = await run(store, {
+      candidates: [candidate({ predicate: "   " }), candidate(), candidate({ object: "Fridays" })],
+    });
+
+    expect(report.outcomes.map((o) => o.kind)).toEqual(["blocked", "created", "created"]);
+  });
+
+  test("a failed provenance edge takes the fact down with it", async () => {
+    // "A fact never exists without its evidence pointer" is the criterion, and
+    // it is one `try/catch` away from being false: swallowing the edge failure
+    // to 'avoid losing the fact' would write precisely the no-provenance row
+    // the rule forbids, and every other test here would stay green.
+    const store = new FakeBrainStore();
+    const failing: ReconcileTransactionRunner = async (fn) =>
+      fn({
+        query: async (sql, params) => {
+          if (sql === INSERT_PROVENANCE_EDGE_SQL) throw new Error("edge insert failed");
+          return store.runner((tx) => tx.query(sql, params ?? []));
+        },
+      });
+
+    await expect(
+      reconcileFacts(
+        {
+          episode: episode(),
+          candidates: [candidate()],
+          producer: "extraction:v1",
+          extractedAt: new Date(),
+        },
+        { withTransaction: failing },
+      ),
+    ).rejects.toThrow("edge insert failed");
+  });
+
+  test("identity is byte-exact — canonicalizing is the resolver's job, not this stage's", async () => {
+    const store = new FakeBrainStore();
+    await run(store, { candidates: [candidate({ subject: "Alice" })] });
+    await run(store, {
+      episode: episode({ id: "ep-2" }),
+      candidates: [candidate({ subject: "alice" })],
+    });
+
+    // Two facts, not one. A `lower()` comparison here would quietly take the
+    // "are these the same entity?" decision away from the seam that exists to
+    // make it — and make it globally, for every workspace, with no reviewer.
+    expect(store.facts).toHaveLength(2);
+  });
+
+  test("surrounding whitespace is trimmed, so it never forks a claim", async () => {
+    const store = new FakeBrainStore();
+    await run(store);
+    const second = await run(store, {
+      episode: episode({ id: "ep-2" }),
+      candidates: [candidate({ subject: "  deploy window  ", object: " Thursdays " })],
+    });
+
+    expect(second.corroborated).toBe(1);
+    expect(store.facts).toHaveLength(1);
+  });
+
+  test("corroboration is scoped to the workspace", async () => {
+    const store = new FakeBrainStore();
+    await run(store);
+    const other = await run(store, {
+      episode: episode({ id: "ep-2", workspaceId: "ws-other" }),
+    });
+
+    // Same claim, different tenant — a corroboration across that line would be
+    // a cross-tenant read dressed as a dedupe.
+    expect(other.created).toBe(1);
+    expect(store.facts).toHaveLength(2);
   });
 
   test("no candidates is a no-op, not an empty transaction", async () => {

--- a/packages/api/src/lib/brain/__tests__/reconcile.test.ts
+++ b/packages/api/src/lib/brain/__tests__/reconcile.test.ts
@@ -62,7 +62,8 @@ interface StoredEdge {
 class FakeBrainStore {
   readonly facts: StoredFact[] = [];
   readonly edges: StoredEdge[] = [];
-  readonly locks: string[] = [];
+  /** Full `pg_advisory_xact_lock` params — the namespace matters as much as the key. */
+  readonly locks: unknown[][] = [];
   transactions = 0;
   private seq = 0;
 
@@ -80,7 +81,7 @@ class FakeBrainStore {
   ): Promise<{ rows: readonly unknown[] }> {
     switch (sql) {
       case RECONCILE_LOCK_SQL: {
-        this.locks.push(String(params[1]));
+        this.locks.push(params);
         return { rows: [] };
       }
       case CORROBORATION_LOOKUP_SQL: {
@@ -551,7 +552,11 @@ describe("the draft candidate", () => {
     });
 
     expect(store.transactions).toBe(1);
-    expect(store.locks).toEqual([WORKSPACE]);
+    // The NAMESPACE is asserted, not just the key: `4771` is what keeps a
+    // reconcile from serializing behind an unrelated per-workspace guard, and
+    // four sibling files now record that the seven two-arg namespaces are
+    // pairwise distinct. Swapping it for another guard's number must fail here.
+    expect(store.locks).toEqual([[4771, WORKSPACE]]);
     expect(store.facts).toHaveLength(3);
   });
 

--- a/packages/api/src/lib/brain/acl.ts
+++ b/packages/api/src/lib/brain/acl.ts
@@ -118,8 +118,12 @@ function isOrgRole(value: string): value is OrgRole {
  * implicitly `any` in the one line that performs the actual overlap — and
  * would stop rejecting a future simplification to a bare `tokens.has(token)`.
  * This keeps them `unknown`.
+ *
+ * Exported (#4771) so the extraction drain narrows a `text[]` off the driver
+ * with the same guard rather than re-introducing the `as` cast this exists to
+ * remove.
  */
-function isUnknownArray(value: unknown): value is readonly unknown[] {
+export function isUnknownArray(value: unknown): value is readonly unknown[] {
   return Array.isArray(value);
 }
 
@@ -464,8 +468,9 @@ export async function resolvePrincipalContext(
     // apart. A row with no `audience_id` key at all is QUERY DRIFT (an added
     // alias, a join) — diff the SQL. A row that has the column but an unusable
     // value is a DATA defect: `audience_id` is `text NOT NULL` but 0180 adds no
-    // non-empty CHECK, so `''` is legally storable and points at the deriver
-    // (#4771), not at this query. Reporting both as "the query changed" would
+    // non-empty CHECK, so `''` is legally storable and points at whatever wrote
+    // the membership row (#4801's sync), not at this query. Reporting both as
+    // "the query changed" would
     // send that investigation to the wrong file.
     //
     // Either way, silently returning fewer memberships would strip a reader's

--- a/packages/api/src/lib/brain/extract.ts
+++ b/packages/api/src/lib/brain/extract.ts
@@ -22,9 +22,16 @@
  *
  * The order is: extract → reconcile (commits) → stamp `extracted_at`. A crash
  * anywhere before the stamp re-queues the episode, the next cycle re-extracts
- * it, and the reconcile stage's corroboration dedupe makes that a no-op — the
+ * it, and the reconcile stage's corroboration dedupe collapses the repeat — the
  * existing fact gains at most an already-present provenance edge. So the cost
- * of a crash is a repeated model call, never a duplicated belief.
+ * of a crash is a repeated model call.
+ *
+ * That "no-op" is conditional and the condition is ours to hold: dedupe is
+ * BYTE-EXACT on the SPO, so it collapses a re-extraction only if the model
+ * reproduces its own output. `llmFactExtractor` therefore pins `temperature: 0`.
+ * A paraphrase would mint a second draft for one claim — not corruption (the
+ * reviewer collapses it), but not free either, which is why determinism is
+ * load-bearing here rather than a preference.
  *
  * Claiming first (stamp, then call the model) was rejected: it converts every
  * crash mid-extraction into an episode marked extracted with zero facts drawn
@@ -34,30 +41,42 @@
  * precisely so this ordering is affordable.
  *
  * The residue is honest and bounded: two processes draining concurrently can
- * both call the model for the same episode. They cannot both write the fact
- * (the reconcile stage serializes per workspace and corroborates), so the cost
- * is duplicate spend in a narrow window, not corruption. An episode-level claim
- * that is ALSO crash-safe needs a stale-claim reaper; that machinery belongs
- * with the review surface's operational story, not here.
+ * both call the model for the same episode. The reconcile stage serializes per
+ * workspace, so identical output corroborates into one fact; divergent output
+ * is two drafts for one claim, on the same terms as the paraphrase above. The
+ * cost is duplicate spend in a narrow window, not corruption. An episode-level
+ * claim that is ALSO crash-safe needs a stale-claim reaper; that machinery
+ * belongs with the review surface's operational story, not here.
  *
  * ## BYO key rides the agent's model seam
  *
  * ADR-0036 §T8 puts BYO-LLM in CORE, on the existing seam: the workspace's own
  * `ModelRouter` config if it has one (EE provides the implementation; the
- * self-hosted no-op returns null), else the platform default — the same
- * resolution order, and the same "never silently bill the platform for a
- * workspace whose key failed to decrypt" refusal, that `runAgent` applies. This
- * fiber adds no second credential path and reads no key of its own.
+ * self-hosted no-op returns null), else the platform default. That RESOLUTION
+ * ORDER is `runAgent`'s exactly; this fiber adds no second credential path and
+ * reads no key of its own.
+ *
+ * The REFUSAL is deliberately broader than the agent's — see
+ * {@link resolveExtractionModel} for why unattended work resolves every
+ * ambiguity to "don't spend, wait" where a live turn falls through to the
+ * platform default.
  *
  * ## Head-of-line, stated because it is a real bound
  *
- * The drain is `ORDER BY ingested_at LIMIT N`. An episode that fails
- * transiently is NOT stamped (so it retries) and therefore occupies one of the
- * N slots next cycle; an episode this fiber will never be able to extract IS
- * stamped (with a warn naming it) so it cannot occupy a slot forever. The
- * failure counters are in the cycle audit for exactly this reason: N
- * permanently-failing episodes at the head of the queue would starve it, and
- * that has to be observable rather than mysterious.
+ * The drain is `ORDER BY ingested_at LIMIT N`, so a queued episode occupies one
+ * of N slots until something takes it off the queue. Exactly two classes are
+ * stamped without producing a fact, and both are DECISIONS rather than guesses:
+ * a by-reference episode M1 has no fetcher for, and an episode the reconcile
+ * gate refuses wholesale. Everything else retries.
+ *
+ * A deterministically-failing episode therefore keeps its slot indefinitely —
+ * stamping it would be a silent drop on a guess, which is the thing this
+ * module's whole ordering avoids. What IS bounded is the SPEND: after
+ * {@link QUARANTINE_AFTER_FAILURES} consecutive failures the process stops
+ * calling a model for it and logs at ERROR. So the honest statement of the
+ * bound is: N permanently-failing episodes at the head of the queue WOULD
+ * starve it, cheaply and loudly, until an operator acts on the error log or the
+ * process restarts.
  */
 
 import { Effect } from "effect";
@@ -69,13 +88,20 @@ import { getSettingAuto } from "@atlas/api/lib/settings";
 import { runPeriodicDbCycle } from "@atlas/api/lib/scheduler/periodic-db-job";
 import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
 import { ADMIN_ACTIONS, logAdminAction } from "@atlas/api/lib/audit";
+import { isUnknownArray } from "@atlas/api/lib/brain/acl";
 import { ModelRouter } from "@atlas/api/lib/effect/services";
 import { runEnterprise } from "@atlas/api/lib/effect/enterprise-layer";
+// The CORE mirror, never `@atlas/ee` — `check-ee-imports.sh` permits exactly one
+// importer in `packages/api/src` and this is not it.
+import { isEnterpriseEnabled } from "@atlas/api/lib/effect/enterprise-config";
 import { getModel, getModelFromWorkspaceConfig } from "@atlas/api/lib/providers";
 import type { RawWorkspaceModelConfig } from "@atlas/api/lib/auth/credentials";
+import { PREDICATE_CARDINALITIES } from "@atlas/api/lib/brain/types";
 import {
+  classifyEpisodeForReconcile,
   reconcileFacts,
   type FactCandidate,
+  type ReconcileBlockReason,
   type ReconcileEpisodeRef,
   type ReconcileReport,
 } from "@atlas/api/lib/brain/reconcile";
@@ -96,9 +122,9 @@ export const BRAIN_EXTRACTION_PRODUCER = "extraction:v1" as const;
  * Tick cadence. Short relative to the connector cadence on purpose — the
  * backlog should drain steadily rather than in daily bursts — but long enough
  * that an idle deployment is not paying for a wake-up loop. A constant, not a
- * knob: the operator lever that matters for cost is the enablement switch and
- * the per-tick batch below, and a third dial would only widen the ways two
- * settings can disagree.
+ * knob: the only cost lever this slice ships is the enablement switch, and a
+ * dial whose safe range depends on the batch size below (also a constant) would
+ * be two settings with one correct combination.
  */
 const INTERVAL_MS = 5 * 60 * 1000;
 
@@ -113,6 +139,34 @@ const MAX_CANDIDATES = 10;
 
 /** Per-episode model call budget. */
 const EXTRACTION_TIMEOUT_MS = 60_000;
+
+/**
+ * Consecutive failures after which this process stops calling a model for an
+ * episode. Bounds SPEND on a deterministically-failing episode (a body that
+ * always trips a content filter, a model id that 404s) without pretending a
+ * few failures prove permanence.
+ */
+const QUARANTINE_AFTER_FAILURES = 3;
+
+/**
+ * Episode id → consecutive failures, for the life of the process.
+ *
+ * Module-level so it survives across ticks, in-memory so it needs no migration
+ * — the same trade the BYOT catalog refresh made for its backoff state. A
+ * restart forgives everything, which is the forgiving direction: the cost of
+ * forgetting is one retry, the cost of a persisted give-up would be a claim
+ * nobody re-examines. Bounded by {@link FAILURE_LEDGER_CAP} so a pathological
+ * backlog cannot grow it without limit.
+ */
+const failureLedger = new Map<string, number>();
+
+/** Ledger entries retained. Far above `BATCH_SIZE`; a bound, not a policy. */
+const FAILURE_LEDGER_CAP = 1_000;
+
+/** Test-only: forget every quarantine, as a process restart would. */
+export function _resetBrainExtractionFailures(): void {
+  failureLedger.clear();
+}
 
 /**
  * Is the extraction fiber switched on?
@@ -131,11 +185,17 @@ export function isBrainExtractionEnabled(): boolean {
 // ---------------------------------------------------------------------------
 
 /**
- * The drain. Served by `idx_brain_episodes_extraction_queue`, the PARTIAL index
- * over exactly this predicate — so the scan is proportional to work remaining
- * rather than to history.
+ * The drain.
  *
- * Oldest first, across workspaces: an episode's claims are most useful soonest
+ * The PREDICATE is served by `idx_brain_episodes_extraction_queue`, which is
+ * partial on `extracted_at IS NULL` — so what is scanned is proportional to work
+ * remaining rather than to history. The ORDERING is not: that index leads with
+ * `workspace_id` and this query has no workspace predicate, so Postgres sorts
+ * the backlog to satisfy `ORDER BY ingested_at LIMIT $1`. Affordable because the
+ * backlog is bounded by how fast the connectors write, and cheap to fix later
+ * with an `(ingested_at) WHERE extracted_at IS NULL` index if it ever isn't.
+ *
+ * Oldest first, ACROSS workspaces: an episode's claims are most useful soonest
  * after it was said, and per-workspace fairness is not something a single
  * ordered queue can express without starving whoever is not first. The batch
  * bound is what keeps one noisy workspace from monopolizing a tick.
@@ -151,8 +211,13 @@ export const DRAIN_EPISODES_SQL = `SELECT id, workspace_id, source, source_id, s
  * Take one episode off the queue. `AND extracted_at IS NULL` makes a re-stamp a
  * no-op rather than a rewrite: a concurrent drainer that got there first keeps
  * its timestamp, so "when did the pass that produced these claims run" stays
- * true. `now()` is the database clock — the queue marker's only reader is this
- * query's own predicate, so it must not depend on a pod's wall clock.
+ * true.
+ *
+ * `now()` is the DATABASE clock, so two drainers' stamps are comparable and
+ * skew-free. The CLAIM's timestamp is not the same value: `brain_facts
+ * .extracted_at` and `provenance.extractedAt` come from the process clock
+ * (`deps.now()`, injectable in tests). The skew between the two is intentional
+ * — one dates a queue transition, the other dates a claim.
  */
 export const STAMP_EXTRACTED_SQL = `UPDATE brain_episodes
           SET extracted_at = now()
@@ -193,7 +258,11 @@ const ExtractionSchema = z.object({
           .describe("The relationship, as a short lowercase verb phrase, e.g. 'reports to'."),
         object: z.string().describe("The value or entity the subject relates to."),
         cardinality: z
-          .enum(["single", "multi"])
+          // Derived from the SSOT tuple, never hand-listed: the value is
+          // written straight into `predicate_cardinality`, whose CHECK is the
+          // same list, and two spellings would drift the first time M2 adds an
+          // arm.
+          .enum(PREDICATE_CARDINALITIES)
           .describe(
             "'single' when the subject can only have ONE such object at a time (a manager, an owner); 'multi' when several can coexist (a language, a skill). When unsure answer 'multi'.",
           ),
@@ -218,7 +287,7 @@ const EXTRACTION_SYSTEM_PROMPT = [
 
 /**
  * Produce candidates for one episode. The injectable seam: tests supply a fake
- * and never touch the AI SDK, and M2's better extractor replaces this one
+ * and never touch the AI SDK, and a later, better extractor replaces this one
  * function without the cycle knowing.
  */
 export type FactExtractor = (input: {
@@ -230,16 +299,43 @@ export type FactExtractor = (input: {
 
 /** The default extractor — one bounded, structured model call per episode. */
 export const llmFactExtractor: FactExtractor = async ({ episode, body, model, modelId }) => {
+  // Truncation is SIGNALLED, not silent, in both directions: the model is told
+  // the text was cut (so it does not confidently extract from a clause that
+  // ends mid-sentence) and the operator is told which episode lost a tail.
+  // The episode is stamped after this pass, so whatever is dropped here is
+  // dropped for good — which is precisely why it cannot be quiet.
+  const truncated = body.length > MAX_BODY_CHARS;
+  if (truncated) {
+    log.warn(
+      {
+        workspaceId: episode.workspaceId,
+        episodeId: episode.id,
+        bodyChars: body.length,
+        cap: MAX_BODY_CHARS,
+      },
+      "brain extraction: episode body exceeds the per-call cap — extracting from the leading portion only, the remainder is not revisited",
+    );
+  }
+  const excerpt = truncated
+    ? `${body.slice(0, MAX_BODY_CHARS)}\n[truncated at ${MAX_BODY_CHARS} characters]`
+    : body;
+
   const { object } = await generateObject({
     model,
     schema: ExtractionSchema,
     system: EXTRACTION_SYSTEM_PROMPT,
+    // Pinned. The reconcile stage's corroboration dedupe is BYTE-EXACT on the
+    // SPO, so a re-extraction that paraphrases its own earlier output mints a
+    // duplicate belief instead of strengthening one — and re-extraction is
+    // routine here (it is the whole crash-safety story). Determinism is not a
+    // quality preference; it is what makes idempotence real.
+    temperature: 0,
     prompt: [
       `Source: ${episode.source}`,
       episode.occurredAt !== null ? `Said at: ${episode.occurredAt.toISOString()}` : null,
       "",
       "Message:",
-      body.slice(0, MAX_BODY_CHARS),
+      excerpt,
     ]
       .filter((line): line is string => line !== null)
       .join("\n"),
@@ -283,46 +379,94 @@ export interface ResolvedExtractionModel {
  * Resolve the model for one workspace: its own BYO configuration if it has one,
  * else the platform default.
  *
- * Returns `null` when the workspace HAS a configuration that could not be used
- * — a key that no longer decrypts. Falling back to the platform default there
- * would bill Atlas for a workspace that explicitly chose to bring its own
- * provider, which is the same refusal `runAgent` makes (it raises a re-enter-
- * your-key error); here there is no user to tell, so the episodes stay queued
- * and the skip is counted until an admin repairs the key.
+ * Returns `null` for EVERY state in which this fiber must not call a model on
+ * this workspace's behalf — a config that cannot be read, a config that cannot
+ * be built into a model, or a deployment where the routing subsystem that owns
+ * BYO configs is supposed to be present and is not. The caller leaves those
+ * episodes queued and counts the skip; repairing the key (or the deployment) is
+ * enough to drain them, with no backfill.
+ *
+ * ## Why the refusal is BROADER than `runAgent`'s
+ *
+ * The resolution ORDER is the agent's (`lib/agent.ts` — workspace config first,
+ * platform default second, one seam, no second credential path). The refusal is
+ * deliberately not: `runAgent` hard-refuses only a decrypt failure and
+ * log-and-falls-through on everything else, because there is a user in the loop
+ * who sees the degraded turn. Here there is nobody, the work is unattended and
+ * repeats every five minutes, and a queued episode is free to hold — so any
+ * ambiguity resolves to "don't spend, wait".
+ *
+ * Two ways that matters concretely, both of which billed the platform for a
+ * BYO workspace in an earlier draft of this function:
+ *
+ *   - **EE absent when it should be present.** The no-op `ModelRouter` returns
+ *     `null` for every workspace, which is indistinguishable from "this
+ *     workspace has no BYO config" — so an EE module that failed to load would
+ *     have silently moved every BYO workspace's whole backlog onto Atlas's own
+ *     key. Probed explicitly, exactly as the BYOT catalog refresh does.
+ *   - **A config that reads but cannot be built.** `getModelFromWorkspaceConfig`
+ *     throws on a malformed bedrock bundle, a missing `baseUrl`, a gateway row
+ *     with no key; `getModel()` throws when the platform provider is
+ *     unconfigured. Left outside the guard those escaped as a per-episode
+ *     throw — counted as a transient failure and retried forever, which is the
+ *     wrong verdict for a fault only an admin can fix.
  */
 export async function resolveExtractionModel(
   workspaceId: string,
 ): Promise<ResolvedExtractionModel | null> {
   const program = Effect.gen(function* () {
     const router = yield* ModelRouter;
-    return yield* router.getWorkspaceModelConfigRaw(workspaceId);
+    // `available: false` on an enterprise deployment means the EE layer did not
+    // load — NOT that this workspace has no BYO config. Fail closed on the one
+    // that cannot be told apart downstream. On a self-hosted install (no EE by
+    // design) the flag is legitimately false and the platform default is the
+    // right answer, so the probe is gated on the deploy-mode mirror in core.
+    if (isEnterpriseEnabled() && !router.available) return { routingUnavailable: true } as const;
+    const config = yield* router.getWorkspaceModelConfigRaw(workspaceId);
+    return { routingUnavailable: false, config } as const;
   });
 
-  let config: RawWorkspaceModelConfig | null = null;
+  let resolved: { routingUnavailable: boolean; config?: RawWorkspaceModelConfig | null };
   try {
-    config = await runEnterprise(program);
+    resolved = await runEnterprise(program);
   } catch (err) {
     log.warn(
-      { workspaceId, err: err instanceof Error ? err.message : String(err) },
+      { workspaceId, err: errorMessage(err) },
       "brain extraction: workspace model config could not be read — leaving this workspace's episodes queued",
     );
     return null;
   }
 
-  if (config) {
-    return {
-      model: getModelFromWorkspaceConfig({
-        model: config.model,
-        baseUrl: config.baseUrl,
-        bedrockRegion: config.bedrockRegion,
-        credentials: config.credentials,
-      }),
-      modelId: config.model,
-    };
+  if (resolved.routingUnavailable) {
+    log.error(
+      { workspaceId },
+      "brain extraction: model routing is unavailable on an enterprise deployment — refusing to extract on the platform key, episodes stay queued",
+    );
+    return null;
   }
 
-  const model = getModel();
-  return { model, modelId: typeof model === "string" ? model : model.modelId };
+  const config = resolved.config ?? null;
+  try {
+    if (config) {
+      return {
+        model: getModelFromWorkspaceConfig({
+          model: config.model,
+          baseUrl: config.baseUrl,
+          bedrockRegion: config.bedrockRegion,
+          credentials: config.credentials,
+        }),
+        modelId: config.model,
+      };
+    }
+    const model = getModel();
+    return { model, modelId: typeof model === "string" ? model : model.modelId };
+  } catch (err) {
+    log.warn(
+      { workspaceId, byo: config !== null, err: errorMessage(err) },
+      "brain extraction: the configured model could not be built — leaving this workspace's episodes queued until the configuration is repaired",
+    );
+    return null;
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -330,11 +474,20 @@ export async function resolveExtractionModel(
 // ---------------------------------------------------------------------------
 
 /** Why an episode was left alone this pass. */
-export type ExtractionSkipReason =
+export const EXTRACTION_SKIP_REASONS = [
   /** The workspace's own model config could not be used — retried next cycle. */
-  | "model_unavailable"
+  "model_unavailable",
   /** Stored by reference (`locator`), which M1 has no fetcher for. Stamped. */
-  | "no_body";
+  "no_body",
+  /**
+   * Failed on every recent attempt, so this process has stopped calling a model
+   * for it — see {@link QUARANTINE_AFTER_FAILURES}. Still queued; still retried
+   * after a restart.
+   */
+  "quarantined",
+] as const;
+
+export type ExtractionSkipReason = (typeof EXTRACTION_SKIP_REASONS)[number];
 
 export interface BrainExtractionCycleResult {
   status: "success" | "failure";
@@ -347,8 +500,16 @@ export interface BrainExtractionCycleResult {
   factsProvisional: number;
   /** Candidates the reconcile stage refused on safety grounds. */
   factsBlocked: number;
-  skippedModelUnavailable: number;
-  skippedNoBody: number;
+  /**
+   * Episodes refused WHOLESALE by the episode-level gate (no grant, no
+   * attributable actor). Counted apart from `extracted` on purpose: a batch
+   * reporting `extracted: 25, factsCreated: 0` reads as a quiet model, whereas
+   * `blockedEpisodes: 25` reads as "our grant derivation is broken", which is
+   * what it would actually mean.
+   */
+  blockedEpisodes: number;
+  /** By reason — a `Record` so a new reason is a compile error, not a miscount. */
+  skipped: Record<ExtractionSkipReason, number>;
   /** Episodes whose pass threw — left queued for the next cycle. */
   failed: number;
   /** Present only on the scan-fault path, mirroring the other DB cycles. */
@@ -357,6 +518,7 @@ export interface BrainExtractionCycleResult {
 
 type EpisodeOutcome =
   | { readonly kind: "extracted"; readonly report: ReconcileReport }
+  | { readonly kind: "blocked"; readonly reason: ReconcileBlockReason }
   | { readonly kind: "skipped"; readonly reason: ExtractionSkipReason }
   | { readonly kind: "failed"; readonly error: string };
 
@@ -380,8 +542,10 @@ function emptyResult(): BrainExtractionCycleResult {
     factsCorroborated: 0,
     factsProvisional: 0,
     factsBlocked: 0,
-    skippedModelUnavailable: 0,
-    skippedNoBody: 0,
+    blockedEpisodes: 0,
+    // Fresh per call — `runPeriodicDbCycle` mutates the result in place, so a
+    // shared object would accumulate across ticks.
+    skipped: { model_unavailable: 0, no_body: 0, quarantined: 0 },
     failed: 0,
   };
 }
@@ -417,7 +581,7 @@ export function runBrainExtractionCycle(
     emptyResult,
     failureResult: (error) => ({ ...emptyResult(), status: "failure", error }),
     scan: () => internalQuery<EpisodeRow>(DRAIN_EPISODES_SQL, [BATCH_SIZE]),
-    applyRow: (row) => extractEpisode(row, { extract, modelFor, reconcile, now }),
+    applyRow: (row) => extractEpisode(row, { extract, modelFor, reconcile, now, failures: failureLedger }),
     defectOutcome: (error) => ({ kind: "failed", error }),
     tally: (result, row, outcome) => tallyEpisode(result, row, outcome),
     emitCycleAudit,
@@ -429,10 +593,32 @@ interface ApplyDeps {
   readonly modelFor: (workspaceId: string) => Promise<ResolvedExtractionModel | null>;
   readonly reconcile: typeof reconcileFacts;
   readonly now: () => Date;
+  /** Consecutive-failure ledger for this process — see the quarantine note. */
+  readonly failures: Map<string, number>;
 }
 
 /** Extract → reconcile → stamp, for one episode. */
 async function extractEpisode(row: EpisodeRow, deps: ApplyDeps): Promise<EpisodeOutcome> {
+  // `visible_to` is `text[] NOT NULL` (0180), so a non-array here is QUERY
+  // DRIFT — a changed SELECT, a driver surprise — not bad tenant data. Coercing
+  // it to `[]` would assert "this episode grants nobody", which the reconcile
+  // stage would then refuse as NO_GRANT and this function would STAMP: a code
+  // bug permanently consuming every episode in the batch, logged under a
+  // message blaming the tenant's grant. Refused as a retryable failure instead,
+  // and named for what it is. (`promotion.ts` splits the same two causes into
+  // `GRANT_NOT_AN_ARRAY` vs `GRANT_UNUSABLE` for this exact reason.)
+  if (!isUnknownArray(row.visible_to)) {
+    log.error(
+      {
+        workspaceId: row.workspace_id,
+        episodeId: row.id,
+        received: typeof row.visible_to,
+      },
+      "brain extraction: an episode's grant did not load as an array — this is an Atlas bug, not a problem with the episode; leaving it queued",
+    );
+    return { kind: "failed", error: "visible_to did not load as an array" };
+  }
+
   const episode = toEpisodeRef(row);
 
   if (row.body === null || row.body.trim() === "") {
@@ -446,6 +632,43 @@ async function extractEpisode(row: EpisodeRow, deps: ApplyDeps): Promise<Episode
     );
     await stampExtracted(episode);
     return { kind: "skipped", reason: "no_body" };
+  }
+
+  // Pre-flight the episode-level gate BEFORE spending a model call. The stage
+  // enforces it again regardless; running it here is purely so an episode whose
+  // grant or actor makes every derived claim unsafe costs nothing rather than
+  // one LLM call per pass. Stamped, because blocking is a DECISION and not a
+  // failure — retrying it forever would re-log the same refusal every five
+  // minutes and hold a queue slot. The evidence itself is never deleted, so a
+  // later slice (a repaired grant derivation, #4801's membership sync) can
+  // re-queue it deliberately.
+  const episodeBlock = classifyEpisodeForReconcile(episode);
+  if (episodeBlock !== null) {
+    log.warn(
+      {
+        workspaceId: episode.workspaceId,
+        episodeId: episode.id,
+        source: episode.source,
+        reason: episodeBlock.reason,
+      },
+      `brain extraction: no fact can safely be drawn from this episode — ${episodeBlock.detail}; marking it extracted without calling a model`,
+    );
+    await stampExtracted(episode);
+    return { kind: "blocked", reason: episodeBlock.reason };
+  }
+
+  // An episode that has failed on every recent attempt stops costing model
+  // calls. In-memory and per-process, matching the BYOT catalog refresh's
+  // backoff precedent ("pod restart resets the backoff state — acceptable
+  // trade-off vs the migration that a persistent counter would require"), and
+  // deliberately NOT a stamp: "failed three times in this process" is not proof
+  // of "unextractable forever", and stamping on a guess is the silent drop this
+  // module's ordering exists to avoid. It still holds a queue slot — the bound
+  // is on SPEND, not on the head of the queue. The ERROR log is the operator's
+  // cue that a slot is stuck.
+  const priorFailures = deps.failures.get(episode.id) ?? 0;
+  if (priorFailures >= QUARANTINE_AFTER_FAILURES) {
+    return { kind: "skipped", reason: "quarantined" };
   }
 
   const resolved = await deps.modelFor(episode.workspaceId);
@@ -473,6 +696,7 @@ async function extractEpisode(row: EpisodeRow, deps: ApplyDeps): Promise<Episode
   // Only after the reconcile transaction has COMMITTED. See the module header
   // on why the reverse order is not merely slower but unsafe.
   await stampExtracted(episode);
+  deps.failures.delete(episode.id);
   return { kind: "extracted", report };
 }
 
@@ -486,8 +710,10 @@ async function stampExtracted(episode: ReconcileEpisodeRef): Promise<void> {
  * `occurred_at` arrives as a `Date` from `pg` but as a string through a JSON
  * round-trip (a region import, a test fixture), and an unparseable value must
  * degrade to "no event time" rather than reach `toISOString()` and throw
- * mid-transaction. `visible_to` is passed through untouched — `parseGrant` is
- * built to read it straight off the driver, `null` elements and all.
+ * mid-transaction. `visible_to`'s ELEMENTS are passed through untouched —
+ * `parseGrant` is built to read them straight off the driver, `null` entries and
+ * all. Whether the column loaded as an array at all is settled by the caller,
+ * which refuses the episode rather than coercing (see `extractEpisode`).
  */
 function toEpisodeRef(row: EpisodeRow): ReconcileEpisodeRef {
   return {
@@ -497,7 +723,8 @@ function toEpisodeRef(row: EpisodeRow): ReconcileEpisodeRef {
     sourceId: row.source_id,
     sourceActor: row.source_actor,
     occurredAt: toDate(row.occurred_at),
-    visibleTo: Array.isArray(row.visible_to) ? (row.visible_to as readonly unknown[]) : [],
+    // Non-array is unreachable here: `extractEpisode` refuses the row first.
+    visibleTo: isUnknownArray(row.visible_to) ? row.visible_to : [],
   };
 }
 
@@ -521,21 +748,49 @@ function tallyEpisode(
       result.factsBlocked += Object.values(outcome.report.blocked).reduce((a, b) => a + b, 0);
       return;
     }
+    case "blocked": {
+      result.blockedEpisodes++;
+      return;
+    }
     case "skipped": {
-      if (outcome.reason === "model_unavailable") result.skippedModelUnavailable++;
-      else result.skippedNoBody++;
+      // Indexed, not branched: adding a reason to EXTRACTION_SKIP_REASONS
+      // cannot silently land in the wrong counter.
+      result.skipped[outcome.reason]++;
       return;
     }
     case "failed": {
       result.failed++;
+      const failures = (failureLedger.get(row.id) ?? 0) + 1;
+      // Evict oldest-first (insertion order) rather than refusing to record —
+      // dropping the NEW entry would make the cap silently disable quarantine
+      // for exactly the pathological backlog it exists to survive.
+      if (!failureLedger.has(row.id) && failureLedger.size >= FAILURE_LEDGER_CAP) {
+        const oldest = failureLedger.keys().next();
+        if (!oldest.done) failureLedger.delete(oldest.value);
+      }
+      failureLedger.set(row.id, failures);
+      if (failures === QUARANTINE_AFTER_FAILURES) {
+        // ERROR, once, at the threshold: from here the episode holds a queue
+        // slot but costs nothing, and only an operator can tell whether that is
+        // a bad message or a broken model.
+        log.error(
+          { workspaceId: row.workspace_id, episodeId: row.id, failures, err: outcome.error },
+          "brain extraction: episode has failed every attempt in this process — no further model calls will be made for it until a restart",
+        );
+        return;
+      }
       // Per-episode, at warn: the episode stays queued, so this is a retry
       // notice rather than an outage — but an id-less "3 failed" in the cycle
       // row would leave an operator nothing to look at.
       log.warn(
-        { workspaceId: row.workspace_id, episodeId: row.id, err: outcome.error },
+        { workspaceId: row.workspace_id, episodeId: row.id, failures, err: outcome.error },
         "brain extraction: episode extraction failed — it stays on the queue and will be retried",
       );
       return;
+    }
+    default: {
+      const unexpected: never = outcome;
+      throw new Error(`Unhandled episode outcome: ${JSON.stringify(unexpected)}`);
     }
   }
 }
@@ -546,6 +801,10 @@ function tallyEpisode(
  * stopped" signal — the same forensic invariant the BYOT refresh cycle carries.
  */
 function emitCycleAudit(result: BrainExtractionCycleResult): void {
+  // The third guard on a call that is already contracted never to throw
+  // (`logAdminAction`) and already wrapped by the cycle skeleton. Kept for
+  // parity with `byot-catalog-refresh.ts`, whose own comment calls this
+  // belt-and-braces at the seam — not because the call is known to be risky.
   try {
     logAdminAction({
       actionType: ADMIN_ACTIONS.brain.extractionCycle,

--- a/packages/api/src/lib/brain/extract.ts
+++ b/packages/api/src/lib/brain/extract.ts
@@ -1,0 +1,570 @@
+/**
+ * The async extraction fiber (#4771, ADR-0036 §Ingestion & connectors) — the
+ * second of T6's two async halves.
+ *
+ * ## Why extraction is a SEPARATE fiber from fetch
+ *
+ * Acceptance criterion 1: "episode freshness never blocks on LLM latency /
+ * 429s". The connector engine (#4770) fetches and stores episodes on the
+ * knowledge-sync cadence and returns; this fiber drains `extracted_at IS NULL`
+ * on its own clock and calls the model. A model outage, a rate-limit storm, or
+ * a workspace whose BYO key was rotated-and-broken therefore costs EXTRACTION
+ * throughput and nothing else — the raw record of what was said keeps landing,
+ * and the backlog is visible in `idx_brain_episodes_extraction_queue` rather
+ * than inferred from a stalled connector.
+ *
+ * Facts are consequently SECOND-ORDER FRESH by design, and there is deliberately
+ * no synchronous fast-path from ingest to a fact. A fast-path would reintroduce
+ * exactly the coupling this split exists to remove, and the review gate means a
+ * fact is not usable the instant it is extracted anyway.
+ *
+ * ## Work-then-stamp, and why not claim-then-work
+ *
+ * The order is: extract → reconcile (commits) → stamp `extracted_at`. A crash
+ * anywhere before the stamp re-queues the episode, the next cycle re-extracts
+ * it, and the reconcile stage's corroboration dedupe makes that a no-op — the
+ * existing fact gains at most an already-present provenance edge. So the cost
+ * of a crash is a repeated model call, never a duplicated belief.
+ *
+ * Claiming first (stamp, then call the model) was rejected: it converts every
+ * crash mid-extraction into an episode marked extracted with zero facts drawn
+ * from it — a silent, permanent drop of a claim nobody will ever look for
+ * again. Migration 0180 states the opposite posture outright ("NULL forever is
+ * a visible backlog, not a silent drop"), and idempotence is cheap here
+ * precisely so this ordering is affordable.
+ *
+ * The residue is honest and bounded: two processes draining concurrently can
+ * both call the model for the same episode. They cannot both write the fact
+ * (the reconcile stage serializes per workspace and corroborates), so the cost
+ * is duplicate spend in a narrow window, not corruption. An episode-level claim
+ * that is ALSO crash-safe needs a stale-claim reaper; that machinery belongs
+ * with the review surface's operational story, not here.
+ *
+ * ## BYO key rides the agent's model seam
+ *
+ * ADR-0036 §T8 puts BYO-LLM in CORE, on the existing seam: the workspace's own
+ * `ModelRouter` config if it has one (EE provides the implementation; the
+ * self-hosted no-op returns null), else the platform default — the same
+ * resolution order, and the same "never silently bill the platform for a
+ * workspace whose key failed to decrypt" refusal, that `runAgent` applies. This
+ * fiber adds no second credential path and reads no key of its own.
+ *
+ * ## Head-of-line, stated because it is a real bound
+ *
+ * The drain is `ORDER BY ingested_at LIMIT N`. An episode that fails
+ * transiently is NOT stamped (so it retries) and therefore occupies one of the
+ * N slots next cycle; an episode this fiber will never be able to extract IS
+ * stamped (with a warn naming it) so it cannot occupy a slot forever. The
+ * failure counters are in the cycle audit for exactly this reason: N
+ * permanently-failing episodes at the head of the queue would starve it, and
+ * that has to be observable rather than mysterious.
+ */
+
+import { Effect } from "effect";
+import { z } from "zod";
+import { generateObject, type LanguageModel } from "ai";
+import { createLogger } from "@atlas/api/lib/logger";
+import { internalQuery } from "@atlas/api/lib/db/internal";
+import { getSettingAuto } from "@atlas/api/lib/settings";
+import { runPeriodicDbCycle } from "@atlas/api/lib/scheduler/periodic-db-job";
+import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
+import { ADMIN_ACTIONS, logAdminAction } from "@atlas/api/lib/audit";
+import { ModelRouter } from "@atlas/api/lib/effect/services";
+import { runEnterprise } from "@atlas/api/lib/effect/enterprise-layer";
+import { getModel, getModelFromWorkspaceConfig } from "@atlas/api/lib/providers";
+import type { RawWorkspaceModelConfig } from "@atlas/api/lib/auth/credentials";
+import {
+  reconcileFacts,
+  type FactCandidate,
+  type ReconcileEpisodeRef,
+  type ReconcileReport,
+} from "@atlas/api/lib/brain/reconcile";
+
+const log = createLogger("brain.extract");
+
+/**
+ * Reserved system actor for every audit row this fiber writes. Matches
+ * `^system:[a-z0-9][a-z0-9_-]*$` (`assertSystemActor`); a rename surfaces as
+ * broken forensic queries.
+ */
+export const BRAIN_EXTRACTION_ACTOR = "system:brain-extraction" as const;
+
+/** The producer label stamped into every fact this path reconciles. */
+export const BRAIN_EXTRACTION_PRODUCER = "extraction:v1" as const;
+
+/**
+ * Tick cadence. Short relative to the connector cadence on purpose — the
+ * backlog should drain steadily rather than in daily bursts — but long enough
+ * that an idle deployment is not paying for a wake-up loop. A constant, not a
+ * knob: the operator lever that matters for cost is the enablement switch and
+ * the per-tick batch below, and a third dial would only widen the ways two
+ * settings can disagree.
+ */
+const INTERVAL_MS = 5 * 60 * 1000;
+
+/** Episodes drained per tick — the per-cycle model-spend bound. */
+const BATCH_SIZE = 25;
+
+/** Body characters sent to the model. Beyond this a chat message is a transcript. */
+const MAX_BODY_CHARS = 8_000;
+
+/** Claims accepted from one episode — a bound on a model that will not stop. */
+const MAX_CANDIDATES = 10;
+
+/** Per-episode model call budget. */
+const EXTRACTION_TIMEOUT_MS = 60_000;
+
+/**
+ * Is the extraction fiber switched on?
+ *
+ * Default OFF while the brain milestone is in flight: the review surface
+ * (#4772) is what makes an extracted fact usable, so until it lands the fiber
+ * would spend a workspace's model budget filling a queue nobody can read. The
+ * switch is platform-scoped because the fiber is process-wide.
+ */
+export function isBrainExtractionEnabled(): boolean {
+  return getSettingAuto("ATLAS_BRAIN_EXTRACTION_ENABLED") === "true";
+}
+
+// ---------------------------------------------------------------------------
+// SQL
+// ---------------------------------------------------------------------------
+
+/**
+ * The drain. Served by `idx_brain_episodes_extraction_queue`, the PARTIAL index
+ * over exactly this predicate — so the scan is proportional to work remaining
+ * rather than to history.
+ *
+ * Oldest first, across workspaces: an episode's claims are most useful soonest
+ * after it was said, and per-workspace fairness is not something a single
+ * ordered queue can express without starving whoever is not first. The batch
+ * bound is what keeps one noisy workspace from monopolizing a tick.
+ */
+export const DRAIN_EPISODES_SQL = `SELECT id, workspace_id, source, source_id, source_actor,
+              body, locator, occurred_at, visible_to
+         FROM brain_episodes
+        WHERE extracted_at IS NULL
+        ORDER BY ingested_at
+        LIMIT $1`;
+
+/**
+ * Take one episode off the queue. `AND extracted_at IS NULL` makes a re-stamp a
+ * no-op rather than a rewrite: a concurrent drainer that got there first keeps
+ * its timestamp, so "when did the pass that produced these claims run" stays
+ * true. `now()` is the database clock — the queue marker's only reader is this
+ * query's own predicate, so it must not depend on a pod's wall clock.
+ */
+export const STAMP_EXTRACTED_SQL = `UPDATE brain_episodes
+          SET extracted_at = now()
+        WHERE id = $1
+          AND workspace_id = $2
+          AND extracted_at IS NULL`;
+
+// ---------------------------------------------------------------------------
+// The extractor
+// ---------------------------------------------------------------------------
+
+/** The row shape the drain returns. */
+interface EpisodeRow {
+  readonly id: string;
+  readonly workspace_id: string;
+  readonly source: string;
+  readonly source_id: string;
+  readonly source_actor: string | null;
+  readonly body: string | null;
+  readonly locator: string | null;
+  readonly occurred_at: Date | string | null;
+  readonly visible_to: unknown;
+  [key: string]: unknown;
+}
+
+/**
+ * What the model is asked for. Kept deliberately close to `brain_facts`'s own
+ * columns: a schema with its own vocabulary would need a translation step, and
+ * a translation step is where a claim quietly changes meaning.
+ */
+const ExtractionSchema = z.object({
+  facts: z
+    .array(
+      z.object({
+        subject: z.string().describe("The entity the claim is about, as named in the text."),
+        predicate: z
+          .string()
+          .describe("The relationship, as a short lowercase verb phrase, e.g. 'reports to'."),
+        object: z.string().describe("The value or entity the subject relates to."),
+        cardinality: z
+          .enum(["single", "multi"])
+          .describe(
+            "'single' when the subject can only have ONE such object at a time (a manager, an owner); 'multi' when several can coexist (a language, a skill). When unsure answer 'multi'.",
+          ),
+      }),
+    )
+    .describe("Durable claims. Empty when the text contains none."),
+});
+
+const EXTRACTION_SYSTEM_PROMPT = [
+  "You extract durable, checkable facts about a company from a single message.",
+  "",
+  "Return a subject-predicate-object triple for each claim that would still be worth knowing next month.",
+  "Extract nothing for small talk, questions, opinions, jokes, greetings, or one-off status noise —",
+  "an empty list is the correct and common answer.",
+  "",
+  "Rules:",
+  "- Use the names exactly as the message writes them. Do not invent identifiers or expand abbreviations.",
+  "- Do not infer anything the message does not state.",
+  "- Keep each field short; the predicate is a verb phrase, not a sentence.",
+  "- Answer 'single' for cardinality only when the subject can have just one such object at a time.",
+].join("\n");
+
+/**
+ * Produce candidates for one episode. The injectable seam: tests supply a fake
+ * and never touch the AI SDK, and M2's better extractor replaces this one
+ * function without the cycle knowing.
+ */
+export type FactExtractor = (input: {
+  readonly episode: ReconcileEpisodeRef;
+  readonly body: string;
+  readonly model: LanguageModel;
+  readonly modelId: string;
+}) => Promise<readonly FactCandidate[]>;
+
+/** The default extractor — one bounded, structured model call per episode. */
+export const llmFactExtractor: FactExtractor = async ({ episode, body, model, modelId }) => {
+  const { object } = await generateObject({
+    model,
+    schema: ExtractionSchema,
+    system: EXTRACTION_SYSTEM_PROMPT,
+    prompt: [
+      `Source: ${episode.source}`,
+      episode.occurredAt !== null ? `Said at: ${episode.occurredAt.toISOString()}` : null,
+      "",
+      "Message:",
+      body.slice(0, MAX_BODY_CHARS),
+    ]
+      .filter((line): line is string => line !== null)
+      .join("\n"),
+    abortSignal: AbortSignal.timeout(EXTRACTION_TIMEOUT_MS),
+  });
+
+  if (object.facts.length > MAX_CANDIDATES) {
+    log.warn(
+      {
+        workspaceId: episode.workspaceId,
+        episodeId: episode.id,
+        returned: object.facts.length,
+        cap: MAX_CANDIDATES,
+      },
+      "brain extraction: model returned more claims than one message can support — keeping the first few",
+    );
+  }
+
+  return object.facts.slice(0, MAX_CANDIDATES).map((fact) => ({
+    subject: fact.subject,
+    predicate: fact.predicate,
+    object: fact.object,
+    predicateCardinality: fact.cardinality,
+    // The model id belongs in provenance: a later pass with a better model has
+    // to be tellable from this one, and the reviewer is entitled to know what
+    // asserted the claim on the source's behalf.
+    detail: { extractor: BRAIN_EXTRACTION_PRODUCER, model: modelId },
+  }));
+};
+
+// ---------------------------------------------------------------------------
+// Model resolution — the agent's seam, nothing new
+// ---------------------------------------------------------------------------
+
+export interface ResolvedExtractionModel {
+  readonly model: LanguageModel;
+  readonly modelId: string;
+}
+
+/**
+ * Resolve the model for one workspace: its own BYO configuration if it has one,
+ * else the platform default.
+ *
+ * Returns `null` when the workspace HAS a configuration that could not be used
+ * — a key that no longer decrypts. Falling back to the platform default there
+ * would bill Atlas for a workspace that explicitly chose to bring its own
+ * provider, which is the same refusal `runAgent` makes (it raises a re-enter-
+ * your-key error); here there is no user to tell, so the episodes stay queued
+ * and the skip is counted until an admin repairs the key.
+ */
+export async function resolveExtractionModel(
+  workspaceId: string,
+): Promise<ResolvedExtractionModel | null> {
+  const program = Effect.gen(function* () {
+    const router = yield* ModelRouter;
+    return yield* router.getWorkspaceModelConfigRaw(workspaceId);
+  });
+
+  let config: RawWorkspaceModelConfig | null = null;
+  try {
+    config = await runEnterprise(program);
+  } catch (err) {
+    log.warn(
+      { workspaceId, err: err instanceof Error ? err.message : String(err) },
+      "brain extraction: workspace model config could not be read — leaving this workspace's episodes queued",
+    );
+    return null;
+  }
+
+  if (config) {
+    return {
+      model: getModelFromWorkspaceConfig({
+        model: config.model,
+        baseUrl: config.baseUrl,
+        bedrockRegion: config.bedrockRegion,
+        credentials: config.credentials,
+      }),
+      modelId: config.model,
+    };
+  }
+
+  const model = getModel();
+  return { model, modelId: typeof model === "string" ? model : model.modelId };
+}
+
+// ---------------------------------------------------------------------------
+// The cycle
+// ---------------------------------------------------------------------------
+
+/** Why an episode was left alone this pass. */
+export type ExtractionSkipReason =
+  /** The workspace's own model config could not be used — retried next cycle. */
+  | "model_unavailable"
+  /** Stored by reference (`locator`), which M1 has no fetcher for. Stamped. */
+  | "no_body";
+
+export interface BrainExtractionCycleResult {
+  status: "success" | "failure";
+  /** Episodes drained this tick. */
+  inspected: number;
+  /** Episodes whose extraction pass completed and were taken off the queue. */
+  extracted: number;
+  factsCreated: number;
+  factsCorroborated: number;
+  factsProvisional: number;
+  /** Candidates the reconcile stage refused on safety grounds. */
+  factsBlocked: number;
+  skippedModelUnavailable: number;
+  skippedNoBody: number;
+  /** Episodes whose pass threw — left queued for the next cycle. */
+  failed: number;
+  /** Present only on the scan-fault path, mirroring the other DB cycles. */
+  error?: string;
+}
+
+type EpisodeOutcome =
+  | { readonly kind: "extracted"; readonly report: ReconcileReport }
+  | { readonly kind: "skipped"; readonly reason: ExtractionSkipReason }
+  | { readonly kind: "failed"; readonly error: string };
+
+export interface BrainExtractionDeps {
+  /** Defaults to {@link llmFactExtractor}. */
+  readonly extract?: FactExtractor;
+  /** Defaults to {@link resolveExtractionModel}. */
+  readonly resolveModel?: (workspaceId: string) => Promise<ResolvedExtractionModel | null>;
+  /** Defaults to `reconcileFacts`. */
+  readonly reconcile?: typeof reconcileFacts;
+  /** Test clock. */
+  readonly now?: () => Date;
+}
+
+function emptyResult(): BrainExtractionCycleResult {
+  return {
+    status: "success",
+    inspected: 0,
+    extracted: 0,
+    factsCreated: 0,
+    factsCorroborated: 0,
+    factsProvisional: 0,
+    factsBlocked: 0,
+    skippedModelUnavailable: 0,
+    skippedNoBody: 0,
+    failed: 0,
+  };
+}
+
+/**
+ * One extraction tick. Never throws — the `runPeriodicDbCycle` skeleton folds a
+ * scan fault into an audited failure result and isolates every per-episode
+ * fault, so a bad row can neither abort the batch nor kill the fiber.
+ */
+export function runBrainExtractionCycle(
+  deps: BrainExtractionDeps = {},
+): Effect.Effect<BrainExtractionCycleResult> {
+  const extract = deps.extract ?? llmFactExtractor;
+  const resolveModel = deps.resolveModel ?? resolveExtractionModel;
+  const reconcile = deps.reconcile ?? reconcileFacts;
+  const now = deps.now ?? (() => new Date());
+
+  // Resolved once per WORKSPACE per cycle, not once per episode: a decrypt is
+  // not free and a workspace usually contributes a run of adjacent episodes.
+  // Cycle-scoped so a key repaired between ticks takes effect on the next one.
+  const models = new Map<string, ResolvedExtractionModel | null>();
+  const modelFor = async (workspaceId: string): Promise<ResolvedExtractionModel | null> => {
+    const cached = models.get(workspaceId);
+    if (cached !== undefined) return cached;
+    const resolved = await resolveModel(workspaceId);
+    models.set(workspaceId, resolved);
+    return resolved;
+  };
+
+  return runPeriodicDbCycle<EpisodeRow, EpisodeOutcome, BrainExtractionCycleResult>({
+    log,
+    label: "Brain extraction",
+    emptyResult,
+    failureResult: (error) => ({ ...emptyResult(), status: "failure", error }),
+    scan: () => internalQuery<EpisodeRow>(DRAIN_EPISODES_SQL, [BATCH_SIZE]),
+    applyRow: (row) => extractEpisode(row, { extract, modelFor, reconcile, now }),
+    defectOutcome: (error) => ({ kind: "failed", error }),
+    tally: (result, row, outcome) => tallyEpisode(result, row, outcome),
+    emitCycleAudit,
+  });
+}
+
+interface ApplyDeps {
+  readonly extract: FactExtractor;
+  readonly modelFor: (workspaceId: string) => Promise<ResolvedExtractionModel | null>;
+  readonly reconcile: typeof reconcileFacts;
+  readonly now: () => Date;
+}
+
+/** Extract → reconcile → stamp, for one episode. */
+async function extractEpisode(row: EpisodeRow, deps: ApplyDeps): Promise<EpisodeOutcome> {
+  const episode = toEpisodeRef(row);
+
+  if (row.body === null || row.body.trim() === "") {
+    // By-reference evidence (a warehouse/KB locator). Nothing in M1 can fetch
+    // it, and leaving it queued would burn a slot at the head of the drain
+    // every cycle forever — so it is stamped, and warned about by id so the
+    // "silent drop" this stamps past is at least an audible one.
+    log.warn(
+      { workspaceId: episode.workspaceId, episodeId: episode.id, source: episode.source },
+      "brain extraction: episode is stored by reference and has no body to extract from — marking it extracted so it cannot block the queue",
+    );
+    await stampExtracted(episode);
+    return { kind: "skipped", reason: "no_body" };
+  }
+
+  const resolved = await deps.modelFor(episode.workspaceId);
+  if (resolved === null) {
+    // NOT stamped: an admin re-entering the workspace's key must be enough to
+    // make these episodes extract, with no backfill to run.
+    return { kind: "skipped", reason: "model_unavailable" };
+  }
+
+  const extractedAt = deps.now();
+  const candidates = await deps.extract({
+    episode,
+    body: row.body,
+    model: resolved.model,
+    modelId: resolved.modelId,
+  });
+
+  const report = await deps.reconcile({
+    episode,
+    candidates,
+    producer: BRAIN_EXTRACTION_PRODUCER,
+    extractedAt,
+  });
+
+  // Only after the reconcile transaction has COMMITTED. See the module header
+  // on why the reverse order is not merely slower but unsafe.
+  await stampExtracted(episode);
+  return { kind: "extracted", report };
+}
+
+async function stampExtracted(episode: ReconcileEpisodeRef): Promise<void> {
+  await internalQuery(STAMP_EXTRACTED_SQL, [episode.id, episode.workspaceId]);
+}
+
+/**
+ * Map a drained row onto the reconcile stage's episode reference.
+ *
+ * `occurred_at` arrives as a `Date` from `pg` but as a string through a JSON
+ * round-trip (a region import, a test fixture), and an unparseable value must
+ * degrade to "no event time" rather than reach `toISOString()` and throw
+ * mid-transaction. `visible_to` is passed through untouched — `parseGrant` is
+ * built to read it straight off the driver, `null` elements and all.
+ */
+function toEpisodeRef(row: EpisodeRow): ReconcileEpisodeRef {
+  return {
+    id: row.id,
+    workspaceId: row.workspace_id,
+    source: row.source,
+    sourceId: row.source_id,
+    sourceActor: row.source_actor,
+    occurredAt: toDate(row.occurred_at),
+    visibleTo: Array.isArray(row.visible_to) ? (row.visible_to as readonly unknown[]) : [],
+  };
+}
+
+function toDate(value: Date | string | null): Date | null {
+  if (value === null) return null;
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function tallyEpisode(
+  result: BrainExtractionCycleResult,
+  row: EpisodeRow,
+  outcome: EpisodeOutcome,
+): void {
+  switch (outcome.kind) {
+    case "extracted": {
+      result.extracted++;
+      result.factsCreated += outcome.report.created;
+      result.factsCorroborated += outcome.report.corroborated;
+      result.factsProvisional += outcome.report.provisional;
+      result.factsBlocked += Object.values(outcome.report.blocked).reduce((a, b) => a + b, 0);
+      return;
+    }
+    case "skipped": {
+      if (outcome.reason === "model_unavailable") result.skippedModelUnavailable++;
+      else result.skippedNoBody++;
+      return;
+    }
+    case "failed": {
+      result.failed++;
+      // Per-episode, at warn: the episode stays queued, so this is a retry
+      // notice rather than an outage — but an id-less "3 failed" in the cycle
+      // row would leave an operator nothing to look at.
+      log.warn(
+        { workspaceId: row.workspace_id, episodeId: row.id, err: outcome.error },
+        "brain extraction: episode extraction failed — it stays on the queue and will be retried",
+      );
+      return;
+    }
+  }
+}
+
+/**
+ * The cycle-level audit row. Emitted on EVERY terminal path (including the
+ * no-database and empty ones), so its ABSENCE over a window is the "the fiber
+ * stopped" signal — the same forensic invariant the BYOT refresh cycle carries.
+ */
+function emitCycleAudit(result: BrainExtractionCycleResult): void {
+  try {
+    logAdminAction({
+      actionType: ADMIN_ACTIONS.brain.extractionCycle,
+      targetType: "brain",
+      targetId: "scheduler",
+      scope: "platform",
+      systemActor: BRAIN_EXTRACTION_ACTOR,
+      status: result.status,
+      metadata: { ...result },
+    });
+  } catch (err) {
+    log.error(
+      { err: errorMessage(err) },
+      "Brain extraction: cycle audit emission threw",
+    );
+  }
+}
+
+/** The fiber's tick cadence. Exported for the registration in `layers.ts`. */
+export function getBrainExtractionIntervalMs(): number {
+  return INTERVAL_MS;
+}

--- a/packages/api/src/lib/brain/extract.ts
+++ b/packages/api/src/lib/brain/extract.ts
@@ -77,7 +77,9 @@
  * module's whole ordering avoids. What IS bounded is the SPEND: after
  * {@link QUARANTINE_AFTER_FAILURES} consecutive failures the episode moves to a
  * widening probe backoff and logs at ERROR, so it costs at most one model call
- * per window instead of one per tick. So the honest statement of the bound is:
+ * per window instead of one per tick — PER PROCESS. The ledger is in-memory and
+ * this fiber has no leader election, so a fleet of R replicas each runs its own
+ * ramp: read every spend figure here as ×R on SaaS. So the honest statement of the bound is:
  * N permanently-failing episodes at the head of the queue WOULD starve it,
  * cheaply and loudly, until an operator acts on the recurring error.
  */
@@ -713,7 +715,11 @@ export function runBrainExtractionCycle(
      * it.
      */
     const settleAndAudit = (result: BrainExtractionCycleResult): void => {
-      const attempted = result.failed + result.extracted + result.blockedEpisodes;
+      // Only outcomes that ACTUALLY called a model are evidence about the
+      // model. A pre-flight block is reached before `modelFor`, so counting it
+      // here would let one workspace's un-attributable actors silently disable
+      // the outage refund for the whole fleet.
+      const attempted = result.failed + result.extracted;
       if (charged.length > 0 && result.failed === attempted) {
         let refunded = 0;
         for (const { episodeId } of charged) {
@@ -744,6 +750,20 @@ export function runBrainExtractionCycle(
               workspaces: new Set(charged.map((c) => c.workspaceId)).size,
             },
             "brain extraction: every episode this tick failed — forgiving one strike each rather than counting an upstream outage against the episodes",
+          );
+        } else {
+          // The third state, and the one an operator investigating "why did my
+          // whole backlog just quarantine" needs most: a total-failure tick
+          // whose strikes we deliberately let stand because every episode had
+          // already spent its one refund. Without this it renders as
+          // `outageRefunded: 0` — byte-identical to a mixed tick.
+          log.warn(
+            {
+              attempted,
+              charged: charged.length,
+              workspaces: new Set(charged.map((c) => c.workspaceId)).size,
+            },
+            "brain extraction: every episode this tick failed, but each had already spent its one outage refund — the strikes stand and quarantine will engage",
           );
         }
       }
@@ -890,7 +910,7 @@ async function extractEpisode(row: EpisodeRow, deps: ApplyDeps): Promise<Episode
   // would be recorded as a successful extraction and STAMPED: a safety refusal
   // permanently consuming the evidence, counted as success. Read it instead.
   if (report.episodeBlocked !== undefined) {
-    log.warn(
+    log.error(
       {
         workspaceId: episode.workspaceId,
         episodeId: episode.id,
@@ -898,7 +918,15 @@ async function extractEpisode(row: EpisodeRow, deps: ApplyDeps): Promise<Episode
       },
       "brain extraction: the reconcile stage refused this episode after the pre-flight passed — the two gates disagreed, which is an Atlas bug; leaving it queued",
     );
-    return { kind: "blocked", reason: report.episodeBlocked };
+    // `failed`, NOT `blocked`. Everywhere else in this file `blocked` means "a
+    // stamped decision"; this path is unstamped and re-attempted, so labelling
+    // it `blocked` would route it around the failure ledger and spend one model
+    // call per tick forever with no bound — the exact class the ledger exists to
+    // cap. Charging it a strike also makes the gate disagreement escalate.
+    return {
+      kind: "failed",
+      error: `reconcile refused the episode post-flight: ${report.episodeBlocked}`,
+    };
   }
 
   // Only after the reconcile transaction has COMMITTED. See the module header
@@ -989,11 +1017,33 @@ function tallyEpisode(
       // longest-failing entry — the one whose count is doing the most work.
       ledger.delete(row.id);
       if (ledger.size >= FAILURE_LEDGER_CAP) {
-        // Evict oldest-first rather than refusing to record — dropping the NEW
-        // entry would silently disable quarantine for exactly the pathological
-        // backlog the cap exists to survive.
-        const oldest = ledger.keys().next();
-        if (!oldest.done) ledger.delete(oldest.value);
+        // Unreachable while the drain is `LIMIT BATCH_SIZE` over a queue whose
+        // head never advances past a failure — the ledger cannot exceed
+        // BATCH_SIZE. Stated because a future drain change (a bigger batch, a
+        // workspace-fair walk) wakes this branch up, and it must not wake up
+        // silently.
+        //
+        // Evict by OLDEST FAILURE, not by insertion order: a quarantined entry
+        // is skipped rather than re-`set`, so its insertion position freezes at
+        // the front and insertion-order eviction would drop the DEEPEST backoff
+        // first — silently disarming the quarantine that was doing the most
+        // work, and restoring its refund eligibility along with it.
+        let victim: string | undefined;
+        let oldest = Infinity;
+        for (const [id, candidate] of ledger) {
+          if (candidate.lastFailureAt < oldest) {
+            oldest = candidate.lastFailureAt;
+            victim = id;
+          }
+        }
+        if (victim !== undefined) {
+          const dropped = ledger.get(victim);
+          ledger.delete(victim);
+          log.warn(
+            { episodeId: victim, failures: dropped?.failures, cap: FAILURE_LEDGER_CAP },
+            "brain extraction: failure ledger at capacity — dropping an episode's strike history, so its quarantine is disarmed and it will be attempted every tick again",
+          );
+        }
       }
       ledger.set(row.id, { ...entry, failures, lastFailureAt: now().getTime() });
       charged.push({ episodeId: row.id, workspaceId: row.workspace_id });
@@ -1001,9 +1051,20 @@ function tallyEpisode(
       // keeps a recurring ERROR in the log instead of one archaeological line
       // that scrolled away days before anyone looked.
       if (failures >= QUARANTINE_AFTER_FAILURES && failures % QUARANTINE_ERROR_EVERY === 0) {
+        // The deadline, not just the policy. Repairing the cause does NOT
+        // shorten the current window, so an operator who fixes a broken model
+        // and watches nothing happen needs to know whether the fiber is dead or
+        // merely waiting — and until when.
+        const shift = Math.min(
+          failures - QUARANTINE_AFTER_FAILURES,
+          QUARANTINE_PROBE_MAX_SHIFT,
+        );
+        const nextProbeAt = new Date(
+          now().getTime() + QUARANTINE_PROBE_BASE_MS * 2 ** shift,
+        ).toISOString();
         log.error(
-          { workspaceId: row.workspace_id, episodeId: row.id, failures, err: outcome.error },
-          "brain extraction: episode keeps failing — it is holding a queue slot and will only be retried on a widening backoff until the cause is fixed",
+          { workspaceId: row.workspace_id, episodeId: row.id, failures, nextProbeAt, err: outcome.error },
+          "brain extraction: episode keeps failing — it holds a queue slot and is next retried at nextProbeAt; fixing the cause does not shorten that window, restart the process to retry sooner",
         );
         return;
       }

--- a/packages/api/src/lib/brain/extract.ts
+++ b/packages/api/src/lib/brain/extract.ts
@@ -169,11 +169,44 @@ const QUARANTINE_PROBE_BASE_MS = 30 * 60 * 1000;
 /** Backoff ceiling: 2^5 × 30 min = 16 h between probes. */
 const QUARANTINE_PROBE_MAX_SHIFT = 5;
 
-/** What the ledger remembers about one struggling episode. */
+/**
+ * Re-emit the quarantine ERROR every Nth failure.
+ *
+ * Its OWN constant rather than a reuse of {@link QUARANTINE_AFTER_FAILURES}:
+ * they answer different questions, and tuning the threshold for spend would
+ * otherwise silently retune the log cadence — at the 16 h probe ceiling, a
+ * threshold of 10 would mean one ERROR every six days.
+ */
+const QUARANTINE_ERROR_EVERY = 3;
+
+/**
+ * What the ledger remembers about one struggling episode.
+ *
+ * `readonly` because every write replaces the whole entry: an in-place
+ * `entry.failures++` would advance the count while leaving `lastFailureAt`
+ * describing an older failure, and the backoff reads both.
+ */
 interface QuarantineEntry {
-  failures: number;
+  readonly failures: number;
   /** Epoch ms of the most recent failure — the backoff window's origin. */
-  lastFailureAt: number;
+  readonly lastFailureAt: number;
+  /**
+   * True once this episode's strike has been forgiven as an outage.
+   *
+   * THE cap that keeps the outage refund from being self-fulfilling. A failing
+   * episode is never stamped, so it stays at the head of the drain — and once
+   * the healthy episodes ahead of it have drained, "every episode this tick
+   * failed" is simply what a poisoned queue looks like, every tick, forever. An
+   * uncapped refund therefore un-charges the same strikes it just charged and
+   * quarantine can never be reached: measured over a simulated day, two
+   * poisoned episodes went from 25 model calls total to 576 and climbing.
+   *
+   * Forgiving each episode exactly ONCE keeps both properties: a genuine outage
+   * costs every episode zero net strikes on its first bad tick, and a
+   * deterministically-failing batch still ratchets into quarantine one tick
+   * later than it otherwise would.
+   */
+  readonly refunded?: true;
 }
 
 /**
@@ -461,7 +494,17 @@ export async function resolveExtractionModel(
     return { routingUnavailable: false, config } as const;
   });
 
-  let resolved: { routingUnavailable: boolean; config?: RawWorkspaceModelConfig | null };
+  // A UNION, not a widened record. `{ routingUnavailable: boolean; config?: … }`
+  // makes `{ routingUnavailable: false }` with no `config` representable — and
+  // that value falls straight through to `getModel()` below, which is the
+  // "silently bill the platform key for a BYO workspace" failure this whole
+  // function exists to prevent. The producer already returns the union; only
+  // the annotation was throwing it away.
+  type RoutingProbe =
+    | { readonly routingUnavailable: true }
+    | { readonly routingUnavailable: false; readonly config: RawWorkspaceModelConfig | null };
+
+  let resolved: RoutingProbe;
   try {
     resolved = await runEnterprise(program);
   } catch (err) {
@@ -480,7 +523,8 @@ export async function resolveExtractionModel(
     return null;
   }
 
-  const config = resolved.config ?? null;
+  // No `?? null` — past the gate above the union guarantees the field.
+  const config = resolved.config;
   try {
     if (config) {
       return {
@@ -496,7 +540,12 @@ export async function resolveExtractionModel(
     const model = getModel();
     return { model, modelId: typeof model === "string" ? model : model.modelId };
   } catch (err) {
-    log.warn(
+    // ERROR, matching the routing-unavailable arm: a config that reads but
+    // cannot be built is non-transient by definition, and every tick from here
+    // stalls this workspace's whole backlog until a human edits configuration.
+    // (The READ failure above stays `warn` — a decrypt or an internal-DB blip
+    // can clear on its own.)
+    log.error(
       { workspaceId, byo: config !== null, err: errorMessage(err) },
       "brain extraction: the configured model could not be built — leaving this workspace's episodes queued until the configuration is repaired",
     );
@@ -515,9 +564,9 @@ export const EXTRACTION_SKIP_REASONS = [
   /** Stored by reference (`locator`), which M1 has no fetcher for. Stamped. */
   "no_body",
   /**
-   * Failed on every recent attempt, so this process has stopped calling a model
-   * for it — see {@link QUARANTINE_AFTER_FAILURES}. Still queued; still retried
-   * after a restart.
+   * Failed on every recent attempt, so this tick did not call a model for it —
+   * see {@link QUARANTINE_AFTER_FAILURES}. Still queued, and re-probed once the
+   * widening backoff elapses, so a repaired model heals it without a restart.
    */
   "quarantined",
 ] as const;
@@ -553,6 +602,14 @@ export interface BrainExtractionCycleResult {
   skipped: Record<ExtractionSkipReason, number>;
   /** Episodes whose pass threw — left queued for the next cycle. */
   failed: number;
+  /**
+   * Strikes forgiven this tick because every attempted episode failed.
+   *
+   * Nonzero says "we chose not to count this against the episodes", which is
+   * exactly the state an operator needs distinguished from "nothing was wrong"
+   * when asking why quarantine has not engaged.
+   */
+  outageRefunded: number;
   /** Present only on the scan-fault path, mirroring the other DB cycles. */
   error?: string;
 }
@@ -584,6 +641,7 @@ function emptyResult(): BrainExtractionCycleResult {
     factsProvisional: 0,
     factsBlocked: 0,
     blockedEpisodes: 0,
+    outageRefunded: 0,
     // Fresh per call — `runPeriodicDbCycle` mutates the result in place, so a
     // shared object would accumulate across ticks.
     blocked: {
@@ -610,59 +668,101 @@ export function runBrainExtractionCycle(
   const reconcile = deps.reconcile ?? reconcileFacts;
   const now = deps.now ?? (() => new Date());
 
-  // Resolved once per WORKSPACE per cycle, not once per episode: a decrypt is
-  // not free and a workspace usually contributes a run of adjacent episodes.
-  // Cycle-scoped so a key repaired between ticks takes effect on the next one.
-  const models = new Map<string, ResolvedExtractionModel | null>();
-  const modelFor = async (workspaceId: string): Promise<ResolvedExtractionModel | null> => {
-    const cached = models.get(workspaceId);
-    if (cached !== undefined) return cached;
-    const resolved = await resolveModel(workspaceId);
-    models.set(workspaceId, resolved);
-    return resolved;
-  };
+  // `Effect.suspend` so the per-tick mutable state below is allocated per RUN
+  // rather than per construction. The scheduler builds a fresh Effect every tick
+  // today, so this is belt-and-braces — but hoisting that call to a `const` is
+  // an obviously-equivalent-looking refactor that would silently turn the model
+  // cache into a process-lifetime one and make `charged` cumulative across
+  // ticks, un-charging strikes from rows a later tick never touched.
+  return Effect.suspend(() => {
+    // Resolved once per WORKSPACE per cycle, not once per episode: a decrypt is
+    // not free and a workspace usually contributes a run of adjacent episodes.
+    // Cycle-scoped so a key repaired between ticks takes effect on the next one.
+    const models = new Map<string, ResolvedExtractionModel | null>();
+    const modelFor = async (workspaceId: string): Promise<ResolvedExtractionModel | null> => {
+      const cached = models.get(workspaceId);
+      if (cached !== undefined) return cached;
+      const resolved = await resolveModel(workspaceId);
+      models.set(workspaceId, resolved);
+      return resolved;
+    };
 
-  // ONE binding, threaded into both halves — `extractEpisode` reads it and
-  // `tallyEpisode` writes it, and they have to be the same object.
-  const failures = failureLedger;
-  const charged: string[] = [];
+    // ONE binding, threaded into both halves — `extractEpisode` reads it and
+    // `tallyEpisode` writes it, and they have to be the same object.
+    const failures = failureLedger;
+    const charged: { episodeId: string; workspaceId: string }[] = [];
 
-  return runPeriodicDbCycle<EpisodeRow, EpisodeOutcome, BrainExtractionCycleResult>({
-    log,
-    label: "Brain extraction",
-    emptyResult,
-    failureResult: (error) => ({ ...emptyResult(), status: "failure", error }),
-    scan: () => internalQuery<EpisodeRow>(DRAIN_EPISODES_SQL, [BATCH_SIZE]),
-    applyRow: (row) => extractEpisode(row, { extract, modelFor, reconcile, now, failures }),
-    defectOutcome: (error) => ({ kind: "failed", error }),
-    tally: (result, row, outcome) => tallyEpisode(result, row, outcome, failures, now, charged),
-    emitCycleAudit,
-  }).pipe(
-    Effect.map((result) => {
-      // An OUTAGE is not evidence about any episode. When every episode the
-      // tick actually attempted failed, the common cause is upstream — a
-      // provider 5xx, a rate-limit storm, an exhausted pool — and charging each
-      // one a strike would quarantine a whole batch of perfectly good episodes
-      // after three bad ticks. Cheaper and more honest than classifying
-      // individual errors: if none of them worked, blame the world, not the
-      // rows. A single failing row among successes is still charged.
+    /**
+     * Forgive one strike each when the whole tick failed, then emit the cycle
+     * row.
+     *
+     * An OUTAGE is not evidence about any episode. When every episode a tick
+     * attempted failed, the common cause is upstream — a provider 5xx, a
+     * rate-limit storm, an exhausted pool — and charging each one a strike would
+     * quarantine a batch of perfectly good episodes after three bad ticks.
+     * Cheaper and more honest than classifying individual errors: if none of
+     * them worked, blame the world, not the rows. A single failing row among
+     * successes is still charged, and the per-episode `refunded` cap keeps a
+     * genuinely poisoned batch from being forgiven forever.
+     *
+     * FUSED with the audit emit deliberately: the skeleton calls
+     * `emitCycleAudit` after the last row and before returning, which is the
+     * only hook that runs with the tick's full verdict in hand and still ahead
+     * of the audit write. Refunding afterwards would leave every audit row
+     * claiming `outageRefunded: 0` — a lie in the one place an operator reads
+     * it.
+     */
+    const settleAndAudit = (result: BrainExtractionCycleResult): void => {
       const attempted = result.failed + result.extracted + result.blockedEpisodes;
-      if (charged.length > 0 && attempted > 1 && result.failed === attempted) {
-        for (const id of charged) {
-          const entry = failures.get(id);
-          if (entry === undefined) continue;
-          if (entry.failures <= 1) failures.delete(id);
-          else failures.set(id, { ...entry, failures: entry.failures - 1 });
+      if (charged.length > 0 && result.failed === attempted) {
+        let refunded = 0;
+        for (const { episodeId } of charged) {
+          const entry = failures.get(episodeId);
+          if (entry === undefined || entry.refunded === true) continue;
+          refunded++;
+          // Decremented to zero, NEVER deleted. Deleting would discard the
+          // `refunded` marker with the entry, so the next tick would forgive the
+          // same episode again — and again — which is the uncapped behaviour
+          // this cap exists to prevent. A zero-failure entry is inert
+          // (`isQuarantined` is false) and is cleared for real by any path that
+          // stamps the episode.
+          failures.set(episodeId, {
+            ...entry,
+            failures: entry.failures - 1,
+            refunded: true,
+          });
         }
-        log.warn(
-          { attempted, workspaces: new Set(charged).size },
-          "brain extraction: every episode this tick failed — treating it as an upstream outage rather than counting a strike against each episode",
-        );
+        if (refunded > 0) {
+          result.outageRefunded = refunded;
+          log.warn(
+            {
+              attempted,
+              refunded,
+              // Genuinely workspaces, not episode ids. The two differ, and the
+              // difference is the discriminator that matters: an upstream
+              // outage crosses tenants, one bad body class does not.
+              workspaces: new Set(charged.map((c) => c.workspaceId)).size,
+            },
+            "brain extraction: every episode this tick failed — forgiving one strike each rather than counting an upstream outage against the episodes",
+          );
+        }
       }
       charged.length = 0;
-      return result;
-    }),
-  );
+      emitCycleAudit(result);
+    };
+
+    return runPeriodicDbCycle<EpisodeRow, EpisodeOutcome, BrainExtractionCycleResult>({
+      log,
+      label: "Brain extraction",
+      emptyResult,
+      failureResult: (error) => ({ ...emptyResult(), status: "failure", error }),
+      scan: () => internalQuery<EpisodeRow>(DRAIN_EPISODES_SQL, [BATCH_SIZE]),
+      applyRow: (row) => extractEpisode(row, { extract, modelFor, reconcile, now, failures }),
+      defectOutcome: (error) => ({ kind: "failed", error }),
+      tally: (result, row, outcome) => tallyEpisode(result, row, outcome, failures, now, charged),
+      emitCycleAudit: settleAndAudit,
+    });
+  });
 }
 
 interface ApplyDeps {
@@ -783,6 +883,24 @@ async function extractEpisode(row: EpisodeRow, deps: ApplyDeps): Promise<Episode
     extractedAt,
   });
 
+  // The stage refused the whole episode despite our pre-flight passing. It
+  // cannot happen while this path passes no `sourcePrincipal` (the two gates
+  // then see identical inputs) — but `ReconcileRequest` exists to let a caller
+  // supply one, and the moment anything here does, an unread `episodeBlocked`
+  // would be recorded as a successful extraction and STAMPED: a safety refusal
+  // permanently consuming the evidence, counted as success. Read it instead.
+  if (report.episodeBlocked !== undefined) {
+    log.warn(
+      {
+        workspaceId: episode.workspaceId,
+        episodeId: episode.id,
+        reason: report.episodeBlocked,
+      },
+      "brain extraction: the reconcile stage refused this episode after the pre-flight passed — the two gates disagreed, which is an Atlas bug; leaving it queued",
+    );
+    return { kind: "blocked", reason: report.episodeBlocked };
+  }
+
   // Only after the reconcile transaction has COMMITTED. See the module header
   // on why the reverse order is not merely slower but unsafe.
   await stampExtracted(episode);
@@ -832,8 +950,8 @@ function tallyEpisode(
   outcome: EpisodeOutcome,
   ledger: Map<string, QuarantineEntry>,
   now: () => Date,
-  /** Ids incremented this tick — the outage rollback's working set. */
-  charged: string[],
+  /** Episodes charged a strike this tick — the outage rollback's working set. */
+  charged: { episodeId: string; workspaceId: string }[],
 ): void {
   switch (outcome.kind) {
     case "extracted": {
@@ -841,7 +959,14 @@ function tallyEpisode(
       result.factsCreated += outcome.report.created;
       result.factsCorroborated += outcome.report.corroborated;
       result.factsProvisional += outcome.report.provisional;
-      result.factsBlocked += Object.values(outcome.report.blocked).reduce((a, b) => a + b, 0);
+      // Fold the per-reason breakdown rather than only its sum: `factsBlocked:
+      // 12` says candidates were refused, `blocked.MALFORMED_CLAIM: 12` says the
+      // extractor is emitting empty triples, and those send an investigation to
+      // different files.
+      for (const [reason, count] of Object.entries(outcome.report.blocked)) {
+        result.blocked[reason as ReconcileBlockReason] += count;
+        result.factsBlocked += count;
+      }
       return;
     }
     case "blocked": {
@@ -857,7 +982,8 @@ function tallyEpisode(
     }
     case "failed": {
       result.failed++;
-      const failures = (ledger.get(row.id)?.failures ?? 0) + 1;
+      const entry = ledger.get(row.id);
+      const failures = (entry?.failures ?? 0) + 1;
       // `delete` before `set` so insertion order tracks RECENCY: `Map.set` on an
       // existing key leaves it in place, which would make the cap evict the
       // longest-failing entry — the one whose count is doing the most work.
@@ -869,12 +995,12 @@ function tallyEpisode(
         const oldest = ledger.keys().next();
         if (!oldest.done) ledger.delete(oldest.value);
       }
-      ledger.set(row.id, { failures, lastFailureAt: now().getTime() });
-      charged.push(row.id);
+      ledger.set(row.id, { ...entry, failures, lastFailureAt: now().getTime() });
+      charged.push({ episodeId: row.id, workspaceId: row.workspace_id });
       // Re-armed, not one-shot: the condition is ongoing, so `>=` with a modulo
       // keeps a recurring ERROR in the log instead of one archaeological line
       // that scrolled away days before anyone looked.
-      if (failures >= QUARANTINE_AFTER_FAILURES && failures % QUARANTINE_AFTER_FAILURES === 0) {
+      if (failures >= QUARANTINE_AFTER_FAILURES && failures % QUARANTINE_ERROR_EVERY === 0) {
         log.error(
           { workspaceId: row.workspace_id, episodeId: row.id, failures, err: outcome.error },
           "brain extraction: episode keeps failing — it is holding a queue slot and will only be retried on a widening backoff until the cause is fixed",

--- a/packages/api/src/lib/brain/extract.ts
+++ b/packages/api/src/lib/brain/extract.ts
@@ -64,19 +64,22 @@
  * ## Head-of-line, stated because it is a real bound
  *
  * The drain is `ORDER BY ingested_at LIMIT N`, so a queued episode occupies one
- * of N slots until something takes it off the queue. Exactly two classes are
- * stamped without producing a fact, and both are DECISIONS rather than guesses:
- * a by-reference episode M1 has no fetcher for, and an episode the reconcile
- * gate refuses wholesale. Everything else retries.
+ * of N slots until something takes it off the queue. An episode is stamped once
+ * its extraction pass COMPLETES — including a pass that found no claim at all,
+ * which is the common case and must not head-of-line block on small talk. Two
+ * further classes are stamped without ever calling a model, and both are
+ * DECISIONS rather than guesses: a by-reference episode M1 has no fetcher for,
+ * and an episode the reconcile gate refuses wholesale. Only a pass that THREW
+ * retries.
  *
  * A deterministically-failing episode therefore keeps its slot indefinitely —
  * stamping it would be a silent drop on a guess, which is the thing this
  * module's whole ordering avoids. What IS bounded is the SPEND: after
- * {@link QUARANTINE_AFTER_FAILURES} consecutive failures the process stops
- * calling a model for it and logs at ERROR. So the honest statement of the
- * bound is: N permanently-failing episodes at the head of the queue WOULD
- * starve it, cheaply and loudly, until an operator acts on the error log or the
- * process restarts.
+ * {@link QUARANTINE_AFTER_FAILURES} consecutive failures the episode moves to a
+ * widening probe backoff and logs at ERROR, so it costs at most one model call
+ * per window instead of one per tick. So the honest statement of the bound is:
+ * N permanently-failing episodes at the head of the queue WOULD starve it,
+ * cheaply and loudly, until an operator acts on the recurring error.
  */
 
 import { Effect } from "effect";
@@ -142,14 +145,39 @@ const EXTRACTION_TIMEOUT_MS = 60_000;
 
 /**
  * Consecutive failures after which this process stops calling a model for an
- * episode. Bounds SPEND on a deterministically-failing episode (a body that
- * always trips a content filter, a model id that 404s) without pretending a
- * few failures prove permanence.
+ * episode every tick. Bounds SPEND on a deterministically-failing episode (a
+ * body that always trips a content filter, a model id that 404s) without
+ * pretending a few failures prove permanence.
  */
 const QUARANTINE_AFTER_FAILURES = 3;
 
 /**
- * Episode id → consecutive failures, for the life of the process.
+ * First probe interval after quarantine, doubling per subsequent failure up to
+ * {@link QUARANTINE_PROBE_MAX_SHIFT}.
+ *
+ * Quarantine is PROBING, not absorbing, and the difference is the whole design.
+ * An absorbing quarantine has one exit — a process restart — and the only
+ * evidence available to enter it is "failed three times", which a fifteen-minute
+ * provider outage produces just as readily as a poisoned body. So an absorbing
+ * version would let a transient upstream fault permanently disable extraction
+ * fleet-wide, silently, until someone redeployed. Backing off and re-probing
+ * costs one model call per episode per window and makes a repaired model
+ * self-healing.
+ */
+const QUARANTINE_PROBE_BASE_MS = 30 * 60 * 1000;
+
+/** Backoff ceiling: 2^5 × 30 min = 16 h between probes. */
+const QUARANTINE_PROBE_MAX_SHIFT = 5;
+
+/** What the ledger remembers about one struggling episode. */
+interface QuarantineEntry {
+  failures: number;
+  /** Epoch ms of the most recent failure — the backoff window's origin. */
+  lastFailureAt: number;
+}
+
+/**
+ * Episode id → consecutive-failure state, for the life of the process.
  *
  * Module-level so it survives across ticks, in-memory so it needs no migration
  * — the same trade the BYOT catalog refresh made for its backoff state. A
@@ -158,7 +186,7 @@ const QUARANTINE_AFTER_FAILURES = 3;
  * nobody re-examines. Bounded by {@link FAILURE_LEDGER_CAP} so a pathological
  * backlog cannot grow it without limit.
  */
-const failureLedger = new Map<string, number>();
+const failureLedger = new Map<string, QuarantineEntry>();
 
 /** Ledger entries retained. Far above `BATCH_SIZE`; a bound, not a policy. */
 const FAILURE_LEDGER_CAP = 1_000;
@@ -403,13 +431,20 @@ export interface ResolvedExtractionModel {
  *     `null` for every workspace, which is indistinguishable from "this
  *     workspace has no BYO config" — so an EE module that failed to load would
  *     have silently moved every BYO workspace's whole backlog onto Atlas's own
- *     key. Probed explicitly, exactly as the BYOT catalog refresh does.
+ *     key. Probed explicitly, as the BYOT catalog refresh does — with one
+ *     difference: it probes unconditionally and caches the verdict per pod,
+ *     while this gates the probe on `isEnterpriseEnabled()` so a self-hosted
+ *     install (legitimately `available: false`, no EE by design) still gets the
+ *     platform default rather than a permanent refusal.
  *   - **A config that reads but cannot be built.** `getModelFromWorkspaceConfig`
  *     throws on a malformed bedrock bundle, a missing `baseUrl`, a gateway row
  *     with no key; `getModel()` throws when the platform provider is
- *     unconfigured. Left outside the guard those escaped as a per-episode
- *     throw — counted as a transient failure and retried forever, which is the
- *     wrong verdict for a fault only an admin can fix.
+ *     STRUCTURALLY unconfigured (gateway with no key, openai-compatible with no
+ *     base URL — a merely missing anthropic/openai key still surfaces at call
+ *     time and lands in the failure ledger instead). Left outside the guard
+ *     those escaped as a per-episode throw — counted as a transient failure and
+ *     retried forever, which is the wrong verdict for a fault only an admin can
+ *     fix.
  */
 export async function resolveExtractionModel(
   workspaceId: string,
@@ -508,6 +543,12 @@ export interface BrainExtractionCycleResult {
    * what it would actually mean.
    */
   blockedEpisodes: number;
+  /**
+   * Which refusal, by reason. `blockedEpisodes: 25` says grant derivation might
+   * be broken; this says whether it is the grant or the actor — the difference
+   * between two very different investigations, and free to record.
+   */
+  blocked: Record<ReconcileBlockReason, number>;
   /** By reason — a `Record` so a new reason is a compile error, not a miscount. */
   skipped: Record<ExtractionSkipReason, number>;
   /** Episodes whose pass threw — left queued for the next cycle. */
@@ -545,6 +586,12 @@ function emptyResult(): BrainExtractionCycleResult {
     blockedEpisodes: 0,
     // Fresh per call — `runPeriodicDbCycle` mutates the result in place, so a
     // shared object would accumulate across ticks.
+    blocked: {
+      NO_PROVENANCE: 0,
+      NO_GRANT: 0,
+      SOURCE_PRINCIPAL_UNRESOLVED: 0,
+      MALFORMED_CLAIM: 0,
+    },
     skipped: { model_unavailable: 0, no_body: 0, quarantined: 0 },
     failed: 0,
   };
@@ -575,17 +622,47 @@ export function runBrainExtractionCycle(
     return resolved;
   };
 
+  // ONE binding, threaded into both halves — `extractEpisode` reads it and
+  // `tallyEpisode` writes it, and they have to be the same object.
+  const failures = failureLedger;
+  const charged: string[] = [];
+
   return runPeriodicDbCycle<EpisodeRow, EpisodeOutcome, BrainExtractionCycleResult>({
     log,
     label: "Brain extraction",
     emptyResult,
     failureResult: (error) => ({ ...emptyResult(), status: "failure", error }),
     scan: () => internalQuery<EpisodeRow>(DRAIN_EPISODES_SQL, [BATCH_SIZE]),
-    applyRow: (row) => extractEpisode(row, { extract, modelFor, reconcile, now, failures: failureLedger }),
+    applyRow: (row) => extractEpisode(row, { extract, modelFor, reconcile, now, failures }),
     defectOutcome: (error) => ({ kind: "failed", error }),
-    tally: (result, row, outcome) => tallyEpisode(result, row, outcome),
+    tally: (result, row, outcome) => tallyEpisode(result, row, outcome, failures, now, charged),
     emitCycleAudit,
-  });
+  }).pipe(
+    Effect.map((result) => {
+      // An OUTAGE is not evidence about any episode. When every episode the
+      // tick actually attempted failed, the common cause is upstream — a
+      // provider 5xx, a rate-limit storm, an exhausted pool — and charging each
+      // one a strike would quarantine a whole batch of perfectly good episodes
+      // after three bad ticks. Cheaper and more honest than classifying
+      // individual errors: if none of them worked, blame the world, not the
+      // rows. A single failing row among successes is still charged.
+      const attempted = result.failed + result.extracted + result.blockedEpisodes;
+      if (charged.length > 0 && attempted > 1 && result.failed === attempted) {
+        for (const id of charged) {
+          const entry = failures.get(id);
+          if (entry === undefined) continue;
+          if (entry.failures <= 1) failures.delete(id);
+          else failures.set(id, { ...entry, failures: entry.failures - 1 });
+        }
+        log.warn(
+          { attempted, workspaces: new Set(charged).size },
+          "brain extraction: every episode this tick failed — treating it as an upstream outage rather than counting a strike against each episode",
+        );
+      }
+      charged.length = 0;
+      return result;
+    }),
+  );
 }
 
 interface ApplyDeps {
@@ -593,12 +670,36 @@ interface ApplyDeps {
   readonly modelFor: (workspaceId: string) => Promise<ResolvedExtractionModel | null>;
   readonly reconcile: typeof reconcileFacts;
   readonly now: () => Date;
-  /** Consecutive-failure ledger for this process — see the quarantine note. */
-  readonly failures: Map<string, number>;
+  /**
+   * Consecutive-failure ledger — see the quarantine note. THE SAME map the
+   * tally writes to: `runBrainExtractionCycle` binds one object into both
+   * halves, because a ledger read through one map and written through another
+   * would leave quarantine permanently disarmed with nothing to notice it.
+   */
+  readonly failures: Map<string, QuarantineEntry>;
+}
+
+/**
+ * Is this episode inside its quarantine backoff window? Reading and writing the
+ * ledger stay in this file's two halves — see {@link ApplyDeps.failures}.
+ */
+function isQuarantined(entry: QuarantineEntry | undefined, now: Date): boolean {
+  if (entry === undefined || entry.failures < QUARANTINE_AFTER_FAILURES) return false;
+  const shift = Math.min(entry.failures - QUARANTINE_AFTER_FAILURES, QUARANTINE_PROBE_MAX_SHIFT);
+  return now.getTime() - entry.lastFailureAt < QUARANTINE_PROBE_BASE_MS * 2 ** shift;
 }
 
 /** Extract → reconcile → stamp, for one episode. */
 async function extractEpisode(row: EpisodeRow, deps: ApplyDeps): Promise<EpisodeOutcome> {
+  // FIRST, before any other work: a quarantined episode should cost nothing at
+  // all this tick, not merely no model call. (It was below the grant guard
+  // once, which meant a permanently-drifted row re-logged an ERROR every five
+  // minutes forever.) Falling THROUGH once the backoff elapses is what keeps
+  // quarantine a backoff rather than a terminal state — a repaired model heals
+  // itself without a redeploy.
+  if (isQuarantined(deps.failures.get(row.id), deps.now())) {
+    return { kind: "skipped", reason: "quarantined" };
+  }
   // `visible_to` is `text[] NOT NULL` (0180), so a non-array here is QUERY
   // DRIFT — a changed SELECT, a driver surprise — not bad tenant data. Coercing
   // it to `[]` would assert "this episode grants nobody", which the reconcile
@@ -607,19 +708,20 @@ async function extractEpisode(row: EpisodeRow, deps: ApplyDeps): Promise<Episode
   // message blaming the tenant's grant. Refused as a retryable failure instead,
   // and named for what it is. (`promotion.ts` splits the same two causes into
   // `GRANT_NOT_AN_ARRAY` vs `GRANT_UNUSABLE` for this exact reason.)
-  if (!isUnknownArray(row.visible_to)) {
+  const visibleTo = row.visible_to;
+  if (!isUnknownArray(visibleTo)) {
     log.error(
       {
         workspaceId: row.workspace_id,
         episodeId: row.id,
-        received: typeof row.visible_to,
+        received: typeof visibleTo,
       },
       "brain extraction: an episode's grant did not load as an array — this is an Atlas bug, not a problem with the episode; leaving it queued",
     );
     return { kind: "failed", error: "visible_to did not load as an array" };
   }
 
-  const episode = toEpisodeRef(row);
+  const episode = toEpisodeRef(row, visibleTo);
 
   if (row.body === null || row.body.trim() === "") {
     // By-reference evidence (a warehouse/KB locator). Nothing in M1 can fetch
@@ -631,6 +733,7 @@ async function extractEpisode(row: EpisodeRow, deps: ApplyDeps): Promise<Episode
       "brain extraction: episode is stored by reference and has no body to extract from — marking it extracted so it cannot block the queue",
     );
     await stampExtracted(episode);
+    deps.failures.delete(episode.id);
     return { kind: "skipped", reason: "no_body" };
   }
 
@@ -654,21 +757,8 @@ async function extractEpisode(row: EpisodeRow, deps: ApplyDeps): Promise<Episode
       `brain extraction: no fact can safely be drawn from this episode — ${episodeBlock.detail}; marking it extracted without calling a model`,
     );
     await stampExtracted(episode);
+    deps.failures.delete(episode.id);
     return { kind: "blocked", reason: episodeBlock.reason };
-  }
-
-  // An episode that has failed on every recent attempt stops costing model
-  // calls. In-memory and per-process, matching the BYOT catalog refresh's
-  // backoff precedent ("pod restart resets the backoff state — acceptable
-  // trade-off vs the migration that a persistent counter would require"), and
-  // deliberately NOT a stamp: "failed three times in this process" is not proof
-  // of "unextractable forever", and stamping on a guess is the silent drop this
-  // module's ordering exists to avoid. It still holds a queue slot — the bound
-  // is on SPEND, not on the head of the queue. The ERROR log is the operator's
-  // cue that a slot is stuck.
-  const priorFailures = deps.failures.get(episode.id) ?? 0;
-  if (priorFailures >= QUARANTINE_AFTER_FAILURES) {
-    return { kind: "skipped", reason: "quarantined" };
   }
 
   const resolved = await deps.modelFor(episode.workspaceId);
@@ -712,10 +802,13 @@ async function stampExtracted(episode: ReconcileEpisodeRef): Promise<void> {
  * degrade to "no event time" rather than reach `toISOString()` and throw
  * mid-transaction. `visible_to`'s ELEMENTS are passed through untouched —
  * `parseGrant` is built to read them straight off the driver, `null` entries and
- * all. Whether the column loaded as an array at all is settled by the caller,
- * which refuses the episode rather than coercing (see `extractEpisode`).
+ * all. Whether the column loaded as an ARRAY is settled before this call and
+ * arrives as an argument, deliberately: read off `row` it needed a `?? []`
+ * fallback here, and that fallback silently asserts "grants nobody", which
+ * reconcile blocks as NO_GRANT and the caller then STAMPS. As a parameter, the
+ * guard in `extractEpisode` is the only way to obtain one.
  */
-function toEpisodeRef(row: EpisodeRow): ReconcileEpisodeRef {
+function toEpisodeRef(row: EpisodeRow, visibleTo: readonly unknown[]): ReconcileEpisodeRef {
   return {
     id: row.id,
     workspaceId: row.workspace_id,
@@ -723,8 +816,7 @@ function toEpisodeRef(row: EpisodeRow): ReconcileEpisodeRef {
     sourceId: row.source_id,
     sourceActor: row.source_actor,
     occurredAt: toDate(row.occurred_at),
-    // Non-array is unreachable here: `extractEpisode` refuses the row first.
-    visibleTo: isUnknownArray(row.visible_to) ? row.visible_to : [],
+    visibleTo,
   };
 }
 
@@ -738,6 +830,10 @@ function tallyEpisode(
   result: BrainExtractionCycleResult,
   row: EpisodeRow,
   outcome: EpisodeOutcome,
+  ledger: Map<string, QuarantineEntry>,
+  now: () => Date,
+  /** Ids incremented this tick — the outage rollback's working set. */
+  charged: string[],
 ): void {
   switch (outcome.kind) {
     case "extracted": {
@@ -750,6 +846,7 @@ function tallyEpisode(
     }
     case "blocked": {
       result.blockedEpisodes++;
+      result.blocked[outcome.reason]++;
       return;
     }
     case "skipped": {
@@ -760,22 +857,27 @@ function tallyEpisode(
     }
     case "failed": {
       result.failed++;
-      const failures = (failureLedger.get(row.id) ?? 0) + 1;
-      // Evict oldest-first (insertion order) rather than refusing to record —
-      // dropping the NEW entry would make the cap silently disable quarantine
-      // for exactly the pathological backlog it exists to survive.
-      if (!failureLedger.has(row.id) && failureLedger.size >= FAILURE_LEDGER_CAP) {
-        const oldest = failureLedger.keys().next();
-        if (!oldest.done) failureLedger.delete(oldest.value);
+      const failures = (ledger.get(row.id)?.failures ?? 0) + 1;
+      // `delete` before `set` so insertion order tracks RECENCY: `Map.set` on an
+      // existing key leaves it in place, which would make the cap evict the
+      // longest-failing entry — the one whose count is doing the most work.
+      ledger.delete(row.id);
+      if (ledger.size >= FAILURE_LEDGER_CAP) {
+        // Evict oldest-first rather than refusing to record — dropping the NEW
+        // entry would silently disable quarantine for exactly the pathological
+        // backlog the cap exists to survive.
+        const oldest = ledger.keys().next();
+        if (!oldest.done) ledger.delete(oldest.value);
       }
-      failureLedger.set(row.id, failures);
-      if (failures === QUARANTINE_AFTER_FAILURES) {
-        // ERROR, once, at the threshold: from here the episode holds a queue
-        // slot but costs nothing, and only an operator can tell whether that is
-        // a bad message or a broken model.
+      ledger.set(row.id, { failures, lastFailureAt: now().getTime() });
+      charged.push(row.id);
+      // Re-armed, not one-shot: the condition is ongoing, so `>=` with a modulo
+      // keeps a recurring ERROR in the log instead of one archaeological line
+      // that scrolled away days before anyone looked.
+      if (failures >= QUARANTINE_AFTER_FAILURES && failures % QUARANTINE_AFTER_FAILURES === 0) {
         log.error(
           { workspaceId: row.workspace_id, episodeId: row.id, failures, err: outcome.error },
-          "brain extraction: episode has failed every attempt in this process — no further model calls will be made for it until a restart",
+          "brain extraction: episode keeps failing — it is holding a queue slot and will only be retried on a widening backoff until the cause is fixed",
         );
         return;
       }
@@ -813,7 +915,10 @@ function emitCycleAudit(result: BrainExtractionCycleResult): void {
       scope: "platform",
       systemActor: BRAIN_EXTRACTION_ACTOR,
       status: result.status,
-      metadata: { ...result },
+      // Deep-ish copy of the two counter records: `{ ...result }` alone would
+      // ALIAS them, so a future skeleton that emitted mid-cycle would log a
+      // snapshot that keeps changing after it was taken.
+      metadata: { ...result, blocked: { ...result.blocked }, skipped: { ...result.skipped } },
     });
   } catch (err) {
     log.error(

--- a/packages/api/src/lib/brain/ingest/episode-sync.ts
+++ b/packages/api/src/lib/brain/ingest/episode-sync.ts
@@ -40,12 +40,18 @@
  *
  * Not "enumerate the full set so absences can be archived" — nothing is
  * archived. ADR-0036 §Ingestion repurposes the cadence to **re-run extraction**
- * (#4771) over a wider window; the fetch side may or may not do anything
- * different, and the Slack source deliberately does not (see its client's
- * header). The mode is still decided and recorded here, because it is the
- * engine's decision to make and #4771 reads the same clock. A pass the client
- * flags `coverageIncomplete` does NOT advance that clock, so whatever is due
- * stays due.
+ * over a wider window; the fetch side may or may not do anything different, and
+ * the Slack source deliberately does not (see its client's header). The mode is
+ * still decided and recorded here because it is the engine's decision to make,
+ * and a pass the client flags `coverageIncomplete` does NOT advance that clock,
+ * so whatever is due stays due.
+ *
+ * The RE-EXTRACTION consumer is not built yet. #4771 shipped the extraction
+ * fiber as a drain of `extracted_at IS NULL` on its own fixed clock; it reads
+ * nothing from `knowledge_sync_state` and never revisits a stamped episode. So
+ * the reconcile cadence currently decides only what the FETCH does — re-reading
+ * this clock is what a "re-extract the last N days with a better model" pass
+ * would hook into.
  *
  * Like the engine it forks, `syncBrainEpisodeSource` NEVER throws: every
  * failure becomes a `status: "error"` outcome so one bad source can't sink the

--- a/packages/api/src/lib/brain/ingest/grant.ts
+++ b/packages/api/src/lib/brain/ingest/grant.ts
@@ -91,9 +91,10 @@ export interface ChatChannelVisibility {
  *   so revocation flows through membership live rather than waiting for
  *   re-ingest.
  *
- *   Membership population is #4771's (the issue's "channel-membership read for
- *   #4771's grant derivation"), so until it lands a private channel's episodes
- *   are visible to NOBODY. That is the fail-closed direction and it is
+ *   Membership population is #4801's, split out of #4771 (which shipped the
+ *   reconcile stage — it INHERITS this grant onto every fact drawn from the
+ *   episode and derives nothing further). Until it lands a private channel's
+ *   episodes, and the facts drawn from them, are visible to NOBODY. That is the fail-closed direction and it is
  *   REPAIRABLE — populating membership makes existing rows visible with no
  *   rewrite, because the grant names the audience and the membership is the
  *   live half. Contrast the failure this module exists to prevent: a

--- a/packages/api/src/lib/brain/reconcile.ts
+++ b/packages/api/src/lib/brain/reconcile.ts
@@ -74,8 +74,9 @@
  * `provenance` edge to the new episode and no second fact row appears. That is
  * what makes re-running extraction over an already-extracted window a no-op
  * (acceptance criterion 5) and what lets `extract.ts` stamp the queue marker
- * AFTER the commit — a crash in that window costs a repeated LLM call, never a
- * duplicated belief.
+ * AFTER the commit — a crash in that window costs a repeated LLM call and, when
+ * the producer reproduces its own output, no duplicated belief. That proviso is
+ * load-bearing; see the byte-exactness note below for what a paraphrase costs.
  *
  * Two writers racing on the same claim would defeat a bare read-then-insert, so
  * the transaction opens by taking a per-workspace transaction-scoped advisory
@@ -117,6 +118,7 @@
 import { createLogger } from "@atlas/api/lib/logger";
 import { getInternalDB } from "@atlas/api/lib/db/internal";
 import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
+import { logGrantAnomalies } from "@atlas/api/lib/brain/acl";
 // The write-side "does this grant name anyone?" predicate, imported rather than
 // re-spelled: `isUsableGrant`'s own docstring exists so the ingest screen and
 // this one can never disagree about what usable MEANS, and two `parseGrant(...)
@@ -327,6 +329,17 @@ export type ReconcileOutcome =
   | { readonly kind: "blocked"; readonly reason: ReconcileBlockReason };
 
 export interface ReconcileReport {
+  /**
+   * Set when the EPISODE was refused wholesale, INDEPENDENT of how many
+   * candidates were offered.
+   *
+   * Without it, a pre-flighting caller that passes an empty candidate list gets
+   * a report byte-identical to a clean "nothing to do" — every counter zero,
+   * because `blocked[reason]` is `candidates.length`. A safety refusal that
+   * reads as success is the one shape this stage must not return, and the
+   * entry-point-agnostic contract means callers that pre-flight are expected.
+   */
+  readonly episodeBlocked?: ReconcileBlockReason;
   readonly created: number;
   readonly corroborated: number;
   /** Created facts carrying `provenance.provisional` — a subset of `created`. */
@@ -487,11 +500,14 @@ export async function reconcileFacts(
   const episodeBlock = classifyEpisodeForReconcile(episode, request.sourcePrincipal);
   if (episodeBlock !== null) {
     const reason = episodeBlock.reason;
-    // Silent when there was nothing to block: a caller that pre-flighted and
-    // passed no candidates has already logged, and a second identical warn per
-    // episode would train an operator to skim them.
-    if (candidates.length > 0) {
-      log.warn(
+    // Downgraded, never silent, when there was nothing to block: a caller that
+    // pre-flighted and passed no candidates has already logged, and a second
+    // identical warn per episode would train an operator to skim them — but
+    // dropping the line entirely would leave a safety refusal with no trace at
+    // all. The verdict also travels in `episodeBlocked` regardless.
+    const level = candidates.length > 0 ? "warn" : "debug";
+    {
+      log[level](
         {
           workspaceId: episode.workspaceId,
           episodeId: episode.id,
@@ -506,6 +522,7 @@ export async function reconcileFacts(
     }
     blocked[reason] = candidates.length;
     return {
+      episodeBlocked: reason,
       created: 0,
       corroborated: 0,
       provisional: 0,
@@ -517,6 +534,18 @@ export async function reconcileFacts(
   // Non-null past the gate above, which blocks the whole episode when the
   // principal cannot be resolved.
   const sourcePrincipal = resolvedPrincipal(episode, request.sourcePrincipal);
+  // `isUsableGrant` above answers "can ANY reader match this?" and discards the
+  // rest of the parse. The half it discards is the one that bites in practice:
+  // a grant like `['user:abc', 'everyone']` passes on its valid token while
+  // carrying a second one whose author believed it was doing something, and the
+  // resulting fact is narrower than intended FOREVER (grants are immutable per
+  // fact version). `logGrantAnomalies` is the seam `acl.ts` built for exactly
+  // this, and this is the write path that holds the row.
+  logGrantAnomalies(episode.visibleTo, {
+    table: "brain_episodes",
+    rowId: episode.id,
+    workspaceId: episode.workspaceId,
+  });
   // Non-string elements (a `null` off `pg`) are inert in the overlap predicate
   // and cannot survive the jsonb round-trip as themselves; dropping them keeps
   // the stored grant readable while the usable-principal check above is what
@@ -689,7 +718,7 @@ export interface EpisodeBlock {
 }
 
 /**
- * The three episode-level safety refusals, in the order they are cheapest.
+ * The three episode-level safety refusals, most consequential first.
  *
  * Exported and pure so a caller can pre-flight BEFORE spending anything on
  * producing candidates: `extract.ts` runs it ahead of the model call, which is
@@ -827,10 +856,10 @@ async function writeCandidate(
     occurredAt: isoOrNull(episode.occurredAt),
     extractedAt: isoOrNull(ctx.extractedAt),
     reconciledAt: ctx.now().toISOString(),
-    ...(Object.keys(item.entityIds).length > 0 ? { entityIds: item.entityIds } : {}),
+    ...entityIdFragment(item.entityIds),
     // Present ONLY when it is true, so a reviewer's filter on the key is not
     // fooled by every fact carrying `provisional: false`.
-    ...(provisional ? { provisional: true as const, unresolved: item.unresolved } : {}),
+    ...provisionalFragment(provisional, item.unresolved),
   } satisfies BrainFactProvenance;
 
   const cardinality: PredicateCardinality = item.candidate.predicateCardinality ?? "multi";
@@ -896,6 +925,28 @@ async function writeCandidate(
   }
 
   return { kind: "created", factId, provisional, tensionEdges };
+}
+
+/**
+ * The two optional halves of the payload, built through ANNOTATED helpers.
+ *
+ * Not inlined as `...(cond ? { … } : {})`. A conditional spread is exempt from
+ * excess-property checking, so `satisfies BrainFactProvenance` on the enclosing
+ * literal catches a renamed REQUIRED key and nothing at all on these two — which
+ * are precisely the keys #4772's review surface filters on. An annotated
+ * fragment restores the check.
+ */
+function provisionalFragment(
+  provisional: boolean,
+  unresolved: readonly EntityRole[],
+): Pick<BrainFactProvenance, "provisional" | "unresolved"> {
+  return provisional ? { provisional: true, unresolved } : {};
+}
+
+function entityIdFragment(
+  entityIds: Partial<Record<EntityRole, string>>,
+): Pick<BrainFactProvenance, "entityIds"> {
+  return Object.keys(entityIds).length > 0 ? { entityIds } : {};
 }
 
 function rowId(row: unknown): string | null {

--- a/packages/api/src/lib/brain/reconcile.ts
+++ b/packages/api/src/lib/brain/reconcile.ts
@@ -1,0 +1,852 @@
+/**
+ * The reconcile stage (#4771, ADR-0036 §Ingestion & connectors, §Temporal,
+ * conflict & provenance) — the ONE place a fact candidate becomes a stored
+ * draft.
+ *
+ * ## Entry-point-agnostic by construction
+ *
+ * ADR-0036 §T6 makes this a stage, not a step of the extraction fiber: M5's
+ * write-back reuses this exact seam, the human-correction entry point reuses
+ * it, and a warehouse-pinned fact will reuse it. So the signature names an
+ * EPISODE and a list of CANDIDATES and nothing else — there is no `episodeRow`
+ * fresh off the extraction drain, no "stamp the queue marker for me" flag, and
+ * no assumption that an LLM produced the candidates. Everything path-specific
+ * (which episodes to walk, what to do with the outcome, when to take the
+ * episode off the extraction queue) belongs to the caller.
+ *
+ * Two consequences worth stating, because both were tempting to violate:
+ *
+ *   - `brain_episodes.extracted_at` is NEVER written here. It is the extraction
+ *     fiber's work-queue marker and means "the extraction pass ran", which is a
+ *     fact about that path and not about reconciliation. `extract.ts` stamps it
+ *     AFTER this stage commits, and leans on the corroboration dedupe below for
+ *     crash-safety rather than on a flag threaded through here.
+ *   - The producer is a plain `producer` string in the provenance payload. A
+ *     `kind: "extraction" | "write-back"` union would have grown an arm per
+ *     entry point and put path knowledge back inside the stage.
+ *
+ * ## What a reviewer receives
+ *
+ * ADR-0036 requires the reviewer to make ONLY the trust call — so a candidate
+ * that reaches `draft` is already fully formed: provenance edge, grant,
+ * resolved entities, corroboration edges, and (for `single`-cardinality
+ * predicates) advisory `in-tension-with` edges. All of it commits in ONE
+ * transaction, so there is no window in which a fact exists without the
+ * provenance edge that justifies it.
+ *
+ * ## Block vs flag — the asymmetry is the safety property
+ *
+ * ADR-0036 §T6 splits failure into two classes that must never share a branch:
+ *
+ *   - **Block + log** — a SAFETY failure. No provenance, no usable grant, or an
+ *     unresolvable source principal. Each means Atlas cannot say where the claim
+ *     came from or who may see it, and there is no draft state that a reviewer
+ *     could repair into a safe one. Nothing is written; the reason is counted
+ *     and logged. (A blocked candidate is not a silent drop: the episode stays
+ *     in `brain_episodes` forever, so the evidence is never lost — only the
+ *     unsafe derived claim is refused.)
+ *   - **Flag provisional** — a QUALITY failure. Subject or object entity
+ *     resolution failed. The claim is still written as a draft, with
+ *     `provenance.provisional = true` naming the unresolved side, because the
+ *     reviewer is exactly the right person to settle "is `the deploy box` the
+ *     same entity as `deploy-01`?". Dropping it instead would make this stage a
+ *     silent fact-dropper, which the issue forbids in both directions.
+ *
+ * ### Why the grant check is `parseGrant(...).principals.length === 0`
+ *
+ * NOT the 0180 CHECK's non-empty test. `chk_brain_facts_grant_nonempty` admits
+ * `['everyone']`: cardinality 1, grants NOBODY, because enforcement is Postgres
+ * array overlap against reader tokens and no reader token is ever malformed
+ * (`acl.ts`). Written as a draft it would be legal, invisible, refused at every
+ * publish forever by #4769's `GRANT_UNUSABLE` classifier, and unrepairable —
+ * #4772's review surface is the repair UI and cannot precede this. Blocking
+ * upstream is the only place that hazard is reachability-proof, and it is what
+ * makes #4769's refusal genuine defence in depth instead of a dead end. The
+ * same rule, for the same reason, screens episodes at the ingest seam
+ * (`ingest/grant.ts::isUsableGrant`).
+ *
+ * ## Corroboration, not duplication
+ *
+ * Re-observing a claim STRENGTHENS it: the existing live fact gains a
+ * `provenance` edge to the new episode and no second fact row appears. That is
+ * what makes re-running extraction over an already-extracted window a no-op
+ * (acceptance criterion 5) and what lets `extract.ts` stamp the queue marker
+ * AFTER the commit — a crash in that window costs a repeated LLM call, never a
+ * duplicated belief.
+ *
+ * Two writers racing on the same claim would defeat a bare read-then-insert, so
+ * the transaction opens by taking a per-workspace transaction-scoped advisory
+ * lock. The rejected alternative was a partial UNIQUE index on
+ * `(workspace_id, subject, predicate, object) WHERE invalidated_at IS NULL` plus
+ * `ON CONFLICT DO NOTHING`: structurally stronger, but it needs a migration to
+ * a table this milestone is still shaping, and it would make an ordinary
+ * bi-temporal case (the same SPO re-asserted over a different validity window,
+ * which M2 owns) unrepresentable rather than merely unusual. The lock is
+ * reversible; the index would be a decision M2 has to live with. Revisit it
+ * when M2 settles supersession.
+ *
+ * Identity is BYTE-EXACT on the trimmed, resolved SPO — deliberately, so the
+ * lookup is served by `idx_brain_facts_subject` and so that deciding whether
+ * `Alice` and `alice` are one entity stays the ENTITY RESOLVER's job. A
+ * `lower()` comparison here would silently take that decision away from the
+ * seam that exists to make it.
+ */
+
+import { createLogger } from "@atlas/api/lib/logger";
+import { getInternalDB } from "@atlas/api/lib/db/internal";
+import { parseGrant } from "@atlas/api/lib/brain/acl";
+import type { PredicateCardinality } from "@atlas/api/lib/brain/types";
+
+const log = createLogger("brain.reconcile");
+
+/**
+ * `classkey` for the per-workspace reconcile advisory lock — the issue number,
+ * matching the convention the other two-arg namespaces follow (last-admin
+ * `3158`, chat-install `3001`, demo-seed `3683`). Distinct from every one of
+ * them so a reconcile never serializes against an unrelated guard on the same
+ * workspace; a `hashtext` collision inside this namespace costs extra
+ * serialization, never correctness.
+ */
+const RECONCILE_LOCK_NAMESPACE = 4771;
+
+/**
+ * Bound how many existing facts one new `single`-cardinality claim may be put
+ * in tension with. The edges are ADVISORY (M2 owns clustering and arbitration),
+ * so a subject/predicate that somehow accumulated hundreds of live objects
+ * should surface the newest few for a reviewer rather than write a fan of
+ * edges nobody reads.
+ */
+const TENSION_EDGE_CAP = 10;
+
+// ---------------------------------------------------------------------------
+// Vocabulary
+// ---------------------------------------------------------------------------
+
+/**
+ * The narrow database handle this stage needs — structurally satisfied by
+ * `pg.PoolClient`, so the transaction runner passes its checked-out client
+ * straight through and a test passes a literal with no `mock.module()`.
+ */
+export interface ReconcileExecutor {
+  query: (sql: string, params?: unknown[]) => Promise<{ rows: readonly unknown[] }>;
+}
+
+/** Runs `fn` inside ONE transaction and returns its result. */
+export type ReconcileTransactionRunner = <T>(
+  fn: (tx: ReconcileExecutor) => Promise<T>,
+) => Promise<T>;
+
+/**
+ * The evidence a candidate hangs off, as this stage needs it.
+ *
+ * Deliberately NOT `BrainEpisode`: that is the stored row and carries fields
+ * (`body`, `ingestedAt`, `extractedAt`) reconciliation must not read or write.
+ * `visibleTo` is `readonly unknown[]` because it usually arrives straight off
+ * `pg` as a `text[]` whose elements may be `null`, and narrowing it optimis-
+ * tically here would move the check into every caller.
+ */
+export interface ReconcileEpisodeRef {
+  readonly id: string;
+  readonly workspaceId: string;
+  /** Connector class — `slack`, `warehouse`, `human`. */
+  readonly source: string;
+  readonly sourceId: string;
+  /** Source-side author principal; null when the source has no author. */
+  readonly sourceActor: string | null;
+  readonly occurredAt: Date | null;
+  readonly visibleTo: readonly unknown[];
+}
+
+/** One proposed claim, from any producer. */
+export interface FactCandidate {
+  readonly subject: string;
+  readonly predicate: string;
+  readonly object: string;
+  /** Valid time, when the producer can establish one. */
+  readonly validFrom?: Date | null;
+  /**
+   * Omit for the conservative default (`multi` — values coexist). `single`
+   * additionally earns the advisory tension edges below; wrongly coexisting is
+   * recoverable at the review gate, wrongly superseding destroys a belief.
+   */
+  readonly predicateCardinality?: PredicateCardinality;
+  /**
+   * Producer-specific provenance (model id, prompt version, confidence, the
+   * pinned SQL of a warehouse fact). Merged UNDER the structural keys, so a
+   * producer can enrich the payload but never overwrite what records where the
+   * claim came from.
+   */
+  readonly detail?: Record<string, unknown>;
+}
+
+/** A resolved entity. `canonical` is what lands in the fact's SPO column. */
+export interface ResolvedEntity {
+  readonly canonical: string;
+  /** Stable id, when the resolver has one. Recorded in provenance. */
+  readonly entityId?: string;
+}
+
+/**
+ * Subject/object entity resolution — an injected seam, not a hardcoded step.
+ *
+ * M1 ships {@link passthroughEntityResolver} as the default: there is no entity
+ * store yet, so the surface form IS the canonical form. The seam exists now
+ * because the FAILURE SEMANTICS are what this slice is pinning — a resolver
+ * that returns `null` (or throws) flags the candidate provisional rather than
+ * dropping it — and retrofitting that asymmetry after a real resolver lands
+ * would mean changing behaviour under live data instead of adding a resolver.
+ */
+export type EntityResolver = (
+  surface: string,
+  context: {
+    readonly workspaceId: string;
+    readonly role: "subject" | "object";
+  },
+) => Promise<ResolvedEntity | null> | ResolvedEntity | null;
+
+/** The M1 default: every non-blank surface form resolves to itself. */
+export const passthroughEntityResolver: EntityResolver = (surface) => ({
+  canonical: surface,
+});
+
+export interface ReconcileRequest {
+  readonly episode: ReconcileEpisodeRef;
+  readonly candidates: readonly FactCandidate[];
+  /**
+   * A label for what produced these candidates — `extraction:v1`, `write-back`,
+   * `human`. Recorded in provenance so a reviewer (and a later re-extraction)
+   * can tell one pass from another.
+   */
+  readonly producer: string;
+  /**
+   * When the pass that produced them ran. `null` for authored claims, which are
+   * not extracted from anything (mirrors `brain_facts.extracted_at`).
+   */
+  readonly extractedAt: Date | null;
+  /**
+   * The principal that ASSERTED these claims, when the caller knows better than
+   * the episode does. A warehouse entry point passes a system principal; the
+   * human-correction path passes the author. Omitted, the principal is derived
+   * from `episode.sourceActor` — and when neither yields one, every candidate
+   * is BLOCKED (`SOURCE_PRINCIPAL_UNRESOLVED`) rather than attributed to
+   * nobody.
+   */
+  readonly sourcePrincipal?: string | null;
+  /** Defaults to {@link passthroughEntityResolver}. */
+  readonly resolveEntity?: EntityResolver;
+}
+
+export interface ReconcileDeps {
+  /** Defaults to a transaction on the internal pool. */
+  readonly withTransaction?: ReconcileTransactionRunner;
+  /** Test clock. */
+  readonly now?: () => Date;
+}
+
+/**
+ * Why a candidate never became a draft. Every one is a SAFETY refusal — see the
+ * module header on why quality failures flag instead.
+ */
+export const RECONCILE_BLOCK_REASONS = {
+  /** The episode carries no id, so the claim would have no evidence pointer. */
+  noProvenance: "NO_PROVENANCE",
+  /** The episode's grant names no principal any reader could ever match. */
+  noGrant: "NO_GRANT",
+  /** Neither the caller nor the episode yields a principal to attribute to. */
+  sourcePrincipalUnresolved: "SOURCE_PRINCIPAL_UNRESOLVED",
+  /**
+   * The candidate itself is not a claim — a blank subject, predicate, or
+   * object. Not in the issue's list because it is not a resolution failure: it
+   * is a malformed proposal, and unlike an unresolved entity there is nothing
+   * for a reviewer to repair (`brain_facts` would happily store `''`, and a
+   * three-column claim with an empty column says nothing). The producer's bug
+   * is logged with the reason.
+   */
+  malformedClaim: "MALFORMED_CLAIM",
+} as const;
+
+export type ReconcileBlockReason =
+  (typeof RECONCILE_BLOCK_REASONS)[keyof typeof RECONCILE_BLOCK_REASONS];
+
+/** What became of one candidate. */
+export type ReconcileOutcome =
+  | {
+      readonly kind: "created";
+      readonly factId: string;
+      /** True when subject and/or object could not be resolved. */
+      readonly provisional: boolean;
+      /** Advisory `in-tension-with` edges written alongside it. */
+      readonly tensionEdges: number;
+    }
+  | {
+      readonly kind: "corroborated";
+      readonly factId: string;
+      /** False when this episode had already been recorded as evidence. */
+      readonly evidenceAdded: boolean;
+    }
+  | { readonly kind: "blocked"; readonly reason: ReconcileBlockReason };
+
+export interface ReconcileReport {
+  readonly created: number;
+  readonly corroborated: number;
+  /** Created facts carrying `provenance.provisional` — a subset of `created`. */
+  readonly provisional: number;
+  readonly blocked: Readonly<Record<ReconcileBlockReason, number>>;
+  /** Per-candidate, in input order. */
+  readonly outcomes: readonly ReconcileOutcome[];
+}
+
+const NO_BLOCKS: Readonly<Record<ReconcileBlockReason, number>> = Object.freeze({
+  NO_PROVENANCE: 0,
+  NO_GRANT: 0,
+  SOURCE_PRINCIPAL_UNRESOLVED: 0,
+  MALFORMED_CLAIM: 0,
+});
+
+// ---------------------------------------------------------------------------
+// SQL
+// ---------------------------------------------------------------------------
+//
+// Exported so the real-Postgres test runs these exact strings against the live
+// schema instead of asserting a paraphrase of them.
+//
+// NOTE for the next editor: none of these may name `status`.
+// `scripts/check-brain-fact-promotion.sh` refuses any statement that touches
+// `brain_facts` and mentions the column — including in a WHERE clause — and
+// that over-breadth is deliberate. The fact insert omits `status` on purpose:
+// migration 0180 defaults it to `draft`, and that default IS the review gate
+// applying itself (#4769). Asking for `draft` explicitly would be the same
+// value written by a second, ungated writer.
+
+/** The per-workspace serialization point — see the module header. */
+export const RECONCILE_LOCK_SQL = `SELECT pg_advisory_xact_lock($1, hashtext($2))`;
+
+/**
+ * Does a live fact already assert exactly this claim? Served by
+ * `idx_brain_facts_subject` (partial on `invalidated_at IS NULL`).
+ *
+ * Deliberately NOT filtered by review state: a claim re-observed after it was
+ * published must corroborate the published fact, not mint a fresh draft
+ * duplicate of it. Deliberately not filtered by grant either — a narrower
+ * re-observation is recorded as EVIDENCE and never widens the existing fact's
+ * `visible_to`, because a grant is immutable per fact version (0180).
+ */
+export const CORROBORATION_LOOKUP_SQL = `SELECT id
+     FROM brain_facts
+    WHERE workspace_id = $1
+      AND subject = $2
+      AND predicate = $3
+      AND object = $4
+      AND invalidated_at IS NULL
+    ORDER BY ingested_at
+    LIMIT 1`;
+
+/**
+ * The draft insert. `visible_to` travels as jsonb → `text[]` for the same
+ * reason the episode insert does: a `text[]` bind of a per-row array is not
+ * expressible as a parallel-array `unnest`.
+ */
+export const INSERT_FACT_SQL = `INSERT INTO brain_facts
+         (workspace_id, subject, predicate, object, valid_from, extracted_at,
+          source_episode_id, provenance, visible_to, predicate_cardinality)
+       VALUES ($1, $2, $3, $4, $5::timestamptz, $6::timestamptz,
+               $7::uuid, $8::jsonb,
+               ARRAY(SELECT jsonb_array_elements_text($9::jsonb)), $10)
+       RETURNING id`;
+
+/**
+ * The evidence pointer, fact → episode. `WHERE NOT EXISTS` makes a re-observed
+ * claim's edge idempotent, so a repeated pass strengthens once and not twice;
+ * the enclosing advisory lock is what makes the guard sound under concurrency.
+ * `RETURNING id` is how the caller learns whether the edge was new.
+ */
+export const INSERT_PROVENANCE_EDGE_SQL = `INSERT INTO brain_edges
+         (workspace_id, edge_type, from_fact_id, to_episode_id)
+       SELECT $1, 'provenance', $2::uuid, $3::uuid
+        WHERE NOT EXISTS (
+          SELECT 1 FROM brain_edges
+           WHERE workspace_id = $1
+             AND edge_type = 'provenance'
+             AND from_fact_id = $2::uuid
+             AND to_episode_id = $3::uuid)
+       RETURNING id`;
+
+/**
+ * Live facts that assert a DIFFERENT object for the same subject+predicate —
+ * the advisory contradiction set. Only consulted for `single` cardinality,
+ * where "one manager" makes two live objects a genuine tension; `multi` values
+ * are supposed to coexist.
+ */
+export const TENSION_CANDIDATES_SQL = `SELECT id
+     FROM brain_facts
+    WHERE workspace_id = $1
+      AND subject = $2
+      AND predicate = $3
+      AND object <> $4
+      AND invalidated_at IS NULL
+      AND id <> $5::uuid
+    ORDER BY ingested_at DESC
+    LIMIT $6`;
+
+/**
+ * The advisory edge. `in-tension-with` is SURFACED with both provenances and
+ * never ranked (ADR-0036) — writing it is not an arbitration, and nothing here
+ * supersedes, invalidates, or reorders anything. M2 owns the clustering that
+ * reads these.
+ */
+export const INSERT_TENSION_EDGE_SQL = `INSERT INTO brain_edges
+         (workspace_id, edge_type, from_fact_id, to_fact_id)
+       SELECT $1, 'in-tension-with', $2::uuid, $3::uuid
+        WHERE NOT EXISTS (
+          SELECT 1 FROM brain_edges
+           WHERE workspace_id = $1
+             AND edge_type = 'in-tension-with'
+             AND from_fact_id = $2::uuid
+             AND to_fact_id = $3::uuid)
+       RETURNING id`;
+
+// ---------------------------------------------------------------------------
+// The stage
+// ---------------------------------------------------------------------------
+
+/**
+ * Turn candidates into fully-formed drafts, or refuse them.
+ *
+ * Throws only on a database failure — the caller decides what that means for
+ * its own bookkeeping (`extract.ts` leaves the episode on the queue, so the
+ * next cycle retries). Every DOMAIN refusal is a counted outcome, never an
+ * exception: a blocked candidate is an ordinary result of running this stage.
+ */
+export async function reconcileFacts(
+  request: ReconcileRequest,
+  deps: ReconcileDeps = {},
+): Promise<ReconcileReport> {
+  const { episode, candidates, producer } = request;
+  const resolveEntity = request.resolveEntity ?? passthroughEntityResolver;
+  const now = deps.now ?? (() => new Date());
+
+  const blocked: Record<ReconcileBlockReason, number> = { ...NO_BLOCKS };
+
+  // ── Episode-level gate ────────────────────────────────────────────────
+  // These are properties of the EVIDENCE, so one failure blocks every candidate
+  // hanging off it. Evaluated before any connection is checked out: a batch that
+  // cannot produce a single safe row must not open a transaction.
+  const episodeBlock = classifyEpisode(episode, request.sourcePrincipal);
+  if (episodeBlock !== null) {
+    const reason = episodeBlock.reason;
+    log.warn(
+      {
+        workspaceId: episode.workspaceId,
+        episodeId: episode.id,
+        source: episode.source,
+        sourceId: episode.sourceId,
+        producer,
+        reason,
+        candidates: candidates.length,
+      },
+      `brain reconcile: blocked every candidate from this episode — ${episodeBlock.detail}`,
+    );
+    blocked[reason] = candidates.length;
+    return {
+      created: 0,
+      corroborated: 0,
+      provisional: 0,
+      blocked,
+      outcomes: candidates.map(() => ({ kind: "blocked" as const, reason })),
+    };
+  }
+
+  // Non-null past the gate above, which blocks the whole episode when the
+  // principal cannot be resolved.
+  const sourcePrincipal = resolvedPrincipal(episode, request.sourcePrincipal);
+  // Non-string elements (a `null` off `pg`) are inert in the overlap predicate
+  // and cannot survive the jsonb round-trip as themselves; dropping them keeps
+  // the stored grant readable while the usable-principal check above is what
+  // actually decided the row is safe.
+  const grantTokens = episode.visibleTo.filter((t): t is string => typeof t === "string");
+
+  if (candidates.length === 0) {
+    return { created: 0, corroborated: 0, provisional: 0, blocked, outcomes: [] };
+  }
+
+  // ── Per-candidate preparation (no database) ───────────────────────────
+  const prepared: (PreparedCandidate | { readonly blockedReason: ReconcileBlockReason })[] = [];
+  for (const candidate of candidates) {
+    const subject = candidate.subject.trim();
+    const predicate = candidate.predicate.trim();
+    const object = candidate.object.trim();
+    if (subject === "" || predicate === "" || object === "") {
+      log.warn(
+        {
+          workspaceId: episode.workspaceId,
+          episodeId: episode.id,
+          producer,
+          hasSubject: subject !== "",
+          hasPredicate: predicate !== "",
+          hasObject: object !== "",
+        },
+        "brain reconcile: blocked a candidate with a blank subject, predicate, or object — a claim with an empty column asserts nothing",
+      );
+      blocked.MALFORMED_CLAIM++;
+      prepared.push({ blockedReason: RECONCILE_BLOCK_REASONS.malformedClaim });
+      continue;
+    }
+
+    const [resolvedSubject, resolvedObject] = await Promise.all([
+      tryResolve(resolveEntity, subject, episode.workspaceId, "subject", episode.id),
+      tryResolve(resolveEntity, object, episode.workspaceId, "object", episode.id),
+    ]);
+
+    const unresolved: string[] = [];
+    if (resolvedSubject === null) unresolved.push("subject");
+    if (resolvedObject === null) unresolved.push("object");
+
+    prepared.push({
+      subject: resolvedSubject?.canonical ?? subject,
+      predicate,
+      object: resolvedObject?.canonical ?? object,
+      unresolved,
+      entityIds: {
+        ...(resolvedSubject?.entityId !== undefined ? { subject: resolvedSubject.entityId } : {}),
+        ...(resolvedObject?.entityId !== undefined ? { object: resolvedObject.entityId } : {}),
+      },
+      candidate,
+    });
+  }
+
+  if (unresolvedCount(prepared) > 0) {
+    log.info(
+      {
+        workspaceId: episode.workspaceId,
+        episodeId: episode.id,
+        producer,
+        provisional: unresolvedCount(prepared),
+      },
+      "brain reconcile: flagged candidates provisional — entity resolution failed, so the reviewer decides",
+    );
+  }
+
+  // ── The one transaction ───────────────────────────────────────────────
+  const withTransaction = deps.withTransaction ?? withBrainTransaction;
+  const outcomes = await withTransaction(async (tx) => {
+    await tx.query(RECONCILE_LOCK_SQL, [RECONCILE_LOCK_NAMESPACE, episode.workspaceId]);
+    const results: ReconcileOutcome[] = [];
+    for (const item of prepared) {
+      if ("blockedReason" in item) {
+        results.push({ kind: "blocked", reason: item.blockedReason });
+        continue;
+      }
+      results.push(
+        await writeCandidate(tx, {
+          item,
+          episode,
+          grantTokens,
+          producer,
+          sourcePrincipal,
+          extractedAt: request.extractedAt,
+          now,
+        }),
+      );
+    }
+    return results;
+  });
+
+  let created = 0;
+  let corroborated = 0;
+  let provisional = 0;
+  for (const outcome of outcomes) {
+    if (outcome.kind === "created") {
+      created++;
+      if (outcome.provisional) provisional++;
+    } else if (outcome.kind === "corroborated") {
+      corroborated++;
+    }
+  }
+
+  return { created, corroborated, provisional, blocked, outcomes };
+}
+
+// ---------------------------------------------------------------------------
+// Internals
+// ---------------------------------------------------------------------------
+
+interface PreparedCandidate {
+  readonly subject: string;
+  readonly predicate: string;
+  readonly object: string;
+  /** `"subject"` / `"object"` — empty when both resolved. */
+  readonly unresolved: readonly string[];
+  readonly entityIds: Record<string, string>;
+  readonly candidate: FactCandidate;
+}
+
+function unresolvedCount(
+  prepared: readonly (PreparedCandidate | { readonly blockedReason: ReconcileBlockReason })[],
+): number {
+  return prepared.filter((p) => !("blockedReason" in p) && p.unresolved.length > 0).length;
+}
+
+/**
+ * The principal a claim is attributed to, or `null`.
+ *
+ * An explicit `sourcePrincipal` wins because the caller knows things the
+ * episode row does not: a warehouse snapshot has no `source_actor` at all
+ * (0180), and the human-correction path knows the Atlas user. Falling back to
+ * the episode's actor keeps the connector path — the only producer today — free
+ * of a field it would always compute the same way.
+ */
+function resolvedPrincipal(
+  episode: ReconcileEpisodeRef,
+  explicit: string | null | undefined,
+): string | null {
+  if (typeof explicit === "string" && explicit.trim() !== "") return explicit.trim();
+  const actor = episode.sourceActor?.trim() ?? "";
+  return actor === "" ? null : `${episode.source}:${actor}`;
+}
+
+/** The three episode-level safety refusals, in the order they are cheapest. */
+function classifyEpisode(
+  episode: ReconcileEpisodeRef,
+  explicitPrincipal: string | null | undefined,
+): { readonly reason: ReconcileBlockReason; readonly detail: string } | null {
+  if (episode.id.trim() === "") {
+    return {
+      reason: RECONCILE_BLOCK_REASONS.noProvenance,
+      detail: "the episode has no id, so no fact could point at the evidence behind it",
+    };
+  }
+  // The load-bearing one. See the module header: NOT the 0180 CHECK's
+  // non-empty test, because that admits a grant that grants nobody.
+  if (parseGrant(episode.visibleTo).principals.length === 0) {
+    return {
+      reason: RECONCILE_BLOCK_REASONS.noGrant,
+      detail:
+        "the episode's grant names no principal any reader could match, so every fact drawn from it would be invisible and permanently unpublishable",
+    };
+  }
+  if (resolvedPrincipal(episode, explicitPrincipal) === null) {
+    return {
+      reason: RECONCILE_BLOCK_REASONS.sourcePrincipalUnresolved,
+      detail:
+        "neither the caller nor the episode names who asserted the claim, and an unattributable claim cannot carry provenance",
+    };
+  }
+  return null;
+}
+
+/**
+ * Resolve one side, converting BOTH a `null` return and a thrown resolver into
+ * the same provisional flag.
+ *
+ * A resolver is injected code: a lookup can time out, a future one will call a
+ * store. Letting it throw would abort the whole episode over a QUALITY problem
+ * and turn the flag path into a block — inverting the asymmetry this stage
+ * exists to hold. Logged (never swallowed) with a narrowed error.
+ */
+async function tryResolve(
+  resolver: EntityResolver,
+  surface: string,
+  workspaceId: string,
+  role: "subject" | "object",
+  episodeId: string,
+): Promise<ResolvedEntity | null> {
+  try {
+    const resolved = await resolver(surface, { workspaceId, role });
+    if (resolved === null || resolved.canonical.trim() === "") return null;
+    return { ...resolved, canonical: resolved.canonical.trim() };
+  } catch (err) {
+    log.warn(
+      {
+        workspaceId,
+        episodeId,
+        role,
+        err: err instanceof Error ? err.message : String(err),
+      },
+      "brain reconcile: entity resolver threw — treating the entity as unresolved and flagging the candidate provisional",
+    );
+    return null;
+  }
+}
+
+interface WriteContext {
+  readonly item: PreparedCandidate;
+  readonly episode: ReconcileEpisodeRef;
+  readonly grantTokens: readonly string[];
+  readonly producer: string;
+  readonly sourcePrincipal: string | null;
+  readonly extractedAt: Date | null;
+  readonly now: () => Date;
+}
+
+/** Corroborate an existing live claim, or create the draft plus its edges. */
+async function writeCandidate(
+  tx: ReconcileExecutor,
+  ctx: WriteContext,
+): Promise<ReconcileOutcome> {
+  const { item, episode } = ctx;
+
+  const existing = await tx.query(CORROBORATION_LOOKUP_SQL, [
+    episode.workspaceId,
+    item.subject,
+    item.predicate,
+    item.object,
+  ]);
+  const existingId = firstId(existing.rows);
+  if (existingId !== null) {
+    // Strengthen: one more piece of evidence for a belief Atlas already holds.
+    // Nothing about the fact itself changes — not its grant, not its review
+    // state, not its validity. (The new episode may be narrower than the fact's
+    // own grant; that is safe because `brain_episodes` is ACL-gated in its own
+    // right by the same predicate, so walking the edge cannot read an episode
+    // the reader is not entitled to.)
+    const edge = await tx.query(INSERT_PROVENANCE_EDGE_SQL, [
+      episode.workspaceId,
+      existingId,
+      episode.id,
+    ]);
+    return { kind: "corroborated", factId: existingId, evidenceAdded: edge.rows.length > 0 };
+  }
+
+  const provisional = item.unresolved.length > 0;
+  const provenance: Record<string, unknown> = {
+    // Producer detail first so the structural keys below always win — a
+    // producer may enrich the payload, never rewrite where the claim came from.
+    ...(item.candidate.detail ?? {}),
+    source: episode.source,
+    sourceId: episode.sourceId,
+    episodeId: episode.id,
+    actor: ctx.sourcePrincipal,
+    producer: ctx.producer,
+    occurredAt: episode.occurredAt?.toISOString() ?? null,
+    extractedAt: ctx.extractedAt?.toISOString() ?? null,
+    reconciledAt: ctx.now().toISOString(),
+    ...(Object.keys(item.entityIds).length > 0 ? { entityIds: item.entityIds } : {}),
+    // Present ONLY when it is true, so a reviewer's filter on the key is not
+    // fooled by every fact carrying `provisional: false`.
+    ...(provisional ? { provisional: true, unresolved: item.unresolved } : {}),
+  };
+
+  const cardinality: PredicateCardinality = item.candidate.predicateCardinality ?? "multi";
+  const validFrom = ctx.item.candidate.validFrom ?? null;
+
+  const inserted = await tx.query(INSERT_FACT_SQL, [
+    episode.workspaceId,
+    item.subject,
+    item.predicate,
+    item.object,
+    isoOrNull(validFrom),
+    isoOrNull(ctx.extractedAt),
+    episode.id,
+    JSON.stringify(provenance),
+    JSON.stringify(ctx.grantTokens),
+    cardinality,
+  ]);
+  const factId = firstId(inserted.rows);
+  if (factId === null) {
+    // `RETURNING id` on a plain INSERT that did not throw — unreachable, and a
+    // silent `return` here would report a fact that does not exist. Throwing
+    // rolls the whole episode back, which is the only honest outcome.
+    throw new Error(
+      `brain reconcile: fact insert returned no id (workspace ${episode.workspaceId}, episode ${episode.id})`,
+    );
+  }
+
+  await tx.query(INSERT_PROVENANCE_EDGE_SQL, [episode.workspaceId, factId, episode.id]);
+
+  let tensionEdges = 0;
+  if (cardinality === "single") {
+    const rivals = await tx.query(TENSION_CANDIDATES_SQL, [
+      episode.workspaceId,
+      item.subject,
+      item.predicate,
+      item.object,
+      factId,
+      TENSION_EDGE_CAP,
+    ]);
+    for (const row of rivals.rows) {
+      const rivalId = rowId(row);
+      if (rivalId === null) continue;
+      const edge = await tx.query(INSERT_TENSION_EDGE_SQL, [
+        episode.workspaceId,
+        factId,
+        rivalId,
+      ]);
+      if (edge.rows.length > 0) tensionEdges++;
+    }
+    if (tensionEdges > 0) {
+      log.info(
+        {
+          workspaceId: episode.workspaceId,
+          episodeId: episode.id,
+          factId,
+          subject: item.subject,
+          predicate: item.predicate,
+          tensionEdges,
+        },
+        "brain reconcile: recorded advisory in-tension-with edges for a single-cardinality predicate — nothing was superseded",
+      );
+    }
+  }
+
+  return { kind: "created", factId, provisional, tensionEdges };
+}
+
+function rowId(row: unknown): string | null {
+  if (typeof row !== "object" || row === null) return null;
+  const id = (row as { id?: unknown }).id;
+  return typeof id === "string" && id !== "" ? id : null;
+}
+
+function firstId(rows: readonly unknown[]): string | null {
+  return rows.length === 0 ? null : rowId(rows[0]);
+}
+
+/**
+ * `Date | null` admits an INVALID Date, whose `toISOString()` throws
+ * synchronously — mid-transaction, where it would roll back a whole episode
+ * over one bad timestamp. A producer's unparseable date degrades to "no valid
+ * time" instead, which is what the nullable column already means.
+ */
+function isoOrNull(value: Date | null): string | null {
+  if (value === null || Number.isNaN(value.getTime())) return null;
+  return value.toISOString();
+}
+
+/**
+ * The default transaction runner: one dedicated connection off the internal
+ * pool, manual BEGIN/COMMIT/ROLLBACK, and the client destroyed if the ROLLBACK
+ * itself fails so a dirty socket cannot poison the next borrower — the same
+ * mechanics as `withWorkspaceAdminLocks` / `withDemoSeedLock`.
+ *
+ * Never nest another pool checkout inside `fn`: the internal pool is bounded
+ * (max 5) and a nested checkout under a held connection is the starvation
+ * deadlock those two functions document.
+ */
+export const withBrainTransaction: ReconcileTransactionRunner = async <T>(
+  fn: (tx: ReconcileExecutor) => Promise<T>,
+): Promise<T> => {
+  const client = await getInternalDB().connect();
+  let rollbackErr: Error | null = null;
+  try {
+    await client.query("BEGIN");
+    const result = await fn({
+      query: async (sql: string, params?: unknown[]) => {
+        const res = await client.query(sql, params);
+        return { rows: res.rows as readonly unknown[] };
+      },
+    });
+    await client.query("COMMIT");
+    return result;
+  } catch (err) {
+    await client.query("ROLLBACK").catch((rbErr: unknown) => {
+      rollbackErr = rbErr instanceof Error ? rbErr : new Error(String(rbErr));
+      log.warn(
+        { err: rollbackErr.message },
+        "brain reconcile: ROLLBACK failed — the client will be destroyed",
+      );
+    });
+    throw err;
+  } finally {
+    client.release(rollbackErr ?? undefined);
+  }
+};

--- a/packages/api/src/lib/brain/reconcile.ts
+++ b/packages/api/src/lib/brain/reconcile.ts
@@ -44,7 +44,10 @@
  *     could repair into a safe one. Nothing is written; the reason is counted
  *     and logged. (A blocked candidate is not a silent drop: the episode stays
  *     in `brain_episodes` forever, so the evidence is never lost — only the
- *     unsafe derived claim is refused.)
+ *     unsafe derived claim is refused.) Those three are the ADR's; there is a
+ *     fourth this module adds, `MALFORMED_CLAIM` — a proposal that is not a
+ *     claim at all. See {@link RECONCILE_BLOCK_REASONS} for why it blocks
+ *     rather than flags.
  *   - **Flag provisional** — a QUALITY failure. Subject or object entity
  *     resolution failed. The claim is still written as a draft, with
  *     `provenance.provisional = true` naming the unresolved side, because the
@@ -90,22 +93,53 @@
  * `Alice` and `alice` are one entity stays the ENTITY RESOLVER's job. A
  * `lower()` comparison here would silently take that decision away from the
  * seam that exists to make it.
+ *
+ * The cost of byte-exactness, stated because it is easy to over-read the
+ * paragraph above: dedupe is only as good as the producer's determinism. Two
+ * passes that phrase one claim differently ("is" vs "is on") are two claims
+ * here, and a pass whose entity resolution CHANGES between runs will miss its
+ * own earlier row. The reviewer collapses those; nothing in this stage can.
+ * `extract.ts` pins its model call to `temperature: 0` for exactly this reason.
+ *
+ * ## What this slice does NOT do
+ *
+ * A fact's grant is INHERITED from its episode verbatim — a claim is never more
+ * visible than the evidence behind it. Deriving a grant from source membership
+ * (a chat channel's roster → `audience:` + a `fact_audience_member` sync) is the
+ * INGEST seam's job for the episode (`ingest/grant.ts`), and the membership sync
+ * that makes a private channel's `audience:` resolve to real people is not in
+ * this slice at all — see #4801. Until it lands, a private channel's episodes
+ * and the facts drawn from them are visible to nobody, which is the fail-closed
+ * direction and repairable with no rewrite (the grant already names the
+ * audience; only the membership rows are missing).
  */
 
 import { createLogger } from "@atlas/api/lib/logger";
 import { getInternalDB } from "@atlas/api/lib/db/internal";
-import { parseGrant } from "@atlas/api/lib/brain/acl";
-import type { PredicateCardinality } from "@atlas/api/lib/brain/types";
+import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
+// The write-side "does this grant name anyone?" predicate, imported rather than
+// re-spelled: `isUsableGrant`'s own docstring exists so the ingest screen and
+// this one can never disagree about what usable MEANS, and two `parseGrant(...)
+// .principals.length === 0` sites would be exactly that disagreement waiting to
+// happen. It lives under `ingest/` for historical reasons but is a pure
+// grant-vocabulary helper with no ingest state.
+import { isUsableGrant } from "@atlas/api/lib/brain/ingest/grant";
+import type {
+  BrainFactProvenance,
+  EntityRole,
+  PredicateCardinality,
+} from "@atlas/api/lib/brain/types";
 
 const log = createLogger("brain.reconcile");
 
 /**
- * `classkey` for the per-workspace reconcile advisory lock — the issue number,
- * matching the convention the other two-arg namespaces follow (last-admin
- * `3158`, chat-install `3001`, demo-seed `3683`). Distinct from every one of
- * them so a reconcile never serializes against an unrelated guard on the same
- * workspace; a `hashtext` collision inside this namespace costs extra
- * serialization, never correctness.
+ * `classkey` for the per-workspace reconcile advisory lock — the `classkey` arg
+ * of the two-arg `pg_advisory_xact_lock(int4, int4)`, valued at this issue's
+ * number per the house convention. Distinct from every other two-arg user
+ * (`lead-outbox` 2870, chat-install 3001, stripe-subscription 3445, last-admin
+ * 3158, demo-seed 3683, knowledge-install 4235) so a reconcile never serializes
+ * behind an unrelated guard on the same workspace; a `hashtext` collision
+ * INSIDE this namespace costs extra serialization, never correctness.
  */
 const RECONCILE_LOCK_NAMESPACE = 4771;
 
@@ -195,12 +229,18 @@ export interface ResolvedEntity {
  * that returns `null` (or throws) flags the candidate provisional rather than
  * dropping it — and retrofitting that asymmetry after a real resolver lands
  * would mean changing behaviour under live data instead of adding a resolver.
+ *
+ * Invoked BEFORE the transaction opens (one `Promise.all` per candidate), which
+ * is load-bearing for the DB-backed resolver this seam anticipates: it may check
+ * out its own connection safely, whereas doing so inside the reconcile
+ * transaction is the bounded-pool starvation deadlock
+ * {@link withBrainTransaction} warns about.
  */
 export type EntityResolver = (
   surface: string,
   context: {
     readonly workspaceId: string;
-    readonly role: "subject" | "object";
+    readonly role: EntityRole;
   },
 ) => Promise<ResolvedEntity | null> | ResolvedEntity | null;
 
@@ -342,9 +382,16 @@ export const CORROBORATION_LOOKUP_SQL = `SELECT id
     LIMIT 1`;
 
 /**
- * The draft insert. `visible_to` travels as jsonb → `text[]` for the same
- * reason the episode insert does: a `text[]` bind of a per-row array is not
- * expressible as a parallel-array `unnest`.
+ * The draft insert.
+ *
+ * `visible_to` travels as jsonb → `text[]` rather than as a native array bind.
+ * NOT for the episode insert's reason — that one is a batch
+ * `jsonb_array_elements` where per-row grants would need a ragged `text[][]`,
+ * and this is a single-row `VALUES` where a plain `$9::text[]` would work
+ * through `pg`. The reason here is {@link ReconcileExecutor}: its `query` takes
+ * `unknown[]`, and it is structurally satisfied by both the `pg` client and a
+ * test literal. Keeping every parameter a JSON scalar means no driver-specific
+ * array marshalling can leak into that seam.
  */
 export const INSERT_FACT_SQL = `INSERT INTO brain_facts
          (workspace_id, subject, predicate, object, valid_from, extracted_at,
@@ -429,23 +476,34 @@ export async function reconcileFacts(
 
   // ── Episode-level gate ────────────────────────────────────────────────
   // These are properties of the EVIDENCE, so one failure blocks every candidate
-  // hanging off it. Evaluated before any connection is checked out: a batch that
-  // cannot produce a single safe row must not open a transaction.
-  const episodeBlock = classifyEpisode(episode, request.sourcePrincipal);
+  // hanging off it — and it is evaluated before any connection is checked out,
+  // so an episode that can produce no safe row never opens a transaction. (A
+  // batch whose candidates are ALL individually malformed still does; only the
+  // episode-level verdict is knowable this early.)
+  //
+  // A caller holding the episode before it has spent anything on producing
+  // candidates should pre-flight this itself — `extract.ts` does, so a
+  // grant-less episode costs no model call.
+  const episodeBlock = classifyEpisodeForReconcile(episode, request.sourcePrincipal);
   if (episodeBlock !== null) {
     const reason = episodeBlock.reason;
-    log.warn(
-      {
-        workspaceId: episode.workspaceId,
-        episodeId: episode.id,
-        source: episode.source,
-        sourceId: episode.sourceId,
-        producer,
-        reason,
-        candidates: candidates.length,
-      },
-      `brain reconcile: blocked every candidate from this episode — ${episodeBlock.detail}`,
-    );
+    // Silent when there was nothing to block: a caller that pre-flighted and
+    // passed no candidates has already logged, and a second identical warn per
+    // episode would train an operator to skim them.
+    if (candidates.length > 0) {
+      log.warn(
+        {
+          workspaceId: episode.workspaceId,
+          episodeId: episode.id,
+          source: episode.source,
+          sourceId: episode.sourceId,
+          producer,
+          reason,
+          candidates: candidates.length,
+        },
+        `brain reconcile: blocked every candidate from this episode — ${episodeBlock.detail}`,
+      );
+    }
     blocked[reason] = candidates.length;
     return {
       created: 0,
@@ -470,7 +528,7 @@ export async function reconcileFacts(
   }
 
   // ── Per-candidate preparation (no database) ───────────────────────────
-  const prepared: (PreparedCandidate | { readonly blockedReason: ReconcileBlockReason })[] = [];
+  const prepared: PreparedEntry[] = [];
   for (const candidate of candidates) {
     const subject = candidate.subject.trim();
     const predicate = candidate.predicate.trim();
@@ -488,7 +546,7 @@ export async function reconcileFacts(
         "brain reconcile: blocked a candidate with a blank subject, predicate, or object — a claim with an empty column asserts nothing",
       );
       blocked.MALFORMED_CLAIM++;
-      prepared.push({ blockedReason: RECONCILE_BLOCK_REASONS.malformedClaim });
+      prepared.push({ kind: "blocked", reason: RECONCILE_BLOCK_REASONS.malformedClaim });
       continue;
     }
 
@@ -497,11 +555,12 @@ export async function reconcileFacts(
       tryResolve(resolveEntity, object, episode.workspaceId, "object", episode.id),
     ]);
 
-    const unresolved: string[] = [];
+    const unresolved: EntityRole[] = [];
     if (resolvedSubject === null) unresolved.push("subject");
     if (resolvedObject === null) unresolved.push("object");
 
     prepared.push({
+      kind: "prepared",
       subject: resolvedSubject?.canonical ?? subject,
       predicate,
       object: resolvedObject?.canonical ?? object,
@@ -532,8 +591,8 @@ export async function reconcileFacts(
     await tx.query(RECONCILE_LOCK_SQL, [RECONCILE_LOCK_NAMESPACE, episode.workspaceId]);
     const results: ReconcileOutcome[] = [];
     for (const item of prepared) {
-      if ("blockedReason" in item) {
-        results.push({ kind: "blocked", reason: item.blockedReason });
+      if (item.kind === "blocked") {
+        results.push({ kind: "blocked", reason: item.reason });
         continue;
       }
       results.push(
@@ -555,11 +614,22 @@ export async function reconcileFacts(
   let corroborated = 0;
   let provisional = 0;
   for (const outcome of outcomes) {
-    if (outcome.kind === "created") {
-      created++;
-      if (outcome.provisional) provisional++;
-    } else if (outcome.kind === "corroborated") {
-      corroborated++;
+    // Exhaustive, with a `never` binding: a fourth outcome arm must be counted
+    // somewhere, and the compiler is the only reviewer that never forgets.
+    switch (outcome.kind) {
+      case "created":
+        created++;
+        if (outcome.provisional) provisional++;
+        break;
+      case "corroborated":
+        corroborated++;
+        break;
+      case "blocked":
+        break;
+      default: {
+        const unexpected: never = outcome;
+        throw new Error(`Unhandled reconcile outcome: ${JSON.stringify(unexpected)}`);
+      }
     }
   }
 
@@ -571,19 +641,27 @@ export async function reconcileFacts(
 // ---------------------------------------------------------------------------
 
 interface PreparedCandidate {
+  readonly kind: "prepared";
   readonly subject: string;
   readonly predicate: string;
   readonly object: string;
-  /** `"subject"` / `"object"` — empty when both resolved. */
-  readonly unresolved: readonly string[];
-  readonly entityIds: Record<string, string>;
+  /** Empty when both sides resolved. */
+  readonly unresolved: readonly EntityRole[];
+  readonly entityIds: Partial<Record<EntityRole, string>>;
   readonly candidate: FactCandidate;
 }
 
-function unresolvedCount(
-  prepared: readonly (PreparedCandidate | { readonly blockedReason: ReconcileBlockReason })[],
-): number {
-  return prepared.filter((p) => !("blockedReason" in p) && p.unresolved.length > 0).length;
+/**
+ * A discriminated union rather than an `in`-probed pair: the transaction loop
+ * switches on `kind`, so a third preparation outcome is a compile error there
+ * instead of a silently-skipped candidate.
+ */
+type PreparedEntry =
+  | PreparedCandidate
+  | { readonly kind: "blocked"; readonly reason: ReconcileBlockReason };
+
+function unresolvedCount(prepared: readonly PreparedEntry[]): number {
+  return prepared.filter((p) => p.kind === "prepared" && p.unresolved.length > 0).length;
 }
 
 /**
@@ -604,11 +682,25 @@ function resolvedPrincipal(
   return actor === "" ? null : `${episode.source}:${actor}`;
 }
 
-/** The three episode-level safety refusals, in the order they are cheapest. */
-function classifyEpisode(
+/** An episode-level refusal: the reason, plus prose an operator can act on. */
+export interface EpisodeBlock {
+  readonly reason: ReconcileBlockReason;
+  readonly detail: string;
+}
+
+/**
+ * The three episode-level safety refusals, in the order they are cheapest.
+ *
+ * Exported and pure so a caller can pre-flight BEFORE spending anything on
+ * producing candidates: `extract.ts` runs it ahead of the model call, which is
+ * the difference between a grant-less episode costing one LLM call and costing
+ * nothing. `reconcileFacts` runs it again regardless — a pre-flight is an
+ * optimization, never the enforcement.
+ */
+export function classifyEpisodeForReconcile(
   episode: ReconcileEpisodeRef,
-  explicitPrincipal: string | null | undefined,
-): { readonly reason: ReconcileBlockReason; readonly detail: string } | null {
+  explicitPrincipal?: string | null,
+): EpisodeBlock | null {
   if (episode.id.trim() === "") {
     return {
       reason: RECONCILE_BLOCK_REASONS.noProvenance,
@@ -616,8 +708,9 @@ function classifyEpisode(
     };
   }
   // The load-bearing one. See the module header: NOT the 0180 CHECK's
-  // non-empty test, because that admits a grant that grants nobody.
-  if (parseGrant(episode.visibleTo).principals.length === 0) {
+  // non-empty test, because that admits a grant that grants nobody. The
+  // predicate is the ingest seam's, imported rather than restated.
+  if (!isUsableGrant(episode.visibleTo)) {
     return {
       reason: RECONCILE_BLOCK_REASONS.noGrant,
       detail:
@@ -647,7 +740,7 @@ async function tryResolve(
   resolver: EntityResolver,
   surface: string,
   workspaceId: string,
-  role: "subject" | "object",
+  role: EntityRole,
   episodeId: string,
 ): Promise<ResolvedEntity | null> {
   try {
@@ -660,7 +753,7 @@ async function tryResolve(
         workspaceId,
         episodeId,
         role,
-        err: err instanceof Error ? err.message : String(err),
+        err: errorMessage(err),
       },
       "brain reconcile: entity resolver threw — treating the entity as unresolved and flagging the candidate provisional",
     );
@@ -699,6 +792,11 @@ async function writeCandidate(
     // own grant; that is safe because `brain_episodes` is ACL-gated in its own
     // right by the same predicate, so walking the edge cannot read an episode
     // the reader is not entitled to.)
+    //
+    // Nor its CARDINALITY: a claim first stored `multi` and re-asserted `single`
+    // stays `multi` and earns no tension edges. Upgrading it would supersede by
+    // side-effect from a corroboration, and supersession is M2's — deliberately
+    // not a stage that runs unattended on every re-observation.
     const edge = await tx.query(INSERT_PROVENANCE_EDGE_SQL, [
       episode.workspaceId,
       existingId,
@@ -708,7 +806,12 @@ async function writeCandidate(
   }
 
   const provisional = item.unresolved.length > 0;
-  const provenance: Record<string, unknown> = {
+  // `satisfies`, not a bare object literal: the payload has three downstream
+  // readers already scheduled (#4772's review surface filters on `provisional`,
+  // #4773's retrieval, #4769's classifier) and `jsonb` enforces nothing at rest,
+  // so the named shape is the only thing that turns a renamed key into a compile
+  // error rather than a blank field in a UI.
+  const provenance = {
     // Producer detail first so the structural keys below always win — a
     // producer may enrich the payload, never rewrite where the claim came from.
     ...(item.candidate.detail ?? {}),
@@ -717,14 +820,18 @@ async function writeCandidate(
     episodeId: episode.id,
     actor: ctx.sourcePrincipal,
     producer: ctx.producer,
-    occurredAt: episode.occurredAt?.toISOString() ?? null,
-    extractedAt: ctx.extractedAt?.toISOString() ?? null,
+    // Through the same guard as the other two timestamps: an INVALID Date's
+    // `toISOString()` throws synchronously, and this call sits inside the
+    // transaction, so an unguarded one would roll a whole episode back over a
+    // bad event time the nullable column is already built to absorb.
+    occurredAt: isoOrNull(episode.occurredAt),
+    extractedAt: isoOrNull(ctx.extractedAt),
     reconciledAt: ctx.now().toISOString(),
     ...(Object.keys(item.entityIds).length > 0 ? { entityIds: item.entityIds } : {}),
     // Present ONLY when it is true, so a reviewer's filter on the key is not
     // fooled by every fact carrying `provisional: false`.
-    ...(provisional ? { provisional: true, unresolved: item.unresolved } : {}),
-  };
+    ...(provisional ? { provisional: true as const, unresolved: item.unresolved } : {}),
+  } satisfies BrainFactProvenance;
 
   const cardinality: PredicateCardinality = item.candidate.predicateCardinality ?? "multi";
   const validFrom = ctx.item.candidate.validFrom ?? null;
@@ -841,7 +948,9 @@ export const withBrainTransaction: ReconcileTransactionRunner = async <T>(
     await client.query("ROLLBACK").catch((rbErr: unknown) => {
       rollbackErr = rbErr instanceof Error ? rbErr : new Error(String(rbErr));
       log.warn(
-        { err: rollbackErr.message },
+        // Scrubbed: a pg error can carry a credentialed connection URL, and a
+        // log line is the one place it must not appear verbatim.
+        { err: errorMessage(rollbackErr) },
         "brain reconcile: ROLLBACK failed — the client will be destroyed",
       );
     });

--- a/packages/api/src/lib/brain/reconcile.ts
+++ b/packages/api/src/lib/brain/reconcile.ts
@@ -505,21 +505,18 @@ export async function reconcileFacts(
     // identical warn per episode would train an operator to skim them — but
     // dropping the line entirely would leave a safety refusal with no trace at
     // all. The verdict also travels in `episodeBlocked` regardless.
-    const level = candidates.length > 0 ? "warn" : "debug";
-    {
-      log[level](
-        {
-          workspaceId: episode.workspaceId,
-          episodeId: episode.id,
-          source: episode.source,
-          sourceId: episode.sourceId,
-          producer,
-          reason,
-          candidates: candidates.length,
-        },
-        `brain reconcile: blocked every candidate from this episode — ${episodeBlock.detail}`,
-      );
-    }
+    const detail = {
+      workspaceId: episode.workspaceId,
+      episodeId: episode.id,
+      source: episode.source,
+      sourceId: episode.sourceId,
+      producer,
+      reason,
+      candidates: candidates.length,
+    };
+    const message = `brain reconcile: blocked every candidate from this episode — ${episodeBlock.detail}`;
+    if (candidates.length > 0) log.warn(detail, message);
+    else log.debug(detail, message);
     blocked[reason] = candidates.length;
     return {
       episodeBlocked: reason,

--- a/packages/api/src/lib/brain/types.ts
+++ b/packages/api/src/lib/brain/types.ts
@@ -139,6 +139,51 @@ export interface BrainFact {
 }
 
 /**
+ * Which side of a subject-predicate-object claim an entity sits on. Spelled
+ * once so the resolver seam, the provisional flag, and the stored provenance
+ * cannot drift into three stringly-typed spellings of the same two words.
+ */
+export type EntityRole = "subject" | "object";
+
+/**
+ * The shape written into `brain_facts.provenance` (#4771).
+ *
+ * The column is `jsonb`, so nothing at rest enforces this — which is exactly
+ * why it is named. There is one writer (the reconcile stage) and at least three
+ * readers already scheduled (#4772's review surface, which must filter on
+ * `provisional`; #4773's `searchBrain`; and the promotion classifier, which
+ * reads the column as `unknown`). Without a named shape, renaming a key is a
+ * silently blank field in a UI rather than a compile error.
+ *
+ * `provisional` / `unresolved` are OPTIONAL and written only when true, so a
+ * reviewer's filter on the key is not defeated by every fact carrying
+ * `provisional: false`. Producer-specific extras (a model id, a confidence, a
+ * warehouse fact's pinned SQL) are the index signature; they are merged UNDER
+ * the structural keys, so a producer can enrich the payload but never restate
+ * where the claim came from.
+ */
+export interface BrainFactProvenance {
+  /** Connector class of the evidence — mirrors `brain_episodes.source`. */
+  readonly source: string;
+  readonly sourceId: string;
+  readonly episodeId: string;
+  /** The principal that asserted the claim. Never null past the block gate. */
+  readonly actor: string | null;
+  /** What produced the candidate — `extraction:v1`, `write-back`, `human`. */
+  readonly producer: string;
+  /** ISO-8601, or null when the source exposed no event time. */
+  readonly occurredAt: string | null;
+  /** ISO-8601 of the extraction pass; null for an authored claim. */
+  readonly extractedAt: string | null;
+  readonly reconciledAt: string;
+  /** Present only for the sides a resolver returned an id for. */
+  readonly entityIds?: Partial<Record<EntityRole, string>>;
+  readonly provisional?: true;
+  readonly unresolved?: readonly EntityRole[];
+  readonly [key: string]: unknown;
+}
+
+/**
  * A typed edge. Each endpoint is a fact OR an episode — exactly one of the two
  * id columns is set, enforced by `chk_brain_edges_{from,to}_endpoint`.
  */

--- a/packages/api/src/lib/db/internal.ts
+++ b/packages/api/src/lib/db/internal.ts
@@ -3429,9 +3429,10 @@ export async function withDemoSeedLock<T>(
 /**
  * Numeric namespace for the per-subscription Stripe webhook lock — the
  * `classkey` arg of the two-arg `pg_advisory_xact_lock(int4, int4)`.
- * Distinct from the last-admin (`3158`), chat-install (`3001`) and
- * lead-outbox (`2870`) two-arg namespaces. Value is this guard's issue
- * number (#3445).
+ * Distinct from the last-admin (`3158`), chat-install (`3001`), lead-outbox
+ * (`2870`), demo-seed (`3683`), knowledge-install (`4235`) and brain-reconcile
+ * (`4771`) two-arg namespaces; all seven are pairwise distinct. Value is this
+ * guard's issue number (#3445).
  */
 const STRIPE_SUBSCRIPTION_LOCK_NAMESPACE = 3445;
 

--- a/packages/api/src/lib/db/internal.ts
+++ b/packages/api/src/lib/db/internal.ts
@@ -3211,9 +3211,10 @@ export async function setWorkspaceRegion(
  * keeps the single-arg `pg_advisory_lock(bigint)` and two-arg `(int4, int4)`
  * lock spaces fully disjoint, so this can never collide with any single-arg
  * user. The two-arg peers are the chat-install gate (`3001`), `lead-outbox`
- * (`2870`), the Stripe webhook lock (`3445`), the demo seed (`3683`), and the
- * knowledge-collection install gate (`4235`); all six namespaces are pairwise
- * distinct. Value is this guard's issue number (#3158).
+ * (`2870`), the Stripe webhook lock (`3445`), the demo seed (`3683`), the
+ * knowledge-collection install gate (`4235`), and the brain reconcile stage
+ * (`4771`); all seven namespaces are pairwise distinct. Value is this guard's
+ * issue number (#3158).
  */
 const LAST_ADMIN_LOCK_NAMESPACE = 3158;
 
@@ -3346,8 +3347,9 @@ export async function withWorkspaceAdminLock<T>(
 /**
  * Numeric namespace for the per-workspace demo-seed advisory lock — the
  * `classkey` arg of the two-arg `pg_advisory_xact_lock(int4, int4)`. Distinct
- * from the last-admin (`3158`), chat-install (`3001`), lead-outbox (`2870`) and
- * Stripe webhook (`3445`) two-arg namespaces; pairwise distinct so a demo seed
+ * from the last-admin (`3158`), chat-install (`3001`), lead-outbox (`2870`),
+ * Stripe webhook (`3445`), knowledge-install (`4235`) and brain-reconcile
+ * (`4771`) two-arg namespaces; pairwise distinct so a demo seed
  * never serializes against an unrelated guard on the same workspace. Value is
  * this guard's issue number (#3683).
  */

--- a/packages/api/src/lib/db/migrations/0180_brain_substrate.sql
+++ b/packages/api/src/lib/db/migrations/0180_brain_substrate.sql
@@ -134,7 +134,10 @@ CREATE UNIQUE INDEX IF NOT EXISTS uq_brain_episodes_source_id
 CREATE UNIQUE INDEX IF NOT EXISTS uq_brain_episodes_workspace_id
   ON brain_episodes (workspace_id, id);
 
--- The extraction fiber's drain query: oldest-unextracted-first, per workspace.
+-- The extraction fiber's backlog. The delivered drain (#4771) is
+-- oldest-unextracted-first ACROSS workspaces, so it uses this index for the
+-- `extracted_at IS NULL` PREDICATE and sorts for its ordering; the leading
+-- `workspace_id` serves a per-workspace backlog read instead.
 -- PARTIAL so the index holds only the backlog — once an episode is extracted
 -- it leaves the index, which keeps the queue scan proportional to work
 -- remaining rather than to history.
@@ -413,8 +416,11 @@ CREATE INDEX IF NOT EXISTS idx_brain_edges_workspace_type
 --
 -- Deliberately NOT Better Auth teams: Atlas has none, and "group" in this
 -- codebase means a connection-group (a set of datasources), not a set of
--- people. Populated by #4771's source-membership entity resolution; consumed
--- by #4768's visibility predicate.
+-- people. Consumed by #4768's visibility predicate. Population is #4801's
+-- membership sync — #4771 shipped the reconcile stage, which INHERITS an
+-- episode's grant rather than deriving one from source membership, so until
+-- #4801 lands this table is empty and a private channel's `audience:` resolves
+-- to nobody (fail-closed, and repairable by writing rows alone).
 CREATE TABLE IF NOT EXISTS fact_audience_member (
   workspace_id text NOT NULL,
   -- The source-derived audience identifier, WITHOUT the `audience:` prefix

--- a/packages/api/src/lib/effect/__tests__/layers.test.ts
+++ b/packages/api/src/lib/effect/__tests__/layers.test.ts
@@ -467,6 +467,9 @@ describe("makeSchedulerLive", () => {
         // #4457 — scheduled internal-DB backups (BackupsManager Tag tick;
         // cadence-window claim in the DB).
         "scheduled_backup",
+        // #4771 — company-brain extraction drain (ADR-0036): a fourth
+        // `runPeriodicDbCycle` job, gated OFF by default.
+        "brain_extraction",
       ],
     },
   ] as const;

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -2350,6 +2350,14 @@ export function makeSchedulerLive(
           "atlas.brain.facts_blocked": result.factsBlocked,
           "atlas.brain.blocked_episodes": result.blockedEpisodes,
           "atlas.brain.failed": result.failed,
+          // The three skip reasons are the fiber's most alert-worthy outcomes
+          // and the span is the alertable surface. Without them,
+          // "EE failed to load and every BYO workspace's backlog is stalled"
+          // and "25 chat messages contained no durable fact" render identically
+          // as `inspected: 25, extracted: 0, failed: 0`.
+          "atlas.brain.skipped_model_unavailable": result.skipped.model_unavailable,
+          "atlas.brain.skipped_no_body": result.skipped.no_body,
+          "atlas.brain.skipped_quarantined": result.skipped.quarantined,
         }),
         onTickFailure: {
           level: "warn",

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -2348,6 +2348,7 @@ export function makeSchedulerLive(
           "atlas.brain.facts_created": result.factsCreated,
           "atlas.brain.facts_corroborated": result.factsCorroborated,
           "atlas.brain.facts_blocked": result.factsBlocked,
+          "atlas.brain.blocked_episodes": result.blockedEpisodes,
           "atlas.brain.failed": result.failed,
         }),
         onTickFailure: {

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -2358,6 +2358,7 @@ export function makeSchedulerLive(
           "atlas.brain.skipped_model_unavailable": result.skipped.model_unavailable,
           "atlas.brain.skipped_no_body": result.skipped.no_body,
           "atlas.brain.skipped_quarantined": result.skipped.quarantined,
+          "atlas.brain.outage_refunded": result.outageRefunded,
         }),
         onTickFailure: {
           level: "warn",

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -224,8 +224,9 @@ function withFiberDeathLog<A, E, R>(
 //     `expert_scheduler`, `promote_decay`, `billing_reconcile`,
 //     `stripe_teardown_sweep`, `unclaimed_grace_reap`, `overage_report`,
 //     the three #4195 DB/refresh jobs `byot_catalog_refresh`,
-//     `openapi_spec_refresh`, `openapi_install_rediscover`, and
-//     `scheduled_backup` (#4457 — the internal-DB backup cycle). Spanned by
+//     `openapi_spec_refresh`, `openapi_install_rediscover`,
+//     `scheduled_backup` (#4457 — the internal-DB backup cycle), and
+//     `brain_extraction` (#4771 — the company-brain episode drain). Spanned by
 //     #2987 (+#3423 for billing_reconcile, #3992 for overage_report, #4195
 //     for the DB/refresh trio) — identical rationale and wrap shape.
 //     `unclaimed_grace_reap` (#3796), the three #4195 jobs, and
@@ -300,6 +301,11 @@ export const SCHEDULER_WORK_SPAN_NAMES = {
   byot_catalog_refresh: "atlas.scheduler.byot_catalog_refresh",
   openapi_spec_refresh: "atlas.scheduler.openapi_spec_refresh",
   openapi_install_rediscover: "atlas.scheduler.openapi_install_rediscover",
+  // #4771 — the company-brain extraction drain (ADR-0036). Another
+  // `runPeriodicDbCycle` job: scan `brain_episodes` with `extracted_at IS
+  // NULL`, extract → reconcile → stamp, one episode at a time. Attaches its
+  // cycle counts via `spanResultAttributes`.
+  brain_extraction: "atlas.scheduler.brain_extraction",
   // #4457 — internal-DB scheduled backups. The tick claims the current
   // cadence window atomically (partial UNIQUE index on
   // `backups.scheduled_window`), then create→verify→purge through the
@@ -2297,6 +2303,58 @@ export function makeSchedulerLive(
           message: "BYOT catalog refresh tick failed — will retry next interval",
         },
         startLog: "BYOT catalog refresh scheduler started",
+      });
+
+      // ── Periodic fiber: company-brain extraction (#4771, ADR-0036) ────────
+      // Drains `brain_episodes` where `extracted_at IS NULL`: extract fact
+      // candidates with the workspace's own model (BYO key rides the agent's
+      // seam), reconcile them into fully-formed drafts, then stamp the queue
+      // marker. Deliberately SEPARATE from the connector cadence — episode
+      // freshness must never block on LLM latency or 429s — and gated OFF by
+      // default until the review surface (#4772) can read what it produces.
+      // Cycle body is the shared `runPeriodicDbCycle` skeleton.
+      yield* registerPeriodicFiber({
+        name: "brain_extraction",
+        intervalMs: () => {
+          // oxlint-disable-next-line @typescript-eslint/no-require-imports -- read the interval constant synchronously at build time (same pattern as byot_catalog_refresh)
+          const { getBrainExtractionIntervalMs } = require("@atlas/api/lib/brain/extract") as {
+            getBrainExtractionIntervalMs: () => number;
+          };
+          return getBrainExtractionIntervalMs();
+        },
+        gate: {
+          check: () => {
+            // oxlint-disable-next-line @typescript-eslint/no-require-imports -- sync gate check at layer build time; dynamic import would force the whole gen async for a boolean
+            const { hasInternalDB } = require("@atlas/api/lib/db/internal") as {
+              hasInternalDB: () => boolean;
+            };
+            // oxlint-disable-next-line @typescript-eslint/no-require-imports -- same reason
+            const { isBrainExtractionEnabled } = require("@atlas/api/lib/brain/extract") as {
+              isBrainExtractionEnabled: () => boolean;
+            };
+            return hasInternalDB() && isBrainExtractionEnabled();
+          },
+          skipLog:
+            "Company-brain extraction not started — needs an internal database and ATLAS_BRAIN_EXTRACTION_ENABLED",
+        },
+        tick: Effect.tryPromise({
+          try: () => import("@atlas/api/lib/brain/extract"),
+          catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+        }).pipe(Effect.flatMap((m) => m.runBrainExtractionCycle())),
+        spanResultAttributes: (result) => ({
+          "atlas.brain.status": result.status,
+          "atlas.brain.inspected": result.inspected,
+          "atlas.brain.extracted": result.extracted,
+          "atlas.brain.facts_created": result.factsCreated,
+          "atlas.brain.facts_corroborated": result.factsCorroborated,
+          "atlas.brain.facts_blocked": result.factsBlocked,
+          "atlas.brain.failed": result.failed,
+        }),
+        onTickFailure: {
+          level: "warn",
+          message: "Company-brain extraction tick failed — will retry next interval",
+        },
+        startLog: "Company-brain extraction scheduler started",
       });
 
       // ── Periodic fiber: shared OpenAPI spec refresh (#2970, Tier-1; #4195) ──

--- a/packages/api/src/lib/settings.ts
+++ b/packages/api/src/lib/settings.ts
@@ -1725,6 +1725,26 @@ const SETTINGS_REGISTRY: SettingDefinition[] = [
     scope: "platform",
     saasVisible: false,
   },
+  {
+    // Company-brain extraction fiber (#4771, ADR-0036 §Ingestion). Default OFF
+    // while the brain milestone is in flight: the review surface (#4772) is
+    // what makes an extracted fact usable, so until it lands the fiber would
+    // spend model budget filling a queue nobody can read. Platform-scoped
+    // because the fiber is process-wide and drains every workspace's episodes.
+    // Read at fiber-registration time by
+    // `lib/brain/extract.ts::isBrainExtractionEnabled`, so a change takes
+    // effect on the next boot rather than on the next tick.
+    key: "ATLAS_BRAIN_EXTRACTION_ENABLED",
+    section: "Knowledge Base",
+    label: "Company Brain Extraction",
+    description:
+      "Draw fact candidates from stored chat episodes with the workspace's configured model and stage them as drafts for review. Off by default; episodes keep being stored either way, so turning it on later extracts the backlog rather than losing it. Applies at restart.",
+    type: "boolean",
+    default: "false",
+    envVar: "ATLAS_BRAIN_EXTRACTION_ENABLED",
+    scope: "platform",
+    saasVisible: false,
+  },
 ];
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
T6's two async halves (ADR-0036 §Ingestion & connectors). Targets
`milestone/v0.2.0-brain-m1`, not `main`.

## Extraction — `lib/brain/extract.ts`

A `registerPeriodicFiber` drain of `brain_episodes` where `extracted_at IS NULL`,
on its own clock. Separate from the connector cadence so **episode freshness never
blocks on LLM latency or 429s** (AC1); facts are second-order fresh by design and
there is no sync fast-path. BYO key rides the agent's existing model seam
(`ModelRouter` → platform default, core per T8). Gated **OFF by default** until the
review surface (#4772) can read what it produces.

Order is **work-then-stamp**: extract → reconcile (commits) → stamp. A crash before
the stamp re-queues the episode and the next pass corroborates. Claim-then-work was
rejected — it turns every crash into an episode marked extracted with zero facts
drawn from it, the silent permanent drop migration 0180 explicitly argues against.

Spend is bounded without pretending a few failures prove permanence: after 3
consecutive failures an episode moves to a widening probe backoff (30 min → 16 h)
rather than being stamped on a guess, and a tick in which *every* attempted episode
failed forgives one strike each (capped per episode) so an upstream outage is not
charged to the rows.

## Reconcile — `lib/brain/reconcile.ts`

One stage, **entry-point-agnostic** — M5's write-back reuses this exact seam, so the
signature names an episode and candidates and nothing else. Entity resolution → grant
→ source principal → provenance → corroboration-dedup → advisory contradiction edges
→ `draft`, all in **one transaction** under a per-workspace advisory lock (AC2).

The insert omits `status` entirely: 0180's default *is* the review gate applying
itself (#4769).

### Block-vs-flag, proven per class by tests (AC3)

* **Block + log** — no provenance / no usable grant / unresolvable source principal,
  plus a malformed claim. The grant test is `parseGrant(...).principals.length === 0`,
  **not** the CHECK's non-empty test: `['everyone']` passes the CHECK, grants nobody,
  and would be refused at every publish forever with no repair UI. Blocking upstream
  is the only place that hazard is reachability-proof, and it is what makes #4769's
  refusal genuine defence in depth rather than a dead end.
* **Flag provisional** — subject/object entity-resolution failure is written as a
  draft with `provenance.provisional`, because the reviewer is the right person to
  settle it. Never a silent fact-dropper in either direction.

Corroboration strengthens rather than duplicates (AC4), which is also what makes
re-running extraction over an already-extracted window a no-op (AC5).

## Not in this slice

Grants are **inherited** from the episode. Deriving one from source membership — the
`fact_audience_member` sync that makes a private channel's `audience:` resolve to
real people — is split out as **#4801**; three comments that pointed at #4771 for it
now point there. Until it lands, private-channel episodes are visible to nobody
(fail-closed, repairable by writing rows alone).

## Review

Internal `/review-panel`: **3 rounds**, all findings addressed. It caught two things
worth naming, both now fixed with regression tests that fail on the old code:

1. An EE module that failed to load made every BYO workspace's backlog resolve to
   Atlas's own key — the no-op `ModelRouter` returns `null` for every workspace,
   which is indistinguishable from "has no BYO config".
2. My own round-2 outage refund made quarantine *unreachable*: a failing episode is
   never stamped, so "every episode this tick failed" is simply what a poisoned queue
   looks like, forever. Simulated over a day, two poisoned episodes went from 25 model
   calls to 576 and climbing. Every quarantine test had one episode, so `attempted > 1`
   was false and the path never ran.

`/ci`: **32/32 gates green**, including the full isolated suite.

## Tests

69 across three suites — a DB-free unit suite for the decision matrix, a DB-free
`extract.test.ts` for the model seam / caps / gate / a source scan pinning AC1
structurally, and a real-Postgres suite for everything only a live schema can settle
(the `draft` default, transaction atomicity, corroboration, tenant scoping, two
reconciles racing for one claim).

Closes #4771 — by hand, since `Closes` does not fire against a non-default base.