### PR TITLE
fix(test-runner): normalise --affected paths at the boundary, and see template-literal imports

### DIFF
--- a/packages/api/scripts/affected.ts
+++ b/packages/api/scripts/affected.ts
@@ -1,0 +1,147 @@
+/**
+ * Affected-test selection for scripts/test-isolated.ts (`--affected`).
+ *
+ * Extracted from the runner so the path mapping can be unit-tested without a
+ * live git repo or a real test run — same reason signal-retry.ts is its own
+ * module. See src/__tests__/test-isolated-affected.test.ts.
+ *
+ * The path contract is the whole point of this module. `git diff --name-only`
+ * emits **repo-root-relative** paths regardless of the cwd it runs in
+ * (`packages/api/src/lib/tools/explore.ts`), while every consumer here wants
+ * them relative to the api package. That conversion happens exactly once, in
+ * `toPackageRelative` at the top of `collectAffectedTests` — previously it did
+ * not happen at all, so `resolve(ROOT, rel)` produced a doubled path
+ * (`packages/api/packages/api/src/...`) that matched nothing on disk and the
+ * `src/` prefix test was never true, silently degrading selection to
+ * basename-only tokens (#4851).
+ */
+
+import { readFileSync } from "node:fs";
+import { basename, relative, resolve } from "node:path";
+
+export interface AffectedContext {
+  /** Absolute path to the repo root — what git's `--name-only` paths are relative to. */
+  repoRoot: string;
+  /** Absolute path to the api package root (the runner's `ROOT`). */
+  packageRoot: string;
+  /** Absolute path to the api source root (the runner's `SRC`). */
+  srcRoot: string;
+  /** Seam for tests: reads a test file's contents. Defaults to readFileSync. */
+  readFile?: (path: string) => string;
+}
+
+/** One changed file, resolved into the two shapes the matcher needs. */
+export interface NormalizedPath {
+  /** Absolute path on disk. */
+  abs: string;
+  /** Path relative to the api package root — `src/lib/x.ts`, or `../types/src/x.ts` for files outside it. */
+  packageRel: string;
+}
+
+/**
+ * The single normalization boundary: repo-root-relative → absolute + package-relative.
+ *
+ * Files outside the api package deliberately survive as `../<pkg>/...` rather
+ * than being dropped — they still contribute a basename token (a change to
+ * `packages/types/src/foo.ts` should reach tests that import `foo`), but they
+ * will not match the `src/` prefix test, so they never earn the richer tokens.
+ */
+export function toPackageRelative(
+  changed: readonly string[],
+  repoRoot: string,
+  packageRoot: string,
+): NormalizedPath[] {
+  return changed.map((repoRel) => {
+    const abs = resolve(repoRoot, repoRel);
+    return { abs, packageRel: relative(packageRoot, abs) };
+  });
+}
+
+export function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Map changed source files → test files whose content looks like it imports them.
+ * Test files that changed directly are always included.
+ *
+ * @param changed Repo-root-relative paths, exactly as `git diff --name-only` emits them.
+ * @param allTests Absolute paths of every discovered test file.
+ */
+export function collectAffectedTests(
+  changed: readonly string[],
+  allTests: Set<string>,
+  ctx: AffectedContext,
+): string[] {
+  const readFile = ctx.readFile ?? ((p: string) => readFileSync(p, "utf8"));
+  const affected = new Set<string>();
+  const sourceTokens = new Set<string>();
+  const srcPrefix = relative(ctx.packageRoot, ctx.srcRoot) + "/";
+
+  for (const { abs, packageRel } of toPackageRelative(changed, ctx.repoRoot, ctx.packageRoot)) {
+    if (!packageRel.endsWith(".ts") && !packageRel.endsWith(".tsx")) continue;
+    if (packageRel.endsWith(".test.ts")) {
+      // Only tests that actually exist in the discovered set — a deleted test
+      // file still shows up in the diff but has nothing to run.
+      if (allTests.has(abs)) affected.add(abs);
+      continue;
+    }
+    // Every source file contributes a basename token. Files inside the api
+    // src root additionally contribute a full stem from src (`lib/tools/explore`)
+    // and a parent-dir stem (`lib/tools`), to catch both direct imports
+    // (`from "../explore"`) and barrel imports (`from "@atlas/api/lib/tools"`)
+    // that land in tests via mock.module(). Over-triggering is preferred to
+    // false negatives.
+    const stemBase = basename(packageRel).replace(/\.(ts|tsx)$/, "");
+    if (stemBase && stemBase !== "index") sourceTokens.add(stemBase);
+    if (packageRel.startsWith(srcPrefix)) {
+      const relFromSrc = packageRel.slice(srcPrefix.length).replace(/\.(ts|tsx)$/, "");
+      const segments = relFromSrc.split("/");
+      // Full stem from src root (`lib/audit/admin`)
+      if (stemBase !== "index") sourceTokens.add(relFromSrc);
+      // Parent dir stem for barrel imports (`lib/audit`) — applies to
+      // both regular files and index.ts files. Skip the bare parent
+      // basename (e.g. `audit`) because short, generic names like `db`,
+      // `types`, `config`, `utils`, `middleware`, `errors`, `auth` would
+      // match nearly every test in the suite via `@scope/pkg/.../db` etc.
+      // The full parent stem (`lib/db`) still catches fully-qualified
+      // barrel imports without the over-match.
+      if (segments.length >= 2) {
+        const parentStem = segments.slice(0, -1).join("/");
+        sourceTokens.add(parentStem);
+      }
+    }
+  }
+
+  if (sourceTokens.size === 0) return [...affected];
+
+  // Build one combined regex so we read each test file once.
+  // Match any quoted module-specifier-shaped string ending in a token:
+  // `"<prefix-ending-in-slash><token><optional ?query>"`. Catches static
+  // `from "..."`, dynamic `import("...")`, and runtime `mock.module("...", ...)`
+  // — the last form is heavily used in api tests so we can't restrict to
+  // static imports. Requires `/` or start-of-specifier before the token
+  // so `admin` doesn't false-positive on `"./admin-like"`.
+  //
+  // Backticks count as delimiters and a trailing `?query` is tolerated because
+  // ~32 api test files import the module under test through a cache-busting
+  // template literal — `import(\`@atlas/api/lib/tools/explore?t=${n}\`)` — to
+  // get fresh module state. A quote-only, token-must-be-last pattern cannot see
+  // those at all, so those files were invisible to --affected via this edge
+  // regardless of the path bug (#4851).
+  const QUOTE = "[\"'`]";
+  const NOT_QUOTE = "[^\"'`]";
+  const pattern = new RegExp(
+    `${QUOTE}(?:${NOT_QUOTE}*/)?(${[...sourceTokens].map(escapeRegex).join("|")})(?:\\?${NOT_QUOTE}*)?${QUOTE}`,
+    "m",
+  );
+
+  for (const testFile of allTests) {
+    if (affected.has(testFile)) continue;
+    if (pattern.test(readFile(testFile))) {
+      affected.add(testFile);
+    }
+  }
+
+  return [...affected];
+}

--- a/packages/api/scripts/test-isolated.ts
+++ b/packages/api/scripts/test-isolated.ts
@@ -17,10 +17,10 @@
  */
 
 import { Glob } from "bun";
-import { readFileSync } from "node:fs";
 import { cpus } from "node:os";
-import { resolve, relative, basename } from "node:path";
+import { resolve, relative } from "node:path";
 import { runFileWithSignalRetry } from "./signal-retry";
+import { collectAffectedTests } from "./affected";
 
 const ROOT = resolve(import.meta.dir, "..");
 const SRC = resolve(ROOT, "src");
@@ -65,7 +65,7 @@ for (let i = 0; i < args.length; i++) {
 }
 
 // --- Affected-mode helpers ---
-async function gitDiffNames(...cmd: string[]): Promise<string[]> {
+async function gitLines(...cmd: string[]): Promise<string[]> {
   const proc = Bun.spawn(cmd, { cwd: ROOT, stdout: "pipe", stderr: "pipe" });
   const [out, err] = await Promise.all([
     new Response(proc.stdout).text(),
@@ -83,86 +83,26 @@ async function gitDiffNames(...cmd: string[]): Promise<string[]> {
   return out.split("\n").map((l) => l.trim()).filter(Boolean);
 }
 
+// The repo root — what git's `--name-only` paths are relative to. Asked of git
+// rather than derived as `resolve(ROOT, "../..")` so a package move can't
+// silently reintroduce the path-doubling bug this replaced (#4851).
+async function gitRepoRoot(): Promise<string> {
+  const [top] = await gitLines("git", "rev-parse", "--show-toplevel");
+  if (!top) throw new Error("git rev-parse --show-toplevel returned no output");
+  return top;
+}
+
 // All repo files changed on the branch: committed since base + staged +
 // unstaged + untracked. Paths are repo-root-relative.
 async function collectChangedFiles(base: string): Promise<string[]> {
   const out = new Set<string>();
   const buckets = await Promise.all([
-    gitDiffNames("git", "diff", "--name-only", `${base}...HEAD`),
-    gitDiffNames("git", "diff", "--name-only", "HEAD"),
-    gitDiffNames("git", "ls-files", "--others", "--exclude-standard"),
+    gitLines("git", "diff", "--name-only", `${base}...HEAD`),
+    gitLines("git", "diff", "--name-only", "HEAD"),
+    gitLines("git", "ls-files", "--others", "--exclude-standard"),
   ]);
   for (const bucket of buckets) for (const f of bucket) out.add(f);
   return [...out];
-}
-
-function escapeRegex(s: string): string {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-// Map changed source files → test files whose content looks like it imports them.
-// Test files that changed directly are always included.
-function collectAffectedTests(changed: string[], allTests: Set<string>): string[] {
-  const affected = new Set<string>();
-  const sourceTokens = new Set<string>();
-  const API_PREFIX = relative(ROOT, SRC) + "/";
-
-  for (const rel of changed) {
-    if (!rel.endsWith(".ts") && !rel.endsWith(".tsx")) continue;
-    const abs = resolve(ROOT, rel);
-    if (rel.endsWith(".test.ts")) {
-      if (allTests.has(abs)) affected.add(abs);
-      continue;
-    }
-    // Source files outside packages/api/src contribute just a basename
-    // token. Source files inside packages/api/src contribute multiple
-    // tokens to catch both direct imports (`from "../admin"`) and barrel
-    // imports (`from "@atlas/api/lib/audit"`) that land in tests via
-    // mock.module(). Over-triggering is preferred to false negatives.
-    const stemBase = basename(rel).replace(/\.(ts|tsx)$/, "");
-    if (stemBase && stemBase !== "index") sourceTokens.add(stemBase);
-    if (rel.startsWith(API_PREFIX)) {
-      const relFromSrc = rel.slice(API_PREFIX.length).replace(/\.(ts|tsx)$/, "");
-      const segments = relFromSrc.split("/");
-      // Full stem from src root (`lib/audit/admin`)
-      if (stemBase !== "index") sourceTokens.add(relFromSrc);
-      // Parent dir stem for barrel imports (`lib/audit`) — applies to
-      // both regular files and index.ts files. Skip the bare parent
-      // basename (e.g. `audit`) because short, generic names like `db`,
-      // `types`, `config`, `utils`, `middleware`, `errors`, `auth` would
-      // match nearly every test in the suite via `@scope/pkg/.../db` etc.
-      // The full parent stem (`lib/db`) still catches fully-qualified
-      // barrel imports without the over-match.
-      if (segments.length >= 2) {
-        const parentStem = segments.slice(0, -1).join("/");
-        sourceTokens.add(parentStem);
-      }
-    }
-  }
-
-  if (sourceTokens.size === 0) return [...affected];
-
-  // Build one combined regex so we read each test file once.
-  // Match any quoted module-specifier-shaped string ending in a token:
-  // `"<prefix-ending-in-slash><token>"`. Catches static `from "..."`,
-  // dynamic `import("...")`, and runtime `mock.module("...", ...)` —
-  // the last form is heavily used in api tests so we can't restrict to
-  // static imports. Requires `/` or start-of-specifier before the token
-  // so `admin` doesn't false-positive on `"./admin-like"`.
-  const pattern = new RegExp(
-    `["'](?:[^"']*/)?(${[...sourceTokens].map(escapeRegex).join("|")})["']`,
-    "m",
-  );
-
-  for (const testFile of allTests) {
-    if (affected.has(testFile)) continue;
-    const text = readFileSync(testFile, "utf8");
-    if (pattern.test(text)) {
-      affected.add(testFile);
-    }
-  }
-
-  return [...affected];
 }
 
 // --- Discover test files ---
@@ -178,13 +118,17 @@ if (filter) {
 }
 
 if (affected) {
-  const changed = await collectChangedFiles(since);
+  const [repoRoot, changed] = await Promise.all([gitRepoRoot(), collectChangedFiles(since)]);
   if (changed.length === 0) {
     console.log(`No changed files vs ${since} — nothing to test.`);
     process.exit(0);
   }
   const testSet = new Set(files);
-  files = collectAffectedTests(changed, testSet);
+  files = collectAffectedTests(changed, testSet, {
+    repoRoot,
+    packageRoot: ROOT,
+    srcRoot: SRC,
+  });
   if (files.length === 0) {
     console.log(
       `Affected-mode: ${changed.length} changed files vs ${since}, but no tests import them.\n` +

--- a/packages/api/src/__tests__/test-isolated-affected.test.ts
+++ b/packages/api/src/__tests__/test-isolated-affected.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Regression tests for --affected selection in scripts/affected.ts.
+ *
+ * `git diff --name-only` emits repo-root-relative paths, but the matcher used
+ * to treat them as package-relative. That produced a doubled absolute path
+ * (`packages/api/packages/api/src/...`), so a directly-changed test file could
+ * never match the discovered set, and the `src/` prefix test was never true —
+ * silently degrading selection to basename-only tokens while still returning a
+ * plausible non-empty result. A red test file survived a green `--affected`
+ * run because of it (#4851, found during #4834).
+ *
+ * These call collectAffectedTests() directly on repo-root-relative inputs with
+ * a readFile seam, so the mapping is pinned without a live git repo or a real
+ * test run.
+ */
+
+import { describe, test, expect } from "bun:test";
+import { collectAffectedTests, toPackageRelative } from "../../scripts/affected";
+
+const REPO_ROOT = "/repo";
+const PACKAGE_ROOT = "/repo/packages/api";
+const SRC_ROOT = "/repo/packages/api/src";
+
+const CTX_BASE = { repoRoot: REPO_ROOT, packageRoot: PACKAGE_ROOT, srcRoot: SRC_ROOT };
+
+/** Absolute path of a test file inside the api package. */
+function t(rel: string): string {
+  return `${SRC_ROOT}/${rel}`;
+}
+
+/**
+ * Build a context whose readFile serves canned test-file bodies. Any test file
+ * not in the map reads as empty (imports nothing), so it can only be selected
+ * by the direct-change path.
+ */
+function ctx(bodies: Record<string, string> = {}) {
+  return { ...CTX_BASE, readFile: (p: string) => bodies[p] ?? "" };
+}
+
+describe("toPackageRelative", () => {
+  test("maps repo-root-relative api paths to package-relative", () => {
+    expect(toPackageRelative(["packages/api/src/lib/tools/explore.ts"], REPO_ROOT, PACKAGE_ROOT))
+      .toEqual([
+        {
+          abs: "/repo/packages/api/src/lib/tools/explore.ts",
+          packageRel: "src/lib/tools/explore.ts",
+        },
+      ]);
+  });
+
+  test("keeps files outside the api package reachable as ../<pkg>/…", () => {
+    const [mapped] = toPackageRelative(["packages/types/src/index.ts"], REPO_ROOT, PACKAGE_ROOT);
+    expect(mapped.abs).toBe("/repo/packages/types/src/index.ts");
+    expect(mapped.packageRel).toBe("../types/src/index.ts");
+  });
+
+  test("never produces a doubled package path — the #4851 regression", () => {
+    const [mapped] = toPackageRelative(["packages/api/src/lib/tools/explore.ts"], REPO_ROOT, PACKAGE_ROOT);
+    expect(mapped.abs).not.toContain("packages/api/packages/api");
+  });
+});
+
+describe("collectAffectedTests — directly changed test files", () => {
+  test("selects a changed test file that exists in the discovered set", () => {
+    const testFile = t("lib/tools/__tests__/explore-backend.test.ts");
+    const selected = collectAffectedTests(
+      ["packages/api/src/lib/tools/__tests__/explore-backend.test.ts"],
+      new Set([testFile]),
+      ctx(),
+    );
+    expect(selected).toEqual([testFile]);
+  });
+
+  test("ignores a changed test file that no longer exists on disk", () => {
+    const selected = collectAffectedTests(
+      ["packages/api/src/lib/tools/__tests__/deleted.test.ts"],
+      new Set([t("lib/tools/__tests__/explore-backend.test.ts")]),
+      ctx(),
+    );
+    expect(selected).toEqual([]);
+  });
+});
+
+describe("collectAffectedTests — source → test tokens", () => {
+  const backend = t("lib/tools/__tests__/explore-backend.test.ts");
+  const failClosed = t("lib/tools/__tests__/explore-fail-closed.test.ts");
+  const unrelated = t("lib/billing/__tests__/entitlements.test.ts");
+
+  const allTests = new Set([backend, failClosed, unrelated]);
+
+  test("a src change reaches importers via the full stem, not just the basename", () => {
+    // Neither body mentions the bare basename `explore` as its own specifier —
+    // only the full stem and the barrel. Under the old basename-only
+    // degradation these would both be missed.
+    const selected = collectAffectedTests(
+      ["packages/api/src/lib/tools/explore.ts"],
+      allTests,
+      ctx({
+        [backend]: `import { run } from "@atlas/api/lib/tools/explore";`,
+        [failClosed]: `mock.module("@atlas/api/lib/tools", () => ({}));`,
+        [unrelated]: `import { entitlements } from "../entitlements";`,
+      }),
+    );
+    expect(new Set(selected)).toEqual(new Set([backend, failClosed]));
+  });
+
+  test("does not select tests that import nothing related", () => {
+    const selected = collectAffectedTests(
+      ["packages/api/src/lib/tools/explore.ts"],
+      allTests,
+      ctx({ [unrelated]: `import { entitlements } from "../entitlements";` }),
+    );
+    expect(selected).toEqual([]);
+  });
+
+  test("a change outside packages/api contributes only a basename token", () => {
+    const typesConsumer = t("lib/billing/__tests__/plan-limits.test.ts");
+    const all = new Set([typesConsumer, unrelated]);
+    const selected = collectAffectedTests(
+      ["packages/types/src/plan-limits.ts"],
+      all,
+      ctx({
+        [typesConsumer]: `import type { PlanLimits } from "@useatlas/types/plan-limits";`,
+        [unrelated]: `import { entitlements } from "../entitlements";`,
+      }),
+    );
+    expect(selected).toEqual([typesConsumer]);
+  });
+
+  test("an out-of-package index.ts contributes no token, so it selects nothing", () => {
+    const selected = collectAffectedTests(
+      ["packages/types/src/index.ts"],
+      allTests,
+      ctx({
+        [backend]: `import "@useatlas/types";`,
+        [failClosed]: `import "../index";`,
+      }),
+    );
+    expect(selected).toEqual([]);
+  });
+
+  test("non-TypeScript changes select nothing", () => {
+    const selected = collectAffectedTests(
+      ["docs/development/testing.md", ".github/workflows/ci.yml"],
+      allTests,
+      ctx({ [backend]: `import "@atlas/api/lib/tools/explore";` }),
+    );
+    expect(selected).toEqual([]);
+  });
+
+  test("sees a cache-busting template-literal dynamic import", () => {
+    // ~32 api test files import the module under test this way to get fresh
+    // module state. Neither the backtick delimiter nor the trailing ?query was
+    // matched before, so these files were invisible to --affected (#4851).
+    const selected = collectAffectedTests(
+      ["packages/api/src/lib/tools/explore.ts"],
+      new Set([backend, unrelated]),
+      ctx({
+        [backend]: "const m = await import(`@atlas/api/lib/tools/explore?t=${testCounter}`);",
+        [unrelated]: `import { entitlements } from "../entitlements";`,
+      }),
+    );
+    expect(selected).toEqual([backend]);
+  });
+
+  test("still requires the token to end the specifier — `?` is not a wildcard", () => {
+    const selected = collectAffectedTests(
+      ["packages/api/src/lib/tools/explore.ts"],
+      new Set([backend]),
+      // `explore-like` must not match on the `explore` token, in any delimiter.
+      ctx({ [backend]: "import x from `./explore-like`;" }),
+    );
+    expect(selected).toEqual([]);
+  });
+
+  test("a bare parent basename does not over-match — `lib/db` yes, `db` no", () => {
+    const dbTest = t("lib/db/__tests__/internal.test.ts");
+    const viaFullParent = t("lib/audit/__tests__/writer.test.ts");
+    const all = new Set([dbTest, viaFullParent]);
+    const selected = collectAffectedTests(
+      ["packages/api/src/lib/db/internal.ts"],
+      all,
+      ctx({
+        [dbTest]: `import { pool } from "@atlas/api/lib/db";`,
+        // Only mentions the generic trailing segment `db`, which must not be a token.
+        [viaFullParent]: `import { x } from "./some/other/db";`,
+      }),
+    );
+    expect(selected).toEqual([dbTest]);
+  });
+});


### PR DESCRIPTION
Closes #4851.

## The bug

`git diff --name-only` emits **repo-root-relative** paths regardless of cwd — the comment at `test-isolated.ts:87` said so — but `collectAffectedTests` treated them as **package-relative** (`ROOT` is `packages/api`). Two failures, one root cause:

1. **A directly-changed test file was never selected.** `allTests.has(abs)` was checked against `packages/api/packages/api/src/...`, which matches nothing.
2. **The richer-token branch was dead.** `rel.startsWith("src/")` was never true, so the full-stem (`lib/tools/explore`) and parent-barrel (`lib/tools`) tokens were never added. Selection silently degraded to basename-only — still returning a plausible non-empty set, so it read as working.

A red test file survived a green local `--affected` run during #4834; only the review panel caught it.

## The fix

Conversion happens **once**, in `toPackageRelative` at the top of `collectAffectedTests` — not patched per use site. Files outside the api package survive as `../<pkg>/...`, so they still contribute a basename token but never earn the src-only tokens.

The repo root comes from `git rev-parse --show-toplevel` rather than a positional `resolve(ROOT, "../..")`, so a package move can't silently reintroduce path doubling.

Selection logic moves to `scripts/affected.ts` so it is unit-testable without a live git repo or a real test run — same rationale as `scripts/signal-retry.ts`.

## Second defect found while verifying

The two files the issue names as must-select — `explore-backend.test.ts` and `explore-fail-closed.test.ts` — **still weren't selected after the path fix**. They import the module under test through a cache-busting template literal:

```ts
await import(`@atlas/api/lib/tools/explore?t=${testCounter}`)
```

The matcher recognised only `"`/`'` delimiters with the token at the very end. **32 api test files** use that form, so they were invisible to `--affected` via this edge regardless of the path bug. Backticks and a trailing `?query` are now matched; the token must still end the specifier, so `./explore-like` stays excluded.

## Verification

| Check | Result |
|---|---|
| Change to `src/lib/tools/explore.ts` | 75 → **78** files selected — targeted, not blanket |
| Criterion-3 targets | `explore-backend` + `explore-fail-closed` now selected (plus `explore-default-chain-fallthrough`, also previously missed) |
| Editing a test file selects that test | ✅ (impossible before) |
| New tests against the **old** mapping | **6 of 13 fail** — the 7 that pass are the negative cases, correct either way |
| Negative guard | change outside `packages/api/src` selects only via basename; out-of-package `index.ts` selects nothing |
| `bun run lint` / `bun run type` | exit 0 |

## Acceptance criteria

- [x] Paths normalised once, at the boundary
- [x] Editing a test file selects that test file
- [x] `explore.ts` selects both explore suites via full-stem/barrel tokens, not incidentally via basename
- [x] A test asserts the selection function directly on repo-root-relative inputs, no live git repo
- [x] Negative test — the fix does not over-select everything
- [x] The `:117-121` comment now matches what the code does