### PR TITLE
fix(api): let a deployment declare it expects no datasource

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,6 +73,15 @@ ATLAS_DATASOURCE_URL=postgresql://atlas:atlas@localhost:5432/atlas_demo
 # ATLAS_ES_AWS_REGION=                         # Selects AWS SigV4 (Amazon OpenSearch Service); keys from AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY (+ AWS_SESSION_TOKEN)
 # ATLAS_ES_AWS_SERVICE=                        # SigV4 service code (default "es"; "aoss" for OpenSearch Serverless)
 # ATLAS_ES_ENGINE=                             # Optional engine override: elasticsearch | opensearch (wins over the URL scheme)
+# ATLAS_DATASOURCE_EXPECTED=false              # Declare that this deployment intentionally has NO process-level analytics
+#                                              # datasource — a multi-tenant deploy whose connections live per workspace, or a
+#                                              # knowledge-only / brain-only box. /health then reports the datasource component
+#                                              # as "disabled" without degrading the top-level status. Leave it UNSET on a
+#                                              # deployment that should have one: undeclared means a missing ATLAS_DATASOURCE_URL
+#                                              # still degrades /health, which is how a misconfiguration stays visible. Set it
+#                                              # per service — it overrides `datasourceExpected` in atlas.config.ts, which several
+#                                              # services may share. It never silences a datasource that IS configured and failing
+#                                              # (that is still error + 503).
 # NOTE: ATLAS_ES_API_KEY is the canonical name. The atlas.config.ts examples wire the same var into the
 # plugin's `apiKey:` field (elasticsearchPlugin({ apiKey: process.env.ATLAS_ES_API_KEY! })), so one
 # variable covers BOTH the CLI auto-read path (above) and an explicit static config.

--- a/.env.example
+++ b/.env.example
@@ -63,6 +63,12 @@ DATABASE_URL=postgresql://atlas:atlas@localhost:5432/atlas
 # Pre-configured for the demo dataset seeded by `bun run db:up`.
 # When atlas.config.ts defines datasources, this env var is not needed.
 ATLAS_DATASOURCE_URL=postgresql://atlas:atlas@localhost:5432/atlas_demo
+# ATLAS_DATASOURCE_EXPECTED=false              # Set ONLY on a deployment that intentionally has no analytics datasource (a
+#                                             # multi-tenant deploy whose connections live per workspace, a knowledge-only box).
+#                                             # /health then stops degrading over the missing datasource. Leave it UNSET
+#                                             # otherwise — that is what keeps a forgotten ATLAS_DATASOURCE_URL visible. Set it
+#                                             # per service; it overrides `datasourceExpected` in atlas.config.ts. See
+#                                             # docs/deployment/multi-datasource for what it does NOT do.
 # ATLAS_DATASOURCE_URL=mysql://user:pass@localhost:3306/mydb
 # ATLAS_DATASOURCE_URL=elasticsearch://my-cluster.es.io:9243   # Elasticsearch (HTTPS; append ?ssl=false for a local cluster). opensearch://host:9200 selects the OpenSearch engine
 # ATLAS_ES_CLOUD_ID=                           # Elastic Cloud ID (<name>:<base64>) — endpoint alternative to the elasticsearch:// URL above
@@ -73,15 +79,6 @@ ATLAS_DATASOURCE_URL=postgresql://atlas:atlas@localhost:5432/atlas_demo
 # ATLAS_ES_AWS_REGION=                         # Selects AWS SigV4 (Amazon OpenSearch Service); keys from AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY (+ AWS_SESSION_TOKEN)
 # ATLAS_ES_AWS_SERVICE=                        # SigV4 service code (default "es"; "aoss" for OpenSearch Serverless)
 # ATLAS_ES_ENGINE=                             # Optional engine override: elasticsearch | opensearch (wins over the URL scheme)
-# ATLAS_DATASOURCE_EXPECTED=false              # Declare that this deployment intentionally has NO process-level analytics
-#                                              # datasource — a multi-tenant deploy whose connections live per workspace, or a
-#                                              # knowledge-only / brain-only box. /health then reports the datasource component
-#                                              # as "disabled" without degrading the top-level status. Leave it UNSET on a
-#                                              # deployment that should have one: undeclared means a missing ATLAS_DATASOURCE_URL
-#                                              # still degrades /health, which is how a misconfiguration stays visible. Set it
-#                                              # per service — it overrides `datasourceExpected` in atlas.config.ts, which several
-#                                              # services may share. It never silences a datasource that IS configured and failing
-#                                              # (that is still error + 503).
 # NOTE: ATLAS_ES_API_KEY is the canonical name. The atlas.config.ts examples wire the same var into the
 # plugin's `apiKey:` field (elasticsearchPlugin({ apiKey: process.env.ATLAS_ES_API_KEY! })), so one
 # variable covers BOTH the CLI auto-read path (above) and an explicit static config.

--- a/apps/docs/content/docs/deployment/multi-datasource.mdx
+++ b/apps/docs/content/docs/deployment/multi-datasource.mdx
@@ -395,6 +395,44 @@ view) but does **not** change the aggregate `status` or trip a 503. This keeps o
 workspace's misconfigured connection from pulling the whole shared region out of
 the load balancer.
 
+### Deployments with no datasource at all
+
+Some deployments legitimately have no process-level analytics datasource: a
+multi-tenant deploy where every connection is registered per workspace, or a
+knowledge-only / brain-only box that answers from the Knowledge Base and Company
+Brain. By default Atlas reports a missing datasource as `degraded` — that is what
+makes a forgotten `ATLAS_DATASOURCE_URL` visible instead of silent.
+
+Declare the absence so the aggregate status stays usable:
+
+```bash
+ATLAS_DATASOURCE_EXPECTED=false
+```
+
+or, in `atlas.config.ts`:
+
+```ts
+export default defineConfig({
+  datasourceExpected: false,
+});
+```
+
+`/api/health` then reports `components.datasource.status: "disabled"` — the state
+that means *intentionally absent* — and leaves the top-level `status` at `ok`.
+Three things this deliberately does **not** do:
+
+- It does not infer intent from the absence. Leave it unset and a missing
+  datasource still degrades, exactly as before.
+- It does not silence a datasource that **is** configured and failing. That is
+  still `status: "error"` + HTTP 503, and the region still leaves the load
+  balancer.
+- It does not disable anything. `ATLAS_DATASOURCE_EXPECTED` only describes what
+  this deployment expects; it never changes which connections are registered.
+
+Set the env var per service when several services share one `atlas.config.ts` —
+it overrides the config field in both directions, so one shared file cannot
+declare an expectation on another service's behalf.
+
 ---
 
 ## Troubleshooting

--- a/apps/docs/content/docs/deployment/multi-datasource.mdx
+++ b/apps/docs/content/docs/deployment/multi-datasource.mdx
@@ -412,14 +412,19 @@ ATLAS_DATASOURCE_EXPECTED=false
 or, in `atlas.config.ts`:
 
 ```ts
+import { defineConfig } from "@atlas/api/lib/config";
+
 export default defineConfig({
   datasourceExpected: false,
 });
 ```
 
-`/api/health` then reports `components.datasource.status: "disabled"` — the state
-that means *intentionally absent* — and leaves the top-level `status` at `ok`.
-Three things this deliberately does **not** do:
+The missing datasource then stops degrading the top-level `status` (anything else
+unhealthy still does). `components.datasource.status` stays `"disabled"`, which
+has always meant simply *no datasource is configured* — an undeclared deployment
+reports `"disabled"` too. What changes is that the component stops carrying the
+`MISSING_DATASOURCE_URL` code, so the admin dashboard no longer shows an error
+for a deliberate state. Four things this deliberately does **not** do:
 
 - It does not infer intent from the absence. Leave it unset and a missing
   datasource still degrades, exactly as before.
@@ -428,6 +433,18 @@ Three things this deliberately does **not** do:
   balancer.
 - It does not disable anything. `ATLAS_DATASOURCE_EXPECTED` only describes what
   this deployment expects; it never changes which connections are registered.
+- It does not clear the other signals. `checks.datasource` still reports
+  `{ "status": "not_configured" }`, and a deployment with neither
+  `ATLAS_DATASOURCE_URL` nor `DATABASE_URL` still carries the startup warning
+  "ATLAS_DATASOURCE_URL is not set…" in `warnings[]`. Both are accurate and stay
+  visible by design; only the aggregate `status` changes.
+
+`ATLAS_DEMO_DATA=true` overrides the declaration — it is itself a statement that
+this deployment expects a datasource, so a demo database that never provisioned
+still degrades. Any value of `ATLAS_DATASOURCE_EXPECTED` other than
+`true`/`false`/`1`/`0` is treated as a failed declaration: Atlas logs a warning
+and falls back to expecting a datasource, so a typo leaves `/health` noisy rather
+than silently green.
 
 Set the env var per service when several services share one `atlas.config.ts` —
 it overrides the config field in both directions, so one shared file cannot

--- a/packages/api/src/api/__tests__/health.test.ts
+++ b/packages/api/src/api/__tests__/health.test.ts
@@ -564,8 +564,7 @@ describe("GET /api/health — internal DB / deploy mode contract", () => {
       { code: "INTERNAL_DB_UNREACHABLE", message: "internal db down" },
     ]);
     const config = await import("@atlas/api/lib/config");
-    // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- partial ResolvedConfig is sufficient for the deployMode path
-    config._setConfigForTest({ deployMode: "saas" } as any);
+    config._setConfigForTest({ deployMode: "saas" });
 
     const response = await app.fetch(healthRequest());
     expect(response.status).toBe(503);
@@ -580,8 +579,7 @@ describe("GET /api/health — internal DB / deploy mode contract", () => {
     internalDBQueryImpl = () => Promise.reject(new Error("connection refused"));
     mockValidateEnvironment.mockResolvedValue([]);
     const config = await import("@atlas/api/lib/config");
-    // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- partial ResolvedConfig is sufficient for the deployMode path
-    config._setConfigForTest({ deployMode: "saas" } as any);
+    config._setConfigForTest({ deployMode: "saas" });
 
     const response = await app.fetch(healthRequest());
     expect(response.status).toBe(503);
@@ -610,8 +608,7 @@ describe("GET /api/health — internal DB / deploy mode contract", () => {
       { code: "INTERNAL_DB_UNREACHABLE", message: "internal db down" },
     ]);
     const config = await import("@atlas/api/lib/config");
-    // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- partial ResolvedConfig is sufficient for the deployMode path
-    config._setConfigForTest({ deployMode: "self-hosted" } as any);
+    config._setConfigForTest({ deployMode: "self-hosted" });
 
     const response = await app.fetch(healthRequest());
     expect(response.status).toBe(200);
@@ -631,8 +628,7 @@ describe("GET /api/health — internal DB / deploy mode contract", () => {
       deployModeDowngraded: {
         reason: 'atlas.config.ts requested deployMode "saas" but enterprise is not enabled — see #1978',
       },
-      // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- partial ResolvedConfig is sufficient for this path
-    } as any);
+    });
 
     const response = await app.fetch(healthRequest());
     expect(response.status).toBe(200);
@@ -646,8 +642,7 @@ describe("GET /api/health — internal DB / deploy mode contract", () => {
   it("omits deployModeDowngraded on a normal boot (#3184)", async () => {
     mockValidateEnvironment.mockResolvedValue([]);
     const config = await import("@atlas/api/lib/config");
-    // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- partial ResolvedConfig is sufficient for the deployMode path
-    config._setConfigForTest({ deployMode: "self-hosted" } as any);
+    config._setConfigForTest({ deployMode: "self-hosted" });
 
     const response = await app.fetch(healthRequest());
     const body = (await response.json()) as Record<string, unknown>;
@@ -757,17 +752,55 @@ describe("GET /api/health — datasource expectation declaration (#4854)", () =>
     expect(checks.datasource?.status).toBe("not_configured");
   });
 
-  it("an unrecognized declaration is treated as undeclared — still degrades", async () => {
+  it("an unrecognized declaration still degrades, and says so in warnings[]", async () => {
     process.env.ATLAS_DATASOURCE_EXPECTED = "nope";
 
     const response = await app.fetch(healthRequest());
     const body = (await response.json()) as Record<string, unknown>;
 
     expect(body.status).toBe("degraded");
+    // The typo has to be visible on the surface the operator set it from — a
+    // once-per-process log line has scrolled away by the time they look.
+    const warnings = body.warnings as string[];
+    expect(warnings.some((w) => w.includes("ATLAS_DATASOURCE_EXPECTED"))).toBe(true);
+    // …without echoing the operator-supplied value: /health is public.
+    expect(warnings.some((w) => w.includes("nope"))).toBe(false);
   });
 
-  // #1981 — the LB-eviction path. A CONFIGURED datasource that fails its probe
-  // must still 503, or the region stays in rotation while queries are dead.
+  it("adds no expectation warning when the declaration parses", async () => {
+    process.env.ATLAS_DATASOURCE_EXPECTED = "false";
+
+    const response = await app.fetch(healthRequest());
+    const body = (await response.json()) as Record<string, unknown>;
+
+    expect(body.warnings).toBeUndefined();
+  });
+
+  // The declaration changes the ROLLUP, not the other signals. A deployment
+  // with neither URL still carries the startup warning, and it must keep
+  // carrying it: suppressing warnings to make a dashboard look clean is the
+  // failure mode #4854 is about, pointed the other way.
+  it("does not suppress the startup warning on a declared-absent deployment", async () => {
+    process.env.ATLAS_DATASOURCE_EXPECTED = "false";
+    delete process.env.DATABASE_URL;
+    mockValidateEnvironment.mockResolvedValue([]);
+    mockGetStartupWarnings.mockReturnValue([
+      "ATLAS_DATASOURCE_URL is not set. Atlas can start without an analytics datasource, but queries will not work.",
+    ]);
+
+    const response = await app.fetch(healthRequest());
+    const body = (await response.json()) as Record<string, unknown>;
+
+    expect(body.status).toBe("ok");
+    expect(body.warnings).toEqual([
+      "ATLAS_DATASOURCE_URL is not set. Atlas can start without an analytics datasource, but queries will not work.",
+    ]);
+  });
+
+  // The LB-eviction path (#1981 for the internal-DB half, #3907 for the
+  // primary-datasource isolation contract). A CONFIGURED datasource that fails
+  // its probe must still 503, or the region stays in rotation while queries are
+  // dead.
   it("a configured datasource that fails still reports error + 503", async () => {
     process.env.ATLAS_DATASOURCE_URL = "postgresql://test:test@localhost:5432/test";
     mockValidateEnvironment.mockResolvedValue([]);
@@ -825,8 +858,7 @@ describe("GET /api/health — datasource expectation declaration (#4854)", () =>
 
   it("accepts the declaration from atlas.config.ts", async () => {
     const config = await import("@atlas/api/lib/config");
-    // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- partial ResolvedConfig is sufficient for this path
-    config._setConfigForTest({ datasourceExpected: false } as any);
+    config._setConfigForTest({ datasourceExpected: false });
 
     const response = await app.fetch(healthRequest());
     const body = (await response.json()) as Record<string, unknown>;
@@ -840,8 +872,7 @@ describe("GET /api/health — datasource expectation declaration (#4854)", () =>
   it("ATLAS_DATASOURCE_EXPECTED=true overrides a config file that says false", async () => {
     process.env.ATLAS_DATASOURCE_EXPECTED = "true";
     const config = await import("@atlas/api/lib/config");
-    // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- partial ResolvedConfig is sufficient for this path
-    config._setConfigForTest({ datasourceExpected: false } as any);
+    config._setConfigForTest({ datasourceExpected: false });
 
     const response = await app.fetch(healthRequest());
     const body = (await response.json()) as Record<string, unknown>;
@@ -948,8 +979,7 @@ describe("GET /api/health — plugin component", () => {
     // Plugin failures are observable in the dashboard but never page oncall.
     process.env.ATLAS_DEPLOY_MODE = "saas";
     const config = await import("@atlas/api/lib/config");
-    // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- partial ResolvedConfig is sufficient for the deployMode path
-    config._setConfigForTest({ deployMode: "saas" } as any);
+    config._setConfigForTest({ deployMode: "saas" });
 
     pluginDescribeImpl = () => [
       { id: "p1", types: ["action"], version: "1.0.0", name: "P1", status: "unhealthy", enabled: true },
@@ -1361,8 +1391,7 @@ describe("GET /api/health — backups component (#4457)", () => {
     // an overdue backup must never pull the region from the LB.
     process.env.ATLAS_DEPLOY_MODE = "saas";
     const config = await import("@atlas/api/lib/config");
-    // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- partial ResolvedConfig is sufficient for the deployMode path
-    config._setConfigForTest({ deployMode: "saas" } as any);
+    config._setConfigForTest({ deployMode: "saas" });
 
     backupHealthImpl = () =>
       Promise.resolve({

--- a/packages/api/src/api/__tests__/health.test.ts
+++ b/packages/api/src/api/__tests__/health.test.ts
@@ -655,6 +655,165 @@ describe("GET /api/health — internal DB / deploy mode contract", () => {
   });
 });
 
+// #4854 — a deployment with NO process-level analytics datasource degraded
+// forever, because the rollup could not tell an intentional absence (a
+// multi-tenant SaaS region, a knowledge-only self-host) from an operator who
+// forgot ATLAS_DATASOURCE_URL. The declaration fixes the first WITHOUT greening
+// the second — which is what the negative cases here pin.
+describe("GET /api/health — datasource expectation declaration (#4854)", () => {
+  const origDatasource = process.env.ATLAS_DATASOURCE_URL;
+  const origDatabaseUrl = process.env.DATABASE_URL;
+  const origExpected = process.env.ATLAS_DATASOURCE_EXPECTED;
+
+  // Staging's exact shape: DATABASE_URL set, ATLAS_DATASOURCE_URL unset, which
+  // makes checkDatasourceUrlPresence raise MISSING_DATASOURCE_URL as an ERROR
+  // (not a warning). So hasDsError is true here even though nothing is broken —
+  // the condition that made the `disabled` component carry an error code.
+  const MISSING_DS_DIAGNOSTIC = {
+    code: "MISSING_DATASOURCE_URL",
+    message: "DATABASE_URL is set but ATLAS_DATASOURCE_URL is not.",
+  };
+
+  beforeEach(() => {
+    delete process.env.ATLAS_DATASOURCE_URL;
+    delete process.env.ATLAS_DATASOURCE_EXPECTED;
+    process.env.DATABASE_URL = "postgresql://internal:internal@localhost:5432/atlas";
+    connMetadata = [];
+    pluginMetadata = [];
+    pluginDescribeImpl = () => [];
+    dsQueryImpl = () =>
+      Promise.resolve({ columns: ["?column?"], rows: [{ "?column?": 1 }] });
+    internalDBQueryImpl = () => Promise.resolve({ rows: [{ "?column?": 1 }] });
+    mockValidateEnvironment.mockReset();
+    mockValidateEnvironment.mockResolvedValue([MISSING_DS_DIAGNOSTIC]);
+    mockGetStartupWarnings.mockReset();
+    mockGetStartupWarnings.mockReturnValue([]);
+    backupHealthImpl = () => Promise.resolve({ expected: false });
+  });
+
+  afterEach(async () => {
+    if (origDatasource !== undefined) process.env.ATLAS_DATASOURCE_URL = origDatasource;
+    else delete process.env.ATLAS_DATASOURCE_URL;
+    if (origDatabaseUrl !== undefined) process.env.DATABASE_URL = origDatabaseUrl;
+    else delete process.env.DATABASE_URL;
+    if (origExpected !== undefined) process.env.ATLAS_DATASOURCE_EXPECTED = origExpected;
+    else delete process.env.ATLAS_DATASOURCE_EXPECTED;
+    const config = await import("@atlas/api/lib/config");
+    config._setConfigForTest(null);
+    const expectation = await import("@atlas/api/lib/db/datasource-expectation");
+    expectation._resetDatasourceExpectationWarning();
+    dsQueryImpl = () =>
+      Promise.resolve({ columns: ["?column?"], rows: [{ "?column?": 1 }] });
+  });
+
+  it("declared not-expected: component 'disabled' and the rollup stays ok", async () => {
+    process.env.ATLAS_DATASOURCE_EXPECTED = "false";
+
+    const response = await app.fetch(healthRequest());
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as Record<string, unknown>;
+
+    expect(body.status).toBe("ok");
+    const components = body.components as Record<string, Record<string, unknown>>;
+    expect(components.datasource?.status).toBe("disabled");
+  });
+
+  it("declared not-expected: the disabled component no longer carries MISSING_DATASOURCE_URL", async () => {
+    process.env.ATLAS_DATASOURCE_EXPECTED = "false";
+
+    const response = await app.fetch(healthRequest());
+    const body = (await response.json()) as Record<string, unknown>;
+    const components = body.components as Record<string, Record<string, unknown>>;
+
+    expect(components.datasource?.message).not.toBe("MISSING_DATASOURCE_URL");
+    expect(components.datasource?.message).toContain("none is expected");
+  });
+
+  // THE NEGATIVE. A fix that simply stopped counting a missing datasource would
+  // pass every positive test above and silently green a self-hosted box that
+  // meant to set ATLAS_DATASOURCE_URL. Intent must be declared, never inferred
+  // from the absence.
+  it("UNDECLARED with no datasource still degrades — unchanged from before #4854", async () => {
+    const response = await app.fetch(healthRequest());
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as Record<string, unknown>;
+
+    expect(body.status).toBe("degraded");
+    const components = body.components as Record<string, Record<string, unknown>>;
+    expect(components.datasource?.status).toBe("disabled");
+    // The undeclared absence is a finding, so it keeps the diagnostic code.
+    expect(components.datasource?.message).toBe("MISSING_DATASOURCE_URL");
+  });
+
+  it("an unrecognized declaration is treated as undeclared — still degrades", async () => {
+    process.env.ATLAS_DATASOURCE_EXPECTED = "nope";
+
+    const response = await app.fetch(healthRequest());
+    const body = (await response.json()) as Record<string, unknown>;
+
+    expect(body.status).toBe("degraded");
+  });
+
+  // #1981 — the LB-eviction path. A CONFIGURED datasource that fails its probe
+  // must still 503, or the region stays in rotation while queries are dead.
+  it("a configured datasource that fails still reports error + 503", async () => {
+    process.env.ATLAS_DATASOURCE_URL = "postgresql://test:test@localhost:5432/test";
+    mockValidateEnvironment.mockResolvedValue([]);
+    dsQueryImpl = () => Promise.reject(new Error("connection refused"));
+
+    const response = await app.fetch(healthRequest());
+    expect(response.status).toBe(503);
+    const body = (await response.json()) as Record<string, unknown>;
+
+    expect(body.status).toBe("error");
+    const components = body.components as Record<string, Record<string, unknown>>;
+    expect(components.datasource?.status).toBe("down");
+  });
+
+  // The declaration answers "is one expected here?", never "is the configured
+  // one healthy?". Declaring none expected while one IS configured and failing
+  // must not buy silence — otherwise the declaration becomes a mute switch for
+  // real outages.
+  it("declared not-expected CANNOT green a configured datasource that fails", async () => {
+    process.env.ATLAS_DATASOURCE_EXPECTED = "false";
+    process.env.ATLAS_DATASOURCE_URL = "postgresql://test:test@localhost:5432/test";
+    mockValidateEnvironment.mockResolvedValue([]);
+    dsQueryImpl = () => Promise.reject(new Error("connection refused"));
+
+    const response = await app.fetch(healthRequest());
+    expect(response.status).toBe(503);
+    const body = (await response.json()) as Record<string, unknown>;
+
+    expect(body.status).toBe("error");
+  });
+
+  it("accepts the declaration from atlas.config.ts", async () => {
+    const config = await import("@atlas/api/lib/config");
+    // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- partial ResolvedConfig is sufficient for this path
+    config._setConfigForTest({ datasourceExpected: false } as any);
+
+    const response = await app.fetch(healthRequest());
+    const body = (await response.json()) as Record<string, unknown>;
+
+    expect(body.status).toBe("ok");
+  });
+
+  // api-staging builds from the PROD atlas.config.ts (#3958), so the env var has
+  // to be able to override the shared file in BOTH directions — otherwise one
+  // service's declaration silently speaks for every service sharing the image.
+  it("ATLAS_DATASOURCE_EXPECTED=true overrides a config file that says false", async () => {
+    process.env.ATLAS_DATASOURCE_EXPECTED = "true";
+    const config = await import("@atlas/api/lib/config");
+    // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- partial ResolvedConfig is sufficient for this path
+    config._setConfigForTest({ datasourceExpected: false } as any);
+
+    const response = await app.fetch(healthRequest());
+    const body = (await response.json()) as Record<string, unknown>;
+
+    expect(body.status).toBe("degraded");
+  });
+});
+
 // #1987 — plugin healthcheck must surface in /health.
 // Plugin failures should NOT escalate to 503 (only datasource + SaaS internal-DB
 // do that). A degraded plugin is observable but does not page oncall.

--- a/packages/api/src/api/__tests__/health.test.ts
+++ b/packages/api/src/api/__tests__/health.test.ts
@@ -664,6 +664,8 @@ describe("GET /api/health — datasource expectation declaration (#4854)", () =>
   const origDatasource = process.env.ATLAS_DATASOURCE_URL;
   const origDatabaseUrl = process.env.DATABASE_URL;
   const origExpected = process.env.ATLAS_DATASOURCE_EXPECTED;
+  const origDemoData = process.env.ATLAS_DEMO_DATA;
+  const origDeployMode = process.env.ATLAS_DEPLOY_MODE;
 
   // Staging's exact shape: DATABASE_URL set, ATLAS_DATASOURCE_URL unset, which
   // makes checkDatasourceUrlPresence raise MISSING_DATASOURCE_URL as an ERROR
@@ -677,6 +679,8 @@ describe("GET /api/health — datasource expectation declaration (#4854)", () =>
   beforeEach(() => {
     delete process.env.ATLAS_DATASOURCE_URL;
     delete process.env.ATLAS_DATASOURCE_EXPECTED;
+    delete process.env.ATLAS_DEMO_DATA;
+    delete process.env.ATLAS_DEPLOY_MODE;
     process.env.DATABASE_URL = "postgresql://internal:internal@localhost:5432/atlas";
     connMetadata = [];
     pluginMetadata = [];
@@ -698,6 +702,10 @@ describe("GET /api/health — datasource expectation declaration (#4854)", () =>
     else delete process.env.DATABASE_URL;
     if (origExpected !== undefined) process.env.ATLAS_DATASOURCE_EXPECTED = origExpected;
     else delete process.env.ATLAS_DATASOURCE_EXPECTED;
+    if (origDemoData !== undefined) process.env.ATLAS_DEMO_DATA = origDemoData;
+    else delete process.env.ATLAS_DEMO_DATA;
+    if (origDeployMode !== undefined) process.env.ATLAS_DEPLOY_MODE = origDeployMode;
+    else delete process.env.ATLAS_DEPLOY_MODE;
     const config = await import("@atlas/api/lib/config");
     config._setConfigForTest(null);
     const expectation = await import("@atlas/api/lib/db/datasource-expectation");
@@ -743,6 +751,10 @@ describe("GET /api/health — datasource expectation declaration (#4854)", () =>
     expect(components.datasource?.status).toBe("disabled");
     // The undeclared absence is a finding, so it keeps the diagnostic code.
     expect(components.datasource?.message).toBe("MISSING_DATASOURCE_URL");
+    // The legacy `checks` surface is unchanged by the declaration in either
+    // direction — it has always reported the configuration fact, not intent.
+    const checks = body.checks as Record<string, Record<string, unknown>>;
+    expect(checks.datasource?.status).toBe("not_configured");
   });
 
   it("an unrecognized declaration is treated as undeclared — still degrades", async () => {
@@ -777,6 +789,30 @@ describe("GET /api/health — datasource expectation declaration (#4854)", () =>
   it("declared not-expected CANNOT green a configured datasource that fails", async () => {
     process.env.ATLAS_DATASOURCE_EXPECTED = "false";
     process.env.ATLAS_DATASOURCE_URL = "postgresql://test:test@localhost:5432/test";
+    mockValidateEnvironment.mockResolvedValue([]);
+    dsQueryImpl = () => Promise.reject(new Error("connection refused"));
+
+    const response = await app.fetch(healthRequest());
+    expect(response.status).toBe(503);
+    const body = (await response.json()) as Record<string, unknown>;
+
+    expect(body.status).toBe("error");
+    // Pins the `dsNotConfigured &&` half of the narrowing, not just the rollup:
+    // drop it and the component reads "down" while claiming no datasource is
+    // expected — a self-contradicting tile shown mid-outage. The rollup
+    // assertion above survives that mutation; this one doesn't.
+    const components = body.components as Record<string, Record<string, unknown>>;
+    expect(components.datasource?.status).toBe("down");
+    expect(components.datasource?.message).not.toContain("none is expected");
+  });
+
+  // `hasDatasource` has two arms — the env var and a `default` in the
+  // ConnectionRegistry. The multi-tenant shape this feature targets is more
+  // likely to register `default` from atlas.config.ts than to set the env var,
+  // so pin the declaration as inert against the registry arm too.
+  it("declared not-expected is inert when 'default' comes from the registry", async () => {
+    process.env.ATLAS_DATASOURCE_EXPECTED = "false";
+    connMetadata = [{ id: "default", dbType: "postgres" }];
     mockValidateEnvironment.mockResolvedValue([]);
     dsQueryImpl = () => Promise.reject(new Error("connection refused"));
 

--- a/packages/api/src/api/__tests__/teams.test.ts
+++ b/packages/api/src/api/__tests__/teams.test.ts
@@ -129,8 +129,7 @@ describe("/api/v1/teams (Azure admin-consent, cap-gated — #3142)", () => {
       await saveOAuthState("teams-cb-ok", { orgId: "org-teams", provider: "teams" });
 
       const config = await import("@atlas/api/lib/config");
-      // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- partial ResolvedConfig is sufficient for the deployMode path
-      config._setConfigForTest({ deployMode: "self-hosted" } as any);
+      config._setConfigForTest({ deployMode: "self-hosted" });
       try {
         const app = await getApp();
         const tenant = "11111111-2222-3333-4444-555555555555";
@@ -156,8 +155,7 @@ describe("/api/v1/teams (Azure admin-consent, cap-gated — #3142)", () => {
       await saveOAuthState("teams-cb-orphan", { provider: "teams" });
 
       const config = await import("@atlas/api/lib/config");
-      // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- partial ResolvedConfig is sufficient for the deployMode path
-      config._setConfigForTest({ deployMode: "saas" } as any);
+      config._setConfigForTest({ deployMode: "saas" });
       try {
         const app = await getApp();
         const tenant = "11111111-2222-3333-4444-555555555555";
@@ -184,8 +182,7 @@ describe("/api/v1/teams (Azure admin-consent, cap-gated — #3142)", () => {
       await saveOAuthState("teams-cb-cap", { orgId: "org-teams", provider: "teams" });
 
       const config = await import("@atlas/api/lib/config");
-      // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- partial ResolvedConfig is sufficient for the deployMode path
-      config._setConfigForTest({ deployMode: "self-hosted" } as any);
+      config._setConfigForTest({ deployMode: "self-hosted" });
       try {
         const app = await getApp();
         const tenant = "11111111-2222-3333-4444-555555555555";

--- a/packages/api/src/api/__tests__/well-known.test.ts
+++ b/packages/api/src/api/__tests__/well-known.test.ts
@@ -41,8 +41,7 @@ function setDeployModeForTest(mode: "saas" | "self-hosted" | undefined) {
     _setConfigForTest(null);
     return;
   }
-  // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- partial ResolvedConfig is sufficient for the deployMode path
-  _setConfigForTest({ deployMode: mode } as any);
+  _setConfigForTest({ deployMode: mode });
 }
 
 // Well-known.ts dynamically imports the auth instance + the

--- a/packages/api/src/api/routes/health.ts
+++ b/packages/api/src/api/routes/health.ts
@@ -24,6 +24,7 @@ import { SENSITIVE_PATTERNS } from "@atlas/api/lib/security";
 import { getSetting } from "@atlas/api/lib/settings";
 import { getApiRegion, getMisroutedCount } from "@atlas/api/lib/residency/misrouting";
 import { getConfig } from "@atlas/api/lib/config";
+import { isDatasourceExpected } from "@atlas/api/lib/db/datasource-expectation";
 import { authenticateRequest } from "@atlas/api/lib/auth/middleware";
 import { getUserRole } from "@atlas/api/lib/auth/permissions";
 import type { PluginStatus } from "@atlas/api/lib/plugins/registry";
@@ -343,6 +344,14 @@ health.openapi(healthRoute, async (c) => {
     );
     const hasDsError = !!dsDiagnostic || !!dsProbeError;
     const dsNotConfigured = !hasDatasource;
+    // #4854 — the absence is only *intentional* when the deployment declares it.
+    // Narrowed by `dsNotConfigured` on purpose: the declaration answers "is one
+    // expected here?", never "is the configured one healthy?", so it is unreachable
+    // on any deployment that has a datasource and therefore cannot touch the
+    // error/503 arm below. Undeclared keeps degrading — see
+    // `lib/db/datasource-expectation.ts` for why intent is never inferred from
+    // the absence itself.
+    const dsIntentionallyAbsent = dsNotConfigured && !isDatasourceExpected();
     const hasKeyError = !!findDiagnostic(diagnostics, "MISSING_API_KEY");
     const hasSemanticError = !!findDiagnostic(
       diagnostics,
@@ -372,7 +381,12 @@ health.openapi(healthRoute, async (c) => {
     let status: "ok" | "degraded" | "error";
     if ((hasDsError && !dsNotConfigured) || internalDbBlocksProbe) status = "error";
     else if (
-      dsNotConfigured ||
+      // A missing datasource degrades unless the deployment declared it wasn't
+      // expected (#4854). The declaration is deliberately absent from the
+      // `error` arm above: that arm requires `!dsNotConfigured`, so a CONFIGURED
+      // datasource that fails still 503s and still leaves the LB (#1981) no
+      // matter what the deployment declares.
+      (dsNotConfigured && !dsIntentionallyAbsent) ||
       hasKeyError ||
       hasSemanticError ||
       hasInternalDbError ||
@@ -622,9 +636,20 @@ health.openapi(healthRoute, async (c) => {
             : ("healthy" as const),
         ...(dsLatencyMs !== undefined && { latencyMs: dsLatencyMs }),
         lastCheckedAt: now,
-        ...(hasDsError && {
-          message: dsProbeError ?? dsDiagnostic?.code ?? "DB_UNREACHABLE",
-        }),
+        // A declared-absent deployment must not carry `MISSING_DATASOURCE_URL`
+        // on a `disabled` component (#4854) — the diagnostic still fires, since
+        // `checkDatasourceUrlPresence` raises it whenever DATABASE_URL is set
+        // without ATLAS_DATASOURCE_URL, but showing an error code for a state the
+        // operator deliberately configured is what made the dashboard read as
+        // broken. An UNDECLARED absence keeps the code: there it is the finding.
+        ...(dsIntentionallyAbsent
+          ? {
+              message:
+                "No analytics datasource is configured, and this deployment declares that none is expected.",
+            }
+          : hasDsError && {
+              message: dsProbeError ?? dsDiagnostic?.code ?? "DB_UNREACHABLE",
+            }),
       },
       internalDb: {
         status: !process.env.DATABASE_URL

--- a/packages/api/src/api/routes/health.ts
+++ b/packages/api/src/api/routes/health.ts
@@ -382,10 +382,8 @@ health.openapi(healthRoute, async (c) => {
     if ((hasDsError && !dsNotConfigured) || internalDbBlocksProbe) status = "error";
     else if (
       // A missing datasource degrades unless the deployment declared it wasn't
-      // expected (#4854). The declaration is deliberately absent from the
-      // `error` arm above: that arm requires `!dsNotConfigured`, so a CONFIGURED
-      // datasource that fails still 503s and still leaves the LB (#1981) no
-      // matter what the deployment declares.
+      // expected (#4854) — see the narrowing where `dsIntentionallyAbsent` is
+      // defined for why this cannot reach the `error` arm above.
       (dsNotConfigured && !dsIntentionallyAbsent) ||
       hasKeyError ||
       hasSemanticError ||
@@ -637,11 +635,13 @@ health.openapi(healthRoute, async (c) => {
         ...(dsLatencyMs !== undefined && { latencyMs: dsLatencyMs }),
         lastCheckedAt: now,
         // A declared-absent deployment must not carry `MISSING_DATASOURCE_URL`
-        // on a `disabled` component (#4854) — the diagnostic still fires, since
-        // `checkDatasourceUrlPresence` raises it whenever DATABASE_URL is set
-        // without ATLAS_DATASOURCE_URL, but showing an error code for a state the
-        // operator deliberately configured is what made the dashboard read as
-        // broken. An UNDECLARED absence keeps the code: there it is the finding.
+        // on a `disabled` component (#4854) — the diagnostic still fires
+        // (`checkDatasourceUrlPresence` in `startup.ts` raises it when no
+        // datasource URL resolves and DATABASE_URL is set), but showing an error
+        // code for a state the operator deliberately configured is what made the
+        // dashboard read as broken: `component-health-tiles.tsx` renders this
+        // field verbatim. An UNDECLARED absence keeps the code — there it is the
+        // finding, and `status` stays `disabled` either way.
         ...(dsIntentionallyAbsent
           ? {
               message:

--- a/packages/api/src/api/routes/health.ts
+++ b/packages/api/src/api/routes/health.ts
@@ -24,7 +24,10 @@ import { SENSITIVE_PATTERNS } from "@atlas/api/lib/security";
 import { getSetting } from "@atlas/api/lib/settings";
 import { getApiRegion, getMisroutedCount } from "@atlas/api/lib/residency/misrouting";
 import { getConfig } from "@atlas/api/lib/config";
-import { isDatasourceExpected } from "@atlas/api/lib/db/datasource-expectation";
+import {
+  resolveDatasourceExpectation,
+  datasourceExpectationWarning,
+} from "@atlas/api/lib/db/datasource-expectation";
 import { authenticateRequest } from "@atlas/api/lib/auth/middleware";
 import { getUserRole } from "@atlas/api/lib/auth/permissions";
 import type { PluginStatus } from "@atlas/api/lib/plugins/registry";
@@ -351,7 +354,8 @@ health.openapi(healthRoute, async (c) => {
     // error/503 arm below. Undeclared keeps degrading — see
     // `lib/db/datasource-expectation.ts` for why intent is never inferred from
     // the absence itself.
-    const dsIntentionallyAbsent = dsNotConfigured && !isDatasourceExpected();
+    const dsExpectation = resolveDatasourceExpectation();
+    const dsIntentionallyAbsent = dsNotConfigured && !dsExpectation.expected;
     const hasKeyError = !!findDiagnostic(diagnostics, "MISSING_API_KEY");
     const hasSemanticError = !!findDiagnostic(
       diagnostics,
@@ -405,6 +409,15 @@ health.openapi(healthRoute, async (c) => {
     if (exploreFailClosed && status === "ok") status = "degraded";
 
     const warnings = [...getStartupWarnings()];
+
+    // #4854 — an unparseable ATLAS_DATASOURCE_EXPECTED is logged once per
+    // process, which is the right volume for a public polled endpoint but the
+    // wrong surface: by the time an operator wonders why their declaration did
+    // nothing, that line has scrolled away. Surface it where they set it. The
+    // deployment is treated as expecting a datasource, so this rides alongside a
+    // `degraded` status rather than explaining an `ok` one.
+    const expectationWarning = datasourceExpectationWarning(dsExpectation);
+    if (expectationWarning) warnings.push(expectationWarning);
 
     // Per-source health from ConnectionRegistry. The bare `describe()`
     // enumerates only native/bare pools; published plugin datasources

--- a/packages/api/src/lib/__tests__/config.test.ts
+++ b/packages/api/src/lib/__tests__/config.test.ts
@@ -243,6 +243,19 @@ describe("validateAndResolve", () => {
     expect("datasourceExpected" in resolved).toBe(false);
   });
 
+  // A contradiction (no datasource expected, here are the datasources) warns
+  // rather than throwing: the resolution is unambiguous — a registered
+  // datasource makes the declaration inert — so refusing to boot over it would
+  // be the worse trade. Both values survive so the operator sees what they wrote.
+  it("accepts a contradictory datasourceExpected + datasources, keeping both", () => {
+    const resolved = validateAndResolve({
+      datasourceExpected: false,
+      datasources: { default: { url: "postgresql://host/data" } },
+    });
+    expect(resolved.datasourceExpected).toBe(false);
+    expect(Object.keys(resolved.datasources)).toEqual(["default"]);
+  });
+
   it("rejects a non-boolean datasourceExpected", () => {
     expect(() => validateAndResolve({ datasourceExpected: "false" })).toThrow(
       /datasourceExpected/,

--- a/packages/api/src/lib/__tests__/config.test.ts
+++ b/packages/api/src/lib/__tests__/config.test.ts
@@ -223,6 +223,32 @@ describe("validateAndResolve", () => {
     expect(resolved.datasources.default.description).toBeUndefined();
   });
 
+  // #4854 — the config-file half of the datasource-expectation declaration.
+  // Both readers (`isDatasourceExpected`) inject a pre-resolved config in their
+  // own tests, so without these the Zod field and the resolver spread could
+  // both be deleted with every other test still green — and a self-hoster
+  // following the docs would get a silently stripped field.
+  it("carries datasourceExpected through", () => {
+    expect(validateAndResolve({ datasourceExpected: false }).datasourceExpected).toBe(false);
+    expect(validateAndResolve({ datasourceExpected: true }).datasourceExpected).toBe(true);
+  });
+
+  // The tri-state invariant: `undeclared` must not collapse into `declared
+  // expected`. Rewriting the resolver's conditional spread as `?? true` is
+  // behaviour-preserving for today's only reader (which tests `=== false`), so
+  // this assertion is the only thing that would catch it.
+  it("omits datasourceExpected entirely when undeclared", () => {
+    const resolved = validateAndResolve({});
+    expect(resolved.datasourceExpected).toBeUndefined();
+    expect("datasourceExpected" in resolved).toBe(false);
+  });
+
+  it("rejects a non-boolean datasourceExpected", () => {
+    expect(() => validateAndResolve({ datasourceExpected: "false" })).toThrow(
+      /datasourceExpected/,
+    );
+  });
+
   it("throws on invalid auth value", () => {
     expect(() => validateAndResolve({ auth: "invalid-mode" })).toThrow(
       "Invalid atlas.config.ts",

--- a/packages/api/src/lib/config.ts
+++ b/packages/api/src/lib/config.ts
@@ -1338,6 +1338,21 @@ export function validateAndResolve(raw: unknown): ResolvedConfig {
     validatePlugins(config.plugins);
   }
 
+  // #4854 — `datasourceExpected: false` says no analytics datasource is expected
+  // here; a `datasources` block says one is. Both cannot be true statements
+  // about the same deployment. A warning rather than a throw: the resolution is
+  // unambiguous (the registered datasource wins — `dsNotConfigured` is false, so
+  // the declaration is inert), and refusing to boot over a contradiction that
+  // changes no behaviour would be a worse trade than saying so.
+  if (config.datasourceExpected === false && Object.keys(config.datasources ?? {}).length > 0) {
+    log.warn(
+      { datasources: Object.keys(config.datasources ?? {}) },
+      "atlas.config.ts declares datasourceExpected: false but also defines datasources — " +
+        "the declaration is ignored for health reporting while a datasource is registered. " +
+        "Remove one of the two.",
+    );
+  }
+
   return {
     datasources: config.datasources ?? {},
     // Conditional spread, not `?? true`: "undeclared" must stay distinguishable
@@ -1772,7 +1787,20 @@ export function _resetConfig(): void {
   _resolved = null;
 }
 
-/** Set the cached config directly. For testing only. */
-export function _setConfigForTest(config: ResolvedConfig | null): void {
-  _resolved = config;
+/**
+ * Set the cached config directly. For testing only.
+ *
+ * Accepts a `Partial` because essentially every caller drives one field (a
+ * deploy mode, a sandbox pin, a datasource expectation) and the rest of
+ * `ResolvedConfig` is irrelevant to what it is testing. Typing this as the full
+ * shape pushed an `as any` cast onto ~100 call sites — a lie repeated a hundred
+ * times, each needing its own oxlint-disable. Told once, here, it stays visible.
+ *
+ * The cast is sound for the intended use and unsound in general: readers of an
+ * absent field see `undefined` where the type promises a value. That is exactly
+ * what a partial fixture means, and it is why this is test-only.
+ */
+export function _setConfigForTest(config: Partial<ResolvedConfig> | null): void {
+  // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- see the note above: one deliberate widening for a test-only seam
+  _resolved = config as any;
 }

--- a/packages/api/src/lib/config.ts
+++ b/packages/api/src/lib/config.ts
@@ -481,6 +481,20 @@ const AtlasConfigSchema = z.object({
   datasources: z.record(z.string(), DatasourceConfigSchema).optional(),
 
   /**
+   * Whether this deployment is expected to have a process-level analytics
+   * datasource at all (#4854). Set `false` on a deployment that intentionally
+   * has none — a multi-tenant SaaS region whose connections live per-workspace,
+   * or a knowledge-only / brain-only self-host — so `/health` reports the
+   * `datasource` component as `disabled` without degrading the top-level rollup.
+   *
+   * Omitted means **expected**: a box that simply forgot `ATLAS_DATASOURCE_URL`
+   * must keep degrading rather than silently reading green. `ATLAS_DATASOURCE_EXPECTED`
+   * overrides this per-service — required when several services share one config
+   * file (see `lib/db/datasource-expectation.ts`).
+   */
+  datasourceExpected: z.boolean().optional(),
+
+  /**
    * Tool names to enable. When omitted, defaults to the two core tools
    * (explore, executeSQL).
    */
@@ -701,6 +715,12 @@ export { AtlasConfigSchema, RateLimitConfigSchema, RLSConditionSchema, RLSPolicy
  */
 export interface ResolvedConfig {
   datasources: Record<string, DatasourceConfig>;
+  /**
+   * Whether a process-level analytics datasource is expected on this deployment
+   * (#4854). Absent means expected — see `lib/db/datasource-expectation.ts`,
+   * which owns the resolution and the env-var override.
+   */
+  datasourceExpected?: boolean;
   tools: string[];
   auth: AuthConfig;
   semanticLayer: string;
@@ -1320,6 +1340,12 @@ export function validateAndResolve(raw: unknown): ResolvedConfig {
 
   return {
     datasources: config.datasources ?? {},
+    // Conditional spread, not `?? true`: "undeclared" must stay distinguishable
+    // from "declared expected" so the resolver here never becomes a second
+    // source of truth for the default (`isDatasourceExpected()` owns it).
+    ...(config.datasourceExpected !== undefined
+      ? { datasourceExpected: config.datasourceExpected }
+      : {}),
     tools: config.tools ?? ["explore", "executeSQL"],
     auth: config.auth ?? "auto",
     semanticLayer: config.semanticLayer ?? "./semantic",

--- a/packages/api/src/lib/db/__tests__/datasource-expectation.test.ts
+++ b/packages/api/src/lib/db/__tests__/datasource-expectation.test.ts
@@ -18,9 +18,11 @@ import { _setConfigForTest } from "@atlas/api/lib/config";
 
 describe("isDatasourceExpected", () => {
   const origExpected = process.env.ATLAS_DATASOURCE_EXPECTED;
+  const origDemoData = process.env.ATLAS_DEMO_DATA;
 
   beforeEach(() => {
     delete process.env.ATLAS_DATASOURCE_EXPECTED;
+    delete process.env.ATLAS_DEMO_DATA;
     _setConfigForTest(null);
     _resetDatasourceExpectationWarning();
   });
@@ -28,6 +30,8 @@ describe("isDatasourceExpected", () => {
   afterEach(() => {
     if (origExpected !== undefined) process.env.ATLAS_DATASOURCE_EXPECTED = origExpected;
     else delete process.env.ATLAS_DATASOURCE_EXPECTED;
+    if (origDemoData !== undefined) process.env.ATLAS_DEMO_DATA = origDemoData;
+    else delete process.env.ATLAS_DEMO_DATA;
     _setConfigForTest(null);
     _resetDatasourceExpectationWarning();
   });
@@ -60,8 +64,37 @@ describe("isDatasourceExpected", () => {
   // An unparseable declaration must fail toward the noisy answer, not the quiet
   // one — a typo'd `ATLAS_DATASOURCE_EXPECTED=fasle` should leave /health
   // degraded so the operator finds it, not green so they never look.
-  it("treats an unrecognized value as undeclared", () => {
+  it("resolves an unrecognized value to expected", () => {
     process.env.ATLAS_DATASOURCE_EXPECTED = "nope";
+    expect(isDatasourceExpected()).toBe(true);
+  });
+
+  // The combination that matters, and the one a "treats it as undeclared"
+  // implementation gets wrong: on a shared image whose config declares
+  // `datasourceExpected: false`, an operator typing `ture` on the ONE service
+  // that does need a datasource must not have the shared file answer for them.
+  // Falling through to the config here would return false — a silent green on
+  // the deployment whose operator was visibly trying to opt back in.
+  it("an unrecognized value does NOT fall through to a config that says false", () => {
+    process.env.ATLAS_DATASOURCE_EXPECTED = "ture";
+    // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- partial ResolvedConfig is sufficient for this path
+    _setConfigForTest({ datasourceExpected: false } as any);
+    expect(isDatasourceExpected()).toBe(true);
+  });
+
+  // ATLAS_DEMO_DATA=true asks Atlas to serve analytics off DATABASE_URL, so it
+  // IS a declaration that a datasource is expected. Reaching the health rollup
+  // with it set and nothing resolved means provisioning failed (startup.ts
+  // raises MISSING_DATASOURCE_URL as an ERROR for exactly this) — a coarse
+  // "none expected" must not bury a failed Neon provision.
+  it("ATLAS_DEMO_DATA=true outranks a declaration of not-expected", () => {
+    process.env.ATLAS_DEMO_DATA = "true";
+    process.env.ATLAS_DATASOURCE_EXPECTED = "false";
+    expect(isDatasourceExpected()).toBe(true);
+
+    delete process.env.ATLAS_DATASOURCE_EXPECTED;
+    // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- partial ResolvedConfig is sufficient for this path
+    _setConfigForTest({ datasourceExpected: false } as any);
     expect(isDatasourceExpected()).toBe(true);
   });
 
@@ -79,12 +112,14 @@ describe("isDatasourceExpected", () => {
 
   // api-staging runs the PROD atlas.config.ts (#3958) and differs only by env
   // vars, so the per-service var has to win in both directions.
-  it("lets the env var override the config file in both directions", () => {
+  it("env true overrides a config file that says false", () => {
     // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- partial ResolvedConfig is sufficient for this path
     _setConfigForTest({ datasourceExpected: false } as any);
     process.env.ATLAS_DATASOURCE_EXPECTED = "true";
     expect(isDatasourceExpected()).toBe(true);
+  });
 
+  it("env false overrides a config file that says true", () => {
     // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- partial ResolvedConfig is sufficient for this path
     _setConfigForTest({ datasourceExpected: true } as any);
     process.env.ATLAS_DATASOURCE_EXPECTED = "false";

--- a/packages/api/src/lib/db/__tests__/datasource-expectation.test.ts
+++ b/packages/api/src/lib/db/__tests__/datasource-expectation.test.ts
@@ -1,0 +1,93 @@
+/**
+ * #4854 — resolution of "is a process-level analytics datasource expected on
+ * this deployment?".
+ *
+ * The route-level contract (what /health does with the answer) is pinned in
+ * `api/__tests__/health.test.ts`. This file pins the resolution itself: the
+ * precedence between the per-service env var and the shared config file, and —
+ * the load-bearing one — that an undeclared deployment resolves to EXPECTED, so
+ * a missing datasource keeps degrading rather than silently reading green.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import {
+  isDatasourceExpected,
+  _resetDatasourceExpectationWarning,
+} from "@atlas/api/lib/db/datasource-expectation";
+import { _setConfigForTest } from "@atlas/api/lib/config";
+
+describe("isDatasourceExpected", () => {
+  const origExpected = process.env.ATLAS_DATASOURCE_EXPECTED;
+
+  beforeEach(() => {
+    delete process.env.ATLAS_DATASOURCE_EXPECTED;
+    _setConfigForTest(null);
+    _resetDatasourceExpectationWarning();
+  });
+
+  afterEach(() => {
+    if (origExpected !== undefined) process.env.ATLAS_DATASOURCE_EXPECTED = origExpected;
+    else delete process.env.ATLAS_DATASOURCE_EXPECTED;
+    _setConfigForTest(null);
+    _resetDatasourceExpectationWarning();
+  });
+
+  // The default is the whole safety property: it is what keeps a self-hosted
+  // box that forgot ATLAS_DATASOURCE_URL degrading on /health.
+  it("defaults to expected when nothing is declared", () => {
+    expect(isDatasourceExpected()).toBe(true);
+  });
+
+  it("treats an empty env var as undeclared", () => {
+    process.env.ATLAS_DATASOURCE_EXPECTED = "";
+    expect(isDatasourceExpected()).toBe(true);
+  });
+
+  it("accepts false/0 as declaring no datasource is expected", () => {
+    for (const value of ["false", "0", "FALSE", " false "]) {
+      process.env.ATLAS_DATASOURCE_EXPECTED = value;
+      expect(isDatasourceExpected()).toBe(false);
+    }
+  });
+
+  it("accepts true/1 as declaring one IS expected", () => {
+    for (const value of ["true", "1", "TRUE"]) {
+      process.env.ATLAS_DATASOURCE_EXPECTED = value;
+      expect(isDatasourceExpected()).toBe(true);
+    }
+  });
+
+  // An unparseable declaration must fail toward the noisy answer, not the quiet
+  // one — a typo'd `ATLAS_DATASOURCE_EXPECTED=fasle` should leave /health
+  // degraded so the operator finds it, not green so they never look.
+  it("treats an unrecognized value as undeclared", () => {
+    process.env.ATLAS_DATASOURCE_EXPECTED = "nope";
+    expect(isDatasourceExpected()).toBe(true);
+  });
+
+  it("reads the declaration from atlas.config.ts", () => {
+    // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- partial ResolvedConfig is sufficient for this path
+    _setConfigForTest({ datasourceExpected: false } as any);
+    expect(isDatasourceExpected()).toBe(false);
+  });
+
+  it("treats an absent config field as undeclared, not as a declaration", () => {
+    // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- partial ResolvedConfig is sufficient for this path
+    _setConfigForTest({ deployMode: "self-hosted" } as any);
+    expect(isDatasourceExpected()).toBe(true);
+  });
+
+  // api-staging runs the PROD atlas.config.ts (#3958) and differs only by env
+  // vars, so the per-service var has to win in both directions.
+  it("lets the env var override the config file in both directions", () => {
+    // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- partial ResolvedConfig is sufficient for this path
+    _setConfigForTest({ datasourceExpected: false } as any);
+    process.env.ATLAS_DATASOURCE_EXPECTED = "true";
+    expect(isDatasourceExpected()).toBe(true);
+
+    // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- partial ResolvedConfig is sufficient for this path
+    _setConfigForTest({ datasourceExpected: true } as any);
+    process.env.ATLAS_DATASOURCE_EXPECTED = "false";
+    expect(isDatasourceExpected()).toBe(false);
+  });
+});

--- a/packages/api/src/lib/db/__tests__/datasource-expectation.test.ts
+++ b/packages/api/src/lib/db/__tests__/datasource-expectation.test.ts
@@ -12,11 +12,20 @@
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
 import {
   isDatasourceExpected,
+  resolveDatasourceExpectation,
+  datasourceExpectationWarning,
   _resetDatasourceExpectationWarning,
 } from "@atlas/api/lib/db/datasource-expectation";
 import { _setConfigForTest } from "@atlas/api/lib/config";
 
-describe("isDatasourceExpected", () => {
+// NB the warn-ONCE latch is deliberately not pinned. Observing it needs a
+// `mock.module("@atlas/api/lib/logger")`, and mocking createLogger process-wide
+// hangs this file — pino loggers carry prototype methods a spread drops, and
+// every module in the `lib/config` graph resolves its logger at import time.
+// The latch governs log volume, not behaviour: `recognized` is returned on
+// every call regardless, and that IS pinned below and surfaced on /health.
+
+describe("resolveDatasourceExpectation", () => {
   const origExpected = process.env.ATLAS_DATASOURCE_EXPECTED;
   const origDemoData = process.env.ATLAS_DEMO_DATA;
 
@@ -39,34 +48,50 @@ describe("isDatasourceExpected", () => {
   // The default is the whole safety property: it is what keeps a self-hosted
   // box that forgot ATLAS_DATASOURCE_URL degrading on /health.
   it("defaults to expected when nothing is declared", () => {
-    expect(isDatasourceExpected()).toBe(true);
+    expect(resolveDatasourceExpectation()).toEqual({
+      expected: true,
+      source: "default",
+      recognized: true,
+    });
   });
 
   it("treats an empty env var as undeclared", () => {
     process.env.ATLAS_DATASOURCE_EXPECTED = "";
-    expect(isDatasourceExpected()).toBe(true);
+    expect(resolveDatasourceExpectation().source).toBe("default");
   });
 
-  it("accepts false/0 as declaring no datasource is expected", () => {
-    for (const value of ["false", "0", "FALSE", " false "]) {
+  for (const value of ["false", "0", "FALSE", " false "]) {
+    it(`accepts ${JSON.stringify(value)} as declaring no datasource is expected`, () => {
       process.env.ATLAS_DATASOURCE_EXPECTED = value;
-      expect(isDatasourceExpected()).toBe(false);
-    }
-  });
+      expect(resolveDatasourceExpectation()).toEqual({
+        expected: false,
+        source: "env",
+        recognized: true,
+      });
+    });
+  }
 
-  it("accepts true/1 as declaring one IS expected", () => {
-    for (const value of ["true", "1", "TRUE"]) {
+  for (const value of ["true", "1", "TRUE"]) {
+    it(`accepts ${JSON.stringify(value)} as declaring one IS expected`, () => {
       process.env.ATLAS_DATASOURCE_EXPECTED = value;
-      expect(isDatasourceExpected()).toBe(true);
-    }
-  });
+      expect(resolveDatasourceExpectation()).toEqual({
+        expected: true,
+        source: "env",
+        recognized: true,
+      });
+    });
+  }
 
   // An unparseable declaration must fail toward the noisy answer, not the quiet
   // one — a typo'd `ATLAS_DATASOURCE_EXPECTED=fasle` should leave /health
   // degraded so the operator finds it, not green so they never look.
-  it("resolves an unrecognized value to expected", () => {
+  it("resolves an unrecognized value to expected, and says it was unrecognized", () => {
     process.env.ATLAS_DATASOURCE_EXPECTED = "nope";
-    expect(isDatasourceExpected()).toBe(true);
+    expect(resolveDatasourceExpectation()).toEqual({
+      expected: true,
+      source: "env-unrecognized",
+      recognized: false,
+    });
   });
 
   // The combination that matters, and the one a "treats it as undeclared"
@@ -77,9 +102,8 @@ describe("isDatasourceExpected", () => {
   // the deployment whose operator was visibly trying to opt back in.
   it("an unrecognized value does NOT fall through to a config that says false", () => {
     process.env.ATLAS_DATASOURCE_EXPECTED = "ture";
-    // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- partial ResolvedConfig is sufficient for this path
-    _setConfigForTest({ datasourceExpected: false } as any);
-    expect(isDatasourceExpected()).toBe(true);
+    _setConfigForTest({ datasourceExpected: false });
+    expect(resolveDatasourceExpectation().expected).toBe(true);
   });
 
   // ATLAS_DEMO_DATA=true asks Atlas to serve analytics off DATABASE_URL, so it
@@ -87,42 +111,84 @@ describe("isDatasourceExpected", () => {
   // with it set and nothing resolved means provisioning failed (startup.ts
   // raises MISSING_DATASOURCE_URL as an ERROR for exactly this) — a coarse
   // "none expected" must not bury a failed Neon provision.
-  it("ATLAS_DEMO_DATA=true outranks a declaration of not-expected", () => {
+  it("ATLAS_DEMO_DATA=true outranks an env declaration of not-expected", () => {
     process.env.ATLAS_DEMO_DATA = "true";
     process.env.ATLAS_DATASOURCE_EXPECTED = "false";
-    expect(isDatasourceExpected()).toBe(true);
+    expect(resolveDatasourceExpectation()).toEqual({
+      expected: true,
+      source: "demo-data",
+      recognized: true,
+    });
+  });
 
-    delete process.env.ATLAS_DATASOURCE_EXPECTED;
-    // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- partial ResolvedConfig is sufficient for this path
-    _setConfigForTest({ datasourceExpected: false } as any);
-    expect(isDatasourceExpected()).toBe(true);
+  it("ATLAS_DEMO_DATA=true outranks a config declaration of not-expected", () => {
+    process.env.ATLAS_DEMO_DATA = "true";
+    _setConfigForTest({ datasourceExpected: false });
+    expect(resolveDatasourceExpectation().expected).toBe(true);
   });
 
   it("reads the declaration from atlas.config.ts", () => {
-    // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- partial ResolvedConfig is sufficient for this path
-    _setConfigForTest({ datasourceExpected: false } as any);
-    expect(isDatasourceExpected()).toBe(false);
+    _setConfigForTest({ datasourceExpected: false });
+    expect(resolveDatasourceExpectation()).toEqual({
+      expected: false,
+      source: "config",
+      recognized: true,
+    });
   });
 
   it("treats an absent config field as undeclared, not as a declaration", () => {
-    // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- partial ResolvedConfig is sufficient for this path
-    _setConfigForTest({ deployMode: "self-hosted" } as any);
-    expect(isDatasourceExpected()).toBe(true);
+    _setConfigForTest({ deployMode: "self-hosted" });
+    expect(resolveDatasourceExpectation()).toEqual({
+      expected: true,
+      source: "default",
+      recognized: true,
+    });
   });
 
   // api-staging runs the PROD atlas.config.ts (#3958) and differs only by env
   // vars, so the per-service var has to win in both directions.
   it("env true overrides a config file that says false", () => {
-    // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- partial ResolvedConfig is sufficient for this path
-    _setConfigForTest({ datasourceExpected: false } as any);
+    _setConfigForTest({ datasourceExpected: false });
     process.env.ATLAS_DATASOURCE_EXPECTED = "true";
-    expect(isDatasourceExpected()).toBe(true);
+    expect(resolveDatasourceExpectation().expected).toBe(true);
   });
 
   it("env false overrides a config file that says true", () => {
-    // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- partial ResolvedConfig is sufficient for this path
-    _setConfigForTest({ datasourceExpected: true } as any);
+    _setConfigForTest({ datasourceExpected: true });
     process.env.ATLAS_DATASOURCE_EXPECTED = "false";
-    expect(isDatasourceExpected()).toBe(false);
+    expect(resolveDatasourceExpectation().expected).toBe(false);
+  });
+
+  it("resolves against an explicitly passed config instead of the singleton", () => {
+    _setConfigForTest({ datasourceExpected: false });
+    expect(resolveDatasourceExpectation(null).expected).toBe(true);
+  });
+
+});
+
+describe("isDatasourceExpected", () => {
+  it("is the boolean projection of the full resolution", () => {
+    expect(isDatasourceExpected()).toBe(resolveDatasourceExpectation().expected);
+  });
+});
+
+describe("datasourceExpectationWarning", () => {
+  it("is undefined for a recognized resolution", () => {
+    expect(
+      datasourceExpectationWarning({ expected: true, source: "default", recognized: true }),
+    ).toBeUndefined();
+  });
+
+  it("explains an unrecognized declaration without echoing the value", () => {
+    const warning = datasourceExpectationWarning({
+      expected: true,
+      source: "env-unrecognized",
+      recognized: false,
+    });
+    expect(warning).toContain("ATLAS_DATASOURCE_EXPECTED");
+    expect(warning).toContain("expecting an analytics datasource");
+    // /health is public and unauthenticated, and the value is operator-supplied
+    // — it belongs in the server log, not in the response body.
+    expect(warning).not.toContain("nope");
   });
 });

--- a/packages/api/src/lib/db/datasource-expectation.ts
+++ b/packages/api/src/lib/db/datasource-expectation.ts
@@ -42,10 +42,42 @@
  * is for self-hosters authoring their own `atlas.config.ts`.
  */
 
-import { getConfig } from "@atlas/api/lib/config";
+import { getConfig, type ResolvedConfig } from "@atlas/api/lib/config";
 import { createLogger } from "@atlas/api/lib/logger";
 
 const log = createLogger("datasource-expectation");
+
+/**
+ * The vocabulary `ATLAS_DATASOURCE_EXPECTED` accepts, split by what it declares.
+ * The warning below is derived from these rather than restating them, so the
+ * message cannot drift from the parser.
+ */
+const NEGATIVE_VALUES = ["false", "0"] as const;
+const POSITIVE_VALUES = ["true", "1"] as const;
+const ACCEPTED_VALUES = [...POSITIVE_VALUES, ...NEGATIVE_VALUES];
+
+/** Where the resolved answer came from — for `/health` and for operators. */
+export type DatasourceExpectationSource =
+  | "demo-data"
+  | "env"
+  | "env-unrecognized"
+  | "config"
+  | "default";
+
+export interface DatasourceExpectation {
+  /** Whether a process-level analytics datasource is expected here. */
+  readonly expected: boolean;
+  /** Which layer decided, most specific first. */
+  readonly source: DatasourceExpectationSource;
+  /**
+   * False only when `ATLAS_DATASOURCE_EXPECTED` was set to something outside
+   * {@link ACCEPTED_VALUES}. Carried as a field rather than left as a log line
+   * so `/health` can surface the typo on the same dashboard the operator set it
+   * from — the `recognized` bit in `BackupCadence` (`lib/backups/cadence.ts`)
+   * exists for the same reason.
+   */
+  readonly recognized: boolean;
+}
 
 /**
  * `/health` is public and polled, so an unparseable declaration would log on
@@ -55,8 +87,12 @@ const log = createLogger("datasource-expectation");
 let warnedUnrecognized = false;
 
 /**
- * Whether this deployment is expected to have a process-level analytics
- * datasource.
+ * Resolve whether this deployment is expected to have a process-level analytics
+ * datasource, and on what grounds.
+ *
+ * `config` defaults to `getConfig()`; pass one explicitly to resolve against a
+ * config that isn't the process singleton (tests, or a caller that already holds
+ * the resolved config).
  *
  * Precedence, most specific first:
  *   1. `ATLAS_DATASOURCE_EXPECTED` — `false`/`0` declares the absence
@@ -83,34 +119,78 @@ let warnedUnrecognized = false;
  * entirely and is unaffected by this declaration — see the `error` arm in
  * `api/routes/health.ts`, which is reachable only when one IS configured.
  */
-export function isDatasourceExpected(): boolean {
+export function resolveDatasourceExpectation(
+  config: ResolvedConfig | null = getConfig(),
+): DatasourceExpectation {
   // A more specific expectation outranks the coarse one. `resolveDatasourceUrl()`
   // consults ATLAS_DEMO_DATA too, so reaching here with it set means the demo
   // datasource did NOT resolve — the failure state, which must stay visible.
-  if (process.env.ATLAS_DEMO_DATA === "true") return true;
+  if (process.env.ATLAS_DEMO_DATA === "true") {
+    return { expected: true, source: "demo-data", recognized: true };
+  }
 
   const declared = process.env.ATLAS_DATASOURCE_EXPECTED?.trim().toLowerCase();
   if (declared !== undefined && declared !== "") {
-    if (declared === "false" || declared === "0") return false;
-    if (declared === "true" || declared === "1") return true;
+    if (NEGATIVE_VALUES.some((v) => v === declared)) {
+      return { expected: false, source: "env", recognized: true };
+    }
+    if (POSITIVE_VALUES.some((v) => v === declared)) {
+      return { expected: true, source: "env", recognized: true };
+    }
     if (!warnedUnrecognized) {
       warnedUnrecognized = true;
       log.warn(
-        { value: declared },
-        "ATLAS_DATASOURCE_EXPECTED is set to an unrecognized value — expected one of true/false/1/0. " +
+        { value: declared, accepted: ACCEPTED_VALUES },
+        `ATLAS_DATASOURCE_EXPECTED is set to an unrecognized value — expected one of ${ACCEPTED_VALUES.join("/")}. ` +
           "Ignoring it AND any atlas.config.ts declaration, and treating the deployment as " +
           "expecting a datasource, so a missing one still degrades /health.",
       );
     }
     // Deliberately does not fall through — see precedence rule 1 above.
-    return true;
+    return { expected: true, source: "env-unrecognized", recognized: false };
   }
 
   // `=== false` rather than falsiness: an absent field must fall through to the
   // default, not be read as a declaration that no datasource is expected.
-  if (getConfig()?.datasourceExpected === false) return false;
+  if (config?.datasourceExpected === false) {
+    return { expected: false, source: "config", recognized: true };
+  }
 
-  return true;
+  return {
+    expected: true,
+    source: config?.datasourceExpected === true ? "config" : "default",
+    recognized: true,
+  };
+}
+
+/**
+ * The answer alone. `/health`'s rollup wants nothing more than the boolean; the
+ * full resolution is for the surfaces that must explain *why*.
+ */
+export function isDatasourceExpected(): boolean {
+  return resolveDatasourceExpectation().expected;
+}
+
+/**
+ * The operator-facing warning for an unparseable declaration, or `undefined`
+ * when there is nothing to say. `/health` folds this into `warnings[]` so a
+ * typo is visible on the dashboard, not only in a boot-time log line that has
+ * long since scrolled away by the time anyone looks.
+ *
+ * Takes the already-resolved expectation rather than re-reading the env so the
+ * caller cannot accidentally report a different resolution than the one it acted
+ * on. Deliberately does NOT echo the offending value: `/health` is public and
+ * unauthenticated, and the value is operator-supplied.
+ */
+export function datasourceExpectationWarning(
+  expectation: DatasourceExpectation,
+): string | undefined {
+  if (expectation.recognized) return undefined;
+  return (
+    `ATLAS_DATASOURCE_EXPECTED is set to an unrecognized value (expected one of ${ACCEPTED_VALUES.join("/")}) — ` +
+    "it is being ignored, so this deployment is treated as expecting an analytics datasource. " +
+    "See the server logs for the value that was set."
+  );
 }
 
 /** @internal Reset the warn-once latch — for testing only. */

--- a/packages/api/src/lib/db/datasource-expectation.ts
+++ b/packages/api/src/lib/db/datasource-expectation.ts
@@ -6,7 +6,9 @@
  * "disabled"` and never 503s (#1981), the second is `"down"` and does. What it
  * could not distinguish is whether the *absence* is intentional. Without that,
  * every deployment that legitimately has no process datasource — a multi-tenant
- * SaaS region whose connections live per-workspace (#4124), a knowledge-only or
+ * SaaS region whose connections live per-workspace (`deploy/api/atlas.config.ts`
+ * registers `datasources.default` only when `ATLAS_DATASOURCE_URL` is set,
+ * precisely so a region without one registers nothing), a knowledge-only or
  * brain-only self-host (#4826) — reports `degraded` forever, which burns the
  * top-level status as a regression signal.
  *
@@ -17,8 +19,17 @@
  * degrading exactly as it does today.
  *
  * Mirrors the `{ expected: false }` shape of the #4457 scheduled-backup
- * tripwire (`lib/backups/health.ts`), and the env-declaration spelling of
- * `isScheduledBackupEnvDisabled()` (`lib/backups/cadence.ts`).
+ * tripwire (`lib/backups/health.ts`) — but deliberately INVERTED on the point
+ * that matters: `scheduledBackupsExpected()` derives the expectation from the
+ * fiber gate, which is exactly what must not happen here. Backups can derive it
+ * because the gate is an independent signal; a missing datasource has no signal
+ * but its own absence. The parser is also more permissive than
+ * `isScheduledBackupEnvDisabled()` (`lib/backups/cadence.ts`) — it trims, folds
+ * case, and accepts a positive form — because a shared image needs to override
+ * the config file in BOTH directions. Don't unify them.
+ *
+ * Not registered in `SAAS_ENV_KEYS` (`lib/effect/saas-env.ts`) on purpose: that
+ * list is the SaaS *boot contract*, and a deployment boots fine without this.
  *
  * ## Why the env var outranks the config file
  *
@@ -50,10 +61,22 @@ let warnedUnrecognized = false;
  * Precedence, most specific first:
  *   1. `ATLAS_DATASOURCE_EXPECTED` — `false`/`0` declares the absence
  *      intentional, `true`/`1` declares one required (so a shared image can
- *      override a config file that says otherwise, per-service).
+ *      override a config file that says otherwise, per-service). An
+ *      UNRECOGNIZED value is a failed declaration, not a missing one: it warns
+ *      and resolves to expected WITHOUT consulting the config file. Falling
+ *      through would let the shared file answer for a service whose operator
+ *      was visibly trying to override it — the exact silent green this module
+ *      exists to prevent.
  *   2. `datasourceExpected` in `atlas.config.ts`.
  *   3. Undeclared → **expected**. This is the load-bearing default: it is what
  *      keeps a self-hosted box that forgot `ATLAS_DATASOURCE_URL` degrading.
+ *
+ * `ATLAS_DEMO_DATA=true` outranks all three. It is itself a declaration that
+ * this deployment expects a datasource (it asks Atlas to serve analytics off
+ * `DATABASE_URL`), so when it resolves to nothing — a Neon integration that
+ * never provisioned — that is a provisioning failure, not an intentional
+ * absence, and `startup.ts` raises it as an ERROR. A coarse "none expected"
+ * must not bury it.
  *
  * Note this answers a question about the DEPLOYMENT, not about the connection's
  * state. A configured datasource that fails its probe is a different condition
@@ -61,6 +84,11 @@ let warnedUnrecognized = false;
  * `api/routes/health.ts`, which is reachable only when one IS configured.
  */
 export function isDatasourceExpected(): boolean {
+  // A more specific expectation outranks the coarse one. `resolveDatasourceUrl()`
+  // consults ATLAS_DEMO_DATA too, so reaching here with it set means the demo
+  // datasource did NOT resolve — the failure state, which must stay visible.
+  if (process.env.ATLAS_DEMO_DATA === "true") return true;
+
   const declared = process.env.ATLAS_DATASOURCE_EXPECTED?.trim().toLowerCase();
   if (declared !== undefined && declared !== "") {
     if (declared === "false" || declared === "0") return false;
@@ -70,9 +98,12 @@ export function isDatasourceExpected(): boolean {
       log.warn(
         { value: declared },
         "ATLAS_DATASOURCE_EXPECTED is set to an unrecognized value — expected one of true/false/1/0. " +
-          "Treating the deployment as expecting a datasource, so a missing one still degrades /health.",
+          "Ignoring it AND any atlas.config.ts declaration, and treating the deployment as " +
+          "expecting a datasource, so a missing one still degrades /health.",
       );
     }
+    // Deliberately does not fall through — see precedence rule 1 above.
+    return true;
   }
 
   // `=== false` rather than falsiness: an absent field must fall through to the

--- a/packages/api/src/lib/db/datasource-expectation.ts
+++ b/packages/api/src/lib/db/datasource-expectation.ts
@@ -1,0 +1,88 @@
+/**
+ * Is a process-level analytics datasource EXPECTED on this deployment? (#4854)
+ *
+ * `/health` already distinguishes "no datasource is configured" from "the
+ * configured datasource is failing" — the first is `components.datasource:
+ * "disabled"` and never 503s (#1981), the second is `"down"` and does. What it
+ * could not distinguish is whether the *absence* is intentional. Without that,
+ * every deployment that legitimately has no process datasource — a multi-tenant
+ * SaaS region whose connections live per-workspace (#4124), a knowledge-only or
+ * brain-only self-host (#4826) — reports `degraded` forever, which burns the
+ * top-level status as a regression signal.
+ *
+ * **Intent is never inferred from the absence itself.** Doing so would turn a
+ * genuine misconfiguration (an operator who meant to set `ATLAS_DATASOURCE_URL`
+ * and didn't) into a silent green — the "prefer errors over silent fallbacks"
+ * rule. So the expectation must be DECLARED, and an undeclared deployment keeps
+ * degrading exactly as it does today.
+ *
+ * Mirrors the `{ expected: false }` shape of the #4457 scheduled-backup
+ * tripwire (`lib/backups/health.ts`), and the env-declaration spelling of
+ * `isScheduledBackupEnvDisabled()` (`lib/backups/cadence.ts`).
+ *
+ * ## Why the env var outranks the config file
+ *
+ * `api-staging` builds from `deploy/api/Dockerfile`, which COPYs the **prod**
+ * `deploy/api/atlas.config.ts` — the separate staging config was retired in
+ * #3958. Staging and prod differ only by env vars. A config-file field alone
+ * would therefore declare the expectation for prod too, and prod *does* have a
+ * datasource: the declaration would suppress the very signal it exists to
+ * preserve. The per-service env var is the load-bearing seam; the config field
+ * is for self-hosters authoring their own `atlas.config.ts`.
+ */
+
+import { getConfig } from "@atlas/api/lib/config";
+import { createLogger } from "@atlas/api/lib/logger";
+
+const log = createLogger("datasource-expectation");
+
+/**
+ * `/health` is public and polled, so an unparseable declaration would log on
+ * every request. Warn once per process instead — enough for an operator to find
+ * the typo, quiet enough not to drown the log.
+ */
+let warnedUnrecognized = false;
+
+/**
+ * Whether this deployment is expected to have a process-level analytics
+ * datasource.
+ *
+ * Precedence, most specific first:
+ *   1. `ATLAS_DATASOURCE_EXPECTED` — `false`/`0` declares the absence
+ *      intentional, `true`/`1` declares one required (so a shared image can
+ *      override a config file that says otherwise, per-service).
+ *   2. `datasourceExpected` in `atlas.config.ts`.
+ *   3. Undeclared → **expected**. This is the load-bearing default: it is what
+ *      keeps a self-hosted box that forgot `ATLAS_DATASOURCE_URL` degrading.
+ *
+ * Note this answers a question about the DEPLOYMENT, not about the connection's
+ * state. A configured datasource that fails its probe is a different condition
+ * entirely and is unaffected by this declaration — see the `error` arm in
+ * `api/routes/health.ts`, which is reachable only when one IS configured.
+ */
+export function isDatasourceExpected(): boolean {
+  const declared = process.env.ATLAS_DATASOURCE_EXPECTED?.trim().toLowerCase();
+  if (declared !== undefined && declared !== "") {
+    if (declared === "false" || declared === "0") return false;
+    if (declared === "true" || declared === "1") return true;
+    if (!warnedUnrecognized) {
+      warnedUnrecognized = true;
+      log.warn(
+        { value: declared },
+        "ATLAS_DATASOURCE_EXPECTED is set to an unrecognized value — expected one of true/false/1/0. " +
+          "Treating the deployment as expecting a datasource, so a missing one still degrades /health.",
+      );
+    }
+  }
+
+  // `=== false` rather than falsiness: an absent field must fall through to the
+  // default, not be read as a declaration that no datasource is expected.
+  if (getConfig()?.datasourceExpected === false) return false;
+
+  return true;
+}
+
+/** @internal Reset the warn-once latch — for testing only. */
+export function _resetDatasourceExpectationWarning(): void {
+  warnedUnrecognized = false;
+}


### PR DESCRIPTION
Closes #4854

`GET /api/health` on staging has been `degraded` permanently — every component healthy, the rollup red — because staging is a multi-tenant deploy with no process-level analytics datasource. That burns the top-level status as a regression signal on the one environment that soaks `main`.

Verified live before the fix:

```
$ curl -s https://api.staging.useatlas.dev/api/health
{"status":"degraded","region":"staging",
 "components":{"datasource":{"status":"disabled","message":"MISSING_DATASOURCE_URL"},
               "internalDb":{"status":"healthy"},"provider":{"status":"healthy"},
               "scheduler":{"status":"healthy"},"sandbox":{"status":"healthy"},
               "plugins":{"status":"healthy"},"backups":{"status":"healthy"}}}   # HTTP 200
```

Note the response contradicting itself: the component says `disabled` (the schema's state for *intentionally absent*), the rollup says `degraded`.

## What was missing

The rollup had no input answering **"is a datasource expected on this deployment at all?"**, so it could not tell an intentional absence from an operator who forgot `ATLAS_DATASOURCE_URL`. This adds one, following the `#4457` scheduled-backup tripwire's `{ expected: false }` precedent a few lines down in the same file.

- `ATLAS_DATASOURCE_EXPECTED=false` (per service), or `datasourceExpected: false` in `atlas.config.ts`
- New `lib/db/datasource-expectation.ts` owns the resolution and documents why

## What it deliberately does not do

- **Intent is never inferred from the absence itself.** Undeclared still degrades — that is what keeps a self-hosted box that meant to set `ATLAS_DATASOURCE_URL` visible instead of silently green.
- **It cannot mute a real failure.** The declaration is narrowed by `dsNotConfigured`, so it is structurally unreachable on a deployment that *has* a datasource. A configured datasource that fails still reports `error` + 503 and still leaves the load balancer (#1981).
- An unrecognized env value falls back to *expected* (the noisy answer) and warns once.

The env var overrides the config field **in both directions**, because `api-staging` builds from the prod `deploy/api/atlas.config.ts` (#3958) and differs only by env vars — a shared config file must not be able to declare an expectation on another service's behalf.

Also drops the `MISSING_DATASOURCE_URL` message from the `disabled` component when the absence is declared. An undeclared absence keeps it: there, it is the finding.

## Tests

`packages/api/src/api/__tests__/health.test.ts` (+8) and a new `lib/db/__tests__/datasource-expectation.test.ts` (+8). The positives are the easy half; these are the ones that matter:

- **undeclared + no datasource still degrades** — a fix that simply stopped counting a missing datasource would pass every positive test and silently green a misconfigured self-host
- **declared not-expected + a configured datasource that FAILS still returns `error` + 503** — the declaration must not become a mute switch
- an unrecognized declaration is treated as undeclared, so a typo leaves the deployment noisy

## Rollout

After merge, set `ATLAS_DATASOURCE_EXPECTED=false` on the **`api-staging` service only** (service-scoped Railway override, not shared scope), then confirm `https://api.staging.useatlas.dev/api/health` returns `"ok"`. Prod `api`/`api-eu`/`api-apac` must **not** get it — they have real datasources and must keep degrading if they ever lose one.

## Verification

- `/ci` — 32/32 gates PASS
- `--affected` — 119 files, all pass
- No wire-schema change (`"disabled"` was already in the enum), so no OpenAPI drift