### PR TITLE
fix(sandbox): treat fail-closed as an outage on /admin/sandbox, not a backend id

### DIFF
--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -50581,10 +50581,27 @@
                   "type": "object",
                   "properties": {
                     "activeBackend": {
-                      "type": "string"
+                      "type": [
+                        "string",
+                        "null"
+                      ]
                     },
                     "platformDefault": {
-                      "type": "string"
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "failClosed": {
+                      "type": "object",
+                      "properties": {
+                        "remediation": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "remediation"
+                      ]
                     },
                     "workspaceOverride": {
                       "type": [

--- a/packages/api/src/api/__tests__/admin-sandbox-fail-closed.test.ts
+++ b/packages/api/src/api/__tests__/admin-sandbox-fail-closed.test.ts
@@ -1,0 +1,323 @@
+/**
+ * #4837 — `/api/v1/admin/sandbox/status` must report a fail-closed deployment as
+ * an OUTAGE, never as a backend id.
+ *
+ * `getExploreBackendType()` gained `"fail-closed"` in #4835. The admin route
+ * typed `activeBackend` as a bare `string` and passed it straight through, so
+ * `/admin/sandbox` — the page whose entire purpose is diagnosing sandboxing —
+ * rendered `Active: fail-closed` in the same monospace slot that otherwise holds
+ * `vercel-sandbox`. It read as one more selectable backend.
+ *
+ * Reachable in SaaS production, not theory: `deploy/api/atlas.config.ts` pins
+ * `priority: ["vercel-sandbox"]` with no `just-bash` on staging and all three
+ * prod regions, and `VERCEL_TOKEN` is a per-service Railway secret that shared
+ * vars do not inherit (#4828). Drop it on one regional service and that region
+ * is fail-closed with explore refusing every request.
+ *
+ * Separate file from `admin-sandbox.test.ts` because Bun's `mock.module()` is
+ * process-global and irreversible — this file needs `getExploreBackendType()` to
+ * return `"fail-closed"` where that one pins `"vercel-sandbox"`. Same reason
+ * `health-sandbox-fail-closed.test.ts` is split from `health.test.ts`.
+ */
+
+import { describe, it, expect, beforeEach, afterAll, mock } from "bun:test";
+import { SANDBOX_PROVIDER_KEYS, SandboxStatusSchema } from "@useatlas/schemas";
+import { createApiTestMocks } from "@atlas/api/testing/api-test-mocks";
+// The real policy module — deliberately NOT mocked. The assertions below tie the
+// admin payload to what the runtime actually does with the SAME inputs, which is
+// the whole point of the parity invariant; mocking it would make them vacuous.
+import {
+  planSandboxSelection,
+  runSandboxPlan,
+  formatSandboxFailClosed,
+  type SandboxSelectionEnv,
+} from "@atlas/api/lib/tools/backends/selection";
+
+const mocks = createApiTestMocks({
+  authUser: {
+    id: "admin-1",
+    mode: "simple-key",
+    label: "Admin",
+    role: "admin",
+    activeOrganizationId: "org-1",
+  },
+});
+
+/**
+ * The live SaaS posture: `deploy/api/atlas.config.ts` pins vercel-sandbox alone,
+ * and the region has lost `VERCEL_TOKEN`, so `vercelAvailable` is false. Every
+ * step is unavailable and the pin carries no `just-bash`, so the plan resolves
+ * fail-closed.
+ */
+const SAAS_PIN_ENV: SandboxSelectionEnv = {
+  atlasSandbox: undefined,
+  vercelAvailable: false,
+  sidecarAvailable: false,
+  nsjailAvailable: false,
+  nsjailFailed: false,
+  configPriority: ["vercel-sandbox"],
+};
+
+// --- Settings mock (overrides the factory's) ---
+
+const mockSettings = new Map<string, string>();
+
+void mock.module("@atlas/api/lib/settings", () => ({
+  getSetting: (key: string, _orgId?: string) => mockSettings.get(key),
+  getSettingAuto: (key: string, _orgId?: string) => mockSettings.get(key),
+  getSettingLive: async (key: string, _orgId?: string) => mockSettings.get(key),
+  getSettingsForAdmin: mock(() => []),
+  getSettingsRegistry: mock(() => []),
+  getSettingDefinition: mock(() => undefined),
+  setSetting: mock(async () => {}),
+  deleteSetting: mock(async () => {}),
+  loadSettings: mock(async () => 0),
+  getAllSettingOverrides: mock(async () => []),
+  _resetSettingsCache: mock(() => {}),
+}));
+
+// --- Config — SaaS, so the remediation omits the just-bash escape hatch ---
+// Overrides the factory's `getConfig: () => null`. `mock.module` is last-write
+// -wins, so this must register after `createApiTestMocks`.
+
+void mock.module("@atlas/api/lib/config", () => ({
+  getConfig: () => ({ deployMode: "saas" as const }),
+  defineConfig: (c: unknown) => c,
+}));
+
+// --- Key mock: the resolver reports that NO backend will construct ---
+
+void mock.module("@atlas/api/lib/tools/explore", () => ({
+  getExploreBackendType: () => "fail-closed",
+  getActiveSandboxPluginId: () => null,
+  snapshotExploreSandboxEnv: () => SAAS_PIN_ENV,
+  explore: { type: "function" },
+  invalidateExploreBackend: mock(() => {}),
+  invalidateOrgExploreBackends: mock(() => {}),
+  markNsjailFailed: mock(() => {}),
+  markSidecarFailed: mock(() => {}),
+  _formatSandboxPriorityFailureForTest: mock(() => ""),
+}));
+
+// --- BYOC credentials — mutable connected list ---
+
+interface MockCredential {
+  id: string;
+  orgId: string;
+  provider: (typeof SANDBOX_PROVIDER_KEYS)[number];
+  credentials: Record<string, unknown>;
+  displayName: string | null;
+  validatedAt: string | null;
+  connectedAt: string;
+}
+
+let mockCredentials: MockCredential[] = [];
+
+void mock.module("@atlas/api/lib/sandbox/credentials", () => ({
+  SANDBOX_PROVIDERS: SANDBOX_PROVIDER_KEYS,
+  getSandboxCredentials: mock(async () => mockCredentials),
+  getSandboxCredentialByProvider: mock(async () => null),
+  saveSandboxCredential: mock(async () => {}),
+  deleteSandboxCredential: mock(async () => true),
+}));
+
+void mock.module("@atlas/api/lib/sandbox/validate", () => ({
+  isSafeExternalUrl: () => true,
+  isBlockedResolvedAddress: () => false,
+  validateVercelCredentials: mock(async () => ({ valid: true as const })),
+  validateE2BCredentials: mock(async () => ({ valid: true as const })),
+  validateDaytonaCredentials: mock(async () => ({ valid: true as const })),
+  validateRailwayCredentials: mock(async () => ({ valid: true as const })),
+  validateCredentials: mock(async () => ({ valid: true as const, displayName: "Acme" })),
+}));
+
+const mockRuntimeAvailability: Record<string, boolean> = {
+  vercel: true,
+  e2b: false,
+  daytona: false,
+  railway: false,
+};
+
+const realSandboxRuntime = await import("@atlas/api/lib/sandbox/runtime");
+
+void mock.module("@atlas/api/lib/sandbox/runtime", () => ({
+  ...realSandboxRuntime,
+  isProviderRuntimeAvailable: async (provider: string) =>
+    mockRuntimeAvailability[provider] ?? false,
+  getProviderRuntimeAvailability: async () => ({ ...mockRuntimeAvailability }),
+  tryCreateByocBackend: mock(async () => null),
+}));
+
+// --- Built-in backend detection — the region lost VERCEL_TOKEN ---
+// This is what makes the pinned backend unavailable, and therefore what makes
+// `availableBackends` honest about there being nothing to select.
+
+void mock.module("@atlas/api/lib/tools/backends/detect", () => ({
+  vercelSandboxAccess: () => undefined,
+  useVercelSandbox: () => false,
+  useSidecar: () => false,
+  _resetVercelSandboxDetectForTest: () => {},
+  _partialCredsWarnedForTest: () => false,
+}));
+
+// --- Plugin registry — no sandbox plugin ahead of the plan ---
+
+void mock.module("@atlas/api/lib/plugins/registry", () => ({
+  plugins: {
+    describe: () => [],
+    get: () => undefined,
+    getStatus: () => undefined,
+    enable: () => false,
+    disable: () => false,
+    isEnabled: () => false,
+    getAllHealthy: () => [],
+    getByType: () => [],
+    size: 0,
+  },
+  PluginRegistry: class {},
+}));
+
+// --- Import sub-router AFTER mocks ---
+
+const { adminSandbox } = await import("../routes/admin-sandbox");
+
+// --- Helpers ---
+
+async function getStatus(): Promise<unknown> {
+  const res = await adminSandbox.request("http://localhost/status");
+  expect(res.status).toBe(200);
+  return await res.json();
+}
+
+/**
+ * Parse through the SHARED wire schema rather than a local interface. The web
+ * page parses the same one, so a payload the page would reject cannot pass here
+ * — the `activeBackend: z.string()` this issue replaced is exactly the kind of
+ * drift a hand-written local interface hides.
+ */
+async function getParsedStatus() {
+  const parsed = SandboxStatusSchema.safeParse(await getStatus());
+  if (!parsed.success) {
+    throw new Error(`status payload failed the shared wire schema: ${parsed.error.message}`);
+  }
+  return parsed.data;
+}
+
+afterAll(() => {
+  mocks.cleanup();
+});
+
+beforeEach(() => {
+  mockSettings.clear();
+  mockCredentials = [];
+});
+
+// --- Tests ---
+
+describe("GET /admin/sandbox/status — fail-closed region (#4837)", () => {
+  it("reports no active backend and no platform default, rather than a 'fail-closed' backend id", async () => {
+    const status = await getParsedStatus();
+
+    expect(status.activeBackend).toBeNull();
+    expect(status.platformDefault).toBeNull();
+    // The regression itself: the sentinel must not survive anywhere an id lives.
+    // A `toBeNull` alone would still pass if some later change reintroduced the
+    // string under a different id field.
+    expect(JSON.stringify(status)).not.toContain('"fail-closed"');
+  });
+
+  it("carries a failClosed block whose remediation names the pinned backend and its credential", async () => {
+    const status = await getParsedStatus();
+
+    expect(status.failClosed).toBeDefined();
+    const remediation = status.failClosed?.remediation ?? "";
+
+    // Names the ACTUAL cause. Generic "install nsjail" advice is unactionable
+    // under a pin that excludes nsjail — #4828's lesson, and the reason this
+    // assertion is positive on the pin AND negative on the wrong advice.
+    expect(remediation).toContain("vercel-sandbox");
+    expect(remediation).toContain("VERCEL_TOKEN");
+    expect(remediation).not.toContain("install the binary");
+    expect(remediation).not.toContain("ATLAS_SANDBOX_URL");
+    // SaaS: the "add just-bash for an unsandboxed fallback" escape hatch is not
+    // offered — a managed deployment must not be told to disable isolation.
+    expect(remediation).not.toContain("just-bash' if you want");
+  });
+
+  it("uses the SAME formatter the boot warning does, so the two surfaces cannot drift", async () => {
+    const status = await getParsedStatus();
+
+    // Byte-for-byte against the shared formatter fed the same inputs. A route
+    // that grew its own copy of the copy would still contain "VERCEL_TOKEN" and
+    // pass the test above; only this one catches the fork.
+    const expected = formatSandboxFailClosed(
+      planSandboxSelection(SAAS_PIN_ENV),
+      SAAS_PIN_ENV,
+      "saas",
+    );
+    expect(status.failClosed?.remediation).toBe(expected);
+  });
+
+  it("agrees with the runtime consequence — the same plan refuses to construct anything", async () => {
+    const status = await getParsedStatus();
+
+    // The admin surface claims an outage; this is the outage. Walking the plan
+    // the route reported on, with every step failing to construct (the missing
+    // VERCEL_TOKEN), yields `fail-closed` — explore has no backend to run and
+    // throws on every request. Payload and runtime, one set of inputs.
+    const outcome = await runSandboxPlan(planSandboxSelection(SAAS_PIN_ENV), async (step) => ({
+      failure: { name: step.kind, reason: "not configured" },
+    }));
+
+    expect(outcome.kind).toBe("fail-closed");
+    expect(status.activeBackend).toBeNull();
+  });
+
+  it("marks no connected BYOC provider active when the platform has failed closed", async () => {
+    mockCredentials = [
+      {
+        id: "cred-vercel",
+        orgId: "org-1",
+        provider: "vercel",
+        credentials: { accessToken: "t", teamId: "team", projectId: "prj" },
+        displayName: "acme",
+        validatedAt: "2026-06-01T00:00:00.000Z",
+        connectedAt: "2026-06-01T00:00:00.000Z",
+      },
+    ];
+
+    const status = await getParsedStatus();
+
+    // No workspace override is set, so the workspace follows the (broken)
+    // platform default. `isActive` must not read "Live" off a merely *connected*
+    // row — the #3375 contradiction invariant, which a null `activeBackend`
+    // makes structurally impossible rather than merely unlikely.
+    expect(status.connectedProviders.every((p) => !p.isActive)).toBe(true);
+    expect(status.activeBackend).toBeNull();
+  });
+
+  it("keeps a usable workspace BYOC override running through the platform outage", async () => {
+    // The override sits ahead of the platform plan, so this workspace's explore
+    // still works. Reporting it as down would be a false alarm — and the outage
+    // block must still be present, because any workspace on the default is down.
+    mockSettings.set("ATLAS_SANDBOX_BACKEND", "vercel-sandbox");
+    mockCredentials = [
+      {
+        id: "cred-vercel",
+        orgId: "org-1",
+        provider: "vercel",
+        credentials: { accessToken: "t", teamId: "team", projectId: "prj" },
+        displayName: "acme",
+        validatedAt: "2026-06-01T00:00:00.000Z",
+        connectedAt: "2026-06-01T00:00:00.000Z",
+      },
+    ];
+
+    const status = await getParsedStatus();
+
+    expect(status.activeBackend).toBe("vercel-sandbox");
+    expect(status.platformDefault).toBeNull();
+    expect(status.failClosed).toBeDefined();
+    expect(status.connectedProviders.find((p) => p.provider === "vercel")?.isActive).toBe(true);
+  });
+});

--- a/packages/api/src/api/__tests__/admin-sandbox-fail-closed.test.ts
+++ b/packages/api/src/api/__tests__/admin-sandbox-fail-closed.test.ts
@@ -107,6 +107,7 @@ void mock.module("@atlas/api/lib/tools/explore", () => ({
   invalidateOrgExploreBackends: mock(() => {}),
   markNsjailFailed: mock(() => {}),
   markSidecarFailed: mock(() => {}),
+  _resetSandboxFailureFlagsForTest: mock(() => {}),
   _formatSandboxPriorityFailureForTest: mock(() => ""),
 }));
 

--- a/packages/api/src/api/__tests__/admin-sandbox-fail-closed.test.ts
+++ b/packages/api/src/api/__tests__/admin-sandbox-fail-closed.test.ts
@@ -98,10 +98,16 @@ void mock.module("@atlas/api/lib/config", () => ({
 
 // --- Key mock: the resolver reports that NO backend will construct ---
 
+// When set, the env snapshot throws — the route's degraded-remediation arm.
+let snapshotThrows: Error | null = null;
+
 void mock.module("@atlas/api/lib/tools/explore", () => ({
   getExploreBackendType: () => "fail-closed",
   getActiveSandboxPluginId: () => null,
-  snapshotExploreSandboxEnv: () => SAAS_PIN_ENV,
+  snapshotExploreSandboxEnv: () => {
+    if (snapshotThrows) throw snapshotThrows;
+    return SAAS_PIN_ENV;
+  },
   explore: { type: "function" },
   invalidateExploreBackend: mock(() => {}),
   invalidateOrgExploreBackends: mock(() => {}),
@@ -244,6 +250,7 @@ afterAll(() => {
 beforeEach(() => {
   mockSettings.clear();
   mockCredentials = [];
+  snapshotThrows = null;
 });
 
 // --- Tests ---
@@ -385,5 +392,36 @@ describe("GET /admin/sandbox/status — fail-closed region (#4837)", () => {
     expect(status.platformDefault).toBeNull();
     expect(status.failClosed).toBeDefined();
     expect(status.connectedProviders.find((p) => p.provider === "vercel")?.isActive).toBe(true);
+  });
+
+  it("still 200s with the outage reported when the remediation cannot be built", async () => {
+    // The route's degraded arm. Three properties, and the first is the one that
+    // matters most: this endpoint must not 500 during the very outage it exists
+    // to report — it runs `describeSandboxFailClosed` under `Effect.promise`,
+    // where a rejection would become a defect.
+    snapshotThrows = new Error(
+      "connect failed: postgres://atlas:hunter2@db.internal:5432/atlas",
+    );
+
+    const status = await getParsedStatus();
+
+    // (1) still an outage, not a 500 and not a downgrade to "healthy".
+    expect(status.activeBackend).toBeNull();
+    expect(status.platformDefault).toBeNull();
+    expect(status.failClosed).toBeDefined();
+
+    // (2) the generic-but-honest wording, never the advice a pin makes
+    //     unactionable (#4828).
+    const remediation = status.failClosed?.remediation ?? "";
+    expect(remediation).toContain("UNAVAILABLE");
+    expect(remediation).toContain("sandbox.priority");
+    expect(remediation).not.toContain("install the binary");
+
+    // (3) the caught error's text never rides out on the response. `message` is
+    //     admin-visible here and ALSO reaches unauthenticated `/api/health` via
+    //     startup warnings, so a connection string in it would be a real leak.
+    expect(remediation).not.toContain("hunter2");
+    expect(remediation).not.toContain("db.internal");
+    expect(JSON.stringify(await getStatus())).not.toContain("hunter2");
   });
 });

--- a/packages/api/src/api/__tests__/admin-sandbox-fail-closed.test.ts
+++ b/packages/api/src/api/__tests__/admin-sandbox-fail-closed.test.ts
@@ -29,9 +29,11 @@ import { createApiTestMocks } from "@atlas/api/testing/api-test-mocks";
 import {
   planSandboxSelection,
   runSandboxPlan,
+  resolveSandboxBackend,
   formatSandboxFailClosed,
   type SandboxSelectionEnv,
 } from "@atlas/api/lib/tools/backends/selection";
+import type { SandboxBackendName } from "@atlas/api/lib/config";
 
 const mocks = createApiTestMocks({
   authUser: {
@@ -59,10 +61,19 @@ const SAAS_PIN_ENV: SandboxSelectionEnv = {
 };
 
 // --- Settings mock (overrides the factory's) ---
+//
+// `mock.module` is last-write-wins for the WHOLE module, so this replaces the
+// shared factory's settings mock rather than extending it. `getSettingOverride`
+// and `isSaasModeForGuard` are carried over deliberately: nothing in the
+// `adminSandbox` sub-router's graph reaches them today, but the failure mode
+// when that stops being true is an `Export named '…' not found` link error at
+// module load, which reads as entirely unrelated to this file.
 
 const mockSettings = new Map<string, string>();
 
 void mock.module("@atlas/api/lib/settings", () => ({
+  getSettingOverride: mock(async () => null),
+  isSaasModeForGuard: mock(async () => true),
   getSetting: (key: string, _orgId?: string) => mockSettings.get(key),
   getSettingAuto: (key: string, _orgId?: string) => mockSettings.get(key),
   getSettingLive: async (key: string, _orgId?: string) => mockSettings.get(key),
@@ -203,6 +214,28 @@ async function getParsedStatus() {
   return parsed.data;
 }
 
+/**
+ * Availability derived from `SAAS_PIN_ENV` itself, so the fixture's
+ * `vercelAvailable: false` — the field that REPRESENTS the missing
+ * `VERCEL_TOKEN` — is load-bearing rather than decorative. Without this, every
+ * assertion below still passed with `vercelAvailable: true`, i.e. with a fixture
+ * describing a perfectly healthy region while the route claimed a total outage.
+ */
+function availableInFixture(kind: SandboxBackendName): boolean {
+  switch (kind) {
+    case "vercel-sandbox":
+      return SAAS_PIN_ENV.vercelAvailable;
+    case "sidecar":
+      return SAAS_PIN_ENV.sidecarAvailable;
+    case "nsjail":
+      return SAAS_PIN_ENV.nsjailAvailable;
+    case "just-bash":
+      // Always constructible — which is precisely why a pin that OMITS it fails
+      // closed instead of falling through to an unsandboxed shell.
+      return true;
+  }
+}
+
 afterAll(() => {
   mocks.cleanup();
 });
@@ -220,10 +253,13 @@ describe("GET /admin/sandbox/status — fail-closed region (#4837)", () => {
 
     expect(status.activeBackend).toBeNull();
     expect(status.platformDefault).toBeNull();
-    // The regression itself: the sentinel must not survive anywhere an id lives.
-    // A `toBeNull` alone would still pass if some later change reintroduced the
-    // string under a different id field.
-    expect(JSON.stringify(status)).not.toContain('"fail-closed"');
+
+    // The regression itself: the sentinel must not survive anywhere on the wire.
+    // Scanned against the RAW response, not the parsed object — `z.object()`
+    // strips unknown keys, so a sentinel reintroduced under a field not yet in
+    // the schema would be invisible in `status`. This is the assertion that
+    // catches it resurfacing under a future id field.
+    expect(JSON.stringify(await getStatus())).not.toContain("fail-closed");
   });
 
   it("carries a failClosed block whose remediation names the pinned backend and its credential", async () => {
@@ -258,19 +294,48 @@ describe("GET /admin/sandbox/status — fail-closed region (#4837)", () => {
     expect(status.failClosed?.remediation).toBe(expected);
   });
 
-  it("agrees with the runtime consequence — the same plan refuses to construct anything", async () => {
+  it("agrees with the runtime consequence — the same inputs refuse to construct anything", async () => {
     const status = await getParsedStatus();
+    const plan = planSandboxSelection(SAAS_PIN_ENV);
 
-    // The admin surface claims an outage; this is the outage. Walking the plan
-    // the route reported on, with every step failing to construct (the missing
-    // VERCEL_TOKEN), yields `fail-closed` — explore has no backend to run and
-    // throws on every request. Payload and runtime, one set of inputs.
-    const outcome = await runSandboxPlan(planSandboxSelection(SAAS_PIN_ENV), async (step) => ({
-      failure: { name: step.kind, reason: "not configured" },
-    }));
+    // Reporting side: the resolver run against the fixture's OWN availability
+    // must independently reach `fail-closed`. This is what ties the mocked
+    // `getExploreBackendType()` to the env snapshot the remediation is built
+    // from — without it the two could describe different deployments.
+    expect(resolveSandboxBackend(plan, availableInFixture)).toBe("fail-closed");
+
+    // Runtime side: walking the same plan, constructing exactly what the fixture
+    // says is available (nothing — `VERCEL_TOKEN` is gone), yields `fail-closed`
+    // rather than `exhausted`. That distinction is the whole safety property:
+    // `exhausted` is the arm explore degrades to an unsandboxed bash backend on,
+    // and a pin without `just-bash` must never reach it.
+    const outcome = await runSandboxPlan(plan, async (step) =>
+      availableInFixture(step.kind)
+        ? { backend: {} }
+        : { failure: { name: step.kind, reason: "not configured" } },
+    );
 
     expect(outcome.kind).toBe("fail-closed");
     expect(status.activeBackend).toBeNull();
+  });
+
+  it("a pin that DOES include just-bash degrades instead — the negative control", async () => {
+    // Proves the assertion above is about the pin's contents, not a property of
+    // `runSandboxPlan` that holds either way. Adding `just-bash` flips
+    // `onExhausted` and the outcome becomes `exhausted`, the degrade-to-
+    // unsandboxed arm. SaaS deliberately omits it (`deploy/api/atlas.config.ts`).
+    const degradablePin = planSandboxSelection({
+      ...SAAS_PIN_ENV,
+      configPriority: ["vercel-sandbox", "just-bash"],
+    });
+    const outcome = await runSandboxPlan(degradablePin, async (step) =>
+      step.kind === "just-bash"
+        ? { failure: { name: step.kind, reason: "stubbed — not constructed in this test" } }
+        : { failure: { name: step.kind, reason: "not configured" } },
+    );
+
+    expect(degradablePin.onExhausted).toBe("just-bash");
+    expect(outcome.kind).toBe("exhausted");
   });
 
   it("marks no connected BYOC provider active when the platform has failed closed", async () => {

--- a/packages/api/src/api/__tests__/admin-sandbox.test.ts
+++ b/packages/api/src/api/__tests__/admin-sandbox.test.ts
@@ -286,6 +286,19 @@ describe("GET /api/v1/admin/sandbox/status — vocabulary normalization", () => 
       expect.objectContaining({ provider: "vercel", isActive: false }),
     ]);
   });
+
+  it("a healthy deployment omits the failClosed key entirely (#4837)", async () => {
+    // The wire-compat half of #4837: `failClosed` is optional rather than
+    // nullable so a healthy payload keeps its pre-#4837 shape and an older web
+    // bundle parsing a newer API keeps working. That only holds if the route
+    // OMITS the key rather than sending `null` — which is what this asserts, and
+    // which the schema-side test in `@useatlas/schemas` cannot.
+    const status = (await getStatus()) as unknown as Record<string, unknown>;
+
+    expect("failClosed" in status).toBe(false);
+    expect(status.activeBackend).toBe("vercel-sandbox");
+    expect(status.platformDefault).toBe("vercel-sandbox");
+  });
 });
 
 describe("GET /api/v1/admin/sandbox/status — BYOC runtime resolution (#3370)", () => {

--- a/packages/api/src/api/routes/admin-sandbox.ts
+++ b/packages/api/src/api/routes/admin-sandbox.ts
@@ -25,6 +25,7 @@ import {
   planSandboxSelection,
   describeSandboxFailClosed,
 } from "@atlas/api/lib/tools/backends/selection";
+import type { SandboxBackendName } from "@atlas/api/lib/config";
 import { useVercelSandbox, useSidecar } from "@atlas/api/lib/tools/backends/detect";
 import {
   getSandboxCredentials,
@@ -260,12 +261,23 @@ adminSandbox.openapi(getStatusRoute, async (c) => {
       // Platform default (the backend that would be used without any workspace
       // override). `ExploreBackendType` includes `"fail-closed"`, which is NOT a
       // backend id — split it out here, once, so nothing downstream can leak the
-      // sentinel into a backend-id field. Every id field on the wire is
-      // `string | null` precisely so this narrowing cannot be skipped: assigning
-      // `platformResolution` directly is a compile error (#4837).
+      // sentinel into a backend-id field (#4837).
+      //
+      // The `satisfies` is the actual guard, and it guards the case that matters.
+      // Nullability alone would NOT: `"fail-closed"` is a string, so assigning
+      // `platformResolution` straight to `string | null` compiles fine — nullable
+      // wire types create an obligation for READERS, not for this writer. What
+      // `satisfies` pins is the next non-backend member: add one to
+      // `ExploreBackendType` (the pinned-but-missing-nsjail case in #4834 is a
+      // live candidate) and this line stops compiling, instead of the new
+      // sentinel silently rendering as an id exactly as `"fail-closed"` did. That
+      // is #4835's `BACKEND_ISOLATION` precedent — make the compiler reject the
+      // unclassified value — applied to the producer.
       const platformResolution = getExploreBackendType();
       const platformFailClosed = platformResolution === "fail-closed";
-      const platformDefault: string | null = platformFailClosed ? null : platformResolution;
+      const platformDefault: string | null = platformFailClosed
+        ? null
+        : (platformResolution satisfies SandboxBackendName | "plugin");
       const activePluginId = getActiveSandboxPluginId();
       const [allBackends, credentials, runtimeAvailability] = yield* Effect.promise(() =>
         Promise.all([
@@ -290,6 +302,17 @@ adminSandbox.openapi(getStatusRoute, async (c) => {
           .map((cred) => SANDBOX_PROVIDER_BACKEND_IDS[cred.provider]),
       );
 
+      // The ONE expression for the platform default that goes on the wire, so
+      // the schema's "`failClosed` present iff `platformDefault === null`" is
+      // true by construction rather than by coincidence. It was previously
+      // re-derived at the response literal while `failClosed` came off
+      // `platformResolution`: two expressions for one invariant, agreeing only
+      // because `getExploreBackendType()` happens to return `"plugin"` before it
+      // can return `"fail-closed"` and because no `await` separated the two
+      // reads of the lazily-set `_activeSandboxPluginId`. Both are facts about
+      // another module; neither belongs in this invariant's proof.
+      const reportedPlatformDefault = activePluginId ?? platformDefault;
+
       // Resolve the effective active backend. `null` means this workspace has
       // none — explore refuses its requests — which is a different question from
       // whether the PLATFORM failed closed: a usable BYOC override sits ahead of
@@ -302,9 +325,9 @@ adminSandbox.openapi(getStatusRoute, async (c) => {
         const found = allBackends.find((b) => b.id === workspaceOverride && b.available);
         activeBackend = found || usableByocBackendIds.has(workspaceOverride)
           ? workspaceOverride
-          : platformDefault;
+          : reportedPlatformDefault;
       } else {
-        activeBackend = activePluginId ?? platformDefault;
+        activeBackend = reportedPlatformDefault;
       }
 
       // Build connected providers list. `isActive` requires BOTH the
@@ -346,19 +369,21 @@ adminSandbox.openapi(getStatusRoute, async (c) => {
       //
       // A message-building fault degrades the WORDS, never the state —
       // `describeSandboxFailClosed` always returns a fail-closed message — and
-      // `failureDetail` is logged rather than swallowed or sent to the client.
+      // `failureDetail` is log-only, never interpolated into the response.
       let failClosed: { remediation: string } | undefined;
-      if (platformFailClosed) {
+      if (reportedPlatformDefault === null) {
         // The inputs are gathered through dynamic imports, inside the seam's own
-        // try: `lib/tools/explore` is partially mocked in ~26 test files, and a
-        // static import of `snapshotExploreSandboxEnv` here is a module LINK
-        // error in every test that mounts this router — even the ones that never
-        // reach this branch. `startup.ts` reaches the same module the same way.
+        // try: the shared test factory (`__mocks__/api-test-mocks.ts`) partially
+        // mocks `lib/tools/explore` for every test built on it, so a STATIC
+        // import of `snapshotExploreSandboxEnv` here is a module LINK error in
+        // every test that mounts this router — even the ones that never reach
+        // this branch.
         //
         // `Effect.promise` (which turns a rejection into a defect) is safe here
-        // because `describeSandboxFailClosed` cannot reject: the thunk, its
+        // because `describeSandboxFailClosed` never rejects: the thunk, its
         // imports included, runs inside that function's own `try`, and both arms
-        // return a message.
+        // return a message. That contract is stated at its definition — a
+        // rejection would 500 the page an operator opened to diagnose the outage.
         const { message, failureDetail } = yield* Effect.promise(() =>
           describeSandboxFailClosed(async () => {
             const [{ snapshotExploreSandboxEnv }, { getConfig }] = await Promise.all([
@@ -370,8 +395,11 @@ adminSandbox.openapi(getStatusRoute, async (c) => {
           }),
         );
         if (failureDetail) {
+          // `requestId` correlates this line with the payload the operator is
+          // looking at — it is the one log they will grep when the page shows the
+          // generic remediation instead of the specific one.
           log.warn(
-            { err: failureDetail },
+            { err: failureDetail, orgId, requestId: c.get("requestId") },
             "Sandbox is fail-closed but the detailed remediation could not be built — reporting the generic outage message",
           );
         }
@@ -381,7 +409,7 @@ adminSandbox.openapi(getStatusRoute, async (c) => {
       return c.json(
         {
           activeBackend,
-          platformDefault: activePluginId ?? platformDefault,
+          platformDefault: reportedPlatformDefault,
           workspaceOverride,
           workspaceSidecarUrl,
           availableBackends: allBackends,

--- a/packages/api/src/api/routes/admin-sandbox.ts
+++ b/packages/api/src/api/routes/admin-sandbox.ts
@@ -21,6 +21,10 @@ import {
   getActiveSandboxPluginId,
   invalidateOrgExploreBackends,
 } from "@atlas/api/lib/tools/explore";
+import {
+  planSandboxSelection,
+  describeSandboxFailClosed,
+} from "@atlas/api/lib/tools/backends/selection";
 import { useVercelSandbox, useSidecar } from "@atlas/api/lib/tools/backends/detect";
 import {
   getSandboxCredentials,
@@ -253,8 +257,15 @@ adminSandbox.openapi(getStatusRoute, async (c) => {
         : null;
       const workspaceSidecarUrl = getSetting("ATLAS_SANDBOX_URL", orgId) ?? null;
 
-      // Platform default (the backend that would be used without any workspace override)
-      const platformDefault = getExploreBackendType();
+      // Platform default (the backend that would be used without any workspace
+      // override). `ExploreBackendType` includes `"fail-closed"`, which is NOT a
+      // backend id — split it out here, once, so nothing downstream can leak the
+      // sentinel into a backend-id field. Every id field on the wire is
+      // `string | null` precisely so this narrowing cannot be skipped: assigning
+      // `platformResolution` directly is a compile error (#4837).
+      const platformResolution = getExploreBackendType();
+      const platformFailClosed = platformResolution === "fail-closed";
+      const platformDefault: string | null = platformFailClosed ? null : platformResolution;
       const activePluginId = getActiveSandboxPluginId();
       const [allBackends, credentials, runtimeAvailability] = yield* Effect.promise(() =>
         Promise.all([
@@ -279,8 +290,11 @@ adminSandbox.openapi(getStatusRoute, async (c) => {
           .map((cred) => SANDBOX_PROVIDER_BACKEND_IDS[cred.provider]),
       );
 
-      // Resolve the effective active backend
-      let activeBackend: string;
+      // Resolve the effective active backend. `null` means this workspace has
+      // none — explore refuses its requests — which is a different question from
+      // whether the PLATFORM failed closed: a usable BYOC override sits ahead of
+      // the platform plan and keeps running through a fail-closed default.
+      let activeBackend: string | null;
       if (workspaceOverride) {
         // The override resolves when it's an available registered backend OR
         // a usable BYOC provider (BYOC backends are built on demand from
@@ -323,6 +337,47 @@ adminSandbox.openapi(getStatusRoute, async (c) => {
         };
       });
 
+      // The outage block, built from the SAME formatter the boot warning uses so
+      // the two cannot tell an operator different stories (#4824's parity
+      // invariant, extended to the admin surface). Composed server-side rather
+      // than assembled from parts in the page: the remediation has to name the
+      // pinned backend and its credential, and re-deriving that in the browser is
+      // how the copy drifts.
+      //
+      // A message-building fault degrades the WORDS, never the state —
+      // `describeSandboxFailClosed` always returns a fail-closed message — and
+      // `failureDetail` is logged rather than swallowed or sent to the client.
+      let failClosed: { remediation: string } | undefined;
+      if (platformFailClosed) {
+        // The inputs are gathered through dynamic imports, inside the seam's own
+        // try: `lib/tools/explore` is partially mocked in ~26 test files, and a
+        // static import of `snapshotExploreSandboxEnv` here is a module LINK
+        // error in every test that mounts this router — even the ones that never
+        // reach this branch. `startup.ts` reaches the same module the same way.
+        //
+        // `Effect.promise` (which turns a rejection into a defect) is safe here
+        // because `describeSandboxFailClosed` cannot reject: the thunk, its
+        // imports included, runs inside that function's own `try`, and both arms
+        // return a message.
+        const { message, failureDetail } = yield* Effect.promise(() =>
+          describeSandboxFailClosed(async () => {
+            const [{ snapshotExploreSandboxEnv }, { getConfig }] = await Promise.all([
+              import("@atlas/api/lib/tools/explore"),
+              import("@atlas/api/lib/config"),
+            ]);
+            const env = snapshotExploreSandboxEnv();
+            return { plan: planSandboxSelection(env), env, deployMode: getConfig()?.deployMode };
+          }),
+        );
+        if (failureDetail) {
+          log.warn(
+            { err: failureDetail },
+            "Sandbox is fail-closed but the detailed remediation could not be built — reporting the generic outage message",
+          );
+        }
+        failClosed = { remediation: message };
+      }
+
       return c.json(
         {
           activeBackend,
@@ -332,6 +387,7 @@ adminSandbox.openapi(getStatusRoute, async (c) => {
           availableBackends: allBackends,
           connectedProviders,
           providerRuntimeAvailability: runtimeAvailability,
+          ...(failClosed && { failClosed }),
         },
         200,
       );

--- a/packages/api/src/api/routes/admin-sandbox.ts
+++ b/packages/api/src/api/routes/admin-sandbox.ts
@@ -26,6 +26,8 @@ import {
   describeSandboxFailClosed,
 } from "@atlas/api/lib/tools/backends/selection";
 import type { SandboxBackendName } from "@atlas/api/lib/config";
+import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
+import type { SandboxFailClosed } from "@useatlas/schemas";
 import { useVercelSandbox, useSidecar } from "@atlas/api/lib/tools/backends/detect";
 import {
   getSandboxCredentials,
@@ -302,15 +304,16 @@ adminSandbox.openapi(getStatusRoute, async (c) => {
           .map((cred) => SANDBOX_PROVIDER_BACKEND_IDS[cred.provider]),
       );
 
-      // The ONE expression for the platform default that goes on the wire, so
-      // the schema's "`failClosed` present iff `platformDefault === null`" is
-      // true by construction rather than by coincidence. It was previously
-      // re-derived at the response literal while `failClosed` came off
-      // `platformResolution`: two expressions for one invariant, agreeing only
-      // because `getExploreBackendType()` happens to return `"plugin"` before it
-      // can return `"fail-closed"` and because no `await` separated the two
-      // reads of the lazily-set `_activeSandboxPluginId`. Both are facts about
-      // another module; neither belongs in this invariant's proof.
+      // The ONE expression for the platform default that goes on the wire — the
+      // outage block, `activeBackend`, and the response field all read it — so
+      // the schema's "`failClosed` present iff `platformDefault === null`" holds
+      // by construction.
+      //
+      // Deriving them separately instead would make that invariant rest on two
+      // facts about ANOTHER module: that `getExploreBackendType()` returns
+      // `"plugin"` before it can return `"fail-closed"`, and that no `await`
+      // separates the two reads of the lazily-set `_activeSandboxPluginId`. Both
+      // are true today; neither belongs in this invariant's proof.
       const reportedPlatformDefault = activePluginId ?? platformDefault;
 
       // Resolve the effective active backend. `null` means this workspace has
@@ -370,7 +373,7 @@ adminSandbox.openapi(getStatusRoute, async (c) => {
       // A message-building fault degrades the WORDS, never the state —
       // `describeSandboxFailClosed` always returns a fail-closed message — and
       // `failureDetail` is log-only, never interpolated into the response.
-      let failClosed: { remediation: string } | undefined;
+      let failClosed: SandboxFailClosed | undefined;
       if (reportedPlatformDefault === null) {
         // The inputs are gathered through dynamic imports, inside the seam's own
         // try: the shared test factory (`__mocks__/api-test-mocks.ts`) partially
@@ -395,11 +398,13 @@ adminSandbox.openapi(getStatusRoute, async (c) => {
           }),
         );
         if (failureDetail) {
-          // `requestId` correlates this line with the payload the operator is
-          // looking at — it is the one log they will grep when the page shows the
-          // generic remediation instead of the specific one.
+          // Scrubbed HERE rather than inside the seam, whose catch arm is
+          // contracted never to throw and so takes no imports. This is the log
+          // line an operator greps when the page shows the generic remediation
+          // instead of the specific one; `orgId`/`requestId` tie it back to the
+          // request that produced that payload.
           log.warn(
-            { err: failureDetail, orgId, requestId: c.get("requestId") },
+            { err: errorMessage(failureDetail), orgId, requestId: c.get("requestId") },
             "Sandbox is fail-closed but the detailed remediation could not be built — reporting the generic outage message",
           );
         }

--- a/packages/api/src/lib/__tests__/startup-sandbox-preflight.test.ts
+++ b/packages/api/src/lib/__tests__/startup-sandbox-preflight.test.ts
@@ -132,8 +132,13 @@ const { validateEnvironment, resetStartupCache, getStartupWarnings } = await imp
 );
 const { getExploreBackendType, snapshotExploreSandboxEnv, _resetSandboxFailureFlagsForTest } =
   await import("@atlas/api/lib/tools/explore");
-const { _setConfigForTest, _resetConfig, configFromEnv } = await import(
+const { _setConfigForTest, _resetConfig, configFromEnv, getConfig } = await import(
   "@atlas/api/lib/config"
+);
+// Real policy module, mocked nowhere — the boot↔admin byte-parity anchor below
+// compares the logged warning against this exact formatter (#4837).
+const { planSandboxSelection, formatSandboxFailClosed } = await import(
+  "@atlas/api/lib/tools/backends/selection"
 );
 
 // ---------------------------------------------------------------------------
@@ -409,6 +414,18 @@ describe("startup sandbox pre-flight names the resolved backend (#4824)", () => 
     expect(
       getStartupWarnings().some((w) => w.includes("Explore tool: UNAVAILABLE")),
     ).toBe(true);
+
+    // Byte-pinned to the SHARED formatter, not just to substrings (#4837).
+    // `/admin/sandbox` composes its remediation from the same
+    // `describeSandboxFailClosed`, and the substring assertions above would all
+    // still pass if boot forked back to its own hand-rolled wording — which is
+    // exactly the drift that made #4828's advice wrong on one surface and right
+    // on another. This is the boot half of that anchor; the admin half lives in
+    // `api/__tests__/admin-sandbox-fail-closed.test.ts`.
+    const env = snapshotExploreSandboxEnv();
+    expect(text).toBe(
+      formatSandboxFailClosed(planSandboxSelection(env), env, getConfig()?.deployMode),
+    );
   });
 
   // ── AC4 — boot and /api/health cannot disagree ────────────────────────────

--- a/packages/api/src/lib/__tests__/startup-sandbox-preflight.test.ts
+++ b/packages/api/src/lib/__tests__/startup-sandbox-preflight.test.ts
@@ -428,6 +428,61 @@ describe("startup sandbox pre-flight names the resolved backend (#4824)", () => 
     );
   });
 
+  it("degrades to the generic outage message, with a SCRUBBED log detail, if the remediation cannot be built (#4837)", async () => {
+    // The boot half of `describeSandboxFailClosed`'s failure arm. Two properties
+    // that only this test pins:
+    //
+    //  1. Losing the remediation must NOT downgrade the reported state — boot
+    //     still records a fail-closed startup warning, which /api/health echoes.
+    //  2. The seam returns the caught text RAW (its catch arm takes no imports so
+    //     it cannot itself throw), so scrubbing happens HERE, at the log site.
+    //     Without this assertion, deleting the `errorMessage(...)` wrapper in
+    //     `startup.ts` is silent — and a pg/better-auth error echoing a
+    //     connection string lands in a log field verbatim.
+    // `deployMode` is read ONLY inside the thunk (`getAtlasConfig()?.deployMode`),
+    // so a throwing getter here fails exactly that gathering step and nothing
+    // earlier — the resolution is already known to be fail-closed by then.
+    // Chosen over stubbing `snapshotExploreSandboxEnv` because ESM exports are
+    // readonly and `mock.module` is process-global, which would leak into the
+    // other 11 cases in this file. The password proves the scrub end to end.
+    const cfg: Record<string, unknown> = {
+      ...configFromEnv(),
+      sandbox: { priority: ["vercel-sandbox"] },
+    };
+    Object.defineProperty(cfg, "deployMode", {
+      get() {
+        throw new Error("connect failed: postgres://atlas:hunter2@db.internal:5432/atlas");
+      },
+      enumerable: true,
+    });
+    _setConfigForTest(cfg as unknown as Parameters<typeof _setConfigForTest>[0]);
+
+    await runPreFlight();
+
+    // (1) still an outage, with the generic-but-honest wording.
+    const warning = getStartupWarnings().find((w) => w.includes("Explore tool: UNAVAILABLE"));
+    expect(warning).toBeDefined();
+    expect(warning).toContain("see the server log");
+    expect(warning).toContain("sandbox.priority");
+    // Never the misdirecting advice a priority pin makes unactionable (#4828).
+    expect(warning).not.toContain("Install nsjail");
+    // The caught text must not ride along on a surface /api/health echoes.
+    expect(warning).not.toContain("hunter2");
+
+    // (2) the log detail is present but scrubbed.
+    const errored = logCalls.find((c) =>
+      c.args.some(
+        (a) => typeof a === "object" && a !== null && "err" in (a as Record<string, unknown>),
+      ),
+    );
+    const meta = errored?.args.find(
+      (a): a is Record<string, unknown> => typeof a === "object" && a !== null && "err" in a,
+    );
+    expect(String(meta?.err)).toContain("connect failed");
+    expect(String(meta?.err)).not.toContain("hunter2");
+    expect(String(meta?.err)).toContain("***");
+  });
+
   // ── AC4 — boot and /api/health cannot disagree ────────────────────────────
 
   it("agrees with getExploreBackendType() across every env shape", async () => {

--- a/packages/api/src/lib/audit/error-scrub.ts
+++ b/packages/api/src/lib/audit/error-scrub.ts
@@ -23,6 +23,12 @@
  *   - It's an `Effect.tryPromise` catch normalizer that returns an
  *     `Error` instance — the pino `err` serializer handles those with
  *     full stack preservation.
+ *   - The catch belongs to a function contracted NEVER to throw, and calling
+ *     into this module would give that catch a dependency it could trip over
+ *     (this module is `mock.module()`d in several test files, so a partial mock
+ *     makes the import `undefined`). Such a catch returns the raw text and its
+ *     CALLERS scrub at the `log` site instead — see
+ *     `describeSandboxFailClosed` in `lib/tools/backends/selection.ts`.
  *
  * `causeToError` walks an Effect `Cause` and returns the first underlying
  * error — typed failure, defect, or `undefined` for pure-interrupt causes.

--- a/packages/api/src/lib/startup.ts
+++ b/packages/api/src/lib/startup.ts
@@ -959,7 +959,7 @@ async function logResolvedExploreBackend(): Promise<void> {
       // impossible to act on and hides the real cause (#4828). This second plan
       // equals the one the resolver used because `planSandboxSelection` is pure
       // and nothing mutates its inputs (`process.env`, `getConfig()`,
-      // `_nsjailFailed`) across the intervening await.
+      // `_nsjailFailed`) across the intervening awaits.
       //
       // `deployMode` is passed straight through, undefined and all: `loadConfig`
       // assigns `_resolved` only after `applyDeployMode`, so a non-null
@@ -967,15 +967,20 @@ async function logResolvedExploreBackend(): Promise<void> {
       // reads it (the just-bash escape hatch) is reachable only via
       // `configPriority`, which itself requires a non-null config.
       //
-      // Message building keeps its own failure arm, inside
-      // `describeSandboxFailClosed` rather than a local try: the resolution is
-      // already known to be fail-closed, and letting a message-building throw
-      // fall to the outer catch would downgrade the single most severe state to
-      // "posture UNKNOWN" — a vaguer claim with misdirecting remediation, and one
-      // that is simply false here (health reports fail-closed correctly from the
-      // resolver alone; it never calls this formatter). That arm now lives in
-      // `selection.ts` so `/admin/sandbox`, which reports the same outage on the
-      // same inputs, degrades to the same words (#4837).
+      // `describeSandboxFailClosed` owns the failure arm for message building —
+      // shared with `/admin/sandbox`, which reports the same outage on the same
+      // inputs and must degrade to the same words (#4837). Keeping that arm out
+      // of the outer catch is the point: the resolution is already known to be
+      // fail-closed, and letting a message-building throw fall through would
+      // downgrade the single most severe state to "posture UNKNOWN" — a vaguer
+      // claim with misdirecting remediation, and one that is simply false here
+      // (health reports fail-closed correctly from the resolver alone; it never
+      // calls this formatter).
+      //
+      // The config read sits inside the thunk for that reason. The explore
+      // import above does NOT, deliberately: it precedes
+      // `getExploreBackendType()`, so if it fails there is no known state to
+      // downgrade and "posture UNKNOWN" is the honest report.
       const { message: msg, failureDetail } = await describeSandboxFailClosed(async () => {
         const { getConfig: getAtlasConfig } = await import("@atlas/api/lib/config");
         const env = snapshotExploreSandboxEnv();

--- a/packages/api/src/lib/startup.ts
+++ b/packages/api/src/lib/startup.ts
@@ -990,7 +990,11 @@ async function logResolvedExploreBackend(): Promise<void> {
           deployMode: getAtlasConfig()?.deployMode,
         };
       });
-      log.error({ backend, ...(failureDetail && { err: failureDetail }) }, msg);
+      // Scrubbed here, not in the seam: `describeSandboxFailClosed`'s catch arm
+      // is contracted never to throw, so it takes no imports and returns the raw
+      // text. A pg/better-auth error echoing a connection string is exactly what
+      // `errorMessage` exists to keep out of this field.
+      log.error({ backend, ...(failureDetail && { err: errorMessage(failureDetail) }) }, msg);
       if (!_startupWarnings.includes(msg)) _startupWarnings.push(msg);
       return;
     }

--- a/packages/api/src/lib/startup.ts
+++ b/packages/api/src/lib/startup.ts
@@ -944,7 +944,7 @@ async function logResolvedExploreBackend(): Promise<void> {
     const { getExploreBackendType, snapshotExploreSandboxEnv } = await import(
       "@atlas/api/lib/tools/explore"
     );
-    const { BACKEND_ISOLATION, planSandboxSelection, formatSandboxFailClosed } = await import(
+    const { BACKEND_ISOLATION, planSandboxSelection, describeSandboxFailClosed } = await import(
       "@atlas/api/lib/tools/backends/selection"
     );
     const backend = getExploreBackendType();
@@ -967,30 +967,24 @@ async function logResolvedExploreBackend(): Promise<void> {
       // reads it (the just-bash escape hatch) is reachable only via
       // `configPriority`, which itself requires a non-null config.
       //
-      // Formatting gets its OWN try: the resolution is already known to be
-      // fail-closed, and letting a message-building throw fall to the outer catch
-      // would downgrade the single most severe state to "posture UNKNOWN" — a
-      // vaguer claim with misdirecting remediation, and one that is simply false
-      // here (health reports fail-closed correctly from the resolver alone; it
-      // never calls this formatter).
-      let msg: string;
-      let failureDetail: string | undefined;
-      try {
+      // Message building keeps its own failure arm, inside
+      // `describeSandboxFailClosed` rather than a local try: the resolution is
+      // already known to be fail-closed, and letting a message-building throw
+      // fall to the outer catch would downgrade the single most severe state to
+      // "posture UNKNOWN" — a vaguer claim with misdirecting remediation, and one
+      // that is simply false here (health reports fail-closed correctly from the
+      // resolver alone; it never calls this formatter). That arm now lives in
+      // `selection.ts` so `/admin/sandbox`, which reports the same outage on the
+      // same inputs, degrades to the same words (#4837).
+      const { message: msg, failureDetail } = await describeSandboxFailClosed(async () => {
         const { getConfig: getAtlasConfig } = await import("@atlas/api/lib/config");
         const env = snapshotExploreSandboxEnv();
-        msg = formatSandboxFailClosed(
-          planSandboxSelection(env),
+        return {
+          plan: planSandboxSelection(env),
           env,
-          getAtlasConfig()?.deployMode,
-        );
-        failureDetail = undefined;
-      } catch (err) {
-        failureDetail = errorMessage(err);
-        msg =
-          "Explore tool: UNAVAILABLE — no sandbox backend will construct, so every explore " +
-          `request is refused. Detailed remediation could not be built: ${failureDetail}. ` +
-          "Check ATLAS_SANDBOX and sandbox.priority in atlas.config.ts.";
-      }
+          deployMode: getAtlasConfig()?.deployMode,
+        };
+      });
       log.error({ backend, ...(failureDetail && { err: failureDetail }) }, msg);
       if (!_startupWarnings.includes(msg)) _startupWarnings.push(msg);
       return;

--- a/packages/api/src/lib/tools/backends/__tests__/selection.test.ts
+++ b/packages/api/src/lib/tools/backends/__tests__/selection.test.ts
@@ -464,7 +464,8 @@ describe("describeSandboxFailClosed — the degraded arm (#4837)", () => {
   it("never rejects — the Effect.promise precondition at the admin call site", async () => {
     // `admin-sandbox.ts` calls this under `Effect.promise`, where a rejection
     // becomes a defect: a 500 on the very page opened to diagnose the outage.
-    // A non-Error throw is the case a naive `err.message` would break on.
+    // A non-Error throw is the case a naive `err.message` would silently report
+    // as `undefined` — CLAUDE.md's type-narrowed-catch rule, pinned.
     const r = await describeSandboxFailClosed(() => {
       throw "a bare string, not an Error";
     });

--- a/packages/api/src/lib/tools/backends/__tests__/selection.test.ts
+++ b/packages/api/src/lib/tools/backends/__tests__/selection.test.ts
@@ -5,6 +5,7 @@ import {
   resolveSandboxBackend,
   formatSandboxPriorityFailure,
   formatSandboxFailClosed,
+  describeSandboxFailClosed,
   type SandboxSelectionEnv,
   type SandboxStep,
   type StepAttempt,
@@ -400,6 +401,76 @@ describe("formatSandboxFailClosed", () => {
 
     expect(msg).toContain("No pinned backend could be identified");
     expect(msg).not.toContain("ATLAS_SANDBOX=nsjail is pinned");
+  });
+});
+
+describe("describeSandboxFailClosed — the degraded arm (#4837)", () => {
+  const saasPin = env({ configPriority: ["vercel-sandbox"] });
+
+  it("returns the detailed remediation when the inputs resolve", () => {
+    // The happy arm must be the shared formatter verbatim, not a paraphrase —
+    // this is what makes the boot warning and /admin/sandbox byte-identical.
+    return describeSandboxFailClosed(() => ({
+      plan: planSandboxSelection(saasPin),
+      env: saasPin,
+      deployMode: "saas",
+    })).then((r) => {
+      expect(r.message).toBe(
+        formatSandboxFailClosed(planSandboxSelection(saasPin), saasPin, "saas"),
+      );
+      expect(r.failureDetail).toBeUndefined();
+    });
+  });
+
+  // The arm the whole function exists for. It is on BOTH the boot path and the
+  // admin path, so a regression here hits every fail-closed deployment twice.
+  it.each([
+    ["a rejected thunk", () => Promise.reject(new Error("boom"))],
+    [
+      "a synchronously throwing thunk",
+      () => {
+        throw new Error("boom");
+      },
+    ],
+  ])("still reports the OUTAGE on %s — losing the words never downgrades the state", async (
+    _label,
+    thunk,
+  ) => {
+    const r = await describeSandboxFailClosed(
+      thunk as () => never,
+    );
+
+    expect(r.message).toContain("UNAVAILABLE");
+    expect(r.message).toContain("every explore");
+    // Never swallowed — the caller logs this.
+    expect(r.failureDetail).toBe("boom");
+  });
+
+  it("keeps the caught error OUT of the message", async () => {
+    // `message` reaches an admin response body and, via `_startupWarnings`, the
+    // UNAUTHENTICATED /api/health. A caught error's text is arbitrary — module
+    // paths, config fragments, third-party client errors echoing URLs or tokens
+    // — so it belongs in the log and nowhere else (CLAUDE.md: no secrets or
+    // stack traces in responses).
+    const r = await describeSandboxFailClosed(() => {
+      throw new Error("postgres://user:hunter2@db.internal:5432 unreachable");
+    });
+
+    expect(r.message).not.toContain("hunter2");
+    expect(r.message).not.toContain("db.internal");
+    expect(r.message).toContain("see the server log");
+  });
+
+  it("never rejects — the Effect.promise precondition at the admin call site", async () => {
+    // `admin-sandbox.ts` calls this under `Effect.promise`, where a rejection
+    // becomes a defect: a 500 on the very page opened to diagnose the outage.
+    // A non-Error throw is the case a naive `err.message` would break on.
+    const r = await describeSandboxFailClosed(() => {
+      throw "a bare string, not an Error";
+    });
+
+    expect(r.message).toContain("UNAVAILABLE");
+    expect(r.failureDetail).toBe("a bare string, not an Error");
   });
 });
 

--- a/packages/api/src/lib/tools/backends/selection.ts
+++ b/packages/api/src/lib/tools/backends/selection.ts
@@ -492,7 +492,7 @@ export const BACKEND_ISOLATION = {
 } as const satisfies Record<SandboxBackendName | "plugin", SandboxIsolationPosture>;
 
 /** The inputs {@link formatSandboxFailClosed} needs, gathered by the caller. */
-interface Inputs {
+export interface SandboxFailClosedInputs {
   readonly plan: SandboxPlan;
   readonly env: SandboxSelectionEnv;
   readonly deployMode: "saas" | "self-hosted" | undefined;
@@ -553,7 +553,7 @@ interface Inputs {
  * already resolved `"fail-closed"`.
  */
 export async function describeSandboxFailClosed(
-  resolveInputs: () => Inputs | PromiseLike<Inputs>,
+  resolveInputs: () => SandboxFailClosedInputs | PromiseLike<SandboxFailClosedInputs>,
 ): Promise<{ readonly message: string; readonly failureDetail?: string }> {
   try {
     const { plan, env, deployMode } = await resolveInputs();
@@ -564,12 +564,17 @@ export async function describeSandboxFailClosed(
         "Explore tool: UNAVAILABLE — no sandbox backend will construct, so every explore " +
         "request is refused. Detailed remediation could not be built — see the server log " +
         "for the cause. Check ATLAS_SANDBOX and sandbox.priority in atlas.config.ts.",
-      // Inlined rather than routed through `errorMessage` on purpose: this catch
-      // must stay total (see "Never rejects" above), and `lib/audit/error-scrub`
-      // is itself partially `mock.module()`d in a dozen test files — a mock that
-      // omits the export would make the error path throw. Scrubbing is not
-      // needed here either, now that this value only ever reaches a log.
-      // @atlas-ok-ternary: keeps the catch arm dependency-free and total
+      // Inlined rather than routed through `errorMessage` so this catch stays
+      // total (see "Never rejects" above): `lib/audit/error-scrub` is itself
+      // partially `mock.module()`d in 8 test files, and a mock that omitted the
+      // export would make the error path itself throw.
+      //
+      // This value is therefore RAW — unscrubbed and untruncated. Both callers
+      // run it through `errorMessage` at their `log` call before it goes
+      // anywhere, which is where scrubbing belongs anyway: the hazard
+      // `error-scrub` exists for (a pg/better-auth error echoing a connection
+      // string) lands in a log field, not here.
+      // @atlas-ok-ternary: the catch arm of a function contracted never to throw
       failureDetail: err instanceof Error ? err.message : String(err),
     };
   }

--- a/packages/api/src/lib/tools/backends/selection.ts
+++ b/packages/api/src/lib/tools/backends/selection.ts
@@ -22,6 +22,7 @@
  */
 
 import type { SandboxBackendName } from "@atlas/api/lib/config";
+import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
 
 /**
  * Immutable snapshot of the environment + config inputs that decide which
@@ -490,3 +491,60 @@ export const BACKEND_ISOLATION = {
   "just-bash": "unsandboxed",
   plugin: "plugin-declared",
 } as const satisfies Record<SandboxBackendName | "plugin", SandboxIsolationPosture>;
+
+/**
+ * {@link formatSandboxFailClosed} plus the degraded message for when its inputs
+ * cannot be gathered — the one place both fail-closed reporters get their prose.
+ *
+ * Two surfaces must say the same thing about the same outage: the boot warning
+ * (`startup.ts`) and `/admin/sandbox` (`admin-sandbox.ts`). They reach it by
+ * different routes — boot resolves the backend during `validateEnvironment()`,
+ * the admin route on each request — so "share the formatter" was not enough:
+ * each also needed the fallback for a formatter that throws, and two hand-rolled
+ * fallbacks are two messages that drift. #4837 made that concrete by adding the
+ * second caller.
+ *
+ * The fallback is deliberately NOT the generic "install nsjail or configure
+ * ATLAS_SANDBOX_URL" advice. Under the SaaS `priority: ["vercel-sandbox"]` pin
+ * that advice is impossible to act on — the pin excludes both — so it would hide
+ * the real cause the same way #4828 did. Naming the two knobs that actually
+ * decide the plan is the honest degradation.
+ *
+ * Losing the remediation must never downgrade the reported STATE: the caller
+ * already knows the resolution is `"fail-closed"`, and this returns a
+ * fail-closed message either way. `failureDetail` is set only on the degraded
+ * arm, so the caller can log why (never swallowed) without the reader of the
+ * message having to care.
+ *
+ * `resolveInputs` is an (optionally async) thunk rather than three parameters
+ * because gathering the inputs is itself what can throw: both callers reach
+ * `lib/tools/explore` through a dynamic `import()` — that module is partially
+ * mocked in ~26 test files, so a static import of a rarely-used export there is
+ * a module LINK error in every one of them regardless of whether they run this
+ * branch. Taking a thunk keeps that import, and the env/config reads after it,
+ * inside this `try` instead of leaving the hazard at each call site.
+ *
+ * Precondition (inherited from {@link formatSandboxFailClosed}): the caller has
+ * already resolved `"fail-closed"`.
+ */
+export async function describeSandboxFailClosed(
+  resolveInputs: () => PromiseLike<{
+    readonly plan: SandboxPlan;
+    readonly env: SandboxSelectionEnv;
+    readonly deployMode: "saas" | "self-hosted" | undefined;
+  }>,
+): Promise<{ readonly message: string; readonly failureDetail?: string }> {
+  try {
+    const { plan, env, deployMode } = await resolveInputs();
+    return { message: formatSandboxFailClosed(plan, env, deployMode) };
+  } catch (err) {
+    const failureDetail = errorMessage(err);
+    return {
+      message:
+        "Explore tool: UNAVAILABLE — no sandbox backend will construct, so every explore " +
+        `request is refused. Detailed remediation could not be built: ${failureDetail}. ` +
+        "Check ATLAS_SANDBOX and sandbox.priority in atlas.config.ts.",
+      failureDetail,
+    };
+  }
+}

--- a/packages/api/src/lib/tools/backends/selection.ts
+++ b/packages/api/src/lib/tools/backends/selection.ts
@@ -22,7 +22,6 @@
  */
 
 import type { SandboxBackendName } from "@atlas/api/lib/config";
-import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
 
 /**
  * Immutable snapshot of the environment + config inputs that decide which
@@ -492,9 +491,17 @@ export const BACKEND_ISOLATION = {
   plugin: "plugin-declared",
 } as const satisfies Record<SandboxBackendName | "plugin", SandboxIsolationPosture>;
 
+/** The inputs {@link formatSandboxFailClosed} needs, gathered by the caller. */
+interface Inputs {
+  readonly plan: SandboxPlan;
+  readonly env: SandboxSelectionEnv;
+  readonly deployMode: "saas" | "self-hosted" | undefined;
+}
+
 /**
- * {@link formatSandboxFailClosed} plus the degraded message for when its inputs
- * cannot be gathered — the one place both fail-closed reporters get their prose.
+ * {@link formatSandboxFailClosed}, plus the degraded message for when the inputs
+ * cannot be gathered OR the formatter itself throws — the one place both
+ * fail-closed reporters get their prose.
  *
  * Two surfaces must say the same thing about the same outage: the boot warning
  * (`startup.ts`) and `/admin/sandbox` (`admin-sandbox.ts`). They reach it by
@@ -502,7 +509,9 @@ export const BACKEND_ISOLATION = {
  * the admin route on each request — so "share the formatter" was not enough:
  * each also needed the fallback for a formatter that throws, and two hand-rolled
  * fallbacks are two messages that drift. #4837 made that concrete by adding the
- * second caller.
+ * second caller. `/api/health` is deliberately NOT a third caller: it reports the
+ * same fail-closed STATE from the same resolver but keeps its own, more hedged
+ * message (`health.ts`) and no remediation at all.
  *
  * The fallback is deliberately NOT the generic "install nsjail or configure
  * ATLAS_SANDBOX_URL" advice. Under the SaaS `priority: ["vercel-sandbox"]` pin
@@ -512,39 +521,56 @@ export const BACKEND_ISOLATION = {
  *
  * Losing the remediation must never downgrade the reported STATE: the caller
  * already knows the resolution is `"fail-closed"`, and this returns a
- * fail-closed message either way. `failureDetail` is set only on the degraded
- * arm, so the caller can log why (never swallowed) without the reader of the
- * message having to care.
+ * fail-closed message either way.
  *
- * `resolveInputs` is an (optionally async) thunk rather than three parameters
- * because gathering the inputs is itself what can throw: both callers reach
- * `lib/tools/explore` through a dynamic `import()` — that module is partially
- * mocked in ~26 test files, so a static import of a rarely-used export there is
- * a module LINK error in every one of them regardless of whether they run this
- * branch. Taking a thunk keeps that import, and the env/config reads after it,
- * inside this `try` instead of leaving the hazard at each call site.
+ * `failureDetail` is set only on the degraded arm and is **log-only** — it is
+ * deliberately NOT interpolated into `message`. `message` reaches an admin HTTP
+ * response body via `failClosed.remediation`, and reaches the UNAUTHENTICATED
+ * `/api/health` through `startup.ts`'s `_startupWarnings`. A caught error's text
+ * is arbitrary (module-resolution paths, config fragments, third-party client
+ * errors echoing URLs or tokens), so putting it there would ship exactly the
+ * "no stack traces / secrets to the user" hazard CLAUDE.md forbids. The caller
+ * logs it instead; nothing is swallowed.
+ *
+ * **Never rejects.** `admin-sandbox.ts` calls this under `Effect.promise`, where
+ * a rejection becomes a defect — a 500 on the very page an operator opened to
+ * diagnose the outage. Both arms return, and the catch arm stays total (no
+ * `await`, no logging, no imported helper) so it cannot itself throw. Keep it
+ * that way if you touch this.
+ *
+ * `resolveInputs` is a thunk rather than three parameters because gathering the
+ * inputs is itself what can throw. `admin-sandbox.ts` reaches
+ * `lib/tools/explore` through a dynamic `import()` inside the thunk — the shared
+ * test factory `packages/api/src/__mocks__/api-test-mocks.ts` partially mocks
+ * that module for every test built on `createApiTestMocks`, so a STATIC import
+ * of a rarely-used export there is a module LINK error in all of them, whether
+ * or not they ever run this branch. (`startup.ts` differs: it imports explore in
+ * its own outer try, where an import failure legitimately means "posture
+ * unknown", and defers only the config read into the thunk.) Either way the
+ * throw lands in this `try` and still produces a fail-closed message.
  *
  * Precondition (inherited from {@link formatSandboxFailClosed}): the caller has
  * already resolved `"fail-closed"`.
  */
 export async function describeSandboxFailClosed(
-  resolveInputs: () => PromiseLike<{
-    readonly plan: SandboxPlan;
-    readonly env: SandboxSelectionEnv;
-    readonly deployMode: "saas" | "self-hosted" | undefined;
-  }>,
+  resolveInputs: () => Inputs | PromiseLike<Inputs>,
 ): Promise<{ readonly message: string; readonly failureDetail?: string }> {
   try {
     const { plan, env, deployMode } = await resolveInputs();
     return { message: formatSandboxFailClosed(plan, env, deployMode) };
   } catch (err) {
-    const failureDetail = errorMessage(err);
     return {
       message:
         "Explore tool: UNAVAILABLE — no sandbox backend will construct, so every explore " +
-        `request is refused. Detailed remediation could not be built: ${failureDetail}. ` +
-        "Check ATLAS_SANDBOX and sandbox.priority in atlas.config.ts.",
-      failureDetail,
+        "request is refused. Detailed remediation could not be built — see the server log " +
+        "for the cause. Check ATLAS_SANDBOX and sandbox.priority in atlas.config.ts.",
+      // Inlined rather than routed through `errorMessage` on purpose: this catch
+      // must stay total (see "Never rejects" above), and `lib/audit/error-scrub`
+      // is itself partially `mock.module()`d in a dozen test files — a mock that
+      // omits the export would make the error path throw. Scrubbing is not
+      // needed here either, now that this value only ever reaches a log.
+      // @atlas-ok-ternary: keeps the catch arm dependency-free and total
+      failureDetail: err instanceof Error ? err.message : String(err),
     };
   }
 }

--- a/packages/api/src/lib/tools/backends/selection.ts
+++ b/packages/api/src/lib/tools/backends/selection.ts
@@ -574,8 +574,32 @@ export async function describeSandboxFailClosed(
       // anywhere, which is where scrubbing belongs anyway: the hazard
       // `error-scrub` exists for (a pg/better-auth error echoing a connection
       // string) lands in a log field, not here.
-      // @atlas-ok-ternary: the catch arm of a function contracted never to throw
-      failureDetail: err instanceof Error ? err.message : String(err),
+      failureDetail: describeThrown(err),
     };
+  }
+}
+
+/**
+ * `err.message` / `String(err)` for the one caller that cannot afford either to
+ * throw: {@link describeSandboxFailClosed}'s catch arm, which is contracted
+ * never to reject.
+ *
+ * Both of those CAN throw — a throwing `message` getter, or a `String()` on a
+ * null-prototype object or a hostile `Symbol.toPrimitive`. Vanishingly unlikely
+ * from that call site's inputs, but "vanishingly unlikely" is not the contract:
+ * `admin-sandbox.ts` runs the caller under `Effect.promise`, where a rejection
+ * becomes a defect and 500s the page an operator opened to diagnose the outage.
+ * The inner catch buys totality for two lines and no imports.
+ *
+ * Returns RAW text — callers scrub at their `log` site (see the caller's doc).
+ */
+function describeThrown(err: unknown): string {
+  try {
+    // @atlas-ok-ternary: raw by design; the caller's log sites apply errorMessage
+    return err instanceof Error ? err.message : String(err);
+  } catch {
+    // intentionally ignored: the thrown value is unrepresentable as a string,
+    // and the whole point here is that this path cannot itself throw.
+    return "<unrepresentable thrown value>";
   }
 }

--- a/packages/api/src/lib/tools/explore.ts
+++ b/packages/api/src/lib/tools/explore.ts
@@ -146,14 +146,14 @@ let _sidecarFailed = false;
  * explore throws on every request. See {@link SandboxResolution} for why that is
  * modelled as a distinct value rather than collapsed into `"just-bash"`.
  *
- * Widening this union makes the distinction a compile error at every consumer
- * that indexes `BACKEND_ISOLATION` (three sites: `health.ts`'s `sandbox`
- * component and `checks.explore.isolated`, plus `startup.ts`), because that
- * table is keyed by real backends only. Consumers that treat the value as an
- * opaque string are NOT caught — `api/routes/admin-sandbox.ts` types both
- * `activeBackend` and `platformDefault` as `string` and will surface
- * `"fail-closed"` to the admin UI as though it were a selectable backend id.
- * Truthful, but untreated (#4834); check such consumers by hand.
+ * Widening this union is a compile error at every consumer that indexes
+ * `BACKEND_ISOLATION` (three sites: `health.ts`'s `sandbox` component and
+ * `checks.explore.isolated`, plus `startup.ts`), because that table is keyed by
+ * real backends only — and at `api/routes/admin-sandbox.ts`, which narrows the
+ * non-backend states out and pins the remainder with `satisfies
+ * SandboxBackendName | "plugin"` (#4837). Those four are the enumeration of
+ * consumers that will stop compiling; any NEW consumer treating the value as an
+ * opaque string is still not caught, so give it the same treatment.
  */
 export type ExploreBackendType = SandboxBackendName | "plugin" | "fail-closed";
 

--- a/packages/schemas/src/__tests__/sandbox.test.ts
+++ b/packages/schemas/src/__tests__/sandbox.test.ts
@@ -108,6 +108,42 @@ describe("SandboxStatusSchema", () => {
     expect(SandboxStatusSchema.safeParse(validStatus).success).toBe(true);
   });
 
+  test("a healthy payload carries no failClosed block", () => {
+    // `failClosed` is optional rather than nullable precisely so the healthy
+    // payload is byte-identical to its pre-#4837 shape — an older web bundle
+    // parsing a newer API must not start failing on a working deployment.
+    const parsed = SandboxStatusSchema.parse(validStatus);
+    expect(parsed.failClosed).toBeUndefined();
+  });
+
+  test("parses the fail-closed payload — null ids plus a remediation", () => {
+    const parsed = SandboxStatusSchema.parse({
+      ...validStatus,
+      activeBackend: null,
+      platformDefault: null,
+      workspaceOverride: null,
+      connectedProviders: [],
+      failClosed: { remediation: "Explore tool: UNAVAILABLE — …" },
+    });
+    expect(parsed.activeBackend).toBeNull();
+    expect(parsed.platformDefault).toBeNull();
+    expect(parsed.failClosed?.remediation).toContain("UNAVAILABLE");
+  });
+
+  test("failClosed requires a remediation — an empty outage block is rejected", () => {
+    // The block exists to carry the operator's fix. An outage announced with no
+    // way to act on it is #4828's failure with extra steps, so the shape must
+    // not admit it.
+    expect(
+      SandboxStatusSchema.safeParse({
+        ...validStatus,
+        activeBackend: null,
+        platformDefault: null,
+        failClosed: {},
+      }).success,
+    ).toBe(false);
+  });
+
   test("rejects a connected provider with a backend-id provider value", () => {
     const result = SandboxConnectedProviderSchema.safeParse({
       ...validStatus.connectedProviders[0],

--- a/packages/schemas/src/__tests__/sandbox.test.ts
+++ b/packages/schemas/src/__tests__/sandbox.test.ts
@@ -110,8 +110,11 @@ describe("SandboxStatusSchema", () => {
 
   test("a healthy payload carries no failClosed block", () => {
     // `failClosed` is optional rather than nullable precisely so the healthy
-    // payload is byte-identical to its pre-#4837 shape — an older web bundle
-    // parsing a newer API must not start failing on a working deployment.
+    // payload keeps its pre-#4837 shape — an older web bundle parsing a newer
+    // API must not start failing on a working deployment. Note this pins the
+    // SCHEMA's tolerance; that the route actually omits the key on a healthy
+    // deployment is pinned server-side in
+    // `packages/api/src/api/__tests__/admin-sandbox.test.ts`.
     const parsed = SandboxStatusSchema.parse(validStatus);
     expect(parsed.failClosed).toBeUndefined();
   });
@@ -130,10 +133,14 @@ describe("SandboxStatusSchema", () => {
     expect(parsed.failClosed?.remediation).toContain("UNAVAILABLE");
   });
 
-  test("failClosed requires a remediation — an empty outage block is rejected", () => {
-    // The block exists to carry the operator's fix. An outage announced with no
-    // way to act on it is #4828's failure with extra steps, so the shape must
-    // not admit it.
+  test("failClosed without a remediation key is rejected", () => {
+    // The block exists to carry the operator's fix, so the KEY is required.
+    //
+    // An empty string is deliberately still accepted (`z.string()`, not
+    // `.min(1)`): the web parses this schema client-side, so a stricter rule
+    // could only ever fire in the browser — turning a server-side inconsistency
+    // into a hard parse failure of the one page whose purpose is reporting the
+    // outage. The page treats empty as absent and keeps the alarm up instead.
     expect(
       SandboxStatusSchema.safeParse({
         ...validStatus,
@@ -142,6 +149,15 @@ describe("SandboxStatusSchema", () => {
         failClosed: {},
       }).success,
     ).toBe(false);
+
+    expect(
+      SandboxStatusSchema.safeParse({
+        ...validStatus,
+        activeBackend: null,
+        platformDefault: null,
+        failClosed: { remediation: "" },
+      }).success,
+    ).toBe(true);
   });
 
   test("rejects a connected provider with a backend-id provider value", () => {

--- a/packages/schemas/src/sandbox.ts
+++ b/packages/schemas/src/sandbox.ts
@@ -98,20 +98,33 @@ export type SandboxConnectedProvider = z.infer<typeof SandboxConnectedProviderSc
  * and that is the whole point (#4837). Backend ids are open (`z.string()` —
  * plugins register their own), so a sentinel living in that field is
  * indistinguishable AT THE TYPE LEVEL from a selectable backend: consumers
- * rendered it in the same monospace slot as `vercel-sandbox`, and
- * `activeBackend === "sidecar"`-style comparisons silently treated an outage as
- * a selection. #4835 refused to widen `BACKEND_ISOLATION` with this value for
- * the same reason; hoisting it out of the id field is that precedent applied to
- * the wire. Presence of this field is now the only way to say it, and the
- * accompanying `null` ids make every consumer handle it or fail to compile.
+ * rendered it in the same monospace slot as `vercel-sandbox`, and the one
+ * `activeBackend === "sidecar"` comparison on the page was safe by accident
+ * rather than by design. #4835 refused to widen `BACKEND_ISOLATION` with this
+ * value for the same reason; hoisting it out of the id field is that precedent
+ * applied to the wire, and the producer side is pinned with a `satisfies` in
+ * `admin-sandbox.ts` so a FUTURE non-backend state cannot silently take the
+ * place `"fail-closed"` used to occupy.
+ *
+ * What the `null` ids buy on the consumer side is narrower than "handle it or
+ * fail to compile", and worth stating precisely: they force the question only
+ * where a consumer actually unwraps the value. `ReactNode` props and template
+ * literals both swallow `null` silently — `<DetailRow value={...}>` renders a
+ * blank row and `` `(${platformDefault})` `` interpolates the string "null" —
+ * so those sites need hand-written handling, which this change supplies.
  */
 export const SandboxFailClosedSchema = z.object({
   /**
    * Operator-facing remediation naming the ACTUAL cause — the pinned backends
    * and the credential each one needs (`VERCEL_TOKEN` under the SaaS
-   * `priority: ["vercel-sandbox"]` pin). Server-composed, byte-identical to the
-   * boot warning, so `/admin/sandbox`, `/api/health` and the startup log cannot
-   * give an operator three different stories about one outage.
+   * `priority: ["vercel-sandbox"]` pin). Server-composed and byte-identical to
+   * the boot warning, both from `describeSandboxFailClosed`.
+   *
+   * `/api/health` is the third surface but not a third message: it reports the
+   * same fail-closed STATE from the same resolver while keeping its own,
+   * deliberately more hedged wording and no remediation, deferring to the
+   * startup warnings (see `health.ts`). So the three agree on state, and the two
+   * that carry remediation carry the same bytes — the drift that mattered.
    *
    * Deliberately not a generic "install nsjail / set ATLAS_SANDBOX_URL" line:
    * a priority pin that excludes those backends makes that advice impossible to
@@ -141,9 +154,29 @@ export const SandboxStatusSchema = z.object({
   platformDefault: z.string().nullable(),
   /**
    * Present if and only if `platformDefault` is `null` — the deployment's
-   * sandbox plan constructs nothing. Optional (rather than nullable) so a
-   * healthy deployment's payload is unchanged from before #4837 and older web
-   * bundles keep parsing it; only the already-broken fail-closed payload is new.
+   * sandbox plan constructs nothing. The producer makes that hold by
+   * construction: `admin-sandbox.ts` derives both from one
+   * `reportedPlatformDefault` binding.
+   *
+   * Optional (rather than nullable) so a healthy deployment's payload is
+   * unchanged from before #4837 and older web bundles keep parsing it; only the
+   * already-broken fail-closed payload is new. The reverse skew — a NEW bundle
+   * against an OLD API — degrades to the original bug rather than to a crash:
+   * the old API sends the `"fail-closed"` string, `activeBackend` is a `string`
+   * so it still parses, and the page renders it as an id with no banner. The fix
+   * is therefore only live once the API side deploys.
+   *
+   * The iff is deliberately NOT enforced with a schema `.refine()`, and the
+   * reason is availability rather than tooling (zod 4 keeps this a `ZodObject`,
+   * so the generated OpenAPI would survive it — `SecurityBucketsSchema` is an
+   * in-repo precedent for a cross-field refine on a response schema). The web
+   * parses THIS schema client-side via `useAdminFetch`, and `@hono/zod-openapi`
+   * does not runtime-validate responses — so a refine could never fire
+   * server-side, and the only thing it could ever do is turn a server-side
+   * inconsistency into a hard parse failure of the one page whose purpose is
+   * reporting the outage. Failing the diagnostic surface closed is worse than
+   * rendering a slightly inconsistent one. For the same reason `remediation` is
+   * `z.string()` and not `.min(1)`; consumers treat empty as absent.
    */
   failClosed: SandboxFailClosedSchema.optional(),
   /**

--- a/packages/schemas/src/sandbox.ts
+++ b/packages/schemas/src/sandbox.ts
@@ -90,11 +90,62 @@ export const SandboxConnectedProviderSchema = z.object({
 
 export type SandboxConnectedProvider = z.infer<typeof SandboxConnectedProviderSchema>;
 
+/**
+ * The deployment is FAIL-CLOSED: no sandbox backend will construct, so the
+ * explore tool refuses every request.
+ *
+ * A separate object rather than a `"fail-closed"` string in `activeBackend`,
+ * and that is the whole point (#4837). Backend ids are open (`z.string()` —
+ * plugins register their own), so a sentinel living in that field is
+ * indistinguishable AT THE TYPE LEVEL from a selectable backend: consumers
+ * rendered it in the same monospace slot as `vercel-sandbox`, and
+ * `activeBackend === "sidecar"`-style comparisons silently treated an outage as
+ * a selection. #4835 refused to widen `BACKEND_ISOLATION` with this value for
+ * the same reason; hoisting it out of the id field is that precedent applied to
+ * the wire. Presence of this field is now the only way to say it, and the
+ * accompanying `null` ids make every consumer handle it or fail to compile.
+ */
+export const SandboxFailClosedSchema = z.object({
+  /**
+   * Operator-facing remediation naming the ACTUAL cause — the pinned backends
+   * and the credential each one needs (`VERCEL_TOKEN` under the SaaS
+   * `priority: ["vercel-sandbox"]` pin). Server-composed, byte-identical to the
+   * boot warning, so `/admin/sandbox`, `/api/health` and the startup log cannot
+   * give an operator three different stories about one outage.
+   *
+   * Deliberately not a generic "install nsjail / set ATLAS_SANDBOX_URL" line:
+   * a priority pin that excludes those backends makes that advice impossible to
+   * act on and hides the real cause (#4828).
+   */
+  remediation: z.string(),
+});
+
+export type SandboxFailClosed = z.infer<typeof SandboxFailClosedSchema>;
+
 export const SandboxStatusSchema = z.object({
-  /** Currently active backend id for this workspace (after override resolution) */
-  activeBackend: z.string(),
-  /** Platform default backend id (no workspace override) */
-  platformDefault: z.string(),
+  /**
+   * Currently active backend id for this workspace (after override resolution),
+   * or `null` when this workspace's explore is fail-closed — see
+   * {@link SandboxFailClosedSchema}.
+   *
+   * Can be a real backend id while `platformDefault` is `null`: a workspace BYOC
+   * override sits ahead of the platform plan and keeps running when the
+   * platform default has failed closed.
+   */
+  activeBackend: z.string().nullable(),
+  /**
+   * Platform default backend id (no workspace override), or `null` when the
+   * deployment's own plan resolves fail-closed. `null` here is exactly the
+   * condition under which `failClosed` is present.
+   */
+  platformDefault: z.string().nullable(),
+  /**
+   * Present if and only if `platformDefault` is `null` — the deployment's
+   * sandbox plan constructs nothing. Optional (rather than nullable) so a
+   * healthy deployment's payload is unchanged from before #4837 and older web
+   * bundles keep parsing it; only the already-broken fail-closed payload is new.
+   */
+  failClosed: SandboxFailClosedSchema.optional(),
   /**
    * Workspace override backend id (if set). Normalized to backend-id
    * vocabulary — legacy stored provider keys are reported as their

--- a/packages/web/src/app/admin/sandbox/__tests__/fail-closed-outage.test.tsx
+++ b/packages/web/src/app/admin/sandbox/__tests__/fail-closed-outage.test.tsx
@@ -54,6 +54,7 @@ function failClosedStatus(overrides: Partial<SandboxStatus> = {}): SandboxStatus
       { id: "vercel-sandbox", name: "Vercel Sandbox", type: "built-in", available: false },
     ],
     connectedProviders: [],
+    providerRuntimeAvailability: { vercel: true, e2b: true, daytona: false, railway: false },
     failClosed: { remediation: REMEDIATION },
     ...overrides,
   });
@@ -69,6 +70,7 @@ function healthyStatus(overrides: Partial<SandboxStatus> = {}): SandboxStatus {
       { id: "vercel-sandbox", name: "Vercel Sandbox", type: "built-in", available: true },
     ],
     connectedProviders: [],
+    providerRuntimeAvailability: { vercel: true, e2b: true, daytona: false, railway: false },
     ...overrides,
   });
 }
@@ -80,13 +82,20 @@ function healthyStatus(overrides: Partial<SandboxStatus> = {}): SandboxStatus {
 //
 // EVERY returned value here is a module-level singleton, and that is not
 // tidiness — it is required. The real hooks return referentially stable
-// functions (`useCallback`), and components depend on that: `ProviderRow` has
-// `useEffect(..., [isConnected, clearConnectError])`. A mock that returns a
-// fresh object literal per call hands React a new `clearError` identity on every
-// render, so that effect re-runs, calls `setState`, re-renders, and loops
-// forever — synchronously. The suite then hangs with NO output and survives
-// `--timeout`, because the blocked event loop never lets the timer fire. Rebuild
-// these objects per call and you will spend an hour finding it again.
+// functions (`useCallback`) and components depend on that. `ProviderRow` runs
+// `useEffect(..., [isConnected, clearConnectError])` whose body calls
+// `setFieldValues({})`. A mock that rebuilds its return per call hands React a
+// new `clearError` identity every render, so the dep array never settles; the
+// body then allocates a fresh `{}` every time, so the state never settles
+// either. The two feed each other and the render never converges.
+//
+// It only bites fixtures with a CONNECTED provider, because the effect body is
+// gated on `if (isConnected)` — which is why the two BYOC cases below are what
+// tripped it. Observed symptom: the whole file hangs with no output at all and
+// does not respond to `--timeout` (no test ever starts, so no test can time
+// out), which reads like a slow suite rather than a mistake.
+//
+// Rebuild these objects per call and you will spend an hour finding it again.
 //
 // `stagedStatus` is set per test BEFORE render for the same identity reason:
 // `useConfigForm` re-baselines when `data` changes identity, so a fresh object
@@ -125,7 +134,25 @@ void mock.module("@/ui/hooks/use-admin-mutation", () => ({
   useAdminMutation: () => adminMutationReturn,
 }));
 
-const { SaasSandboxView, SandboxOutageNotice, SelfHostedSandboxView } = await import("../page");
+// Staged deploy mode, so the page-level tests below can exercise BOTH views'
+// wiring to the same payload.
+let modeReturn = {
+  deployMode: "saas" as "saas" | "self-hosted",
+  loading: false,
+  error: null,
+  resolved: true,
+};
+
+void mock.module("@/ui/hooks/use-deploy-mode", () => ({
+  useDeployMode: () => modeReturn,
+}));
+
+const {
+  default: SandboxPage,
+  SaasSandboxView,
+  SandboxOutageNotice,
+  SelfHostedSandboxView,
+} = await import("../page");
 stagedStatus = healthyStatus();
 
 // ── Harness ───────────────────────────────────────────────────────
@@ -178,10 +205,17 @@ function renderSelfHosted(status: SandboxStatus) {
   );
 }
 
+function renderPage(status: SandboxStatus, deployMode: "saas" | "self-hosted") {
+  stagedStatus = status;
+  modeReturn = { deployMode, loading: false, error: null, resolved: true };
+  return render(createElement(SandboxPage), { wrapper });
+}
+
 // House convention, and load-bearing here: RTL binds queries to `document.body`,
 // so a test that throws before an inline `cleanup()` leaks DOM into the next one.
 afterEach(() => {
   cleanup();
+  modeReturn = { deployMode: "saas", loading: false, error: null, resolved: true };
 });
 
 // ── SaaS view ─────────────────────────────────────────────────────
@@ -232,11 +266,15 @@ describe("SaasSandboxView — fail-closed region (#4837)", () => {
     expect(queryByText("Down")).toBeNull();
   });
 
-  test("a usable BYOC override keeps running — the managed card is not marked down", () => {
-    // The override sits ahead of the platform plan, so this workspace's explore
-    // still works. Flagging it down would be a false alarm, and an operator who
-    // learns to dismiss one alarm dismisses the next.
-    const { queryByText } = renderSaas(
+  test("with a live BYOC override the managed card is still Down, and offers no 'Use this'", () => {
+    // The card offers "follow the platform default". That default constructs
+    // nothing, so the OPTION is down regardless of what this workspace currently
+    // runs on — and the button must not be offered, because clicking it would
+    // move a working workspace off its BYOC backend and onto the outage.
+    //
+    // The workspace's own health is a different question, and the banner is
+    // where it is answered (`workspaceStillRunning`) — see the page-level tests.
+    const { getByText, queryAllByText } = renderSaas(
       failClosedStatus({
         activeBackend: "e2b-sandbox",
         workspaceOverride: "e2b-sandbox",
@@ -251,7 +289,8 @@ describe("SaasSandboxView — fail-closed region (#4837)", () => {
         ],
       }),
     );
-    expect(queryByText("Down")).toBeNull();
+    getByText("Down");
+    expect(queryAllByText("Use this").length).toBe(0);
   });
 });
 
@@ -266,12 +305,19 @@ describe("SelfHostedSandboxView — fail-closed deployment (#4837)", () => {
     expect(queryByText("fail-closed")).toBeNull();
   });
 
+  test("words the Platform default row too, rather than rendering an empty one", () => {
+    // Asserted POSITIVELY. `DetailRow.value` is `ReactNode`, so a bare null
+    // renders as nothing at all — a "does not contain 'null'" check passes just
+    // as happily on a silently blank row, which is the failure this row had.
+    const { getByText } = renderSelfHosted(failClosedStatus());
+    getByText(/None — fails closed/);
+  });
+
   test("never interpolates a bare 'null' into the platform-default copy", () => {
-    // `DetailRow.value` is `ReactNode` and template literals stringify `null`,
-    // so the nullable type ALONE would have shipped a blank row and a literal
-    // "Using the platform default (null)." — the same class of bug in new words.
-    // This is what the schema docblock means by "the compiler does not catch
-    // consumers that swallow null".
+    // The other half: template literals DO stringify null, so the nullable type
+    // alone would have shipped a literal "Using the platform default (null)."
+    // Together with the test above this covers both ways the compiler lets a
+    // null through — what the schema docblock means by "swallowed silently".
     const { queryByText, container } = renderSelfHosted(failClosedStatus());
     expect(queryByText(/\(null\)/)).toBeNull();
     expect(container.textContent).not.toContain("null");
@@ -347,5 +393,62 @@ describe("SandboxOutageNotice — remediation (#4837)", () => {
     getByRole("alert");
     getByText(/every request is refused/);
     getByText(/No remediation was reported/);
+  });
+});
+
+// ── Page-level wiring ─────────────────────────────────────────────
+// The component tests above pass props by hand, so they all stay green if the
+// banner is deleted from the page or wired to the wrong field. These cover the
+// three predicates only the page owns: the `platformDefault === null` gate, the
+// `failClosed?.remediation` plumbing, and `activeBackend !== null` →
+// `workspaceStillRunning`.
+
+describe("SandboxPage — outage banner wiring (#4837)", () => {
+  test.each(["saas", "self-hosted"] as const)(
+    "renders the outage banner above the %s view",
+    (mode) => {
+      const { getByRole } = renderPage(failClosedStatus(), mode);
+
+      const alert = getByRole("alert");
+      expect(alert.textContent).toContain("every request is refused");
+      // Plumbed from the payload, not re-composed locally.
+      expect(alert.textContent).toContain("VERCEL_TOKEN");
+    },
+  );
+
+  test.each(["saas", "self-hosted"] as const)(
+    "renders NO banner on a healthy %s deployment",
+    (mode) => {
+      const { queryByRole } = renderPage(healthyStatus(), mode);
+      expect(queryByRole("alert")).toBeNull();
+    },
+  );
+
+  test("passes workspaceStillRunning from activeBackend, not from the outage block", () => {
+    // Both fixtures carry `failClosed`; only `activeBackend` differs. If the
+    // page wired the softer headline to the wrong field, one of these flips.
+    const { getByRole } = renderPage(
+      failClosedStatus({
+        activeBackend: "e2b-sandbox",
+        workspaceOverride: "e2b-sandbox",
+        connectedProviders: [
+          {
+            provider: "e2b",
+            displayName: "Acme",
+            connectedAt: "2026-06-01T00:00:00.000Z",
+            validatedAt: null,
+            isActive: true,
+          },
+        ],
+      }),
+      "saas",
+    );
+    expect(getByRole("alert").textContent).toContain(
+      "this workspace is running on its own backend",
+    );
+    cleanup();
+
+    const stillDown = renderPage(failClosedStatus(), "saas");
+    expect(stillDown.getByRole("alert").textContent).toContain("every request is refused");
   });
 });

--- a/packages/web/src/app/admin/sandbox/__tests__/fail-closed-outage.test.tsx
+++ b/packages/web/src/app/admin/sandbox/__tests__/fail-closed-outage.test.tsx
@@ -1,0 +1,182 @@
+/**
+ * #4837 — a fail-closed deployment must read as an OUTAGE on /admin/sandbox.
+ *
+ * The SaaS view is the one that matters, and it is the one the issue's
+ * `Active: fail-closed` row could not even warn about: this view never rendered
+ * `activeBackend` at all. It derived "Managed is live" from `!connectedProviders
+ * .some(isActive)`, so a region whose explore was refusing every request showed
+ * "Atlas Cloud Sandbox · Live" — a green light on a total outage, on the page an
+ * operator opens to diagnose exactly that.
+ *
+ * Reachable in production: `deploy/api/atlas.config.ts` pins
+ * `priority: ["vercel-sandbox"]` with no `just-bash` on staging and all three
+ * prod regions, and `VERCEL_TOKEN` is a per-service Railway secret that shared
+ * vars do not inherit (#4828).
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+import { render, cleanup } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { AtlasProvider, type AtlasAuthClient } from "@/ui/context";
+import { SaasSandboxView, SandboxOutageNotice } from "../page";
+import type { SandboxStatus } from "@/ui/lib/admin-schemas";
+
+const stubAuthClient: AtlasAuthClient = {
+  signIn: { email: async () => ({}) },
+  signUp: { email: async () => ({}) },
+  signOut: async () => {},
+  useSession: () => ({ data: null, isPending: false }),
+};
+
+function wrapper({ children }: { children: ReactNode }) {
+  return createElement(
+    QueryClientProvider,
+    { client: new QueryClient() },
+    createElement(AtlasProvider, {
+      config: {
+        apiUrl: "http://localhost:3001",
+        isCrossOrigin: false as const,
+        authClient: stubAuthClient,
+      },
+      children,
+    }),
+  );
+}
+
+/** The wire payload a fail-closed SaaS region actually sends. */
+function failClosedStatus(overrides: Partial<SandboxStatus> = {}): SandboxStatus {
+  return {
+    activeBackend: null,
+    platformDefault: null,
+    workspaceOverride: null,
+    workspaceSidecarUrl: null,
+    availableBackends: [
+      { id: "vercel-sandbox", name: "Vercel Sandbox", type: "built-in", available: false },
+    ],
+    connectedProviders: [],
+    failClosed: {
+      remediation:
+        "Explore tool: UNAVAILABLE — every backend in sandbox.priority (vercel-sandbox) is " +
+        "unavailable and the pin has no 'just-bash' fallback, so the tool fails closed and " +
+        "refuses every request. For Vercel Sandbox off-Vercel, set VERCEL_TEAM_ID, " +
+        "VERCEL_PROJECT_ID, and VERCEL_TOKEN.",
+    },
+    ...overrides,
+  };
+}
+
+function healthyStatus(): SandboxStatus {
+  return {
+    activeBackend: "vercel-sandbox",
+    platformDefault: "vercel-sandbox",
+    workspaceOverride: null,
+    workspaceSidecarUrl: null,
+    availableBackends: [
+      { id: "vercel-sandbox", name: "Vercel Sandbox", type: "built-in", available: true },
+    ],
+    connectedProviders: [],
+  };
+}
+
+function renderView(status: SandboxStatus) {
+  const onSelectBackend = mock(async (_backendId: string) => undefined);
+  const onSelectManaged = mock(async () => undefined);
+  const utils = render(
+    createElement(SaasSandboxView, {
+      status,
+      onSelectBackend,
+      onSelectManaged,
+      onRefetch: mock(() => {}),
+      saving: false,
+    }),
+    { wrapper },
+  );
+  return { ...utils, onSelectBackend, onSelectManaged };
+}
+
+describe("SaasSandboxView — fail-closed region (#4837)", () => {
+  test("the managed card reads Down, never Live, when the platform default failed closed", () => {
+    const { getByText, queryByText } = renderView(failClosedStatus());
+
+    getByText("Down");
+    // The regression: "Live" on a region where explore refuses every request.
+    expect(queryByText("Live")).toBeNull();
+    // "Available" would be just as wrong — it is not available, it is broken.
+    expect(queryByText("Available")).toBeNull();
+    cleanup();
+  });
+
+  test("offers no 'Use this' on the managed card — selecting the broken default is not a fix", () => {
+    const { queryAllByText } = renderView(failClosedStatus());
+    expect(queryAllByText("Use this").length).toBe(0);
+    cleanup();
+  });
+
+  test("a healthy region is unchanged — the managed card still reads Live", () => {
+    // Guards the other direction: the Down state must be gated on the outage,
+    // not accidentally on "no BYOC provider is live", which is the normal case.
+    const { getByText, queryByText } = renderView(healthyStatus());
+    getByText("Live");
+    expect(queryByText("Down")).toBeNull();
+    cleanup();
+  });
+
+  test("a usable BYOC override keeps running — the managed card is not marked down", () => {
+    // The override sits ahead of the platform plan, so this workspace's explore
+    // still works. Flagging it down would be a false alarm, and an operator who
+    // learns to dismiss one alarm dismisses the next.
+    const { queryByText } = renderView(
+      failClosedStatus({
+        activeBackend: "e2b-sandbox",
+        workspaceOverride: "e2b-sandbox",
+        connectedProviders: [
+          {
+            provider: "e2b",
+            displayName: "Acme",
+            connectedAt: "2026-06-01T00:00:00.000Z",
+            validatedAt: null,
+            isActive: true,
+          },
+        ],
+      }),
+    );
+    expect(queryByText("Down")).toBeNull();
+    cleanup();
+  });
+});
+
+describe("SandboxOutageNotice — remediation (#4837)", () => {
+  const { failClosed } = failClosedStatus();
+
+  test("renders the server's remediation verbatim, naming the pin and its credential", () => {
+    if (!failClosed) throw new Error("fixture must carry a failClosed block");
+    const { getByRole, getByText } = render(
+      createElement(SandboxOutageNotice, { failClosed, workspaceStillRunning: false }),
+      { wrapper },
+    );
+
+    getByRole("alert");
+    getByText(/every request is refused/);
+    // The AC that separates this from #4828: the operator is told which backend
+    // is pinned and which credential it needs — not "install nsjail", which the
+    // pin makes impossible to act on.
+    getByText(/vercel-sandbox/);
+    getByText(/VERCEL_TOKEN/);
+    cleanup();
+  });
+
+  test("softens the headline when a workspace BYOC backend is still running", () => {
+    if (!failClosed) throw new Error("fixture must carry a failClosed block");
+    const { getByText, queryByText } = render(
+      createElement(SandboxOutageNotice, { failClosed, workspaceStillRunning: true }),
+      { wrapper },
+    );
+
+    getByText(/this workspace is running on its own backend/i);
+    // A blanket "every request is refused" here would be a false alarm for a
+    // workspace whose explore demonstrably works.
+    expect(queryByText("Explore tool unavailable — every request is refused")).toBeNull();
+    cleanup();
+  });
+});

--- a/packages/web/src/app/admin/sandbox/__tests__/fail-closed-outage.test.tsx
+++ b/packages/web/src/app/admin/sandbox/__tests__/fail-closed-outage.test.tsx
@@ -15,7 +15,7 @@
  */
 
 import { afterEach, describe, expect, mock, test } from "bun:test";
-import { render, cleanup } from "@testing-library/react";
+import { render, cleanup, fireEvent } from "@testing-library/react";
 import { createElement, type ReactNode } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { AtlasProvider, type AtlasAuthClient } from "@/ui/context";
@@ -256,6 +256,9 @@ describe("SaasSandboxView — fail-closed region (#4837)", () => {
       }),
     );
     expect(queryAllByText("Use this").length).toBeGreaterThan(0);
+    // Closes the three-way down/live/available loop: "Available" is the label
+    // round 2 stopped rendering on an outage, so it must still render here.
+    expect(queryAllByText("Available").length).toBeGreaterThan(0);
   });
 
   test("a healthy region is unchanged — the managed card still reads Live", () => {
@@ -291,6 +294,34 @@ describe("SaasSandboxView — fail-closed region (#4837)", () => {
     );
     getByText("Down");
     expect(queryAllByText("Use this").length).toBe(0);
+  });
+
+  test("the disconnect confirmation does not promise a fallback that cannot run", async () => {
+    // The most harmful shape of #4837: not a confusing label but an active
+    // reassurance. The live BYOC backend is the ONLY thing keeping this
+    // workspace's explore alive, and the old copy told the operator that
+    // disconnecting it would "fall back to Atlas Cloud Sandbox" — the platform
+    // default that constructs nothing.
+    const { getByText, findByText, queryByText } = renderSaas(
+      failClosedStatus({
+        activeBackend: "e2b-sandbox",
+        workspaceOverride: "e2b-sandbox",
+        connectedProviders: [
+          {
+            provider: "e2b",
+            displayName: "Acme",
+            connectedAt: "2026-06-01T00:00:00.000Z",
+            validatedAt: null,
+            isActive: true,
+          },
+        ],
+      }),
+    );
+
+    fireEvent.click(getByText("Disconnect"));
+
+    await findByText(/leaves this workspace with no working sandbox/);
+    expect(queryByText(/fall back to Atlas Cloud Sandbox/)).toBeNull();
   });
 });
 
@@ -404,17 +435,35 @@ describe("SandboxOutageNotice — remediation (#4837)", () => {
 // `workspaceStillRunning`.
 
 describe("SandboxPage — outage banner wiring (#4837)", () => {
-  test.each(["saas", "self-hosted"] as const)(
-    "renders the outage banner above the %s view",
-    (mode) => {
-      const { getByRole } = renderPage(failClosedStatus(), mode);
+  test.each([
+    ["saas", "Bring your own cloud"],
+    ["self-hosted", "Sandbox backend"],
+  ] as const)("renders the outage banner ABOVE the %s view", (mode, viewMarker) => {
+    const { getByRole, getByText } = renderPage(failClosedStatus(), mode);
 
-      const alert = getByRole("alert");
-      expect(alert.textContent).toContain("every request is refused");
-      // Plumbed from the payload, not re-composed locally.
-      expect(alert.textContent).toContain("VERCEL_TOKEN");
-    },
-  );
+    const alert = getByRole("alert");
+    expect(alert.textContent).toContain("every request is refused");
+    // Plumbed from the payload, not re-composed locally.
+    expect(alert.textContent).toContain("VERCEL_TOKEN");
+
+    // "Above" asserted as document order, not just as co-existence — an outage
+    // banner below the fold of the thing it is warning about is not a warning.
+    const view = getByText(viewMarker);
+    expect(alert.compareDocumentPosition(view) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  test("renders the outage without a remediation when the block carries an empty one", () => {
+    // The schema deliberately admits `remediation: ""` (a `.min(1)` could only
+    // fail the diagnostic page closed in the browser). `|| null` is the consumer
+    // that makes "empty" mean "absent" — pinned here so that coercion cannot be
+    // dropped silently.
+    const { getByRole, getByText } = renderPage(
+      failClosedStatus({ failClosed: { remediation: "" } }),
+      "saas",
+    );
+    expect(getByRole("alert").textContent).toContain("every request is refused");
+    getByText(/No remediation was reported/);
+  });
 
   test.each(["saas", "self-hosted"] as const)(
     "renders NO banner on a healthy %s deployment",

--- a/packages/web/src/app/admin/sandbox/__tests__/fail-closed-outage.test.tsx
+++ b/packages/web/src/app/admin/sandbox/__tests__/fail-closed-outage.test.tsx
@@ -1,26 +1,134 @@
 /**
  * #4837 — a fail-closed deployment must read as an OUTAGE on /admin/sandbox.
  *
- * The SaaS view is the one that matters, and it is the one the issue's
- * `Active: fail-closed` row could not even warn about: this view never rendered
- * `activeBackend` at all. It derived "Managed is live" from `!connectedProviders
- * .some(isActive)`, so a region whose explore was refusing every request showed
- * "Atlas Cloud Sandbox · Live" — a green light on a total outage, on the page an
- * operator opens to diagnose exactly that.
+ * Both views were wrong, in different ways. The self-hosted view rendered the
+ * raw `"fail-closed"` string in the monospace "Active" slot, reading as one more
+ * backend id — the symptom the issue is named after. The SaaS view was worse: it
+ * never rendered `activeBackend` at all and derived "Managed is live" from
+ * `!connectedProviders.some(isActive)`, so a region whose explore was refusing
+ * every request showed "Atlas Cloud Sandbox · Live". A green light on a total
+ * outage, on the page an operator opens to diagnose exactly that.
  *
- * Reachable in production: `deploy/api/atlas.config.ts` pins
- * `priority: ["vercel-sandbox"]` with no `just-bash` on staging and all three
- * prod regions, and `VERCEL_TOKEN` is a per-service Railway secret that shared
- * vars do not inherit (#4828).
+ * Reachable in production both ways: the SaaS pin (#4828 — see
+ * `formatSandboxFailClosed`), and self-hosted via `ATLAS_SANDBOX=nsjail` with no
+ * usable binary (#4829).
  */
 
-import { describe, expect, mock, test } from "bun:test";
+import { afterEach, describe, expect, mock, test } from "bun:test";
 import { render, cleanup } from "@testing-library/react";
 import { createElement, type ReactNode } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { AtlasProvider, type AtlasAuthClient } from "@/ui/context";
-import { SaasSandboxView, SandboxOutageNotice } from "../page";
-import type { SandboxStatus } from "@/ui/lib/admin-schemas";
+import { SandboxStatusSchema, type SandboxStatus } from "@/ui/lib/admin-schemas";
+
+// ── Fixtures ──────────────────────────────────────────────────────
+// Every fixture is round-tripped through the SHARED wire schema before it
+// reaches a component, so a fixture cannot drift from the contract the API
+// emits — the drift that produced #4837 in the first place.
+
+function asWirePayload(status: SandboxStatus): SandboxStatus {
+  return SandboxStatusSchema.parse(status);
+}
+
+/**
+ * An abridged but structurally faithful remediation. The real
+ * `formatSandboxFailClosed` output also appends an `Unavailable: …` clause and a
+ * sentence about BYOC/plugin front-of-line; byte-parity with the real formatter
+ * is enforced in `packages/api/src/api/__tests__/admin-sandbox-fail-closed.test.ts`,
+ * not here. What matters here is that the page renders the server's string
+ * verbatim rather than composing its own.
+ */
+const REMEDIATION =
+  "Explore tool: UNAVAILABLE — every backend in sandbox.priority (vercel-sandbox) is " +
+  "unavailable and the pin has no 'just-bash' fallback, so the tool fails closed and " +
+  "refuses every request. For Vercel Sandbox off-Vercel, set VERCEL_TEAM_ID, " +
+  "VERCEL_PROJECT_ID, and VERCEL_TOKEN.";
+
+function failClosedStatus(overrides: Partial<SandboxStatus> = {}): SandboxStatus {
+  return asWirePayload({
+    activeBackend: null,
+    platformDefault: null,
+    workspaceOverride: null,
+    workspaceSidecarUrl: null,
+    availableBackends: [
+      { id: "vercel-sandbox", name: "Vercel Sandbox", type: "built-in", available: false },
+    ],
+    connectedProviders: [],
+    failClosed: { remediation: REMEDIATION },
+    ...overrides,
+  });
+}
+
+function healthyStatus(overrides: Partial<SandboxStatus> = {}): SandboxStatus {
+  return asWirePayload({
+    activeBackend: "vercel-sandbox",
+    platformDefault: "vercel-sandbox",
+    workspaceOverride: null,
+    workspaceSidecarUrl: null,
+    availableBackends: [
+      { id: "vercel-sandbox", name: "Vercel Sandbox", type: "built-in", available: true },
+    ],
+    connectedProviders: [],
+    ...overrides,
+  });
+}
+
+// ── Hook mocks ────────────────────────────────────────────────────
+//
+// `SelfHostedSandboxView` reads its status through `useConfigForm` →
+// `useAdminFetch` rather than taking it as a prop, so the fetch has to be staged.
+//
+// EVERY returned value here is a module-level singleton, and that is not
+// tidiness — it is required. The real hooks return referentially stable
+// functions (`useCallback`), and components depend on that: `ProviderRow` has
+// `useEffect(..., [isConnected, clearConnectError])`. A mock that returns a
+// fresh object literal per call hands React a new `clearError` identity on every
+// render, so that effect re-runs, calls `setState`, re-renders, and loops
+// forever — synchronously. The suite then hangs with NO output and survives
+// `--timeout`, because the blocked event loop never lets the timer fire. Rebuild
+// these objects per call and you will spend an hour finding it again.
+//
+// `stagedStatus` is set per test BEFORE render for the same identity reason:
+// `useConfigForm` re-baselines when `data` changes identity, so a fresh object
+// per render would re-baseline forever.
+
+let stagedStatus: SandboxStatus;
+
+const adminFetchReturn = {
+  get data() {
+    return stagedStatus;
+  },
+  loading: false,
+  error: null,
+  setError: () => {},
+  refetch: () => {},
+};
+const inProgressSet = { has: () => false, start: () => {}, stop: () => {} };
+
+void mock.module("@/ui/hooks/use-admin-fetch", () => ({
+  useAdminFetch: () => adminFetchReturn,
+  useInProgressSet: () => inProgressSet,
+  friendlyError: (e: { message: string }) => e.message,
+}));
+
+const adminMutationReturn = {
+  mutate: async () => ({ ok: true as const, data: undefined }),
+  saving: false,
+  error: null,
+  clearError: () => {},
+  errorsByItemId: {},
+  isMutating: () => false,
+  reset: () => {},
+};
+
+void mock.module("@/ui/hooks/use-admin-mutation", () => ({
+  useAdminMutation: () => adminMutationReturn,
+}));
+
+const { SaasSandboxView, SandboxOutageNotice, SelfHostedSandboxView } = await import("../page");
+stagedStatus = healthyStatus();
+
+// ── Harness ───────────────────────────────────────────────────────
 
 const stubAuthClient: AtlasAuthClient = {
   signIn: { email: async () => ({}) },
@@ -44,89 +152,91 @@ function wrapper({ children }: { children: ReactNode }) {
   );
 }
 
-/** The wire payload a fail-closed SaaS region actually sends. */
-function failClosedStatus(overrides: Partial<SandboxStatus> = {}): SandboxStatus {
-  return {
-    activeBackend: null,
-    platformDefault: null,
-    workspaceOverride: null,
-    workspaceSidecarUrl: null,
-    availableBackends: [
-      { id: "vercel-sandbox", name: "Vercel Sandbox", type: "built-in", available: false },
-    ],
-    connectedProviders: [],
-    failClosed: {
-      remediation:
-        "Explore tool: UNAVAILABLE — every backend in sandbox.priority (vercel-sandbox) is " +
-        "unavailable and the pin has no 'just-bash' fallback, so the tool fails closed and " +
-        "refuses every request. For Vercel Sandbox off-Vercel, set VERCEL_TEAM_ID, " +
-        "VERCEL_PROJECT_ID, and VERCEL_TOKEN.",
-    },
-    ...overrides,
-  };
-}
-
-function healthyStatus(): SandboxStatus {
-  return {
-    activeBackend: "vercel-sandbox",
-    platformDefault: "vercel-sandbox",
-    workspaceOverride: null,
-    workspaceSidecarUrl: null,
-    availableBackends: [
-      { id: "vercel-sandbox", name: "Vercel Sandbox", type: "built-in", available: true },
-    ],
-    connectedProviders: [],
-  };
-}
-
-function renderView(status: SandboxStatus) {
-  const onSelectBackend = mock(async (_backendId: string) => undefined);
-  const onSelectManaged = mock(async () => undefined);
-  const utils = render(
+function renderSaas(status: SandboxStatus) {
+  return render(
     createElement(SaasSandboxView, {
       status,
-      onSelectBackend,
-      onSelectManaged,
+      onSelectBackend: mock(async (_backendId: string) => undefined),
+      onSelectManaged: mock(async () => undefined),
       onRefetch: mock(() => {}),
       saving: false,
     }),
     { wrapper },
   );
-  return { ...utils, onSelectBackend, onSelectManaged };
 }
+
+function renderSelfHosted(status: SandboxStatus) {
+  stagedStatus = status;
+  return render(
+    createElement(SelfHostedSandboxView, {
+      onSelectBackend: mock(async (_backendId: string) => undefined),
+      onSetSidecarUrl: mock(async (_url: string) => undefined),
+      onReset: mock(async () => {}),
+      saving: false,
+    }),
+    { wrapper },
+  );
+}
+
+// House convention, and load-bearing here: RTL binds queries to `document.body`,
+// so a test that throws before an inline `cleanup()` leaks DOM into the next one.
+afterEach(() => {
+  cleanup();
+});
+
+// ── SaaS view ─────────────────────────────────────────────────────
 
 describe("SaasSandboxView — fail-closed region (#4837)", () => {
   test("the managed card reads Down, never Live, when the platform default failed closed", () => {
-    const { getByText, queryByText } = renderView(failClosedStatus());
+    const { getByText, queryByText } = renderSaas(failClosedStatus());
 
     getByText("Down");
     // The regression: "Live" on a region where explore refuses every request.
     expect(queryByText("Live")).toBeNull();
     // "Available" would be just as wrong — it is not available, it is broken.
     expect(queryByText("Available")).toBeNull();
-    cleanup();
   });
 
   test("offers no 'Use this' on the managed card — selecting the broken default is not a fix", () => {
-    const { queryAllByText } = renderView(failClosedStatus());
+    const { queryAllByText } = renderSaas(failClosedStatus());
     expect(queryAllByText("Use this").length).toBe(0);
-    cleanup();
+  });
+
+  test("POSITIVE CONTROL — 'Use this' is the real label, so the assertion above can fail", () => {
+    // Without this, `length === 0` would also pass if the button were renamed,
+    // restyled, or deleted outright. Here the managed card is NOT selected (a
+    // BYOC row is live), so the button must be present.
+    const { queryAllByText } = renderSaas(
+      healthyStatus({
+        activeBackend: "e2b-sandbox",
+        workspaceOverride: "e2b-sandbox",
+        connectedProviders: [
+          {
+            provider: "e2b",
+            displayName: "Acme",
+            connectedAt: "2026-06-01T00:00:00.000Z",
+            validatedAt: null,
+            isActive: true,
+          },
+        ],
+      }),
+    );
+    expect(queryAllByText("Use this").length).toBeGreaterThan(0);
   });
 
   test("a healthy region is unchanged — the managed card still reads Live", () => {
     // Guards the other direction: the Down state must be gated on the outage,
     // not accidentally on "no BYOC provider is live", which is the normal case.
-    const { getByText, queryByText } = renderView(healthyStatus());
+    const { getByText, queryByText } = renderSaas(healthyStatus());
     getByText("Live");
     expect(queryByText("Down")).toBeNull();
-    cleanup();
   });
 
   test("a usable BYOC override keeps running — the managed card is not marked down", () => {
     // The override sits ahead of the platform plan, so this workspace's explore
     // still works. Flagging it down would be a false alarm, and an operator who
     // learns to dismiss one alarm dismisses the next.
-    const { queryByText } = renderView(
+    const { queryByText } = renderSaas(
       failClosedStatus({
         activeBackend: "e2b-sandbox",
         workspaceOverride: "e2b-sandbox",
@@ -142,17 +252,58 @@ describe("SaasSandboxView — fail-closed region (#4837)", () => {
       }),
     );
     expect(queryByText("Down")).toBeNull();
-    cleanup();
   });
 });
 
-describe("SandboxOutageNotice — remediation (#4837)", () => {
-  const { failClosed } = failClosedStatus();
+// ── Self-hosted view — the row the issue is named after ────────────
 
+describe("SelfHostedSandboxView — fail-closed deployment (#4837)", () => {
+  test("the Active row says explore refuses requests instead of showing an id", () => {
+    const { getByText, queryByText } = renderSelfHosted(failClosedStatus());
+
+    getByText(/None — explore refuses every request/);
+    // The literal regression: the sentinel rendered as a backend id.
+    expect(queryByText("fail-closed")).toBeNull();
+  });
+
+  test("never interpolates a bare 'null' into the platform-default copy", () => {
+    // `DetailRow.value` is `ReactNode` and template literals stringify `null`,
+    // so the nullable type ALONE would have shipped a blank row and a literal
+    // "Using the platform default (null)." — the same class of bug in new words.
+    // This is what the schema docblock means by "the compiler does not catch
+    // consumers that swallow null".
+    const { queryByText, container } = renderSelfHosted(failClosedStatus());
+    expect(queryByText(/\(null\)/)).toBeNull();
+    expect(container.textContent).not.toContain("null");
+  });
+
+  test("the status pill reads Down, outranking Override/Default", () => {
+    const { getByText, queryByText } = renderSelfHosted(failClosedStatus());
+    getByText("Down");
+    // "Default" describes which knob is in effect — not the operator's problem
+    // when nothing runs at all.
+    expect(queryByText("Default")).toBeNull();
+  });
+
+  test("a healthy deployment still shows the backend id in the Active row", () => {
+    // Positive control for the three above: proves the outage copy is gated on
+    // the outage rather than always rendered.
+    const { getAllByText, queryByText } = renderSelfHosted(healthyStatus());
+    expect(getAllByText("vercel-sandbox").length).toBeGreaterThan(0);
+    expect(queryByText(/None — explore refuses every request/)).toBeNull();
+    expect(queryByText("Down")).toBeNull();
+  });
+});
+
+// ── Outage banner ─────────────────────────────────────────────────
+
+describe("SandboxOutageNotice — remediation (#4837)", () => {
   test("renders the server's remediation verbatim, naming the pin and its credential", () => {
-    if (!failClosed) throw new Error("fixture must carry a failClosed block");
     const { getByRole, getByText } = render(
-      createElement(SandboxOutageNotice, { failClosed, workspaceStillRunning: false }),
+      createElement(SandboxOutageNotice, {
+        remediation: REMEDIATION,
+        workspaceStillRunning: false,
+      }),
       { wrapper },
     );
 
@@ -163,13 +314,14 @@ describe("SandboxOutageNotice — remediation (#4837)", () => {
     // pin makes impossible to act on.
     getByText(/vercel-sandbox/);
     getByText(/VERCEL_TOKEN/);
-    cleanup();
   });
 
   test("softens the headline when a workspace BYOC backend is still running", () => {
-    if (!failClosed) throw new Error("fixture must carry a failClosed block");
     const { getByText, queryByText } = render(
-      createElement(SandboxOutageNotice, { failClosed, workspaceStillRunning: true }),
+      createElement(SandboxOutageNotice, {
+        remediation: REMEDIATION,
+        workspaceStillRunning: true,
+      }),
       { wrapper },
     );
 
@@ -177,6 +329,23 @@ describe("SandboxOutageNotice — remediation (#4837)", () => {
     // A blanket "every request is refused" here would be a false alarm for a
     // workspace whose explore demonstrably works.
     expect(queryByText("Explore tool unavailable — every request is refused")).toBeNull();
-    cleanup();
+  });
+
+  test("still raises the alarm when the remediation is missing", () => {
+    // Losing the remediation must never downgrade the reported state. The
+    // headline is driven by the outage, not by the string, so a payload without
+    // a `failClosed` block still shows the outage — it just cannot say how to
+    // fix it. The presentation-layer half of that principle.
+    const { getByRole, getByText } = render(
+      createElement(SandboxOutageNotice, {
+        remediation: null,
+        workspaceStillRunning: false,
+      }),
+      { wrapper },
+    );
+
+    getByRole("alert");
+    getByText(/every request is refused/);
+    getByText(/No remediation was reported/);
   });
 });

--- a/packages/web/src/app/admin/sandbox/page.tsx
+++ b/packages/web/src/app/admin/sandbox/page.tsx
@@ -443,6 +443,7 @@ export function SaasSandboxView({
                 providerKey={key}
                 connection={provider ?? null}
                 isActive={provider?.isActive ?? false}
+                platformDown={status.platformDefault === null}
                 // Absent field (older API) defaults to available so the page
                 // degrades to its pre-#3370 behavior rather than locking
                 // every card.
@@ -535,6 +536,7 @@ function ProviderRow({
   providerKey,
   connection,
   isActive,
+  platformDown,
   runtimeAvailable,
   needsReconnect,
   onSelect,
@@ -544,6 +546,12 @@ function ProviderRow({
   providerKey: SandboxProviderKey;
   connection: ConnectedProvider | null;
   isActive: boolean;
+  /**
+   * The platform default constructs nothing (#4837). Only the disconnect
+   * confirmation reads it — that is the one place this row makes a promise about
+   * what happens AFTER the workspace stops using this backend.
+   */
+  platformDown: boolean;
   runtimeAvailable: boolean;
   needsReconnect: boolean;
   onSelect: () => Promise<unknown>;
@@ -716,8 +724,17 @@ function ProviderRow({
                   <AlertDialogTitle>Disconnect {info.label}?</AlertDialogTitle>
                   <AlertDialogDescription>
                     This removes your {info.label} credentials.
+                    {/* What execution falls back TO depends on whether the
+                        platform default works. Promising "Atlas Cloud Sandbox"
+                        while the platform is fail-closed is the #4837 bug in its
+                        most harmful form: not a confusing label but an active
+                        reassurance, on the click that drops the workspace into
+                        the outage it is currently escaping via this very
+                        backend. */}
                     {isActive &&
-                      " Since this is your active sandbox, execution will fall back to Atlas Cloud Sandbox."}
+                      (platformDown
+                        ? " This is your active sandbox, and the platform default is currently unavailable — disconnecting leaves this workspace with no working sandbox, and explore will refuse every request."
+                        : " Since this is your active sandbox, execution will fall back to Atlas Cloud Sandbox.")}
                   </AlertDialogDescription>
                 </AlertDialogHeader>
                 <AlertDialogFooter>
@@ -922,6 +939,17 @@ export function SelfHostedSandboxView({
                   await onReset();
                 }}
                 disabled={saving}
+                // Reset clears the override so the platform default takes over.
+                // When that default constructs nothing, the shortcut silently
+                // drops this workspace into the outage — the same trap as the
+                // managed card's "Use this" and the BYOC disconnect copy. The
+                // Select below still offers "Use platform default (none — fails
+                // closed)", which says what it costs; this button cannot.
+                title={
+                  status.platformDefault === null
+                    ? "The platform default has no usable backend — clearing the override would leave explore refusing every request."
+                    : undefined
+                }
               >
                 <RotateCcw className="mr-1.5 size-3.5" />
                 Reset

--- a/packages/web/src/app/admin/sandbox/page.tsx
+++ b/packages/web/src/app/admin/sandbox/page.tsx
@@ -46,7 +46,6 @@ import {
   SANDBOX_PROVIDER_BACKEND_IDS,
   SandboxStatusSchema,
   type SandboxConnectedProvider as ConnectedProvider,
-  type SandboxFailClosed,
   type SandboxProviderKey,
   type SandboxStatus,
 } from "@/ui/lib/admin-schemas";
@@ -158,20 +157,18 @@ function StatusPill({ kind, label }: { kind: StatusKind; label: string }) {
  * The deployment's sandbox plan constructs nothing, so explore refuses every
  * request. Presented as an OUTAGE, above both views, because that is what it is
  * — this is the page an operator opens to diagnose sandboxing, and before #4837
- * the state arrived here as the string `"fail-closed"` rendered in the same
- * monospace "Active" slot as `vercel-sandbox`, reading as one more backend id.
+ * neither view said so. The self-hosted view rendered the string `"fail-closed"`
+ * in the same monospace "Active" slot as `vercel-sandbox`, reading as one more
+ * backend id; the SaaS view never rendered `activeBackend` at all and showed
+ * "Atlas Cloud Sandbox · Live", which is the worse half of the bug.
  *
- * Reachable in SaaS production, not just in theory: `deploy/api/atlas.config.ts`
- * pins `priority: ["vercel-sandbox"]` with no `just-bash` on staging and all
- * three prod regions, and `VERCEL_TOKEN` is a per-service Railway secret that
- * shared vars do not inherit — drop it on one regional service and that region
- * is here.
+ * Reachable in SaaS production, not just in theory (#4828 — see
+ * `formatSandboxFailClosed`, which composes the message this renders).
  *
  * `remediation` is rendered verbatim, never paraphrased or supplemented: the
  * server composed it from the resolved plan, so it names the pinned backend and
  * the credential it actually needs. Local copy would either duplicate that
- * derivation or regress to the generic "install nsjail" advice that a pin
- * excluding nsjail makes impossible to act on (#4828).
+ * derivation or regress to generic advice a priority pin makes unactionable.
  *
  * Exported for `__tests__/fail-closed-outage.test.tsx`, on the same footing as
  * `SaasSandboxView` below: it renders from the page shell (above BOTH views), so
@@ -179,10 +176,17 @@ function StatusPill({ kind, label }: { kind: StatusKind; label: string }) {
  * hooks to assert copy that has nothing to do with either.
  */
 export function SandboxOutageNotice({
-  failClosed,
+  remediation,
   workspaceStillRunning,
 }: {
-  failClosed: SandboxFailClosed;
+  /**
+   * Nullable on purpose. The headline is driven by the outage STATE
+   * (`platformDefault === null`), not by this string, so a payload that somehow
+   * arrives without a `failClosed` block still raises the alarm — it just cannot
+   * say how to fix it. Losing the remediation must never downgrade the reported
+   * state, and this is where that principle meets the DOM.
+   */
+  remediation: string | null;
   /**
    * A workspace BYOC override resolved despite the platform outage. It sits
    * ahead of the platform plan, so this workspace's explore still works — the
@@ -206,7 +210,14 @@ export function SandboxOutageNotice({
             ? "No platform sandbox backend can be constructed on this deployment. This workspace's own connected backend still runs, but any workspace falling back to the platform default has no working sandbox."
             : "No sandbox backend can be constructed on this deployment, and it is configured to refuse rather than run unsandboxed. Explore tool calls fail until this is fixed."}
         </p>
-        <p className="font-mono text-xs leading-relaxed">{failClosed.remediation}</p>
+        {remediation ? (
+          <p className="font-mono text-xs leading-relaxed">{remediation}</p>
+        ) : (
+          <p>
+            No remediation was reported — check the API startup warnings for the
+            pinned backend and its missing credential.
+          </p>
+        )}
       </AlertDescription>
     </Alert>
   );
@@ -298,11 +309,12 @@ export default function SandboxPage() {
               onRetry={clearMutationError}
             />
 
-            {/* Above BOTH views: the outage is deploy-mode-independent, and the
-                SaaS view is where it is actually reachable in production. */}
-            {data?.failClosed && (
+            {/* Gated on the outage STATE, not on the optional `failClosed`
+                block: the banner is the loudest signal on the page, so it must
+                not be the thing that disappears if the block ever goes missing. */}
+            {data && data.platformDefault === null && (
               <SandboxOutageNotice
-                failClosed={data.failClosed}
+                remediation={data.failClosed?.remediation || null}
                 workspaceStillRunning={data.activeBackend !== null}
               />
             )}
@@ -379,11 +391,20 @@ export function SaasSandboxView({
   const isManagedSelected = !connected.some((p) => p.isActive);
   // Selected is not the same as running. "Managed" means *follow the platform
   // default*, and a null `platformDefault` is the deployment saying it has no
-  // default to follow (#4837). Without this split, the SaaS view — the one that
-  // never rendered `activeBackend` at all, so the issue's `Active: fail-closed`
-  // row could not even warn here — showed "Atlas Cloud Sandbox · Live" on a
-  // region where explore was refusing every request.
-  const isManagedDown = isManagedSelected && status.platformDefault === null;
+  // default to follow (#4837). Without this third state the SaaS view — which
+  // never rendered `activeBackend` at all, so the self-hosted view's
+  // `Active: fail-closed` row could not even warn here — showed
+  // "Atlas Cloud Sandbox · Live" on a region refusing every explore request.
+  //
+  // Collapsed to one value rather than an `isActive` + `isDown` pair so
+  // "selected but down" cannot be spelled as `{ isActive: false, isDown: true }`
+  // — an incoherent card the type system would otherwise permit.
+  const managedState: ManagedState =
+    isManagedSelected && status.platformDefault === null
+      ? "down"
+      : isManagedSelected
+        ? "live"
+        : "available";
 
   return (
     <>
@@ -393,8 +414,7 @@ export function SaasSandboxView({
           description="Atlas-hosted sandbox. No setup — always available."
         />
         <ManagedSandboxShell
-          isActive={isManagedSelected}
-          isDown={isManagedDown}
+          state={managedState}
           // "Managed" means *follow the platform default* (the SaaS
           // `vercel-sandbox` pin in deploy/api/atlas.config.ts), so it
           // clears the workspace override rather than writing a value —
@@ -442,47 +462,48 @@ export function SaasSandboxView({
 
 // ── Managed Sandbox ───────────────────────────────────────────────
 
+/**
+ * The three readings of the managed card, as one value.
+ *
+ * `"live"` and `"down"` are the pair this card must never confuse — that
+ * confusion IS #4837 — and `"available"` (not selected, still offerable) is a
+ * third thing rather than the negation of either.
+ */
+type ManagedState = "available" | "live" | "down";
+
+const MANAGED_PRESENTATION: Record<
+  ManagedState,
+  { status: StatusKind; label: string }
+> = {
+  available: { status: "ready", label: "Available" },
+  live: { status: "connected", label: "Live" },
+  // `unavailable` is the closest existing StatusKind; the destructive banner
+  // above carries the alarm, this pill just must not read as "Live".
+  down: { status: "unavailable", label: "Down" },
+};
+
 function ManagedSandboxShell({
-  isActive,
-  isDown,
+  state,
   onSelect,
   saving,
 }: {
-  isActive: boolean;
-  /**
-   * Selected but not running — the platform default failed closed (#4837).
-   * Only meaningful together with `isActive`; the caller derives it that way.
-   * "Live" and "Down" are the two readings this card must never confuse, so the
-   * down state wins over the active state everywhere below.
-   */
-  isDown: boolean;
+  state: ManagedState;
   onSelect: () => Promise<unknown>;
   saving: boolean;
 }) {
-  const status: StatusKind = isDown
-    ? "unavailable"
-    : isActive
-      ? "connected"
-      : "ready";
+  const { status, label } = MANAGED_PRESENTATION[state];
   return (
     <Shell
       icon={Cloud}
       title="Atlas Cloud Sandbox"
       description="Managed Firecracker microVM with network isolation. Recommended for most workspaces."
       status={status}
-      trailing={
-        isDown ? (
-          <StatusPill kind="unavailable" label="Down" />
-        ) : isActive ? (
-          <StatusPill kind="connected" label="Live" />
-        ) : (
-          <StatusPill kind="ready" label="Available" />
-        )
-      }
+      trailing={<StatusPill kind={status} label={label} />}
       actions={
-        // No "Use this" while it is down: selecting the platform default is
-        // exactly what is already in effect and broken.
-        !isActive && !isDown && (
+        // Offered only when selecting it would change something. Not while live
+        // (already in effect) and not while down — selecting the platform
+        // default is exactly what is in effect and broken.
+        state === "available" && (
           <Button size="sm" onClick={onSelect} disabled={saving}>
             {saving && <Loader2 className="mr-1.5 size-3.5 animate-spin" />}
             Use this
@@ -490,17 +511,17 @@ function ManagedSandboxShell({
         )
       }
     >
-      {isDown ? (
+      {state === "down" ? (
         <p className="text-xs text-destructive">
           This deployment has no working sandbox backend — see the outage above.
           Connect your own cloud below to restore the explore tool for this
           workspace.
         </p>
-      ) : isActive ? null : (
+      ) : state === "available" ? (
         <p className="text-xs text-muted-foreground">
           Switch back here anytime — no credentials required.
         </p>
-      )}
+      ) : null}
     </Shell>
   );
 }
@@ -800,7 +821,13 @@ type SelfHostedFormValues = {
   sidecarUrl: string;
 };
 
-function SelfHostedSandboxView({
+/**
+ * Exported for `__tests__/fail-closed-outage.test.tsx` — this view owns the row
+ * #4837 is literally named after (`Active: fail-closed` in the monospace slot),
+ * and self-hosted reaches fail-closed through the `ATLAS_SANDBOX=nsjail` pin
+ * with no usable binary (#4829). Same footing as `SaasSandboxView` below.
+ */
+export function SelfHostedSandboxView({
   onSelectBackend,
   onSetSidecarUrl,
   onReset,
@@ -837,11 +864,11 @@ function SelfHostedSandboxView({
   if (!status || !fields || !values) return null;
 
   const availableBackends = status.availableBackends.filter((b) => b.available);
-  // `activeBackend` is `string | null`, so a fail-closed deployment can no
-  // longer match a backend id here — the comparison audit AC3 asks for. It was
-  // already correct by accident (`"fail-closed" !== "sidecar"`); it is now
-  // correct by construction, and the same holds for every other id comparison
-  // on this page.
+  // This is the ONLY place on the page that compares `activeBackend` against a
+  // backend id, and it is the one #4837 asks to audit ("audit every consumer
+  // that compares `activeBackend` against a backend id"). It was already correct
+  // by accident — `"fail-closed" !== "sidecar"` — and is now correct by
+  // construction, since the sentinel can no longer reach this value at all.
   const showSidecarUrl =
     values.backend === "sidecar" ||
     (!values.backend && status.activeBackend === "sidecar");
@@ -926,10 +953,10 @@ function SelfHostedSandboxView({
         }
       >
         <DetailList>
-          {/* `mono` is reserved for real backend ids. A null renders as worded
-              destructive text instead, so the outage can never be mistaken for
-              one more id in the same monospace slot — the exact misreading
-              #4837 is about. */}
+          {/* In this detail list `mono` is reserved for values that ARE ids. A
+              null renders as worded destructive text instead, so the outage can
+              never be mistaken for one more id in the same monospace slot — the
+              exact misreading #4837 is about. */}
           <DetailRow
             label="Active"
             value={

--- a/packages/web/src/app/admin/sandbox/page.tsx
+++ b/packages/web/src/app/admin/sandbox/page.tsx
@@ -399,12 +399,15 @@ export function SaasSandboxView({
   // Collapsed to one value rather than an `isActive` + `isDown` pair so
   // "selected but down" cannot be spelled as `{ isActive: false, isDown: true }`
   // — an incoherent card the type system would otherwise permit.
+  //
+  // `down` is checked FIRST and independently of selection. The card offers
+  // "follow the platform default"; if that default constructs nothing the option
+  // is down whether or not this workspace currently sits on it. Gating down-ness
+  // on selection left the un-selected case reading "Available" with a live
+  // "Use this" button — one click moving the workspace off a working BYOC
+  // backend and onto the outage.
   const managedState: ManagedState =
-    isManagedSelected && status.platformDefault === null
-      ? "down"
-      : isManagedSelected
-        ? "live"
-        : "available";
+    status.platformDefault === null ? "down" : isManagedSelected ? "live" : "available";
 
   return (
     <>
@@ -825,7 +828,7 @@ type SelfHostedFormValues = {
  * Exported for `__tests__/fail-closed-outage.test.tsx` — this view owns the row
  * #4837 is literally named after (`Active: fail-closed` in the monospace slot),
  * and self-hosted reaches fail-closed through the `ATLAS_SANDBOX=nsjail` pin
- * with no usable binary (#4829). Same footing as `SaasSandboxView` below.
+ * with no usable binary (#4829). Same footing as `SaasSandboxView` above.
  */
 export function SelfHostedSandboxView({
   onSelectBackend,
@@ -953,10 +956,10 @@ export function SelfHostedSandboxView({
         }
       >
         <DetailList>
-          {/* In this detail list `mono` is reserved for values that ARE ids. A
-              null renders as worded destructive text instead, so the outage can
-              never be mistaken for one more id in the same monospace slot — the
-              exact misreading #4837 is about. */}
+          {/* `mono` marks machine literals (ids, URLs). A null renders as worded
+              destructive text instead, so the outage can never be mistaken for
+              one more id in the same monospace slot — the exact misreading
+              #4837 is about. */}
           <DetailRow
             label="Active"
             value={

--- a/packages/web/src/app/admin/sandbox/page.tsx
+++ b/packages/web/src/app/admin/sandbox/page.tsx
@@ -12,6 +12,7 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -45,6 +46,7 @@ import {
   SANDBOX_PROVIDER_BACKEND_IDS,
   SandboxStatusSchema,
   type SandboxConnectedProvider as ConnectedProvider,
+  type SandboxFailClosed,
   type SandboxProviderKey,
   type SandboxStatus,
 } from "@/ui/lib/admin-schemas";
@@ -58,6 +60,7 @@ import {
   Cloud,
   Cpu,
   Loader2,
+  OctagonX,
   Plus,
   RotateCcw,
   Save,
@@ -149,6 +152,66 @@ function StatusPill({ kind, label }: { kind: StatusKind; label: string }) {
   );
 }
 
+// ── Fail-closed outage ────────────────────────────────────────────
+
+/**
+ * The deployment's sandbox plan constructs nothing, so explore refuses every
+ * request. Presented as an OUTAGE, above both views, because that is what it is
+ * — this is the page an operator opens to diagnose sandboxing, and before #4837
+ * the state arrived here as the string `"fail-closed"` rendered in the same
+ * monospace "Active" slot as `vercel-sandbox`, reading as one more backend id.
+ *
+ * Reachable in SaaS production, not just in theory: `deploy/api/atlas.config.ts`
+ * pins `priority: ["vercel-sandbox"]` with no `just-bash` on staging and all
+ * three prod regions, and `VERCEL_TOKEN` is a per-service Railway secret that
+ * shared vars do not inherit — drop it on one regional service and that region
+ * is here.
+ *
+ * `remediation` is rendered verbatim, never paraphrased or supplemented: the
+ * server composed it from the resolved plan, so it names the pinned backend and
+ * the credential it actually needs. Local copy would either duplicate that
+ * derivation or regress to the generic "install nsjail" advice that a pin
+ * excluding nsjail makes impossible to act on (#4828).
+ *
+ * Exported for `__tests__/fail-closed-outage.test.tsx`, on the same footing as
+ * `SaasSandboxView` below: it renders from the page shell (above BOTH views), so
+ * reaching it through the page would mean mocking the fetch and deploy-mode
+ * hooks to assert copy that has nothing to do with either.
+ */
+export function SandboxOutageNotice({
+  failClosed,
+  workspaceStillRunning,
+}: {
+  failClosed: SandboxFailClosed;
+  /**
+   * A workspace BYOC override resolved despite the platform outage. It sits
+   * ahead of the platform plan, so this workspace's explore still works — the
+   * deployment default is what is down. Saying "every request is refused" here
+   * would be a false alarm, and an operator who dismisses one alarm as noise
+   * dismisses the next one too.
+   */
+  workspaceStillRunning: boolean;
+}) {
+  return (
+    <Alert variant="destructive" role="alert">
+      <OctagonX />
+      <AlertTitle>
+        {workspaceStillRunning
+          ? "Platform sandbox unavailable — this workspace is running on its own backend"
+          : "Explore tool unavailable — every request is refused"}
+      </AlertTitle>
+      <AlertDescription>
+        <p>
+          {workspaceStillRunning
+            ? "No platform sandbox backend can be constructed on this deployment. This workspace's own connected backend still runs, but any workspace falling back to the platform default has no working sandbox."
+            : "No sandbox backend can be constructed on this deployment, and it is configured to refuse rather than run unsandboxed. Explore tool calls fail until this is fixed."}
+        </p>
+        <p className="font-mono text-xs leading-relaxed">{failClosed.remediation}</p>
+      </AlertDescription>
+    </Alert>
+  );
+}
+
 // ── Page ──────────────────────────────────────────────────────────
 
 export default function SandboxPage() {
@@ -235,6 +298,15 @@ export default function SandboxPage() {
               onRetry={clearMutationError}
             />
 
+            {/* Above BOTH views: the outage is deploy-mode-independent, and the
+                SaaS view is where it is actually reachable in production. */}
+            {data?.failClosed && (
+              <SandboxOutageNotice
+                failClosed={data.failClosed}
+                workspaceStillRunning={data.activeBackend !== null}
+              />
+            )}
+
             {data &&
               (isSaas ? (
                 <SaasSandboxView
@@ -301,10 +373,17 @@ export function SaasSandboxView({
   saving: boolean;
 }) {
   const connected = status.connectedProviders;
-  // Managed is the active card whenever no BYOC provider row is live —
+  // Managed is the SELECTED card whenever no BYOC provider row is live —
   // `isActive` is server-derived in backend-id vocabulary (#3375), so this
   // can't disagree with the runtime resolution.
-  const isManagedActive = !connected.some((p) => p.isActive);
+  const isManagedSelected = !connected.some((p) => p.isActive);
+  // Selected is not the same as running. "Managed" means *follow the platform
+  // default*, and a null `platformDefault` is the deployment saying it has no
+  // default to follow (#4837). Without this split, the SaaS view — the one that
+  // never rendered `activeBackend` at all, so the issue's `Active: fail-closed`
+  // row could not even warn here — showed "Atlas Cloud Sandbox · Live" on a
+  // region where explore was refusing every request.
+  const isManagedDown = isManagedSelected && status.platformDefault === null;
 
   return (
     <>
@@ -314,7 +393,8 @@ export function SaasSandboxView({
           description="Atlas-hosted sandbox. No setup — always available."
         />
         <ManagedSandboxShell
-          isActive={isManagedActive}
+          isActive={isManagedSelected}
+          isDown={isManagedDown}
           // "Managed" means *follow the platform default* (the SaaS
           // `vercel-sandbox` pin in deploy/api/atlas.config.ts), so it
           // clears the workspace override rather than writing a value —
@@ -364,14 +444,26 @@ export function SaasSandboxView({
 
 function ManagedSandboxShell({
   isActive,
+  isDown,
   onSelect,
   saving,
 }: {
   isActive: boolean;
+  /**
+   * Selected but not running — the platform default failed closed (#4837).
+   * Only meaningful together with `isActive`; the caller derives it that way.
+   * "Live" and "Down" are the two readings this card must never confuse, so the
+   * down state wins over the active state everywhere below.
+   */
+  isDown: boolean;
   onSelect: () => Promise<unknown>;
   saving: boolean;
 }) {
-  const status: StatusKind = isActive ? "connected" : "ready";
+  const status: StatusKind = isDown
+    ? "unavailable"
+    : isActive
+      ? "connected"
+      : "ready";
   return (
     <Shell
       icon={Cloud}
@@ -379,14 +471,18 @@ function ManagedSandboxShell({
       description="Managed Firecracker microVM with network isolation. Recommended for most workspaces."
       status={status}
       trailing={
-        isActive ? (
+        isDown ? (
+          <StatusPill kind="unavailable" label="Down" />
+        ) : isActive ? (
           <StatusPill kind="connected" label="Live" />
         ) : (
           <StatusPill kind="ready" label="Available" />
         )
       }
       actions={
-        !isActive && (
+        // No "Use this" while it is down: selecting the platform default is
+        // exactly what is already in effect and broken.
+        !isActive && !isDown && (
           <Button size="sm" onClick={onSelect} disabled={saving}>
             {saving && <Loader2 className="mr-1.5 size-3.5 animate-spin" />}
             Use this
@@ -394,7 +490,13 @@ function ManagedSandboxShell({
         )
       }
     >
-      {isActive ? null : (
+      {isDown ? (
+        <p className="text-xs text-destructive">
+          This deployment has no working sandbox backend — see the outage above.
+          Connect your own cloud below to restore the explore tool for this
+          workspace.
+        </p>
+      ) : isActive ? null : (
         <p className="text-xs text-muted-foreground">
           Switch back here anytime — no credentials required.
         </p>
@@ -735,11 +837,24 @@ function SelfHostedSandboxView({
   if (!status || !fields || !values) return null;
 
   const availableBackends = status.availableBackends.filter((b) => b.available);
+  // `activeBackend` is `string | null`, so a fail-closed deployment can no
+  // longer match a backend id here — the comparison audit AC3 asks for. It was
+  // already correct by accident (`"fail-closed" !== "sidecar"`); it is now
+  // correct by construction, and the same holds for every other id comparison
+  // on this page.
   const showSidecarUrl =
     values.backend === "sidecar" ||
     (!values.backend && status.activeBackend === "sidecar");
   const hasOverride = Boolean(status.workspaceOverride);
-  const shellStatus: StatusKind = hasOverride ? "connected" : "ready";
+  // A null `activeBackend` is this workspace's explore being down, and it must
+  // outrank "Override"/"Default" — those describe which knob is in effect, which
+  // is not the operator's problem when nothing runs.
+  const isDown = status.activeBackend === null;
+  const shellStatus: StatusKind = isDown
+    ? "unavailable"
+    : hasOverride
+      ? "connected"
+      : "ready";
 
   return (
     <section>
@@ -753,13 +868,15 @@ function SelfHostedSandboxView({
         description={
           hasOverride
             ? `This workspace overrides the platform default.`
-            : `Using the platform default (${status.platformDefault}).`
+            : status.platformDefault === null
+              ? `The platform default has no usable backend, so explore requests are refused.`
+              : `Using the platform default (${status.platformDefault}).`
         }
         status={shellStatus}
         trailing={
           <StatusPill
             kind={shellStatus}
-            label={hasOverride ? "Override" : "Default"}
+            label={isDown ? "Down" : hasOverride ? "Override" : "Default"}
           />
         }
         actions={
@@ -809,8 +926,28 @@ function SelfHostedSandboxView({
         }
       >
         <DetailList>
-          <DetailRow label="Active" value={status.activeBackend} mono />
-          <DetailRow label="Platform default" value={status.platformDefault} mono />
+          {/* `mono` is reserved for real backend ids. A null renders as worded
+              destructive text instead, so the outage can never be mistaken for
+              one more id in the same monospace slot — the exact misreading
+              #4837 is about. */}
+          <DetailRow
+            label="Active"
+            value={
+              status.activeBackend ?? (
+                <span className="text-destructive">None — explore refuses every request</span>
+              )
+            }
+            mono={status.activeBackend !== null}
+          />
+          <DetailRow
+            label="Platform default"
+            value={
+              status.platformDefault ?? (
+                <span className="text-destructive">None — fails closed</span>
+              )
+            }
+            mono={status.platformDefault !== null}
+          />
           {status.workspaceSidecarUrl && (
             <DetailRow
               label="Sidecar URL"
@@ -828,7 +965,9 @@ function SelfHostedSandboxView({
             </SelectTrigger>
             <SelectContent>
               <SelectItem value="__default__">
-                Use platform default ({status.platformDefault})
+                {status.platformDefault === null
+                  ? "Use platform default (none — fails closed)"
+                  : `Use platform default (${status.platformDefault})`}
               </SelectItem>
               {availableBackends.map((b) => (
                 <SelectItem key={b.id} value={b.id}>

--- a/packages/web/src/ui/lib/admin-schemas.ts
+++ b/packages/web/src/ui/lib/admin-schemas.ts
@@ -565,6 +565,7 @@ export {
   SandboxStatusSchema,
   type SandboxProviderKey,
   type SandboxConnectedProvider,
+  type SandboxFailClosed,
   type SandboxStatus,
 } from "@useatlas/schemas";
 


### PR DESCRIPTION
`getExploreBackendType()` can return `"fail-closed"` since #4835, and `/admin/sandbox` rendered it verbatim — on the page whose entire purpose is diagnosing sandboxing.

This is a reachable SaaS production state, not a theoretical one: `deploy/api/atlas.config.ts` pins `sandbox: { priority: ["vercel-sandbox"] }` with no `just-bash` on staging and all three prod regions, and `VERCEL_TOKEN` is a per-service Railway secret that shared vars do not inherit (#4828).

**Both views were wrong, and the SaaS one was worse.** Self-hosted showed `Active: fail-closed` in the same monospace slot that otherwise holds `vercel-sandbox`. The SaaS view never rendered `activeBackend` at all — it derived "Managed is live" from `!connectedProviders.some(isActive)`, so a region refusing every explore request displayed **"Atlas Cloud Sandbox · Live"**.

## Acceptance criteria

- [x] **`fail-closed` distinguishable at the TYPE LEVEL from a backend id.** Backend ids are open (`z.string()` — plugins register their own), so #4835's closed-enum trick wasn't available. Instead the sentinel leaves the id field entirely: `activeBackend`/`platformDefault` become `string | null`, with a separate optional `failClosed: { remediation }`.
  Nullability alone does **not** make skipping the narrowing a compile error — a string-literal union assigns freely to `string | null`, and an early version of this PR claimed otherwise. The real guard is `platformResolution satisfies SandboxBackendName | "plugin"`, which makes a *future* non-backend member a compile error at the admin route, joining `health.ts` and `startup.ts`. Verified by temporarily widening `ExploreBackendType`: 4 sites break, including this one.
- [x] **Presented as an OUTAGE.** Destructive banner above both views; managed card reads **Down**, never Live; self-hosted rows say "None — explore refuses every request" instead of rendering blank or `(null)`.
- [x] **Remediation names the actual cause.** Composed server-side by the existing `formatSandboxFailClosed`, so it names the pinned backend and `VERCEL_TOKEN` — never the generic "install nsjail" advice the pin makes impossible to act on.
- [x] **Audited every consumer comparing `activeBackend` against a backend id.** The one comparison (`page.tsx`, `=== "sidecar"`) was safe by accident; it is now safe by construction. The audit also surfaced three *affordances* that silently assumed a working platform default — see below.
- [x] **Tests for the payload + the runtime consequence.** Plus the outage's runtime meaning: `runSandboxPlan` on the same inputs yields `fail-closed`, with a negative control proving a pin that *does* include `just-bash` yields `exhausted` instead.
- [x] **Boot, `/api/health` and `/admin/sandbox` agree.** New shared `describeSandboxFailClosed` seam; boot and admin are byte-pinned to it from both sides. `/api/health` deliberately keeps its own hedged wording and no remediation — it agrees on *state*, which is the part that was drifting.

## Beyond the letter of the issue

The consumer audit turned up affordances that were wrong in the same way the render was, one of them worse than the original bug:

- **The BYOC disconnect dialog said "execution will fall back to Atlas Cloud Sandbox."** When the platform default is fail-closed that is false, and the live BYOC backend is the only thing keeping that workspace's explore alive. Not a confusing label but an active reassurance, on the click that drops the workspace into the outage.
- **The managed card offered "Use this"** while the default constructed nothing — one click moving a working workspace onto the outage.
- **Self-hosted "Reset"** clears the override onto the same broken default, where the Select beside it is labelled "(none — fails closed)".

## Notes

- **`fail-closed` genuinely refuses; it does not degrade to bash.** I verified this at runtime because the whole framing depends on it: a pin without `just-bash` gets `onExhausted: "fail-closed"` → outcome `kind: "fail-closed"` → `explore.ts` **throws**. The `case "exhausted"` arm that returns `createBashBackend` is reachable only from the default chain or a pin that explicitly opts in. (A comment in `saas-guards.ts` on `main` claims the opposite — out of scope here, routed to #4834.)
- **`failureDetail` is log-only.** It was briefly interpolated into the remediation, which reaches an admin response *and* the unauthenticated `/api/health` via startup warnings. Scrubbing happens at both log sites; the seam's catch arm stays import-free so it cannot itself throw (`Effect.promise` turns a rejection into a 500 on the outage page).
- **No schema `.refine()` for the `failClosed` ⟺ `platformDefault === null` invariant** — the web parses this schema client-side, so a refine could only ever fail the diagnostic page closed. The producer makes it true by construction instead (one `reportedPlatformDefault` binding).
- **Healthy payloads are unchanged**, so an older web bundle keeps parsing; only the already-broken payload has a new shape.
- `explore.ts` touched only to correct a docblock this PR falsified (it named `admin-sandbox.ts` as untreated). No semantic changes there — #4834 owns that territory.

## Review

Internal `/review-panel`: **3 rounds to clean.** Round 1 found the compile-error claim was false (two reviewers verified with `tsc`); round 2 found a log-scrubbing regression and that deleting the entire banner left the suite green; round 3 found the disconnect-dialog copy. Every fix was verified by mutation — revert the behavior, confirm the test goes red.

`/ci`: all 32 gates green.

Closes #4837
