### PR TITLE
fix(www): lead /blog with the launch announcement, not Friday's post

### DIFF
--- a/apps/www/src/data/posts.ts
+++ b/apps/www/src/data/posts.ts
@@ -1,7 +1,13 @@
 // ---------------------------------------------------------------------------
-// Blog post index — newest first. The first entry renders as the featured
-// lead on /blog. Single source of truth for the index page, the sitemap,
-// and per-post BlogPosting structured data.
+// Blog post index. The first entry renders as the featured lead on /blog and
+// supplies the /blog sitemap `lastModified`. Single source of truth for the
+// index page, the sitemap, and per-post BlogPosting structured data.
+//
+// Ordering is newest-first, with one deliberate exception: the launch-week
+// run (Jul 27–31) is led by "Atlas is public" and then reads forward Mon→Fri,
+// so the index opens on the launch announcement rather than on Friday's post.
+// The static export (`output: "export"`) renders every entry at build time —
+// there is no date gate, so a future-dated post is live the moment it merges.
 // ---------------------------------------------------------------------------
 
 export interface Post {
@@ -16,22 +22,22 @@ export interface Post {
 
 export const POSTS: Post[] = [
   {
-    slug: "the-process-is-the-region",
-    title: "Yours, anywhere: the process is the region",
+    slug: "atlas-is-public",
+    title: "Atlas is public",
     description:
-      "Self-hosted Atlas is free and your data never leaves. On Atlas Cloud, residency is enforced by topology rather than by a filter: each region is its own deployment holding no route to any other, so a cross-region query is unexpressible rather than blocked. Plus the carve-out I couldn't engineer away.",
-    isoDate: "2026-07-31",
-    dateLabel: "July 31, 2026",
+      "The AI data analyst you can run anywhere is live. Plain-English answers over SQL warehouses and REST APIs, governed by a semantic layer you author, on infrastructure you control. Here's the whole surface, and what each day this week goes deep on.",
+    isoDate: "2026-07-27",
+    dateLabel: "July 27, 2026",
     readingTime: "5 min read",
-    tag: "How it works",
+    tag: "Road to launch",
   },
   {
-    slug: "a-strangers-agent",
-    title: "Hand a stranger's agent your data",
+    slug: "grounded-in-your-context",
+    title: "Grounded in your context",
     description:
-      "An AI client I've never seen can discover Atlas, provision itself a workspace, and be querying inside a minute with no human in the loop. Here's the model that makes that defensible: two endpoints, one tool versus sixteen, and the same validation pipeline a person gets.",
-    isoDate: "2026-07-30",
-    dateLabel: "July 30, 2026",
+      "Ask two tools what revenue was last quarter and you can get two different numbers. Atlas reads your definitions first: a YAML semantic layer you author, a Knowledge Base mirroring your own docs through ten vendor connectors, and the query patterns it keeps as people approve them.",
+    isoDate: "2026-07-28",
+    dateLabel: "July 28, 2026",
     readingTime: "6 min read",
     tag: "How it works",
   },
@@ -46,24 +52,24 @@ export const POSTS: Post[] = [
     tag: "How it works",
   },
   {
-    slug: "grounded-in-your-context",
-    title: "Grounded in your context",
+    slug: "a-strangers-agent",
+    title: "Hand a stranger's agent your data",
     description:
-      "Ask two tools what revenue was last quarter and you can get two different numbers. Atlas reads your definitions first: a YAML semantic layer you author, a Knowledge Base mirroring your own docs through ten vendor connectors, and the query patterns it keeps as people approve them.",
-    isoDate: "2026-07-28",
-    dateLabel: "July 28, 2026",
+      "An AI client I've never seen can discover Atlas, provision itself a workspace, and be querying inside a minute with no human in the loop. Here's the model that makes that defensible: two endpoints, one tool versus sixteen, and the same validation pipeline a person gets.",
+    isoDate: "2026-07-30",
+    dateLabel: "July 30, 2026",
     readingTime: "6 min read",
     tag: "How it works",
   },
   {
-    slug: "atlas-is-public",
-    title: "Atlas is public",
+    slug: "the-process-is-the-region",
+    title: "Yours, anywhere: the process is the region",
     description:
-      "The AI data analyst you can run anywhere is live. Plain-English answers over SQL warehouses and REST APIs, governed by a semantic layer you author, on infrastructure you control. Here's the whole surface, and what each day this week goes deep on.",
-    isoDate: "2026-07-27",
-    dateLabel: "July 27, 2026",
+      "Self-hosted Atlas is free and your data never leaves. On Atlas Cloud, residency is enforced by topology rather than by a filter: each region is its own deployment holding no route to any other, so a cross-region query is unexpressible rather than blocked. Plus the carve-out I couldn't engineer away.",
+    isoDate: "2026-07-31",
+    dateLabel: "July 31, 2026",
     readingTime: "5 min read",
-    tag: "Road to launch",
+    tag: "How it works",
   },
   {
     slug: "the-last-mile",


### PR DESCRIPTION
## Why

Launch day. All five launch-week posts merged Jul 24–26, and `www` is **`main`-direct-to-prod** (static `output: "export"`, no date gate) — so the entire week has been live on www.useatlas.dev since before launch. `POSTS[0]` was `the-process-is-the-region` (Jul 31), which made **Friday's residency post the featured hero** on `/blog`.

A visitor landing on the blog today sees *"Yours, anywhere: the process is the region"* instead of *"Atlas is public."*

This is Option A from the [Week Runbook](https://app.notion.com/p/3a9bd4d2e3a681238016e5de16c77a69) — the recommended one-commit fix, which hadn't landed.

## What

Reorder only. No date gate, no build mechanism, no ongoing obligation.

- `atlas-is-public` (Jul 27) → `POSTS[0]`, so it's the featured lead
- The rest of the launch-week run reads forward **Mon→Fri**, so the index opens on the announcement and then walks the week
- Archive posts (Jul 23 and older) unchanged, still newest-first
- Header comment updated to record the deliberate exception and the no-date-gate constraint

### Side effect, and it's a good one

`apps/www/src/app/sitemap.ts:17` derives the `/blog` `lastModified` from `POSTS[0].isoDate`. It was advertising a **future** date; now it's today's.

```
- <lastmod>2026-07-31T00:00:00.000Z</lastmod>
+ <lastmod>2026-07-27T00:00:00.000Z</lastmod>
```

## Not doing

Restoring the true daily drip (Option B) needs **one build per day** — a static export evaluates any date comparison at build time, not request time. A missed daily build during launch week = a missed post. Deferred deliberately; recorded in the runbook.

## Verification

Ran in `apps/www`:

- `bun run type` — clean
- `bun run test` — 14 pass / 0 fail
- `bun run build` — static export succeeds, all 15 blog routes prerender

Built output confirms the order:

```
$ grep -o 'href="/blog/[a-z-]*"' out/blog.html | head -5
href="/blog/atlas-is-public"
href="/blog/grounded-in-your-context"
href="/blog/the-live-security-pass"
href="/blog/a-strangers-agent"
href="/blog/the-process-is-the-region"
```

Scope note: I ran the `apps/www` gates rather than the full 32-gate `/ci`, since the change is one data file whose only consumers are `blog/page.tsx` and `sitemap.ts`. Full CI runs on this PR.

⚠️ **Merging publishes immediately** — `www` is main-direct, so this goes live on www.useatlas.dev as soon as it lands. That's the intent.