### PR TITLE
chore(types): bump @useatlas/types to 0.6.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -452,7 +452,7 @@
     },
     "packages/types": {
       "name": "@useatlas/types",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "devDependencies": {
         "@typescript/native-preview": "^7.0.0-dev.20260623.1",
       },

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useatlas/types",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Shared types for the Atlas text-to-SQL agent",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Step 1 of the publish sequence: bump the package's own version only.

## Why

#4836 (PR #4848) moved the provenance attribution triple (`actor`, `sourceId`, `occurredAt`) behind a discriminated `attribution` union on `BrainFactProvenanceView`. The version was not bumped at the time — `/release` and `/publish` own the version trains — so npm's `0.5.0` and this repo's `0.5.0` have been describing **different shapes**. This ends that drift.

Minor bump: at `0.x` a breaking change takes the minor slot.

## Deliberately NOT in this PR

Dependency refs stay where they are:

| ref | pin | effect |
|---|---|---|
| `packages/sdk`, `packages/react` | `^0.1.0` | minor-locked, resolves `0.1.x` — unaffected |
| `create-atlas/templates/{docker,nextjs-standalone}` | `^0.5.0` | minor-locked at `0.x`, keeps resolving `0.5.0` |
| `plugins/chat` (peer) | `>=0.1.6` | satisfied by `0.6.0` |

Bumping refs before the publish lands is the documented failure mode — scaffolds fail `npm install` on a version that isn't on the registry yet, and Deploy Validation goes red. Refs are a separate follow-up **after** the tag publishes.

## Guards

- `check-unpublished-versions` → `⏳ @useatlas/types@0.6.0 not yet on npm (latest: 0.5.0) — bump introduced by this change; tag it after merge.` (the bumping-PR exemption, working as designed)
- `check-published-symbols` → `@useatlas/types@^0.5.0 → 0.5.0... ok` — scaffold-bound source uses no value export that only exists in 0.6.0, confirming the templates are safe to leave pinned.

## After merge

`git tag types-v0.6.0 && git push origin types-v0.6.0` (one tag — never more than 3 per push), then verify `publish.yml` and npm.