### PR TITLE
docs(brain): scope the fixture-built ACL assertions, and stop reusing "two axes"

### DIFF
--- a/packages/api/src/lib/brain/__tests__/candidates-pg.test.ts
+++ b/packages/api/src/lib/brain/__tests__/candidates-pg.test.ts
@@ -29,6 +29,19 @@
  *   6. **Does a real page satisfy its own wire schema?** The route parses every
  *      response through it, so a coercion that violated it would be a 500.
  *
+ * ## What the ACL assertions here do NOT prove
+ *
+ * The reader contexts below are HAND-BUILT: `audienceIds` is a literal, and the
+ * candidate reads consume it as given — nothing here re-resolves membership. So
+ * claim 3 above is about the PREDICATE composed into these statements, not about
+ * how a principal came to hold those audience ids. Seeding a
+ * `fact_audience_member` row here would be inert; its absence is deliberate.
+ *
+ * Membership RESOLUTION is proven in `acl-visibility-pg.test.ts` and
+ * `wedge-loop-pg.test.ts`, which build contexts through
+ * `resolvePrincipalContext(pool, …)`. Put any case that turns on resolution
+ * there, not here.
+ *
  * Opt in locally with:
  *   bun run db:up && export TEST_DATABASE_URL=postgresql://atlas:atlas@localhost:5432/atlas
  */

--- a/packages/api/src/lib/brain/__tests__/search-pg.test.ts
+++ b/packages/api/src/lib/brain/__tests__/search-pg.test.ts
@@ -26,6 +26,20 @@
  *      behavior, and the only thing a fresh deployment returns.
  *   6. **Does content mode actually hide a draft fact?**
  *
+ * ## What the ACL assertions here do NOT prove
+ *
+ * The reader contexts below are HAND-BUILT: `audienceIds` is a literal, and
+ * `searchBrainCore` consumes `ctx.audienceIds` as given — it never re-resolves
+ * membership. So every ACL claim in this file is a statement about the SQL
+ * PREDICATE given a context, not about how that context came to be. Seeding a
+ * `fact_audience_member` row here would be inert; its absence is deliberate.
+ *
+ * The other half — that a real principal resolves to the audience ids assumed
+ * here — is proven in `acl-visibility-pg.test.ts` and `wedge-loop-pg.test.ts`,
+ * which build their contexts through `resolvePrincipalContext(pool, …)`. Read
+ * this file as predicate coverage; do not read it as end-to-end ACL proof, and
+ * if you add a case that turns on membership RESOLUTION, put it there instead.
+ *
  * Opt in locally with:
  *   bun run db:up && export TEST_DATABASE_URL=postgresql://atlas:atlas@localhost:5432/atlas
  */

--- a/packages/types/src/brain.ts
+++ b/packages/types/src/brain.ts
@@ -306,7 +306,12 @@ export interface BrainFactCandidateSummary {
  * (warehouse facts resolve live through the semantic layer and are
  * `executeSQL`'s), so it can never appear here.
  *
- * `document` is the class that makes the two axes distinct: a KB document is
+ * (Not to be confused with the "two different axes" of `lib/knowledge/search.ts`,
+ * which names what GATED a row — content-mode alone vs. content-mode + ACL.
+ * That is a third, orthogonal distinction; the pairing here is result class vs.
+ * trust ordering.)
+ *
+ * `document` is the class that separates result class from trust ordering: a KB document is
  * ADR-0028 descriptive prose, not a claim about the world, so it has no
  * position in a truth ordering at all. Its {@link BrainDocumentResult.trustTier}
  * is `null` rather than an invented 4 — a number would imply "less


### PR DESCRIPTION
Closes out the two non-blocking notes recorded at the Brain M1 milestone merge (#4814, merge commit `4b639fc0d`). **Comments only — no logic changes**; the diff is 33 comment lines plus one reworded sentence.

## 1. Fixture-scoped ACL assertions are now labeled as such

`search-pg.test.ts` and `candidates-pg.test.ts` hand-build `BrainPrincipalContext` with a literal `audienceIds`. `searchBrainCore` consumes `ctx.audienceIds` **as given** and never re-resolves membership, and `candidates.ts` has no resolution path at all — so every ACL claim in those two files is a statement about the **SQL predicate given a context**, not about how a principal came to hold those audience ids. A `fact_audience_member` seed there would be inert.

That is legitimate predicate coverage, but nothing said so, and the failure mode is a reader mistaking it for end-to-end ACL proof. Each header now scopes the claim and points at `acl-visibility-pg.test.ts` and `wedge-loop-pg.test.ts` — which build their contexts through `resolvePrincipalContext(pool, …)` — as where a resolution-dependent case belongs.

## 2. `types/brain.ts` stops reusing "two axes"

"Two different axes" is a taken term of art in `lib/knowledge/search.ts:37`, meaning what **gated** a row (content-mode alone vs. content-mode + ACL). `types/brain.ts` had reused the bare phrase for a different pairing — result class vs. trust ordering. It was locally disambiguated and is **not** the descriptive-vs-authoritative inversion caught during #4774, but the collision is avoidable: the distinction is now named directly, with a cross-reference marking the other sense as orthogonal.

## Verification

Claims in the new comments were checked against the code rather than taken from the review notes:
- `acl-visibility-pg.test.ts` uses `resolvePrincipalContext` (:40, :390, :490, :498)
- `wedge-loop-pg.test.ts` uses it (:57, :114, :618)
- `candidates.ts` contains no `resolvePrincipalContext` / `audienceIds` reference — confirming the "consumes as given" claim
- `knowledge/search.ts:37` still carries the term of art the cross-reference points at