### PR TITLE
refactor(saas-guards): derive the sandbox pin's fail-closed rule from planSandboxSelection

### DIFF
--- a/packages/api/src/lib/effect/__tests__/saas-guards.test.ts
+++ b/packages/api/src/lib/effect/__tests__/saas-guards.test.ts
@@ -81,9 +81,7 @@ void mock.module("@atlas/api/lib/settings", () => ({
   _resetSettingsCache: () => {},
 }));
 
-// The sandbox backend union, used to type the priority shapes the
-// `SandboxCredsGuardLive` sweep enumerates. Type-only, so it is unaffected by
-// the dynamic-import dance the block below describes.
+// Type-only, so unaffected by the dynamic-import dance the block below describes.
 import type { SandboxBackendName } from "@atlas/api/lib/config";
 
 // Type-only imports for the tagged error classes and the `Config` Tag
@@ -899,6 +897,39 @@ describe("SandboxCredsGuardLive", () => {
     );
   });
 
+  // The reported `priority` comes from the PLANNER's list, not the caller's
+  // (#4838). Identical today — the planner returns what it was handed — so this
+  // pins the operator-facing consequence rather than current mechanics: an
+  // operator debugging a boot failure must see every backend the decision
+  // covered, not just the one the guard checks credentials for.
+  test("reports the whole pinned list, not just vercel-sandbox, on a multi-backend pin", async () => {
+    await withCleanEnv(() =>
+      withVercelIds({}, async () => {
+        const exit = await Effect.runPromiseExit(
+          Effect.void.pipe(
+            Effect.provide(
+              SandboxCredsGuardLive.pipe(
+                Layer.provide(
+                  makeTestConfigLayer({
+                    deployMode: "saas",
+                    sandbox: { priority: ["sidecar", "vercel-sandbox"] },
+                  }),
+                ),
+              ),
+            ),
+          ),
+        );
+        expect(Exit.isFailure(exit)).toBe(true);
+        const failure = Exit.isFailure(exit) && exit.cause._tag === "Fail" ? exit.cause.error : null;
+        expect(failure).toBeInstanceOf(SandboxCredentialsMissingError);
+        expect((failure as TSandboxCredentialsMissingError).priority).toEqual([
+          "sidecar",
+          "vercel-sandbox",
+        ]);
+      }),
+    );
+  });
+
   test("succeeds in SaaS when all Vercel credentials are present", async () => {
     await withCleanEnv(() =>
       withVercelIds({ teamId: "team_x", projectId: "prj_x" }, async () => {
@@ -1001,9 +1032,9 @@ describe("SandboxCredsGuardLive", () => {
   // growing back. It hardcodes no outcomes: for every priority shape it computes
   // the expectation by calling the planner directly and reading `onExhausted`,
   // then asserts the guard agrees. A re-hand-rolled copy therefore fails here on
-  // the first shape where the two disagree — including the silent direction
-  // (planner says fail-closed, guard says "not pinned", region boots green with
-  // explore refusing every request). The named cases above pin today's four
+  // any shape where the two disagree — including the silent direction (planner
+  // says fail-closed, guard says "not pinned", so the region boots green with a
+  // deny-all pin nothing enforces). The named cases above pin today's four
   // documented shapes and cannot catch a rewrite that diverges only outside
   // them, which is why they are not sufficient on their own.
   //
@@ -1013,22 +1044,28 @@ describe("SandboxCredsGuardLive", () => {
   //
   // The space is every ORDERING of every subset of the backend names, not just
   // every subset: `sandbox.priority` is `z.array(z.enum(...)).min(1)` with no
-  // ordering constraint, and a mirror keyed on position rather than membership
-  // (`priority[0] !== "vercel-sandbox"`, or "the fallback goes last") agrees
-  // with the planner on every canonically-ordered subset while diverging in
-  // production on `["sidecar", "vercel-sandbox"]`.
+  // ordering constraint, so a mirror keyed on position rather than membership
+  // agrees with the planner on every canonically-ordered subset while diverging
+  // in production. Each such mirror needs its own counterexample:
+  // `priority[0] !== "vercel-sandbox"` diverges on `["sidecar","vercel-sandbox"]`,
+  // "the fallback goes last" on `["just-bash","vercel-sandbox"]`.
   //
   // Names are read off `BACKEND_ISOLATION`, whose
-  // `satisfies Record<SandboxBackendName | "plugin">` makes a newly-added
-  // backend a compile error until it is classified there — so a new backend
-  // widens this enumeration automatically rather than silently leaving its
-  // shapes untested. (`plugin` is excluded: it is an isolation posture for the
-  // front-of-line plugin seam, never a `sandbox.priority` entry. That exclusion
-  // is hand-maintained — a second non-priority key would need adding here.)
+  // `satisfies Record<SandboxBackendName | "plugin", SandboxIsolationPosture>`
+  // makes a newly-added backend a compile error until it is classified there —
+  // so a new backend widens this enumeration automatically rather than silently
+  // leaving its shapes untested. (`plugin` is excluded: it is an isolation
+  // posture for the front-of-line plugin seam, never a `sandbox.priority` entry.
+  // That exclusion is hand-maintained — a second non-priority key would need
+  // adding here.) Widening is not free: the sweep is Σ C(n,k)·k!, so 65 shapes
+  // at 4 backends but 327 at 5 and 1957 at 6 — a 6th backend wants capping
+  // (sampling, or subsets of size ≤ 3) rather than a straight enumeration.
   test("fail-closed determination cannot drift from planSandboxSelection (every priority ordering)", async () => {
     // No explicit type predicate on the filter: TS infers `SandboxBackendName[]`
     // here, and an inferred narrowing is checked where a hand-written
-    // `name is SandboxBackendName` would be an unchecked assertion.
+    // `name is SandboxBackendName` would be an unchecked assertion. The
+    // `Object.keys` cast is the one unchecked step, sound because the table is a
+    // closed `as const` literal.
     const backends = (
       Object.keys(BACKEND_ISOLATION) as Array<keyof typeof BACKEND_ISOLATION>
     ).filter((name) => name !== "plugin");
@@ -1064,9 +1101,22 @@ describe("SandboxCredsGuardLive", () => {
     // have `vercelAvailable: true` while its explicit creds are incomplete.
     // Nothing about "creds missing" implies "vercel unavailable" — this
     // assertion is what licenses the snapshot, not any such equivalence.
+    // Between them these snapshots differ from the base in EVERY field, and no
+    // pair of fields is left at a constant combination — so a dependence on any
+    // single field, or on a conjunction of two, is caught. Keep both properties
+    // if you edit them: with only the first two entries a planner gating on
+    // `sidecarAvailable && nsjailFailed` slipped through, since that pair was
+    // never (true, true).
+    //
+    // Residual, deliberately not chased: `atlasSandbox` is a string, so sampling
+    // cannot close a planner that gates on some third literal. That direction is
+    // loud rather than silent — the guard would fail boot on a region that would
+    // in fact have degraded — and a source/arm flip is caught structurally by
+    // the whole-plan branch below.
     const ALT_AVAILABILITY = [
       { atlasSandbox: "nsjail", vercelAvailable: true, sidecarAvailable: true, nsjailAvailable: true, nsjailFailed: false },
       { atlasSandbox: undefined, vercelAvailable: true, sidecarAvailable: false, nsjailAvailable: true, nsjailFailed: true },
+      { atlasSandbox: undefined, vercelAvailable: false, sidecarAvailable: true, nsjailAvailable: false, nsjailFailed: true },
     ] as const;
 
     const observed: Array<{
@@ -1143,13 +1193,22 @@ describe("SandboxCredsGuardLive", () => {
     expect(divergent).toEqual([]);
 
     // Anti-vacuity, and load-bearing rather than decorative: a determination
-    // stuck at one constant would agree with a co-broken copy trivially. The
-    // first line is what catches the SILENT-INERT direction — a planner that
-    // stopped classifying any pin as fail-closed would empty `divergent` (guard
-    // and planner both go quiet, region boots green, explore refuses every
-    // request) and this is the only assertion that notices. Do not delete it as
-    // redundant. The second line cannot fail independently — `undefined` always
-    // takes the `default-chain` arm — and documents the pairing.
+    // stuck at one constant would agree with a co-broken copy trivially.
+    //
+    // The first line catches the SILENT-INERT direction. A planner that stopped
+    // classifying any pin as fail-closed empties `divergent` — guard and planner
+    // go quiet together — and the deny-all pin then degrades to the unsandboxed
+    // `just-bash` fallback (`explore.ts`, `case "exhausted"`), i.e. agent shell
+    // on the host, while boot and `/health` stay green. It is the only assertion
+    // IN THIS SWEEP that notices; the named `["vercel-sandbox"]` cases above
+    // would also go red, but nothing inside the loop would. Do not delete it as
+    // redundant.
+    //
+    // The second line is unlikely to fail alone — `undefined`, any non-vercel
+    // pin, and any list containing `just-bash` all satisfy it — so it mostly
+    // documents the pairing. It would still catch the inverse regression, a
+    // planner classifying EVERYTHING as fail-closed-on-vercel, which blocks boot
+    // on every deploy.
     expect(observed.some((o) => o.plannerFailsClosedOnVercel)).toBe(true);
     expect(observed.some((o) => !o.plannerFailsClosedOnVercel)).toBe(true);
   });

--- a/packages/api/src/lib/effect/__tests__/saas-guards.test.ts
+++ b/packages/api/src/lib/effect/__tests__/saas-guards.test.ts
@@ -1026,9 +1026,12 @@ describe("SandboxCredsGuardLive", () => {
   // front-of-line plugin seam, never a `sandbox.priority` entry. That exclusion
   // is hand-maintained — a second non-priority key would need adding here.)
   test("fail-closed determination cannot drift from planSandboxSelection (every priority ordering)", async () => {
+    // No explicit type predicate on the filter: TS infers `SandboxBackendName[]`
+    // here, and an inferred narrowing is checked where a hand-written
+    // `name is SandboxBackendName` would be an unchecked assertion.
     const backends = (
       Object.keys(BACKEND_ISOLATION) as Array<keyof typeof BACKEND_ISOLATION>
-    ).filter((name): name is SandboxBackendName => name !== "plugin");
+    ).filter((name) => name !== "plugin");
 
     const orderings = (items: readonly SandboxBackendName[]): SandboxBackendName[][] =>
       items.length === 0
@@ -1055,6 +1058,12 @@ describe("SandboxCredsGuardLive", () => {
     // the invariance directly: if a future planner change lets `atlasSandbox` or
     // a detection flag reach the config-priority arm, this fails rather than
     // letting the guard's fiction quietly become a wrong model of production.
+    //
+    // The fiction is NOT self-evidently harmless: `useVercelSandbox()` returns
+    // true on `process.env.VERCEL` alone, so a Vercel-hosted region really does
+    // have `vercelAvailable: true` while its explicit creds are incomplete.
+    // Nothing about "creds missing" implies "vercel unavailable" — this
+    // assertion is what licenses the snapshot, not any such equivalence.
     const ALT_AVAILABILITY = [
       { atlasSandbox: "nsjail", vercelAvailable: true, sidecarAvailable: true, nsjailAvailable: true, nsjailFailed: false },
       { atlasSandbox: undefined, vercelAvailable: true, sidecarAvailable: false, nsjailAvailable: true, nsjailFailed: true },
@@ -1087,11 +1096,23 @@ describe("SandboxCredsGuardLive", () => {
 
           for (const availability of ALT_AVAILABILITY) {
             const alt = planSandboxSelection({ configPriority: priority, ...availability });
-            expect({ priority, source: alt.source, onExhausted: alt.onExhausted }).toEqual({
-              priority,
-              source: plan.source,
-              onExhausted: plan.onExhausted,
-            });
+            if (plan.source === "config-priority") {
+              // The guard reads BOTH `onExhausted` and `configPriority`, so the
+              // WHOLE arm has to be availability-invariant — not just the two
+              // fields the decision branches on. A planner that reordered or
+              // filtered `configPriority` by availability would otherwise slip
+              // through here and hand the guard a different list than the one
+              // the region actually runs.
+              expect({ priority, alt }).toEqual({ priority, alt: plan });
+            } else {
+              // The default chain's `steps` are legitimately availability-driven;
+              // only the two fields the guard consults must hold steady.
+              expect({ priority, source: alt.source, onExhausted: alt.onExhausted }).toEqual({
+                priority,
+                source: plan.source,
+                onExhausted: plan.onExhausted,
+              });
+            }
           }
 
           const exit = await Effect.runPromiseExit(
@@ -1121,12 +1142,14 @@ describe("SandboxCredsGuardLive", () => {
     const divergent = observed.filter((o) => o.guardFired !== o.plannerFailsClosedOnVercel);
     expect(divergent).toEqual([]);
 
-    // Anti-vacuity: a determination stuck at one constant would agree with a
-    // co-broken copy trivially, so require the sweep to have actually reached
-    // the fail-closed outcome before its agreement counts for anything. (The
-    // negative outcome is guaranteed by `undefined` always taking the
-    // `default-chain` arm, so the second line documents the pairing rather than
-    // being independently falsifiable.)
+    // Anti-vacuity, and load-bearing rather than decorative: a determination
+    // stuck at one constant would agree with a co-broken copy trivially. The
+    // first line is what catches the SILENT-INERT direction — a planner that
+    // stopped classifying any pin as fail-closed would empty `divergent` (guard
+    // and planner both go quiet, region boots green, explore refuses every
+    // request) and this is the only assertion that notices. Do not delete it as
+    // redundant. The second line cannot fail independently — `undefined` always
+    // takes the `default-chain` arm — and documents the pairing.
     expect(observed.some((o) => o.plannerFailsClosedOnVercel)).toBe(true);
     expect(observed.some((o) => !o.plannerFailsClosedOnVercel)).toBe(true);
   });

--- a/packages/api/src/lib/effect/__tests__/saas-guards.test.ts
+++ b/packages/api/src/lib/effect/__tests__/saas-guards.test.ts
@@ -81,6 +81,11 @@ void mock.module("@atlas/api/lib/settings", () => ({
   _resetSettingsCache: () => {},
 }));
 
+// The sandbox backend union, used to type the priority shapes the
+// `SandboxCredsGuardLive` sweep enumerates. Type-only, so it is unaffected by
+// the dynamic-import dance the block below describes.
+import type { SandboxBackendName } from "@atlas/api/lib/config";
+
 // Type-only imports for the tagged error classes and the `Config` Tag
 // type — needed because the runtime values are pulled in via dynamic
 // `await import(...)` after the logger mock is installed, which gives
@@ -177,6 +182,13 @@ const {
 } = await import("../saas-guards");
 const { Config, Migration, Settings } = await import("../layers");
 const { _resetEncryptionKeyCache } = await import("@atlas/api/lib/db/encryption-keys");
+// The planner that `SandboxCredsGuardLive` derives its fail-closed determination
+// from (#4838), plus the backend table its sweep enumerates. Imported here so
+// the divergence test computes expectations from the SAME source of truth the
+// guard consults, rather than hardcoding outcomes.
+const { planSandboxSelection, BACKEND_ISOLATION } = await import(
+  "@atlas/api/lib/tools/backends/selection"
+);
 
 // ── Test helpers ────────────────────────────────────────────────────
 
@@ -980,6 +992,143 @@ describe("SandboxCredsGuardLive", () => {
         expect(Exit.isSuccess(exit)).toBe(true);
       }),
     );
+  });
+
+  // ── Divergence detector (#4838) ────────────────────────────────────────
+  //
+  // The guard DERIVES "does this pin fail closed?" from `planSandboxSelection`
+  // instead of restating the rule, and this test is what stops a second copy
+  // growing back. It hardcodes no outcomes: for every priority shape it computes
+  // the expectation by calling the planner directly and reading `onExhausted`,
+  // then asserts the guard agrees. A re-hand-rolled copy therefore fails here on
+  // the first shape where the two disagree — including the silent direction
+  // (planner says fail-closed, guard says "not pinned", region boots green with
+  // explore refusing every request). The named cases above pin today's four
+  // documented shapes and cannot catch a rewrite that diverges only outside
+  // them, which is why they are not sufficient on their own.
+  //
+  // If you deliberately change the guard's vercel half, do NOT mirror the edit
+  // into the expectation below — that silently restores agreement and retires
+  // the check. Add a named case instead.
+  //
+  // The space is every ORDERING of every subset of the backend names, not just
+  // every subset: `sandbox.priority` is `z.array(z.enum(...)).min(1)` with no
+  // ordering constraint, and a mirror keyed on position rather than membership
+  // (`priority[0] !== "vercel-sandbox"`, or "the fallback goes last") agrees
+  // with the planner on every canonically-ordered subset while diverging in
+  // production on `["sidecar", "vercel-sandbox"]`.
+  //
+  // Names are read off `BACKEND_ISOLATION`, whose
+  // `satisfies Record<SandboxBackendName | "plugin">` makes a newly-added
+  // backend a compile error until it is classified there — so a new backend
+  // widens this enumeration automatically rather than silently leaving its
+  // shapes untested. (`plugin` is excluded: it is an isolation posture for the
+  // front-of-line plugin seam, never a `sandbox.priority` entry. That exclusion
+  // is hand-maintained — a second non-priority key would need adding here.)
+  test("fail-closed determination cannot drift from planSandboxSelection (every priority ordering)", async () => {
+    const backends = (
+      Object.keys(BACKEND_ISOLATION) as Array<keyof typeof BACKEND_ISOLATION>
+    ).filter((name): name is SandboxBackendName => name !== "plugin");
+
+    const orderings = (items: readonly SandboxBackendName[]): SandboxBackendName[][] =>
+      items.length === 0
+        ? [[]]
+        : items.flatMap((item, i) =>
+            orderings([...items.slice(0, i), ...items.slice(i + 1)]).map((rest) => [item, ...rest]),
+          );
+    const subsets = backends.reduce<SandboxBackendName[][]>(
+      (acc, name) => [...acc, ...acc.map((subset) => [...subset, name])],
+      [[]],
+    );
+    // `undefined` (no `sandbox` block at all) alongside every ordering, so the
+    // absent-priority shape is covered next to the empty-array one. `[]` is
+    // schema-unreachable (`.min(1)`) but cheap to pin.
+    const shapes: Array<readonly SandboxBackendName[] | undefined> = [
+      undefined,
+      ...subsets.flatMap(orderings),
+    ];
+
+    // The guard feeds the planner a fabricated "nothing detected" availability
+    // snapshot. That is sound only while the config-priority arm ignores
+    // availability entirely — and the sweep below could never catch that
+    // assumption breaking, because it fabricates the SAME snapshot. So assert
+    // the invariance directly: if a future planner change lets `atlasSandbox` or
+    // a detection flag reach the config-priority arm, this fails rather than
+    // letting the guard's fiction quietly become a wrong model of production.
+    const ALT_AVAILABILITY = [
+      { atlasSandbox: "nsjail", vercelAvailable: true, sidecarAvailable: true, nsjailAvailable: true, nsjailFailed: false },
+      { atlasSandbox: undefined, vercelAvailable: true, sidecarAvailable: false, nsjailAvailable: true, nsjailFailed: true },
+    ] as const;
+
+    const observed: Array<{
+      priority: readonly SandboxBackendName[] | undefined;
+      guardFired: boolean;
+      plannerFailsClosedOnVercel: boolean;
+    }> = [];
+
+    await withCleanEnv(() =>
+      // Every Vercel credential absent, so the guard fires if and only if its
+      // pin determination says to — making `guardFired` a faithful readout of
+      // the determination rather than of credential presence.
+      withVercelIds({}, async () => {
+        for (const priority of shapes) {
+          const baseEnv = {
+            configPriority: priority,
+            atlasSandbox: undefined,
+            vercelAvailable: false,
+            sidecarAvailable: false,
+            nsjailAvailable: false,
+            nsjailFailed: false,
+          } as const;
+          const plan = planSandboxSelection(baseEnv);
+          const plannerFailsClosedOnVercel =
+            plan.onExhausted === "fail-closed" &&
+            plan.configPriority.includes("vercel-sandbox");
+
+          for (const availability of ALT_AVAILABILITY) {
+            const alt = planSandboxSelection({ configPriority: priority, ...availability });
+            expect({ priority, source: alt.source, onExhausted: alt.onExhausted }).toEqual({
+              priority,
+              source: plan.source,
+              onExhausted: plan.onExhausted,
+            });
+          }
+
+          const exit = await Effect.runPromiseExit(
+            Effect.void.pipe(
+              Effect.provide(
+                SandboxCredsGuardLive.pipe(
+                  Layer.provide(
+                    makeTestConfigLayer({
+                      deployMode: "saas",
+                      ...(priority !== undefined && { sandbox: { priority } }),
+                    }),
+                  ),
+                ),
+              ),
+            ),
+          );
+          observed.push({
+            priority,
+            guardFired: Exit.isFailure(exit),
+            plannerFailsClosedOnVercel,
+          });
+        }
+      }),
+    );
+
+    // Reported as a list so a failure names every diverging shape at once.
+    const divergent = observed.filter((o) => o.guardFired !== o.plannerFailsClosedOnVercel);
+    expect(divergent).toEqual([]);
+
+    // Anti-vacuity: a determination stuck at one constant would agree with a
+    // co-broken copy trivially, so require the sweep to have actually reached
+    // the fail-closed outcome before its agreement counts for anything. (The
+    // negative outcome is guaranteed by `undefined` always taking the
+    // `default-chain` arm, so the second line documents the pairing rather than
+    // being independently falsifiable.)
+    expect(observed.some((o) => o.plannerFailsClosedOnVercel)).toBe(true);
+    expect(observed.some((o) => !o.plannerFailsClosedOnVercel)).toBe(true);
   });
 });
 

--- a/packages/api/src/lib/effect/saas-guards.ts
+++ b/packages/api/src/lib/effect/saas-guards.ts
@@ -89,6 +89,11 @@ import { Data, Effect, Layer } from "effect";
 import { createLogger } from "@atlas/api/lib/logger";
 import { resolveDeployEnv } from "@atlas/api/lib/env-profile";
 import type { SandboxBackendName } from "@atlas/api/lib/config";
+// Static (not lazy-imported like the other guards' dependencies): `selection.ts`
+// is pure policy whose only import is a `import type`, so it pulls in no runtime
+// graph to wall off — and it is mocked nowhere, so a static value import here
+// can't be erased by another test file's partial `mock.module()`.
+import { planSandboxSelection } from "@atlas/api/lib/tools/backends/selection";
 import { Config, Settings } from "./layers";
 import { Migration, PluginRegistry } from "./services";
 import { readSaasEnv, type SaasEnv } from "./saas-env";
@@ -773,26 +778,58 @@ export const TurnstileGuardLive: Layer.Layer<never, TurnstileSecretRequiredError
 // ══════════════════════════════════════════════════════════════════════
 
 /**
- * Whether the resolved sandbox priority pins `vercel-sandbox` as a required
- * backend with no unsandboxed fallback — the SaaS deny-all posture
- * (`sandbox.priority: ["vercel-sandbox"]` in `deploy/api/atlas.config.ts`).
+ * The pinned priority list when it requires `vercel-sandbox` with no unsandboxed
+ * fallback — the SaaS deny-all posture (`sandbox.priority: ["vercel-sandbox"]`
+ * in `deploy/api/atlas.config.ts`) — or `null` when this guard stays inert.
  *
- * Mirrors `planSandboxSelection`'s fail-closed determination
- * (`lib/tools/backends/selection.ts`): a `just-bash` entry means the deploy
- * opted into degrade-on-exhaustion, so a missing credential is NOT fatal and
- * the guard must not fire. Absent `vercel-sandbox` from the list entirely
- * (self-hosted, a sidecar/nsjail-pinned deploy) → not pinned, so a differently
- * -configured deploy is never blocked by this guard.
+ * The fail-closed half is **derived** from {@link planSandboxSelection}
+ * (`lib/tools/backends/selection.ts`), never restated here. That planner is the
+ * single statement of the priority policy, and this guard used to keep a second
+ * hand-written copy of its rule (#4838). A second copy can drift *silently*:
+ * the planner deciding fail-closed while the guard decides "not pinned" is the
+ * outage described below with no boot error at all. Deleting the copy is what
+ * removes that; the powerset sweep in `saas-guards.test.ts` is what stops it
+ * growing back.
+ *
+ * Only the vercel half is this guard's own question, and it is deliberately
+ * MEMBERSHIP rather than need: a `["sidecar", "vercel-sandbox"]` pin still fails
+ * boot on absent Vercel credentials even though sidecar would serve every
+ * request, because the operator asked for a backend this region cannot
+ * construct. A pin that never names `vercel-sandbox` is never blocked by a
+ * missing Vercel token.
+ *
+ * Returning the planner's own list rather than the caller's keeps the boot error
+ * naming the exact list the decision was made on, should the planner ever
+ * normalize what it is handed.
+ *
+ * Comparing `onExhausted` narrows `SandboxPlan` to the `config-priority` arm —
+ * the `default-chain` arm types that field as the literal `"just-bash"` — which
+ * is why `plan.configPriority` type-checks below. That is load-bearing: if the
+ * default chain ever gains a fail-closed exhaustion, the narrowing stops and
+ * this becomes a compile error instead of quietly widening which deploys the
+ * guard fires on. (The default chain's *other* route to a refusal — an
+ * unavailable `ATLAS_SANDBOX=nsjail` hard-fail step — is a runtime availability
+ * fact about nsjail, not a Vercel-credential contract, and is correctly out of
+ * scope here.)
  */
-function sandboxPriorityPinsVercel(
+function pinnedVercelPriority(
   priority: readonly SandboxBackendName[] | undefined,
-): boolean {
-  if (!priority || priority.length === 0) return false;
-  if (!priority.includes("vercel-sandbox")) return false;
-  // `just-bash` in the list ⇒ an unsandboxed fallback is allowed, so a missing
-  // VERCEL_TOKEN degrades rather than hard-fails — don't fail boot.
-  if (priority.includes("just-bash")) return false;
-  return true;
+): readonly SandboxBackendName[] | null {
+  const plan = planSandboxSelection({
+    // `configPriority` is the only input that reaches the config-priority arm:
+    // the planner gives it absolute precedence and returns before consulting any
+    // availability field. The rest are a "nothing detected" fiction, supplied
+    // because every `SandboxSelectionEnv` field is required — and asserted to
+    // stay harmless by the sweep's invariance check rather than assumed.
+    configPriority: priority,
+    atlasSandbox: undefined,
+    vercelAvailable: false,
+    sidecarAvailable: false,
+    nsjailAvailable: false,
+    nsjailFailed: false,
+  });
+  if (plan.onExhausted !== "fail-closed") return null;
+  return plan.configPriority.includes("vercel-sandbox") ? plan.configPriority : null;
 }
 
 /**
@@ -825,8 +862,8 @@ export const SandboxCredsGuardLive: Layer.Layer<never, SandboxCredentialsMissing
     if (config.deployMode !== "saas") return;
     if (relaxSaasGuardForDev("SandboxCreds")) return;
 
-    const priority = config.sandbox?.priority;
-    if (!sandboxPriorityPinsVercel(priority)) return;
+    const pinned = pinnedVercelPriority(config.sandbox?.priority);
+    if (pinned === null) return;
 
     const { vercelSandboxCredentialStatus } = yield* Effect.promise(
       () => import("@atlas/api/lib/tools/backends/detect"),
@@ -841,7 +878,7 @@ export const SandboxCredsGuardLive: Layer.Layer<never, SandboxCredentialsMissing
 
     yield* Effect.fail(
       new SandboxCredentialsMissingError({
-        priority: [...(priority ?? [])],
+        priority: [...pinned],
         missing,
         message:
           `SaaS region booted with sandbox.priority pinned to vercel-sandbox (the deny-all posture — ` +

--- a/packages/api/src/lib/effect/saas-guards.ts
+++ b/packages/api/src/lib/effect/saas-guards.ts
@@ -784,12 +784,10 @@ export const TurnstileGuardLive: Layer.Layer<never, TurnstileSecretRequiredError
  *
  * The fail-closed half is **derived** from {@link planSandboxSelection}
  * (`lib/tools/backends/selection.ts`), never restated here. That planner is the
- * single statement of the priority policy, and this guard used to keep a second
- * hand-written copy of its rule (#4838). A second copy can drift *silently*:
- * the planner deciding fail-closed while the guard decides "not pinned" is the
- * outage described below with no boot error at all. Deleting the copy is what
- * removes that; the powerset sweep in `saas-guards.test.ts` is what stops it
- * growing back.
+ * single statement of the priority policy; this guard used to keep a second
+ * hand-written copy of its rule, which could drift silently (#4838). Deleting
+ * the copy is what removes that — the every-ordering sweep in
+ * `saas-guards.test.ts` is what stops it growing back, and carries the argument.
  *
  * Only the vercel half is this guard's own question, and it is deliberately
  * MEMBERSHIP rather than need: a `["sidecar", "vercel-sandbox"]` pin still fails


### PR DESCRIPTION
## What

`sandboxPriorityPinsVercel` kept a hand-written copy of the fail-closed determination `planSandboxSelection` already computes. It now derives from the exported planner, and the hand-mirrored predicate is gone rather than left beside the new call.

The rewritten helper (`pinnedVercelPriority`) also returns the planner's own priority list instead of a boolean, so the boot error names the exact list the decision was made on — and the `?? []` fallback at the call site, which only existed because a boolean couldn't prove non-emptiness, disappears.

`packages/api/src/lib/tools/backends/selection.ts` is **unchanged** (byte-identical to `main`) — read-only for this issue, since #4837/#4834 are in flight nearby.

## Why it matters

`SandboxCredsGuardLive` is what fails SaaS boot when `sandbox.priority` pins `vercel-sandbox` with no fallback and the Vercel credentials are absent (#4461). Two copies of that rule drift silently and one-directionally: the planner says fail-closed, the guard says "not pinned", and a region boots green with a deny-all pin nothing enforces. The guard is SaaS-only and dev-relaxable, so nothing else backstops it.

## The divergence test

The acceptance criterion was specifically that a test must **fail** if the two determinations diverged — not merely re-assert current behaviour. The sweep computes every expectation by calling `planSandboxSelection` directly, so it fails on any shape where a re-hand-rolled copy disagrees.

It enumerates every **ordering** of every subset (65 sequences + `undefined`), not just every subset: `sandbox.priority` has no ordering constraint, and a mirror keyed on position agrees with the planner on every canonically-ordered subset while diverging in production. It also asserts the config-priority arm is availability-invariant, since the guard feeds the planner a fabricated "nothing detected" snapshot — a fiction that is not self-evidently harmless, because `useVercelSandbox()` returns true on `process.env.VERCEL` alone.

Mutation-verified. Each of these passes on `main`'s test and fails here:

| Mutation | Before | After |
|---|---|---|
| Hand-mirror drops the `just-bash` carve-out | fail | fail |
| Planner's rule evolves, exact old hand-mirror stays | **95/0 pass** | fail |
| Positional mirror `priority[0] !== "vercel-sandbox"` | **95/0 pass** | fail |
| Positional mirror "the fallback goes last" | **95/0 pass** | fail |
| Planner: `atlasSandbox` outranks `configPriority` | **95/0 pass** | fail |
| Planner: `configPriority` filtered by availability | **95/0 pass** | fail |
| Planner: `configPriority` reordered by availability | **95/0 pass** | fail |
| Planner: arm gated on `sidecarAvailable && nsjailFailed` | **95/0 pass** | fail |

The second row is the load-bearing one: the guard reverted to the *exact* original hand-mirror plus a planner rule change gave **94 pass / 1 fail — only the new test caught it.** Every pre-existing behaviour test passed straight through the drift, which is what the AC was asking for.

## Behaviour

Unchanged for all four documented shapes, pinned by named cases: pin without `just-bash` fires; pin with `just-bash` does not; no `vercel-sandbox` in the list does not (so sidecar/nsjail-pinned self-hosted deploys are never blocked); empty/absent priority does not.

One added named case pins the operator-facing consequence of reporting the planner's list: a `["sidecar", "vercel-sandbox"]` pin must name both backends in the boot error.

## Review

Three `/review-panel` rounds. Round 1 raised comment overclaims; round 2 (silent-failure-hunter + type-design-analyzer, independently) found the invariance assertion projected away `configPriority`; round 3 found the availability sampling left `sidecarAvailable && nsjailFailed` at a constant pair, and caught a comment of mine naming the wrong consequence for the silent-inert regression — `explore.ts` `case "exhausted"` returns `createBashBackend`, so a deny-all pin degrades to unsandboxed shell on the host rather than refusing requests. All fixed and re-verified by mutation.

Closes #4838
