### PR TITLE
ci: run CI + Deploy Validation on hotfix/** pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main, "milestone/**"]
+    branches: [main, "milestone/**", "hotfix/**"]
   pull_request:
     branches: [main, "milestone/**"]
   # Manual lever: lets an operator/agent re-create required check runs when
@@ -21,6 +21,16 @@ on:
 # `main`-only and cannot be branch-filtered here, so milestone-branch PRs are
 # gated by everything EXCEPT CodeQL. It runs on the milestone branch's own PR
 # into `main`, which is the merge that matters for that gate.
+#
+# `hotfix/**` is `push:`-only, and the asymmetry is the point. A hotfix cut when
+# `main` is NOT prod-plus-one-fix branches from the tag `prod` serves, so the SHA
+# that ships is never the SHA a PR tests: `pull_request` checks run against the
+# MERGE result (`main` + the fix, including whatever unreleased arc `main` is
+# carrying), which is a different tree than prod receives. The `push:` trigger is
+# what puts CI on the hotfix commit itself. No `pull_request` entry is needed —
+# a hotfix PR targets `main`, so it already matches the filter above.
+# Runbook: docs/development/release-process.md § When `main` is NOT a safe
+# hotfix source.
 
 permissions:
   contents: read

--- a/.github/workflows/deploy-validation.yml
+++ b/.github/workflows/deploy-validation.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches: [main, "milestone/**"]
   push:
-    branches: [main, "milestone/**"]
+    branches: [main, "milestone/**", "hotfix/**"]
   # Manual lever: lets an operator/agent re-create required check runs when
   # GitHub drops pull_request event deliveries (observed 2026-06-10 on #3358).
   workflow_dispatch:
@@ -12,6 +12,11 @@ on:
 # `milestone/**` mirrors ci.yml — see the longer rationale there. Scaffold drift
 # is exactly the class of break that hides until the milestone lands, so the
 # gate has to travel with the stacked PRs, not wait for the final merge.
+#
+# `hotfix/**` mirrors ci.yml too, and matters here for the same reason: a hotfix
+# branched off the tag `prod` serves is the one release path whose SHA no
+# pull_request ever validates. Deploy Validation is a required check, so without
+# this the scaffolds are unverified on exactly the tree going to prod.
 
 permissions:
   contents: read


### PR DESCRIPTION
Closes the gap the hotfix-lane dry run found (#4845, merged as `6895a3f57`).

## The gap

A hotfix cut when `main` is *not* prod-plus-one-fix branches from the tag `prod` serves — which makes it **the one release path whose SHA nothing validates**:

- `push:` was gated on `[main, "milestone/**"]`, so pushing a hotfix branch ran **zero checks**
- Opening a PR into `main` doesn't cover it — `pull_request` checks run against the **merge result** (`main` + the fix, including whatever unreleased arc `main` is carrying), which is a different tree than prod receives

So the exact tree shipped to prod was untested unless someone remembered a manual `workflow_dispatch`. That's a footgun aimed at the highest-stakes, least-rehearsed path in the repo.

## The change

```diff
   push:
-    branches: [main, "milestone/**"]
+    branches: [main, "milestone/**", "hotfix/**"]
```

in both `ci.yml` and `deploy-validation.yml`.

**`push:`-only, deliberately.** A hotfix PR targets `main` and already matches the existing `pull_request` filter — adding `hotfix/**` there would do nothing. The asymmetry vs `milestone/**` (which needs both, because PRs stack *onto* milestone branches) is explained in the file comment so it doesn't read as an oversight.

**Mirrored into `deploy-validation.yml`** for the same reason: it's a required check, so without it the scaffolds go unverified on precisely the tree going to prod.

## Security check

The workflow-edit hook flagged the generic injection classes. Verified against this change specifically:

- Neither workflow interpolates `github.head_ref` / `github.ref_name` / `pull_request.head.ref` into any `run:` step — grepped both files, zero hits
- `push` events do not fire for forks, so only collaborators can create a `hotfix/**` branch

Widening a `push` branch filter adds no untrusted-input surface here.

## Still not covered

CodeQL — `Analyze (javascript-typescript)` is default setup, `main`-only, and cannot be branch-filtered. Unchanged, and the caveat stays documented in both workflow files and in the runbook.

## Freeze note

CI config only. No product surface, no deploy path, and it cannot affect the running prod services. Landing it now rather than after Aug 3 because the lane it protects is one you might actually need this week.