### PR TITLE
feat(api): observe entirely-malformed brain grants — the deny+log gap a push-down predicate leaves open (#4797)

### DIFF
--- a/packages/api/src/lib/brain/__tests__/grant-sweep-logging.test.ts
+++ b/packages/api/src/lib/brain/__tests__/grant-sweep-logging.test.ts
@@ -1,0 +1,238 @@
+/**
+ * The "log" half of #4797 — the sweep's actual deliverable.
+ *
+ * Split into its own file for the same reason as `acl-logging.test.ts`: it
+ * needs `mock.module("@atlas/api/lib/logger")` installed before the module
+ * under test is imported, and the sibling suites deliberately run with no
+ * module mocking at all.
+ *
+ * Why it exists rather than trusting the log calls to stay put: EVERY
+ * `log.warn` in `grant-sweep.ts` could be deleted and both sibling suites
+ * would stay green — verified by replacing the module's logger with a no-op,
+ * which left `22 pass / 0 fail`. That is a worse hole here than in `acl.ts`.
+ * There, the log is the reporting half of an enforcement that is structural
+ * either way; HERE the log IS the product. The module writes nothing, gates
+ * nothing, and repairs nothing — a count on a span and this line are its
+ * entire output, and the line is the only half that names the rows an operator
+ * has to go fix.
+ *
+ * The digest contract is also a behavioural claim and is pinned here: the
+ * module's whole cadence argument (daily, not the audience sync's 30m) rests on
+ * a clean cycle being SILENT. A sweep that warned every cycle regardless would
+ * be the alert fatigue the design went out of its way to avoid.
+ *
+ * Every VALUE export of `lib/logger.ts` is stubbed, per the mock-all-exports
+ * rule — a partial factory works right up until some module in the import
+ * graph reaches a missing name and fails at link time with `Export named 'X'
+ * not found` in a file that has nothing to do with this one.
+ */
+
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+
+type LogCall = { level: "error" | "warn" | "info" | "debug"; payload: unknown; message: string };
+const logCalls: LogCall[] = [];
+
+void mock.module("@atlas/api/lib/logger", () => ({
+  createLogger: () => ({
+    error: (payload: unknown, message: string) => logCalls.push({ level: "error", payload, message }),
+    warn: (payload: unknown, message: string) => logCalls.push({ level: "warn", payload, message }),
+    info: (payload: unknown, message: string) => logCalls.push({ level: "info", payload, message }),
+    debug: (payload: unknown, message: string) => logCalls.push({ level: "debug", payload, message }),
+  }),
+  getLogger: () => ({ error: () => {}, warn: () => {}, info: () => {}, debug: () => {}, level: "info" }),
+  setLogLevel: () => true,
+  getRequestContext: () => undefined,
+  ACTOR_KINDS: ["human", "agent", "mcp", "scheduler", "api_key"] as const,
+  withRequestContext: <T,>(_ctx: unknown, fn: () => T): T => fn(),
+  redactPaths: [] as string[],
+  scrubErrSerializer: (value: unknown) => value,
+  scrubLogFormatter: (obj: unknown) => obj,
+  hashShareToken: (token: string) => token,
+}));
+
+const { runGrantSweepCycle, getGrantSweepIntervalMs, MAX_TIMER_DELAY_MS } = await import(
+  "@atlas/api/lib/brain/grant-sweep"
+);
+const { ACL_GATED_TABLES } = await import("@atlas/api/lib/brain/acl");
+
+type Row = {
+  readonly workspace_id: string;
+  readonly id: string;
+  readonly visible_to: readonly unknown[];
+  readonly status: string | null;
+};
+
+const row = (id: string, visibleTo: readonly unknown[], workspaceId = "ws-1"): Row => ({
+  workspace_id: workspaceId,
+  id,
+  visible_to: visibleTo,
+  status: null,
+});
+
+function withDatabaseUrl<T>(fn: () => Promise<T>): Promise<T> {
+  const prior = process.env.DATABASE_URL;
+  process.env.DATABASE_URL = "postgres://stub/stub";
+  return fn().finally(() => {
+    if (prior === undefined) delete process.env.DATABASE_URL;
+    else process.env.DATABASE_URL = prior;
+  });
+}
+
+const sweep = (byTable: Partial<Record<string, readonly Row[]>>, rowCap?: number) =>
+  withDatabaseUrl(() =>
+    runGrantSweepCycle({
+      ...(rowCap !== undefined ? { rowCap } : {}),
+      query: (sql: string) => {
+        const table = ACL_GATED_TABLES.find((t) => sql.includes(`FROM ${t}`));
+        return Promise.resolve(table ? (byTable[table] ?? []) : []);
+      },
+    }),
+  );
+
+/** Warn lines whose message contains `needle`. */
+const warns = (needle: string) =>
+  logCalls.filter((c) => c.level === "warn" && c.message.includes(needle));
+
+const payloadOf = (call: LogCall | undefined) => call?.payload as Record<string, unknown> | undefined;
+
+beforeEach(() => {
+  logCalls.length = 0;
+});
+
+describe("the findings line", () => {
+  it("names the rows, the grant, and the scope — one line per cycle", async () => {
+    await sweep({
+      brain_facts: [row("f_1", ["everyone"]), row("f_2", ["role:bogus"], "ws-2")],
+      brain_episodes: [row("e_1", ["team:eng"])],
+    });
+
+    const found = warns("no parseable principal");
+    expect(found).toHaveLength(1);
+
+    const payload = payloadOf(found[0]);
+    expect(payload?.malformedRows).toBe(3);
+    expect(payload?.malformedWorkspaces).toBe(2);
+    expect(payload?.rowsScanned).toBe(3);
+    // The fix list: an operator debugging "the agent doesn't know X" has to be
+    // able to go from this line to the rows without another query.
+    expect(payload?.sample).toEqual([
+      { table: "brain_facts", workspaceId: "ws-1", rowId: "f_1", status: null, grant: ["everyone"] },
+      { table: "brain_facts", workspaceId: "ws-2", rowId: "f_2", status: null, grant: ["role:bogus"] },
+      { table: "brain_episodes", workspaceId: "ws-1", rowId: "e_1", status: null, grant: ["team:eng"] },
+    ]);
+    // The message has to say what an operator should DO, not just what happened.
+    expect(found[0]?.message).toContain("invisible to every reader");
+    expect(found[0]?.message).toContain("Re-grant");
+  });
+
+  it("is SILENT on a clean cycle — the digest contract the daily cadence rests on", async () => {
+    // The whole "1 line/day/replica is a digest, 48 is noise" argument assumes
+    // a healthy deployment says nothing at all. A sweep that logged every cycle
+    // regardless would be the alert fatigue the design exists to avoid.
+    await sweep({ brain_facts: [row("f_1", ["org"]), row("f_2", ["user:u1"])] });
+
+    expect(warns("no parseable principal")).toHaveLength(0);
+    expect(logCalls.filter((c) => c.level === "warn")).toHaveLength(0);
+  });
+
+  it("bounds the sample and says so when it clipped", async () => {
+    // Without the cap this line carries one object per malformed row, verbatim
+    // grants included — on the fiber whose stated property is that its cost is
+    // bounded by CADENCE rather than by row count. Deleting the `.slice` left
+    // every other test green.
+    const many = Array.from({ length: 25 }, (_, i) => row(`f_${i}`, ["everyone"]));
+    await sweep({ brain_facts: many });
+
+    const payload = payloadOf(warns("no parseable principal")[0]);
+    expect(payload?.malformedRows).toBe(25);
+    expect(payload?.sample).toHaveLength(20);
+    expect(payload?.sampleTruncated).toBe(true);
+  });
+
+  it("does not claim truncation when the sample fits", async () => {
+    await sweep({ brain_facts: [row("f_1", ["everyone"])] });
+
+    const payload = payloadOf(warns("no parseable principal")[0]);
+    expect(payload?.sampleTruncated).toBe(false);
+  });
+});
+
+describe("the fault lines are distinguishable", () => {
+  it("reports an unreadable row shape separately, naming the table", async () => {
+    // The "wrong file" argument: an unreadable shape is query drift and a
+    // malformed grant is a data defect. Reporting them alike would send the
+    // investigation to the wrong place — and the two tables' projections
+    // deliberately differ, so the line has to say WHICH one drifted.
+    await sweep({
+      brain_episodes: [
+        { workspace_id: "ws-1", id: "e_1", visible_to: "not-an-array", status: null } as never,
+      ],
+    });
+
+    const drift = warns("unreadable shape");
+    expect(drift).toHaveLength(1);
+    expect(payloadOf(drift[0])?.table).toBe("brain_episodes");
+    expect(payloadOf(drift[0])?.unreadable).toBe(1);
+    // Not counted as a finding.
+    expect(warns("no parseable principal")).toHaveLength(0);
+  });
+
+  it("reports the row cap as a floor, not a total", async () => {
+    // `countIsFloor` reaches the span, but "the count is a floor" as something
+    // an operator can read exists only here.
+    await sweep({ brain_facts: [row("f_1", ["everyone"]), row("f_2", ["everyone"])] }, 2);
+
+    const capped = warns("row cap was reached");
+    expect(capped).toHaveLength(1);
+    expect(payloadOf(capped[0])?.rowCap).toBe(2);
+    expect(capped[0]?.message).toContain("floor, not a total");
+  });
+
+  it("names the table whose scan failed", async () => {
+    await withDatabaseUrl(() =>
+      runGrantSweepCycle({
+        query: (sql: string) =>
+          sql.includes("FROM brain_episodes")
+            ? Promise.reject(new Error("relation gone"))
+            : Promise.resolve([]),
+      }),
+    );
+
+    const failed = warns("scan failed");
+    expect(failed).toHaveLength(1);
+    expect(payloadOf(failed[0])?.table).toBe("brain_episodes");
+    expect(payloadOf(failed[0])?.err).toContain("relation gone");
+  });
+});
+
+describe("the interval knob's two fallback arms are distinguishable", () => {
+  function withInterval<T>(value: string | undefined, fn: () => T): T {
+    const key = "ATLAS_BRAIN_GRANT_SWEEP_INTERVAL_HOURS";
+    const prior = process.env[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+    try {
+      return fn();
+    } finally {
+      if (prior === undefined) delete process.env[key];
+      else process.env[key] = prior;
+    }
+  }
+
+  it("stays silent on an UNSET knob but warns on an unparseable one", async () => {
+    // Both return the default, so the return value alone cannot tell them
+    // apart — an operator whose typo is being ignored has only this line.
+    withInterval("", () => getGrantSweepIntervalMs());
+    expect(logCalls.filter((c) => c.level === "warn")).toHaveLength(0);
+
+    withInterval("nonsense", () => getGrantSweepIntervalMs());
+    expect(warns("non-positive or unparseable")).toHaveLength(1);
+  });
+
+  it("warns when clamping an over-large interval", async () => {
+    // Unclamped this value stops the fiber ticking entirely, so the clamp
+    // changes behaviour silently unless it says so.
+    expect(withInterval("600", () => getGrantSweepIntervalMs())).toBe(MAX_TIMER_DELAY_MS);
+    expect(warns("exceeds the max timer delay")).toHaveLength(1);
+  });
+});

--- a/packages/api/src/lib/brain/__tests__/grant-sweep-logging.test.ts
+++ b/packages/api/src/lib/brain/__tests__/grant-sweep-logging.test.ts
@@ -54,6 +54,7 @@ const { runGrantSweepCycle, getGrantSweepIntervalMs, MAX_TIMER_DELAY_MS } = awai
   "@atlas/api/lib/brain/grant-sweep"
 );
 const { ACL_GATED_TABLES } = await import("@atlas/api/lib/brain/acl");
+type AclGatedTable = (typeof ACL_GATED_TABLES)[number];
 
 type Row = {
   readonly workspace_id: string;
@@ -78,7 +79,11 @@ function withDatabaseUrl<T>(fn: () => Promise<T>): Promise<T> {
   });
 }
 
-const sweep = (byTable: Partial<Record<string, readonly Row[]>>, rowCap?: number) =>
+// Keyed on `AclGatedTable`, NOT `string`: a typo'd fixture key would otherwise
+// compile, serve zero rows, and make the silence assertion below pass for the
+// wrong reason. The sibling suite was fixed here first; this file inherited the
+// hole when it was written.
+const sweep = (byTable: Partial<Record<AclGatedTable, readonly Row[]>>, rowCap?: number) =>
   withDatabaseUrl(() =>
     runGrantSweepCycle({
       ...(rowCap !== undefined ? { rowCap } : {}),
@@ -129,8 +134,13 @@ describe("the findings line", () => {
     // The whole "1 line/day/replica is a digest, 48 is noise" argument assumes
     // a healthy deployment says nothing at all. A sweep that logged every cycle
     // regardless would be the alert fatigue the design exists to avoid.
-    await sweep({ brain_facts: [row("f_1", ["org"]), row("f_2", ["user:u1"])] });
+    const result = await sweep({
+      brain_facts: [row("f_1", ["org"]), row("f_2", ["user:u1"])],
+    });
 
+    // Non-vacuity backstop: silence is also what an EMPTY scan produces, so the
+    // claim means nothing without proof that rows were actually examined.
+    expect(result.rowsScanned).toBe(2);
     expect(warns("no parseable principal")).toHaveLength(0);
     expect(logCalls.filter((c) => c.level === "warn")).toHaveLength(0);
   });
@@ -219,7 +229,11 @@ describe("the interval knob's two fallback arms are distinguishable", () => {
     }
   }
 
-  it("stays silent on an UNSET knob but warns on an unparseable one", async () => {
+  it("stays silent on an EMPTY knob but warns on an unparseable one", async () => {
+    // `""`, not undefined: the registry defines `default: "24"`, so
+    // `getSettingAuto` never returns undefined for this key and the empty
+    // string is the reachable "operator cleared the field" arm.
+    //
     // Both return the default, so the return value alone cannot tell them
     // apart — an operator whose typo is being ignored has only this line.
     withInterval("", () => getGrantSweepIntervalMs());

--- a/packages/api/src/lib/brain/__tests__/grant-sweep-pg.test.ts
+++ b/packages/api/src/lib/brain/__tests__/grant-sweep-pg.test.ts
@@ -303,6 +303,11 @@ describeIfPg("brain malformed-grant sweep (real Postgres)", () => {
     // silently inverts when someone adds a fixture. Assert the cap's own
     // contract instead, and prove the draft row via the full count.
     const expectedTotal = perTable * 2 + 1;
+    // Non-vacuity: deriving from the fixture count removed the brittle literal
+    // AND the tripwire — drop two malformed fixtures and `sampleTruncated`
+    // silently flips to false, so the cap contract below stops being exercised
+    // with the test still green.
+    expect(expectedTotal).toBeGreaterThan(MALFORMED_SAMPLE_CAP);
     expect(result.sample).toHaveLength(Math.min(expectedTotal, MALFORMED_SAMPLE_CAP));
     expect(result.sampleTruncated).toBe(expectedTotal > MALFORMED_SAMPLE_CAP);
 

--- a/packages/api/src/lib/brain/__tests__/grant-sweep-pg.test.ts
+++ b/packages/api/src/lib/brain/__tests__/grant-sweep-pg.test.ts
@@ -34,7 +34,11 @@ import { Pool } from "pg";
 import { runMigrations } from "@atlas/api/lib/db/migrate";
 import { MANAGED_AUTH_MIGRATIONS } from "@atlas/api/lib/db/internal";
 import { ACL_GATED_TABLES, parseGrant, type AclGatedTable } from "@atlas/api/lib/brain/acl";
-import { grantScanSql, runGrantSweepCycle } from "@atlas/api/lib/brain/grant-sweep";
+import {
+  MALFORMED_SAMPLE_CAP,
+  grantScanSql,
+  runGrantSweepCycle,
+} from "@atlas/api/lib/brain/grant-sweep";
 
 const TEST_DB_URL = process.env.TEST_DATABASE_URL;
 const describeIfPg = TEST_DB_URL ? describe : describe.skip;
@@ -298,8 +302,9 @@ describeIfPg("brain malformed-grant sweep (real Postgres)", () => {
     // how many fixtures happen to precede the row of interest — a test that
     // silently inverts when someone adds a fixture. Assert the cap's own
     // contract instead, and prove the draft row via the full count.
-    expect(result.sample).toHaveLength(20);
-    expect(result.sampleTruncated).toBe(true);
+    const expectedTotal = perTable * 2 + 1;
+    expect(result.sample).toHaveLength(Math.min(expectedTotal, MALFORMED_SAMPLE_CAP));
+    expect(result.sampleTruncated).toBe(expectedTotal > MALFORMED_SAMPLE_CAP);
 
     // The draft in WS_B is invisible to the review queue as well as to every
     // reader, so it is the row least likely to surface any other way. Counted

--- a/packages/api/src/lib/brain/__tests__/grant-sweep-pg.test.ts
+++ b/packages/api/src/lib/brain/__tests__/grant-sweep-pg.test.ts
@@ -71,6 +71,17 @@ const GRANTS: ReadonlyArray<{
   // prefix and does not parse, so any pre-filter reasoning about the
   // parameterised arms silently under-reports exactly here.
   { label: "role-bogus", visibleTo: ["role:bogus"], malformed: true },
+  // The NULL-element arm. These are the rows an `'org' = ANY(visible_to)`
+  // narrow SILENTLY DROPPED: `= ANY` is three-valued, so over an array with a
+  // NULL element and no match it yields NULL, `NOT NULL` is NULL, and `WHERE
+  // NULL` excludes the row. Both are legal at rest (0180's CHECK counts
+  // non-NULL non-empty elements; one survivor is enough), both parse to zero
+  // principals, and `grantProblem` admits `["everyone", null]` from an import
+  // bundle today. Without these two fixtures the cross-check below passes
+  // vacuously — the only other NULL fixture, `padded-org`, carries `org` and is
+  // shed for the right reason.
+  { label: "malformed-with-null", visibleTo: ["everyone", null], malformed: true },
+  { label: "role-bogus-with-null", visibleTo: ["role:bogus", null], malformed: true },
   { label: "role-platform-admin", visibleTo: ["role:platform_admin"], malformed: true },
   { label: "bare-prefixes", visibleTo: ["user:", "audience:"], malformed: true },
   { label: "case-variant-audience", visibleTo: ["Audience:eng"], malformed: true },
@@ -129,22 +140,35 @@ describeIfPg("brain malformed-grant sweep (real Postgres)", () => {
     );
   }
 
-  /** The sweep's own query, run for real. Returns the rows it would parse. */
-  async function narrowedScan(table: AclGatedTable) {
-    const { rows } = await pool.query(grantScanSql(table), [10_000]);
-    return rows as Array<{ id: string; visible_to: unknown[]; status: string | null }>;
+  /**
+   * The sweep's own query, run for real, scoped to one workspace.
+   *
+   * Scoped deliberately: `grantScanSql` is deployment-wide, but these
+   * assertions label rows from a WS-only map, so an unscoped scan made the
+   * result depend on whether the `WS_B` fixture had been seeded yet — a test
+   * that passes on ordering and fails with a message pointing nowhere near the
+   * cause. The narrow itself is unaffected; only the row set is.
+   */
+  async function narrowedScan(table: AclGatedTable, workspaceId = WS) {
+    const { rows } = await pool.query<{ id: string; visible_to: unknown[]; status: string | null }>(
+      `SELECT * FROM (${grantScanSql(table)}) s WHERE workspace_id = $2`,
+      [10_000, workspaceId],
+    );
+    return rows;
   }
 
   /**
    * The same projection WITHOUT the narrow — the control arm. Anything this
    * flags and {@link narrowedScan} does not is a row the optimisation dropped.
    */
-  async function unnarrowedScan(table: AclGatedTable) {
+  async function unnarrowedScan(table: AclGatedTable, workspaceId = WS) {
     const status = table === "brain_facts" ? "status" : "NULL::text AS status";
-    const { rows } = await pool.query(
-      `SELECT workspace_id, id, visible_to, ${status} FROM ${table} ORDER BY workspace_id, id`,
+    const { rows } = await pool.query<{ id: string; visible_to: unknown[]; status: string | null }>(
+      `SELECT workspace_id, id, visible_to, ${status} FROM ${table}
+        WHERE workspace_id = $1 ORDER BY workspace_id, id`,
+      [workspaceId],
     );
-    return rows as Array<{ id: string; visible_to: unknown[]; status: string | null }>;
+    return rows;
   }
 
   const flagged = (rows: Array<{ visible_to: unknown[] }>, key: (i: number) => string) =>
@@ -241,7 +265,10 @@ describeIfPg("brain malformed-grant sweep (real Postgres)", () => {
       `SELECT id FROM brain_facts WHERE workspace_id = $1 AND subject = 'role-bogus'`,
       [WS],
     );
-    expect(rows.some((r) => r.id === labelled[0]!.id)).toBe(true);
+    // Asserted before the index, so a seed/label drift fails legibly here
+    // rather than as a TypeError from a non-null assertion.
+    expect(labelled).toHaveLength(1);
+    expect(rows.some((r) => r.id === labelled[0]?.id)).toBe(true);
   });
 
   it("counts rows and distinct workspaces across both tables", async () => {
@@ -265,14 +292,24 @@ describeIfPg("brain malformed-grant sweep (real Postgres)", () => {
     expect(result.status).toBe("success");
     expect(result.malformedRows).toBe(perTable * 2 + 1);
     expect(result.malformedWorkspaces).toBe(2);
-    expect(result.scanTruncated).toBe(false);
+    expect(result.countIsFloor).toBe(false);
 
-    // The draft is in the flagged set — invisible to the review queue as well
-    // as to every reader, so it is the row least likely to surface any other
-    // way. It also proves `status` survives the projection into the log sample.
-    expect(result.sample.some((s) => s.status === "draft" && s.workspaceId === WS_B)).toBe(true);
+    // The sample is CAPPED, so membership assertions over it would depend on
+    // how many fixtures happen to precede the row of interest — a test that
+    // silently inverts when someone adds a fixture. Assert the cap's own
+    // contract instead, and prove the draft row via the full count.
+    expect(result.sample).toHaveLength(20);
+    expect(result.sampleTruncated).toBe(true);
+
+    // The draft in WS_B is invisible to the review queue as well as to every
+    // reader, so it is the row least likely to surface any other way. Counted
+    // via a direct scan rather than the capped sample.
+    const wsBRows = await narrowedScan("brain_facts", WS_B);
+    expect(wsBRows).toHaveLength(1);
+    expect(wsBRows[0]?.status).toBe("draft");
     // Episodes carry a NULL status; facts never do.
-    expect(result.sample.some((s) => s.table === "brain_episodes" && s.status === null)).toBe(true);
+    const episodeRows = await narrowedScan("brain_episodes");
+    expect(episodeRows.every((r) => r.status === null)).toBe(true);
   });
 
   it("respects the row cap and reports the truncation", async () => {
@@ -283,7 +320,7 @@ describeIfPg("brain malformed-grant sweep (real Postgres)", () => {
       }),
     );
 
-    expect(result.scanTruncated).toBe(true);
+    expect(result.countIsFloor).toBe(true);
     expect(result.rowsScanned).toBe(4); // 2 per table, both capped
   });
 });

--- a/packages/api/src/lib/brain/__tests__/grant-sweep-pg.test.ts
+++ b/packages/api/src/lib/brain/__tests__/grant-sweep-pg.test.ts
@@ -1,0 +1,289 @@
+/**
+ * Real-Postgres coverage for the malformed-grant sweep (#4797, ADR-0036).
+ *
+ * `grant-sweep.test.ts` pins what counts as malformed — the parse, the
+ * boundary with `logGrantAnomalies`, the degradation shape. All of that runs
+ * against fixture rows and none of it needs a database.
+ *
+ * What only real Postgres can settle is the SAFETY OF THE NARROW, which is the
+ * one place this module could silently under-report. `NOT ('org' =
+ * ANY(visible_to))` runs in the database, over `text[]` with NULL elements in
+ * it, against grants that migration 0180's CHECK legally admits. The claim it
+ * has to survive is not "it sheds most rows" but "it sheds ONLY rows that
+ * demonstrably carry a valid principal" — and the counter-example that matters
+ * (`['role:bogus']`: valid prefix, does not parse) is invisible to any
+ * assertion made in TypeScript about SQL text.
+ *
+ * So the shape here is a CROSS-CHECK: seed every legal-at-rest grant, run the
+ * narrowed scan, and separately run an UNNARROWED scan over the same rows
+ * through the same parse. The two must flag exactly the same set. If the narrow
+ * ever drops a row TS would call malformed, that equality breaks — which is the
+ * only test that can fail in the direction this module cares about.
+ *
+ * Also pinned: that `grantScanSql` executes at all against the live schema. The
+ * per-table status projection (`brain_episodes` has no `status` column) is a
+ * runtime error on one of the two tables if it is written once and shared.
+ *
+ * Opt in locally with:
+ *   bun run db:up
+ *   export TEST_DATABASE_URL=postgresql://atlas:atlas@localhost:5433/atlas_dev
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { Pool } from "pg";
+import { runMigrations } from "@atlas/api/lib/db/migrate";
+import { MANAGED_AUTH_MIGRATIONS } from "@atlas/api/lib/db/internal";
+import { ACL_GATED_TABLES, parseGrant, type AclGatedTable } from "@atlas/api/lib/brain/acl";
+import { grantScanSql, runGrantSweepCycle } from "@atlas/api/lib/brain/grant-sweep";
+
+const TEST_DB_URL = process.env.TEST_DATABASE_URL;
+const describeIfPg = TEST_DB_URL ? describe : describe.skip;
+const PG_TEST_TIMEOUT_MS = 60_000;
+
+const WS = "ws-sweep-pg";
+const WS_B = "ws-sweep-pg-b";
+
+/**
+ * Every grant below is legal at rest under `chk_brain_*_grant_nonempty`, which
+ * requires one non-NULL non-empty element and says nothing about the grammar.
+ * `malformed` is the EXPECTATION — derived by hand, not from `parseGrant`, so
+ * this table is an independent statement of the contract rather than a mirror
+ * of the implementation.
+ */
+const GRANTS: ReadonlyArray<{
+  label: string;
+  visibleTo: (string | null)[];
+  malformed: boolean;
+}> = [
+  // --- carries a valid principal: must never be flagged ---
+  { label: "org", visibleTo: ["org"], malformed: false },
+  { label: "role-member", visibleTo: ["role:member"], malformed: false },
+  { label: "user", visibleTo: ["user:user-1"], malformed: false },
+  { label: "audience", visibleTo: ["audience:eng"], malformed: false },
+  // Partly malformed — logGrantAnomalies' remit at read time, not this sweep's.
+  { label: "half-malformed", visibleTo: ["everyone", "user:user-1"], malformed: false },
+  { label: "padded-org", visibleTo: ["org", null, ""], malformed: false },
+  { label: "padded-user", visibleTo: ["", "user:user-2"], malformed: false },
+
+  // --- entirely malformed: the rows this sweep exists for ---
+  //
+  // The four that a prefix-based SQL narrow would DROP. Each has a valid
+  // prefix and does not parse, so any pre-filter reasoning about the
+  // parameterised arms silently under-reports exactly here.
+  { label: "role-bogus", visibleTo: ["role:bogus"], malformed: true },
+  { label: "role-platform-admin", visibleTo: ["role:platform_admin"], malformed: true },
+  { label: "bare-prefixes", visibleTo: ["user:", "audience:"], malformed: true },
+  { label: "case-variant-audience", visibleTo: ["Audience:eng"], malformed: true },
+  // The obvious ones, kept for completeness — they prove far less.
+  { label: "everyone", visibleTo: ["everyone"], malformed: true },
+  { label: "team-eng", visibleTo: ["team:eng"], malformed: true },
+  { label: "shouty-org", visibleTo: ["ORG"], malformed: true },
+  { label: "padded-org-space", visibleTo: ["org "], malformed: true },
+  // Legal at rest AND entirely unusable: one non-empty element, no grammar.
+  { label: "empty-plus-junk", visibleTo: ["", "everyone"], malformed: true },
+];
+
+const EXPECTED_MALFORMED = GRANTS.filter((g) => g.malformed).map((g) => g.label).toSorted();
+
+/** `hasInternalDB()` reads DATABASE_URL; set inside tests, never at top level. */
+function withDatabaseUrl<T>(fn: () => Promise<T>): Promise<T> {
+  const prior = process.env.DATABASE_URL;
+  process.env.DATABASE_URL = TEST_DB_URL ?? "postgres://stub/stub";
+  return fn().finally(() => {
+    if (prior === undefined) delete process.env.DATABASE_URL;
+    else process.env.DATABASE_URL = prior;
+  });
+}
+
+describeIfPg("brain malformed-grant sweep (real Postgres)", () => {
+  let pool: Pool;
+  const schemaName = `brain_sweep_${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
+
+  /** Insert an episode; its `source_id` carries the fixture label. */
+  async function seedEpisode(
+    workspaceId: string,
+    label: string,
+    visibleTo: readonly (string | null)[],
+  ): Promise<string> {
+    const { rows } = await pool.query<{ id: string }>(
+      `INSERT INTO brain_episodes (workspace_id, source, source_id, body, visible_to)
+       VALUES ($1, 'test', $2, 'evidence', $3::text[])
+       RETURNING id`,
+      [workspaceId, label, visibleTo],
+    );
+    return rows[0]!.id;
+  }
+
+  async function seedFact(opts: {
+    workspaceId: string;
+    episodeId: string;
+    subject: string;
+    visibleTo: readonly (string | null)[];
+    status?: "draft" | "published" | "archived";
+  }): Promise<void> {
+    await pool.query(
+      `INSERT INTO brain_facts
+         (workspace_id, subject, predicate, object, source_episode_id, provenance, status, visible_to)
+       VALUES ($1, $2, 'is', 'thing', $3, '{"actor":"test"}'::jsonb, $4, $5::text[])`,
+      [opts.workspaceId, opts.subject, opts.episodeId, opts.status ?? "published", opts.visibleTo],
+    );
+  }
+
+  /** The sweep's own query, run for real. Returns the rows it would parse. */
+  async function narrowedScan(table: AclGatedTable) {
+    const { rows } = await pool.query(grantScanSql(table), [10_000]);
+    return rows as Array<{ id: string; visible_to: unknown[]; status: string | null }>;
+  }
+
+  /**
+   * The same projection WITHOUT the narrow — the control arm. Anything this
+   * flags and {@link narrowedScan} does not is a row the optimisation dropped.
+   */
+  async function unnarrowedScan(table: AclGatedTable) {
+    const status = table === "brain_facts" ? "status" : "NULL::text AS status";
+    const { rows } = await pool.query(
+      `SELECT workspace_id, id, visible_to, ${status} FROM ${table} ORDER BY workspace_id, id`,
+    );
+    return rows as Array<{ id: string; visible_to: unknown[]; status: string | null }>;
+  }
+
+  const flagged = (rows: Array<{ visible_to: unknown[] }>, key: (i: number) => string) =>
+    rows
+      .map((r, i) => ({ label: key(i), parsed: parseGrant(r.visible_to) }))
+      .filter((r) => r.parsed.principals.length === 0)
+      .map((r) => r.label)
+      .toSorted();
+
+  beforeAll(async () => {
+    // `search_path` baked into the connection string rather than SET from an
+    // unawaited `pool.on("connect")` handler — same reasoning as
+    // `acl-visibility-pg.test.ts`: no window in which a checked-out client is
+    // still pointed at `public` and runs the migration set against the
+    // developer's real database.
+    pool = new Pool({
+      connectionString: TEST_DB_URL,
+      options: `-c search_path="${schemaName}",public`,
+    });
+    const bootstrap = new Pool({ connectionString: TEST_DB_URL });
+    try {
+      await bootstrap.query(`CREATE SCHEMA IF NOT EXISTS "${schemaName}"`);
+    } finally {
+      await bootstrap.end();
+    }
+    await runMigrations(pool, { skip: MANAGED_AUTH_MIGRATIONS });
+
+    // Seed both tables with the same grant matrix. The episode carrying each
+    // fact is granted `org` so the fact's own grant is the only variable — a
+    // malformed EPISODE grant would otherwise be indistinguishable from the
+    // fact's in the totals.
+    const carrier = await seedEpisode(WS, "carrier", ["org"]);
+    for (const g of GRANTS) {
+      await seedFact({
+        workspaceId: WS,
+        episodeId: carrier,
+        subject: g.label,
+        visibleTo: g.visibleTo,
+      });
+      await seedEpisode(WS, `ep-${g.label}`, g.visibleTo);
+    }
+  }, PG_TEST_TIMEOUT_MS);
+
+  afterAll(async () => {
+    if (!pool) return;
+    await pool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+    await pool.end();
+  });
+
+  it("executes against the live schema for every gated table", async () => {
+    // The status projection branches per table; written once and shared it is a
+    // 42703 on `brain_episodes`, which has no `status` column.
+    for (const table of ACL_GATED_TABLES) {
+      const rows = await narrowedScan(table);
+      expect(Array.isArray(rows)).toBe(true);
+      expect(rows.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("the `org` narrow sheds ONLY rows that carry a valid principal", async () => {
+    // The load-bearing test. Narrowed and unnarrowed scans must flag the same
+    // set — the narrow may drop rows, but never a row the parse would flag.
+    for (const table of ACL_GATED_TABLES) {
+      const narrowed = await narrowedScan(table);
+      const all = await unnarrowedScan(table);
+
+      const byId = (rows: Array<{ id: string; visible_to: unknown[] }>) =>
+        flagged(rows, (i) => rows[i]!.id);
+
+      expect({ table, flagged: byId(narrowed) }).toEqual({ table, flagged: byId(all) });
+      // And it must actually be narrowing, or the assertion above is vacuous.
+      expect(narrowed.length).toBeLessThan(all.length);
+    }
+  });
+
+  it("flags exactly the hand-listed malformed grants, not a superset", async () => {
+    const rows = await narrowedScan("brain_facts");
+    const { rows: labelled } = await pool.query<{ id: string; subject: string }>(
+      `SELECT id, subject FROM brain_facts WHERE workspace_id = $1`,
+      [WS],
+    );
+    const subjectById = new Map(labelled.map((r) => [r.id, r.subject]));
+
+    expect(flagged(rows, (i) => subjectById.get(rows[i]!.id) ?? "?")).toEqual(EXPECTED_MALFORMED);
+  });
+
+  it("keeps `role:bogus` — the row a prefix-based narrow would drop", async () => {
+    // Called out on its own because it is the single fixture that distinguishes
+    // a real parse from every cheaper approximation. If someone "optimises" the
+    // scan into a prefix predicate, the equality test above and this one are
+    // what break.
+    const rows = await narrowedScan("brain_facts");
+    const { rows: labelled } = await pool.query<{ id: string }>(
+      `SELECT id FROM brain_facts WHERE workspace_id = $1 AND subject = 'role-bogus'`,
+      [WS],
+    );
+    expect(rows.some((r) => r.id === labelled[0]!.id)).toBe(true);
+  });
+
+  it("counts rows and distinct workspaces across both tables", async () => {
+    // A second workspace, so `malformedWorkspaces` is provably a DISTINCT count
+    // and not a row count that happens to match.
+    const carrierB = await seedEpisode(WS_B, "carrier-b", ["org"]);
+    await seedFact({
+      workspaceId: WS_B,
+      episodeId: carrierB,
+      subject: "b-malformed",
+      visibleTo: ["role:bogus"],
+      status: "draft",
+    });
+
+    const result = await withDatabaseUrl(() =>
+      runGrantSweepCycle({ query: (sql, params) => pool.query(sql, params).then((r) => r.rows) }),
+    );
+
+    // Facts + episodes from WS, plus the one draft fact in WS_B.
+    const perTable = EXPECTED_MALFORMED.length;
+    expect(result.status).toBe("success");
+    expect(result.malformedRows).toBe(perTable * 2 + 1);
+    expect(result.malformedWorkspaces).toBe(2);
+    expect(result.scanTruncated).toBe(false);
+
+    // The draft is in the flagged set — invisible to the review queue as well
+    // as to every reader, so it is the row least likely to surface any other
+    // way. It also proves `status` survives the projection into the log sample.
+    expect(result.sample.some((s) => s.status === "draft" && s.workspaceId === WS_B)).toBe(true);
+    // Episodes carry a NULL status; facts never do.
+    expect(result.sample.some((s) => s.table === "brain_episodes" && s.status === null)).toBe(true);
+  });
+
+  it("respects the row cap and reports the truncation", async () => {
+    const result = await withDatabaseUrl(() =>
+      runGrantSweepCycle({
+        query: (sql, params) => pool.query(sql, params).then((r) => r.rows),
+        rowCap: 2,
+      }),
+    );
+
+    expect(result.scanTruncated).toBe(true);
+    expect(result.rowsScanned).toBe(4); // 2 per table, both capped
+  });
+});

--- a/packages/api/src/lib/brain/__tests__/grant-sweep.test.ts
+++ b/packages/api/src/lib/brain/__tests__/grant-sweep.test.ts
@@ -22,10 +22,11 @@
  */
 
 import { describe, expect, it } from "bun:test";
-import { ACL_GATED_TABLES } from "@atlas/api/lib/brain/acl";
+import { ACL_GATED_TABLES, type AclGatedTable } from "@atlas/api/lib/brain/acl";
 import {
   DEFAULT_GRANT_SWEEP_INTERVAL_HOURS,
   GRANT_SWEEP_ROW_CAP,
+  MAX_TIMER_DELAY_MS,
   getGrantSweepIntervalMs,
   grantScanSql,
   runGrantSweepCycle,
@@ -34,12 +35,12 @@ import {
 
 const WORKSPACE = "ws-1";
 
-interface Row {
+type Row = {
   readonly workspace_id: string;
   readonly id: string;
   readonly visible_to: readonly unknown[];
   readonly status: string | null;
-}
+};
 
 const row = (id: string, visibleTo: readonly unknown[], overrides: Partial<Row> = {}): Row => ({
   workspace_id: WORKSPACE,
@@ -64,20 +65,25 @@ function withDatabaseUrl<T>(fn: () => Promise<T>): Promise<T> {
  * that only cares about facts still exercises the real two-table iteration.
  */
 function harness(
-  byTable: Partial<Record<string, readonly Row[]>>,
+  byTable: Partial<Record<AclGatedTable, readonly Row[]>>,
   extra: Omit<GrantSweepDeps, "query"> = {},
 ) {
   const scans: string[] = [];
+  const bindings: (unknown[] | undefined)[] = [];
   const deps: GrantSweepDeps = {
     ...extra,
-    query: (<T>(sql: string) => {
+    query: (sql: string, params?: unknown[]) => {
       const table = ACL_GATED_TABLES.find((t) => sql.includes(`FROM ${t}`));
       if (!table) throw new Error(`scan SQL named no gated table: ${sql}`);
+      // The cap must reach `$1`. Unbound, this is a Postgres bind error that
+      // only the -pg suite sees — and that suite is skipped without
+      // TEST_DATABASE_URL, so a local gate would go green on a broken scan.
+      bindings.push(params);
       scans.push(table);
-      return Promise.resolve((byTable[table] ?? []) as unknown as T[]);
-    }) as GrantSweepDeps["query"],
+      return Promise.resolve(byTable[table] ?? []);
+    },
   };
-  return { deps, scans };
+  return { deps, scans, bindings };
 }
 
 describe("runGrantSweepCycle — what counts as malformed", () => {
@@ -135,9 +141,13 @@ describe("runGrantSweepCycle — what counts as malformed", () => {
 
     expect(result.malformedRows).toBe(0);
     expect(result.sample).toEqual([]);
+    // Non-vacuity: `toBe(0)` also holds when the harness served NOTHING (a
+    // typo'd fixture key used to do exactly that). Pin the rows actually
+    // examined so this test can only pass by parsing them.
+    expect(result.rowsScanned).toBe(3);
   });
 
-  it("flags a grant of only NULL/'' elements — legal at rest, usable by nobody", async () => {
+  it("flags `['', 'everyone']` — legal at rest, usable by nobody", async () => {
     // 0180's CHECK admits `[NULL, '']`? No — it requires one non-NULL non-empty
     // element. But `['', 'everyone']` IS admitted, and parses to zero
     // principals. The CHECK is a cardinality test; this is a grammar test, and
@@ -183,6 +193,25 @@ describe("runGrantSweepCycle — scope", () => {
     ]);
   });
 
+  it("does NOT flag a grammatical grant that happens to match nobody", async () => {
+    // The other invisible-to-everyone class, and deliberately out of scope.
+    // `audience: eng` (leading space) and `user:deleted-id` PARSE — `acl.ts`
+    // accepts any non-empty remainder, because it has no business assuming a
+    // shape for Better Auth ids or source-derived audience ids. They may still
+    // match no reader token, but deciding that needs existence checks against
+    // `user` / `fact_audience_member` — a per-row cross-table read this sweep
+    // must not acquire. "Parses to a principal" is the whole boundary.
+    const { deps } = harness({
+      brain_facts: [row("f_1", ["audience: eng"]), row("f_2", ["user:deleted-id"])],
+      brain_episodes: [row("e_1", ["audience:archived-channel"])],
+    });
+
+    const result = await withDatabaseUrl(() => runGrantSweepCycle(deps));
+
+    expect(result.malformedRows).toBe(0);
+    expect(result.rowsScanned).toBe(3);
+  });
+
   it("counts distinct workspaces, not rows", async () => {
     const { deps } = harness({
       brain_facts: [
@@ -205,7 +234,9 @@ describe("runGrantSweepCycle — scope", () => {
       const { deps, scans } = harness({ brain_facts: [row("f_1", ["everyone"])] });
       const result = await runGrantSweepCycle(deps);
 
-      expect(result.status).toBe("success");
+      // `skipped`, not `success`: nothing ran. `success` here would pair an
+      // all-clear status with all-null ("we do not know") counters.
+      expect(result.status).toBe("skipped");
       // `null`, not 0 — the sweep did not run, and 0 would read as all-clear.
       expect(result.malformedRows).toBeNull();
       expect(scans).toEqual([]);
@@ -219,7 +250,13 @@ describe("runGrantSweepCycle — the scan SQL", () => {
   it("narrows on the exact `org` token and nothing else", () => {
     for (const table of ACL_GATED_TABLES) {
       const sql = grantScanSql(table);
-      expect(sql).toContain("NOT ('org' = ANY(visible_to))");
+      expect(sql).toContain("NOT (visible_to @> ARRAY['org'])");
+      // `= ANY` is the NULL-UNSAFE spelling of the same idea and reads as a
+      // synonym: over an array with a NULL element and no match it yields NULL,
+      // `NOT NULL` is NULL, and `WHERE NULL` drops the row — so every
+      // entirely-malformed grant carrying a NULL element went unreported. The
+      // pg cross-check proves the behaviour; this stops the text coming back.
+      expect(sql).not.toContain("= ANY(");
       // The grammar-duplication guard. A predicate mentioning any
       // PARAMETERISED arm is a second derivation of `parsePrincipal`, and the
       // obvious version of it ("no element has a known prefix") silently drops
@@ -250,10 +287,10 @@ describe("runGrantSweepCycle — the scan SQL", () => {
 describe("runGrantSweepCycle — degradation is visible", () => {
   it("reports a partial scan as `degraded`, keeping the counters it has", async () => {
     const deps: GrantSweepDeps = {
-      query: (<T>(sql: string) => {
+      query: (sql: string) => {
         if (sql.includes("FROM brain_episodes")) return Promise.reject(new Error("relation gone"));
-        return Promise.resolve([row("f_1", ["everyone"])] as unknown as T[]);
-      }) as GrantSweepDeps["query"],
+        return Promise.resolve([row("f_1", ["everyone"])]);
+      },
     };
 
     const result = await withDatabaseUrl(() => runGrantSweepCycle(deps));
@@ -276,6 +313,20 @@ describe("runGrantSweepCycle — degradation is visible", () => {
     expect(result.rowsScanned).toBeNull();
   });
 
+  it("keeps the FIRST error when both tables fail", async () => {
+    // `firstError ??=` — the earlier fault is usually the cause and the later
+    // one the consequence. With one failing table this arm is unreachable.
+    const deps: GrantSweepDeps = {
+      query: (sql: string) =>
+        Promise.reject(new Error(sql.includes("FROM brain_facts") ? "facts-gone" : "episodes-gone")),
+    };
+
+    const result = await withDatabaseUrl(() => runGrantSweepCycle(deps));
+
+    expect(result.status).toBe("failure");
+    expect(result.error).toContain("facts-gone");
+  });
+
   it("never throws — a rejected scan is a result, not an exception", async () => {
     const deps: GrantSweepDeps = { query: () => Promise.reject(new Error("boom")) };
     // The fiber routes this through `Effect.tryPromise`, but the contract the
@@ -290,7 +341,7 @@ describe("runGrantSweepCycle — degradation is visible", () => {
 
     const result = await withDatabaseUrl(() => runGrantSweepCycle(deps));
 
-    expect(result.scanTruncated).toBe(true);
+    expect(result.countIsFloor).toBe(true);
     // The count is a FLOOR — reported, not silently presented as a total.
     expect(result.malformedRows).toBe(1);
   });
@@ -300,7 +351,7 @@ describe("runGrantSweepCycle — degradation is visible", () => {
 
     const result = await withDatabaseUrl(() => runGrantSweepCycle(deps));
 
-    expect(result.scanTruncated).toBe(false);
+    expect(result.countIsFloor).toBe(false);
   });
 
   it("neither clears nor flags a row whose shape it cannot read", async () => {
@@ -319,6 +370,12 @@ describe("runGrantSweepCycle — degradation is visible", () => {
     expect(result.malformedRows).toBe(1);
     expect(result.sample.map((s) => s.rowId)).toEqual(["f_2"]);
     expect(result.rowsScanned).toBe(2);
+    expect(result.unreadableRows).toBe(1);
+    // A row that could not be READ is not a row the sweep cleared, so the
+    // cycle's count is unverified rather than clean. Reporting `success` here
+    // is how a projection change that made EVERY row unreadable would have
+    // shown up as a healthy deployment.
+    expect(result.status).toBe("degraded");
   });
 });
 
@@ -363,7 +420,25 @@ describe("getGrantSweepIntervalMs", () => {
     }
   });
 
-  it("keeps a generous default row cap", () => {
-    expect(GRANT_SWEEP_ROW_CAP).toBeGreaterThanOrEqual(10_000);
+  it("clamps an over-large interval instead of letting the fiber stop ticking", () => {
+    // Past MAX_TIMER_DELAY_MS Effect's clock treats the duration as INFINITE:
+    // `Schedule.spaced` runs one boot tick and never re-arms. 600h is a
+    // plausible "dial this way down" keystroke, and unclamped it would produce
+    // permanent silence indistinguishable from a dead fiber — the exact
+    // outcome the fiber registration comment says it exists to avoid.
+    expect(withInterval("600", getGrantSweepIntervalMs)).toBe(MAX_TIMER_DELAY_MS);
+    expect(600 * 3_600_000).toBeGreaterThan(MAX_TIMER_DELAY_MS);
+    // Just under the bound is honoured, so the clamp is not swallowing sane values.
+    expect(withInterval("500", getGrantSweepIntervalMs)).toBe(500 * 3_600_000);
+  });
+
+  it("binds the DEFAULT row cap when no override is injected", async () => {
+    // Every truncation test injects `rowCap`, so the production default was
+    // exercised only by the -pg suite — which is skipped without a database.
+    const { deps, bindings } = harness({ brain_facts: [row("f_1", ["org"])] });
+    await withDatabaseUrl(() => runGrantSweepCycle(deps));
+
+    expect(bindings).toHaveLength(ACL_GATED_TABLES.length);
+    expect(bindings.every((b) => b?.[0] === GRANT_SWEEP_ROW_CAP)).toBe(true);
   });
 });

--- a/packages/api/src/lib/brain/__tests__/grant-sweep.test.ts
+++ b/packages/api/src/lib/brain/__tests__/grant-sweep.test.ts
@@ -26,7 +26,9 @@ import { ACL_GATED_TABLES, type AclGatedTable } from "@atlas/api/lib/brain/acl";
 import {
   DEFAULT_GRANT_SWEEP_INTERVAL_HOURS,
   GRANT_SWEEP_ROW_CAP,
+  MALFORMED_SAMPLE_CAP,
   MAX_TIMER_DELAY_MS,
+  MIN_GRANT_SWEEP_INTERVAL_MS,
   getGrantSweepIntervalMs,
   grantScanSql,
   runGrantSweepCycle,
@@ -298,6 +300,12 @@ describe("runGrantSweepCycle — degradation is visible", () => {
     expect(result.status).toBe("degraded");
     expect(result.malformedRows).toBe(1);
     expect(result.error).toContain("relation gone");
+    // The whole reason this field is not just `scanTruncated`: a half-scan is
+    // not a complete one. Without this arm the span reports a partial count as
+    // a total, which is the fabricated all-clear the rename exists to remove.
+    expect(result.countIsFloor).toBe(true);
+    // ...and the cap was NOT the cause, which is what the span discriminates.
+    expect(result.scanTruncated).toBe(false);
   });
 
   it("reports all-null counters when EVERY table's scan fails", async () => {
@@ -311,6 +319,8 @@ describe("runGrantSweepCycle — degradation is visible", () => {
     expect(result.malformedRows).toBeNull();
     expect(result.malformedWorkspaces).toBeNull();
     expect(result.rowsScanned).toBeNull();
+    // The cycle that scanned NOTHING is the strongest case for "not a total".
+    expect(result.countIsFloor).toBe(true);
   });
 
   it("keeps the FIRST error when both tables fail", async () => {
@@ -318,13 +328,15 @@ describe("runGrantSweepCycle — degradation is visible", () => {
     // one the consequence. With one failing table this arm is unreachable.
     const deps: GrantSweepDeps = {
       query: (sql: string) =>
-        Promise.reject(new Error(sql.includes("FROM brain_facts") ? "facts-gone" : "episodes-gone")),
+        Promise.reject(new Error(`${ACL_GATED_TABLES.find((t) => sql.includes(`FROM ${t}`))}-gone`)),
     };
 
     const result = await withDatabaseUrl(() => runGrantSweepCycle(deps));
 
     expect(result.status).toBe("failure");
-    expect(result.error).toContain("facts-gone");
+    // Derived from the registry, not hardcoded: a reorder of ACL_GATED_TABLES
+    // must not fail this test while first-wins still holds.
+    expect(result.error).toContain(`${ACL_GATED_TABLES[0]}-gone`);
   });
 
   it("never throws — a rejected scan is a result, not an exception", async () => {
@@ -344,6 +356,23 @@ describe("runGrantSweepCycle — degradation is visible", () => {
     expect(result.countIsFloor).toBe(true);
     // The count is a FLOOR — reported, not silently presented as a total.
     expect(result.malformedRows).toBe(1);
+  });
+
+  it("caps the RESULT's sample, not only the log payload", async () => {
+    // Two independent `.slice` call sites. The logging suite pins the log
+    // payload; without this the returned `sample` could go unbounded and only
+    // the -pg suite would notice — and that suite is silently skipped without
+    // TEST_DATABASE_URL, so every local gate would stay green.
+    const many = Array.from({ length: MALFORMED_SAMPLE_CAP + 5 }, (_, i) =>
+      row(`f_${i}`, ["everyone"]),
+    );
+    const { deps } = harness({ brain_facts: many });
+
+    const result = await withDatabaseUrl(() => runGrantSweepCycle(deps));
+
+    expect(result.malformedRows).toBe(MALFORMED_SAMPLE_CAP + 5);
+    expect(result.sample).toHaveLength(MALFORMED_SAMPLE_CAP);
+    expect(result.sampleTruncated).toBe(true);
   });
 
   it("does not flag truncation on a short scan", async () => {
@@ -430,6 +459,15 @@ describe("getGrantSweepIntervalMs", () => {
     expect(600 * 3_600_000).toBeGreaterThan(MAX_TIMER_DELAY_MS);
     // Just under the bound is honoured, so the clamp is not swallowing sane values.
     expect(withInterval("500", getGrantSweepIntervalMs)).toBe(500 * 3_600_000);
+  });
+
+  it("clamps an interval below the floor — cadence is this module's control", async () => {
+    // The upper clamp alone left the knob able to defeat the property the whole
+    // design rests on: 0.0001h is ~3 full two-table scans per second, each able
+    // to emit a findings line.
+    expect(withInterval("0.0001", getGrantSweepIntervalMs)).toBe(MIN_GRANT_SWEEP_INTERVAL_MS);
+    // Just above the floor is honoured, so the clamp is not eating sane values.
+    expect(withInterval("1", getGrantSweepIntervalMs)).toBe(3_600_000);
   });
 
   it("binds the DEFAULT row cap when no override is injected", async () => {

--- a/packages/api/src/lib/brain/__tests__/grant-sweep.test.ts
+++ b/packages/api/src/lib/brain/__tests__/grant-sweep.test.ts
@@ -1,0 +1,369 @@
+/**
+ * The malformed-grant sweep (#4797, ADR-0036 §Access control & residency).
+ *
+ * Two things are actually under test, and only one of them is "does it find the
+ * broken row".
+ *
+ * The FIRST is that the sweep's notion of "malformed" is `acl.ts`'s parse and
+ * not a cheaper lookalike. Every fixture below that matters is NEARLY VALID —
+ * `['role:bogus']`, `['Audience:eng']`, `['user:']` — because a junk fixture
+ * like `['zzz']` passes under a prefix check, a regex, or an empty-array test
+ * just as happily as under the real parser, and would prove nothing about which
+ * of them is running. `['role:bogus']` is the sharp one: valid prefix, does not
+ * parse, entirely malformed, and exactly the row a SQL pre-filter over prefixes
+ * would drop.
+ *
+ * The SECOND is the boundary between this sweep and `logGrantAnomalies`. A
+ * PARTLY-malformed grant (`['user:abc', 'everyone']`) is already reported at
+ * read time by the caller holding the row; flagging it here too would
+ * double-count it and drown the entirely-malformed row this exists to surface.
+ * So "has at least one usable principal ⇒ not this sweep's business" is a
+ * behavioural contract, not an implementation detail.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { ACL_GATED_TABLES } from "@atlas/api/lib/brain/acl";
+import {
+  DEFAULT_GRANT_SWEEP_INTERVAL_HOURS,
+  GRANT_SWEEP_ROW_CAP,
+  getGrantSweepIntervalMs,
+  grantScanSql,
+  runGrantSweepCycle,
+  type GrantSweepDeps,
+} from "../grant-sweep";
+
+const WORKSPACE = "ws-1";
+
+interface Row {
+  readonly workspace_id: string;
+  readonly id: string;
+  readonly visible_to: readonly unknown[];
+  readonly status: string | null;
+}
+
+const row = (id: string, visibleTo: readonly unknown[], overrides: Partial<Row> = {}): Row => ({
+  workspace_id: WORKSPACE,
+  id,
+  visible_to: visibleTo,
+  status: null,
+  ...overrides,
+});
+
+/** `hasInternalDB()` reads DATABASE_URL; set inside tests, never at top level. */
+function withDatabaseUrl<T>(fn: () => Promise<T>): Promise<T> {
+  const prior = process.env.DATABASE_URL;
+  process.env.DATABASE_URL = "postgres://stub/stub";
+  return fn().finally(() => {
+    if (prior === undefined) delete process.env.DATABASE_URL;
+    else process.env.DATABASE_URL = prior;
+  });
+}
+
+/**
+ * A sweep wired to per-table fixtures. Both gated tables are served, so a test
+ * that only cares about facts still exercises the real two-table iteration.
+ */
+function harness(
+  byTable: Partial<Record<string, readonly Row[]>>,
+  extra: Omit<GrantSweepDeps, "query"> = {},
+) {
+  const scans: string[] = [];
+  const deps: GrantSweepDeps = {
+    ...extra,
+    query: (<T>(sql: string) => {
+      const table = ACL_GATED_TABLES.find((t) => sql.includes(`FROM ${t}`));
+      if (!table) throw new Error(`scan SQL named no gated table: ${sql}`);
+      scans.push(table);
+      return Promise.resolve((byTable[table] ?? []) as unknown as T[]);
+    }) as GrantSweepDeps["query"],
+  };
+  return { deps, scans };
+}
+
+describe("runGrantSweepCycle — what counts as malformed", () => {
+  it("flags a grant whose only token has a VALID PREFIX but does not parse", async () => {
+    // The fixture with no cover. A prefix check, a regex over `role:|user:|
+    // audience:|org`, or a SQL narrow that looks for "no element with a known
+    // prefix" all call this row clean. Only `parsePrincipal`'s role-membership
+    // test calls it malformed — which is the whole claim of this module.
+    const { deps } = harness({ brain_facts: [row("f_1", ["role:bogus"])] });
+
+    const result = await withDatabaseUrl(() => runGrantSweepCycle(deps));
+
+    expect(result.status).toBe("success");
+    expect(result.malformedRows).toBe(1);
+    expect(result.malformedWorkspaces).toBe(1);
+    expect(result.sample).toEqual([
+      { table: "brain_facts", workspaceId: WORKSPACE, rowId: "f_1", status: null, grant: ["role:bogus"] },
+    ]);
+  });
+
+  it("flags case-variant and bare-prefix tokens — the parser is byte-exact", async () => {
+    // `Audience:eng` and `ROLE:admin` differ from a valid token by one byte, and
+    // `user:` is a valid prefix with nothing after it. All three are malformed
+    // because Postgres's `&&` is byte-exact and the parser must not be kinder
+    // than the operator that enforces the grant.
+    const { deps } = harness({
+      brain_facts: [row("f_1", ["Audience:eng"]), row("f_2", ["ROLE:admin"])],
+      brain_episodes: [row("e_1", ["user:"]), row("e_2", ["org "])],
+    });
+
+    const result = await withDatabaseUrl(() => runGrantSweepCycle(deps));
+
+    expect(result.malformedRows).toBe(4);
+    expect(result.sample.map((s) => s.rowId).toSorted()).toEqual(["e_1", "e_2", "f_1", "f_2"]);
+  });
+
+  it("flags `role:platform_admin` — a platform role is not an org grant", async () => {
+    const { deps } = harness({ brain_facts: [row("f_1", ["role:platform_admin"])] });
+
+    const result = await withDatabaseUrl(() => runGrantSweepCycle(deps));
+
+    expect(result.malformedRows).toBe(1);
+  });
+
+  it("does NOT flag a grant with one usable principal — that is logGrantAnomalies' remit", async () => {
+    // The double-count guard. `['user:abc', 'everyone']` is reported at read
+    // time by the caller holding the row; repeating it here would bury the
+    // entirely-malformed row in the noise of every partly-sloppy grant.
+    const { deps } = harness({
+      brain_facts: [row("f_1", ["user:abc", "everyone"]), row("f_2", ["role:member", "team:eng"])],
+      brain_episodes: [row("e_1", ["audience:chat-channel:slack:C1", null, ""])],
+    });
+
+    const result = await withDatabaseUrl(() => runGrantSweepCycle(deps));
+
+    expect(result.malformedRows).toBe(0);
+    expect(result.sample).toEqual([]);
+  });
+
+  it("flags a grant of only NULL/'' elements — legal at rest, usable by nobody", async () => {
+    // 0180's CHECK admits `[NULL, '']`? No — it requires one non-NULL non-empty
+    // element. But `['', 'everyone']` IS admitted, and parses to zero
+    // principals. The CHECK is a cardinality test; this is a grammar test, and
+    // the gap between them is exactly what this sweep reports.
+    const { deps } = harness({ brain_facts: [row("f_1", ["", "everyone"])] });
+
+    const result = await withDatabaseUrl(() => runGrantSweepCycle(deps));
+
+    expect(result.malformedRows).toBe(1);
+  });
+});
+
+describe("runGrantSweepCycle — scope", () => {
+  it("scans BOTH gated tables, iterating the registry", async () => {
+    const { deps, scans } = harness({});
+
+    await withDatabaseUrl(() => runGrantSweepCycle(deps));
+
+    expect(scans.toSorted()).toEqual([...ACL_GATED_TABLES].toSorted());
+  });
+
+  it("flags DRAFT facts — an unreviewable row is the most stuck one, not the least", async () => {
+    // `loadFactCandidates` ANDs the ACL predicate, so a malformed draft is
+    // invisible to the reviewer too: it can never be reviewed or promoted. A
+    // published-only sweep would hide the one class with a decision pending.
+    const { deps } = harness({
+      brain_facts: [
+        row("f_draft", ["everyone"], { status: "draft" }),
+        row("f_pub", ["team:eng"], { status: "published" }),
+        row("f_arch", ["role:bogus"], { status: "archived" }),
+      ],
+    });
+
+    const result = await withDatabaseUrl(() => runGrantSweepCycle(deps));
+
+    expect(result.malformedRows).toBe(3);
+    // Status rides along so an operator can deprioritise `archived` — it is a
+    // triage field in the log line, never a filter in the query.
+    expect(result.sample.map((s) => [s.rowId, s.status])).toEqual([
+      ["f_draft", "draft"],
+      ["f_pub", "published"],
+      ["f_arch", "archived"],
+    ]);
+  });
+
+  it("counts distinct workspaces, not rows", async () => {
+    const { deps } = harness({
+      brain_facts: [
+        row("f_1", ["everyone"], { workspace_id: "ws-a" }),
+        row("f_2", ["everyone"], { workspace_id: "ws-a" }),
+        row("f_3", ["everyone"], { workspace_id: "ws-b" }),
+      ],
+    });
+
+    const result = await withDatabaseUrl(() => runGrantSweepCycle(deps));
+
+    expect(result.malformedRows).toBe(3);
+    expect(result.malformedWorkspaces).toBe(2);
+  });
+
+  it("no-ops cleanly without an internal DB", async () => {
+    const prior = process.env.DATABASE_URL;
+    delete process.env.DATABASE_URL;
+    try {
+      const { deps, scans } = harness({ brain_facts: [row("f_1", ["everyone"])] });
+      const result = await runGrantSweepCycle(deps);
+
+      expect(result.status).toBe("success");
+      // `null`, not 0 — the sweep did not run, and 0 would read as all-clear.
+      expect(result.malformedRows).toBeNull();
+      expect(scans).toEqual([]);
+    } finally {
+      if (prior !== undefined) process.env.DATABASE_URL = prior;
+    }
+  });
+});
+
+describe("runGrantSweepCycle — the scan SQL", () => {
+  it("narrows on the exact `org` token and nothing else", () => {
+    for (const table of ACL_GATED_TABLES) {
+      const sql = grantScanSql(table);
+      expect(sql).toContain("NOT ('org' = ANY(visible_to))");
+      // The grammar-duplication guard. A predicate mentioning any
+      // PARAMETERISED arm is a second derivation of `parsePrincipal`, and the
+      // obvious version of it ("no element has a known prefix") silently drops
+      // `['role:bogus']` — under-reporting, in the direction that matters.
+      expect(sql).not.toContain("role:");
+      expect(sql).not.toContain("user:");
+      expect(sql).not.toContain("audience:");
+      expect(sql).not.toMatch(/LIKE|SIMILAR TO|~/);
+    }
+  });
+
+  it("projects status from brain_facts and NULL from brain_episodes", () => {
+    // `brain_episodes` has no status column; a shared projection would make the
+    // scan fail on one of the two tables at runtime.
+    expect(grantScanSql("brain_facts")).toMatch(/SELECT workspace_id, id, visible_to, status/);
+    expect(grantScanSql("brain_episodes")).toContain("NULL::text AS status");
+  });
+
+  it("orders the capped prefix stably", () => {
+    // Without an ORDER BY, a truncated sweep reports a different arbitrary
+    // slice each cycle and the count wanders for no reason.
+    for (const table of ACL_GATED_TABLES) {
+      expect(grantScanSql(table)).toContain("ORDER BY workspace_id, id");
+    }
+  });
+});
+
+describe("runGrantSweepCycle — degradation is visible", () => {
+  it("reports a partial scan as `degraded`, keeping the counters it has", async () => {
+    const deps: GrantSweepDeps = {
+      query: (<T>(sql: string) => {
+        if (sql.includes("FROM brain_episodes")) return Promise.reject(new Error("relation gone"));
+        return Promise.resolve([row("f_1", ["everyone"])] as unknown as T[]);
+      }) as GrantSweepDeps["query"],
+    };
+
+    const result = await withDatabaseUrl(() => runGrantSweepCycle(deps));
+
+    expect(result.status).toBe("degraded");
+    expect(result.malformedRows).toBe(1);
+    expect(result.error).toContain("relation gone");
+  });
+
+  it("reports all-null counters when EVERY table's scan fails", async () => {
+    const deps: GrantSweepDeps = { query: () => Promise.reject(new Error("db down")) };
+
+    const result = await withDatabaseUrl(() => runGrantSweepCycle(deps));
+
+    expect(result.status).toBe("failure");
+    // Not 0. A failed sweep reporting zero is indistinguishable from a healthy
+    // deployment on the span, hiding exactly the number this module exists for.
+    expect(result.malformedRows).toBeNull();
+    expect(result.malformedWorkspaces).toBeNull();
+    expect(result.rowsScanned).toBeNull();
+  });
+
+  it("never throws — a rejected scan is a result, not an exception", async () => {
+    const deps: GrantSweepDeps = { query: () => Promise.reject(new Error("boom")) };
+    // The fiber routes this through `Effect.tryPromise`, but the contract the
+    // scheduler relies on is that the cycle itself resolves.
+    await expect(withDatabaseUrl(() => runGrantSweepCycle(deps))).resolves.toBeDefined();
+  });
+
+  it("flags truncation when the row cap is reached", async () => {
+    const { deps } = harness({ brain_facts: [row("f_1", ["everyone"]), row("f_2", ["org"])] }, {
+      rowCap: 2,
+    });
+
+    const result = await withDatabaseUrl(() => runGrantSweepCycle(deps));
+
+    expect(result.scanTruncated).toBe(true);
+    // The count is a FLOOR — reported, not silently presented as a total.
+    expect(result.malformedRows).toBe(1);
+  });
+
+  it("does not flag truncation on a short scan", async () => {
+    const { deps } = harness({ brain_facts: [row("f_1", ["everyone"])] }, { rowCap: 10 });
+
+    const result = await withDatabaseUrl(() => runGrantSweepCycle(deps));
+
+    expect(result.scanTruncated).toBe(false);
+  });
+
+  it("neither clears nor flags a row whose shape it cannot read", async () => {
+    // Query drift, not a data defect. Counting it as malformed would send the
+    // investigation to the wrong file; counting it as clean would let a
+    // projection change silently zero the sweep out.
+    const { deps } = harness({
+      brain_facts: [
+        { workspace_id: WORKSPACE, id: "f_1", visible_to: "not-an-array", status: null } as never,
+        row("f_2", ["everyone"]),
+      ],
+    });
+
+    const result = await withDatabaseUrl(() => runGrantSweepCycle(deps));
+
+    expect(result.malformedRows).toBe(1);
+    expect(result.sample.map((s) => s.rowId)).toEqual(["f_2"]);
+    expect(result.rowsScanned).toBe(2);
+  });
+});
+
+describe("getGrantSweepIntervalMs", () => {
+  /** Drive the registry knob through its env mirror; restored on the way out. */
+  function withInterval<T>(value: string | undefined, fn: () => T): T {
+    const key = "ATLAS_BRAIN_GRANT_SWEEP_INTERVAL_HOURS";
+    const prior = process.env[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+    try {
+      return fn();
+    } finally {
+      if (prior === undefined) delete process.env[key];
+      else process.env[key] = prior;
+    }
+  }
+
+  it("defaults to daily — a permanent defect is a digest, not an event stream", () => {
+    expect(withInterval(undefined, getGrantSweepIntervalMs)).toBe(
+      DEFAULT_GRANT_SWEEP_INTERVAL_HOURS * 3_600_000,
+    );
+    expect(DEFAULT_GRANT_SWEEP_INTERVAL_HOURS).toBe(24);
+  });
+
+  it("honours a set value", () => {
+    // Asserted so the fallback cases below are not vacuously passing on a knob
+    // that is never read at all.
+    expect(withInterval("6", getGrantSweepIntervalMs)).toBe(6 * 3_600_000);
+    expect(withInterval("0.5", getGrantSweepIntervalMs)).toBe(1_800_000);
+  });
+
+  it("falls back to the default on unparseable or non-positive — never to disabled", () => {
+    // Unlike the staleness bound, `0` does NOT disable here: there is no
+    // enforcement to escape from, so a "disabled" arm would buy nothing but a
+    // way to lose the only observer of a permanent defect class by typo.
+    for (const bad of ["", "nonsense", "0", "-4", "NaN"]) {
+      expect({ bad, ms: withInterval(bad, getGrantSweepIntervalMs) }).toEqual({
+        bad,
+        ms: DEFAULT_GRANT_SWEEP_INTERVAL_HOURS * 3_600_000,
+      });
+    }
+  });
+
+  it("keeps a generous default row cap", () => {
+    expect(GRANT_SWEEP_ROW_CAP).toBeGreaterThanOrEqual(10_000);
+  });
+});

--- a/packages/api/src/lib/brain/__tests__/grant-sweep.test.ts
+++ b/packages/api/src/lib/brain/__tests__/grant-sweep.test.ts
@@ -33,6 +33,7 @@ import {
   grantScanSql,
   runGrantSweepCycle,
   type GrantSweepDeps,
+  type GrantSweepResult,
 } from "../grant-sweep";
 
 const WORKSPACE = "ws-1";
@@ -373,6 +374,44 @@ describe("runGrantSweepCycle — degradation is visible", () => {
     expect(result.malformedRows).toBe(MALFORMED_SAMPLE_CAP + 5);
     expect(result.sample).toHaveLength(MALFORMED_SAMPLE_CAP);
     expect(result.sampleTruncated).toBe(true);
+  });
+
+  it("keeps `scanTruncated ⇒ countIsFloor` on every return path", async () => {
+    // A cross-field invariant that no single test above covers: the cap is one
+    // of the fold's three causes, so the unfolded flag can never be the more
+    // optimistic of the two. Drift here would let an alert reading
+    // `countIsFloor` miss a capped scan — the exact case the fold exists for.
+    const cases: GrantSweepResult[] = [
+      // skipped — nothing ran
+      await (async () => {
+        const prior = process.env.DATABASE_URL;
+        delete process.env.DATABASE_URL;
+        try {
+          return await runGrantSweepCycle(harness({}).deps);
+        } finally {
+          if (prior !== undefined) process.env.DATABASE_URL = prior;
+        }
+      })(),
+      // failure — every table's scan threw
+      await withDatabaseUrl(() =>
+        runGrantSweepCycle({ query: () => Promise.reject(new Error("down")) }),
+      ),
+      // success, capped
+      await withDatabaseUrl(() =>
+        runGrantSweepCycle(harness({ brain_facts: [row("f_1", ["everyone"])] }, { rowCap: 1 }).deps),
+      ),
+      // success, clean
+      await withDatabaseUrl(() =>
+        runGrantSweepCycle(harness({ brain_facts: [row("f_1", ["org"])] }).deps),
+      ),
+    ];
+
+    for (const result of cases) {
+      if (result.scanTruncated) expect(result.countIsFloor).toBe(true);
+    }
+    // Non-vacuity: at least one case must actually have been truncated, or the
+    // implication above is satisfied by an empty antecedent every time.
+    expect(cases.some((r) => r.scanTruncated)).toBe(true);
   });
 
   it("does not flag truncation on a short scan", async () => {

--- a/packages/api/src/lib/brain/acl.ts
+++ b/packages/api/src/lib/brain/acl.ts
@@ -45,14 +45,20 @@
  * `principalTokens` guards its `user:`/`audience:` arms. It also means the
  * parser can be permissive without being unsafe.
  *
- * Stored-side anomalies are logged only where a caller invokes
+ * Stored-side anomalies are logged at read time only where a caller invokes
  * `logGrantAnomalies` on rows it already holds — see that function's comment
  * for why that is the only honest read-time seam a push-down predicate leaves
- * open. NOTE THE RESIDUAL GAP: a grant that is ENTIRELY malformed
- * (`['everyone']`) is correctly invisible and is logged by nobody, because no
- * reader ever holds the row. Closing that needs a write-time or sweep-time
- * observer (#4771's deriver, or a `registerPeriodicFiber` scan) and is
- * deliberately out of this slice — tracked on #4797.
+ * open. It cannot reach the grant that is ENTIRELY malformed (`['everyone']`,
+ * `['role:bogus']`): that row is correctly invisible to every reader, so no
+ * caller ever holds it, so no read-time seam can log it.
+ *
+ * That half is closed by `lib/brain/grant-sweep.ts` (#4797) — the
+ * `brain_grant_sweep` periodic fiber, which scans both gated tables through
+ * THIS module's `parseGrant` and reports a count on its span plus one bounded
+ * warn line per cycle. It is a SWEEP and not a write-time hook because a
+ * region-migration import bundle carries grants `grantProblem` legally admits
+ * on a route #4771's deriver does not own. It observes only: it adds no
+ * write-side rejection, and must not acquire one (see below).
  *
  * ## The one thing that must never become stricter
  *

--- a/packages/api/src/lib/brain/acl.ts
+++ b/packages/api/src/lib/brain/acl.ts
@@ -52,12 +52,14 @@
  * `['role:bogus']`): that row is correctly invisible to every reader, so no
  * caller ever holds it, so no read-time seam can log it.
  *
- * That half is closed by `lib/brain/grant-sweep.ts` (#4797) — the
+ * That half is observed by `lib/brain/grant-sweep.ts` (#4797) — the
  * `brain_grant_sweep` periodic fiber, which scans both gated tables through
- * THIS module's `parseGrant` and reports a count on its span plus one bounded
- * warn line per cycle. It is a SWEEP and not a write-time hook because a
+ * THIS module's `parseGrant` and reports a count on its span plus a bounded
+ * warn line naming the rows. The count is a FLOOR, not a proof of absence: the
+ * scan is capped per cycle and a failed table degrades it, both of which the
+ * result reports. It is a SWEEP and not a write-time hook because a
  * region-migration import bundle carries grants `grantProblem` legally admits
- * on a route #4771's deriver does not own. It observes only: it adds no
+ * on a route the ingest-time deriver does not own. It observes only: it adds no
  * write-side rejection, and must not acquire one (see below).
  *
  * ## The one thing that must never become stricter

--- a/packages/api/src/lib/brain/grant-sweep.ts
+++ b/packages/api/src/lib/brain/grant-sweep.ts
@@ -90,15 +90,20 @@ export const DEFAULT_GRANT_SWEEP_INTERVAL_HOURS = 24;
  * majority never reaches it, so this is not a fraction of the table's row count.
  *
  * A bound, not a policy — but a bound that is REPORTED rather than silent, via
- * `scanTruncated`. A sweep that quietly stopped at the cap would read as
+ * `countIsFloor` (and `scan_truncated` on the span, which names this cause
+ * specifically). A sweep that quietly stopped at the cap would read as
  * "nothing more to find" on exactly the deployments too large for it to have
  * looked, which is the failure mode this module exists to remove one instance
  * of. Generous enough that hitting it is itself the finding.
  */
 export const GRANT_SWEEP_ROW_CAP = 50_000;
 
-/** How many malformed rows one log line carries. A bound, not a policy. */
-const MALFORMED_SAMPLE_CAP = 20;
+/**
+ * How many malformed rows one log line (and {@link GrantSweepResult.sample})
+ * carries. A bound, not a policy. Exported so tests assert against it rather
+ * than restating `20` — a literal that silently inverts when fixtures change.
+ */
+export const MALFORMED_SAMPLE_CAP = 20;
 
 /**
  * The scan, per gated table.
@@ -207,11 +212,25 @@ export interface GrantSweepResult {
    */
   readonly unreadableRows: number | null;
   /**
-   * `malformedRows` is a FLOOR rather than a total — the scan hit
-   * {@link GRANT_SWEEP_ROW_CAP}, or a table's scan failed. Both causes are
-   * folded here so an alert can read one field; `status` and `error` say which.
+   * `malformedRows` is a FLOOR rather than a total. THREE causes are folded
+   * here so an alert can read one field: the scan hit
+   * {@link GRANT_SWEEP_ROW_CAP}, a table's scan failed, or rows came back in a
+   * shape this module could not read (a row it could not read is not a row it
+   * cleared). `scan_truncated` on the span discriminates the first — the three
+   * have different remediations and the fold must not cost the cause.
+   *
+   * `true` on the all-tables-failed path too: the cycle that scanned NOTHING is
+   * the strongest case for "this count is not a total", and reporting `false`
+   * there inverted the field's own rule.
    */
   readonly countIsFloor: boolean;
+  /**
+   * The row cap alone — {@link countIsFloor}'s cap arm, unfolded. Kept beside
+   * the fold because the three causes have different remediations, and an
+   * operator seeing only `countIsFloor` cannot tell "raise the cap" from "fix
+   * the scan".
+   */
+  readonly scanTruncated: boolean;
   readonly sample: readonly MalformedGrantRow[];
   /** {@link sample} was clipped to its cap; more rows are in the log line. */
   readonly sampleTruncated: boolean;
@@ -219,10 +238,14 @@ export interface GrantSweepResult {
 }
 
 /**
- * Frozen, not merely `readonly`. `readonly` is compile-time only, and this
- * object (and its `sample` array) is shared by reference across every no-result
- * return in the process — a type-violating `push` would poison every subsequent
- * cycle's report. `acl.ts`'s `DENY_ALL` is frozen for the same reason.
+ * Frozen, not merely `readonly` — `readonly` is compile-time only.
+ *
+ * Both call sites SPREAD this, so each return gets a fresh outer object; it is
+ * the `sample` ARRAY that genuinely escapes by reference into every no-result
+ * report in the process, and a type-violating `push` on it would poison all of
+ * them. That inner freeze is the load-bearing half; the outer one keeps the
+ * constant honest about being a constant. `acl.ts`'s `DENY_ALL` freezes its
+ * `params` for exactly the same reason.
  */
 const NO_RESULT: Omit<GrantSweepResult, "status"> = Object.freeze({
   malformedRows: null,
@@ -230,6 +253,7 @@ const NO_RESULT: Omit<GrantSweepResult, "status"> = Object.freeze({
   rowsScanned: null,
   unreadableRows: null,
   countIsFloor: false,
+  scanTruncated: false,
   sample: Object.freeze([]) as readonly MalformedGrantRow[],
   sampleTruncated: false,
 });
@@ -259,6 +283,18 @@ export interface GrantSweepDeps {
 export const MAX_TIMER_DELAY_MS = 2 ** 31 - 1;
 
 /**
+ * Floor on the interval (3 minutes).
+ *
+ * The clamp above is not enough on its own: this is the module whose entire
+ * design argument is that CADENCE is the control against alert fatigue, and an
+ * unguarded `…_HOURS=0.0001` runs a full two-table scan roughly three times a
+ * second — with a findings warn line each cycle on any deployment that has a
+ * malformed row. Guarding one end and not the other would leave the knob able
+ * to defeat the property it exists to set.
+ */
+export const MIN_GRANT_SWEEP_INTERVAL_MS = 180_000;
+
+/**
  * How often the sweep runs, in milliseconds.
  *
  * Unparseable or non-positive falls back to the DEFAULT rather than disabling.
@@ -286,6 +322,13 @@ export function getGrantSweepIntervalMs(): number {
     return DEFAULT_GRANT_SWEEP_INTERVAL_HOURS * 3_600_000;
   }
   const ms = hours * 3_600_000;
+  if (ms < MIN_GRANT_SWEEP_INTERVAL_MS) {
+    log.warn(
+      { raw, minMinutes: MIN_GRANT_SWEEP_INTERVAL_MS / 60_000 },
+      "ATLAS_BRAIN_GRANT_SWEEP_INTERVAL_HOURS is below the minimum sweep interval — clamping, since a permanent defect does not need re-reporting this often",
+    );
+    return MIN_GRANT_SWEEP_INTERVAL_MS;
+  }
   if (ms > MAX_TIMER_DELAY_MS) {
     log.warn(
       { raw, maxHours: MAX_TIMER_DELAY_MS / 3_600_000 },
@@ -431,13 +474,23 @@ export async function runGrantSweepCycle(deps: GrantSweepDeps = {}): Promise<Gra
   }
 
   if (failures === ACL_GATED_TABLES.length) {
-    return { status: "failure", ...NO_RESULT, ...(firstError ? { error: firstError } : {}) };
+    // `countIsFloor: true` overrides NO_RESULT's `false`: nothing was scanned,
+    // which is the strongest case for "not a total" the field has.
+    return {
+      status: "failure",
+      ...NO_RESULT,
+      countIsFloor: true,
+      ...(firstError ? { error: firstError } : {}),
+    };
   }
 
-  // Both causes of an incomplete count, folded into one field an alert can read:
-  // the row cap, and a table whose scan failed. `scanTruncated` alone would have
-  // read a half-scan (one table errored) as a complete one.
-  const countIsFloor = truncated || failures > 0;
+  // Every cause of an incomplete count, folded into one field an alert can
+  // read. `truncated` alone would have read a half-scan (one table errored) as
+  // a complete one; `truncated || failures` would have read a cycle whose rows
+  // were all UNREADABLE as a complete one — reporting `malformed_rows: 0,
+  // count_is_floor: false` while nothing was actually examined, which is the
+  // fabricated all-clear `unreadableRows` was added to prevent.
+  const countIsFloor = truncated || failures > 0 || unreadable > 0;
 
   if (truncated) {
     // The "no silent caps" half of the contract. A capped sweep reports a
@@ -461,6 +514,7 @@ export async function runGrantSweepCycle(deps: GrantSweepDeps = {}): Promise<Gra
         malformedRows: malformed.length,
         malformedWorkspaces: workspaces.size,
         rowsScanned: scanned,
+        unreadableRows: unreadable,
         countIsFloor,
         sample: malformed.slice(0, MALFORMED_SAMPLE_CAP),
         sampleTruncated: malformed.length > MALFORMED_SAMPLE_CAP,
@@ -475,15 +529,24 @@ export async function runGrantSweepCycle(deps: GrantSweepDeps = {}): Promise<Gra
     // read. It is deliberately NOT set by FINDINGS: malformed rows are a
     // steady-state defect, and folding them in would make `degraded` permanent
     // on any deployment that has one — and therefore ignorable, which is the
-    // failure this whole module is shaped around avoiding. An unreadable row is
-    // the opposite kind of thing: a code defect that gets fixed, so it cannot
-    // pin the status.
+    // failure this whole module is shaped around avoiding.
+    //
+    // The two arms it IS set by are not equally self-limiting, and the
+    // difference is worth stating rather than implying. An unreadable row is a
+    // code defect (`visible_to` is `text[] NOT NULL`, so no DATA can produce
+    // one) and gets fixed, so it cannot pin the status. A failing table CAN pin
+    // it indefinitely — a revoked `SELECT`, or a third entry added to
+    // `ACL_GATED_TABLES` before its migration reaches every region. That is
+    // accepted: a permanently failing scan is an operator action item, not a
+    // steady-state property of the data, and a sweep that cannot read its own
+    // tables should not be reporting `success`.
     status: failures > 0 || unreadable > 0 ? "degraded" : "success",
     malformedRows: malformed.length,
     malformedWorkspaces: workspaces.size,
     rowsScanned: scanned,
     unreadableRows: unreadable,
     countIsFloor,
+    scanTruncated: truncated,
     sample: malformed.slice(0, MALFORMED_SAMPLE_CAP),
     sampleTruncated: malformed.length > MALFORMED_SAMPLE_CAP,
     ...(firstError ? { error: firstError } : {}),

--- a/packages/api/src/lib/brain/grant-sweep.ts
+++ b/packages/api/src/lib/brain/grant-sweep.ts
@@ -442,6 +442,12 @@ export async function runGrantSweepCycle(deps: GrantSweepDeps = {}): Promise<Gra
   // `skipped`, not `success` — nothing ran, and the counters are null to say
   // so. Reporting `success` here was the one state {@link GrantSweepResult}
   // documents as impossible: an all-clear status over "we do not know".
+  //
+  // `countIsFloor` stays FALSE here, unlike the all-tables-failed path below,
+  // and the two are not inconsistent: that path ATTEMPTED a count and could not
+  // complete it, so its zero is a floor. This one never attempted one — there
+  // is no count for a floor to be a floor OF. (`status` already distinguishes
+  // them, and the fiber's gate makes this path near-unreachable in production.)
   if (!hasInternalDB()) return { status: "skipped", ...NO_RESULT };
 
   const query = deps.query ?? internalQuery;
@@ -524,9 +530,13 @@ export async function runGrantSweepCycle(deps: GrantSweepDeps = {}): Promise<Gra
   }
 
   return {
-    // `degraded` means the counters are a partial or unverified floor — one
-    // table's scan failed, or rows came back in a shape this module could not
-    // read. It is deliberately NOT set by FINDINGS: malformed rows are a
+    // `degraded` means the counters are a partial or unverified floor through
+    // a FAULT — one table's scan failed, or rows came back in a shape this
+    // module could not read. A cap hit also makes them a floor and stays
+    // `success` on purpose: the cap is an operator-tunable bound working as
+    // configured, not something going wrong, and `countIsFloor` +
+    // `scan_truncated` already carry it. So the fold has three causes and this
+    // status takes two. It is deliberately NOT set by FINDINGS: malformed rows are a
     // steady-state defect, and folding them in would make `degraded` permanent
     // on any deployment that has one — and therefore ignorable, which is the
     // failure this whole module is shaped around avoiding.

--- a/packages/api/src/lib/brain/grant-sweep.ts
+++ b/packages/api/src/lib/brain/grant-sweep.ts
@@ -1,0 +1,401 @@
+/**
+ * The entirely-malformed-grant sweep (#4797, ADR-0036 §Access control &
+ * residency) — the observer that closes the residual gap `acl.ts`'s header
+ * discloses.
+ *
+ * #4768's acceptance criterion is "unknown/malformed grant ⇒ row invisible AND
+ * logged". The invisible half is structural: the predicate is an array overlap
+ * against the reader's tokens and no reader token is ever malformed, so a
+ * malformed stored token matches nothing. The logged half was only partly
+ * delivered. `logGrantAnomalies` fires on rows a caller ALREADY HOLDS, which
+ * catches `['user:abc', 'everyone']` — a grant that passes on its valid token
+ * while carrying a second one the author believed was doing something. But a
+ * grant that is ENTIRELY malformed (`['everyone']`, `['role:bogus']`) is
+ * correctly invisible to every reader, so no caller ever holds the row, so
+ * nothing logs it. A push-down predicate cannot log the rows it excluded; that
+ * is the point of pushing it down.
+ *
+ * This is the seam that can. It is a SWEEP and not a write-time hook because a
+ * write-time hook cannot close the acceptance criterion: a region-migration
+ * import bundle carries grants that `grantProblem` legally admits, on a route
+ * #4771's deriver does not own. A sweep is indifferent to how the row arrived.
+ *
+ * ## An OBSERVER, never a gate
+ *
+ * Nothing here rejects, repairs, or writes. Migration 0180's
+ * `chk_brain_{facts,episodes}_grant_nonempty` is the ceiling on what may be
+ * stored, `grantProblem` in `api/routes/admin-migrate.ts` mirrors it exactly,
+ * and a row Postgres legally stores but Atlas code refuses is a workspace that
+ * cannot be migrated between regions — discovered at cutover, long after the
+ * row landed. `acl.ts`'s parser is deliberately stricter than both and must
+ * never be hoisted to import time, so this module reads it from a scheduler
+ * fiber where it can only ever produce a log line and a number.
+ *
+ * ## Why a gauge, and why daily
+ *
+ * A malformed grant is a PERMANENT data defect — nothing repairs it
+ * automatically, so the naive sweep reports the same rows identically forever,
+ * on every replica, and the signal becomes ignorable. That is the same outcome
+ * as not having it.
+ *
+ * The resolution is that the two channels want opposite things and only one of
+ * them is an alert. The COUNT on the span is a gauge: it wants continuous
+ * re-emission, because that is what makes it alertable on a threshold and what
+ * makes it visibly return to zero when someone fixes the rows. Emitting it once
+ * — the per-row stamp column considered and rejected on #4797 — converts it
+ * into an edge-triggered event that goes silent WHILE THE DEFECT PERSISTS, so a
+ * report landing during a log rotation is lost forever. The LOG LINE is not the
+ * alert; it is the fix list read after the gauge fires, and its cost is bounded
+ * by cadence rather than by row count.
+ *
+ * So fatigue is a cadence problem, and the cadence is the control: this fiber
+ * defaults to DAILY, not to the audience sync's 30 minutes. One line per day
+ * per replica is a digest; forty-eight is noise. A permanent condition does not
+ * become more urgent by being restated every half hour.
+ *
+ * ## Why its own fiber
+ *
+ * Not folded into `brain_audience_sync`. That cycle is gated on Slack chat
+ * installs and is workspace-opt-out-able; a workspace with no installs still
+ * has facts, and a grant defect there is exactly as invisible. Enablement here
+ * is the internal DB and nothing else — an operator should not have to opt in
+ * to learning that their data is broken.
+ *
+ * ## Drafts are in scope, and there is no status filter at all
+ *
+ * `loadFactCandidates` (`lib/brain/candidates.ts`) ANDs `aclVisibilityClause`
+ * into the review queue, so an entirely-malformed DRAFT is invisible to the
+ * reviewer too: it can never be reviewed, never promoted, never archived. It is
+ * the most stuck row in the system, not the least, and filtering to `published`
+ * would hide precisely the class that still has a human decision pending. The
+ * only status-awareness in this module is carrying the column into the log
+ * sample so an operator can deprioritise `archived` — never a `WHERE`.
+ * `brain_episodes` has no `status` column at all, which is why the projection
+ * branches per table.
+ */
+
+import { createLogger } from "@atlas/api/lib/logger";
+import { hasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
+import { getSettingAuto } from "@atlas/api/lib/settings";
+import { ACL_GATED_TABLES, parseGrant, type AclGatedTable } from "@atlas/api/lib/brain/acl";
+
+const log = createLogger("brain.grant-sweep");
+
+/** Daily. See the module header on why this is not the audience sync's 30m. */
+export const DEFAULT_GRANT_SWEEP_INTERVAL_HOURS = 24;
+
+/**
+ * Rows examined per table per cycle.
+ *
+ * A bound, not a policy — but a bound that is REPORTED rather than silent, via
+ * `scanTruncated`. A sweep that quietly stopped at the cap would read as
+ * "nothing more to find" on exactly the deployments too large for it to have
+ * looked, which is the failure mode this module exists to remove one instance
+ * of. Generous enough that hitting it is itself the finding.
+ */
+export const GRANT_SWEEP_ROW_CAP = 50_000;
+
+/** How many malformed rows one log line carries. A bound, not a policy. */
+const MALFORMED_SAMPLE_CAP = 20;
+
+/**
+ * The scan, per gated table.
+ *
+ * ## The narrow is one exact string, and that is deliberate
+ *
+ * `parsePrincipal` / `parseGrant` in `acl.ts` are the ONLY authority on what a
+ * valid principal is. The tempting optimisation here is a SQL predicate that
+ * pre-filters malformed rows so the fiber never has to parse them — and it is a
+ * grammar duplication, the exact failure `acl.ts` and `audience/sync.ts` both
+ * spend paragraphs on: two independent derivations agree until one of them
+ * changes, and then the sweep goes quiet about the rows it stopped recognising.
+ *
+ * Worse, the obvious narrow is unsafe in the direction that matters. "Rows
+ * where no element has a valid prefix" DROPS `['role:bogus']` — valid prefix,
+ * does not parse, entirely malformed, and exactly the row being looked for. A
+ * pre-filter must never exclude a row TS would call malformed, which rules out
+ * every predicate that reasons about the PARAMETERISED arms.
+ *
+ * `NOT ('org' = ANY(visible_to))` is safe because `org` is a single exact
+ * token, not a grammar: a row containing it demonstrably has a valid principal,
+ * so excluding it can never hide a finding, and the rule survives any change to
+ * the `role:`/`user:`/`audience:` arms because it does not mention them.
+ * ADR-0036's "the public majority carries an explicit `[org]`" is what makes it
+ * worth having — it should shed most of the table.
+ *
+ * It is a heap FILTER, not an index scan: the GIN index on `visible_to` cannot
+ * serve a negation. What it buys is rows-not-sent-over-the-wire, which is the
+ * cost that actually scales here, since the parse must happen in TS.
+ *
+ * `ORDER BY workspace_id, id` makes the capped prefix stable across cycles
+ * rather than whatever the heap happened to return, so a truncated sweep
+ * reports the same rows each day instead of a different arbitrary slice.
+ */
+export function grantScanSql(table: AclGatedTable): string {
+  // `table` is a union member, not caller input — it cannot be an arbitrary
+  // identifier. The status projection branches because `brain_episodes` has no
+  // such column; see the module header.
+  const status = table === "brain_facts" ? "status" : "NULL::text AS status";
+  return `
+  SELECT workspace_id, id, visible_to, ${status}
+    FROM ${table}
+   WHERE NOT ('org' = ANY(visible_to))
+   ORDER BY workspace_id, id
+   LIMIT $1`;
+}
+
+/** One row the sweep flagged, as it appears in the log sample. */
+export interface MalformedGrantRow {
+  readonly table: AclGatedTable;
+  readonly workspaceId: string;
+  readonly rowId: string;
+  readonly status: string | null;
+  /** The stored grant verbatim, so the log line is a fix list and not a lookup. */
+  readonly grant: readonly unknown[];
+}
+
+/**
+ * What one cycle found. `null` on the counters means the sweep COULD NOT RUN —
+ * distinct from `0`, which means it ran and found nothing.
+ *
+ * The distinction is the whole point of reporting a count at all. A failed
+ * sweep reporting `0` is indistinguishable from a healthy deployment on the
+ * span, and would hide exactly the number this module exists to show.
+ */
+export interface GrantSweepResult {
+  readonly status: "success" | "degraded" | "failure";
+  readonly malformedRows: number | null;
+  readonly malformedWorkspaces: number | null;
+  readonly rowsScanned: number | null;
+  /** A table hit {@link GRANT_SWEEP_ROW_CAP}; the count is a floor, not a total. */
+  readonly scanTruncated: boolean;
+  readonly sample: readonly MalformedGrantRow[];
+  readonly error?: string;
+}
+
+const NO_RESULT: Omit<GrantSweepResult, "status"> = {
+  malformedRows: null,
+  malformedWorkspaces: null,
+  rowsScanned: null,
+  scanTruncated: false,
+  sample: [],
+};
+
+/**
+ * The query surface this module needs — injectable, so tests pass a literal
+ * rather than mocking a module. Shaped as `internalQuery`'s rows-array return
+ * (not `pg`'s `{ rows }`), matching `AudienceSyncDeps.query`.
+ */
+export type GrantSweepQuery = <T extends Record<string, unknown>>(
+  sql: string,
+  params?: unknown[],
+) => Promise<T[]>;
+
+export interface GrantSweepDeps {
+  readonly query?: GrantSweepQuery;
+  /** Row cap per table. Injectable so a test can drive truncation cheaply. */
+  readonly rowCap?: number;
+}
+
+/**
+ * How often the sweep runs, in milliseconds.
+ *
+ * Unparseable or non-positive falls back to the DEFAULT rather than disabling.
+ * A typo in an operator's override should not quietly switch off the only
+ * observer of a permanent defect class — and unlike the staleness bound, there
+ * is no enforcement here to escape from, so "0 disables" would buy nothing but
+ * a way to lose the signal by accident.
+ */
+export function getGrantSweepIntervalMs(): number {
+  const raw = getSettingAuto("ATLAS_BRAIN_GRANT_SWEEP_INTERVAL_HOURS");
+  if (raw === undefined || raw === "") return DEFAULT_GRANT_SWEEP_INTERVAL_HOURS * 3_600_000;
+  const hours = Number.parseFloat(raw);
+  if (!Number.isFinite(hours) || hours <= 0) {
+    log.warn(
+      { raw },
+      "ATLAS_BRAIN_GRANT_SWEEP_INTERVAL_HOURS is non-positive or unparseable — using the default",
+    );
+    return DEFAULT_GRANT_SWEEP_INTERVAL_HOURS * 3_600_000;
+  }
+  return hours * 3_600_000;
+}
+
+/** Narrow one scanned row, or `null` if its shape is unreadable. */
+function readScanRow(
+  row: unknown,
+): { workspaceId: string; rowId: string; status: string | null; grant: readonly unknown[] } | null {
+  if (typeof row !== "object" || row === null) return null;
+  const record = row as Record<string, unknown>;
+  const workspaceId = record.workspace_id;
+  const rowId = record.id;
+  const grant = record.visible_to;
+  if (typeof workspaceId !== "string" || typeof rowId !== "string") return null;
+  // `visible_to` is `text[] NOT NULL`, so a non-array here is query drift, not
+  // data. Reported as unreadable rather than coerced: a row whose grant cannot
+  // be read is not a row this sweep may pronounce clean, and counting it as
+  // malformed would put a shape bug in the same bucket as a data defect and
+  // send the investigation to the wrong file. See {@link GrantSweepResult}.
+  if (!Array.isArray(grant)) return null;
+  const status = record.status;
+  return {
+    workspaceId,
+    rowId,
+    status: typeof status === "string" ? status : null,
+    grant: grant as readonly unknown[],
+  };
+}
+
+/**
+ * Scan one gated table. Never throws — a per-table failure degrades the cycle
+ * rather than taking the other table down with it.
+ */
+async function sweepTable(
+  query: GrantSweepQuery,
+  table: AclGatedTable,
+  rowCap: number,
+): Promise<{
+  ok: boolean;
+  scanned: number;
+  truncated: boolean;
+  unreadable: number;
+  malformed: MalformedGrantRow[];
+  error?: string;
+}> {
+  try {
+    const rows = await query<Record<string, unknown>>(grantScanSql(table), [rowCap]);
+    const malformed: MalformedGrantRow[] = [];
+    let unreadable = 0;
+    for (const raw of rows) {
+      const row = readScanRow(raw);
+      if (!row) {
+        unreadable++;
+        continue;
+      }
+      // THE parse — `acl.ts`'s, not a second opinion about it. A row is flagged
+      // only when the module that decides visibility finds no principal in it,
+      // which is what makes this count and the predicate's silence the same
+      // fact rather than two derivations that agree for now.
+      const parsed = parseGrant(row.grant);
+      if (parsed.principals.length > 0) continue;
+      malformed.push({
+        table,
+        workspaceId: row.workspaceId,
+        rowId: row.rowId,
+        status: row.status,
+        grant: row.grant,
+      });
+    }
+    return {
+      ok: true,
+      scanned: rows.length,
+      truncated: rows.length >= rowCap,
+      unreadable,
+      malformed,
+    };
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    log.warn(
+      { table, err: error },
+      "brain grant sweep: scan failed — this table's malformed-grant count is unavailable this cycle",
+    );
+    return { ok: false, scanned: 0, truncated: false, unreadable: 0, malformed: [], error };
+  }
+}
+
+/**
+ * Run one malformed-grant sweep. Never throws.
+ *
+ * Returns all-`null` counters when it could not run at all, so the span records
+ * "we do not know" rather than a fabricated all-clear. A partial run — one
+ * table scanned, one failed — is `degraded` with the counters it does have,
+ * because half a floor is still more useful than none.
+ */
+export async function runGrantSweepCycle(deps: GrantSweepDeps = {}): Promise<GrantSweepResult> {
+  if (!hasInternalDB()) return { status: "success", ...NO_RESULT };
+
+  const query = deps.query ?? internalQuery;
+  const rowCap = deps.rowCap ?? GRANT_SWEEP_ROW_CAP;
+
+  const malformed: MalformedGrantRow[] = [];
+  const workspaces = new Set<string>();
+  let scanned = 0;
+  let truncated = false;
+  let unreadable = 0;
+  let failures = 0;
+  let firstError: string | undefined;
+
+  // Iterated, not hardcoded: a third gated table must not silently fall out of
+  // the sweep's coverage while `aclVisibilityClause` still gates it.
+  for (const table of ACL_GATED_TABLES) {
+    const out = await sweepTable(query, table, rowCap);
+    if (!out.ok) {
+      failures++;
+      firstError ??= out.error;
+      continue;
+    }
+    scanned += out.scanned;
+    truncated ||= out.truncated;
+    unreadable += out.unreadable;
+    for (const row of out.malformed) {
+      malformed.push(row);
+      workspaces.add(row.workspaceId);
+    }
+  }
+
+  if (failures === ACL_GATED_TABLES.length) {
+    return { status: "failure", ...NO_RESULT, ...(firstError ? { error: firstError } : {}) };
+  }
+
+  if (unreadable > 0) {
+    // Separate from the malformed count on purpose — see {@link readScanRow}.
+    log.warn(
+      { unreadable, scanned },
+      "brain grant sweep: scanned rows had an unreadable shape — the scan query's projection changed; these rows were neither cleared nor flagged",
+    );
+  }
+
+  if (truncated) {
+    // The "no silent caps" half of the contract. A capped sweep reports a
+    // FLOOR, and an operator reading the count has to know that.
+    log.warn(
+      { rowCap, scanned },
+      "brain grant sweep: the row cap was reached — the malformed-grant count is a floor, not a total, and rows past the cap were not examined",
+    );
+  }
+
+  if (malformed.length > 0) {
+    // The #4797 event. `warn` and with the row ids, because the operator-visible
+    // symptom is a fact that silently vanished from the brain: debugging starts
+    // from "the agent doesn't know X" with nothing to search for, and the only
+    // answer that helps names the rows and shows the grant that was stored.
+    //
+    // Emitted every cycle for as long as the rows exist. That is a gauge, not a
+    // repeat — see the module header on why reporting once would be worse.
+    log.warn(
+      {
+        malformedRows: malformed.length,
+        malformedWorkspaces: workspaces.size,
+        rowsScanned: scanned,
+        scanTruncated: truncated,
+        sample: malformed.slice(0, MALFORMED_SAMPLE_CAP),
+        sampleTruncated: malformed.length > MALFORMED_SAMPLE_CAP,
+      },
+      "brain grant sweep: rows carry no parseable principal — they are invisible to every reader AND to the review queue, and nothing repairs them automatically. Re-grant them at the source or re-import with a valid grant",
+    );
+  }
+
+  return {
+    // `degraded` means one table's scan failed, so the counters are a partial
+    // floor. It is deliberately NOT set by findings: malformed rows are a
+    // steady-state defect, and folding them in would make `degraded` permanent
+    // on any deployment that has one — and therefore ignorable, which is the
+    // failure this whole module is shaped around avoiding.
+    status: failures > 0 ? "degraded" : "success",
+    malformedRows: malformed.length,
+    malformedWorkspaces: workspaces.size,
+    rowsScanned: scanned,
+    scanTruncated: truncated,
+    sample: malformed.slice(0, MALFORMED_SAMPLE_CAP),
+    ...(firstError ? { error: firstError } : {}),
+  };
+}

--- a/packages/api/src/lib/brain/grant-sweep.ts
+++ b/packages/api/src/lib/brain/grant-sweep.ts
@@ -17,8 +17,9 @@
  *
  * This is the seam that can. It is a SWEEP and not a write-time hook because a
  * write-time hook cannot close the acceptance criterion: a region-migration
- * import bundle carries grants that `grantProblem` legally admits, on a route
- * #4771's deriver does not own. A sweep is indifferent to how the row arrived.
+ * import bundle carries grants that `grantProblem` legally admits, on a route the
+ * ingest-time grant deriver (#4770, inherited onto facts by #4771's reconcile)
+ * does not own. A sweep is indifferent to how the row arrived.
  *
  * ## An OBSERVER, never a gate
  *
@@ -42,7 +43,7 @@
  * them is an alert. The COUNT on the span is a gauge: it wants continuous
  * re-emission, because that is what makes it alertable on a threshold and what
  * makes it visibly return to zero when someone fixes the rows. Emitting it once
- * — the per-row stamp column considered and rejected on #4797 — converts it
+ * — which a per-row "already reported" stamp column would do — converts it
  * into an edge-triggered event that goes silent WHILE THE DEFECT PERSISTS, so a
  * report landing during a log rotation is lost forever. The LOG LINE is not the
  * alert; it is the fix list read after the gauge fires, and its cost is bounded
@@ -85,7 +86,8 @@ const log = createLogger("brain.grant-sweep");
 export const DEFAULT_GRANT_SWEEP_INTERVAL_HOURS = 24;
 
 /**
- * Rows examined per table per cycle.
+ * Rows examined per table per cycle, AFTER the `org` narrow — the public
+ * majority never reaches it, so this is not a fraction of the table's row count.
  *
  * A bound, not a policy — but a bound that is REPORTED rather than silent, via
  * `scanTruncated`. A sweep that quietly stopped at the cap would read as
@@ -116,16 +118,39 @@ const MALFORMED_SAMPLE_CAP = 20;
  * pre-filter must never exclude a row TS would call malformed, which rules out
  * every predicate that reasons about the PARAMETERISED arms.
  *
- * `NOT ('org' = ANY(visible_to))` is safe because `org` is a single exact
+ * `NOT (visible_to @> ARRAY['org'])` is safe because `org` is a single exact
  * token, not a grammar: a row containing it demonstrably has a valid principal,
  * so excluding it can never hide a finding, and the rule survives any change to
  * the `role:`/`user:`/`audience:` arms because it does not mention them.
  * ADR-0036's "the public majority carries an explicit `[org]`" is what makes it
  * worth having — it should shed most of the table.
  *
- * It is a heap FILTER, not an index scan: the GIN index on `visible_to` cannot
- * serve a negation. What it buys is rows-not-sent-over-the-wire, which is the
- * cost that actually scales here, since the parse must happen in TS.
+ * ## Why `@>` and NOT `'org' = ANY(visible_to)`
+ *
+ * The two read as synonyms and are not. `= ANY` is a scalar comparison folded
+ * over the elements, so it inherits SQL's three-valued logic: over an array
+ * containing a NULL element with no match it evaluates to NULL, not FALSE.
+ * `NOT NULL` is NULL, and `WHERE NULL` DROPS THE ROW.
+ *
+ * `['everyone', NULL]` and `['role:bogus', NULL]` are legal at rest — 0180's
+ * CHECK counts non-NULL non-empty elements and one survivor is enough — parse
+ * to zero principals, and are exactly what this sweep exists to find. Under
+ * `= ANY` all of them were silently excluded by the pre-filter, and the cycle
+ * reported `malformed_rows: 0, status: success`: a fabricated all-clear on the
+ * module's only signal, in the under-reporting direction, on rows an import
+ * bundle can carry today (`grantProblem` admits `["everyone", null]`).
+ *
+ * `@>` is array containment, which is two-valued over element NULLs: it answers
+ * FALSE, `NOT` answers TRUE, and the row is examined. It also matches the GIN
+ * index's own operator class, so the shape stays legible next to
+ * `idx_brain_*_visible_to`. This is a correctness fix, not a style preference —
+ * do not "simplify" it back to `= ANY`.
+ *
+ * It is still a heap FILTER, not an index scan — a NEGATED containment is not
+ * an index-scannable predicate, whichever operator sits inside it. (`= ANY(col)`
+ * would not have been GIN-servable in either polarity either; `array_ops` serves
+ * `&&`, `@>`, `<@`, `=`.) What the narrow buys is rows-not-sent-over-the-wire,
+ * which is the cost that actually scales here, since the parse must be in TS.
  *
  * `ORDER BY workspace_id, id` makes the capped prefix stable across cycles
  * rather than whatever the heap happened to return, so a truncated sweep
@@ -139,7 +164,7 @@ export function grantScanSql(table: AclGatedTable): string {
   return `
   SELECT workspace_id, id, visible_to, ${status}
     FROM ${table}
-   WHERE NOT ('org' = ANY(visible_to))
+   WHERE NOT (visible_to @> ARRAY['org'])
    ORDER BY workspace_id, id
    LIMIT $1`;
 }
@@ -163,39 +188,75 @@ export interface MalformedGrantRow {
  * span, and would hide exactly the number this module exists to show.
  */
 export interface GrantSweepResult {
-  readonly status: "success" | "degraded" | "failure";
+  /**
+   * `skipped` is a FOURTH state, not a flavour of success: there is no internal
+   * DB, so nothing ran. Without it the no-DB path returned `success` with
+   * all-null counters — the one combination this type's doc calls impossible.
+   */
+  readonly status: "success" | "degraded" | "failure" | "skipped";
   readonly malformedRows: number | null;
   readonly malformedWorkspaces: number | null;
   readonly rowsScanned: number | null;
-  /** A table hit {@link GRANT_SWEEP_ROW_CAP}; the count is a floor, not a total. */
-  readonly scanTruncated: boolean;
+  /**
+   * Rows the scan returned whose SHAPE could not be read (query drift, not a
+   * data defect — see {@link readScanRow}). Non-zero forces `degraded`, because
+   * a row that could not be read is one this sweep did not clear: without that,
+   * a projection change that made EVERY row unreadable reported
+   * `success / malformedRows: 0`, a fabricated all-clear on the module's only
+   * signal.
+   */
+  readonly unreadableRows: number | null;
+  /**
+   * `malformedRows` is a FLOOR rather than a total — the scan hit
+   * {@link GRANT_SWEEP_ROW_CAP}, or a table's scan failed. Both causes are
+   * folded here so an alert can read one field; `status` and `error` say which.
+   */
+  readonly countIsFloor: boolean;
   readonly sample: readonly MalformedGrantRow[];
+  /** {@link sample} was clipped to its cap; more rows are in the log line. */
+  readonly sampleTruncated: boolean;
   readonly error?: string;
 }
 
-const NO_RESULT: Omit<GrantSweepResult, "status"> = {
+/**
+ * Frozen, not merely `readonly`. `readonly` is compile-time only, and this
+ * object (and its `sample` array) is shared by reference across every no-result
+ * return in the process — a type-violating `push` would poison every subsequent
+ * cycle's report. `acl.ts`'s `DENY_ALL` is frozen for the same reason.
+ */
+const NO_RESULT: Omit<GrantSweepResult, "status"> = Object.freeze({
   malformedRows: null,
   malformedWorkspaces: null,
   rowsScanned: null,
-  scanTruncated: false,
-  sample: [],
-};
+  unreadableRows: null,
+  countIsFloor: false,
+  sample: Object.freeze([]) as readonly MalformedGrantRow[],
+  sampleTruncated: false,
+});
 
 /**
  * The query surface this module needs — injectable, so tests pass a literal
  * rather than mocking a module. Shaped as `internalQuery`'s rows-array return
  * (not `pg`'s `{ rows }`), matching `AudienceSyncDeps.query`.
  */
-export type GrantSweepQuery = <T extends Record<string, unknown>>(
+export type GrantSweepQuery = (
   sql: string,
   params?: unknown[],
-) => Promise<T[]>;
+) => Promise<readonly Record<string, unknown>[]>;
 
 export interface GrantSweepDeps {
   readonly query?: GrantSweepQuery;
   /** Row cap per table. Injectable so a test can drive truncation cheaply. */
   readonly rowCap?: number;
 }
+
+/**
+ * Effect's clock treats any duration above this as INFINITE — `unsafeSchedule`
+ * returns without arming a timer, so `Schedule.spaced` runs its first tick and
+ * then never ticks again. Shared bound with
+ * `scheduler/knowledge-bundle-sync.ts`'s `MAX_TIMER_DELAY_MS` (#4236).
+ */
+export const MAX_TIMER_DELAY_MS = 2 ** 31 - 1;
 
 /**
  * How often the sweep runs, in milliseconds.
@@ -205,6 +266,13 @@ export interface GrantSweepDeps {
  * observer of a permanent defect class — and unlike the staleness bound, there
  * is no enforcement here to escape from, so "0 disables" would buy nothing but
  * a way to lose the signal by accident.
+ *
+ * Over-large values are CLAMPED for the same reason, and the reason is not
+ * cosmetic: past `MAX_TIMER_DELAY_MS` (~596.5h) Effect never re-arms the timer,
+ * so `…_HOURS=600` — a plausible "dial this way down" keystroke — yields one
+ * boot tick and then permanent silence. That is indistinguishable from a dead
+ * fiber, and "nothing to notice but an ABSENCE of spans" is precisely the
+ * outcome this fiber's registration comment says it exists to avoid.
  */
 export function getGrantSweepIntervalMs(): number {
   const raw = getSettingAuto("ATLAS_BRAIN_GRANT_SWEEP_INTERVAL_HOURS");
@@ -217,7 +285,15 @@ export function getGrantSweepIntervalMs(): number {
     );
     return DEFAULT_GRANT_SWEEP_INTERVAL_HOURS * 3_600_000;
   }
-  return hours * 3_600_000;
+  const ms = hours * 3_600_000;
+  if (ms > MAX_TIMER_DELAY_MS) {
+    log.warn(
+      { raw, maxHours: MAX_TIMER_DELAY_MS / 3_600_000 },
+      "ATLAS_BRAIN_GRANT_SWEEP_INTERVAL_HOURS exceeds the max timer delay — clamping, since a larger value would stop the fiber ticking entirely",
+    );
+    return MAX_TIMER_DELAY_MS;
+  }
+  return ms;
 }
 
 /** Narrow one scanned row, or `null` if its shape is unreadable. */
@@ -249,20 +325,24 @@ function readScanRow(
  * Scan one gated table. Never throws — a per-table failure degrades the cycle
  * rather than taking the other table down with it.
  */
+type TableScan =
+  | {
+      readonly ok: true;
+      readonly scanned: number;
+      readonly truncated: boolean;
+      readonly unreadable: number;
+      readonly malformed: readonly MalformedGrantRow[];
+    }
+  /** `error` is non-optional exactly where it is guaranteed. */
+  | { readonly ok: false; readonly error: string };
+
 async function sweepTable(
   query: GrantSweepQuery,
   table: AclGatedTable,
   rowCap: number,
-): Promise<{
-  ok: boolean;
-  scanned: number;
-  truncated: boolean;
-  unreadable: number;
-  malformed: MalformedGrantRow[];
-  error?: string;
-}> {
+): Promise<TableScan> {
   try {
-    const rows = await query<Record<string, unknown>>(grantScanSql(table), [rowCap]);
+    const rows = await query(grantScanSql(table), [rowCap]);
     const malformed: MalformedGrantRow[] = [];
     let unreadable = 0;
     for (const raw of rows) {
@@ -285,20 +365,25 @@ async function sweepTable(
         grant: row.grant,
       });
     }
-    return {
-      ok: true,
-      scanned: rows.length,
-      truncated: rows.length >= rowCap,
-      unreadable,
-      malformed,
-    };
+    if (unreadable > 0) {
+      // Logged HERE, not in the cycle, because `table` is in scope only here —
+      // and the two projections deliberately differ (`status` vs `NULL::text AS
+      // status`), so "the scan query's projection changed" is useless without
+      // saying which one. The per-table catch below carries `table` for the
+      // same reason.
+      log.warn(
+        { table, unreadable, scanned: rows.length },
+        "brain grant sweep: scanned rows had an unreadable shape — this table's scan projection changed; these rows were neither cleared nor flagged",
+      );
+    }
+    return { ok: true, scanned: rows.length, truncated: rows.length >= rowCap, unreadable, malformed };
   } catch (err) {
     const error = err instanceof Error ? err.message : String(err);
     log.warn(
       { table, err: error },
       "brain grant sweep: scan failed — this table's malformed-grant count is unavailable this cycle",
     );
-    return { ok: false, scanned: 0, truncated: false, unreadable: 0, malformed: [], error };
+    return { ok: false, error };
   }
 }
 
@@ -311,7 +396,10 @@ async function sweepTable(
  * because half a floor is still more useful than none.
  */
 export async function runGrantSweepCycle(deps: GrantSweepDeps = {}): Promise<GrantSweepResult> {
-  if (!hasInternalDB()) return { status: "success", ...NO_RESULT };
+  // `skipped`, not `success` — nothing ran, and the counters are null to say
+  // so. Reporting `success` here was the one state {@link GrantSweepResult}
+  // documents as impossible: an all-clear status over "we do not know".
+  if (!hasInternalDB()) return { status: "skipped", ...NO_RESULT };
 
   const query = deps.query ?? internalQuery;
   const rowCap = deps.rowCap ?? GRANT_SWEEP_ROW_CAP;
@@ -346,13 +434,10 @@ export async function runGrantSweepCycle(deps: GrantSweepDeps = {}): Promise<Gra
     return { status: "failure", ...NO_RESULT, ...(firstError ? { error: firstError } : {}) };
   }
 
-  if (unreadable > 0) {
-    // Separate from the malformed count on purpose — see {@link readScanRow}.
-    log.warn(
-      { unreadable, scanned },
-      "brain grant sweep: scanned rows had an unreadable shape — the scan query's projection changed; these rows were neither cleared nor flagged",
-    );
-  }
+  // Both causes of an incomplete count, folded into one field an alert can read:
+  // the row cap, and a table whose scan failed. `scanTruncated` alone would have
+  // read a half-scan (one table errored) as a complete one.
+  const countIsFloor = truncated || failures > 0;
 
   if (truncated) {
     // The "no silent caps" half of the contract. A capped sweep reports a
@@ -376,7 +461,7 @@ export async function runGrantSweepCycle(deps: GrantSweepDeps = {}): Promise<Gra
         malformedRows: malformed.length,
         malformedWorkspaces: workspaces.size,
         rowsScanned: scanned,
-        scanTruncated: truncated,
+        countIsFloor,
         sample: malformed.slice(0, MALFORMED_SAMPLE_CAP),
         sampleTruncated: malformed.length > MALFORMED_SAMPLE_CAP,
       },
@@ -385,17 +470,22 @@ export async function runGrantSweepCycle(deps: GrantSweepDeps = {}): Promise<Gra
   }
 
   return {
-    // `degraded` means one table's scan failed, so the counters are a partial
-    // floor. It is deliberately NOT set by findings: malformed rows are a
+    // `degraded` means the counters are a partial or unverified floor — one
+    // table's scan failed, or rows came back in a shape this module could not
+    // read. It is deliberately NOT set by FINDINGS: malformed rows are a
     // steady-state defect, and folding them in would make `degraded` permanent
     // on any deployment that has one — and therefore ignorable, which is the
-    // failure this whole module is shaped around avoiding.
-    status: failures > 0 ? "degraded" : "success",
+    // failure this whole module is shaped around avoiding. An unreadable row is
+    // the opposite kind of thing: a code defect that gets fixed, so it cannot
+    // pin the status.
+    status: failures > 0 || unreadable > 0 ? "degraded" : "success",
     malformedRows: malformed.length,
     malformedWorkspaces: workspaces.size,
     rowsScanned: scanned,
-    scanTruncated: truncated,
+    unreadableRows: unreadable,
+    countIsFloor,
     sample: malformed.slice(0, MALFORMED_SAMPLE_CAP),
+    sampleTruncated: malformed.length > MALFORMED_SAMPLE_CAP,
     ...(firstError ? { error: firstError } : {}),
   };
 }

--- a/packages/api/src/lib/effect/__tests__/layers.test.ts
+++ b/packages/api/src/lib/effect/__tests__/layers.test.ts
@@ -474,6 +474,11 @@ describe("makeSchedulerLive", () => {
         // its extraction sibling this is gated ON by default: it grants no
         // model budget, and off would leave private-channel facts invisible.
         "brain_audience_sync",
+        // #4797 — company-brain malformed-grant sweep (ADR-0036). Gated on the
+        // internal DB alone: it is an integrity observer, not a feature, and a
+        // flag would let a deployment opt out of hearing that its rows are
+        // invisible.
+        "brain_grant_sweep",
       ],
     },
   ] as const;

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -2513,7 +2513,9 @@ export function makeSchedulerLive(
             // `tryPromise`, NOT `promise` — the same reasoning as
             // `brain_audience_sync` above. `runGrantSweepCycle` documents "never
             // throws" and catches its own per-table faults, but `hasInternalDB()`
-            // and the settings read sit outside that net. `Effect.promise` routes
+            // sits outside that net (unlike the sibling, this cycle performs no
+            // settings read — the interval is resolved in the `intervalMs` thunk
+            // at registration, outside the tick). `Effect.promise` routes
             // a rejection to the DEFECT channel, which `registerPeriodicFiber`'s
             // `catchAll` recovery does not catch — so one unforeseen throw would
             // kill this fiber for the life of the process, and the signal would
@@ -2533,9 +2535,15 @@ export function makeSchedulerLive(
           "atlas.brain.grant_sweep.malformed_rows": result.malformedRows ?? -1,
           "atlas.brain.grant_sweep.malformed_workspaces": result.malformedWorkspaces ?? -1,
           "atlas.brain.grant_sweep.rows_scanned": result.rowsScanned ?? -1,
+          // Rows the scan returned but could not READ. Non-zero means the
+          // malformed count is unverified rather than clean — it forces
+          // `degraded`, so this and `status` move together.
+          "atlas.brain.grant_sweep.unreadable_rows": result.unreadableRows ?? -1,
           // Whether `malformed_rows` is a total or a floor. Alerting on the
-          // count without this would read a capped scan as a complete one.
-          "atlas.brain.grant_sweep.scan_truncated": result.scanTruncated,
+          // count without this would read a capped scan — or a cycle where one
+          // table's scan failed — as a complete one. Both causes are folded in,
+          // so an alert reads one field rather than joining two.
+          "atlas.brain.grant_sweep.count_is_floor": result.countIsFloor,
         }),
         onTickFailure: {
           level: "warn",

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -314,6 +314,12 @@ export const SCHEDULER_WORK_SPAN_NAMES = {
   // adding AND revoking. Its `members_revoked` attribute is the alertable one:
   // a spike is either a real offboarding or a resolver that stopped resolving.
   brain_audience_sync: "atlas.scheduler.brain_audience_sync",
+  // #4797 — the entirely-malformed-grant sweep (ADR-0036). The one observer of
+  // a row whose `visible_to` names no principal: invisible to every reader by
+  // construction, therefore never held by a caller, therefore logged by nobody
+  // at read time. DAILY by default — the defect is permanent, so its count is a
+  // gauge and its log line is a digest, not an event stream.
+  brain_grant_sweep: "atlas.scheduler.brain_grant_sweep",
   // #4457 — internal-DB scheduled backups. The tick claims the current
   // cadence window atomically (partial UNIQUE index on
   // `backups.scheduled_window`), then create→verify→purge through the
@@ -2464,6 +2470,78 @@ export function makeSchedulerLive(
           message: "Company-brain audience sync tick failed — will retry next interval",
         },
         startLog: "Company-brain audience sync scheduler started",
+      });
+
+      // ── Periodic fiber: malformed-grant sweep (#4797, ADR-0036) ──────────
+      // Closes the deny+log gap `acl.ts`'s header discloses: a row whose
+      // `visible_to` parses to NO principal is invisible to every reader by
+      // construction, so no caller ever holds it and `logGrantAnomalies` never
+      // fires on it. A sweep is the only seam that can see it — and it must be
+      // a sweep rather than a write-time hook, because a region-migration
+      // import bundle carries grants `grantProblem` legally admits on a route
+      // #4771's deriver does not own.
+      //
+      // Gated on the internal DB ALONE — no feature flag. An operator should
+      // not have to opt in to learning that their data is broken, and unlike
+      // the audience sync this needs no chat install to be useful. The
+      // `yield* Migration` barrier above sequences it after `MigrationLive`, so
+      // the eager boot tick cannot race 0180 creating the tables.
+      yield* registerPeriodicFiber({
+        name: "brain_grant_sweep",
+        intervalMs: () => {
+          // oxlint-disable-next-line @typescript-eslint/no-require-imports -- read the interval synchronously at fiber-registration time (same pattern as brain_audience_sync). NOTE the knob is hot-reloadable in the registry but is read ONCE here, so a change takes effect at restart.
+          const { getGrantSweepIntervalMs } = require("@atlas/api/lib/brain/grant-sweep") as {
+            getGrantSweepIntervalMs: () => number;
+          };
+          return getGrantSweepIntervalMs();
+        },
+        gate: {
+          check: () => {
+            // oxlint-disable-next-line @typescript-eslint/no-require-imports -- sync gate check at layer build time; dynamic import would force the whole gen async for a boolean
+            const { hasInternalDB } = require("@atlas/api/lib/db/internal") as {
+              hasInternalDB: () => boolean;
+            };
+            return hasInternalDB();
+          },
+          skipLog: "Company-brain grant sweep not started — needs an internal database",
+        },
+        tick: Effect.tryPromise({
+          try: () => import("@atlas/api/lib/brain/grant-sweep"),
+          catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+        }).pipe(
+          Effect.flatMap((m) =>
+            // `tryPromise`, NOT `promise` — the same reasoning as
+            // `brain_audience_sync` above. `runGrantSweepCycle` documents "never
+            // throws" and catches its own per-table faults, but `hasInternalDB()`
+            // and the settings read sit outside that net. `Effect.promise` routes
+            // a rejection to the DEFECT channel, which `registerPeriodicFiber`'s
+            // `catchAll` recovery does not catch — so one unforeseen throw would
+            // kill this fiber for the life of the process, and the signal would
+            // revert to exactly the silence #4797 exists to end, with nothing to
+            // notice but an ABSENCE of spans.
+            Effect.tryPromise({
+              try: () => m.runGrantSweepCycle(),
+              catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+            }),
+          ),
+        ),
+        spanResultAttributes: (result) => ({
+          "atlas.brain.grant_sweep.status": result.status,
+          // `-1` encodes "the sweep could not run" — span attributes have no
+          // null, and reporting 0 would be indistinguishable from all-clear,
+          // which is precisely the silence this fiber exists to remove.
+          "atlas.brain.grant_sweep.malformed_rows": result.malformedRows ?? -1,
+          "atlas.brain.grant_sweep.malformed_workspaces": result.malformedWorkspaces ?? -1,
+          "atlas.brain.grant_sweep.rows_scanned": result.rowsScanned ?? -1,
+          // Whether `malformed_rows` is a total or a floor. Alerting on the
+          // count without this would read a capped scan as a complete one.
+          "atlas.brain.grant_sweep.scan_truncated": result.scanTruncated,
+        }),
+        onTickFailure: {
+          level: "warn",
+          message: "Company-brain grant sweep tick failed — will retry next interval",
+        },
+        startLog: "Company-brain grant sweep scheduler started",
       });
 
       // ── Periodic fiber: shared OpenAPI spec refresh (#2970, Tier-1; #4195) ──

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -2539,11 +2539,15 @@ export function makeSchedulerLive(
           // malformed count is unverified rather than clean — it forces
           // `degraded`, so this and `status` move together.
           "atlas.brain.grant_sweep.unreadable_rows": result.unreadableRows ?? -1,
-          // Whether `malformed_rows` is a total or a floor. Alerting on the
-          // count without this would read a capped scan — or a cycle where one
-          // table's scan failed — as a complete one. Both causes are folded in,
-          // so an alert reads one field rather than joining two.
+          // Whether `malformed_rows` is a total or a floor — the ONE field an
+          // alert reads. All three causes are folded in (row cap, a failed
+          // table, unreadable rows), so alerting never has to join two fields.
           "atlas.brain.grant_sweep.count_is_floor": result.countIsFloor,
+          // ...and the cause discriminator the fold would otherwise cost. A cap
+          // hit means "raise the cap"; a failed table means "fix the scan".
+          // Folding without this made a permanently-capped deployment
+          // indistinguishable from a broken one on the span alone.
+          "atlas.brain.grant_sweep.scan_truncated": result.scanTruncated,
         }),
         onTickFailure: {
           level: "warn",

--- a/packages/api/src/lib/settings.ts
+++ b/packages/api/src/lib/settings.ts
@@ -1829,7 +1829,7 @@ const SETTINGS_REGISTRY: SettingDefinition[] = [
     section: "Knowledge Base",
     label: "Company Brain Grant Sweep Interval",
     description:
-      "How often Atlas scans company-brain facts and episodes for access grants that name nobody, in hours (default 24). Such rows are invisible to every reader and to the review queue, and nothing repairs them automatically — the sweep only counts and logs them, and never rejects or changes anything. Applies at restart; non-positive or unparseable values fall back to the default.",
+      "How often Atlas scans company-brain facts and episodes for access grants that name nobody, in hours (default 24). Such rows are invisible to every reader and to the review queue, and nothing repairs them automatically — the sweep only counts and logs them, and never rejects or changes anything. Applies at restart; non-positive or unparseable values fall back to the default, values below 0.05 hours (3 minutes) are clamped up, and values above ~596 hours are clamped down to the maximum timer delay.",
     type: "number",
     default: "24",
     envVar: "ATLAS_BRAIN_GRANT_SWEEP_INTERVAL_HOURS",

--- a/packages/api/src/lib/settings.ts
+++ b/packages/api/src/lib/settings.ts
@@ -1814,6 +1814,28 @@ const SETTINGS_REGISTRY: SettingDefinition[] = [
     scope: "platform",
     saasVisible: false,
   },
+  {
+    // Cadence of the malformed-grant sweep (#4797). DAILY by default, and the
+    // gap from the audience sync's 30 minutes is the point: a malformed grant
+    // is a PERMANENT data defect, so the sweep re-reports the same rows every
+    // cycle forever. The count on the span is a gauge and wants that; the log
+    // line is the fix list and does not. Cadence is what keeps the second one
+    // a digest rather than noise — see `lib/brain/grant-sweep.ts`'s header.
+    //
+    // Platform-scoped: this observes a data-integrity defect in the operator's
+    // deployment, and a workspace admin turning down the rate at which their
+    // own broken rows get reported is the self-serving direction.
+    key: "ATLAS_BRAIN_GRANT_SWEEP_INTERVAL_HOURS",
+    section: "Knowledge Base",
+    label: "Company Brain Grant Sweep Interval",
+    description:
+      "How often Atlas scans company-brain facts and episodes for access grants that name nobody, in hours (default 24). Such rows are invisible to every reader and to the review queue, and nothing repairs them automatically — the sweep only counts and logs them, and never rejects or changes anything. Applies at restart; non-positive or unparseable values fall back to the default.",
+    type: "number",
+    default: "24",
+    envVar: "ATLAS_BRAIN_GRANT_SWEEP_INTERVAL_HOURS",
+    scope: "platform",
+    saasVisible: false,
+  },
 ];
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #4797. Targets `milestone/v0.2.0-brain-m1` — the **last open issue** in milestone #91.

## What this closes

#4768's criterion is *"unknown/malformed grant ⇒ row invisible **and logged**"*. The invisible half is structural. The logged half was only partly delivered: `logGrantAnomalies` fires on rows a caller **already holds**, so it catches `['user:abc','everyone']` but never `['everyone']` — that row is invisible to every reader, so no caller ever holds it, so nothing logs it. A push-down predicate cannot log the rows it excluded; that is the point of pushing it down.

`lib/brain/grant-sweep.ts` + the `brain_grant_sweep` periodic fiber scan both `ACL_GATED_TABLES` through `acl.ts`'s own `parseGrant`, reporting counts on the span and a bounded warn line per cycle.

A **sweep, not a write-time hook**: a region-migration import bundle carries grants `grantProblem` legally admits on a route the ingest-time deriver does not own (AC 2). **No write-side rejection is added** and none may be (AC 3) — a row Postgres legally stores but Atlas refuses is a workspace that cannot be migrated between regions, discovered at cutover. `acl.ts`'s residual-gap paragraph now points at the implemented seam (AC 4).

## The design decision

The issue's ACs rule out a write-time-only fix, so the genuinely open question was one the issue never mentions: **a malformed grant is permanent, so what stops the sweep re-reporting it forever, on every replica?**

Resolved as: the two channels want opposite things and only one is an alert.

- The **span count is a gauge** — it *wants* continuous re-emission, because that is what makes it alertable on a threshold and what makes it visibly return to zero when someone fixes the rows.
- The **log line is the fix list**, read after the gauge fires, and its cost is bounded by **cadence**.

So fatigue is a cadence problem: this fiber defaults to **daily**, not the audience sync's 30 minutes. One line/day/replica is a digest; forty-eight is noise.

A per-row stamp column was considered and rejected: it converts the gauge into an edge-triggered event that goes silent *while the defect persists* (a report landing during a log rotation is lost forever), and costs a migration plus a write path onto `brain_facts` — and #4797 says *observer, never a gate*.

Shape follows #4808's `sweepStaleness`: cycle counts on the span, `null`/`-1` when the sweep itself could not run, a bounded id sample modelled on `revokedUserIds`.

## The narrow, and the bug review caught in it

`parseGrant` is the **only** authority on what a valid principal is, so the scan duplicates no grammar. The narrow is one exact token:

```sql
WHERE NOT (visible_to @> ARRAY['org'])
```

`org` is a single token, not a grammar — a row carrying it demonstrably has a valid principal, so excluding it can never hide a finding, and the rule survives any change to the `role:`/`user:`/`audience:` arms because it does not mention them.

**It shipped in review as `NOT ('org' = ANY(visible_to))`, which was wrong**, and two panelists found it independently:

| grant | `= ANY` | `@>` |
|---|---|---|
| `{everyone}` | kept ✅ | kept ✅ |
| `{everyone,NULL}` | **NULL → DROPPED** ❌ | kept ✅ |
| `{role:bogus,NULL}` | **NULL → DROPPED** ❌ | kept ✅ |

`= ANY` is a scalar comparison folded over elements, so it inherits three-valued logic: over an array with a NULL element and no match it yields NULL, `NOT NULL` is NULL, and `WHERE NULL` drops the row. Both dropped grants pass 0180's CHECK, parse to zero principals, and `grantProblem` admits `["everyone", null]` from an import bundle **today**. The cycle reported `malformed_rows: 0, status: success` — a fabricated all-clear in the under-reporting direction.

The pg cross-check was **vacuous against it**: its only NULL-bearing fixtures also carried `org`, so they were shed for the right reason and the equality held regardless. Fixed, plus the two fixtures that fail against the old SQL and a unit-level `not.toContain("= ANY(")` so a regression is visible without a database.

## Scope decisions

- **Drafts are in scope, with no status filter at all.** `loadFactCandidates` ANDs `aclVisibilityClause`, so an entirely-malformed draft is invisible to the *reviewer* too — it can never be reviewed, promoted, or archived. The most stuck row, not the least. `status` rides into the log sample as a triage field (NULL for `brain_episodes`, which has no such column), never a `WHERE`.
- `ACL_GATED_TABLES` is iterated, not hardcoded.
- `Effect.tryPromise`, not `promise` — a rejection in the defect channel would kill the fiber for the process lifetime.
- One settings knob (`ATLAS_BRAIN_GRANT_SWEEP_INTERVAL_HOURS`, platform-scoped), no enable flag: an operator should not have to opt in to learning their data is broken. Gated on the internal DB alone.
- **No migration** — head stays 0182; `migrate.test.ts` counts and the applied-migrations fixture are untouched.

## Verification

`/ci` — **32/32 gates green**. Full suite: 974 api + 317 web + 52 ee + 38 mcp + 49 cli + 17 react files, 0 failures. `-pg` files re-run separately against real Postgres (they skip when `TEST_DATABASE_URL` is unset).

**Tests: 28 unit + 9 logging + 6 real-Postgres**, every guard mutation-probed — deleted, confirmed a test fails, and checked *which* test. Fixtures are deliberately **near-valid** (`role:bogus`, `Audience:eng`, `user:`, `role:platform_admin`), because a junk fixture like `zzz` passes under a prefix check just as happily as under the real parser. The pg suite cross-checks the narrowed scan against an unnarrowed one through the same parse — the only assertion that can fail in the under-reporting direction.

The probe found real gaps the tests didn't cover: the interval-fallback branch (the sibling knob's test only asserts the default with the knob *unset* — a different branch), the log line (swapping the logger for a no-op left 22/22 green), and the sample cap.

## Review panel — 3 rounds to CLEAN

- **Round 1** — the `= ANY` bug; the log line had zero coverage (added `grant-sweep-logging.test.ts`, joining the `acl-logging`/`search-logging` convention); unreadable rows reported `success`/`0`; `status: "success"` with all-null counters; an over-large interval silently stopped the fiber (past 2³¹−1 ms Effect treats the duration as infinite).
- **Round 2** — my round-1 fix introduced its own defect: `countIsFloor` was added to be the one field an alert reads and shipped folding **two of its three causes**; the span *lost* the cap discriminator; the new logging harness reintroduced the exact `Record<string,…>` vacuity hole round 1 closed in its sibling.
- **Round 3** — CLEAN; three LOW nits fixed inline.