### PR TITLE
fix(security): close GHSA-j8v8-g9cx-5qf4 — bind SCIM provider ownership

### DIFF
--- a/packages/api/src/lib/auth/__tests__/scim-provider-ownership.test.ts
+++ b/packages/api/src/lib/auth/__tests__/scim-provider-ownership.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Contract-pinning tests for the `providerOwnership` mitigation of
+ * GHSA-j8v8-g9cx-5qf4 (HIGH, @better-auth/scim).
+ *
+ * The advisory has NO fix on the 1.6.x stable line — the only upstream patch is
+ * the breaking 1.7.0-beta.4+. `providerOwnership: { enabled: true }` is the
+ * advisory's supported workaround, and it is opt-in, so nothing in the type
+ * system or the plugin's defaults keeps it on. A future refactor of
+ * `buildPlugins()` that drops the option would silently reopen a HIGH
+ * account-takeover hole with every test still green.
+ *
+ * These tests pin the mechanism rather than the mere presence of a flag: they
+ * assert the plugin's OWN schema gains the `userId` binding column when the
+ * option is on and lacks it when off, so the pin fails if upstream ever
+ * repurposes the option name.
+ *
+ * The residual half — providers created BEFORE the flag keep `userId = NULL`
+ * and stay ownerless, because the column is nullable and nothing backfills it —
+ * is covered by migration 0184 and its real-Postgres test
+ * (`scim-provider-seal-ownerless-pg.test.ts`).
+ */
+
+import { describe, expect, it } from "bun:test";
+import { scim } from "@better-auth/scim";
+
+/** Field names the plugin declares on its `scimProvider` model. */
+function scimProviderFields(plugin: ReturnType<typeof scim>): string[] {
+  return Object.keys(plugin.schema?.scimProvider?.fields ?? {}).sort();
+}
+
+describe("SCIM providerOwnership mitigation (GHSA-j8v8-g9cx-5qf4)", () => {
+  it("adds the `userId` owner-binding column when ownership is enabled", () => {
+    const plugin = scim({ storeSCIMToken: "encrypted", providerOwnership: { enabled: true } });
+    expect(scimProviderFields(plugin)).toContain("userId");
+  });
+
+  it("does NOT bind an owner when ownership is left at its default — the vulnerable shape", () => {
+    // The negative half. If this ever starts containing `userId`, upstream has
+    // changed the default (or shipped the 1.7.0 behaviour into 1.6.x) and the
+    // workaround plus migration 0184 can be revisited.
+    const plugin = scim({ storeSCIMToken: "encrypted" });
+    expect(scimProviderFields(plugin)).not.toContain("userId");
+  });
+
+  it("the owner column is the ONLY schema difference the option introduces", () => {
+    // Guards against the option quietly doing more than advertised — a
+    // surprise column or table would change the migration story for a
+    // security fix shipped under a freeze.
+    const off = scimProviderFields(scim({ storeSCIMToken: "encrypted" }));
+    const on = scimProviderFields(scim({ storeSCIMToken: "encrypted", providerOwnership: { enabled: true } }));
+    expect(on.filter((f) => !off.includes(f))).toEqual(["userId"]);
+    expect(off.filter((f) => !on.includes(f))).toEqual([]);
+  });
+
+  it("binds the owner as a nullable column — which is WHY migration 0184 exists", () => {
+    // Documents the fail-open shape at the root of the residual risk: the
+    // plugin's access check is `provider.userId && provider.userId !== userId`,
+    // so a NULL owner short-circuits and grants access. A nullable column
+    // means pre-existing rows are never backfilled by enabling the flag.
+    const plugin = scim({ storeSCIMToken: "encrypted", providerOwnership: { enabled: true } });
+    const userId = plugin.schema?.scimProvider?.fields?.userId as { required?: boolean } | undefined;
+    expect(userId).toBeDefined();
+    expect(userId?.required).toBe(false);
+  });
+});

--- a/packages/api/src/lib/auth/server.ts
+++ b/packages/api/src/lib/auth/server.ts
@@ -2893,6 +2893,33 @@ export function buildPlugins() {
     plugins.push(
       scim({
         storeSCIMToken: "encrypted",
+        // GHSA-j8v8-g9cx-5qf4 (HIGH) — without this, a non-organization
+        // ("personal") SCIM provider is created with no owner, and the
+        // plugin's management access check is
+        //
+        //   } else if (provider.userId && provider.userId !== userId) throw
+        //
+        // so a NULL `userId` short-circuits and ANY authenticated user can
+        // read, list, delete, or regenerate the token of someone else's
+        // provider. `organizationId` is `.optional()` on the plugin's
+        // generate-token body, so personal providers are reachable here even
+        // though the Atlas admin surface is org-scoped.
+        //
+        // The 1.6.x stable line is NOT patched — the only upstream fix is the
+        // breaking 1.7.0-beta.4+ (removes this option, makes binding
+        // mandatory, adds a permanent column). This flag is the advisory's
+        // supported workaround: it stamps `userId` on every personal provider
+        // at creation, so the check above actually fires.
+        //
+        // It is only HALF the fix. The column is nullable and nothing
+        // backfills it, so providers created before this flag stay ownerless
+        // forever — migration 0184 seals those, and explains why it stamps a
+        // sentinel rather than deleting. Both halves are required.
+        //
+        // Enabling this adds `scimProvider.userId`; Better Auth's schema-diff
+        // auto-migrate creates it at boot, before the Atlas migration runner,
+        // so 0184 can rely on it being present.
+        providerOwnership: { enabled: true },
         async beforeSCIMTokenGenerated(data) {
           // Cast needed: the admin plugin adds `role` to the user
           // object but the SCIM plugin's hook type only includes base

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -250,7 +250,11 @@ describe("runMigrations", () => {
     //   BEFORE publish-time widening, the ACL input that decides whether a
     //   reader gained by widening sees who stated the claim first, where and
     //   when, ADR-0036 §T5 amendment 2026-07-27, #4836) = 184.
-    expect(count).toBe(184);
+    //   Plus 0184 (seals ownerless personal SCIM providers by stamping a
+    //   reserved owner id — the residual half of GHSA-j8v8-g9cx-5qf4, which has
+    //   no fix on the @better-auth/scim 1.6.x line; `providerOwnership` only
+    //   binds providers created after it is enabled) = 185.
+    expect(count).toBe(185);
 
     // Advisory lock acquired before anything else
     expect(queries[0]).toContain("pg_advisory_lock");
@@ -463,6 +467,7 @@ describe("runMigrations", () => {
         "0181_brain_fts.sql",
         "0182_audience_member_synced_at.sql",
         "0183_brain_facts_pre_widening_grant.sql",
+        "0184_scim_provider_seal_ownerless.sql",
       ],
     });
 

--- a/packages/api/src/lib/db/__tests__/scim-provider-seal-ownerless-pg.test.ts
+++ b/packages/api/src/lib/db/__tests__/scim-provider-seal-ownerless-pg.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Real-Postgres tests for migration 0184 — sealing ownerless personal SCIM
+ * providers (GHSA-j8v8-g9cx-5qf4).
+ *
+ * Why real Postgres: the migration is a guarded `DO $$ ... $$` block whose
+ * whole value is in its WHERE clause (`userId IS NULL AND organizationId IS
+ * NULL`) and its two existence guards. A mocked query layer evaluates none of
+ * that — it would happily report success against SQL that seals the wrong rows
+ * or throws on a database where SCIM was never enabled.
+ *
+ * The load-bearing assertions here are the NEGATIVE ones: that the migration
+ * leaves org-scoped providers and already-owned providers untouched, and that
+ * it no-ops rather than erroring when the table or column is absent. A test
+ * that only checked "the ownerless row got sealed" would pass just as well
+ * against `UPDATE "scimProvider" SET "userId" = ...` with no WHERE clause at
+ * all — which would lock every tenant out of their own SCIM administration.
+ *
+ * `scimProvider` is owned by Better Auth, not by the Atlas migration runner, so
+ * these tests stand the table up themselves rather than relying on a prior
+ * migration to have created it.
+ *
+ * Skipped cleanly when `TEST_DATABASE_URL` is unset (matches `migrate-pg` /
+ * `connection-group-descriptions-pg`). CI's api-tests workflow provides the
+ * Postgres service.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { Pool } from "pg";
+
+const TEST_DB_URL = process.env.TEST_DATABASE_URL;
+const describeIfPg = TEST_DB_URL ? describe : describe.skip;
+
+const PG_TIMEOUT_MS = 30_000;
+const SENTINEL = "00000000-0000-0000-0000-000000000000";
+
+const MIGRATION_SQL = readFileSync(
+  join(import.meta.dir, "..", "migrations", "0184_scim_provider_seal_ownerless.sql"),
+  "utf8",
+);
+
+describeIfPg("migration 0184 — seal ownerless SCIM providers (GHSA-j8v8-g9cx-5qf4)", () => {
+  let pool: Pool;
+  const schemaName = `scimseal_${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: TEST_DB_URL });
+    pool.on("connect", (client) => {
+      void client.query(`SET search_path TO "${schemaName}"`).catch((err) => {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(`scim-provider-seal-ownerless-pg: SET search_path failed: ${message}`);
+      });
+    });
+    await pool.query(`CREATE SCHEMA IF NOT EXISTS "${schemaName}"`);
+  }, PG_TIMEOUT_MS);
+
+  afterAll(async () => {
+    await pool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+    await pool.end();
+  }, PG_TIMEOUT_MS);
+
+  /**
+   * Stand up the plugin-owned table as `providerOwnership: { enabled: true }`
+   * shapes it: `userId` present and NULLABLE (the fail-open shape the advisory
+   * turns on).
+   */
+  async function createTableWithOwnerColumn(): Promise<void> {
+    await pool.query(`DROP TABLE IF EXISTS "scimProvider"`);
+    await pool.query(`
+      CREATE TABLE "scimProvider" (
+        id             TEXT PRIMARY KEY,
+        "providerId"   TEXT NOT NULL,
+        "scimToken"    TEXT NOT NULL,
+        "organizationId" TEXT,
+        "userId"       TEXT
+      )
+    `);
+  }
+
+  async function ownerOf(id: string): Promise<string | null> {
+    const { rows } = await pool.query<{ userId: string | null }>(
+      `SELECT "userId" FROM "scimProvider" WHERE id = $1`,
+      [id],
+    );
+    return rows[0]?.userId ?? null;
+  }
+
+  describe("with the table and owner column present", () => {
+    beforeEach(async () => {
+      await createTableWithOwnerColumn();
+      await pool.query(
+        `INSERT INTO "scimProvider" (id, "providerId", "scimToken", "organizationId", "userId") VALUES
+           ('p-ownerless', 'corp-idp',  'tok-1', NULL,      NULL),
+           ('p-owned',     'mine-idp',  'tok-2', NULL,      'user-alice'),
+           ('p-org',       'acme-idp',  'tok-3', 'org-acme', NULL),
+           ('p-org-owned', 'beta-idp',  'tok-4', 'org-beta', 'user-bob')`,
+      );
+      await pool.query(MIGRATION_SQL);
+    }, PG_TIMEOUT_MS);
+
+    it("seals the ownerless PERSONAL provider — the exploitable row", async () => {
+      expect(await ownerOf("p-ownerless")).toBe(SENTINEL);
+    });
+
+    it("leaves an already-owned personal provider alone", async () => {
+      // Negative: a legitimate owner must not be overwritten with the sentinel,
+      // which would lock them out of their own connection.
+      expect(await ownerOf("p-owned")).toBe("user-alice");
+    });
+
+    it("leaves ORG-scoped providers alone even when ownerless", async () => {
+      // Negative, and the most important one. Org-scoped rows take the
+      // membership/role branch and were never vulnerable. Sealing them would
+      // break SCIM administration for every enterprise tenant — the exact
+      // blast radius a WHERE-clause slip would produce.
+      expect(await ownerOf("p-org")).toBeNull();
+      expect(await ownerOf("p-org-owned")).toBe("user-bob");
+    });
+
+    it("seals exactly one row — no collateral writes", async () => {
+      const { rows } = await pool.query<{ n: string }>(
+        `SELECT COUNT(*)::text AS n FROM "scimProvider" WHERE "userId" = $1`,
+        [SENTINEL],
+      );
+      expect(rows[0]?.n).toBe("1");
+    });
+
+    it("is idempotent — a second run changes nothing", async () => {
+      await pool.query(MIGRATION_SQL);
+      expect(await ownerOf("p-ownerless")).toBe(SENTINEL);
+      expect(await ownerOf("p-owned")).toBe("user-alice");
+      expect(await ownerOf("p-org")).toBeNull();
+    });
+
+    it("sealed rows keep their token — provisioning is not destroyed", async () => {
+      // The sentinel locks the MANAGEMENT endpoints, not the /scim/v2 protocol
+      // routes, which authenticate by bearer token alone. Deleting the row (the
+      // advisory's other suggestion) would have broken live provisioning.
+      const { rows } = await pool.query<{ scimToken: string }>(
+        `SELECT "scimToken" FROM "scimProvider" WHERE id = 'p-ownerless'`,
+      );
+      expect(rows[0]?.scimToken).toBe("tok-1");
+    });
+  });
+
+  describe("guards", () => {
+    it("no-ops when the scimProvider table is absent (SCIM never enabled)", async () => {
+      await pool.query(`DROP TABLE IF EXISTS "scimProvider"`);
+      // Must not throw: a self-hosted deploy without EE SCIM runs this
+      // migration too, and an error here would abort the whole boot migration.
+      // Awaited deliberately — an un-awaited `.resolves` assertion passes even
+      // when the query rejects, which is the exact false-green this file exists
+      // to rule out.
+      await expect(pool.query(MIGRATION_SQL)).resolves.toBeDefined();
+    }, PG_TIMEOUT_MS);
+
+    it("no-ops when the userId column is absent (providerOwnership not yet applied)", async () => {
+      // Ordering safety net: if Better Auth's boot auto-migrate has not yet
+      // added the column, the migration must skip rather than fail.
+      await pool.query(`DROP TABLE IF EXISTS "scimProvider"`);
+      await pool.query(`
+        CREATE TABLE "scimProvider" (
+          id             TEXT PRIMARY KEY,
+          "providerId"   TEXT NOT NULL,
+          "scimToken"    TEXT NOT NULL,
+          "organizationId" TEXT
+        )
+      `);
+      await pool.query(`INSERT INTO "scimProvider" VALUES ('p1', 'idp', 'tok', NULL)`);
+      await expect(pool.query(MIGRATION_SQL)).resolves.toBeDefined();
+    }, PG_TIMEOUT_MS);
+  });
+});

--- a/packages/api/src/lib/db/internal.ts
+++ b/packages/api/src/lib/db/internal.ts
@@ -1019,6 +1019,12 @@ export const MANAGED_AUTH_MIGRATIONS = [
   // Auth's auto-migrate never re-adds the column (see server.ts / the migration
   // header).
   "0159_drop_user_stripe_customer_id.sql",
+  // Seals ownerless personal SCIM providers (GHSA-j8v8-g9cx-5qf4). MANAGED_AUTH
+  // because it UPDATEs the @better-auth/scim plugin's "scimProvider" table,
+  // which only exists in managed mode with EE SCIM enabled. The migration is
+  // additionally guarded on both the table and the "userId" column, so it
+  // no-ops rather than erroring where SCIM was never turned on.
+  "0184_scim_provider_seal_ownerless.sql",
 ];
 
 /**

--- a/packages/api/src/lib/db/migrations/0184_scim_provider_seal_ownerless.sql
+++ b/packages/api/src/lib/db/migrations/0184_scim_provider_seal_ownerless.sql
@@ -1,0 +1,88 @@
+-- 0184 — seal ownerless non-org SCIM providers (GHSA-j8v8-g9cx-5qf4).
+--
+-- The advisory: @better-auth/scim does not bind non-organization ("personal")
+-- SCIM providers to their creator in the default configuration. The plugin's
+-- management access check is
+--
+--   } else if (provider.userId && provider.userId !== userId) throw FORBIDDEN
+--
+-- so a NULL `userId` short-circuits the `&&` and ANY authenticated user can
+-- read, list, delete, or REGENERATE THE TOKEN of another user's personal
+-- provider. Regenerating rotates it: the legitimate token stops working and
+-- the caller holds a valid one.
+--
+-- The 1.6.x stable line is NOT patched (the only upstream fix is the breaking
+-- 1.7.0-beta.4+). The supported mitigation is `providerOwnership: { enabled:
+-- true }`, wired in `lib/auth/server.ts` alongside this migration. But that
+-- flag only stamps `userId` on providers created AFTER it is enabled — the
+-- column is nullable and nothing backfills it, so every pre-existing personal
+-- provider stays ownerless and exploitable indefinitely. This migration closes
+-- that residual set.
+--
+-- WHY A SENTINEL AND NOT `DELETE`:
+--
+-- The advisory suggests deleting ownerless rows, but that is destructive and
+-- unrecoverable — it discards a live IdP's provisioning connection. Stamping a
+-- reserved, non-existent owner id instead makes the row fail CLOSED against
+-- every real user (no `user.id` can equal it) while preserving the row and its
+-- token. That mirrors exactly what upstream 1.7.0 does ("connections created
+-- before the upgrade carry no owner and become unreachable through the
+-- management endpoints, so reclaim them at the database level") and it is
+-- reversible: an operator reclaims a connection by setting `userId` to the
+-- intended owner, then regenerating the token.
+--
+-- ACTIVE PROVISIONING IS UNAFFECTED. The /scim/v2/* protocol routes
+-- authenticate through `authMiddlewareFactory`, which resolves the Bearer
+-- token via `verifySCIMToken` and never consults `provider.userId`. Only the
+-- MANAGEMENT endpoints (generate-token, get-provider-connection, the
+-- connection list, delete) go through the ownership check. A sealed row keeps
+-- syncing users; it just cannot be administered until reclaimed.
+--
+-- Org-scoped providers are deliberately untouched: they take the
+-- `provider.organizationId` branch, which already enforces org membership and
+-- role, and were never affected by this advisory.
+--
+-- Guarded on both the table and the column because `scimProvider` is owned by
+-- Better Auth, not by this runner: the table only exists once the EE SCIM
+-- plugin has booted, and the `userId` column only once `providerOwnership` is
+-- enabled. Better Auth's schema-diff auto-migrate runs on EVERY boot BEFORE
+-- this runner (see the note in lib/auth/server.ts), so on an EE deploy the
+-- column is present by the time this executes. On a deploy where SCIM was
+-- never enabled, both guards no-op instead of erroring.
+
+DO $$
+DECLARE
+  sealed integer;
+BEGIN
+  -- Unqualified so the lookup resolves against the caller's search_path, and
+  -- `current_schema()` for the same reason — mirrors 0090 / 0085 / 0153. A
+  -- hardcoded 'public' would make this migration silently no-op wherever the
+  -- runner operates in another schema (every -pg test harness does), which on a
+  -- SECURITY migration is the worst possible failure: a clean green run that
+  -- sealed nothing.
+  IF to_regclass('"scimProvider"') IS NULL THEN
+    RAISE NOTICE '0184: scimProvider table absent (SCIM never enabled) — skipping';
+    RETURN;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = current_schema()
+      AND table_name = 'scimProvider'
+      AND column_name = 'userId'
+  ) THEN
+    RAISE NOTICE '0184: scimProvider."userId" absent (providerOwnership not yet applied) — skipping';
+    RETURN;
+  END IF;
+
+  UPDATE "scimProvider"
+     SET "userId" = '00000000-0000-0000-0000-000000000000'
+   WHERE "userId" IS NULL
+     AND "organizationId" IS NULL;
+
+  GET DIAGNOSTICS sealed = ROW_COUNT;
+
+  IF sealed > 0 THEN
+    RAISE WARNING '0184: sealed % ownerless personal SCIM provider(s) (GHSA-j8v8-g9cx-5qf4). They keep provisioning but are unreachable from the management endpoints until an operator sets "userId" to the intended owner and regenerates the token.', sealed;
+  END IF;
+END $$;


### PR DESCRIPTION
Closes the fourth advisory from the container scan, left open by #4863.

## Why the bump couldn't fix it

`@better-auth/scim`'s **1.6.x stable line is not patched** — the advisory says so outright. The only upstream fix is `1.7.0-beta.4+`, which is breaking (removes `providerOwnership`, makes binding mandatory, adds a permanent column, orphans pre-existing connections). This applies the advisory's supported workaround instead.

## The hole

```js
} else if (provider.userId && provider.userId !== userId) throw FORBIDDEN
```

A NULL `userId` short-circuits the `&&`. Any authenticated user could read, list, delete, or **regenerate the token of** another user's non-organization ("personal") SCIM provider. Regeneration rotates it — the legitimate token stops working and the caller holds a valid one.

Reachable here: `scim()` had no `providerOwnership`, and `organizationId` is `.optional()` on the plugin's generate-token body, so personal providers can exist even though the Atlas admin surface is org-scoped. Org-scoped providers were never affected — they take the membership/role branch.

## Two halves, both required

1. **`providerOwnership: { enabled: true }`** — stamps `userId` at creation so the check fires.
2. **Migration 0184** — the flag alone is a *half* fix. The column it adds is **nullable** and nothing backfills it, so every provider created before the flag keeps `userId = NULL` and stays exploitable indefinitely. 0184 seals those.

## Why a sentinel, not DELETE

The advisory suggests deleting ownerless rows. That irreversibly discards a live IdP's provisioning connection. Stamping a reserved owner id fails closed against every real user while preserving the row and its token — exactly what upstream 1.7.0 does (pre-existing connections "become unreachable through the management endpoints") — and it is reversible: an operator reclaims one by setting `userId` to the intended owner and regenerating the token.

**Active provisioning is unaffected.** `/scim/v2/*` authenticates via `authMiddlewareFactory` → `verifySCIMToken` on the Bearer token and never consults `provider.userId`. Only the management endpoints use the ownership check. A sealed connection keeps syncing users; it just can't be administered until reclaimed.

## A bug the tests caught

The migration's first draft hardcoded `public` in its guards. That made it **silently no-op under any other search_path** — a clean green run that sealed nothing, which on a security migration is the worst possible outcome. The real-Postgres test caught it; the guards now follow the repo's `to_regclass(...)` / `current_schema()` convention (0090 / 0085 / 0153).

## Tests lead with the negatives

A positive-only test ("the ownerless row got sealed") would pass just as well against an unguarded `UPDATE` that locks every tenant out of their own SCIM administration. So the load-bearing assertions are:

- org-scoped providers untouched, even when ownerless
- already-owned personal providers untouched (no clobbering a real owner)
- exactly one row written — no collateral writes
- idempotent across re-runs
- token preserved (provisioning not destroyed)
- absent-table **and** absent-column guards no-op rather than aborting boot migrations
- and on the config side: the plugin schema gains `userId` **only** with the flag on, and the column is asserted **nullable** — documenting precisely why 0184 has to exist

## Verification

- `/ci` **32/32 green**, run with `TEST_DATABASE_URL` attached so the `-pg` tests actually executed rather than skipping
- migration `-pg` suite 8/8, contract suite 4/4, `migrate.test.ts` 62/62

🤖 Generated with [Claude Code](https://claude.com/claude-code)