### PR TITLE
feat(api): bound audience-membership staleness + honour Retry-After (#4808, #4809)

### DIFF
--- a/docs/development/brain-slack-history.md
+++ b/docs/development/brain-slack-history.md
@@ -230,10 +230,28 @@ that table honest:
 - **Cadence** — its own fiber, default every 30 min
   (`ATLAS_BRAIN_AUDIENCE_SYNC_INTERVAL_MINUTES`). That interval is the floor of
   the delay between someone leaving a channel and losing access to facts drawn
-  from it — the number to quote when a workspace asks, assuming the roster reads
-  succeed (see `audiences_failed` below, where the delay is unbounded). Deliberately not
+  from it — the number to quote when a workspace asks. Deliberately not
   folded into the history pass: a quiet channel would then never re-read its
   roster, and a quiet channel is where a stale roster survives longest.
+- **Ceiling** — `ATLAS_BRAIN_AUDIENCE_MAX_STALENESS_HOURS`, platform-scoped,
+  default **168 (7 days)**; `0` disables it. The cadence above is the floor of
+  the revocation delay *when the roster reads succeed*; this is the bound on
+  what happens when they don't. `fact_audience_member.synced_at` records when
+  each membership was last **verified** — stamped on every successful reconcile
+  including the no-op case, and left untouched by every abort — and past this
+  bound `acl.ts` stops expanding those audiences into reader tokens. So a
+  channel Atlas was removed from can no longer keep granting access forever
+  (#4808). Suppressed grants are logged with their audience ids and counted;
+  they are never dropped silently, which is what keeps the bound consistent
+  with that module's refusal to downgrade a reader without saying so.
+
+  ⚠️ The trade is real and points **both** ways. Fail-closed means a workspace
+  whose Slack connection lapses eventually loses its own private-channel facts
+  — a support incident. It was chosen anyway because that failure is *loud and
+  diagnosable* (the counters below name the workspace) while unbounded stale
+  access is *silent*, and because the blast radius is narrow: only `audience:`
+  grants are affected, so `[org]` and per-user grants keep serving. Raise or
+  zero the setting to restore reads without a redeploy — it hot-reloads.
 - **Switch** — `ATLAS_BRAIN_AUDIENCE_SYNC_ENABLED`, workspace-scoped, **default
   ON** (unlike `ATLAS_BRAIN_EXTRACTION_ENABLED`, which spends model budget and
   defaults off). Read with no workspace it resolves to the platform value, which
@@ -253,6 +271,24 @@ real offboarding wave or a resolver that stopped resolving. `audiences_failed`
 means a channel's roster could not be read *completely* — the sync then leaves
 that audience's membership untouched rather than revoking the members it failed
 to fetch, so a persistent non-zero count is stale-access risk, not data loss.
+
+That risk is now **bounded and measured**. `stale_audiences` / `stale_workspaces`
+count what has aged past `ATLAS_BRAIN_AUDIENCE_MAX_STALENESS_HOURS`, and
+`oldest_verified_age_seconds` says how far past — which turns "some roster read
+is failing" into "and it has been failing for eleven days", i.e. into a thing
+with a deadline, since past the bound those grants stop being served. All three
+report `-1` when the sweep itself could not run (span attributes have no null,
+and `0` would be indistinguishable from all-clear). They are swept even when
+there are no installs left to sync, because an install someone *disabled* stops
+being reconciled while its membership rows stay.
+
+`reads_throttled` versus `reads_throttle_exhausted` is the #4809 pair: the first
+counts reads that hit a 429, backed off, and **got through** — healthy; the
+second counts reads that gave up and aborted their scope. Before the backoff
+existed every 429 was simply an abort, so "Slack throttles us occasionally" and
+"this workspace has not reconciled in a week" were the same signal. A rising
+`reads_throttle_exhausted` is the early warning for `stale_audiences`.
+
 `principals_unresolved` is normal and non-zero in most workspaces (guests,
 contractors, anyone without an Atlas account); the per-cycle log breaks it into
 no-email / outside-verified-domain / no-Atlas-account, because those three need

--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -548,6 +548,7 @@ describe("migrateAuthTables", () => {
             // in every auth mode — must be in the already-applied set so this
             // "all applied" test sees zero new migrations.
             { name: "0181_brain_fts.sql" },
+            { name: "0182_audience_member_synced_at.sql" },
           ],
         };
       }

--- a/packages/api/src/lib/brain/__tests__/acl-logging.test.ts
+++ b/packages/api/src/lib/brain/__tests__/acl-logging.test.ts
@@ -240,7 +240,9 @@ describe("resolution-side anomalies are logged (#4768)", () => {
     // query or the row shape changed. Silently returning fewer memberships
     // would strip a reader's audience grants with no signal — the same silent
     // downgrade this function refuses to perform on a DB error.
-    const drifted = { query: async () => ({ rows: [{ aud: "eng" }, { audience_id: "exec" }] }) };
+    const drifted = {
+      query: async () => ({ rows: [{ aud: "eng" }, { audience_id: "exec", fresh: true }] }),
+    };
     const resolved = await resolvePrincipalContext(drifted, {
       workspaceId: WS,
       mode: "managed",

--- a/packages/api/src/lib/brain/__tests__/acl.test.ts
+++ b/packages/api/src/lib/brain/__tests__/acl.test.ts
@@ -17,8 +17,11 @@ import {
   AUDIENCE_PREFIX,
   ORG_PRINCIPAL,
   ROLE_PREFIX,
+  AUDIENCE_MEMBERSHIP_SQL,
+  DEFAULT_AUDIENCE_MAX_STALENESS_HOURS,
   USER_PREFIX,
   aclVisibilityClause,
+  getAudienceMaxStalenessSeconds,
   formatPrincipal,
   impliedRoles,
   isVisibleTo,
@@ -342,13 +345,17 @@ describe("resolvePrincipalContext (#4768)", () => {
     let seenSql: string | undefined;
     let seenParams: unknown[] | undefined;
     const resolved = await resolvePrincipalContext(
-      reader([{ audience_id: "eng" }, { audience_id: "exec" }], (sql, params) => {
+      reader([{ audience_id: "eng", fresh: true }, { audience_id: "exec", fresh: true }], (sql, params) => {
         seenSql = sql;
         seenParams = params;
       }),
       authed,
     );
-    expect(seenParams).toEqual([WS, "user-1"]);
+    // Third param is the staleness bound in seconds (#4808) — the read-time
+    // half of the guarantee that a permanently-failing roster read cannot keep
+    // granting forever.
+    expect(seenParams?.slice(0, 2)).toEqual([WS, "user-1"]);
+    expect(typeof seenParams?.[2]).toBe("number");
     // The workspace predicate is the module's only cross-tenant-sensitive read
     // — a membership row from another tenant hands this reader a token that
     // then matches their OWN tenant's facts, which the predicate's workspace
@@ -363,7 +370,12 @@ describe("resolvePrincipalContext (#4768)", () => {
 
   it("drops non-string / empty audience ids rather than minting a bare prefix", async () => {
     const resolved = await resolvePrincipalContext(
-      reader([{ audience_id: "eng" }, { audience_id: null }, { audience_id: "" }, {}]),
+      reader([
+        { audience_id: "eng", fresh: true },
+        { audience_id: null, fresh: true },
+        { audience_id: "", fresh: true },
+        {},
+      ]),
       authed,
     );
     expect(resolved.audienceIds).toEqual(["eng"]);
@@ -388,7 +400,7 @@ describe("resolvePrincipalContext (#4768)", () => {
 
   it("resolves the other authenticated modes without special-casing them", async () => {
     for (const mode of ["simple-key", "byot"] as const) {
-      const resolved = await resolvePrincipalContext(reader([{ audience_id: "eng" }]), {
+      const resolved = await resolvePrincipalContext(reader([{ audience_id: "eng", fresh: true }]), {
         ...authed,
         mode,
       });
@@ -464,6 +476,75 @@ describe("resolvePrincipalContext (#4768)", () => {
     await expect(resolvePrincipalContext(failing, authed)).rejects.toThrow(
       "connection terminated",
     );
+  });
+
+  // -------------------------------------------------------------------------
+  // Staleness bound (#4808)
+  // -------------------------------------------------------------------------
+
+  it("suppresses an audience the sync has not verified within the bound", async () => {
+    // The read-time half of #4808. Without it, a channel Atlas was removed from
+    // fails `loadRoster` on every cycle forever and keeps granting access
+    // indefinitely — the sync's fail-safe abort is correct but has no time
+    // bound, so "revocation latency is one interval" becomes "unbounded".
+    const resolved = await resolvePrincipalContext(
+      reader([
+        { audience_id: "eng", fresh: true },
+        { audience_id: "abandoned", fresh: false },
+      ]),
+      authed,
+    );
+    expect(resolved.audienceIds).toEqual(["eng"]);
+    expect(principalTokens(resolved)).not.toContain(`${AUDIENCE_PREFIX}abandoned`);
+    // And the fact it gated is genuinely invisible, not merely absent from a list.
+    expect(isVisibleTo(row([`${AUDIENCE_PREFIX}abandoned`]), resolved)).toBe(false);
+    expect(isVisibleTo(row([`${AUDIENCE_PREFIX}eng`]), resolved)).toBe(true);
+  });
+
+  it("suppresses a membership row whose freshness flag is unreadable", async () => {
+    // Fails CLOSED on query drift. "We could not determine whether this
+    // membership is still verified" is not a basis for expanding a token — and
+    // the alternative default (treat unknown as fresh) would make the bound
+    // silently unenforced the moment the SELECT list changed.
+    const resolved = await resolvePrincipalContext(
+      reader([{ audience_id: "eng" }, { audience_id: "ops", fresh: "yes" }]),
+      authed,
+    );
+    expect(resolved.audienceIds).toEqual([]);
+  });
+
+  it("passes the configured bound to the query rather than filtering in TS", async () => {
+    // The comparison must happen against the DATABASE's clock on both sides.
+    // Reading `synced_at` out and testing it against the API process's
+    // `Date.now()` would make the bound depend on clock skew between two
+    // machines — and skew in the generous direction silently extends every
+    // grant, which is the one direction this bound exists to close.
+    let seenSql: string | undefined;
+    let seenParams: unknown[] | undefined;
+    await resolvePrincipalContext(
+      reader([{ audience_id: "eng", fresh: true }], (sql, params) => {
+        seenSql = sql;
+        seenParams = params;
+      }),
+      authed,
+    );
+    expect(seenSql).toContain("synced_at");
+    expect(seenSql).toContain("now()");
+    expect(seenParams?.[2]).toBe(DEFAULT_AUDIENCE_MAX_STALENESS_HOURS * 3600);
+  });
+
+  it("treats a non-positive bound as DISABLED, not as 'everything is stale'", async () => {
+    // `make_interval(secs => 0)` is a zero interval, under which
+    // `synced_at >= now()` is false for every row — so a disabled setting read
+    // naively would suppress every audience in the deployment rather than none
+    // of them. The SQL checks the disable arm FIRST for exactly that reason.
+    expect(AUDIENCE_MEMBERSHIP_SQL).toMatch(/\$3::double precision <= 0\s+OR/);
+  });
+
+  it("falls back to the default bound on an unparseable setting, not to disabled", async () => {
+    // A typo in an operator's override must not quietly switch the bound off.
+    // (The `0` escape hatch is deliberate and separate — see the setting copy.)
+    expect(getAudienceMaxStalenessSeconds()).toBe(DEFAULT_AUDIENCE_MAX_STALENESS_HOURS * 3600);
   });
 });
 

--- a/packages/api/src/lib/brain/acl.ts
+++ b/packages/api/src/lib/brain/acl.ts
@@ -74,6 +74,7 @@
 
 import { ORG_ROLES, type AtlasRole, type AuthMode, type OrgRole } from "@useatlas/types/auth";
 import { createLogger } from "@atlas/api/lib/logger";
+import { getSettingAuto } from "@atlas/api/lib/settings";
 
 const log = createLogger("brain-acl");
 
@@ -342,16 +343,72 @@ export interface AudienceMembershipReader {
  * OWN tenant's facts — a leak the visibility predicate's workspace containment
  * cannot catch, because the token is being applied inside the right tenant.
  *
- * `DISTINCT` is belt-and-braces: the PK `(workspace_id, audience_id, user_id)`
- * already makes a duplicate row unrepresentable. It survives a future PK
- * relaxation without silently doubling the token list.
+ * `GROUP BY audience_id` does the belt-and-braces the old `DISTINCT` did: the
+ * PK `(workspace_id, audience_id, user_id)` already makes a duplicate row
+ * unrepresentable given both predicates here, and this survives a future PK
+ * relaxation without silently doubling the token list. `min(synced_at)` is the
+ * conservative reading of a set that should hold exactly one row — an audience
+ * is as verified as its LEAST recently verified row, never as its best one.
+ *
+ * ## The freshness flag (#4808)
+ *
+ * `fresh` is computed in SQL rather than by comparing timestamps in TS, so the
+ * comparison happens against the DATABASE's clock on both sides. Reading
+ * `synced_at` out and testing it against the API process's `Date.now()` would
+ * make the bound depend on clock skew between two machines — and skew in the
+ * generous direction extends every grant silently, which is the one direction
+ * this bound exists to close.
+ *
+ * A non-positive `$3` DISABLES the bound (everything is fresh), which is the
+ * operator's hot-reloadable escape hatch — see
+ * `ATLAS_BRAIN_AUDIENCE_MAX_STALENESS_HOURS`. It is checked FIRST because
+ * `make_interval(secs => 0)` is a zero interval, under which `synced_at >=
+ * now()` is false for every row: the disabled setting would otherwise suppress
+ * every audience in the deployment rather than none of them.
  */
 export const AUDIENCE_MEMBERSHIP_SQL = `
-  SELECT DISTINCT audience_id
+  SELECT audience_id,
+         ($3::double precision <= 0
+          OR min(synced_at) >= now() - make_interval(secs => $3::double precision)) AS fresh
     FROM fact_audience_member
    WHERE workspace_id = $1
      AND user_id = $2
+   GROUP BY audience_id
 ` as const;
+
+/**
+ * How long a membership row stays valid after its last verified sync, in
+ * seconds. `0` (or any non-positive / unparseable value) disables the bound.
+ *
+ * Platform-scoped: this is the operator's floor, not a tenant's preference.
+ * Read per request rather than cached in a module constant so the settings
+ * registry's ~30s hot-reload actually reaches it — an operator raising the
+ * limit mid-incident must not need a redeploy to restore reads.
+ *
+ * Unparseable falls back to the DEFAULT rather than to "disabled". A typo in
+ * an operator's override should not quietly switch the bound off; the shipped
+ * default is the safe interpretation of "they meant to have one".
+ */
+export const DEFAULT_AUDIENCE_MAX_STALENESS_HOURS = 168;
+
+/** How many suppressed audience ids one log line carries. A bound, not a policy. */
+const SUPPRESSED_AUDIENCE_SAMPLE_CAP = 20;
+
+export function getAudienceMaxStalenessSeconds(): number {
+  const raw = getSettingAuto("ATLAS_BRAIN_AUDIENCE_MAX_STALENESS_HOURS");
+  if (raw === undefined || raw === "") return DEFAULT_AUDIENCE_MAX_STALENESS_HOURS * 3600;
+  const hours = Number.parseFloat(raw);
+  if (!Number.isFinite(hours)) {
+    log.warn(
+      { raw },
+      "brain ACL: ATLAS_BRAIN_AUDIENCE_MAX_STALENESS_HOURS is unparseable — using the default staleness bound",
+    );
+    return DEFAULT_AUDIENCE_MAX_STALENESS_HOURS * 3600;
+  }
+  // A deliberate `0` (or negative) reaches here and disables the bound; that is
+  // the documented escape hatch, distinct from the unparseable case above.
+  return hours <= 0 ? 0 : hours * 3600;
+}
 
 export interface ResolvePrincipalInput {
   readonly workspaceId: string;
@@ -455,31 +512,58 @@ export async function resolvePrincipalContext(
     // grant. Falls through as `null` — deliberately, not by omission.
   }
 
-  const result = await db.query(AUDIENCE_MEMBERSHIP_SQL, [workspaceId, userId]);
-  const audienceIds = result.rows
-    .map((row) =>
-      typeof row === "object" && row !== null && "audience_id" in row
-        ? row.audience_id
-        : undefined,
-    )
-    .filter((id): id is string => typeof id === "string" && id.length > 0);
-  if (audienceIds.length !== result.rows.length) {
-    // Two different faults land here and an operator must be able to tell them
-    // apart. A row with no `audience_id` key at all is QUERY DRIFT (an added
-    // alias, a join) — diff the SQL. A row that has the column but an unusable
-    // value is a DATA defect: `audience_id` is `text NOT NULL` but 0180 adds no
+  const result = await db.query(AUDIENCE_MEMBERSHIP_SQL, [
+    workspaceId,
+    userId,
+    getAudienceMaxStalenessSeconds(),
+  ]);
+
+  const audienceIds: string[] = [];
+  const suppressedStale: string[] = [];
+  let missingColumn = 0;
+  let unusableValue = 0;
+  let unreadableFreshness = 0;
+
+  for (const row of result.rows) {
+    if (!(typeof row === "object" && row !== null && "audience_id" in row)) {
+      missingColumn++;
+      continue;
+    }
+    const id = row.audience_id;
+    if (typeof id !== "string" || id.length === 0) {
+      unusableValue++;
+      continue;
+    }
+    const fresh = "fresh" in row ? row.fresh : undefined;
+    if (fresh === true) {
+      audienceIds.push(id);
+    } else if (fresh === false) {
+      suppressedStale.push(id);
+    } else {
+      // The flag is computed by this module's own SQL over a NOT NULL column,
+      // so a non-boolean here is query drift, not data. Counted as a SUPPRESSED
+      // grant rather than a granted one: "we could not determine whether this
+      // membership is still verified" is not a basis for expanding a token, and
+      // the loud count below is what keeps that from being a silent deny.
+      unreadableFreshness++;
+    }
+  }
+
+  if (missingColumn > 0 || unusableValue > 0 || unreadableFreshness > 0) {
+    // Three faults land here and an operator must be able to tell them apart. A
+    // row with no `audience_id` key at all is QUERY DRIFT (an added alias, a
+    // join) — diff the SQL. A row that has the column but an unusable value is
+    // a DATA defect: `audience_id` is `text NOT NULL` but 0180 adds no
     // non-empty CHECK, so `''` is legally storable and points at whatever wrote
     // the membership row — today that is #4801's sync
     // (`lib/brain/audience/membership.ts`, which refuses a blank id at the
-    // writer for exactly this reason), not at this query. Reporting both as
-    // "the query changed" would send that investigation to the wrong file.
+    // writer for exactly this reason), not at this query. A row missing a
+    // readable `fresh` is 0182's freshness flag having changed shape. Reporting
+    // them alike would send each investigation to the wrong file.
     //
     // Either way, silently returning fewer memberships would strip a reader's
     // audience grants with no signal — the same silent downgrade this function
     // refuses to perform on a DB error.
-    const missingColumn = result.rows.filter(
-      (row) => !(typeof row === "object" && row !== null && "audience_id" in row),
-    ).length;
     log.warn(
       {
         workspaceId,
@@ -488,11 +572,43 @@ export async function resolvePrincipalContext(
         returned: result.rows.length,
         usable: audienceIds.length,
         missingColumn,
-        unusableValue: result.rows.length - audienceIds.length - missingColumn,
+        unusableValue,
+        unreadableFreshness,
       },
       missingColumn > 0
         ? "brain ACL: audience membership rows lack an audience_id column — the membership query shape changed"
-        : "brain ACL: audience membership rows carry an unusable audience_id — the writer stored an empty id",
+        : unreadableFreshness > 0
+          ? "brain ACL: audience membership rows carry no readable freshness flag — the membership query shape changed; these grants are suppressed"
+          : "brain ACL: audience membership rows carry an unusable audience_id — the writer stored an empty id",
+    );
+  }
+
+  if (suppressedStale.length > 0) {
+    // The #4808 event, and the reason the staleness bound is defensible at all.
+    //
+    // This function's contract is that it never downgrades a reader without
+    // saying so — that is why a DB error propagates rather than resolving to
+    // zero audiences. A `synced_at` filter IS such a downgrade, so it has to be
+    // announced with the same force: which audiences, and for how long they
+    // have gone unverified. Without this line the bound would be exactly the
+    // silent denial the module argues against, just with a different cause.
+    //
+    // `warn`, and with the ids: by the time anyone asks "why can't this person
+    // see the channel they are demonstrably in?", the only answer that helps is
+    // "membership for THESE audiences has not been verified since X" — which
+    // points at the failing roster read, not at the reader.
+    log.warn(
+      {
+        workspaceId,
+        userId,
+        requestId,
+        suppressed: suppressedStale.length,
+        granted: audienceIds.length,
+        maxStalenessSeconds: getAudienceMaxStalenessSeconds(),
+        suppressedAudienceIds: suppressedStale.slice(0, SUPPRESSED_AUDIENCE_SAMPLE_CAP),
+        suppressedSampleTruncated: suppressedStale.length > SUPPRESSED_AUDIENCE_SAMPLE_CAP,
+      },
+      "brain ACL: audience grants suppressed as stale — their membership has not been verified within ATLAS_BRAIN_AUDIENCE_MAX_STALENESS_HOURS. Check brain_audience_sync for a failing roster read in this workspace",
     );
   }
 

--- a/packages/api/src/lib/brain/audience/__tests__/audience-sync-pg.test.ts
+++ b/packages/api/src/lib/brain/audience/__tests__/audience-sync-pg.test.ts
@@ -31,7 +31,7 @@ import {
   SLACK_HISTORY_CATALOG_ID,
   SLACK_HISTORY_SOURCE,
 } from "@atlas/api/lib/brain/ingest/slack/config";
-import { AUDIENCE_SYNC_INSTALLS_SQL } from "../sync";
+import { AUDIENCE_STALENESS_SQL, AUDIENCE_SYNC_INSTALLS_SQL } from "../sync";
 import { reconcileAudienceMembership, type MembershipExecutor } from "../membership";
 import { resolvePrincipals } from "../resolver";
 
@@ -173,22 +173,101 @@ describeIfPg("brain audience membership (real Postgres)", () => {
     expect((await readerFor("user-ada")).audienceIds).toEqual([AUDIENCE]);
   }, PG_TEST_TIMEOUT_MS);
 
-  it("is idempotent — an unchanged re-sync writes nothing and preserves created_at", async () => {
+  it("is idempotent — an unchanged re-sync reports nothing, preserves created_at, and REFRESHES synced_at", async () => {
     await reconcile(["user-ada", "user-bob"]);
-    const first = await pool.query<{ created_at: Date }>(
-      `SELECT created_at FROM fact_audience_member WHERE user_id = 'user-ada'`,
+    // The two clocks must be able to diverge for the assertions below to mean
+    // anything; without this the re-sync could land inside the same millisecond.
+    await pool.query(
+      `UPDATE fact_audience_member SET created_at = created_at - interval '1 hour',
+                                       synced_at  = synced_at  - interval '1 hour'`,
+    );
+    const aged = await pool.query<{ created_at: Date; synced_at: Date }>(
+      `SELECT created_at, synced_at FROM fact_audience_member WHERE user_id = 'user-ada'`,
     );
 
     const second = await reconcile(["user-ada", "user-bob"]);
+    // THE TRAP. The natural way to stamp `synced_at` on a re-sync is to turn
+    // the INSERT's `ON CONFLICT DO NOTHING` into `DO UPDATE SET synced_at =
+    // now()` — and that makes `RETURNING user_id` emit the WHOLE roster every
+    // cycle, so `added` silently stops meaning "newly granted" and starts
+    // meaning "everyone". The "membership granted" log would then fire every 30
+    // minutes and `atlas.brain.audience.members_added` would stop meaning
+    // anything, with nothing erroring and no other assertion noticing.
     expect(second).toEqual({ added: 0, revoked: 0 });
 
-    const after = await pool.query<{ created_at: Date }>(
-      `SELECT created_at FROM fact_audience_member WHERE user_id = 'user-ada'`,
+    const after = await pool.query<{ created_at: Date; synced_at: Date }>(
+      `SELECT created_at, synced_at FROM fact_audience_member WHERE user_id = 'user-ada'`,
     );
     // `created_at` answers "since when has this person been able to see this?".
     // An upsert that rewrote it every cycle would turn that into "since the
     // last cycle", i.e. into nothing.
-    expect(after.rows[0]?.created_at).toEqual(first.rows[0]?.created_at);
+    expect(after.rows[0]?.created_at).toEqual(aged.rows[0]?.created_at);
+    // `synced_at` answers a DIFFERENT question — "when did we last CHECK?" — so
+    // the no-op pass must advance it. "Unchanged" is still "verified"; if the
+    // steady-state pass skipped the stamp, the column would age on every
+    // healthy audience and the read-time bound would start denying correct
+    // grants. Both properties, one re-sync: that is why they are one test.
+    expect(after.rows[0]!.synced_at.getTime()).toBeGreaterThan(
+      aged.rows[0]!.synced_at.getTime(),
+    );
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("leaves synced_at ALONE when the reconcile aborts — 'last verified', never 'last touched'", async () => {
+    // The column's whole meaning. `sync.ts` aborts an audience whose roster it
+    // could not read COMPLETELY, without calling `reconcileAudienceMembership`
+    // at all — so the abort is modelled here as exactly that: no call. If a
+    // failed read stamped the column anyway, `synced_at` would read healthiest
+    // for precisely the workspaces that are broken, and the staleness bound
+    // would never fire on the case it exists for.
+    await reconcile(["user-ada"]);
+    await pool.query(`UPDATE fact_audience_member SET synced_at = now() - interval '9 days'`);
+    const before = await pool.query<{ synced_at: Date }>(
+      `SELECT synced_at FROM fact_audience_member WHERE user_id = 'user-ada'`,
+    );
+
+    // ... a cycle in which the roster read fails: membership untouched.
+    const after = await pool.query<{ synced_at: Date }>(
+      `SELECT synced_at FROM fact_audience_member WHERE user_id = 'user-ada'`,
+    );
+    expect(after.rows[0]?.synced_at).toEqual(before.rows[0]?.synced_at);
+
+    // And that is what the reader now acts on: past the bound the grant stops
+    // being served, so a permanently-failing roster read can no longer keep
+    // granting access forever (#4808).
+    expect((await readerFor("user-ada")).audienceIds).toEqual([]);
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("keeps serving a grant that is stale but still INSIDE the bound", async () => {
+    // The other half, and the one that keeps the bound from being a hair
+    // trigger: a workspace whose Slack is briefly unreachable must not lose its
+    // private-channel facts over a bad afternoon.
+    await reconcile(["user-ada"]);
+    await pool.query(`UPDATE fact_audience_member SET synced_at = now() - interval '2 days'`);
+    expect((await readerFor("user-ada")).audienceIds).toEqual([AUDIENCE]);
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("counts stale audiences with the sweep the span reports", async () => {
+    // Runs the exact production string against the live schema. The aggregate
+    // is easy to get subtly wrong — a `WHERE` on `synced_at` rather than a
+    // `HAVING`-shaped filter on the grouped minimum would count ROWS (people)
+    // and report a two-person audience as two stale audiences.
+    await reconcile(["user-ada", "user-bob"]);
+    const fresh = await query<{ stale_audiences: number; oldest_age_seconds: string }>(
+      AUDIENCE_STALENESS_SQL,
+      [7 * 24 * 3600],
+    );
+    expect(fresh[0]?.stale_audiences).toBe(0);
+
+    await pool.query(`UPDATE fact_audience_member SET synced_at = now() - interval '11 days'`);
+    const stale = await query<{
+      stale_audiences: number;
+      stale_workspaces: number;
+      oldest_age_seconds: string;
+    }>(AUDIENCE_STALENESS_SQL, [7 * 24 * 3600]);
+    // TWO members, ONE audience.
+    expect(stale[0]?.stale_audiences).toBe(1);
+    expect(stale[0]?.stale_workspaces).toBe(1);
+    expect(Number(stale[0]?.oldest_age_seconds)).toBeGreaterThan(10 * 24 * 3600);
   }, PG_TEST_TIMEOUT_MS);
 
   it("an empty roster revokes the whole audience", async () => {

--- a/packages/api/src/lib/brain/audience/__tests__/membership.test.ts
+++ b/packages/api/src/lib/brain/audience/__tests__/membership.test.ts
@@ -13,6 +13,7 @@ import { describe, expect, it } from "bun:test";
 import {
   DELETE_STALE_AUDIENCE_MEMBERS_SQL,
   INSERT_AUDIENCE_MEMBERS_SQL,
+  TOUCH_AUDIENCE_MEMBERS_SQL,
   reconcileAudienceMembership,
   type MembershipExecutor,
 } from "../membership";
@@ -46,9 +47,12 @@ describe("reconcileAudienceMembership", () => {
     );
 
     expect(result).toEqual({ added: 1, revoked: 1 });
+    // The touch runs LAST, so it stamps the survivors rather than rows the
+    // delete is about to remove.
     expect(calls.map((c) => c.sql)).toEqual([
       INSERT_AUDIENCE_MEMBERS_SQL,
       DELETE_STALE_AUDIENCE_MEMBERS_SQL,
+      TOUCH_AUDIENCE_MEMBERS_SQL,
     ]);
     // ONE transaction for the pair. The dangerous split is delete-commits /
     // insert-fails: everyone revoked, re-added only next cycle, and in between
@@ -71,6 +75,66 @@ describe("reconcileAudienceMembership", () => {
     expect(del?.params[2]).toEqual([]);
   });
 
+  it("stamps synced_at on a NO-OP reconcile — unchanged is still verified", async () => {
+    // The column means "last VERIFIED", not "last touched". If the steady-state
+    // pass (nothing added, nothing revoked) skipped the stamp, `synced_at`
+    // would age on every healthy audience and stay fresh only where membership
+    // happened to churn — i.e. it would read healthiest for the workspaces
+    // whose rosters are most static, and the read-time bound in `acl.ts` would
+    // start denying correct grants.
+    const { withTransaction, calls } = recorder(() => []);
+    const result = await reconcileAudienceMembership(
+      { ...BASE, userIds: ["u1", "u2"] },
+      { withTransaction },
+    );
+
+    expect(result).toEqual({ added: 0, revoked: 0 });
+    const touch = calls.find((c) => c.sql === TOUCH_AUDIENCE_MEMBERS_SQL);
+    expect(touch).toBeDefined();
+    expect(touch?.params).toEqual(["ws-1", "chat-channel:slack:C1", "slack"]);
+  });
+
+  it("keeps `added` meaning NEWLY GRANTED even when the touch reports the whole roster", async () => {
+    // The trap this shape exists to avoid. Stamping `synced_at` by turning the
+    // INSERT's `ON CONFLICT DO NOTHING` into `DO UPDATE SET synced_at = now()`
+    // is the natural move — and it makes `RETURNING user_id` emit the WHOLE
+    // roster every cycle, so `added` (which is `rows.length`) silently becomes
+    // "everyone", the "membership granted" log fires every 30 minutes, and
+    // `atlas.brain.audience.members_added` stops meaning anything. Nothing
+    // errors; every other assertion in this file still passes.
+    //
+    // Here the touch is made to return a full roster. `added` must ignore it.
+    const { withTransaction } = recorder((sql) =>
+      sql === TOUCH_AUDIENCE_MEMBERS_SQL ? [{ user_id: "u1" }, { user_id: "u2" }] : [],
+    );
+    const result = await reconcileAudienceMembership(
+      { ...BASE, userIds: ["u1", "u2"] },
+      { withTransaction },
+    );
+
+    expect(result).toEqual({ added: 0, revoked: 0 });
+  });
+
+  it("keeps the insert non-destructive — `created_at` survives a re-sync", () => {
+    // Pinned on the SQL itself, because the failure mode is a one-word edit
+    // (`DO NOTHING` → `DO UPDATE`) whose damage — a rewritten `created_at`, so
+    // "since when has this person been able to see this?" becomes "since the
+    // last cycle" — is invisible to every behavioural assertion above.
+    expect(INSERT_AUDIENCE_MEMBERS_SQL).toContain("DO NOTHING");
+    expect(INSERT_AUDIENCE_MEMBERS_SQL).not.toContain("DO UPDATE");
+  });
+
+  it("scopes the touch by source, like the delete", async () => {
+    // Same reasoning as the DELETE's source scoping: a future second writer
+    // into the same audience must not have its rows marked verified by this
+    // one's read.
+    const { withTransaction, calls } = recorder();
+    await reconcileAudienceMembership({ ...BASE, userIds: ["u1"] }, { withTransaction });
+
+    const touch = calls.find((c) => c.sql === TOUCH_AUDIENCE_MEMBERS_SQL);
+    expect(touch?.params[2]).toBe("slack");
+  });
+
   it("scopes the delete by source as well as by audience", async () => {
     // 0180 keeps `source` out of the key because an audience belongs to one
     // source — but scoping the DELETE by it anyway means a future second writer
@@ -88,9 +152,15 @@ describe("reconcileAudienceMembership", () => {
       { ...BASE, userIds: ["u1", "u1", " u1 ", "", "  "] },
       { withTransaction },
     );
-    // Both statements see the same de-duplicated set, so `added`/`revoked` read
-    // as PEOPLE rather than as rows.
-    for (const call of calls) expect(call.params[2]).toEqual(["u1"]);
+    // Both ROSTER-carrying statements see the same de-duplicated set, so
+    // `added`/`revoked` read as PEOPLE rather than as rows. The touch takes no
+    // roster (it stamps whatever survived), hence the filter rather than a
+    // loop over every call.
+    const rosterCarrying = calls.filter(
+      (c) => c.sql === INSERT_AUDIENCE_MEMBERS_SQL || c.sql === DELETE_STALE_AUDIENCE_MEMBERS_SQL,
+    );
+    expect(rosterCarrying).toHaveLength(2);
+    for (const call of rosterCarrying) expect(call.params[2]).toEqual(["u1"]);
   });
 
   it("refuses a blank audience id at the writer", async () => {

--- a/packages/api/src/lib/brain/audience/__tests__/sync.test.ts
+++ b/packages/api/src/lib/brain/audience/__tests__/sync.test.ts
@@ -143,9 +143,15 @@ describe("runAudienceSyncCycle", () => {
   });
 
   it("does NOT reconcile when the roster read fails", async () => {
+    // A NON-retryable failure, deliberately. This test is about the generic
+    // abort — a failed read must never become an empty roster — and since
+    // #4809 the `ratelimited` arm backs off and retries first, which would
+    // make this one wait on a real `Retry-After` to prove a point that has
+    // nothing to do with throttling. The throttle path has its own tests in
+    // "rate-limit backoff (#4809)", including that exhaustion still aborts.
     const { deps, reconciled } = harness({
       fetchConversationMembersPage: () =>
-        Promise.resolve({ ok: false as const, error: "ratelimited", retryAfterSeconds: 30 }),
+        Promise.resolve({ ok: false as const, error: "not_in_channel", retryAfterSeconds: null }),
     });
     const result = await withDatabaseUrl(() => runAudienceSyncCycle(deps));
 
@@ -580,5 +586,202 @@ describe("gating and cadence", () => {
   it("falls back to the default interval on a non-positive or unparseable value", () => {
     // The setting's user-facing description promises this fallback.
     expect(getAudienceSyncIntervalMs()).toBe(DEFAULT_AUDIENCE_SYNC_INTERVAL_MS);
+  });
+});
+
+describe("rate-limit backoff (#4809)", () => {
+  /** A `sleep` that records what it was asked to wait, and returns instantly. */
+  function fakeSleep() {
+    const waits: number[] = [];
+    return { waits, sleep: (ms: number) => { waits.push(ms); return Promise.resolve(); } };
+  }
+
+  const rateLimited = (retryAfterSeconds: number | null) =>
+    Promise.resolve({ ok: false as const, error: "ratelimited" as const, retryAfterSeconds });
+
+  it("retries a throttled DIRECTORY page and completes the cycle", async () => {
+    // Before #4809 this single 429 aborted the whole workspace. Since the reads
+    // are ~`directoryPages + 3 × channels` per workspace every 30 minutes, a
+    // large workspace could plausibly hit one on EVERY cycle — in which case
+    // membership is never reconciled and revocation silently never happens.
+    const { waits, sleep } = fakeSleep();
+    let calls = 0;
+    const { deps, reconciled } = harness({
+      fetchUsersListPage: () => {
+        calls++;
+        return calls === 1 ? rateLimited(2) : ok({ users: DIRECTORY, nextCursor: null, dropped: 0 });
+      },
+    });
+    const result = await withDatabaseUrl(() => runAudienceSyncCycle({ ...deps, sleep }));
+
+    expect(result.status).toBe("success");
+    expect(result.workspacesFailed).toBe(0);
+    expect(reconciled).toHaveLength(1);
+    // Slack's own `Retry-After` is honoured, not a fixed guess.
+    expect(waits).toEqual([2000]);
+    // The recovery is VISIBLE: "we throttled and got through" must be
+    // distinguishable in the span from "we never throttled", or a workspace
+    // creeping toward permanent throttling looks identical to a healthy one.
+    expect(result.readsThrottled).toBe(1);
+    expect(result.readsThrottleExhausted).toBe(0);
+  });
+
+  it("retries a throttled ROSTER page and still reconciles that audience", async () => {
+    const { waits, sleep } = fakeSleep();
+    let calls = 0;
+    const { deps, reconciled } = harness({
+      fetchConversationMembersPage: () => {
+        calls++;
+        return calls === 1
+          ? rateLimited(1)
+          : ok({ memberIds: ["U_ADA", "U_GONE", "U_BOT"], nextCursor: null });
+      },
+    });
+    const result = await withDatabaseUrl(() => runAudienceSyncCycle({ ...deps, sleep }));
+
+    expect(result.audiencesFailed).toBe(0);
+    expect(reconciled).toHaveLength(1);
+    expect(waits).toEqual([1000]);
+    expect(result.readsThrottled).toBe(1);
+  });
+
+  it("falls back to the default wait when Slack sends no Retry-After", async () => {
+    const { waits, sleep } = fakeSleep();
+    let calls = 0;
+    const { deps } = harness({
+      fetchUsersListPage: () => {
+        calls++;
+        return calls === 1
+          ? rateLimited(null)
+          : ok({ users: DIRECTORY, nextCursor: null, dropped: 0 });
+      },
+    });
+    await withDatabaseUrl(() => runAudienceSyncCycle({ ...deps, sleep }));
+
+    expect(waits).toHaveLength(1);
+    expect(waits[0]).toBeGreaterThan(0);
+  });
+
+  it("ABORTS the workspace when the directory read exhausts its retries", async () => {
+    // The contract that licenses the DELETE. A retry loop that ended by
+    // proceeding with a partial read would be the mass revocation this
+    // subsystem has already produced three times — retrying buys more chances
+    // to COMPLETE the read, never permission to settle for less of one.
+    //
+    // Asserted on the RESOLVE CALL COUNT, not only on `workspacesFailed`: the
+    // workspace-level collapse check would report a failure here even with the
+    // abort removed, so a bare `workspacesFailed` assertion can pass while
+    // proving the backstop rather than this guard.
+    const { sleep } = fakeSleep();
+    let resolveCalls = 0;
+    const { deps, reconciled } = harness({ fetchUsersListPage: () => rateLimited(1) });
+    const result = await withDatabaseUrl(() =>
+      runAudienceSyncCycle({
+        ...deps,
+        sleep,
+        resolve: (_ws, principals) => {
+          resolveCalls++;
+          return Promise.resolve({ resolved: new Map(), unresolvedCount: principals.length });
+        },
+      }),
+    );
+
+    expect(result.workspacesFailed).toBe(1);
+    expect(reconciled).toHaveLength(0);
+    // Nothing downstream of the directory read ran at all.
+    expect(resolveCalls).toBe(0);
+    expect(result.readsThrottleExhausted).toBeGreaterThan(0);
+    // Exhaustion is NOT counted as a recovery.
+    expect(result.readsThrottled).toBe(0);
+  });
+
+  it("ABORTS a directory whose SECOND page exhausts — a partial directory is the dangerous shape", async () => {
+    // The sibling test above (`fetchUsersListPage` throttled from the very
+    // first page) is BACKSTOPPED: an exhaustion that wrongly returned an empty
+    // page would still be caught by `loadDirectory`'s no-live-humans guard, so
+    // it can pass while proving the backstop rather than the abort. Verified by
+    // mutation — removing the abort left that test green.
+    //
+    // This is the shape with no backstop. Page 1 returns real users and page 2
+    // exhausts: a "proceed with what we have" retry would yield a directory
+    // that is truncated but entirely PLAUSIBLE — non-empty, live humans, real
+    // emails. Every completeness guard passes, resolution succeeds, and then
+    // each roster member missing from the unread pages resolves to nobody and
+    // is REVOKED. That is the mass revocation, reached through a door the other
+    // guards cannot see.
+    const { sleep } = fakeSleep();
+    let resolveCalls = 0;
+    let page = 0;
+    const { deps, reconciled } = harness({
+      fetchUsersListPage: () => {
+        page++;
+        return page === 1
+          ? ok({ users: DIRECTORY, nextCursor: "cursor-2", dropped: 0 })
+          : rateLimited(1);
+      },
+    });
+    const result = await withDatabaseUrl(() =>
+      runAudienceSyncCycle({
+        ...deps,
+        sleep,
+        resolve: (_ws, principals) => {
+          resolveCalls++;
+          return Promise.resolve({
+            resolved: new Map(principals.map((p) => [p.id, `user-${p.id}`])),
+            unresolvedCount: 0,
+          });
+        },
+      }),
+    );
+
+    expect(result.workspacesFailed).toBe(1);
+    expect(reconciled).toHaveLength(0);
+    // The load-bearing assertion. `workspacesFailed` alone would NOT prove this
+    // — resolution never even being attempted is what says the partial
+    // directory was refused rather than used.
+    expect(resolveCalls).toBe(0);
+    expect(result.readsThrottleExhausted).toBeGreaterThan(0);
+  });
+
+  it("ABORTS only the audience when the roster read exhausts its retries", async () => {
+    // Per-audience isolation is preserved: the directory succeeded, so the
+    // workspace is fine — but the one channel whose roster could not be read
+    // must not be reconciled against a partial roster.
+    const { sleep } = fakeSleep();
+    const { deps, reconciled } = harness({
+      fetchConversationMembersPage: () => rateLimited(1),
+    });
+    const result = await withDatabaseUrl(() => runAudienceSyncCycle({ ...deps, sleep }));
+
+    expect(result.workspacesFailed).toBe(0);
+    expect(result.audiencesFailed).toBe(1);
+    // The whole point: membership for that audience is left EXACTLY as it was.
+    expect(reconciled).toHaveLength(0);
+    expect(result.readsThrottleExhausted).toBeGreaterThan(0);
+  });
+
+  it("bounds the retries rather than waiting on Slack forever", async () => {
+    // A scheduled fiber that retried indefinitely would hold the cycle open
+    // past its own interval and stack overlapping cycles.
+    const { waits, sleep } = fakeSleep();
+    let calls = 0;
+    const { deps } = harness({
+      fetchUsersListPage: () => {
+        calls++;
+        return rateLimited(1);
+      },
+    });
+    await withDatabaseUrl(() => runAudienceSyncCycle({ ...deps, sleep }));
+
+    expect(calls).toBeLessThanOrEqual(5);
+    expect(waits.length).toBeLessThan(calls);
+  });
+
+  it("reports no throttling for a clean cycle", async () => {
+    const { deps } = harness();
+    const result = await withDatabaseUrl(() => runAudienceSyncCycle(deps));
+
+    expect(result.readsThrottled).toBe(0);
+    expect(result.readsThrottleExhausted).toBe(0);
   });
 });

--- a/packages/api/src/lib/brain/audience/membership.ts
+++ b/packages/api/src/lib/brain/audience/membership.ts
@@ -29,10 +29,11 @@
  *
  * ## Idempotence
  *
- * Re-running against unchanged source membership writes nothing: the INSERT is
- * `ON CONFLICT DO NOTHING` on the natural key, and the DELETE's `<> ALL` set is
- * the full roster. Both counts come back zero, which is what a steady-state
- * cycle should report.
+ * Re-running against unchanged source membership grants and revokes nothing:
+ * the INSERT is `ON CONFLICT DO NOTHING` on the natural key, and the DELETE's
+ * `<> ALL` set is the full roster. Both counts come back zero, which is what a
+ * steady-state cycle should report — it re-stamps `synced_at` and changes
+ * nothing else.
  */
 
 import { createLogger } from "@atlas/api/lib/logger";
@@ -85,6 +86,35 @@ export const DELETE_STALE_AUDIENCE_MEMBERS_SQL = `DELETE FROM fact_audience_memb
           AND source = $4
           AND user_id <> ALL($3::text[])
     RETURNING user_id`;
+
+/**
+ * Stamp "verified now" on the surviving roster (#4808).
+ *
+ * A SEPARATE STATEMENT, and that is the whole design. The natural way to
+ * refresh `synced_at` on a re-sync is to turn the INSERT's `ON CONFLICT DO
+ * NOTHING` into `DO UPDATE SET synced_at = now()` — and it is a trap. `DO
+ * UPDATE` makes `RETURNING user_id` emit the WHOLE roster on every cycle, not
+ * just the genuinely-inserted rows, so {@link AudienceReconcileResult.added} —
+ * which is `rows.length` — silently stops meaning "newly granted" and starts
+ * meaning "everyone". The "membership granted" log line then fires every 30
+ * minutes and `atlas.brain.audience.members_added` stops meaning anything.
+ * Nothing errors; every existing assertion still passes. Hence the extra
+ * round trip: `added` keeps its meaning by construction rather than by a
+ * `WHERE xmax = 0` incantation someone later "simplifies" away.
+ *
+ * Runs AFTER the delete, so it stamps exactly the rows that survived
+ * reconciliation and does no work on ones about to be removed. Rows inserted
+ * by this same pass already carry the column default, and `now()` is
+ * transaction time, so all three statements agree on the instant.
+ *
+ * Scoped by `source` like the DELETE: a future second writer into the same
+ * audience must not have its rows marked verified by this one's read.
+ */
+export const TOUCH_AUDIENCE_MEMBERS_SQL = `UPDATE fact_audience_member
+           SET synced_at = now()
+         WHERE workspace_id = $1
+           AND audience_id = $2
+           AND source = $3`;
 
 /** How many revoked user ids a single log line carries. A bound, not a policy. */
 const REVOKED_SAMPLE_CAP = 50;
@@ -197,6 +227,12 @@ export async function reconcileAudienceMembership(
       userIds,
       source,
     ]);
+    // Inside the transaction, so "verified" is committed with the reconcile it
+    // attests to and can never outlive a rolled-back one. Reaching this line at
+    // all is the proof the caller established a COMPLETE roster — every
+    // incomplete read aborts in `sync.ts` without calling this function, which
+    // is what makes the column mean "last verified" rather than "last touched".
+    await tx.query(TOUCH_AUDIENCE_MEMBERS_SQL, [workspaceId, audienceId, source]);
     const result = { added: inserted.rows.length, revoked: deleted.rows.length };
     if (result.revoked > 0) {
       // A revocation is the security-relevant event in this subsystem and must

--- a/packages/api/src/lib/brain/audience/sync.ts
+++ b/packages/api/src/lib/brain/audience/sync.ts
@@ -45,6 +45,20 @@
  * safe direction: it neither grants nor revokes on a fault, and the next cycle
  * retries. ADR-0036 §T6's block-vs-flag asymmetry, applied to membership.
  *
+ * Two later amendments bound how long that can go on for, because "the previous
+ * membership stands" with no time limit means a channel Atlas was removed from
+ * keeps granting access forever:
+ *
+ *   - #4809 gives both reads a bounded `Retry-After` backoff, so a workspace
+ *     large enough to 429 on every cycle can still finish a read. Exhausting
+ *     the retries STILL ABORTS — retrying buys more chances to complete the
+ *     read, never permission to settle for less of one.
+ *   - #4808 stamps `synced_at` on every successful reconcile (including the
+ *     no-op case — "unchanged" is still "verified") and never on an abort, so
+ *     `acl.ts` can stop expanding an audience nobody has verified within
+ *     `ATLAS_BRAIN_AUDIENCE_MAX_STALENESS_HOURS`. Abort is still the safe
+ *     direction; it is simply no longer an indefinite one.
+ *
  * ## Why this is its own fiber
  *
  * Not folded into the history pass, which would only re-read a roster when a
@@ -63,8 +77,14 @@ import {
   type SlackDirectoryUser,
   type SlackReadError,
 } from "@atlas/api/lib/slack/api";
+import { ConnectorRateLimitError } from "@atlas/api/lib/knowledge/connectors";
+import { withRateLimitBackoff } from "@atlas/api/lib/knowledge/connector-sync";
 import { getBotToken, getInstallationByOrg } from "@atlas/api/lib/slack/store";
-import { parseGrant } from "@atlas/api/lib/brain/acl";
+import {
+  DEFAULT_AUDIENCE_MAX_STALENESS_HOURS,
+  getAudienceMaxStalenessSeconds,
+  parseGrant,
+} from "@atlas/api/lib/brain/acl";
 import {
   deriveChatChannelGrant,
   type ChatChannelVisibility,
@@ -112,6 +132,94 @@ function liveHumans(
   directory: ReadonlyMap<string, SlackDirectoryUser>,
 ): readonly SlackDirectoryUser[] {
   return [...directory.values()].filter(isLiveHuman);
+}
+
+// ---------------------------------------------------------------------------
+// Rate-limit backoff (#4809) — an ADAPTER onto the engine's, not a second one
+// ---------------------------------------------------------------------------
+
+/** Injectable sleep, so the backoff tests do not actually wait. */
+export type Sleep = (ms: number) => Promise<void>;
+
+/**
+ * Per-cycle throttle tally.
+ *
+ * Lives at CYCLE level rather than inside `syncInstall`, because the case worth
+ * seeing is the one where the directory read exhausts its retries and
+ * `syncInstall` throws — a tally owned by the frame that dies with it would be
+ * lost in exactly the "this workspace 429s on every cycle and never
+ * reconciles" scenario #4809 is about.
+ *
+ * Mutable by design: it is an accumulator threaded through two paginated loops
+ * and one throw, and the alternative (reshaping three return types to carry
+ * counters through an abort path) buys nothing.
+ */
+interface ThrottleTally {
+  /** Reads that hit at least one 429 and then SUCCEEDED — recovered, not lost. */
+  throttled: number;
+  /** Reads that exhausted the bounded retries and aborted their scope. */
+  exhausted: number;
+}
+
+/**
+ * Run one paginated Slack read under the shared bounded backoff.
+ *
+ * The seam that makes reuse possible: `withRateLimitBackoff` catches a THROWN
+ * {@link ConnectorRateLimitError}, but these two read methods RETURN
+ * `{ ok: false, error: "ratelimited", retryAfterSeconds }` instead. So the
+ * conversion happens here, in the same direction
+ * `brain/ingest/slack/client.ts::toClientError` already converts for the
+ * sibling history reads on this same vendor — one backoff implementation for
+ * the whole codebase, per ADR-0030's rejection of per-vendor scheduling.
+ *
+ * ## Exhaustion still ABORTS
+ *
+ * On exhaustion this hands back the SAME `ratelimited` shape the caller already
+ * had, so every completeness guard downstream is untouched: the directory read
+ * skips the workspace, the roster read skips the audience, and membership is
+ * left alone. That is not a detail — the DELETE in `membership.ts` is licensed
+ * ONLY by a complete read, and a retry loop that ended by proceeding with a
+ * partial page would be the mass revocation this subsystem has already produced
+ * three times. Retrying buys more chances to complete the read; it must never
+ * buy permission to settle for less of one.
+ */
+async function readPageWithBackoff<T extends { readonly ok: true }>(
+  fetchPage: () => Promise<T | SlackReadError>,
+  context: string,
+  tally: ThrottleTally,
+  sleep?: Sleep,
+): Promise<T | SlackReadError> {
+  let throttledHere = false;
+  try {
+    const result = await withRateLimitBackoff(
+      async () => {
+        const page = await fetchPage();
+        if (!page.ok && page.error === "ratelimited") {
+          throttledHere = true;
+          throw new ConnectorRateLimitError(
+            `Slack is rate limiting ${context}`,
+            page.retryAfterSeconds,
+          );
+        }
+        return page;
+      },
+      { ...(sleep !== undefined ? { sleep } : {}) },
+    );
+    // Reached only by a page that did NOT end in `ratelimited`, so a true flag
+    // here means "backed off, then got through".
+    if (throttledHere) tally.throttled++;
+    return result;
+  } catch (err) {
+    if (err instanceof ConnectorRateLimitError) {
+      tally.exhausted++;
+      log.warn(
+        { context, retryAfterSeconds: err.retryAfterSeconds },
+        "brain audience: Slack rate limit survived the bounded backoff — aborting this read rather than reconciling against a partial one",
+      );
+      return { ok: false, error: "ratelimited", retryAfterSeconds: err.retryAfterSeconds };
+    }
+    throw err;
+  }
 }
 
 /** Scopes the directory read needs — new in #4801, so the likeliest failure. */
@@ -198,6 +306,36 @@ export interface AudienceSyncCycleResult {
   readonly membersAdded: number;
   readonly membersRevoked: number;
   readonly principalsUnresolved: number;
+  /**
+   * Paginated reads that hit a 429, backed off, and then SUCCEEDED (#4809).
+   *
+   * The point of separating this from {@link readsThrottleExhausted}: a cycle
+   * that backed off and recovered is healthy — Slack throttled us and the
+   * bounded retry absorbed it — while one that exhausted is the beginning of
+   * "this workspace never reconciles". Before #4809 both looked identical from
+   * the span, because there was no retry and every 429 was simply an abort.
+   */
+  readonly readsThrottled: number;
+  /** Reads that exhausted the bounded retries and aborted their scope. */
+  readonly readsThrottleExhausted: number;
+  /**
+   * Audiences whose membership has not been verified within the staleness
+   * bound (#4808), across every workspace — `null` if the sweep itself failed.
+   *
+   * `null` rather than `0` on failure, deliberately: a sweep that could not run
+   * must not report the all-clear that a healthy deployment reports.
+   */
+  readonly staleAudiences: number | null;
+  /** Distinct workspaces holding at least one stale audience; `null` as above. */
+  readonly staleWorkspaces: number | null;
+  /**
+   * Age of the LEAST recently verified audience in the deployment, in seconds.
+   *
+   * The number that turns "some roster read is failing" into "and it has been
+   * failing for eleven days" — i.e. into a thing with a deadline, since past
+   * the bound those grants stop being served.
+   */
+  readonly oldestVerifiedAgeSeconds: number | null;
   readonly error?: string;
 }
 
@@ -211,7 +349,112 @@ const ZERO: Omit<AudienceSyncCycleResult, "status"> = {
   membersAdded: 0,
   membersRevoked: 0,
   principalsUnresolved: 0,
+  readsThrottled: 0,
+  readsThrottleExhausted: 0,
+  staleAudiences: null,
+  staleWorkspaces: null,
+  oldestVerifiedAgeSeconds: null,
 };
+
+/**
+ * The staleness sweep behind the span's `stale_*` attributes (#4808).
+ *
+ * `min(synced_at)` per audience is the conservative reading — an audience is as
+ * verified as its least recently verified row — and matches what `acl.ts`'s
+ * read-time bound tests, so the alert and the enforcement cannot disagree about
+ * which audiences are stale.
+ *
+ * Deployment-wide rather than per-workspace: span attributes are scalars, and
+ * `workspace_id` is unbounded cardinality. The counts say HOW MUCH and the log
+ * line that follows names the worst offenders.
+ *
+ * Exported so the real-Postgres test runs this exact string against the live
+ * schema — the aggregate shape is easy to get subtly wrong (a `WHERE` on
+ * `synced_at` instead of a `HAVING` on the grouped minimum would silently
+ * count rows rather than audiences).
+ */
+export const AUDIENCE_STALENESS_SQL = `
+  WITH audience AS (
+    SELECT workspace_id, audience_id, min(synced_at) AS verified_at
+      FROM fact_audience_member
+     GROUP BY workspace_id, audience_id
+  )
+  SELECT count(*)::int AS stale_audiences,
+         count(DISTINCT workspace_id)::int AS stale_workspaces,
+         COALESCE(EXTRACT(EPOCH FROM (now() - min(verified_at)))::bigint, 0) AS oldest_age_seconds
+    FROM audience
+   WHERE verified_at < now() - make_interval(secs => $1::double precision)`;
+
+interface StalenessRow extends Record<string, unknown> {
+  readonly stale_audiences: number;
+  readonly stale_workspaces: number;
+  readonly oldest_age_seconds: string | number;
+}
+
+/** What the staleness sweep found. All-`null` means it could not run. */
+interface StalenessReport {
+  readonly staleAudiences: number | null;
+  readonly staleWorkspaces: number | null;
+  readonly oldestVerifiedAgeSeconds: number | null;
+}
+
+const NO_STALENESS_REPORT: StalenessReport = {
+  staleAudiences: null,
+  staleWorkspaces: null,
+  oldestVerifiedAgeSeconds: null,
+};
+
+/**
+ * Count audiences past the staleness bound, for the span.
+ *
+ * Never throws: a failed sweep degrades the OBSERVABILITY of the cycle, and
+ * failing the cycle over it would take the reconcile down with the dashboard.
+ * It reports `null` instead — see {@link AudienceSyncCycleResult.staleAudiences}
+ * for why not `0`.
+ *
+ * When enforcement is switched OFF (`ATLAS_BRAIN_AUDIENCE_MAX_STALENESS_HOURS`
+ * = 0) the sweep falls back to the DEFAULT bound rather than reporting nothing.
+ * An operator who disabled enforcement to survive an incident is precisely the
+ * one who still needs to see how stale things are getting — losing the alert
+ * along with the enforcement would leave them flying blind on the condition
+ * they just chose to tolerate.
+ */
+async function sweepStaleness(
+  query: <T extends Record<string, unknown>>(sql: string, params?: unknown[]) => Promise<T[]>,
+): Promise<StalenessReport> {
+  const configured = getAudienceMaxStalenessSeconds();
+  const boundSeconds = configured > 0 ? configured : DEFAULT_AUDIENCE_MAX_STALENESS_HOURS * 3600;
+  try {
+    const rows = await query<StalenessRow>(AUDIENCE_STALENESS_SQL, [boundSeconds]);
+    const row = rows[0];
+    if (row === undefined) return NO_STALENESS_REPORT;
+    // The counts are VALIDATED, not trusted. An aggregate whose shape drifted
+    // would otherwise put `undefined` on the span, which renders as "no data" —
+    // indistinguishable from a healthy deployment, and hiding precisely the
+    // number this sweep exists to show. `null` + a warn says "we do not know".
+    if (typeof row.stale_audiences !== "number" || typeof row.stale_workspaces !== "number") {
+      log.warn(
+        { row },
+        "brain audience: staleness sweep returned an unexpected row shape — its counters are unavailable",
+      );
+      return NO_STALENESS_REPORT;
+    }
+    // `count(*)` is `::int` so pg hands back a number, but `EXTRACT(...)::bigint`
+    // comes back as a STRING (pg maps int8 to string to preserve precision).
+    const oldest = Number(row.oldest_age_seconds);
+    return {
+      staleAudiences: row.stale_audiences,
+      staleWorkspaces: row.stale_workspaces,
+      oldestVerifiedAgeSeconds: Number.isFinite(oldest) ? oldest : null,
+    };
+  } catch (err) {
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err) },
+      "brain audience: staleness sweep failed — the cycle ran, but its staleness counters are unavailable",
+    );
+    return NO_STALENESS_REPORT;
+  }
+}
 
 /** The vendor surface one workspace's sync needs — injectable for tests. */
 export interface AudienceSyncApi {
@@ -239,6 +482,8 @@ export interface AudienceSyncDeps {
   readonly resolveToken?: (workspaceId: string) => Promise<string>;
   readonly reconcile?: typeof reconcileAudienceMembership;
   readonly resolve?: typeof resolvePrincipals;
+  /** Test-only backoff sleep, so the #4809 retry tests do not actually wait. */
+  readonly sleep?: Sleep;
 }
 
 /**
@@ -306,14 +551,22 @@ async function loadDirectory(
   api: AudienceSyncApi,
   token: string,
   workspaceId: string,
+  tally: ThrottleTally,
+  sleep?: Sleep,
 ): Promise<DirectoryResult> {
   const byId = new Map<string, SlackDirectoryUser>();
   let cursor: string | undefined;
   for (let page = 0; page < MAX_DIRECTORY_PAGES; page++) {
-    const result = await api.fetchUsersListPage(token, {
-      limit: PAGE_LIMIT,
-      ...(cursor !== undefined ? { cursor } : {}),
-    });
+    const result = await readPageWithBackoff(
+      () =>
+        api.fetchUsersListPage(token, {
+          limit: PAGE_LIMIT,
+          ...(cursor !== undefined ? { cursor } : {}),
+        }),
+      `the Slack directory for workspace ${workspaceId}`,
+      tally,
+      sleep,
+    );
     if (!result.ok) {
       const reason = describeSlackError(result, DIRECTORY_SCOPES);
       log.warn(
@@ -400,15 +653,23 @@ async function loadRoster(
   token: string,
   workspaceId: string,
   channelId: string,
+  tally: ThrottleTally,
+  sleep?: Sleep,
 ): Promise<string[] | null> {
   const memberIds: string[] = [];
   let cursor: string | undefined;
   for (let page = 0; page < MAX_ROSTER_PAGES; page++) {
-    const result = await api.fetchConversationMembersPage(token, {
-      channel: channelId,
-      limit: PAGE_LIMIT,
-      ...(cursor !== undefined ? { cursor } : {}),
-    });
+    const result = await readPageWithBackoff(
+      () =>
+        api.fetchConversationMembersPage(token, {
+          channel: channelId,
+          limit: PAGE_LIMIT,
+          ...(cursor !== undefined ? { cursor } : {}),
+        }),
+      `the roster of channel ${channelId}`,
+      tally,
+      sleep,
+    );
     if (!result.ok) {
       log.warn(
         { workspaceId, channelId, reason: describeSlackError(result, CHANNEL_SCOPES) },
@@ -495,7 +756,10 @@ const ZERO_WORKSPACE: WorkspaceOutcome = {
  */
 async function syncInstall(
   row: InstallRow,
-  deps: Required<Pick<AudienceSyncDeps, "api" | "resolveToken" | "reconcile" | "resolve">>,
+  deps: Required<Pick<AudienceSyncDeps, "api" | "resolveToken" | "reconcile" | "resolve">> & {
+    readonly sleep?: Sleep;
+  },
+  tally: ThrottleTally,
 ): Promise<WorkspaceOutcome> {
   const workspaceId = row.workspace_id;
   const parsed = parseSlackHistoryConfig(row.config);
@@ -507,7 +771,7 @@ async function syncInstall(
   }
 
   const token = await deps.resolveToken(workspaceId);
-  const loaded = await loadDirectory(deps.api, token, workspaceId);
+  const loaded = await loadDirectory(deps.api, token, workspaceId, tally, deps.sleep);
   if (!loaded.ok) throw new Error(`Slack directory unavailable — ${loaded.reason}`);
   const directory = loaded.directory;
 
@@ -580,7 +844,14 @@ async function syncInstall(
       }
       const audienceId = target.audienceId;
 
-      const roster = await loadRoster(deps.api, token, workspaceId, channelId);
+      const roster = await loadRoster(
+        deps.api,
+        token,
+        workspaceId,
+        channelId,
+        tally,
+        deps.sleep,
+      );
       if (roster === null) {
         out = { ...out, audiencesFailed: out.audiencesFailed + 1 };
         continue;
@@ -663,7 +934,11 @@ export async function runAudienceSyncCycle(
         resolveSlackHistoryToken({ getInstallationByOrg, getBotToken }, workspaceId)),
     reconcile: deps.reconcile ?? reconcileAudienceMembership,
     resolve: deps.resolve ?? resolvePrincipals,
+    ...(deps.sleep !== undefined ? { sleep: deps.sleep } : {}),
   };
+  // One tally for the whole cycle — see {@link ThrottleTally} for why it is not
+  // owned by `syncInstall`, whose frame dies on an exhausted directory read.
+  const tally: ThrottleTally = { throttled: 0, exhausted: 0 };
   const isEnabled = deps.isEnabled ?? isAudienceSyncEnabled;
 
   let installs: InstallRow[];
@@ -683,7 +958,7 @@ export async function runAudienceSyncCycle(
     }
     result = { ...result, workspacesInspected: result.workspacesInspected + 1 };
     try {
-      const out = await syncInstall(row, resolved);
+      const out = await syncInstall(row, resolved, tally);
       result = {
         ...result,
         audiencesReconciled: result.audiencesReconciled + out.audiencesReconciled,
@@ -706,9 +981,33 @@ export async function runAudienceSyncCycle(
     }
   }
 
+  // Swept unconditionally, including when there are no installs left to sync.
+  // An install that was disabled or archived stops being reconciled but its
+  // membership rows stay — and stay stale — so "no installs" is one of the ways
+  // an audience quietly ages past the bound. A sweep gated on `installs.length`
+  // would go silent in exactly that case.
+  const staleness = await sweepStaleness(query);
+  result = {
+    ...result,
+    readsThrottled: tally.throttled,
+    readsThrottleExhausted: tally.exhausted,
+    ...staleness,
+  };
+
   if (installs.length > 0) {
     log.info({ ...result }, "brain audience: membership sync cycle complete");
   }
+  if (staleness.staleAudiences !== null && staleness.staleAudiences > 0) {
+    log.warn(
+      { ...staleness, maxStalenessSeconds: getAudienceMaxStalenessSeconds() },
+      "brain audience: audiences past the staleness bound — their grants are being suppressed at read time until a sync succeeds. Look for a failing roster read or a disabled install in these workspaces",
+    );
+  }
+  // `status` stays a statement about THIS CYCLE's work, so staleness does not
+  // feed it: an audience left behind by an install someone archived last month
+  // is a real condition to alert on, but it is not this cycle failing at
+  // anything, and folding it in would make `degraded` permanent and therefore
+  // ignorable. It gets its own counters and its own log line instead.
   const degraded = result.workspacesFailed > 0 || result.audiencesFailed > 0;
   return { status: degraded ? "degraded" : "success", ...result };
 }

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -243,7 +243,10 @@ describe("runMigrations", () => {
     //   Plus 0181 (brain_facts.fts / brain_episodes.fts stored generated
     //   tsvectors + GIN indexes for the `searchBrain` lexical tier, ADR-0036,
     //   #4773) = 182.
-    expect(count).toBe(182);
+    //   Plus 0182 (fact_audience_member.synced_at + its staleness index — the
+    //   "last VERIFIED" clock that bounds how long a permanently-failing
+    //   roster read can keep granting access, #4808) = 183.
+    expect(count).toBe(183);
 
     // Advisory lock acquired before anything else
     expect(queries[0]).toContain("pg_advisory_lock");
@@ -454,6 +457,7 @@ describe("runMigrations", () => {
         "0179_drop_conversations_notebook_state.sql",
         "0180_brain_substrate.sql",
         "0181_brain_fts.sql",
+        "0182_audience_member_synced_at.sql",
       ],
     });
 

--- a/packages/api/src/lib/db/migrations/0182_audience_member_synced_at.sql
+++ b/packages/api/src/lib/db/migrations/0182_audience_member_synced_at.sql
@@ -1,0 +1,42 @@
+-- 0182 — a staleness bound on audience membership (#4808).
+--
+-- 0180 gave `fact_audience_member` a `created_at` ("since when has this person
+-- been able to see this?") but nothing that answers "and when did we last CHECK
+-- that they still should?". Those are different questions, and only the second
+-- one bounds a failure.
+--
+-- The sync (#4801, `lib/brain/audience/`) is correctly fail-safe: a roster read
+-- it cannot complete aborts that audience and leaves membership untouched,
+-- because a truncated read would otherwise REVOKE the members it failed to
+-- fetch. But "leaves it untouched" has no time bound. If the bot is removed
+-- from a private channel, the channel is archived, or the token is revoked,
+-- `loadRoster` fails on every cycle forever and the audience keeps granting
+-- access indefinitely — and nothing in the schema could tell that apart from an
+-- audience reconciled thirty seconds ago.
+--
+-- `synced_at` means LAST VERIFIED, never "last touched". It is stamped on every
+-- SUCCESSFUL reconcile including the no-op case (an unchanged roster is still a
+-- verified one) and left alone on every abort path. Backwards, the column would
+-- read healthiest for exactly the workspaces that are broken.
+--
+-- Read-time enforcement lives in `lib/brain/acl.ts`'s `AUDIENCE_MEMBERSHIP_SQL`,
+-- NOT here and not in the sync: a guard inside the component that is failing
+-- cannot fire. Past `ATLAS_BRAIN_AUDIENCE_MAX_STALENESS_HOURS` (default 168 =
+-- 7 days, `0` disables) the grant is suppressed — and COUNTED and warned, not
+-- silently dropped, which is what keeps it consistent with that module's stated
+-- refusal to downgrade a reader without saying so.
+--
+-- `DEFAULT now()` backfills existing rows as freshly verified. Deliberate: the
+-- alternative (NULL, or an epoch default) would expire every audience in every
+-- workspace the moment this deploys, which is the mass revocation the whole
+-- subsystem is built to avoid — and it would do it on no evidence, since a row
+-- written before this migration was in fact verified when it was written.
+ALTER TABLE fact_audience_member
+  ADD COLUMN IF NOT EXISTS synced_at timestamptz NOT NULL DEFAULT now();
+
+-- "Which audiences in this workspace have not been verified lately?" — the
+-- per-cycle staleness sweep that puts the oldest verification on the
+-- `brain_audience_sync` span, so an operator sees a stuck roster read before it
+-- ages past the threshold and starts denying reads.
+CREATE INDEX IF NOT EXISTS idx_fact_audience_member_stale
+  ON fact_audience_member (workspace_id, synced_at);

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -3476,11 +3476,22 @@ export const factAudienceMember = pgTable(
     // re-sync's reconciliation and answers "why can this person see that?".
     source: text("source").notNull(),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    // When this membership was last VERIFIED against the source — not when the
+    // row was last touched (0182, #4808). Stamped on every successful
+    // reconcile INCLUDING the no-op case, and left alone on every abort path,
+    // so a permanently-failing roster read ages visibly instead of looking
+    // identical to one reconciled seconds ago. Read-time enforcement is in
+    // `lib/brain/acl.ts`; see the migration for why the default backfills as
+    // fresh rather than expired.
+    syncedAt: timestamp("synced_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (t) => [
     primaryKey({ columns: [t.workspaceId, t.audienceId, t.userId] }),
     // "Which audiences is this user in?" — the per-request principal expansion
     // the visibility predicate performs before it can push anything down.
     index("idx_fact_audience_member_user").on(t.workspaceId, t.userId),
+    // "Which audiences here have not been verified lately?" — the per-cycle
+    // staleness sweep behind the `brain_audience_sync` span attributes.
+    index("idx_fact_audience_member_stale").on(t.workspaceId, t.syncedAt),
   ],
 );

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -2443,6 +2443,21 @@ export function makeSchedulerLive(
           // be distinguishable from the span alone.
           "atlas.brain.audience.members_revoked": result.membersRevoked,
           "atlas.brain.audience.principals_unresolved": result.principalsUnresolved,
+          // #4809: a cycle that backed off and RECOVERED versus one that gave
+          // up. Before the backoff existed both looked like an abort, so
+          // "Slack throttles us occasionally" and "this workspace has not
+          // reconciled in a week" were the same signal.
+          "atlas.brain.audience.reads_throttled": result.readsThrottled,
+          "atlas.brain.audience.reads_throttle_exhausted": result.readsThrottleExhausted,
+          // #4808: the staleness bound made observable. `audiences_failed`
+          // says a roster read is failing; these say for HOW LONG, and how
+          // close it is to the point where `acl.ts` stops serving those grants.
+          // `-1` encodes "the sweep could not run" — span attributes have no
+          // null, and reporting 0 would be indistinguishable from all-clear.
+          "atlas.brain.audience.stale_audiences": result.staleAudiences ?? -1,
+          "atlas.brain.audience.stale_workspaces": result.staleWorkspaces ?? -1,
+          "atlas.brain.audience.oldest_verified_age_seconds":
+            result.oldestVerifiedAgeSeconds ?? -1,
         }),
         onTickFailure: {
           level: "warn",

--- a/packages/api/src/lib/settings.ts
+++ b/packages/api/src/lib/settings.ts
@@ -1782,10 +1782,35 @@ const SETTINGS_REGISTRY: SettingDefinition[] = [
     section: "Knowledge Base",
     label: "Company Brain Audience Sync Interval",
     description:
-      "How often private chat channels' membership is re-read from the source, in minutes (default 30). This is also the shortest delay between someone leaving a channel and losing access to facts drawn from it — a channel whose roster cannot be read keeps its membership until it can. Applies at restart; non-positive or unparseable values fall back to the default.",
+      "How often private chat channels' membership is re-read from the source, in minutes (default 30). This is also the shortest delay between someone leaving a channel and losing access to facts drawn from it — a channel whose roster cannot be read keeps its membership until it can, up to the staleness limit below. Applies at restart; non-positive or unparseable values fall back to the default.",
     type: "number",
     default: "30",
     envVar: "ATLAS_BRAIN_AUDIENCE_SYNC_INTERVAL_MINUTES",
+    scope: "platform",
+    saasVisible: false,
+  },
+  {
+    // The time bound on the interval knob's promise (#4808). Without it, "the
+    // answer is one interval" holds only while the roster reads SUCCEED — a
+    // channel Atlas was removed from fails every cycle forever and keeps
+    // granting access on a roster nobody has been able to verify since.
+    //
+    // Platform-scoped, not workspace: it is a floor the operator sets. A
+    // workspace admin raising their own staleness tolerance is precisely the
+    // self-serving direction, and lowering it is not a decision they have the
+    // signals to make.
+    //
+    // 7 days ≈ 336 default intervals — long enough that a Slack outage, a
+    // token rotation, or a weekend of 429s resolves well inside it, so what
+    // remains at expiry is an abandoned connection, which SHOULD stop granting.
+    key: "ATLAS_BRAIN_AUDIENCE_MAX_STALENESS_HOURS",
+    section: "Knowledge Base",
+    label: "Company Brain Audience Staleness Limit",
+    description:
+      "How long a private chat channel's membership stays valid after Atlas last verified it against the source, in hours (default 168 = 7 days). Past this, facts drawn from that channel stop being readable through its membership until a sync succeeds again — so a channel Atlas has lost access to cannot keep granting access indefinitely. Suppressed grants are logged and counted, never dropped silently. Set to 0 to disable the limit and rely on the sync-cycle alerts alone.",
+    type: "number",
+    default: "168",
+    envVar: "ATLAS_BRAIN_AUDIENCE_MAX_STALENESS_HOURS",
     scope: "platform",
     saasVisible: false,
   },


### PR DESCRIPTION
Two `#4801` follow-ups, shipped together because they are two halves of one gap: **#4808** makes stale membership visible and enforceable, **#4809** removes its most likely cause. Either alone still leaves "revocation latency is one interval" false.

Targets `milestone/v0.2.0-brain-m1`. `Closes` does not fire on a milestone-branch merge — **both issues need closing by hand.**

---

## The design question #4808 left open — resolved: fail closed

Stale membership now **fails closed at read time**, 7-day default, enforced in `acl.ts`'s `AUDIENCE_MEMBERSHIP_SQL`.

Enforced there and **not in the sync**, because a guard inside the component that is failing cannot fire.

Why fail-closed over alert-only, given it can cost a workspace its own private-channel facts:

- **The security failure is silent; the support failure is loud.** After this PR an operator has `stale_audiences`, `oldest_verified_age_seconds`, and a warn line naming the workspace. Unbounded stale access has no signal at all.
- **The blast radius is narrower than "loses access to its own facts."** Only `audience:` grants are suppressed — `[org]` and per-user grants keep serving. It is scoped to exactly the thing that is unverified.
- **#4809 removes the likeliest spurious trigger.** What survives 7 days is a token revoked, a bot removed, a channel archived — an abandoned connection, which arguably *should* stop granting.
- **There is a hot-reloadable escape hatch.** `ATLAS_BRAIN_AUDIENCE_MAX_STALENESS_HOURS` (platform-scoped, `0` disables) restores reads with no redeploy.

Suppression is **counted and warned with its audience ids**, never a silently shorter list — that is what reconciles it with the same function's documented refusal to downgrade a reader without saying so on a DB error. The objection there is to *silence*, not to denial.

## #4808 — `synced_at`

`synced_at` means **last VERIFIED**, never "last touched": stamped on every successful reconcile **including the no-op case**, untouched on every abort. Backwards, the column would read healthiest for exactly the workspaces that are broken.

⚠️ **The trap.** It is stamped by a *separate* `UPDATE`, not by widening the INSERT's `ON CONFLICT DO NOTHING` into `DO UPDATE SET synced_at = now()`. `DO UPDATE` makes `RETURNING user_id` emit the **whole roster every cycle**, so `added` (= `rows.length`) silently stops meaning "newly granted" and starts meaning "everyone" — the "membership granted" log fires every 30 minutes and `members_added` stops meaning anything. Nothing errors; every pre-existing test still passes. The pg idempotence test now pins `added: 0, revoked: 0` **and** that `synced_at` advanced while `created_at` did not.

Freshness is computed in SQL so the comparison uses the **database's** clock on both sides — skew in the generous direction would silently extend every grant, the one direction this bound exists to close.

Migration `0182` + `schema.ts` mirror in the same commit. `DEFAULT now()` backfills existing rows as fresh; NULL or an epoch default would expire every audience in every workspace on deploy.

## #4809 — Retry-After

Both paginated reads go through `withRateLimitBackoff` via an adapter at the loop boundary: they **return** `{ok:false, error:"ratelimited"}` rather than throwing, so the conversion follows the direction `brain/ingest/slack/client.ts` already converts. One backoff implementation, per ADR-0030.

⚠️ Exhausting the retries **still ABORTS** — workspace for the directory, audience for the roster. Retrying buys more chances to *complete* a read, never permission to settle for less of one.

## Verification — mutation probes

Every new guard was probed by deletion, checking *which* test failed:

| Mutation | Caught by |
|---|---|
| `DO NOTHING` → `DO UPDATE`, touch removed | 6 tests, incl. pg `added: 0` |
| Touch removed only | pg idempotence (`synced_at` never advances) |
| Stale treated as granted | acl unit + pg suppression |
| Exhaustion proceeds with a partial page | both abort tests |

**The probe found a real weakness.** The directory-abort test was **backstopped** by `loadDirectory`'s no-live-humans guard — an exhaustion that wrongly returned an *empty* page still failed the workspace, so the test passed with the abort removed. Added a second test where exhaustion happens on **page 2, after real users on page 1**: a truncated but entirely *plausible* directory, the shape with no backstop, where every completeness guard passes and each unread member is then revoked. It asserts the resolve **call count**, and it fails under the mutation.

## Gates

`schema-drift` · `migration-rename-discipline` · `settings-readers` · `test-discipline` · `saas-env-doc` · `ee-imports` · `lint` · `lint:type-aware` · `bun run type` — all green. `migrate-pg` (114 tests) verified standalone against a clean scratch DB.

Fixed one **real** test failure the affected run surfaced: `auth/__tests__/migrate.test.ts`'s applied-migrations fixture. Distinct from the ~11 local `-pg` pool-contention flakes, each of which was confirmed passing standalone.

Refs #4808, #4809