### PR TITLE
fix(ci): scope the migration advisory lock to its target schema

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -511,11 +511,13 @@ jobs:
           TEST_DATABASE_URL: postgresql://atlas:atlas@localhost:5432/atlas
         run: bun run scripts/test-isolated.ts --shard ${{ matrix.shard }}/4
     services:
-      # Postgres for the migration smoke test. The other 3 shards see
-      # the same service (matrix shares the `services` block), which is
-      # fine — only one shard at a time runs the migrate-pg test, and
-      # it scopes its writes to a per-test schema so concurrent shards
-      # don't trample each other.
+      # Postgres for the real-Postgres suites. Each matrix leg is its own
+      # runner and gets its own service container — shards do NOT share this
+      # Postgres, so cross-shard interference is not a thing. Contention is
+      # always *within* a shard, between the `-pg` suites the runner happens
+      # to have in flight concurrently; those scope their writes to a private
+      # scratch schema, and the migration advisory lock is keyed to that schema
+      # so they no longer serialize against each other (#4844).
       postgres:
         image: postgres:16-alpine
         env:

--- a/packages/api/scripts/test-isolated.ts
+++ b/packages/api/scripts/test-isolated.ts
@@ -17,6 +17,7 @@
  */
 
 import { Glob } from "bun";
+import { appendFileSync } from "node:fs";
 import { cpus } from "node:os";
 import { resolve, relative } from "node:path";
 import { runFileWithSignalRetry } from "./signal-retry";
@@ -221,6 +222,38 @@ console.log(
     `  |  Time: ${totalMs}ms`,
 );
 console.log("─".repeat(60));
+
+// GitHub Actions job summary — renders on the run page, so a red shard names
+// the failing suite (and its duration, which is what identifies a setup-budget
+// timeout) without anyone downloading raw job logs first (#4844).
+const stepSummary = process.env.GITHUB_STEP_SUMMARY;
+if (stepSummary) {
+  const heading = shardTotal > 1 ? `api-tests (${shardIndex + 1}/${shardTotal})` : "api-tests";
+  const lines = [
+    `### ${failed > 0 ? "❌" : "✅"} ${heading}`,
+    "",
+    `${results.length} files · ${passed} passed · ${failed} failed` +
+      (totalRetries > 0 ? ` · ${totalRetries} signal retries` : "") +
+      ` · ${totalMs}ms`,
+  ];
+  if (failed > 0) {
+    lines.push("", "| Failed suite | Duration | Signal |", "| --- | --- | --- |");
+    for (const r of results.filter((r) => r.exitCode !== 0)) {
+      lines.push(
+        `| \`${relative(ROOT, r.file)}\` | ${r.durationMs.toFixed(0)}ms | ${r.signalCode ?? "—"} |`,
+      );
+    }
+  }
+  try {
+    // Append, not overwrite — GITHUB_STEP_SUMMARY is shared across a job's steps.
+    appendFileSync(stepSummary, lines.join("\n") + "\n");
+  } catch (err) {
+    // Never let a summary-write problem mask the real test result.
+    console.warn(
+      `Could not write GITHUB_STEP_SUMMARY: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
 
 if (failed > 0) {
   console.log("\nFailed files:");

--- a/packages/api/src/lib/db/__tests__/migrate-lock-scope-pg.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate-lock-scope-pg.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Real-Postgres coverage for the migration advisory lock's schema scoping (#4844).
+ *
+ * `runMigrations` serialises concurrent migrators on
+ * `pg_advisory_lock(hashtext(...))`. The key used to be the bare constant
+ * `'atlas_migrations'`, which is **database-wide** — so every `-pg` test suite
+ * blocked on one lock even though each runs its migrations into its own private
+ * scratch schema. Measured on this repo: one suite 0.9s, eight concurrent
+ * suites 30.5s wall, landing exactly on the suites' 30s `beforeAll` budget and
+ * failing a different one per run.
+ *
+ * Two properties matter and both are asserted here:
+ *   1. In `public` the key is **bit-identical** to the historical constant, so a
+ *      rolling deploy can never have old and new instances holding different
+ *      keys (which would let them migrate concurrently — the race the lock
+ *      exists to prevent).
+ *   2. Two different scratch schemas get different keys, and a lock held in one
+ *      does not block the other. That is the actual fix.
+ *
+ * Skips cleanly when `TEST_DATABASE_URL` is unset. Opt in locally with:
+ *   bun run db:up && export TEST_DATABASE_URL=postgresql://atlas:atlas@localhost:5432/atlas
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { Pool } from "pg";
+import { ADVISORY_LOCK_KEY_SQL } from "@atlas/api/lib/db/migrate";
+
+const TEST_DB_URL = process.env.TEST_DATABASE_URL;
+const describeIfPg = TEST_DB_URL ? describe : describe.skip;
+const PG_TEST_TIMEOUT_MS = 30_000;
+
+const suffix = `${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
+const SCHEMA_A = `lockscope_a_${suffix}`;
+const SCHEMA_B = `lockscope_b_${suffix}`;
+
+/** Read the lock key that a session with the given search_path would use. */
+async function keyForSchema(pool: Pool, schema: string): Promise<number> {
+  const client = await pool.connect();
+  try {
+    await client.query(`SET search_path TO "${schema}"`);
+    const { rows } = await client.query(`SELECT ${ADVISORY_LOCK_KEY_SQL} AS key`);
+    return rows[0].key as number;
+  } finally {
+    client.release();
+  }
+}
+
+describeIfPg("migration advisory lock is scoped to the target schema (real Postgres)", () => {
+  let pool: Pool;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: TEST_DB_URL, max: 4 });
+    await pool.query(`CREATE SCHEMA IF NOT EXISTS "${SCHEMA_A}"`);
+    await pool.query(`CREATE SCHEMA IF NOT EXISTS "${SCHEMA_B}"`);
+  }, PG_TEST_TIMEOUT_MS);
+
+  afterAll(async () => {
+    await pool.query(`DROP SCHEMA IF EXISTS "${SCHEMA_A}" CASCADE`);
+    await pool.query(`DROP SCHEMA IF EXISTS "${SCHEMA_B}" CASCADE`);
+    await pool.end();
+  }, PG_TEST_TIMEOUT_MS);
+
+  it(
+    "keeps the historical key in public, so a rolling deploy can't split the lock",
+    async () => {
+      const client = await pool.connect();
+      try {
+        await client.query("SET search_path TO public");
+        const { rows } = await client.query(
+          `SELECT ${ADVISORY_LOCK_KEY_SQL} AS scoped,
+                  hashtext('atlas_migrations') AS legacy`,
+        );
+        expect(rows[0].scoped).toBe(rows[0].legacy);
+      } finally {
+        client.release();
+      }
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "gives distinct scratch schemas distinct keys",
+    async () => {
+      const [a, b] = await Promise.all([
+        keyForSchema(pool, SCHEMA_A),
+        keyForSchema(pool, SCHEMA_B),
+      ]);
+      expect(a).not.toBe(b);
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "does not block a migrator working in a different schema",
+    async () => {
+      const holder = await pool.connect();
+      const other = await pool.connect();
+      try {
+        await holder.query(`SET search_path TO "${SCHEMA_A}"`);
+        await holder.query(`SELECT pg_advisory_lock(${ADVISORY_LOCK_KEY_SQL})`);
+
+        // A migrator targeting SCHEMA_B must acquire immediately. try_ is used
+        // rather than a blocking lock so a regression fails fast as `false`
+        // instead of hanging until the suite timeout.
+        await other.query(`SET search_path TO "${SCHEMA_B}"`);
+        const { rows } = await other.query(
+          `SELECT pg_try_advisory_lock(${ADVISORY_LOCK_KEY_SQL}) AS acquired`,
+        );
+        expect(rows[0].acquired).toBe(true);
+
+        await other.query(`SELECT pg_advisory_unlock(${ADVISORY_LOCK_KEY_SQL})`);
+      } finally {
+        await holder.query(`SELECT pg_advisory_unlock_all()`).catch(() => {});
+        holder.release();
+        other.release();
+      }
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "still serialises two migrators targeting the same schema",
+    async () => {
+      // The negative half: scoping must not have disabled the lock outright.
+      const holder = await pool.connect();
+      const rival = await pool.connect();
+      try {
+        await holder.query(`SET search_path TO "${SCHEMA_A}"`);
+        await holder.query(`SELECT pg_advisory_lock(${ADVISORY_LOCK_KEY_SQL})`);
+
+        await rival.query(`SET search_path TO "${SCHEMA_A}"`);
+        const { rows } = await rival.query(
+          `SELECT pg_try_advisory_lock(${ADVISORY_LOCK_KEY_SQL}) AS acquired`,
+        );
+        expect(rows[0].acquired).toBe(false);
+      } finally {
+        await holder.query(`SELECT pg_advisory_unlock_all()`).catch(() => {});
+        holder.release();
+        rival.release();
+      }
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+});

--- a/packages/api/src/lib/db/migrate.ts
+++ b/packages/api/src/lib/db/migrate.ts
@@ -54,6 +54,23 @@ export interface RunMigrationsOptions {
 }
 
 /**
+ * Advisory-lock key for the migration runner, evaluated server-side so it
+ * always reflects the session's *effective* schema rather than anything the
+ * caller believes it set.
+ *
+ * `coalesce` matters: `current_schema()` is NULL when the search_path names
+ * only schemas that don't exist, and `pg_advisory_lock(NULL)` is strict — it
+ * returns NULL and takes **no lock at all**. Without the coalesce a broken
+ * search_path would silently run migrations unserialized instead of failing.
+ */
+export const ADVISORY_LOCK_KEY_SQL =
+  "hashtext('atlas_migrations' || CASE WHEN coalesce(current_schema(), 'public') = 'public'" +
+  " THEN '' ELSE ':' || current_schema() END)";
+
+const ADVISORY_LOCK_SQL = `SELECT pg_advisory_lock(${ADVISORY_LOCK_KEY_SQL})`;
+const ADVISORY_UNLOCK_SQL = `SELECT pg_advisory_unlock(${ADVISORY_LOCK_KEY_SQL})`;
+
+/**
  * Run all pending migrations against the given pool.
  *
  * 1. Creates the tracking table if it doesn't exist.
@@ -76,15 +93,29 @@ export async function runMigrations(pool: MigrationPool, options: RunMigrationsO
 
   try {
     // Acquire an advisory lock so concurrent server instances don't race.
-    // hashtext('atlas_migrations') produces a stable int4 key.
-    await client.query("SELECT pg_advisory_lock(hashtext('atlas_migrations'))");
+    // hashtext(...) produces a stable int4 key.
+    //
+    // The key is scoped to the schema the migrations actually write into,
+    // because that — specifically its `__atlas_migrations` table — is the
+    // resource being protected. A bare constant key is database-wide, which
+    // made every `-pg` test suite serialize on one lock even though each runs
+    // into its own private scratch schema: 8 concurrent suites took 30.5s wall
+    // versus 0.9s for one, landing exactly on the suites' 30s `beforeAll`
+    // budget and failing a random one per run (#4844).
+    //
+    // `public` deliberately keeps the original bare key rather than
+    // `atlas_migrations:public`. Production only ever migrates `public`, so the
+    // key stays bit-identical and a rolling deploy can't end up with old and
+    // new instances holding *different* keys — which would let them migrate
+    // concurrently, the exact race this lock exists to prevent.
+    await client.query(ADVISORY_LOCK_SQL);
 
     try {
       return await _runMigrationsLocked(client, options.skip ?? [], (err) => {
         rollbackErr = err;
       });
     } finally {
-      await client.query("SELECT pg_advisory_unlock(hashtext('atlas_migrations'))").catch((err: unknown) => {
+      await client.query(ADVISORY_UNLOCK_SQL).catch((err: unknown) => {
         // Unlock may legitimately fail if the connection is broken (in
         // which case the client is about to be destroyed anyway). Debug
         // so a genuine SQL-level failure still leaves a trace.


### PR DESCRIPTION
Closes #4844.

## Root cause

`runMigrations` serialises concurrent migrators on `pg_advisory_lock(hashtext('atlas_migrations'))`. **That key is a constant, so the lock is database-wide** — every `-pg` suite blocked on one lock even though each runs its migrations into its own private scratch schema.

Measured on this repo (13 shard-2 `-pg` suites, local Postgres):

| Concurrent `-pg` suites | Wall |
|---|---|
| 1 | 907ms |
| 2 | 4,639ms |
| 4 | 8,154ms |
| 8 | **30,530ms** |

Linear scaling is the signature of serialization, and N=8 lands *exactly* on the suites' 30s `beforeAll` budget. Whichever suite drew the last lock blew its setup — which is precisely why it was a **different suite each time, at essentially exactly 30000ms**.

## Two corrections to the issue's framing

**It is not shard 3/4.** Round-robin assignment (`i % 4`) shifts whenever any test file is added or removed, so shard membership isn't stable across branches. Both reported suites sit in **shard 2/4** on today's `main`. And shard 3 isn't even the `-pg`-heaviest — shard 4 has 16, shard 2 has 13, shard 3 has 10. Any shard can draw a cluster.

**Shards do not share a Postgres.** Each matrix leg is its own runner with its own service container. The workflow comment claiming otherwise is corrected here — it is what sent the original diagnosis looking for cross-shard interference.

**The `FATAL: password authentication failed for user "test"` burst is a red herring.** ~88 non-pg suites set a dummy `postgresql://test:test@localhost:5432/test` that points at the same host. Running 24 of them as aggressors moved a `-pg` suite from 4.86s → 5.20s. Not the mechanism.

## The fix

The lock key is scoped to `current_schema()` — the schema whose `__atlas_migrations` table is the resource actually being protected.

Two deliberate details:

- **`public` keeps the original bare key**, not `atlas_migrations:public`. Production only ever migrates `public`, so the key stays bit-identical and a rolling deploy can never end up with old and new instances holding *different* keys — which would let them migrate concurrently, the exact race the lock exists to prevent.
- **`coalesce` guards NULL.** `current_schema()` is NULL when search_path names only missing schemas, and `pg_advisory_lock(NULL)` is strict — it returns NULL and takes **no lock at all**. Without the coalesce a broken search_path would silently run migrations unserialized.

**Fix class chosen:** scope the lock, not a private database per suite (`CREATE DATABASE` × 37 suites is far heavier), not serializing `-pg` suites (that keeps the wall cost and only makes it explicit), and **not raising the 30s budget** — the budget is a useful tripwire and raising it would hide the next regression.

## Validation

13 concurrent `-pg` suites — deliberately harsher than CI, which runs 4 at a time interleaved with ~230 non-pg files:

| | Before | After |
|---|---|---|
| Wall | 52.3s | **21.4s** |
| Worst suite | 52.26s | **21.35s** |
| `durable-state-pg` | 25.06s | 8.83s |
| Migration failures | 1 (`relation "query_suggestions" does not exist`) | **0** |

**12 iterations under that storm: zero failures.** `migrate-pg` (114 tests) and both originally-failing suites pass.

New `migrate-lock-scope-pg.test.ts` pins both halves — that `public` still hashes to the historical key, and that a lock held in one schema doesn't block another *while still blocking a rival in the same schema* (the negative case, so scoping can't have silently disabled the lock).

## Acceptance criteria

- [x] Root-caused — and the "why shard 3/4" premise is falsified, with evidence
- [x] Fix class decided, alternatives rejected with reasons
- [x] Failing suite name + duration in the CI summary via `GITHUB_STEP_SUMMARY`, no log download
- [x] Confirmed under concurrent aggressor load, 12 iterations green