### PR TITLE
fix(startup): name the resolved sandbox backend in the boot pre-flight

### DIFF
--- a/packages/api/src/api/routes/health.ts
+++ b/packages/api/src/api/routes/health.ts
@@ -18,6 +18,7 @@ import {
 import { getWhitelistedTables } from "@atlas/api/lib/semantic";
 import { createLogger } from "@atlas/api/lib/logger";
 import { getExploreBackendType, getActiveSandboxPluginId } from "@atlas/api/lib/tools/explore";
+import { BACKEND_ISOLATION } from "@atlas/api/lib/tools/backends/selection";
 import { detectAuthMode } from "@atlas/api/lib/auth/detect";
 import { SENSITIVE_PATTERNS } from "@atlas/api/lib/security";
 import { getSetting } from "@atlas/api/lib/settings";
@@ -625,12 +626,20 @@ health.openapi(healthRoute, async (c) => {
         status: schedulerEnabled ? "healthy" as const : "disabled" as const,
         lastCheckedAt: now,
       },
-      // just-bash means no isolation — report degraded so operators know
+      // An unsandboxed backend means no isolation — report degraded so operators
+      // know. Posture comes from BACKEND_ISOLATION rather than a `=== "just-bash"`
+      // comparison, so a future unsandboxed backend cannot report itself healthy
+      // by not being named here (#4824).
       sandbox: {
-        status: exploreBackend === "just-bash" ? "degraded" as const : "healthy" as const,
+        status:
+          BACKEND_ISOLATION[exploreBackend] === "unsandboxed"
+            ? "degraded" as const
+            : "healthy" as const,
         backend: exploreBackend,
         lastCheckedAt: now,
-        ...(exploreBackend === "just-bash" && { message: "No sandbox isolation — using just-bash fallback" }),
+        ...(BACKEND_ISOLATION[exploreBackend] === "unsandboxed" && {
+          message: `No sandbox isolation — using ${exploreBackend} fallback`,
+        }),
       },
       plugins: pluginsComponent,
       backups: backupsComponent,
@@ -702,7 +711,10 @@ health.openapi(healthRoute, async (c) => {
             },
         explore: {
           backend: exploreBackend,
-          isolated: exploreBackend !== "just-bash",
+          // `!== "unsandboxed"` (not `=== "isolated"`) so a plugin backend keeps
+          // reporting isolated:true as it always has — its `isolationVerified:
+          // false` below is what says Atlas has not confirmed the claim.
+          isolated: BACKEND_ISOLATION[exploreBackend] !== "unsandboxed",
           ...(exploreBackend === "plugin" && { isolationVerified: false }),
           ...(() => {
             const pluginId = exploreBackend === "plugin" ? getActiveSandboxPluginId() : null;

--- a/packages/api/src/lib/__tests__/startup-sandbox-preflight-unresolvable.test.ts
+++ b/packages/api/src/lib/__tests__/startup-sandbox-preflight-unresolvable.test.ts
@@ -8,8 +8,10 @@
  * RESOLVE the backend is not evidence that the deployment is unsandboxed, and
  * that string is what a security review greps for.
  *
- * Its own file because it needs `lib/tools/explore` to throw on import, which
- * is incompatible with the sibling suites that drive the real module.
+ * Its own file because it needs `lib/tools/explore`'s exports to throw on
+ * ACCESS, which the sibling suite driving the real module cannot tolerate in the
+ * same process — this `mock.module` would leak into it. The isolated per-file
+ * runner is what keeps them apart.
  */
 import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
 import { createConnectionMock } from "@atlas/api/testing/connection";
@@ -72,20 +74,22 @@ void mock.module("@atlas/api/lib/tools/explore-nsjail", () => ({
   },
 }));
 
-// The resolution seam itself fails — e.g. a malformed sandbox.priority, or a
-// module-init failure anywhere in explore's transitive graph.
+// The resolution seam itself fails — e.g. a module-init failure anywhere in
+// explore's transitive graph. (sandbox.priority cannot cause this: it is
+// zod-validated at config load and planSandboxSelection has no throw path.)
 void mock.module("@atlas/api/lib/tools/explore", () => ({
   get getExploreBackendType(): never {
-    throw new Error("explore module failed to initialize");
-  },
-  get BACKEND_ISOLATION(): never {
     throw new Error("explore module failed to initialize");
   },
   markNsjailFailed: () => {},
   markSidecarFailed: () => {},
   getActiveSandboxPluginId: () => null,
   invalidateExploreBackend: () => {},
+  invalidateOrgExploreBackends: () => {},
   snapshotExploreSandboxEnv: () => ({}),
+  _resetSandboxFailureFlagsForTest: () => {},
+  _formatSandboxPriorityFailureForTest: () => "",
+  explore: {},
 }));
 
 const { validateEnvironment, resetStartupCache, getStartupWarnings } = await import(

--- a/packages/api/src/lib/__tests__/startup-sandbox-preflight-unresolvable.test.ts
+++ b/packages/api/src/lib/__tests__/startup-sandbox-preflight-unresolvable.test.ts
@@ -1,0 +1,142 @@
+/**
+ * #4824 — when the backend cannot be resolved at all, boot must NOT fall back
+ * to asserting "no process isolation".
+ *
+ * `logResolvedExploreBackend()` wraps its resolution in a try/catch. The
+ * tempting "helpful" edit is to log the just-bash line from that catch so boot
+ * always says something — which reintroduces #4824 by a new route: a failure to
+ * RESOLVE the backend is not evidence that the deployment is unsandboxed, and
+ * that string is what a security review greps for.
+ *
+ * Its own file because it needs `lib/tools/explore` to throw on import, which
+ * is incompatible with the sibling suites that drive the real module.
+ */
+import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
+import { createConnectionMock } from "@atlas/api/testing/connection";
+import { mockIsSupportedProvider, mockGetMissingProviderConfig } from "./provider-config-mock";
+
+const logCalls: unknown[][] = [];
+const record = () => (...args: unknown[]) => {
+  logCalls.push(args);
+};
+const captureLogger = {
+  debug: record(),
+  info: record(),
+  warn: record(),
+  error: record(),
+  child: () => captureLogger,
+};
+
+void mock.module("@atlas/api/lib/logger", () => ({
+  createLogger: () => captureLogger,
+  getLogger: () => captureLogger,
+  getRequestContext: () => undefined,
+}));
+
+void mock.module("fs", () => ({
+  existsSync: () => false,
+  readdirSync: () => ["orders.yml"],
+  constants: { F_OK: 0, W_OK: 2, R_OK: 4, X_OK: 1 },
+  accessSync: () => {
+    const err = new Error("ENOENT: no such file or directory") as NodeJS.ErrnoException;
+    err.code = "ENOENT";
+    throw err;
+  },
+}));
+
+void mock.module("@atlas/api/lib/db/connection", () =>
+  createConnectionMock({
+    resolveDatasourceUrl: () => process.env.ATLAS_DATASOURCE_URL || null,
+  }),
+);
+
+void mock.module("@atlas/api/lib/providers", () => ({
+  getDefaultProvider: () => "anthropic",
+  isSupportedProvider: mockIsSupportedProvider,
+  getMissingProviderConfig: mockGetMissingProviderConfig,
+  PROVIDER_KEY_MAP: {
+    anthropic: "ANTHROPIC_API_KEY",
+    openai: "OPENAI_API_KEY",
+    bedrock: "AWS_ACCESS_KEY_ID",
+    ollama: "",
+    gateway: "AI_GATEWAY_API_KEY",
+  },
+}));
+
+void mock.module("@atlas/api/lib/tools/explore-nsjail", () => ({
+  findNsjailBinary: () => null,
+  isNsjailAvailable: () => false,
+  testNsjailCapabilities: async () => ({ ok: true }),
+  createNsjailBackend: async () => {
+    throw new Error("not used in this test");
+  },
+}));
+
+// The resolution seam itself fails — e.g. a malformed sandbox.priority, or a
+// module-init failure anywhere in explore's transitive graph.
+void mock.module("@atlas/api/lib/tools/explore", () => ({
+  get getExploreBackendType(): never {
+    throw new Error("explore module failed to initialize");
+  },
+  get BACKEND_ISOLATION(): never {
+    throw new Error("explore module failed to initialize");
+  },
+  markNsjailFailed: () => {},
+  markSidecarFailed: () => {},
+  getActiveSandboxPluginId: () => null,
+  invalidateExploreBackend: () => {},
+  snapshotExploreSandboxEnv: () => ({}),
+}));
+
+const { validateEnvironment, resetStartupCache, getStartupWarnings } = await import(
+  "@atlas/api/lib/startup"
+);
+const { _resetConfig } = await import("@atlas/api/lib/config");
+
+describe("unresolvable explore backend (#4824)", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    _resetConfig();
+    resetStartupCache();
+    logCalls.length = 0;
+    process.env.PATH = "";
+    delete process.env.ATLAS_SANDBOX;
+    delete process.env.ATLAS_SANDBOX_URL;
+    delete process.env.ATLAS_RUNTIME;
+    delete process.env.VERCEL;
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    _resetConfig();
+    resetStartupCache();
+  });
+
+  it("does not claim 'no process isolation' when the backend cannot be resolved", async () => {
+    await validateEnvironment();
+
+    expect(
+      logCalls.some((args) =>
+        args.some((a) => typeof a === "string" && a.includes("no process isolation")),
+      ),
+    ).toBe(false);
+    expect(
+      logCalls.some((args) =>
+        args.some((a) => typeof a === "string" && a.startsWith("Explore tool:")),
+      ),
+    ).toBe(false);
+  });
+
+  it("surfaces the unknown posture as a startup warning", async () => {
+    await validateEnvironment();
+
+    // Silence would be worse than a wrong line: /api/health resolves the backend
+    // through the same seam, so this failure breaks its reporting too.
+    expect(
+      getStartupWarnings().some(
+        (w) => w.includes("Could not resolve") && w.includes("UNKNOWN"),
+      ),
+    ).toBe(true);
+  });
+});

--- a/packages/api/src/lib/__tests__/startup-sandbox-preflight.test.ts
+++ b/packages/api/src/lib/__tests__/startup-sandbox-preflight.test.ts
@@ -4,10 +4,10 @@
  *
  * The bug: the pre-flight dispatch asked "are we running ON Vercel"
  * (`ATLAS_RUNTIME` / `VERCEL`) rather than "are we USING Vercel Sandbox". Since
- * #2383, a Railway host reaches Vercel Sandbox with `VERCEL_TOKEN` plus a
- * team/project id from either env or `sandbox.vercel` in atlas.config.ts — a
- * shape that sets none of the
- * host-detection vars, so boot fell through to nsjail auto-detect, found no
+ * #2383 a Railway host reaches Vercel Sandbox with `VERCEL_TOKEN` plus a
+ * team/project id from env — or, since #3706, from `sandbox.vercel` in
+ * atlas.config.ts. That shape sets none of the host-detection vars, so boot
+ * fell through to nsjail auto-detect, found no
  * binary, and logged "no process isolation" on every Railway deploy while
  * health correctly reported `vercel-sandbox`. Execution was fine; only the log
  * lied — and it lied in the exact string a security review greps for.
@@ -23,12 +23,13 @@
  * stopped proving anything. `beforeEach` clears them via
  * `_resetSandboxFailureFlagsForTest()`, so NO case depends on test order.
  *
- * `PATH` is cleared in `beforeEach` so explore's own nsjail binary detection is
- * deterministically false on any host, including a dev box with nsjail
+ * The mocked `fs.accessSync` throws for every candidate, so explore's own nsjail
+ * binary detection is false on any host, including a dev box with nsjail
  * installed. The `ATLAS_SANDBOX=nsjail` cases short-circuit that detection via
  * the env pin (`useNsjail()` returns true for the pin without probing PATH).
  */
 import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
+import type { ExploreBackendType } from "@atlas/api/lib/tools/explore";
 import { createConnectionMock } from "@atlas/api/testing/connection";
 import { mockIsSupportedProvider, mockGetMissingProviderConfig } from "./provider-config-mock";
 
@@ -69,10 +70,12 @@ void mock.module("@atlas/api/lib/logger", () => ({
 // without touching a database or the filesystem.
 // ---------------------------------------------------------------------------
 
-// findNsjailBinary() walks PATH with accessSync(candidate, constants.X_OK).
-// Both are supplied so an EMPTY PATH is the real reason detection returns null —
-// an incomplete mock would instead throw a TypeError that the probe's catch
-// swallows as "not found", which looks identical but tests nothing.
+// findNsjailBinary() walks PATH with accessSync(candidate, constants.X_OK). This
+// stub throws ENOENT for every candidate, so detection is null regardless of
+// host — the empty PATH in beforeEach is belt-and-braces, not the mechanism.
+// Supplying `constants` matters anyway: without it the probe throws a TypeError
+// that its catch swallows as "not found", which looks identical but tests
+// nothing about the code under test.
 void mock.module("fs", () => ({
   existsSync: () => false,
   readdirSync: () => ["orders.yml"],
@@ -129,9 +132,6 @@ const { getExploreBackendType, snapshotExploreSandboxEnv, _resetSandboxFailureFl
 const { _setConfigForTest, _resetConfig, configFromEnv } = await import(
   "@atlas/api/lib/config"
 );
-type ExploreBackendType = Awaited<
-  ReturnType<typeof import("@atlas/api/lib/tools/explore").getExploreBackendType>
->;
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -170,6 +170,17 @@ function claimedNoIsolation(): boolean {
   return logCalls.some((c) =>
     c.args.some((a) => typeof a === "string" && a.includes("no process isolation")),
   );
+}
+
+/**
+ * A `typeof fetch`-compatible stub, built structurally rather than cast: the
+ * lib typings carry `preconnect`, so a bare arrow fails the type gate and the
+ * usual `as unknown as typeof fetch` would erase future signature changes.
+ */
+function healthyFetch(): typeof fetch {
+  return Object.assign(async () => new Response(null, { status: 200 }), {
+    preconnect: () => {},
+  });
 }
 
 async function runPreFlight(): Promise<void> {
@@ -263,7 +274,7 @@ describe("startup sandbox pre-flight names the resolved backend (#4824)", () => 
 
   it("names sidecar when a healthy sidecar is configured", async () => {
     process.env.ATLAS_SANDBOX_URL = "http://sidecar.test";
-    globalThis.fetch = (async () => new Response(null, { status: 200 })) as typeof fetch;
+    globalThis.fetch = healthyFetch();
 
     await runPreFlight();
 
@@ -283,22 +294,31 @@ describe("startup sandbox pre-flight names the resolved backend (#4824)", () => 
     expect(claimedNoIsolation()).toBe(false);
   });
 
-  it("does NOT name nsjail when the pin is set but the binary is missing", async () => {
-    // isBackendAvailable("nsjail") is `ATLAS_SANDBOX === "nsjail" || useNsjail()`,
-    // so the env pin alone reported nsjail as available with no binary on the
-    // box — and the terminal line would have named a backend that hard-fails on
-    // the first explore call. checkExplicitNsjail() marks it failed for exactly
-    // this reason; without that, this is a fresh false claim of the #4824 kind.
+  it("names no backend at all when the nsjail pin cannot be satisfied", async () => {
+    // ATLAS_SANDBOX=nsjail is hard-fail by contract: explore refuses to run
+    // rather than degrading. Naming a backend would be wrong in BOTH directions
+    // — "nsjail active" (it isn't; isBackendAvailable is `pin || useNsjail()`,
+    // so the pin alone still reports available) and "just-bash" (the pin will
+    // not degrade to it). The pre-flight must say the tool is unavailable.
+    //
+    // Critically, the pre-flight must NOT call markNsjailFailed() to force the
+    // resolver's hand: planSandboxSelection only emits the hard-fail step while
+    // `!nsjailFailed`, so setting the flag would DELETE the pin's hard-fail
+    // contract and silently degrade the box to unsandboxed just-bash.
     process.env.ATLAS_SANDBOX = "nsjail";
     mockNsjailBinaryPath = null;
 
     await runPreFlight();
 
-    expect(loggedBackend()).not.toBe("nsjail");
-    expect(getExploreBackendType()).not.toBe("nsjail");
-    // This box genuinely has no isolation, so the warning is correct here.
-    expect(loggedBackend()).toBe("just-bash");
-    expect(claimedNoIsolation()).toBe(true);
+    expect(loggedBackend()).toBeUndefined();
+    expect(claimedNoIsolation()).toBe(false);
+    expect(
+      logCalls.some((c) =>
+        c.args.some((a) => typeof a === "string" && a.includes("Explore tool: unavailable")),
+      ),
+    ).toBe(true);
+    // The hard-fail step must survive — this is the security-critical assertion.
+    expect(snapshotExploreSandboxEnv().nsjailFailed).toBe(false);
   });
 
   // ── AC4 — boot and /api/health cannot disagree ────────────────────────────
@@ -340,7 +360,7 @@ describe("startup sandbox pre-flight names the resolved backend (#4824)", () => 
       // agreement, not degradation.
       mockNsjailBinaryPath = shape.env.ATLAS_SANDBOX === "nsjail" ? "/usr/local/bin/nsjail" : null;
       mockCapabilityResult = { ok: true };
-      globalThis.fetch = (async () => new Response(null, { status: 200 })) as typeof fetch;
+      globalThis.fetch = healthyFetch();
 
       await runPreFlight();
 

--- a/packages/api/src/lib/__tests__/startup-sandbox-preflight.test.ts
+++ b/packages/api/src/lib/__tests__/startup-sandbox-preflight.test.ts
@@ -108,8 +108,9 @@ void mock.module("@atlas/api/lib/providers", () => ({
 
 // The nsjail binary probe the pre-flight drives, controlled per-test. This is a
 // SEPARATE seam from explore's own `useNsjail()` detection, which stays real and
-// resolves false via the empty PATH — so a test can hand the pre-flight a binary
-// without also convincing explore that nsjail is available.
+// resolves false because the mocked accessSync throws for every candidate (see
+// the fs mock above) — so a test can hand the pre-flight a binary without also
+// convincing explore that nsjail is available.
 let mockNsjailBinaryPath: string | null = null;
 let mockCapabilityResult: { ok: boolean; error?: string } = { ok: true };
 let nsjailProbeRan = false;
@@ -319,6 +320,29 @@ describe("startup sandbox pre-flight names the resolved backend (#4824)", () => 
     ).toBe(true);
     // The hard-fail step must survive — this is the security-critical assertion.
     expect(snapshotExploreSandboxEnv().nsjailFailed).toBe(false);
+  });
+
+  it("admits no isolation when the nsjail pin degrades on broken namespaces", async () => {
+    // The sibling of the case above, and the realistic container shape: the
+    // binary is present but CLONE_NEWUSER is denied. checkExplicitNsjail() calls
+    // markNsjailFailed() here (pre-existing, #4829), which DELETES the pin's
+    // hard-fail step — so the pin does NOT hold and explore runs unsandboxed.
+    //
+    // Boot must therefore say "no process isolation" and name just-bash, exactly
+    // as /api/health does. Claiming the deployment is fail-closed here would be
+    // #4824's false claim at inverted polarity: reassuring an operator that
+    // explore refuses to run while it is executing agent shell on the host.
+    process.env.ATLAS_SANDBOX = "nsjail";
+    mockNsjailBinaryPath = "/usr/local/bin/nsjail";
+    mockCapabilityResult = { ok: false, error: "clone failed: EPERM" };
+
+    await runPreFlight();
+
+    expect(nsjailProbeRan).toBe(true);
+    expect(snapshotExploreSandboxEnv().nsjailFailed).toBe(true);
+    expect(loggedBackend()).toBe("just-bash");
+    expect(getExploreBackendType()).toBe("just-bash");
+    expect(claimedNoIsolation()).toBe(true);
   });
 
   // ── AC4 — boot and /api/health cannot disagree ────────────────────────────

--- a/packages/api/src/lib/__tests__/startup-sandbox-preflight.test.ts
+++ b/packages/api/src/lib/__tests__/startup-sandbox-preflight.test.ts
@@ -1,0 +1,320 @@
+/**
+ * #4824 — the startup sandbox pre-flight must name the backend the process
+ * ACTUALLY uses, and must name the same one `/api/health` reports.
+ *
+ * The bug: the pre-flight dispatch asked "are we running ON Vercel"
+ * (`ATLAS_RUNTIME` / `VERCEL`) rather than "are we USING Vercel Sandbox". Since
+ * #3706, a Railway host reaches Vercel Sandbox through `VERCEL_TEAM_ID` /
+ * `VERCEL_PROJECT_ID` / `VERCEL_TOKEN` — a shape that sets none of the
+ * host-detection vars, so boot fell through to nsjail auto-detect, found no
+ * binary, and logged "no process isolation" on every Railway deploy while
+ * health correctly reported `vercel-sandbox`. Execution was fine; only the log
+ * lied — and it lied in the exact string a security review greps for.
+ *
+ * These tests drive the REAL `lib/tools/explore` module (not a stub) so the
+ * parity assertions compare the pre-flight against the genuine
+ * `getExploreBackendType()` that `/api/health` calls, rather than against a
+ * mock that could agree with anything.
+ *
+ * ── Ordering is load-bearing ────────────────────────────────────────────────
+ * `explore`'s `_nsjailFailed` flag is monotonic (false → true, no reset export)
+ * and `_nsjailAvailable` caches on first read. The suite therefore runs every
+ * case that needs a clean nsjail chain BEFORE the final degradation case, which
+ * deliberately trips `markNsjailFailed()`. `PATH` is cleared in `beforeEach` so
+ * explore's own binary detection is deterministically false on any host.
+ */
+import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
+import { createConnectionMock } from "@atlas/api/testing/connection";
+import { mockIsSupportedProvider, mockGetMissingProviderConfig } from "./provider-config-mock";
+
+// ---------------------------------------------------------------------------
+// Log capture — startup.ts binds its logger at module load, so this mock must
+// be installed before the dynamic import below.
+// ---------------------------------------------------------------------------
+
+interface LogCall {
+  readonly level: "debug" | "info" | "warn" | "error";
+  readonly args: readonly unknown[];
+}
+
+const logCalls: LogCall[] = [];
+
+function record(level: LogCall["level"]) {
+  return (...args: unknown[]) => {
+    logCalls.push({ level, args });
+  };
+}
+
+const captureLogger = {
+  debug: record("debug"),
+  info: record("info"),
+  warn: record("warn"),
+  error: record("error"),
+  child: () => captureLogger,
+};
+
+void mock.module("@atlas/api/lib/logger", () => ({
+  createLogger: () => captureLogger,
+  getLogger: () => captureLogger,
+  getRequestContext: () => undefined,
+}));
+
+// ---------------------------------------------------------------------------
+// Heavy I/O mocks so validateEnvironment() reaches the sandbox pre-flight
+// without touching a database or the filesystem.
+// ---------------------------------------------------------------------------
+
+void mock.module("fs", () => ({
+  existsSync: () => false,
+  readdirSync: () => ["orders.yml"],
+}));
+
+void mock.module("@atlas/api/lib/db/connection", () =>
+  createConnectionMock({
+    resolveDatasourceUrl: () => process.env.ATLAS_DATASOURCE_URL || null,
+  }),
+);
+
+void mock.module("@atlas/api/lib/providers", () => ({
+  getDefaultProvider: () => "anthropic",
+  isSupportedProvider: mockIsSupportedProvider,
+  getMissingProviderConfig: mockGetMissingProviderConfig,
+  PROVIDER_KEY_MAP: {
+    anthropic: "ANTHROPIC_API_KEY",
+    openai: "OPENAI_API_KEY",
+    bedrock: "AWS_ACCESS_KEY_ID",
+    ollama: "",
+    gateway: "AI_GATEWAY_API_KEY",
+  },
+}));
+
+// The nsjail binary probe the pre-flight drives. Controlled per-test; explore's
+// own detection stays real (and false, via an empty PATH).
+let mockNsjailBinaryPath: string | null = null;
+let mockCapabilityResult: { ok: boolean; error?: string } = { ok: true };
+let nsjailProbeRan = false;
+
+void mock.module("@atlas/api/lib/tools/explore-nsjail", () => ({
+  findNsjailBinary: () => mockNsjailBinaryPath,
+  isNsjailAvailable: () => mockNsjailBinaryPath !== null,
+  testNsjailCapabilities: async () => {
+    nsjailProbeRan = true;
+    return mockCapabilityResult;
+  },
+  createNsjailBackend: async () => {
+    throw new Error("not used in this test");
+  },
+}));
+
+const { validateEnvironment, resetStartupCache } = await import("@atlas/api/lib/startup");
+const { getExploreBackendType, snapshotExploreSandboxEnv } = await import(
+  "@atlas/api/lib/tools/explore"
+);
+const { _setConfigForTest, _resetConfig } = await import("@atlas/api/lib/config");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const SANDBOX_VARS = [
+  "ATLAS_RUNTIME",
+  "VERCEL",
+  "VERCEL_TEAM_ID",
+  "VERCEL_PROJECT_ID",
+  "VERCEL_TOKEN",
+  "ATLAS_SANDBOX",
+  "ATLAS_SANDBOX_URL",
+  "ATLAS_SANDBOX_PRIORITY",
+  "ATLAS_NSJAIL_PATH",
+] as const;
+
+/** The single "Explore tool: …" line the pre-flight emits, or undefined. */
+function exploreBackendLine(): LogCall | undefined {
+  return logCalls.find((c) =>
+    c.args.some((a) => typeof a === "string" && a.startsWith("Explore tool:")),
+  );
+}
+
+/** The backend name the pre-flight log claims, read from its structured field. */
+function loggedBackend(): string | undefined {
+  const line = exploreBackendLine();
+  if (!line) return undefined;
+  const meta = line.args[0];
+  if (meta && typeof meta === "object" && "backend" in meta) {
+    return String((meta as { backend: unknown }).backend);
+  }
+  return undefined;
+}
+
+/** True when boot asserted the deployment has no process isolation. */
+function claimedNoIsolation(): boolean {
+  return logCalls.some((c) =>
+    c.args.some((a) => typeof a === "string" && a.includes("no process isolation")),
+  );
+}
+
+async function runPreFlight(): Promise<void> {
+  resetStartupCache();
+  logCalls.length = 0;
+  nsjailProbeRan = false;
+  await validateEnvironment();
+}
+
+describe("startup sandbox pre-flight names the resolved backend (#4824)", () => {
+  const originalEnv = { ...process.env };
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    _resetConfig();
+    for (const v of SANDBOX_VARS) delete process.env[v];
+    // nsjail binary deterministically absent for explore's own detection.
+    process.env.PATH = "";
+    mockNsjailBinaryPath = null;
+    mockCapabilityResult = { ok: true };
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    globalThis.fetch = originalFetch;
+    _resetConfig();
+    resetStartupCache();
+  });
+
+  // ── AC1 — the reported bug ────────────────────────────────────────────────
+
+  it("does NOT claim 'no process isolation' on a Railway-shaped Vercel Sandbox deploy", async () => {
+    // Railway: Vercel Sandbox reached via env credentials, with none of the
+    // on-Vercel host vars set and no nsjail binary anywhere.
+    process.env.VERCEL_TEAM_ID = "team_test";
+    process.env.VERCEL_PROJECT_ID = "prj_test";
+    process.env.VERCEL_TOKEN = "tok_test";
+
+    await runPreFlight();
+
+    expect(claimedNoIsolation()).toBe(false);
+    expect(loggedBackend()).toBe("vercel-sandbox");
+  });
+
+  it("names vercel-sandbox under the deployed sandbox.priority pin", async () => {
+    // Mirrors deploy/api/atlas.config.ts — the pin that makes this the shape
+    // actually running on staging and all three prod regions.
+    process.env.VERCEL_TEAM_ID = "team_test";
+    process.env.VERCEL_PROJECT_ID = "prj_test";
+    process.env.VERCEL_TOKEN = "tok_test";
+    _setConfigForTest({ sandbox: { priority: ["vercel-sandbox"] } } as never);
+
+    await runPreFlight();
+
+    expect(claimedNoIsolation()).toBe(false);
+    expect(loggedBackend()).toBe("vercel-sandbox");
+  });
+
+  // ── AC2 — deleting the warning is the tempting wrong fix ──────────────────
+
+  it("STILL warns 'no process isolation' on a genuine just-bash deployment", async () => {
+    // Bare self-hosted box: no Vercel credentials, no sidecar, no nsjail.
+    await runPreFlight();
+
+    expect(loggedBackend()).toBe("just-bash");
+    expect(claimedNoIsolation()).toBe(true);
+  });
+
+  // ── AC3 — the nsjail and sidecar paths keep working ───────────────────────
+
+  it("names vercel-sandbox when running ON Vercel", async () => {
+    process.env.ATLAS_RUNTIME = "vercel";
+
+    await runPreFlight();
+
+    expect(loggedBackend()).toBe("vercel-sandbox");
+    expect(claimedNoIsolation()).toBe(false);
+  });
+
+  it("names sidecar when a healthy sidecar is configured", async () => {
+    process.env.ATLAS_SANDBOX_URL = "http://sidecar.test";
+    globalThis.fetch = (async () => new Response(null, { status: 200 })) as typeof fetch;
+
+    await runPreFlight();
+
+    expect(loggedBackend()).toBe("sidecar");
+    expect(claimedNoIsolation()).toBe(false);
+  });
+
+  it("names nsjail when ATLAS_SANDBOX=nsjail and capabilities pass", async () => {
+    process.env.ATLAS_SANDBOX = "nsjail";
+    mockNsjailBinaryPath = "/usr/local/bin/nsjail";
+    mockCapabilityResult = { ok: true };
+
+    await runPreFlight();
+
+    expect(nsjailProbeRan).toBe(true);
+    expect(loggedBackend()).toBe("nsjail");
+    expect(claimedNoIsolation()).toBe(false);
+  });
+
+  // ── AC4 — boot and /api/health cannot disagree ────────────────────────────
+
+  it("agrees with getExploreBackendType() across every env shape", async () => {
+    const shapes: ReadonlyArray<{ name: string; env: Record<string, string> }> = [
+      { name: "bare", env: {} },
+      { name: "on-Vercel", env: { ATLAS_RUNTIME: "vercel" } },
+      {
+        name: "Railway + Vercel creds",
+        env: {
+          VERCEL_TEAM_ID: "team_test",
+          VERCEL_PROJECT_ID: "prj_test",
+          VERCEL_TOKEN: "tok_test",
+        },
+      },
+      { name: "sidecar", env: { ATLAS_SANDBOX_URL: "http://sidecar.test" } },
+      { name: "explicit nsjail", env: { ATLAS_SANDBOX: "nsjail" } },
+    ];
+
+    for (const shape of shapes) {
+      for (const v of SANDBOX_VARS) delete process.env[v];
+      Object.assign(process.env, shape.env);
+      // Keep the nsjail and sidecar probes healthy so this case measures
+      // agreement, not degradation.
+      mockNsjailBinaryPath = shape.env.ATLAS_SANDBOX === "nsjail" ? "/usr/local/bin/nsjail" : null;
+      mockCapabilityResult = { ok: true };
+      globalThis.fetch = (async () => new Response(null, { status: 200 })) as typeof fetch;
+
+      await runPreFlight();
+
+      expect(loggedBackend(), `pre-flight named a backend for ${shape.name}`).toBeDefined();
+      expect(loggedBackend(), `boot vs health disagree for ${shape.name}`).toBe(
+        getExploreBackendType(),
+      );
+    }
+  });
+
+  // ── The trap: skipping the probe silently corrupts the health surface ─────
+  //
+  // MUST RUN LAST — this case trips the monotonic `_nsjailFailed` flag.
+
+  it("still probes nsjail (feeding health) even when Vercel Sandbox wins", async () => {
+    // A Railway host that happens to ship an nsjail binary whose namespaces do
+    // not work. vercel-sandbox wins the priority chain regardless, so the naive
+    // fix — "the resolved backend isn't nsjail, skip the probe" — would never
+    // call markNsjailFailed(). `/api/health` would then advertise nsjail as an
+    // available backend on a host where it demonstrably cannot start.
+    process.env.VERCEL_TEAM_ID = "team_test";
+    process.env.VERCEL_PROJECT_ID = "prj_test";
+    process.env.VERCEL_TOKEN = "tok_test";
+    mockNsjailBinaryPath = "/usr/local/bin/nsjail";
+    mockCapabilityResult = { ok: false, error: "clone failed: EPERM" };
+
+    expect(snapshotExploreSandboxEnv().nsjailFailed).toBe(false);
+
+    await runPreFlight();
+
+    // The probe ran and recorded the failure — this is the assertion the naive
+    // "skip the probe" fix fails.
+    expect(nsjailProbeRan).toBe(true);
+    expect(snapshotExploreSandboxEnv().nsjailFailed).toBe(true);
+
+    // …and the log still names the backend that actually won.
+    expect(loggedBackend()).toBe("vercel-sandbox");
+    expect(claimedNoIsolation()).toBe(false);
+  });
+});

--- a/packages/api/src/lib/__tests__/startup-sandbox-preflight.test.ts
+++ b/packages/api/src/lib/__tests__/startup-sandbox-preflight.test.ts
@@ -4,8 +4,9 @@
  *
  * The bug: the pre-flight dispatch asked "are we running ON Vercel"
  * (`ATLAS_RUNTIME` / `VERCEL`) rather than "are we USING Vercel Sandbox". Since
- * #3706, a Railway host reaches Vercel Sandbox through `VERCEL_TEAM_ID` /
- * `VERCEL_PROJECT_ID` / `VERCEL_TOKEN` — a shape that sets none of the
+ * #2383, a Railway host reaches Vercel Sandbox with `VERCEL_TOKEN` plus a
+ * team/project id from either env or `sandbox.vercel` in atlas.config.ts — a
+ * shape that sets none of the
  * host-detection vars, so boot fell through to nsjail auto-detect, found no
  * binary, and logged "no process isolation" on every Railway deploy while
  * health correctly reported `vercel-sandbox`. Execution was fine; only the log
@@ -16,12 +17,16 @@
  * `getExploreBackendType()` that `/api/health` calls, rather than against a
  * mock that could agree with anything.
  *
- * ── Ordering is load-bearing ────────────────────────────────────────────────
- * `explore`'s `_nsjailFailed` flag is monotonic (false → true, no reset export)
- * and `_nsjailAvailable` caches on first read. The suite therefore runs every
- * case that needs a clean nsjail chain BEFORE the final degradation case, which
- * deliberately trips `markNsjailFailed()`. `PATH` is cleared in `beforeEach` so
- * explore's own binary detection is deterministically false on any host.
+ * `explore`'s `_nsjailFailed` / `_sidecarFailed` flags are monotonic in
+ * production, so several cases here would otherwise leak degradation into the
+ * ones after them — and the failure mode is a still-passing test that silently
+ * stopped proving anything. `beforeEach` clears them via
+ * `_resetSandboxFailureFlagsForTest()`, so NO case depends on test order.
+ *
+ * `PATH` is cleared in `beforeEach` so explore's own nsjail binary detection is
+ * deterministically false on any host, including a dev box with nsjail
+ * installed. The `ATLAS_SANDBOX=nsjail` cases short-circuit that detection via
+ * the env pin (`useNsjail()` returns true for the pin without probing PATH).
  */
 import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
 import { createConnectionMock } from "@atlas/api/testing/connection";
@@ -64,9 +69,19 @@ void mock.module("@atlas/api/lib/logger", () => ({
 // without touching a database or the filesystem.
 // ---------------------------------------------------------------------------
 
+// findNsjailBinary() walks PATH with accessSync(candidate, constants.X_OK).
+// Both are supplied so an EMPTY PATH is the real reason detection returns null —
+// an incomplete mock would instead throw a TypeError that the probe's catch
+// swallows as "not found", which looks identical but tests nothing.
 void mock.module("fs", () => ({
   existsSync: () => false,
   readdirSync: () => ["orders.yml"],
+  constants: { F_OK: 0, W_OK: 2, R_OK: 4, X_OK: 1 },
+  accessSync: () => {
+    const err = new Error("ENOENT: no such file or directory") as NodeJS.ErrnoException;
+    err.code = "ENOENT";
+    throw err;
+  },
 }));
 
 void mock.module("@atlas/api/lib/db/connection", () =>
@@ -88,8 +103,10 @@ void mock.module("@atlas/api/lib/providers", () => ({
   },
 }));
 
-// The nsjail binary probe the pre-flight drives. Controlled per-test; explore's
-// own detection stays real (and false, via an empty PATH).
+// The nsjail binary probe the pre-flight drives, controlled per-test. This is a
+// SEPARATE seam from explore's own `useNsjail()` detection, which stays real and
+// resolves false via the empty PATH — so a test can hand the pre-flight a binary
+// without also convincing explore that nsjail is available.
 let mockNsjailBinaryPath: string | null = null;
 let mockCapabilityResult: { ok: boolean; error?: string } = { ok: true };
 let nsjailProbeRan = false;
@@ -107,10 +124,14 @@ void mock.module("@atlas/api/lib/tools/explore-nsjail", () => ({
 }));
 
 const { validateEnvironment, resetStartupCache } = await import("@atlas/api/lib/startup");
-const { getExploreBackendType, snapshotExploreSandboxEnv } = await import(
-  "@atlas/api/lib/tools/explore"
+const { getExploreBackendType, snapshotExploreSandboxEnv, _resetSandboxFailureFlagsForTest } =
+  await import("@atlas/api/lib/tools/explore");
+const { _setConfigForTest, _resetConfig, configFromEnv } = await import(
+  "@atlas/api/lib/config"
 );
-const { _setConfigForTest, _resetConfig } = await import("@atlas/api/lib/config");
+type ExploreBackendType = Awaited<
+  ReturnType<typeof import("@atlas/api/lib/tools/explore").getExploreBackendType>
+>;
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -136,12 +157,10 @@ function exploreBackendLine(): LogCall | undefined {
 }
 
 /** The backend name the pre-flight log claims, read from its structured field. */
-function loggedBackend(): string | undefined {
-  const line = exploreBackendLine();
-  if (!line) return undefined;
-  const meta = line.args[0];
-  if (meta && typeof meta === "object" && "backend" in meta) {
-    return String((meta as { backend: unknown }).backend);
+function loggedBackend(): ExploreBackendType | undefined {
+  const meta = exploreBackendLine()?.args[0];
+  if (meta && typeof meta === "object" && "backend" in meta && typeof meta.backend === "string") {
+    return meta.backend as ExploreBackendType;
   }
   return undefined;
 }
@@ -166,6 +185,7 @@ describe("startup sandbox pre-flight names the resolved backend (#4824)", () => 
 
   beforeEach(() => {
     _resetConfig();
+    _resetSandboxFailureFlagsForTest();
     for (const v of SANDBOX_VARS) delete process.env[v];
     // nsjail binary deterministically absent for explore's own detection.
     process.env.PATH = "";
@@ -201,7 +221,18 @@ describe("startup sandbox pre-flight names the resolved backend (#4824)", () => 
     process.env.VERCEL_TEAM_ID = "team_test";
     process.env.VERCEL_PROJECT_ID = "prj_test";
     process.env.VERCEL_TOKEN = "tok_test";
-    _setConfigForTest({ sandbox: { priority: ["vercel-sandbox"] } } as never);
+    // A real ResolvedConfig, not a cast-away partial: every required field keeps
+    // its default so anything validateEnvironment() reads stays defined, and the
+    // priority literal is still checked against SandboxBackendName.
+    _setConfigForTest({
+      ...configFromEnv(),
+      sandbox: {
+        priority: ["vercel-sandbox"],
+        // Prod resolves team/project from config, not env — only VERCEL_TOKEN
+        // is a per-service Railway secret. This mirrors that split.
+        vercel: { teamId: "team_test", projectId: "prj_test" },
+      },
+    });
 
     await runPreFlight();
 
@@ -252,12 +283,39 @@ describe("startup sandbox pre-flight names the resolved backend (#4824)", () => 
     expect(claimedNoIsolation()).toBe(false);
   });
 
+  it("does NOT name nsjail when the pin is set but the binary is missing", async () => {
+    // isBackendAvailable("nsjail") is `ATLAS_SANDBOX === "nsjail" || useNsjail()`,
+    // so the env pin alone reported nsjail as available with no binary on the
+    // box — and the terminal line would have named a backend that hard-fails on
+    // the first explore call. checkExplicitNsjail() marks it failed for exactly
+    // this reason; without that, this is a fresh false claim of the #4824 kind.
+    process.env.ATLAS_SANDBOX = "nsjail";
+    mockNsjailBinaryPath = null;
+
+    await runPreFlight();
+
+    expect(loggedBackend()).not.toBe("nsjail");
+    expect(getExploreBackendType()).not.toBe("nsjail");
+    // This box genuinely has no isolation, so the warning is correct here.
+    expect(loggedBackend()).toBe("just-bash");
+    expect(claimedNoIsolation()).toBe(true);
+  });
+
   // ── AC4 — boot and /api/health cannot disagree ────────────────────────────
 
   it("agrees with getExploreBackendType() across every env shape", async () => {
-    const shapes: ReadonlyArray<{ name: string; env: Record<string, string> }> = [
-      { name: "bare", env: {} },
-      { name: "on-Vercel", env: { ATLAS_RUNTIME: "vercel" } },
+    // `expected` is not redundant with the agreement assertion. Without it the
+    // loop compares getExploreBackendType() against itself and stays green even
+    // if every shape silently collapsed to just-bash — agreement is cheap, and
+    // agreement on the WRONG value is exactly the failure this file exists to
+    // catch. Pinning the literal makes such a collapse a loud failure.
+    const shapes: ReadonlyArray<{
+      name: string;
+      env: Record<string, string>;
+      expected: ExploreBackendType;
+    }> = [
+      { name: "bare", env: {}, expected: "just-bash" },
+      { name: "on-Vercel", env: { ATLAS_RUNTIME: "vercel" }, expected: "vercel-sandbox" },
       {
         name: "Railway + Vercel creds",
         env: {
@@ -265,9 +323,14 @@ describe("startup sandbox pre-flight names the resolved backend (#4824)", () => 
           VERCEL_PROJECT_ID: "prj_test",
           VERCEL_TOKEN: "tok_test",
         },
+        expected: "vercel-sandbox",
       },
-      { name: "sidecar", env: { ATLAS_SANDBOX_URL: "http://sidecar.test" } },
-      { name: "explicit nsjail", env: { ATLAS_SANDBOX: "nsjail" } },
+      {
+        name: "sidecar",
+        env: { ATLAS_SANDBOX_URL: "http://sidecar.test" },
+        expected: "sidecar",
+      },
+      { name: "explicit nsjail", env: { ATLAS_SANDBOX: "nsjail" }, expected: "nsjail" },
     ];
 
     for (const shape of shapes) {
@@ -281,35 +344,37 @@ describe("startup sandbox pre-flight names the resolved backend (#4824)", () => 
 
       await runPreFlight();
 
-      expect(loggedBackend(), `pre-flight named a backend for ${shape.name}`).toBeDefined();
-      expect(loggedBackend(), `boot vs health disagree for ${shape.name}`).toBe(
-        getExploreBackendType(),
+      expect(loggedBackend(), `pre-flight named the wrong backend for ${shape.name}`).toBe(
+        shape.expected,
+      );
+      expect(getExploreBackendType(), `health resolved wrong for ${shape.name}`).toBe(
+        shape.expected,
       );
     }
   });
 
   // ── The trap: skipping the probe silently corrupts the health surface ─────
-  //
-  // MUST RUN LAST — this case trips the monotonic `_nsjailFailed` flag.
 
   it("still probes nsjail (feeding health) even when Vercel Sandbox wins", async () => {
     // A Railway host that happens to ship an nsjail binary whose namespaces do
     // not work. vercel-sandbox wins the priority chain regardless, so the naive
     // fix — "the resolved backend isn't nsjail, skip the probe" — would never
-    // call markNsjailFailed(). `/api/health` would then advertise nsjail as an
-    // available backend on a host where it demonstrably cannot start.
+    // call markNsjailFailed(). _nsjailFailed gates both tryCreateBackend and
+    // isBackendAvailable, so leaving it unset means a host whose winning backend
+    // fails to construct at request time falls through to a known-broken nsjail.
     process.env.VERCEL_TEAM_ID = "team_test";
     process.env.VERCEL_PROJECT_ID = "prj_test";
     process.env.VERCEL_TOKEN = "tok_test";
     mockNsjailBinaryPath = "/usr/local/bin/nsjail";
     mockCapabilityResult = { ok: false, error: "clone failed: EPERM" };
 
+    // Asserting the pre-condition is what makes the post-condition meaningful
+    // rather than possibly-already-true.
     expect(snapshotExploreSandboxEnv().nsjailFailed).toBe(false);
 
     await runPreFlight();
 
-    // The probe ran and recorded the failure — this is the assertion the naive
-    // "skip the probe" fix fails.
+    // The two assertions the naive "skip the probe" fix fails.
     expect(nsjailProbeRan).toBe(true);
     expect(snapshotExploreSandboxEnv().nsjailFailed).toBe(true);
 

--- a/packages/api/src/lib/__tests__/startup.test.ts
+++ b/packages/api/src/lib/__tests__/startup.test.ts
@@ -409,7 +409,15 @@ describe("sandbox diagnostics", () => {
     await validateEnvironment();
     const warnings = getStartupWarnings();
     expect(
-      warnings.some((w) => w.includes("namespace creation failed") && w.includes("falling back to just-bash")),
+      // #4824: the fallback is named as "the next backend in the priority
+      // chain", not hardcoded to just-bash — on a Vercel-Sandbox-credentialed
+      // host the next backend is vercel-sandbox, and claiming just-bash there
+      // is the same false-isolation claim this issue fixed.
+      warnings.some(
+        (w) =>
+          w.includes("namespace creation failed") &&
+          w.includes("next backend in the sandbox priority chain"),
+      ),
     ).toBe(true);
     expect(mockMarkNsjailFailedCalled).toBe(true);
   });

--- a/packages/api/src/lib/__tests__/startup.test.ts
+++ b/packages/api/src/lib/__tests__/startup.test.ts
@@ -61,18 +61,8 @@ void mock.module("@atlas/api/lib/tools/explore", () => ({
   markNsjailFailed: () => { mockMarkNsjailFailedCalled = true; },
   markSidecarFailed: () => { mockMarkSidecarFailedCalled = true; },
   getExploreBackendType: () => mockExploreBackend,
-  // Required by logResolvedExploreBackend(); omitting it sends the pre-flight
-  // down its "could not resolve" branch and silently voids these assertions.
-  BACKEND_ISOLATION: {
-    "vercel-sandbox": "isolated",
-    nsjail: "isolated",
-    sidecar: "isolated",
-    "just-bash": "unsandboxed",
-    plugin: "plugin-declared",
-  },
   getActiveSandboxPluginId: () => null,
   invalidateExploreBackend: () => {},
-  _resetSandboxFailureFlagsForTest: () => {},
 }));
 
 const { validateEnvironment, getStartupWarnings, resetStartupCache } =

--- a/packages/api/src/lib/__tests__/startup.test.ts
+++ b/packages/api/src/lib/__tests__/startup.test.ts
@@ -51,12 +51,28 @@ void mock.module("@atlas/api/lib/tools/explore-nsjail", () => ({
 let mockMarkNsjailFailedCalled = false;
 let mockMarkSidecarFailedCalled = false;
 
+// The backend the pre-flight will name. These cases assert on
+// getStartupWarnings() rather than on the terminal log line, so the default is
+// just a plausible value — the naming behaviour itself is covered by
+// startup-sandbox-preflight.test.ts against the REAL explore module.
+let mockExploreBackend: "just-bash" | "vercel-sandbox" | "nsjail" | "sidecar" = "just-bash";
+
 void mock.module("@atlas/api/lib/tools/explore", () => ({
   markNsjailFailed: () => { mockMarkNsjailFailedCalled = true; },
   markSidecarFailed: () => { mockMarkSidecarFailedCalled = true; },
-  getExploreBackendType: () => "just-bash",
+  getExploreBackendType: () => mockExploreBackend,
+  // Required by logResolvedExploreBackend(); omitting it sends the pre-flight
+  // down its "could not resolve" branch and silently voids these assertions.
+  BACKEND_ISOLATION: {
+    "vercel-sandbox": "isolated",
+    nsjail: "isolated",
+    sidecar: "isolated",
+    "just-bash": "unsandboxed",
+    plugin: "plugin-declared",
+  },
   getActiveSandboxPluginId: () => null,
   invalidateExploreBackend: () => {},
+  _resetSandboxFailureFlagsForTest: () => {},
 }));
 
 const { validateEnvironment, getStartupWarnings, resetStartupCache } =
@@ -389,6 +405,7 @@ describe("sandbox diagnostics", () => {
     delete process.env.ATLAS_SANDBOX;
     delete process.env.ATLAS_RUNTIME;
     delete process.env.VERCEL;
+    mockExploreBackend = "just-bash";
   });
 
   it("no sandbox warning when nsjail found and capabilities pass", async () => {
@@ -411,8 +428,8 @@ describe("sandbox diagnostics", () => {
     expect(
       // #4824: the fallback is named as "the next backend in the priority
       // chain", not hardcoded to just-bash — on a Vercel-Sandbox-credentialed
-      // host the next backend is vercel-sandbox, and claiming just-bash there
-      // is the same false-isolation claim this issue fixed.
+      // host a higher-priority backend (vercel-sandbox) handles execution, so
+      // claiming just-bash there is the same false-isolation claim this fixed.
       warnings.some(
         (w) =>
           w.includes("namespace creation failed") &&
@@ -449,6 +466,7 @@ describe("sandbox diagnostics", () => {
   it("no sandbox warning on Vercel runtime", async () => {
     process.env.VERCEL = "1";
     mockNsjailBinaryPath = null; // no nsjail on Vercel
+    mockExploreBackend = "vercel-sandbox";
 
     await validateEnvironment();
     const warnings = getStartupWarnings();

--- a/packages/api/src/lib/startup.ts
+++ b/packages/api/src/lib/startup.ts
@@ -840,28 +840,24 @@ async function checkSandboxPreFlight(): Promise<void> {
 
   // This dispatch picks WHICH LOCAL RESOURCE IS WORTH PROBING — it does not
   // decide which backend is active. Those were the same question until #2383
-  // added off-Vercel Vercel Sandbox support, where a non-Vercel host (Railway)
-  // reaches Vercel Sandbox with VERCEL_TOKEN plus a team/project id from either
-  // env or `sandbox.vercel` in atlas.config.ts. That shape sets none of the
-  // host-detection vars and has nothing local to probe, so it lands on the
-  // auto-detect arm — and naming the backend from this dispatch is what made
-  // boot log "no process isolation" on every Railway deploy while /api/health
-  // correctly reported `vercel-sandbox` (#4824).
+  // added off-Vercel Vercel Sandbox support (VERCEL_TOKEN plus a team/project
+  // id from env — or, since #3706, from `sandbox.vercel` in atlas.config.ts).
+  // That shape sets none of the host-detection vars and has nothing local to
+  // probe, so a Railway deploy lands on the auto-detect arm — and naming the
+  // backend from this dispatch is what made boot log "no process isolation"
+  // there while /api/health correctly reported `vercel-sandbox` (#4824).
   //
-  // The probes are also load-bearing beyond their logging: a failed nsjail
-  // namespace test, a missing pinned binary, or an unreachable sidecar calls
-  // markNsjailFailed()/markSidecarFailed(), and those flags are what make
-  // getExploreBackendType() — and therefore /api/health — report a degraded
-  // chain. They run for those side effects even when a different backend wins.
+  // Each probe is also load-bearing beyond its logging; see autoDetectNsjail().
   const isVercelHost = process.env.ATLAS_RUNTIME === "vercel" || !!process.env.VERCEL;
-  let pinnedNsjailUsable = true;
+  let pinnedNsjail: PinnedNsjailOutcome = "usable";
   if (!isVercelHost) {
     // On a Vercel host the default chain always resolves vercel-sandbox, so
-    // there is nothing local worth probing. (A Vercel host that ALSO pins a
-    // sidecar or nsjail skips that probe — pre-existing, and the one hole in
-    // the paragraph above.)
+    // there is nothing local worth probing. Two pre-existing holes: a Vercel
+    // host that ALSO sets ATLAS_SANDBOX / ATLAS_SANDBOX_URL, or one pinned via
+    // `sandbox.priority`, skips that backend's probe entirely — so health can
+    // name a backend nothing verified.
     if (process.env.ATLAS_SANDBOX === "nsjail") {
-      pinnedNsjailUsable = await checkExplicitNsjail();
+      pinnedNsjail = await checkExplicitNsjail();
     } else if (process.env.ATLAS_SANDBOX_URL) {
       await checkSidecarHealth();
     } else {
@@ -869,16 +865,30 @@ async function checkSandboxPreFlight(): Promise<void> {
     }
   }
 
-  if (pinnedNsjailUsable) {
-    await logResolvedExploreBackend();
-  } else {
-    // Naming a backend here would be wrong in BOTH directions: "nsjail active"
-    // (it isn't) and "just-bash" (the pin refuses to degrade). Say what is
-    // actually true — explore will not run at all until the pin is satisfiable.
-    log.error(
-      "Explore tool: unavailable — ATLAS_SANDBOX=nsjail is pinned but nsjail is not usable. " +
-        "Explore will fail on every request until nsjail is installed or the pin is removed.",
-    );
+  switch (pinnedNsjail) {
+    case "usable":
+    case "degraded":
+      // "degraded" already tripped markNsjailFailed(), so the resolver now
+      // reports just-bash — which is the truth, and matches /api/health. Naming
+      // it here is the "no process isolation" warning doing its job.
+      await logResolvedExploreBackend();
+      break;
+    case "hard-fail":
+      // Naming a backend would be wrong in both directions: "nsjail active" is
+      // false, and "just-bash" is not what the pin resolves to at boot. Say
+      // nothing about per-request behaviour — tryCreateBackend sets
+      // _nsjailFailed on its first failure, after which the chain degrades.
+      log.error(
+        "Explore tool: unavailable — ATLAS_SANDBOX=nsjail is pinned but the nsjail binary was not found. " +
+          "Install nsjail or set ATLAS_NSJAIL_PATH; until then explore cannot start under the pin.",
+      );
+      break;
+    case "unverified":
+      log.error(
+        "Explore tool: isolation UNVERIFIED — the pinned nsjail probe could not complete. " +
+          "The pin is still armed, so explore will attempt nsjail and fail if it cannot initialize.",
+      );
+      break;
   }
 }
 
@@ -915,8 +925,6 @@ async function logResolvedExploreBackend(): Promise<void> {
       "@atlas/api/lib/tools/backends/selection"
     );
     const backend = getExploreBackendType();
-    // Table lookup rather than `=== "just-bash"` so a future backend must
-    // declare its posture instead of defaulting into the reassuring branch.
     if (BACKEND_ISOLATION[backend] === "unsandboxed") {
       log.info(
         { backend },
@@ -942,12 +950,27 @@ async function logResolvedExploreBackend(): Promise<void> {
 }
 
 /**
- * Probe the explicitly pinned nsjail backend. Returns false when the pin cannot
- * be satisfied — `ATLAS_SANDBOX=nsjail` is hard-fail by contract, so explore
- * refuses to run rather than degrading, and the caller must not name a backend.
+ * Outcome of probing the explicitly pinned nsjail backend. A boolean collapsed
+ * three states whose operator advice differs — and, worse, made boot claim
+ * "explore will fail" on the one path where it actually degrades and runs.
  */
-async function checkExplicitNsjail(): Promise<boolean> {
-  let pinnedNsjailUsable = true;
+type PinnedNsjailOutcome =
+  /** Namespaces verified; the pin holds. */
+  | "usable"
+  /** Binary absent. `_nsjailFailed` untouched, so the hard-fail step survives. */
+  | "hard-fail"
+  /**
+   * Namespaces broken. `markNsjailFailed()` has already run, which deletes the
+   * hard-fail step from `planSandboxSelection` — so the pin does NOT hold and
+   * explore degrades to unsandboxed just-bash. Tracked as #4829.
+   */
+  | "degraded"
+  /** The probe itself threw; isolation is neither confirmed nor refuted. */
+  | "unverified";
+
+/** Probe the explicitly pinned nsjail backend (`ATLAS_SANDBOX=nsjail`). */
+async function checkExplicitNsjail(): Promise<PinnedNsjailOutcome> {
+  let outcome: PinnedNsjailOutcome = "usable";
   try {
     const { findNsjailBinary, testNsjailCapabilities } = await import(
       "@atlas/api/lib/tools/explore-nsjail"
@@ -960,10 +983,16 @@ async function checkExplicitNsjail(): Promise<boolean> {
       const semanticRoot = getDefaultSemanticRoot();
       const capResult = await testNsjailCapabilities(nsjailPath, semanticRoot);
       if (capResult.ok) {
+        // Probe result only. Must NOT start with "Explore tool:" —
+        // logResolvedExploreBackend() owns that prefix, and the tests read it.
         log.info("nsjail namespace capabilities verified");
       } else {
+        // Pre-existing (#4829): this call clears the pin's hard-fail step, so
+        // the deployment silently degrades to unsandboxed just-bash rather than
+        // refusing to run. Reporting it as "degraded" is what stops boot from
+        // claiming a fail-closed posture the process does not have.
         markNsjailFailed();
-        pinnedNsjailUsable = false;
+        outcome = "degraded";
         const msg =
           `nsjail explicitly requested (ATLAS_SANDBOX=nsjail) but namespace creation failed: ${capResult.error}. ` +
           "This platform may not support Linux namespaces. " +
@@ -974,10 +1003,9 @@ async function checkExplicitNsjail(): Promise<boolean> {
     } else {
       // Deliberately does NOT call markNsjailFailed(): planSandboxSelection only
       // emits the hard-fail step while `!nsjailFailed`, so setting the flag here
-      // would DELETE the pin's hard-fail contract and silently degrade the
-      // deployment to unsandboxed just-bash. The pin means "refuse to run
-      // without nsjail"; the caller suppresses the backend line instead.
-      pinnedNsjailUsable = false;
+      // would delete the pin's hard-fail contract at boot and degrade the
+      // deployment to unsandboxed just-bash before a single request arrives.
+      outcome = "hard-fail";
       const msg =
         "ATLAS_SANDBOX=nsjail is set but nsjail binary was not found. " +
         "Install nsjail or set ATLAS_NSJAIL_PATH to the binary location.";
@@ -985,17 +1013,17 @@ async function checkExplicitNsjail(): Promise<boolean> {
       if (!_startupWarnings.includes(msg)) _startupWarnings.push(msg);
     }
   } catch (err) {
-    // The pin's isolation is UNVERIFIED, not merely unlogged: without a
-    // completed probe, isBackendAvailable("nsjail") still reports the pin as
-    // available, so naming a backend would assert isolation nobody confirmed.
+    // Isolation is UNVERIFIED, not refuted: `_nsjailFailed` is untouched, so
+    // isBackendAvailable("nsjail") still reports the pin as available and naming
+    // a backend would assert isolation nobody confirmed.
     const msg =
       `Could not verify the pinned nsjail sandbox (ATLAS_SANDBOX=nsjail): ${errorMessage(err)}. ` +
       "Isolation is UNVERIFIED. Check the nsjail installation or set ATLAS_NSJAIL_PATH.";
     log.error(msg);
     if (!_startupWarnings.includes(msg)) _startupWarnings.push(msg);
-    pinnedNsjailUsable = false;
+    outcome = "unverified";
   }
-  return pinnedNsjailUsable;
+  return outcome;
 }
 
 async function checkSidecarHealth(): Promise<void> {
@@ -1008,6 +1036,7 @@ async function checkSidecarHealth(): Promise<void> {
     const healthUrl = new URL("/health", sidecarUrl).toString();
     const resp = await fetch(healthUrl, { signal: AbortSignal.timeout(5000) });
     if (resp.ok) {
+      // Probe result only — see the "Explore tool:" prefix note above.
       log.info({ url: sidecarUrl }, "Sandbox sidecar healthy at %s", sidecarUrl);
     } else {
       markSidecarFailed();
@@ -1038,8 +1067,7 @@ async function checkSidecarHealth(): Promise<void> {
  * `isBackendAvailable("nsjail")`. Short-circuiting it — the tempting "we
  * already know the backend, skip the probe" fix — would leave `_nsjailFailed`
  * unset, so a host whose winning backend fails to construct at request time
- * would fall through to a known-broken nsjail instead of skipping it, and
- * `/api/health` would name nsjail on a box where it cannot start (#4824).
+ * would fall through to a known-broken nsjail instead of skipping it (#4824).
  */
 async function autoDetectNsjail(): Promise<void> {
   try {

--- a/packages/api/src/lib/startup.ts
+++ b/packages/api/src/lib/startup.ts
@@ -838,15 +838,73 @@ async function checkSandboxPreFlight(): Promise<void> {
     }
   }
 
-  const isVercel = process.env.ATLAS_RUNTIME === "vercel" || !!process.env.VERCEL;
-  if (isVercel) {
-    log.info("Explore tool: Vercel sandbox active");
+  // Probe whichever backend this env shape points at. Every probe is
+  // load-bearing beyond its own logging: a failed nsjail namespace test or an
+  // unreachable sidecar calls markNsjailFailed()/markSidecarFailed(), and those
+  // flags are what make getExploreBackendType() — and therefore /api/health —
+  // report a degraded chain. So the probes run for their side effects even when
+  // the backend that ultimately wins is something else entirely (#4824).
+  //
+  // NOTE: this dispatch asks "which local resource is worth probing", NOT
+  // "which backend is active". Those were the same question until #3706 let a
+  // non-Vercel host (Railway) reach Vercel Sandbox via VERCEL_TEAM_ID /
+  // VERCEL_PROJECT_ID / VERCEL_TOKEN — a shape that has nothing local to probe
+  // yet falls through to the auto-detect arm. Naming the backend from this
+  // dispatch is what made boot log "no process isolation" on every Railway
+  // deploy while health correctly reported `vercel-sandbox`.
+  const isVercelHost = process.env.ATLAS_RUNTIME === "vercel" || !!process.env.VERCEL;
+  if (isVercelHost) {
+    // Nothing local to probe — Vercel Sandbox needs no binary and no sidecar.
   } else if (process.env.ATLAS_SANDBOX === "nsjail") {
     await checkExplicitNsjail();
   } else if (process.env.ATLAS_SANDBOX_URL) {
     await checkSidecarHealth();
   } else {
     await autoDetectNsjail();
+  }
+
+  // ONE terminal line naming the active backend, resolved AFTER every probe so
+  // the failure flags they just set are reflected. Sourcing it from the same
+  // getExploreBackendType() that /api/health reads is what makes it impossible
+  // for boot and health to name different backends for the same process.
+  await logResolvedExploreBackend();
+}
+
+/**
+ * Log the explore backend the process will actually use, read from the single
+ * source of truth `/api/health` reads (`getExploreBackendType()`).
+ *
+ * Must be called AFTER the pre-flight probes: `getExploreBackendType()` consults
+ * `_nsjailFailed` / `_sidecarFailed`, so resolving before the probes would
+ * report a degraded chain optimistically.
+ *
+ * The "no process isolation" warning is deliberately preserved for a genuine
+ * `just-bash` deployment — that deployment really has no isolation and the line
+ * is the correct and valuable thing to say there. What changed is that it is now
+ * gated on the RESOLVED backend rather than on "we couldn't find nsjail".
+ */
+async function logResolvedExploreBackend(): Promise<void> {
+  try {
+    const { getExploreBackendType } = await import(
+      "@atlas/api/lib/tools/explore"
+    );
+    const backend = getExploreBackendType();
+    if (backend === "just-bash") {
+      log.info(
+        { backend },
+        "Explore tool: just-bash (no process isolation). Install nsjail or configure ATLAS_SANDBOX_URL for sandboxed execution.",
+      );
+    } else {
+      log.info({ backend }, "Explore tool: %s active", backend);
+    }
+  } catch (err) {
+    // Deliberately does NOT fall back to the just-bash line: asserting "no
+    // process isolation" when we simply failed to resolve the backend is
+    // exactly the false claim #4824 was filed about.
+    log.warn(
+      { err: errorMessage(err) },
+      "Could not resolve the active explore backend for the startup log",
+    );
   }
 }
 
@@ -863,7 +921,9 @@ async function checkExplicitNsjail(): Promise<void> {
       const semanticRoot = getDefaultSemanticRoot();
       const capResult = await testNsjailCapabilities(nsjailPath, semanticRoot);
       if (capResult.ok) {
-        log.info("Explore tool: nsjail sandbox active");
+        // Probe result only — the active backend is named once, by
+        // logResolvedExploreBackend(), after every probe has run (#4824).
+        log.info("nsjail namespace capabilities verified");
       } else {
         markNsjailFailed();
         const msg =
@@ -896,7 +956,9 @@ async function checkSidecarHealth(): Promise<void> {
     const healthUrl = new URL("/health", sidecarUrl).toString();
     const resp = await fetch(healthUrl, { signal: AbortSignal.timeout(5000) });
     if (resp.ok) {
-      log.info({ url: sidecarUrl }, "Explore tool: sidecar sandbox active");
+      // Probe result only — the active backend is named once, by
+      // logResolvedExploreBackend(), after every probe has run (#4824).
+      log.info({ url: sidecarUrl }, "Sandbox sidecar healthy at %s", sidecarUrl);
     } else {
       markSidecarFailed();
       const msg =
@@ -916,8 +978,18 @@ async function checkSidecarHealth(): Promise<void> {
   }
 }
 
+/**
+ * Auto-detect branch of the sandbox pre-flight.
+ *
+ * This probe is load-bearing beyond its own logging: a failed namespace test
+ * calls `markNsjailFailed()`, which is what makes `isBackendAvailable("nsjail")`
+ * — and therefore `/api/health` — report nsjail as unusable. So it ALWAYS runs,
+ * even when the backend that wins is something else entirely. Short-circuiting
+ * it (the tempting "we already know the backend, skip the probe" fix) would
+ * leave `_nsjailFailed` unset and make health advertise nsjail as available
+ * when it demonstrably is not (#4824).
+ */
 async function autoDetectNsjail(): Promise<void> {
-  let nsjailActive = false;
   try {
     const { findNsjailBinary, testNsjailCapabilities } = await import(
       "@atlas/api/lib/tools/explore-nsjail"
@@ -929,14 +1001,11 @@ async function autoDetectNsjail(): Promise<void> {
     if (nsjailPath) {
       const semanticRoot = getDefaultSemanticRoot();
       const capResult = await testNsjailCapabilities(nsjailPath, semanticRoot);
-      if (capResult.ok) {
-        log.info("Explore tool: nsjail sandbox active");
-        nsjailActive = true;
-      } else {
+      if (!capResult.ok) {
         markNsjailFailed();
         const msg =
           `nsjail available but namespace creation failed: ${capResult.error} — ` +
-          "falling back to just-bash (no process isolation).";
+          "falling back to the next backend in the sandbox priority chain.";
         log.warn(msg);
         if (!_startupWarnings.includes(msg)) _startupWarnings.push(msg);
       }
@@ -944,12 +1013,6 @@ async function autoDetectNsjail(): Promise<void> {
   } catch (err) {
     const detail = errorMessage(err);
     log.warn({ err: detail }, "Sandbox pre-flight check skipped");
-  }
-
-  if (!nsjailActive) {
-    log.info(
-      "Explore tool: just-bash (no process isolation). Install nsjail or configure ATLAS_SANDBOX_URL for sandboxed execution.",
-    );
   }
 }
 

--- a/packages/api/src/lib/startup.ts
+++ b/packages/api/src/lib/startup.ts
@@ -854,11 +854,14 @@ async function checkSandboxPreFlight(): Promise<void> {
   // getExploreBackendType() — and therefore /api/health — report a degraded
   // chain. They run for those side effects even when a different backend wins.
   const isVercelHost = process.env.ATLAS_RUNTIME === "vercel" || !!process.env.VERCEL;
+  let pinnedNsjailUsable = true;
   if (!isVercelHost) {
-    // On a Vercel host there is nothing local to probe — Vercel Sandbox needs
-    // no binary and no sidecar — so every arm below is skipped.
+    // On a Vercel host the default chain always resolves vercel-sandbox, so
+    // there is nothing local worth probing. (A Vercel host that ALSO pins a
+    // sidecar or nsjail skips that probe — pre-existing, and the one hole in
+    // the paragraph above.)
     if (process.env.ATLAS_SANDBOX === "nsjail") {
-      await checkExplicitNsjail();
+      pinnedNsjailUsable = await checkExplicitNsjail();
     } else if (process.env.ATLAS_SANDBOX_URL) {
       await checkSidecarHealth();
     } else {
@@ -866,7 +869,17 @@ async function checkSandboxPreFlight(): Promise<void> {
     }
   }
 
-  await logResolvedExploreBackend();
+  if (pinnedNsjailUsable) {
+    await logResolvedExploreBackend();
+  } else {
+    // Naming a backend here would be wrong in BOTH directions: "nsjail active"
+    // (it isn't) and "just-bash" (the pin refuses to degrade). Say what is
+    // actually true — explore will not run at all until the pin is satisfiable.
+    log.error(
+      "Explore tool: unavailable — ATLAS_SANDBOX=nsjail is pinned but nsjail is not usable. " +
+        "Explore will fail on every request until nsjail is installed or the pin is removed.",
+    );
+  }
 }
 
 /**
@@ -878,7 +891,8 @@ async function checkSandboxPreFlight(): Promise<void> {
  * 1. **After the probes.** `getExploreBackendType()` consults `_nsjailFailed` /
  *    `_sidecarFailed`, so resolving first would report a degraded chain
  *    optimistically.
- * 2. **After `checkConfigFile()`.** It reads `getConfig()?.sandbox?.priority`;
+ * 2. **After `checkConfigFile()`.** `snapshotExploreSandboxEnv()` reads
+ *    `getConfig()?.sandbox?.priority`;
  *    an unresolved config silently yields a different chain. Holds today
  *    because `checkConfigFile()` is step 5.5 of `validateEnvironment()` and the
  *    pre-flight is step 10 — sequential awaits in the same function.
@@ -896,8 +910,9 @@ async function checkSandboxPreFlight(): Promise<void> {
  */
 async function logResolvedExploreBackend(): Promise<void> {
   try {
-    const { getExploreBackendType, BACKEND_ISOLATION } = await import(
-      "@atlas/api/lib/tools/explore"
+    const { getExploreBackendType } = await import("@atlas/api/lib/tools/explore");
+    const { BACKEND_ISOLATION } = await import(
+      "@atlas/api/lib/tools/backends/selection"
     );
     const backend = getExploreBackendType();
     // Table lookup rather than `=== "just-bash"` so a future backend must
@@ -905,7 +920,8 @@ async function logResolvedExploreBackend(): Promise<void> {
     if (BACKEND_ISOLATION[backend] === "unsandboxed") {
       log.info(
         { backend },
-        "Explore tool: just-bash (no process isolation). Install nsjail or configure ATLAS_SANDBOX_URL for sandboxed execution.",
+        "Explore tool: %s (no process isolation). Install nsjail or configure ATLAS_SANDBOX_URL for sandboxed execution.",
+        backend,
       );
     } else {
       log.info({ backend }, "Explore tool: %s active", backend);
@@ -925,7 +941,13 @@ async function logResolvedExploreBackend(): Promise<void> {
   }
 }
 
-async function checkExplicitNsjail(): Promise<void> {
+/**
+ * Probe the explicitly pinned nsjail backend. Returns false when the pin cannot
+ * be satisfied — `ATLAS_SANDBOX=nsjail` is hard-fail by contract, so explore
+ * refuses to run rather than degrading, and the caller must not name a backend.
+ */
+async function checkExplicitNsjail(): Promise<boolean> {
+  let pinnedNsjailUsable = true;
   try {
     const { findNsjailBinary, testNsjailCapabilities } = await import(
       "@atlas/api/lib/tools/explore-nsjail"
@@ -941,6 +963,7 @@ async function checkExplicitNsjail(): Promise<void> {
         log.info("nsjail namespace capabilities verified");
       } else {
         markNsjailFailed();
+        pinnedNsjailUsable = false;
         const msg =
           `nsjail explicitly requested (ATLAS_SANDBOX=nsjail) but namespace creation failed: ${capResult.error}. ` +
           "This platform may not support Linux namespaces. " +
@@ -949,12 +972,12 @@ async function checkExplicitNsjail(): Promise<void> {
         if (!_startupWarnings.includes(msg)) _startupWarnings.push(msg);
       }
     } else {
-      // isBackendAvailable("nsjail") is `ATLAS_SANDBOX === "nsjail" ||
-      // useNsjail()`, so the env pin ALONE reports nsjail as available even with
-      // no binary on the box — and both the boot log and /api/health would then
-      // name a backend that hard-fails on the first explore call. Marking it
-      // failed here is what keeps the pin from advertising itself (#4824).
-      markNsjailFailed();
+      // Deliberately does NOT call markNsjailFailed(): planSandboxSelection only
+      // emits the hard-fail step while `!nsjailFailed`, so setting the flag here
+      // would DELETE the pin's hard-fail contract and silently degrade the
+      // deployment to unsandboxed just-bash. The pin means "refuse to run
+      // without nsjail"; the caller suppresses the backend line instead.
+      pinnedNsjailUsable = false;
       const msg =
         "ATLAS_SANDBOX=nsjail is set but nsjail binary was not found. " +
         "Install nsjail or set ATLAS_NSJAIL_PATH to the binary location.";
@@ -962,9 +985,17 @@ async function checkExplicitNsjail(): Promise<void> {
       if (!_startupWarnings.includes(msg)) _startupWarnings.push(msg);
     }
   } catch (err) {
-    const detail = errorMessage(err);
-    log.warn({ err: detail }, "Sandbox pre-flight check skipped");
+    // The pin's isolation is UNVERIFIED, not merely unlogged: without a
+    // completed probe, isBackendAvailable("nsjail") still reports the pin as
+    // available, so naming a backend would assert isolation nobody confirmed.
+    const msg =
+      `Could not verify the pinned nsjail sandbox (ATLAS_SANDBOX=nsjail): ${errorMessage(err)}. ` +
+      "Isolation is UNVERIFIED. Check the nsjail installation or set ATLAS_NSJAIL_PATH.";
+    log.error(msg);
+    if (!_startupWarnings.includes(msg)) _startupWarnings.push(msg);
+    pinnedNsjailUsable = false;
   }
+  return pinnedNsjailUsable;
 }
 
 async function checkSidecarHealth(): Promise<void> {

--- a/packages/api/src/lib/startup.ts
+++ b/packages/api/src/lib/startup.ts
@@ -838,45 +838,56 @@ async function checkSandboxPreFlight(): Promise<void> {
     }
   }
 
-  // Probe whichever backend this env shape points at. Every probe is
-  // load-bearing beyond its own logging: a failed nsjail namespace test or an
-  // unreachable sidecar calls markNsjailFailed()/markSidecarFailed(), and those
-  // flags are what make getExploreBackendType() — and therefore /api/health —
-  // report a degraded chain. So the probes run for their side effects even when
-  // the backend that ultimately wins is something else entirely (#4824).
+  // This dispatch picks WHICH LOCAL RESOURCE IS WORTH PROBING — it does not
+  // decide which backend is active. Those were the same question until #2383
+  // added off-Vercel Vercel Sandbox support, where a non-Vercel host (Railway)
+  // reaches Vercel Sandbox with VERCEL_TOKEN plus a team/project id from either
+  // env or `sandbox.vercel` in atlas.config.ts. That shape sets none of the
+  // host-detection vars and has nothing local to probe, so it lands on the
+  // auto-detect arm — and naming the backend from this dispatch is what made
+  // boot log "no process isolation" on every Railway deploy while /api/health
+  // correctly reported `vercel-sandbox` (#4824).
   //
-  // NOTE: this dispatch asks "which local resource is worth probing", NOT
-  // "which backend is active". Those were the same question until #3706 let a
-  // non-Vercel host (Railway) reach Vercel Sandbox via VERCEL_TEAM_ID /
-  // VERCEL_PROJECT_ID / VERCEL_TOKEN — a shape that has nothing local to probe
-  // yet falls through to the auto-detect arm. Naming the backend from this
-  // dispatch is what made boot log "no process isolation" on every Railway
-  // deploy while health correctly reported `vercel-sandbox`.
+  // The probes are also load-bearing beyond their logging: a failed nsjail
+  // namespace test, a missing pinned binary, or an unreachable sidecar calls
+  // markNsjailFailed()/markSidecarFailed(), and those flags are what make
+  // getExploreBackendType() — and therefore /api/health — report a degraded
+  // chain. They run for those side effects even when a different backend wins.
   const isVercelHost = process.env.ATLAS_RUNTIME === "vercel" || !!process.env.VERCEL;
-  if (isVercelHost) {
-    // Nothing local to probe — Vercel Sandbox needs no binary and no sidecar.
-  } else if (process.env.ATLAS_SANDBOX === "nsjail") {
-    await checkExplicitNsjail();
-  } else if (process.env.ATLAS_SANDBOX_URL) {
-    await checkSidecarHealth();
-  } else {
-    await autoDetectNsjail();
+  if (!isVercelHost) {
+    // On a Vercel host there is nothing local to probe — Vercel Sandbox needs
+    // no binary and no sidecar — so every arm below is skipped.
+    if (process.env.ATLAS_SANDBOX === "nsjail") {
+      await checkExplicitNsjail();
+    } else if (process.env.ATLAS_SANDBOX_URL) {
+      await checkSidecarHealth();
+    } else {
+      await autoDetectNsjail();
+    }
   }
 
-  // ONE terminal line naming the active backend, resolved AFTER every probe so
-  // the failure flags they just set are reflected. Sourcing it from the same
-  // getExploreBackendType() that /api/health reads is what makes it impossible
-  // for boot and health to name different backends for the same process.
   await logResolvedExploreBackend();
 }
 
 /**
- * Log the explore backend the process will actually use, read from the single
- * source of truth `/api/health` reads (`getExploreBackendType()`).
+ * Emit the ONE line naming the explore backend this process will actually use,
+ * read from the same `getExploreBackendType()` that `/api/health` reports.
  *
- * Must be called AFTER the pre-flight probes: `getExploreBackendType()` consults
- * `_nsjailFailed` / `_sidecarFailed`, so resolving before the probes would
- * report a degraded chain optimistically.
+ * Two ordering dependencies, both real:
+ *
+ * 1. **After the probes.** `getExploreBackendType()` consults `_nsjailFailed` /
+ *    `_sidecarFailed`, so resolving first would report a degraded chain
+ *    optimistically.
+ * 2. **After `checkConfigFile()`.** It reads `getConfig()?.sandbox?.priority`;
+ *    an unresolved config silently yields a different chain. Holds today
+ *    because `checkConfigFile()` is step 5.5 of `validateEnvironment()` and the
+ *    pre-flight is step 10 — sequential awaits in the same function.
+ *
+ * Sharing the resolver means boot and health cannot disagree *about the same
+ * inputs*. They can still differ later in the process's life, legitimately:
+ * sandbox-plugin detection is lazy (`_activeSandboxPluginId` is unset until the
+ * first explore call, so a plugin-isolated deploy is not named `plugin` here),
+ * and a backend can be marked failed at request time.
  *
  * The "no process isolation" warning is deliberately preserved for a genuine
  * `just-bash` deployment — that deployment really has no isolation and the line
@@ -885,11 +896,13 @@ async function checkSandboxPreFlight(): Promise<void> {
  */
 async function logResolvedExploreBackend(): Promise<void> {
   try {
-    const { getExploreBackendType } = await import(
+    const { getExploreBackendType, BACKEND_ISOLATION } = await import(
       "@atlas/api/lib/tools/explore"
     );
     const backend = getExploreBackendType();
-    if (backend === "just-bash") {
+    // Table lookup rather than `=== "just-bash"` so a future backend must
+    // declare its posture instead of defaulting into the reassuring branch.
+    if (BACKEND_ISOLATION[backend] === "unsandboxed") {
       log.info(
         { backend },
         "Explore tool: just-bash (no process isolation). Install nsjail or configure ATLAS_SANDBOX_URL for sandboxed execution.",
@@ -900,11 +913,15 @@ async function logResolvedExploreBackend(): Promise<void> {
   } catch (err) {
     // Deliberately does NOT fall back to the just-bash line: asserting "no
     // process isolation" when we simply failed to resolve the backend is
-    // exactly the false claim #4824 was filed about.
-    log.warn(
-      { err: errorMessage(err) },
-      "Could not resolve the active explore backend for the startup log",
-    );
+    // exactly the false claim #4824 was filed about. Surfaced as a startup
+    // warning because the same throw breaks /api/health's own reporting, so
+    // the isolation posture of this process is genuinely unknown.
+    const msg =
+      `Could not resolve the active explore backend: ${errorMessage(err)}. ` +
+      "The sandbox isolation posture of this process is UNKNOWN and /api/health " +
+      "will fail to report it. Check sandbox.priority in atlas.config.ts.";
+    log.error(msg);
+    if (!_startupWarnings.includes(msg)) _startupWarnings.push(msg);
   }
 }
 
@@ -921,8 +938,6 @@ async function checkExplicitNsjail(): Promise<void> {
       const semanticRoot = getDefaultSemanticRoot();
       const capResult = await testNsjailCapabilities(nsjailPath, semanticRoot);
       if (capResult.ok) {
-        // Probe result only — the active backend is named once, by
-        // logResolvedExploreBackend(), after every probe has run (#4824).
         log.info("nsjail namespace capabilities verified");
       } else {
         markNsjailFailed();
@@ -934,6 +949,12 @@ async function checkExplicitNsjail(): Promise<void> {
         if (!_startupWarnings.includes(msg)) _startupWarnings.push(msg);
       }
     } else {
+      // isBackendAvailable("nsjail") is `ATLAS_SANDBOX === "nsjail" ||
+      // useNsjail()`, so the env pin ALONE reports nsjail as available even with
+      // no binary on the box — and both the boot log and /api/health would then
+      // name a backend that hard-fails on the first explore call. Marking it
+      // failed here is what keeps the pin from advertising itself (#4824).
+      markNsjailFailed();
       const msg =
         "ATLAS_SANDBOX=nsjail is set but nsjail binary was not found. " +
         "Install nsjail or set ATLAS_NSJAIL_PATH to the binary location.";
@@ -956,8 +977,6 @@ async function checkSidecarHealth(): Promise<void> {
     const healthUrl = new URL("/health", sidecarUrl).toString();
     const resp = await fetch(healthUrl, { signal: AbortSignal.timeout(5000) });
     if (resp.ok) {
-      // Probe result only — the active backend is named once, by
-      // logResolvedExploreBackend(), after every probe has run (#4824).
       log.info({ url: sidecarUrl }, "Sandbox sidecar healthy at %s", sidecarUrl);
     } else {
       markSidecarFailed();
@@ -981,13 +1000,15 @@ async function checkSidecarHealth(): Promise<void> {
 /**
  * Auto-detect branch of the sandbox pre-flight.
  *
- * This probe is load-bearing beyond its own logging: a failed namespace test
- * calls `markNsjailFailed()`, which is what makes `isBackendAvailable("nsjail")`
- * — and therefore `/api/health` — report nsjail as unusable. So it ALWAYS runs,
- * even when the backend that wins is something else entirely. Short-circuiting
- * it (the tempting "we already know the backend, skip the probe" fix) would
- * leave `_nsjailFailed` unset and make health advertise nsjail as available
- * when it demonstrably is not (#4824).
+ * The probe runs whenever this arm is reached, regardless of which backend
+ * ultimately wins, because it is load-bearing beyond its own logging: a failed
+ * namespace test calls `markNsjailFailed()`, and that flag gates
+ * `tryCreateBackend("nsjail")` (`lib/tools/explore.ts`) as well as
+ * `isBackendAvailable("nsjail")`. Short-circuiting it — the tempting "we
+ * already know the backend, skip the probe" fix — would leave `_nsjailFailed`
+ * unset, so a host whose winning backend fails to construct at request time
+ * would fall through to a known-broken nsjail instead of skipping it, and
+ * `/api/health` would name nsjail on a box where it cannot start (#4824).
  */
 async function autoDetectNsjail(): Promise<void> {
   try {

--- a/packages/api/src/lib/tools/backends/selection.ts
+++ b/packages/api/src/lib/tools/backends/selection.ts
@@ -273,3 +273,34 @@ export function formatSandboxPriorityFailure(
 
   return `All backends in sandbox.priority (${priority.join(", ")}) failed to initialize.${summary} ${guidance.join(" ")}`;
 }
+
+/** Isolation posture of a sandbox backend. */
+export type SandboxIsolationPosture = "isolated" | "unsandboxed" | "plugin-declared";
+
+/**
+ * Isolation posture of each backend, so operator-facing surfaces don't have to
+ * re-derive "does this one actually isolate?" from a string equality check.
+ *
+ * `satisfies Record<…>` is the point: adding a backend to
+ * `SANDBOX_BACKEND_NAMES` without classifying it here is a compile error, so a
+ * future unsandboxed backend can never silently inherit the reassuring branch
+ * of a caller's `=== "just-bash"` test — the same fail-open shape that let the
+ * #4824 boot dispatch assert the wrong isolation posture.
+ *
+ * `plugin` is `plugin-declared`: the plugin supplies its own security metadata
+ * (surfaced by `logSandboxPlugins()`), and `/api/health` reports
+ * `isolationVerified: false` for it because Atlas has not verified that claim.
+ * This table must not claim isolation on the plugin's behalf.
+ *
+ * Lives here rather than beside `ExploreBackendType` in `lib/tools/explore.ts`
+ * deliberately: explore is the most-mocked module in the package (a dozen-plus
+ * partial `mock.module` sites), so a new VALUE export there breaks every static
+ * importer under those mocks. This module is pure policy and is not mocked.
+ */
+export const BACKEND_ISOLATION = {
+  "vercel-sandbox": "isolated",
+  nsjail: "isolated",
+  sidecar: "isolated",
+  "just-bash": "unsandboxed",
+  plugin: "plugin-declared",
+} as const satisfies Record<SandboxBackendName | "plugin", SandboxIsolationPosture>;

--- a/packages/api/src/lib/tools/backends/selection.ts
+++ b/packages/api/src/lib/tools/backends/selection.ts
@@ -282,20 +282,26 @@ export type SandboxIsolationPosture = "isolated" | "unsandboxed" | "plugin-decla
  * re-derive "does this one actually isolate?" from a string equality check.
  *
  * `satisfies Record<…>` is the point: adding a backend to
- * `SANDBOX_BACKEND_NAMES` without classifying it here is a compile error, so a
- * future unsandboxed backend can never silently inherit the reassuring branch
- * of a caller's `=== "just-bash"` test — the same fail-open shape that let the
- * #4824 boot dispatch assert the wrong isolation posture.
+ * `SANDBOX_BACKEND_NAMES` without classifying it HERE is a compile error, so a
+ * new unsandboxed backend cannot slip in unclassified — the fail-open shape
+ * that let the #4824 boot dispatch assert the wrong isolation posture. Callers
+ * must still route through this table rather than string-comparing; nothing
+ * lints for that. The three that do: `health.ts` (twice) and `startup.ts`.
  *
  * `plugin` is `plugin-declared`: the plugin supplies its own security metadata
  * (surfaced by `logSandboxPlugins()`), and `/api/health` reports
  * `isolationVerified: false` for it because Atlas has not verified that claim.
  * This table must not claim isolation on the plugin's behalf.
  *
+ * Both current consumers collapse `plugin-declared` to "not unsandboxed"; the
+ * separate value exists so a future surface can distinguish verified from
+ * declared isolation without re-deriving it.
+ *
  * Lives here rather than beside `ExploreBackendType` in `lib/tools/explore.ts`
- * deliberately: explore is the most-mocked module in the package (a dozen-plus
- * partial `mock.module` sites), so a new VALUE export there breaks every static
- * importer under those mocks. This module is pure policy and is not mocked.
+ * deliberately: explore is partially mocked in 40+ test files, so a new VALUE
+ * export there is `undefined` for any production importer running under those
+ * mocks (`health.ts` imports this table statically). This module is pure policy
+ * and is mocked nowhere.
  */
 export const BACKEND_ISOLATION = {
   "vercel-sandbox": "isolated",

--- a/packages/api/src/lib/tools/explore.ts
+++ b/packages/api/src/lib/tools/explore.ts
@@ -131,27 +131,6 @@ let _sidecarFailed = false;
 
 export type ExploreBackendType = SandboxBackendName | "plugin";
 
-/**
- * Isolation posture of each backend, so operator-facing surfaces don't have to
- * re-derive "does this one actually isolate?" from a string equality check.
- *
- * `satisfies Record<ExploreBackendType, …>` is the point: adding a backend to
- * `SANDBOX_BACKEND_NAMES` without classifying it here is a compile error, so a
- * future unsandboxed backend can never silently inherit the reassuring branch
- * of a caller's `=== "just-bash"` test. That fail-open default is what let the
- * boot log assert the wrong isolation posture in #4824.
- *
- * `plugin` is `plugin-declared`: the plugin supplies its own security metadata
- * (surfaced by `logSandboxPlugins()` and `/api/health`'s `isolationVerified`),
- * so this table must not claim isolation on its behalf.
- */
-export const BACKEND_ISOLATION = {
-  "vercel-sandbox": "isolated",
-  nsjail: "isolated",
-  sidecar: "isolated",
-  "just-bash": "unsandboxed",
-  plugin: "plugin-declared",
-} as const satisfies Record<ExploreBackendType, "isolated" | "unsandboxed" | "plugin-declared">;
 
 /** Name of the active sandbox plugin (if any). Set during backend init. */
 let _activeSandboxPluginId: string | null = null;
@@ -398,6 +377,12 @@ export function invalidateOrgExploreBackends(orgId: string): void {
  * makes them leak across cases in a test file, so a suite exercising several
  * env shapes would otherwise depend on test ORDER to stay honest, and the
  * failure mode is a still-passing test that no longer proves what it claims.
+ *
+ * Also clears the `_nsjailAvailable` binary-detection memo (`useNsjail()`'s
+ * cache) — not a failure flag, but cached on first read, so a suite that varies
+ * `PATH` / `ATLAS_NSJAIL_PATH` between cases needs it dropped too. Does NOT
+ * clear `_activeSandboxPluginId` or `backendCache`; a suite that exercises a
+ * plugin backend must handle those itself.
  */
 export function _resetSandboxFailureFlagsForTest(): void {
   _nsjailFailed = false;

--- a/packages/api/src/lib/tools/explore.ts
+++ b/packages/api/src/lib/tools/explore.ts
@@ -131,7 +131,6 @@ let _sidecarFailed = false;
 
 export type ExploreBackendType = SandboxBackendName | "plugin";
 
-
 /** Name of the active sandbox plugin (if any). Set during backend init. */
 let _activeSandboxPluginId: string | null = null;
 

--- a/packages/api/src/lib/tools/explore.ts
+++ b/packages/api/src/lib/tools/explore.ts
@@ -131,6 +131,28 @@ let _sidecarFailed = false;
 
 export type ExploreBackendType = SandboxBackendName | "plugin";
 
+/**
+ * Isolation posture of each backend, so operator-facing surfaces don't have to
+ * re-derive "does this one actually isolate?" from a string equality check.
+ *
+ * `satisfies Record<ExploreBackendType, …>` is the point: adding a backend to
+ * `SANDBOX_BACKEND_NAMES` without classifying it here is a compile error, so a
+ * future unsandboxed backend can never silently inherit the reassuring branch
+ * of a caller's `=== "just-bash"` test. That fail-open default is what let the
+ * boot log assert the wrong isolation posture in #4824.
+ *
+ * `plugin` is `plugin-declared`: the plugin supplies its own security metadata
+ * (surfaced by `logSandboxPlugins()` and `/api/health`'s `isolationVerified`),
+ * so this table must not claim isolation on its behalf.
+ */
+export const BACKEND_ISOLATION = {
+  "vercel-sandbox": "isolated",
+  nsjail: "isolated",
+  sidecar: "isolated",
+  "just-bash": "unsandboxed",
+  plugin: "plugin-declared",
+} as const satisfies Record<ExploreBackendType, "isolated" | "unsandboxed" | "plugin-declared">;
+
 /** Name of the active sandbox plugin (if any). Set during backend init. */
 let _activeSandboxPluginId: string | null = null;
 
@@ -366,6 +388,21 @@ export function invalidateOrgExploreBackends(orgId: string): void {
       closeCachedBackend(cached, key);
     }
   }
+}
+
+/**
+ * Clear the process-lifetime backend degradation flags. Testing only.
+ *
+ * `_nsjailFailed` / `_sidecarFailed` are deliberately monotonic in production —
+ * a backend that failed once must not be retried into the request path. That
+ * makes them leak across cases in a test file, so a suite exercising several
+ * env shapes would otherwise depend on test ORDER to stay honest, and the
+ * failure mode is a still-passing test that no longer proves what it claims.
+ */
+export function _resetSandboxFailureFlagsForTest(): void {
+  _nsjailFailed = false;
+  _sidecarFailed = false;
+  _nsjailAvailable = null;
 }
 
 /** Permanently mark nsjail as failed and clear the backend cache.


### PR DESCRIPTION
## What

The startup pre-flight logged `Explore tool: just-bash (no process isolation)` on every Railway deploy — staging and all three prod regions — while explore was in fact running on Vercel Sandbox with full isolation. Execution was always correct; only the log lied, and it asserted the **opposite of the truth** in the exact string a security review greps for.

The dispatch asked *"are we running **on** Vercel"* (`ATLAS_RUNTIME` / `VERCEL`), not *"are we **using** Vercel Sandbox"*. Those were the same question until #2383 added off-Vercel support, where `VERCEL_TOKEN` plus a team/project id (from env, or since #3706 from `sandbox.vercel` in `atlas.config.ts`) lets a Railway service reach Vercel Sandbox. That shape sets none of the host-detection vars, so boot fell through to nsjail auto-detect, found no binary, and printed the just-bash line regardless of what actually resolved.

## How

The probes now report **probe results**, and a single terminal line names the backend resolved by `getExploreBackendType()` — the same function `/api/health` reads — so boot and health cannot disagree about the same inputs.

Two things deliberately preserved:

- **The "no process isolation" warning still fires for a genuine `just-bash` deployment.** That deployment really has no isolation; the line is correct and valuable there. It is now gated on the **resolved backend** rather than on "we couldn't find nsjail". Pinned by a test, since deleting the line is the tempting wrong fix.
- **`autoDetectNsjail()` still always probes.** The probe calls `markNsjailFailed()`, which gates `tryCreateBackend("nsjail")` and `isBackendAvailable("nsjail")`. The naive fix — "the resolved backend isn't nsjail, skip the probe" — would leave `_nsjailFailed` unset, so a host whose winning backend fails to construct at request time falls through to a known-broken nsjail. Resolution happens **after** the probes so the degraded chain is reflected.

`BACKEND_ISOLATION` (in `lib/tools/backends/selection.ts`) replaces `=== "just-bash"` string comparisons in both boot and `/api/health`. Its `satisfies Record<…>` makes adding a backend without classifying its isolation posture a compile error, so a future unsandboxed backend cannot inherit the reassuring branch.

`ATLAS_SANDBOX=nsjail` failures are now reported as what they actually are, rather than collapsed into one message:

| Outcome | Reality | Boot says |
|---|---|---|
| `usable` | pin holds | names nsjail |
| `hard-fail` (binary absent) | flag untouched, hard-fail step intact | names no backend — both "nsjail active" and "just-bash" would be wrong |
| `degraded` (namespaces broken) | `markNsjailFailed()` already cleared the pin's hard-fail step, so explore runs **unsandboxed** | names just-bash, warning and all — matching `/api/health` |
| `unverified` (probe threw) | neither confirmed nor refuted | says exactly that |

## Acceptance criteria

- [x] Railway-shaped deploy (Vercel Sandbox via env creds, no nsjail binary) does **not** log "no process isolation"; it names the backend actually in use
- [x] A genuine `just-bash` deployment **still** gets the warning — pinned by a test
- [x] The nsjail and sidecar pre-flight paths keep their existing behaviour
- [x] Pre-flight and `/api/health` cannot report different backends — a test asserts agreement across all five env shapes (bare, on-Vercel, Railway+Vercel-creds, sidecar, explicit nsjail), each pinned to an expected literal so the loop can't pass by comparing the resolver to itself
- [x] Config resolution precedes the pre-flight's `getExploreBackendType()` call — **verified, not changed**: `checkConfigFile()` (which calls `loadConfig()`) is step 5.5 of `validateEnvironment()` and the pre-flight is step 10, sequential awaits in the same function

## Testing

`packages/api/src/lib/__tests__/startup-sandbox-preflight.test.ts` drives the **real** `lib/tools/explore` module rather than a stub, so the parity assertions compare against the genuine resolver instead of a mock that would agree with anything. Order-independence comes from `_resetSandboxFailureFlagsForTest()` in `beforeEach`, not from case ordering.

Mutation-verified — each of these makes the suite fail:

| Mutation | Caught by |
|---|---|
| Naive fix: skip the nsjail probe when the resolved backend isn't just-bash | `nsjailProbeRan` |
| Delete the "no process isolation" line entirely | 2 tests |
| Re-introduce the round-1 `markNsjailFailed()` regression (below) | `nsjailFailed` stays false |

## Review notes

Three `/review-panel` rounds. Round 2 caught a **security regression I introduced in round 1**: to stop boot naming nsjail for a pinned-but-missing binary, I called `markNsjailFailed()`. But `_nsjailFailed` is an input to the *planner*, not just a reporting flag — `planSandboxSelection` only emits the hard-fail step while `!nsjailFailed`. Setting it would have deleted the pin's hard-fail contract and silently degraded a deploy that explicitly asked to refuse-without-nsjail into running agent shell unsandboxed on the host. Reverted, and the regression is now pinned by a test.

Two findings were deliberately **deferred**, both because they live in the shared resolver and fixing them only at the boot log would reintroduce the boot/health divergence this PR closes:

- **#4828** — `getExploreBackendType()` returns `"just-bash"` for a fail-closed `sandbox.priority` pin, where explore actually throws on every request. Affects `/api/health` identically.
- **#4829** (security) — `ATLAS_SANDBOX=nsjail` + failing namespace probe clears the hard-fail step, so the deploy degrades to unsandboxed rather than refusing. Pre-existing; this PR makes boot *report* it honestly but does not change the behaviour.

Closes #4824
