### PR TITLE
feat(web,api): live gateway catalog for the SaaS default model picker

### DIFF
--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -39054,6 +39054,13 @@
                           },
                           "recommended": {
                             "type": "boolean"
+                          },
+                          "supportsTools": {
+                            "type": [
+                              "boolean",
+                              "null"
+                            ],
+                            "description": "Whether the model can call tools, i.e. whether it can drive the agent loop. `null` means unknown — the BYOT direct-provider catalogs publish no capability data — and must be treated as 'do not filter out', not as `false`."
                           }
                         },
                         "required": [
@@ -39065,7 +39072,8 @@
                           "maxOutputTokens",
                           "inputPrice",
                           "outputPrice",
-                          "recommended"
+                          "recommended",
+                          "supportsTools"
                         ]
                       }
                     },

--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -39026,7 +39026,18 @@
                             "type": "string"
                           },
                           "type": {
-                            "type": "string"
+                            "type": "string",
+                            "enum": [
+                              "language",
+                              "embedding",
+                              "image",
+                              "video",
+                              "reranking",
+                              "transcription",
+                              "realtime",
+                              "speech",
+                              "other"
+                            ]
                           },
                           "contextWindow": {
                             "type": [

--- a/bun.lock
+++ b/bun.lock
@@ -452,7 +452,7 @@
     },
     "packages/types": {
       "name": "@useatlas/types",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "devDependencies": {
         "@typescript/native-preview": "^7.0.0-dev.20260623.1",
       },

--- a/ee/src/platform/model-routing.test.ts
+++ b/ee/src/platform/model-routing.test.ts
@@ -38,6 +38,8 @@ const getGatewayCatalogMock = mock(async () => ({
 mock.module("@atlas/api/lib/gateway-catalog", () => ({
   getGatewayCatalog: getGatewayCatalogMock,
   peekModelContextWindow: () => null,
+  isSelectableGatewayModel: (m: { type: string; supportsTools: boolean | null }) =>
+    m.type === "language" && m.supportsTools !== false,
   warmGatewayCatalog: () => {},
   __resetGatewayCatalogCacheForTests: () => {},
   __getRecommendedIdsForTests: () => [] as readonly string[],

--- a/ee/src/platform/model-routing.test.ts
+++ b/ee/src/platform/model-routing.test.ts
@@ -581,6 +581,8 @@ describe("reconcileModelDeprecation", () => {
       inputPrice: null,
       outputPrice: null,
       recommended: false,
+      // BYOT direct-provider catalogs publish no capability data (#4869).
+      supportsTools: null,
     };
   }
 

--- a/ee/src/platform/model-routing.test.ts
+++ b/ee/src/platform/model-routing.test.ts
@@ -31,8 +31,16 @@ const getGatewayCatalogMock = mock(async () => ({
   fetchedAt: "2026-05-10T00:00:00.000Z",
   fallback: false,
 }));
+// Mock ALL exports (repo rule). A partial factory means the next module in
+// this graph to import a gateway-catalog export gets `undefined` and fails at
+// call time, not at import — the failure surfaces far from the cause (#4869
+// review).
 mock.module("@atlas/api/lib/gateway-catalog", () => ({
   getGatewayCatalog: getGatewayCatalogMock,
+  peekModelContextWindow: () => null,
+  warmGatewayCatalog: () => {},
+  __resetGatewayCatalogCacheForTests: () => {},
+  __getRecommendedIdsForTests: () => [] as readonly string[],
 }));
 
 // Import after mocks

--- a/packages/api/src/api/__tests__/admin-model-config.test.ts
+++ b/packages/api/src/api/__tests__/admin-model-config.test.ts
@@ -459,6 +459,11 @@ const mockGetGatewayCatalog: Mock<() => unknown> = mock(async () => ({
 void mock.module("@atlas/api/lib/gateway-catalog", () => ({
   getGatewayCatalog: mockGetGatewayCatalog,
   peekModelContextWindow: mock(() => null),
+  // Real implementation, not a stub: the route's capability gate is the thing
+  // under test in the PUT cases, and a stubbed predicate would assert the mock
+  // rather than the rule (#4869 review).
+  isSelectableGatewayModel: (m: { type: string; supportsTools: boolean | null }) =>
+    m.type === "language" && m.supportsTools !== false,
   warmGatewayCatalog: mock(() => {}),
   __resetGatewayCatalogCacheForTests: mock(() => {}),
   __getRecommendedIdsForTests: mock(() => new Set<string>()),

--- a/packages/api/src/api/__tests__/admin-model-config.test.ts
+++ b/packages/api/src/api/__tests__/admin-model-config.test.ts
@@ -452,8 +452,14 @@ const mockGetGatewayCatalog: Mock<() => unknown> = mock(async () => ({
   fallback: false,
 }));
 
+// mock.module replaces the WHOLE module — every export the real file has must
+// be listed here or an unrelated importer (agent-compaction imports
+// peekModelContextWindow/warmGatewayCatalog) dies with a link-time
+// "Export named 'x' not found". Add new gateway-catalog exports here too.
 void mock.module("@atlas/api/lib/gateway-catalog", () => ({
   getGatewayCatalog: mockGetGatewayCatalog,
+  peekModelContextWindow: mock(() => null),
+  warmGatewayCatalog: mock(() => {}),
   __resetGatewayCatalogCacheForTests: mock(() => {}),
   __getRecommendedIdsForTests: mock(() => new Set<string>()),
 }));

--- a/packages/api/src/api/routes/admin-model-config.ts
+++ b/packages/api/src/api/routes/admin-model-config.ts
@@ -152,7 +152,7 @@ const GatewayCatalogModelSchema = z.object({
     description:
       "Whether the model can call tools, i.e. whether it can drive the agent loop. `null` means unknown — the BYOT direct-provider catalogs publish no capability data — and must be treated as 'do not filter out', not as `false`.",
   }),
-});
+}) satisfies z.ZodType<GatewayCatalogModel, unknown>;
 
 const GatewayCatalogResponseSchema = z.object({
   models: z.array(GatewayCatalogModelSchema),

--- a/packages/api/src/api/routes/admin-model-config.ts
+++ b/packages/api/src/api/routes/admin-model-config.ts
@@ -39,6 +39,8 @@ import {
 } from "@atlas/api/lib/bedrock-catalog";
 import {
   BEDROCK_REGIONS,
+  GATEWAY_MODEL_TYPES,
+  isSelectableGatewayModel,
   type BedrockCredentialBundle,
   type BedrockRegion,
   type GatewayCatalogModel,
@@ -129,11 +131,18 @@ const TestResultSchema = z.object({
   modelName: z.string().optional(),
 });
 
+// Kept route-local for the `.openapi()` annotations, but the shape must not
+// drift from `@useatlas/schemas`' `GatewayCatalogModelSchema` — this one
+// generates `apps/docs/openapi.json`, so a looser field here documents a
+// contract the client actually enforces more strictly. `type` was `z.string()`,
+// which published the enum as a free-form string; the `satisfies` at the
+// bottom now fails the build if the shape and the shared type diverge (#4869
+// review).
 const GatewayCatalogModelSchema = z.object({
   id: z.string(),
   name: z.string(),
   provider: z.string(),
-  type: z.string(),
+  type: z.enum(GATEWAY_MODEL_TYPES),
   contextWindow: z.number().nullable(),
   maxOutputTokens: z.number().nullable(),
   inputPrice: z.string().nullable(),
@@ -263,6 +272,35 @@ const catalogRoute = createRoute({
 // Router
 // ---------------------------------------------------------------------------
 
+
+/**
+ * Verdict on whether a gateway model id may be saved.
+ *
+ * `"unusable"` ONLY when a fresh, live (non-fallback) catalog positively
+ * contains the id and says it can't drive the agent loop. Everything else —
+ * cold cache, gateway outage, id absent from the catalog — returns `"allow"`.
+ * Fail-open is deliberate: rejecting a config write because our cache happened
+ * to be cold is a worse failure than the mis-pin this guards against, and a
+ * workspace legitimately pinned to a retired version must still be able to
+ * re-save its own config.
+ */
+async function classifyGatewayModel(modelId: string): Promise<"allow" | "unusable"> {
+  try {
+    const catalog = await getGatewayCatalog();
+    if (catalog.fallback) return "allow";
+    const hit = catalog.models.find((m) => m.id === modelId);
+    if (!hit) return "allow";
+    return isSelectableGatewayModel(hit) ? "allow" : "unusable";
+  } catch (err) {
+    // Never block a settings write on a catalog problem.
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err), modelId },
+      "admin-model-config: gateway capability check unavailable; allowing the write",
+    );
+    return "allow";
+  }
+}
+
 const adminModelConfig = createAdminRouter();
 // F-53 — BYOT model config (provider, key, model) is a settings cluster surface.
 adminModelConfig.use(requirePermission("admin:settings"));
@@ -303,6 +341,32 @@ adminModelConfig.openapi(setConfigRoute, async (c) => {
     }
 
     const body = c.req.valid("json");
+
+    // Server-side capability gate for gateway models (#4869 review). The
+    // picker's `isSelectable` filter is a BROWSER filter — this endpoint took
+    // `model: z.string().min(1)` and never consulted the catalog, so anything
+    // could be pinned via the API, or via a stale tab, and the workspace would
+    // then run an agent that cannot call tools.
+    //
+    // Deliberately fails OPEN on anything short of a definite answer: only a
+    // FRESH, NON-FALLBACK catalog that actually contains the id can reject it.
+    // A cold cache, a gateway outage, or an id the catalog doesn't carry (a
+    // retired version a workspace is legitimately pinned to) all pass through.
+    // Blocking a config write because our cache was cold would be a worse
+    // failure than the one this prevents.
+    if (body.provider === "gateway") {
+      const verdict = yield* Effect.promise(() => classifyGatewayModel(body.model));
+      if (verdict === "unusable") {
+        return c.json(
+          {
+            error: "validation",
+            message: `"${body.model}" cannot call tools, so it cannot run queries or read the semantic layer. Pick a model that supports tool calling.`,
+            requestId,
+          },
+          400,
+        );
+      }
+    }
 
     // For BYOT providers (anthropic/openai/azure-openai/custom): omitting
     // apiKey is only valid when an existing healthy key can be preserved.

--- a/packages/api/src/api/routes/admin-model-config.ts
+++ b/packages/api/src/api/routes/admin-model-config.ts
@@ -18,7 +18,7 @@ import { ModelConfigError } from "@atlas/api/lib/model-routing/errors";
 import type { RawWorkspaceModelConfig } from "@atlas/api/lib/auth/credentials";
 import { WorkspaceModelConfigSchema as ModelConfigSchema } from "@useatlas/schemas";
 import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
-import { getGatewayCatalog } from "@atlas/api/lib/gateway-catalog";
+import { getGatewayCatalog, isSelectableGatewayModel } from "@atlas/api/lib/gateway-catalog";
 import {
   AnthropicCatalogRateLimited,
   AnthropicCatalogUnauthorized,
@@ -40,7 +40,6 @@ import {
 import {
   BEDROCK_REGIONS,
   GATEWAY_MODEL_TYPES,
-  isSelectableGatewayModel,
   type BedrockCredentialBundle,
   type BedrockRegion,
   type GatewayCatalogModel,

--- a/packages/api/src/api/routes/admin-model-config.ts
+++ b/packages/api/src/api/routes/admin-model-config.ts
@@ -139,6 +139,10 @@ const GatewayCatalogModelSchema = z.object({
   inputPrice: z.string().nullable(),
   outputPrice: z.string().nullable(),
   recommended: z.boolean(),
+  supportsTools: z.boolean().nullable().openapi({
+    description:
+      "Whether the model can call tools, i.e. whether it can drive the agent loop. `null` means unknown — the BYOT direct-provider catalogs publish no capability data — and must be treated as 'do not filter out', not as `false`.",
+  }),
 });
 
 const GatewayCatalogResponseSchema = z.object({

--- a/packages/api/src/lib/__tests__/agent-compaction.test.ts
+++ b/packages/api/src/lib/__tests__/agent-compaction.test.ts
@@ -26,6 +26,10 @@ import {
   COMPACTION_STREAM_PART_TYPE,
   type CompactionSettings,
 } from "@atlas/api/lib/agent-compaction";
+import {
+  getGatewayCatalog,
+  __resetGatewayCatalogCacheForTests,
+} from "@atlas/api/lib/gateway-catalog";
 import { setSetting, _resetSettingsCache } from "@atlas/api/lib/settings";
 import { _resetPool, type InternalPool } from "@atlas/api/lib/db/internal";
 
@@ -484,6 +488,87 @@ describe("resolveCompactionSettings — per-model window + override (#3760)", ()
     const s = resolveCompactionSettings("claude-opus-4-8");
     expect(s.contextWindowSource).toBe("catalog");
     expect(s.contextWindowTokens).toBe(200_000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Live gateway catalog tier (#4869)
+// ---------------------------------------------------------------------------
+
+describe("resolveCompactionSettings — live gateway catalog tier (#4869)", () => {
+  const origDbUrl = process.env.DATABASE_URL;
+  const realFetch = globalThis.fetch;
+
+  function warmCatalogWith(entries: unknown[]): Promise<unknown> {
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ data: entries }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })) as unknown as typeof globalThis.fetch;
+    return getGatewayCatalog();
+  }
+
+  beforeEach(() => {
+    delete process.env.ATLAS_COMPACTION_CONTEXT_WINDOW_TOKENS;
+    process.env.DATABASE_URL = "postgresql://test:test@localhost:5432/test";
+    _resetPool(mockPool);
+    _resetSettingsCache();
+    __resetGatewayCatalogCacheForTests();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    delete process.env.ATLAS_COMPACTION_CONTEXT_WINDOW_TOKENS;
+    if (origDbUrl !== undefined) process.env.DATABASE_URL = origDbUrl;
+    else delete process.env.DATABASE_URL;
+    _resetPool(null);
+    _resetSettingsCache();
+    __resetGatewayCatalogCacheForTests();
+  });
+
+  it("resolves a real window for a family the static table has never heard of", async () => {
+    // The point of the whole change: the picker now exposes the full gateway,
+    // and the static table only knows Claude/GPT/Gemini/Mistral/Llama. Before
+    // this tier, a GLM workspace silently compacted against the safe default.
+    const cold = resolveCompactionSettings("zai/glm-5.2");
+    expect(cold.contextWindowSource).toBe("default");
+
+    await warmCatalogWith([{ id: "zai/glm-5.2", type: "language", context_window: 1_040_000 }]);
+
+    const warm = resolveCompactionSettings("zai/glm-5.2");
+    expect(warm.contextWindowTokens).toBe(1_040_000);
+    expect(warm.contextWindowSource).toBe("catalog");
+  });
+
+  it("prefers the per-model live window over the per-family static guess", async () => {
+    // The static table maps every `claude` id to 200k. Opus 4.8 is really 1M —
+    // a per-family table cannot express that, so compaction fired ~5x too early.
+    expect(resolveCompactionSettings("anthropic/claude-opus-4.8").contextWindowTokens).toBe(
+      200_000,
+    );
+
+    await warmCatalogWith([
+      { id: "anthropic/claude-opus-4.8", type: "language", context_window: 1_000_000 },
+    ]);
+
+    expect(resolveCompactionSettings("anthropic/claude-opus-4.8").contextWindowTokens).toBe(
+      1_000_000,
+    );
+  });
+
+  it("still lets an explicit operator override win over the live catalog", async () => {
+    await warmCatalogWith([{ id: "zai/glm-5.2", type: "language", context_window: 1_040_000 }]);
+    process.env.ATLAS_COMPACTION_CONTEXT_WINDOW_TOKENS = "50000";
+    const s = resolveCompactionSettings("zai/glm-5.2");
+    expect(s.contextWindowTokens).toBe(50_000);
+    expect(s.contextWindowSource).toBe("override");
+  });
+
+  it("falls through to the static table when the live catalog lacks the id", async () => {
+    await warmCatalogWith([{ id: "some/other-model", type: "language", context_window: 999 }]);
+    const s = resolveCompactionSettings("gpt-4o");
+    expect(s.contextWindowTokens).toBe(128_000);
+    expect(s.contextWindowSource).toBe("catalog");
   });
 });
 

--- a/packages/api/src/lib/__tests__/agent-compaction.test.ts
+++ b/packages/api/src/lib/__tests__/agent-compaction.test.ts
@@ -564,6 +564,49 @@ describe("resolveCompactionSettings — live gateway catalog tier (#4869)", () =
     expect(s.contextWindowSource).toBe("override");
   });
 
+  it("WARMS the catalog for a Claude id, whose static-table hit used to skip the warm", async () => {
+    // The regression this guards (#4869 review): `warmGatewayCatalog()` sat in
+    // the tier-4 branch, below the static family table. The table's `claude`
+    // rule matches every Anthropic id, so tier 4 was unreachable for them and
+    // the warm never fired — meaning tier 2 never populated for the SaaS
+    // DEFAULT models and `anthropic/claude-sonnet-5` sized compaction at the
+    // static 200k against a real 1M window, on every turn, indefinitely.
+    //
+    // Asserted via the outbound fetch because that IS the observable effect of
+    // the warm; asserting the returned window would pass either way on a cold
+    // cache (both paths return 200k on turn 1 — the bug is that turn 2 also
+    // returns 200k, forever).
+    let fetches = 0;
+    globalThis.fetch = (async () => {
+      fetches += 1;
+      return new Response(JSON.stringify({ data: [] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as unknown as typeof globalThis.fetch;
+
+    const s = resolveCompactionSettings("anthropic/claude-sonnet-5");
+    // Still 200k on THIS turn — the peek is sync and the cache was cold.
+    expect(s.contextWindowTokens).toBe(200_000);
+    // ...but the warm fired, so a later turn resolves from tier 2.
+    await Promise.resolve();
+    expect(fetches).toBe(1);
+  });
+
+  it("does NOT warm for a slashless BYOT/self-hosted id", async () => {
+    // Air-gapped self-hosted deploys use hyphen-format ids. They must never
+    // trigger an outbound call to the gateway.
+    let fetches = 0;
+    globalThis.fetch = (async () => {
+      fetches += 1;
+      return new Response(JSON.stringify({ data: [] }), { status: 200 });
+    }) as unknown as typeof globalThis.fetch;
+
+    resolveCompactionSettings("claude-opus-4-8");
+    await Promise.resolve();
+    expect(fetches).toBe(0);
+  });
+
   it("falls through to the static table when the live catalog lacks the id", async () => {
     await warmCatalogWith([{ id: "some/other-model", type: "language", context_window: 999 }]);
     const s = resolveCompactionSettings("gpt-4o");

--- a/packages/api/src/lib/__tests__/byot-catalog-l2-wiring.test.ts
+++ b/packages/api/src/lib/__tests__/byot-catalog-l2-wiring.test.ts
@@ -122,6 +122,8 @@ const ANTHROPIC_PERSISTED: GatewayCatalogModel = {
   inputPrice: null,
   outputPrice: null,
   recommended: true,
+  // BYOT direct-provider catalogs publish no capability data (#4869).
+  supportsTools: null,
 };
 
 const OPENAI_PERSISTED: GatewayCatalogModel = {

--- a/packages/api/src/lib/__tests__/gateway-catalog-warn.test.ts
+++ b/packages/api/src/lib/__tests__/gateway-catalog-warn.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Stale-shortlist warning behavior (#4869 review).
+ *
+ * Split into its own file for one reason: `gateway-catalog.ts` captures its
+ * logger at module-init time (`const log = createLogger(...)`). A `mock.module`
+ * in a file that ALSO statically imports the module never takes effect, because
+ * ES import hoisting runs the import first — an earlier version of these tests
+ * intercepted `console.warn` instead and passed even with the fix reverted
+ * (pino does not route through console). Mocking the logger and then importing
+ * the subject dynamically is what makes the assertion real.
+ *
+ * What's under test: `applyRecommended` must NOT warn that an operator's
+ * shortlist is stale when the catalog it's comparing against is the 4-model
+ * bundled fallback. The shipped shortlist names 9 models, so during a gateway
+ * outage this told the operator to "prune or replace" 8 CORRECT ids — once per
+ * request, at a 60s fallback TTL, for the whole incident.
+ */
+
+import { afterEach, beforeEach, describe, expect, test, mock } from "bun:test";
+
+const warnLog: Array<{ ctx: unknown; msg: string }> = [];
+
+void mock.module("@atlas/api/lib/logger", () => ({
+  createLogger: () => ({
+    info: () => {},
+    warn: (ctx: unknown, msg: string) => void warnLog.push({ ctx, msg }),
+    error: () => {},
+    debug: () => {},
+  }),
+  getRequestContext: () => null,
+  withRequestContext: (_ctx: unknown, fn: () => unknown) => fn(),
+}));
+
+type FetchFn = typeof globalThis.fetch;
+const realFetch: FetchFn = globalThis.fetch;
+
+function mockFetchOk(body: unknown): FetchFn {
+  return mock(
+    async () =>
+      new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+  ) as unknown as FetchFn;
+}
+
+// Dynamic — must resolve AFTER the mock above is installed.
+const { getGatewayCatalog, __resetGatewayCatalogCacheForTests } = await import(
+  "@atlas/api/lib/gateway-catalog"
+);
+
+describe("applyRecommended — stale-shortlist warning", () => {
+  let saved: string | undefined;
+
+  beforeEach(() => {
+    saved = process.env.ATLAS_RECOMMENDED_MODELS;
+    warnLog.length = 0;
+    __resetGatewayCatalogCacheForTests();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    if (saved === undefined) delete process.env.ATLAS_RECOMMENDED_MODELS;
+    else process.env.ATLAS_RECOMMENDED_MODELS = saved;
+    __resetGatewayCatalogCacheForTests();
+  });
+
+  function staleWarnings() {
+    return warnLog.filter((w) => w.msg.includes("prune or replace"));
+  }
+
+  test("warns for an id a LIVE catalog genuinely does not serve", async () => {
+    process.env.ATLAS_RECOMMENDED_MODELS = "a/one,ghost/retired-model";
+    globalThis.fetch = mockFetchOk({ data: [{ id: "a/one", type: "language" }] });
+
+    const res = await getGatewayCatalog();
+
+    expect(res.fallback).toBe(false);
+    const warned = staleWarnings();
+    expect(warned).toHaveLength(1);
+    expect(JSON.stringify(warned[0]?.ctx)).toContain("ghost/retired-model");
+    // ...and the real id is still starred.
+    expect(res.models.find((m) => m.id === "a/one")?.recommended).toBe(true);
+  });
+
+  test("does NOT warn when the catalog is the bundled fallback", async () => {
+    // Every one of these IS served by the live gateway — they're simply absent
+    // from the 4-model emergency manifest, which is not evidence of anything.
+    process.env.ATLAS_RECOMMENDED_MODELS = "anthropic/claude-opus-5,zai/glm-5.2";
+    globalThis.fetch = mock(
+      async () => new Response("gateway down", { status: 503 }),
+    ) as unknown as FetchFn;
+
+    const res = await getGatewayCatalog();
+
+    expect(res.fallback).toBe(true);
+    expect(staleWarnings()).toHaveLength(0);
+  });
+
+  test("de-duplicates the warning across repeated catalog reads", async () => {
+    // `applyRecommended` runs on every read (several per admin page load). An
+    // un-deduped warn buries the one stale id that matters under repeats.
+    process.env.ATLAS_RECOMMENDED_MODELS = "ghost/retired-model";
+    globalThis.fetch = mockFetchOk({ data: [{ id: "a/one", type: "language" }] });
+
+    await getGatewayCatalog();
+    await getGatewayCatalog();
+    await getGatewayCatalog();
+
+    expect(staleWarnings()).toHaveLength(1);
+  });
+});

--- a/packages/api/src/lib/__tests__/gateway-catalog-warn.test.ts
+++ b/packages/api/src/lib/__tests__/gateway-catalog-warn.test.ts
@@ -97,6 +97,24 @@ describe("applyRecommended — stale-shortlist warning", () => {
     expect(staleWarnings()).toHaveLength(0);
   });
 
+  test("warns distinctly when a shortlisted id IS served but cannot call tools", async () => {
+    // A different fault from "retired", and it was silent: the picker filters
+    // the entry out, so the Recommended group just rendered short with no
+    // explanation anywhere (#4869 review).
+    process.env.ATLAS_RECOMMENDED_MODELS = "a/chat-only";
+    globalThis.fetch = mockFetchOk({
+      data: [{ id: "a/chat-only", type: "language", supported_parameters: ["max_tokens"] }],
+    });
+
+    await getGatewayCatalog();
+
+    const unusable = warnLog.filter((w) => w.msg.includes("cannot call tools"));
+    expect(unusable).toHaveLength(1);
+    expect(JSON.stringify(unusable[0]?.ctx)).toContain("a/chat-only");
+    // ...and it is NOT reported as retired — it is served, just unusable.
+    expect(warnLog.filter((w) => w.msg.includes("prune or replace"))).toHaveLength(0);
+  });
+
   test("de-duplicates the warning across repeated catalog reads", async () => {
     // `applyRecommended` runs on every read (several per admin page load). An
     // un-deduped warn buries the one stale id that matters under repeats.

--- a/packages/api/src/lib/__tests__/gateway-catalog.test.ts
+++ b/packages/api/src/lib/__tests__/gateway-catalog.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test, mock } from "bun:test";
+import { isSelectableGatewayModel } from "@useatlas/types";
+
 import {
   __resetGatewayCatalogCacheForTests,
   __getRecommendedIdsForTests,
@@ -169,12 +171,31 @@ describe("gateway-catalog", () => {
     expect(entry?.outputPrice).toBe("0.000075");
   });
 
-  test("unknown type values fall back to 'language'", async () => {
+  test("an unknown type fails CLOSED to 'other', never to 'language'", async () => {
+    // The old behavior mapped an unrecognized type to `language` — the ONE
+    // value that passes the picker's type gate — so a type the gateway adds
+    // tomorrow would be offered as a selectable chat model. The capability
+    // gate can't backstop it: `supported_parameters` is absent on 97 of the
+    // 101 current non-language entries, so such an entry gets
+    // `supportsTools: null` and `null !== false` passes (#4869 review).
     globalThis.fetch = mockFetchOk({
       data: [{ id: "x/audio-model", type: "audio" }],
     });
     const res = await getGatewayCatalog();
-    expect(res.models[0]?.type).toBe("language");
+    expect(res.models[0]?.type).toBe("other");
+  });
+
+  test("an unknown-typed entry is NOT selectable, even with no capability data", async () => {
+    // The end-to-end version of the above: this is the property that actually
+    // matters, asserted through the shared predicate the picker filters on and
+    // the API enforces — not through the normalizer's internals.
+    globalThis.fetch = mockFetchOk({
+      data: [{ id: "x/audio-model", type: "audio" }],
+    });
+    const res = await getGatewayCatalog();
+    const entry = res.models[0]!;
+    expect(entry.supportsTools).toBeNull(); // no supported_parameters ⇒ unknown
+    expect(isSelectableGatewayModel(entry)).toBe(false);
   });
 
   test("the types the gateway actually serves are NOT swept into 'language'", async () => {
@@ -191,6 +212,24 @@ describe("gateway-catalog", () => {
     });
     const res = await getGatewayCatalog();
     expect(res.models.map((m) => m.type)).toEqual(["transcription", "realtime", "speech"]);
+  });
+
+  describe("bundled fallback is never treated as authoritative (#4869 review)", () => {
+    async function forceFallback() {
+      globalThis.fetch = mock(async () => new Response("down", { status: 503 })) as unknown as FetchFn;
+      return getGatewayCatalog();
+    }
+
+    test("peekModelContextWindow returns null off a fallback cache", async () => {
+      const res = await forceFallback();
+      expect(res.fallback).toBe(true);
+      // sonnet-5 IS in FALLBACK_MODELS with a contextWindow, so a naive peek
+      // would happily return it. Four hand-maintained constants must not size
+      // compaction — the manifest had opus-4.8 at 200k against a real 1M.
+      expect(peekModelContextWindow("anthropic/claude-sonnet-5")).toBeNull();
+      expect(peekModelContextWindow("anthropic/claude-opus-4.8")).toBeNull();
+    });
+
   });
 
   describe("tool-calling capability (#4869)", () => {

--- a/packages/api/src/lib/__tests__/gateway-catalog.test.ts
+++ b/packages/api/src/lib/__tests__/gateway-catalog.test.ts
@@ -3,6 +3,7 @@ import {
   __resetGatewayCatalogCacheForTests,
   __getRecommendedIdsForTests,
   getGatewayCatalog,
+  peekModelContextWindow,
 } from "../gateway-catalog";
 
 type FetchFn = typeof globalThis.fetch;
@@ -24,16 +25,26 @@ function mockFetchFail(status: number): FetchFn {
 }
 
 describe("gateway-catalog", () => {
+  // The shortlist is a hot-reloadable setting (#4869), so tests pin it through
+  // the env tier rather than relying on the registry default — which is
+  // curation and will drift as models ship. Saved/restored per test to stay
+  // self-contained (no top-level env writes).
+  let savedRecommended: string | undefined;
+
   beforeEach(() => {
+    savedRecommended = process.env.ATLAS_RECOMMENDED_MODELS;
     __resetGatewayCatalogCacheForTests();
   });
 
   afterEach(() => {
     globalThis.fetch = realFetch;
+    if (savedRecommended === undefined) delete process.env.ATLAS_RECOMMENDED_MODELS;
+    else process.env.ATLAS_RECOMMENDED_MODELS = savedRecommended;
     __resetGatewayCatalogCacheForTests();
   });
 
   test("normalizes a live catalog payload", async () => {
+    process.env.ATLAS_RECOMMENDED_MODELS = "anthropic/claude-opus-4.8";
     globalThis.fetch = mockFetchOk({
       data: [
         {
@@ -73,9 +84,11 @@ describe("gateway-catalog", () => {
     const res = await getGatewayCatalog();
     expect(res.fallback).toBe(true);
     expect(res.models.length).toBeGreaterThan(0);
-    // Every fallback entry must be in the recommended set.
+    // Every fallback entry must be usable by the agent loop — a gateway outage
+    // must not leave the picker's capability filter with nothing to show.
     for (const model of res.models) {
-      expect(__getRecommendedIdsForTests().has(model.id)).toBe(true);
+      expect(model.type).toBe("language");
+      expect(model.supportsTools).toBe(true);
     }
   });
 
@@ -162,5 +175,158 @@ describe("gateway-catalog", () => {
     });
     const res = await getGatewayCatalog();
     expect(res.models[0]?.type).toBe("language");
+  });
+
+  test("the types the gateway actually serves are NOT swept into 'language'", async () => {
+    // Regression guard (#4869): `transcription` / `realtime` / `speech` were
+    // missing from GATEWAY_MODEL_TYPES, so the unknown-type fallback above
+    // silently relabelled 13 live models as chat models. The fallback is a
+    // fail-OPEN, so every type the gateway really publishes must be listed.
+    globalThis.fetch = mockFetchOk({
+      data: [
+        { id: "openai/whisper-1", type: "transcription" },
+        { id: "openai/gpt-realtime-2", type: "realtime" },
+        { id: "openai/tts-1", type: "speech" },
+      ],
+    });
+    const res = await getGatewayCatalog();
+    expect(res.models.map((m) => m.type)).toEqual(["transcription", "realtime", "speech"]);
+  });
+
+  describe("tool-calling capability (#4869)", () => {
+    test("reads `tools` out of supported_parameters", async () => {
+      globalThis.fetch = mockFetchOk({
+        data: [
+          {
+            id: "a/agentic",
+            type: "language",
+            supported_parameters: ["max_tokens", "tools", "tool_choice"],
+          },
+          {
+            id: "a/chat-only",
+            type: "language",
+            supported_parameters: ["max_tokens", "temperature"],
+          },
+        ],
+      });
+      const res = await getGatewayCatalog();
+      expect(res.models.find((m) => m.id === "a/agentic")?.supportsTools).toBe(true);
+      expect(res.models.find((m) => m.id === "a/chat-only")?.supportsTools).toBe(false);
+    });
+
+    test("a missing supported_parameters is unknown (null), NOT false", async () => {
+      // The distinction is load-bearing: the picker filters on
+      // `supportsTools !== false`, so collapsing absent→false here would hide
+      // every model the moment upstream renamed the field.
+      globalThis.fetch = mockFetchOk({ data: [{ id: "a/no-capability-data", type: "language" }] });
+      const res = await getGatewayCatalog();
+      expect(res.models[0]?.supportsTools).toBeNull();
+    });
+
+    test("a non-array supported_parameters is unknown, not a crash", async () => {
+      globalThis.fetch = mockFetchOk({
+        data: [{ id: "a/weird", type: "language", supported_parameters: "tools" }],
+      });
+      const res = await getGatewayCatalog();
+      expect(res.models[0]?.supportsTools).toBeNull();
+    });
+  });
+
+  describe("settings-backed shortlist (#4869)", () => {
+    const TWO_MODELS = {
+      data: [
+        { id: "a/one", type: "language" },
+        { id: "b/two", type: "language" },
+      ],
+    };
+
+    test("stars exactly the IDs named in ATLAS_RECOMMENDED_MODELS", async () => {
+      process.env.ATLAS_RECOMMENDED_MODELS = "b/two";
+      globalThis.fetch = mockFetchOk(TWO_MODELS);
+      const res = await getGatewayCatalog();
+      expect(res.models.find((m) => m.id === "a/one")?.recommended).toBe(false);
+      expect(res.models.find((m) => m.id === "b/two")?.recommended).toBe(true);
+    });
+
+    test("tolerates whitespace and empty entries", async () => {
+      process.env.ATLAS_RECOMMENDED_MODELS = " b/two , , a/one ,";
+      globalThis.fetch = mockFetchOk(TWO_MODELS);
+      const res = await getGatewayCatalog();
+      expect(res.models.every((m) => m.recommended)).toBe(true);
+    });
+
+    test("a blank setting means no Recommended group, not the seeded default", async () => {
+      process.env.ATLAS_RECOMMENDED_MODELS = "";
+      globalThis.fetch = mockFetchOk(TWO_MODELS);
+      const res = await getGatewayCatalog();
+      expect(res.models.some((m) => m.recommended)).toBe(false);
+    });
+
+    test("an edit applies WITHOUT waiting out the catalog TTL", async () => {
+      // The whole point of moving curation out of source was that it shouldn't
+      // need a deploy; it must not need a 30-minute cache expiry either. The
+      // second read is served from cache (fetch called once) yet reflects the
+      // new shortlist.
+      const fetchMock = mock(
+        async () =>
+          new Response(JSON.stringify(TWO_MODELS), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
+      );
+      globalThis.fetch = fetchMock as unknown as FetchFn;
+
+      process.env.ATLAS_RECOMMENDED_MODELS = "a/one";
+      const before = await getGatewayCatalog();
+      expect(before.models.find((m) => m.id === "a/one")?.recommended).toBe(true);
+      expect(before.models.find((m) => m.id === "b/two")?.recommended).toBe(false);
+
+      process.env.ATLAS_RECOMMENDED_MODELS = "b/two";
+      const after = await getGatewayCatalog();
+      expect(after.models.find((m) => m.id === "a/one")?.recommended).toBe(false);
+      expect(after.models.find((m) => m.id === "b/two")?.recommended).toBe(true);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    test("the overlay does not mutate the shared cache entry", async () => {
+      // The cached array is handed to every concurrent caller; stamping it in
+      // place would leak one request's resolved shortlist into the next.
+      globalThis.fetch = mockFetchOk(TWO_MODELS);
+      process.env.ATLAS_RECOMMENDED_MODELS = "a/one";
+      await getGatewayCatalog();
+      process.env.ATLAS_RECOMMENDED_MODELS = "";
+      const cleared = await getGatewayCatalog();
+      expect(cleared.models.some((m) => m.recommended)).toBe(false);
+    });
+
+    test("__getRecommendedIdsForTests reflects the live setting", () => {
+      process.env.ATLAS_RECOMMENDED_MODELS = "x/y,z/w";
+      expect([...__getRecommendedIdsForTests()]).toEqual(["x/y", "z/w"]);
+    });
+  });
+
+  describe("peekModelContextWindow (#4869)", () => {
+    test("returns null on a cold cache and never fetches", () => {
+      const fetchMock = mock(async () => new Response("{}", { status: 200 }));
+      globalThis.fetch = fetchMock as unknown as FetchFn;
+      expect(peekModelContextWindow("a/one")).toBeNull();
+      expect(fetchMock).toHaveBeenCalledTimes(0);
+    });
+
+    test("serves the per-model window once the catalog is warm", async () => {
+      globalThis.fetch = mockFetchOk({
+        data: [
+          { id: "zai/glm-5.2", type: "language", context_window: 1_040_000 },
+          { id: "a/no-window", type: "language" },
+        ],
+      });
+      await getGatewayCatalog();
+      expect(peekModelContextWindow("zai/glm-5.2")).toBe(1_040_000);
+      // Present in the catalog but with no window published → still a miss, so
+      // the caller falls through to its static table rather than to `0`.
+      expect(peekModelContextWindow("a/no-window")).toBeNull();
+      expect(peekModelContextWindow("not/in-catalog")).toBeNull();
+      expect(peekModelContextWindow(undefined)).toBeNull();
+    });
   });
 });

--- a/packages/api/src/lib/__tests__/gateway-catalog.test.ts
+++ b/packages/api/src/lib/__tests__/gateway-catalog.test.ts
@@ -6,6 +6,7 @@ import {
   __getRecommendedIdsForTests,
   getGatewayCatalog,
   peekModelContextWindow,
+  warmGatewayCatalog,
 } from "../gateway-catalog";
 
 type FetchFn = typeof globalThis.fetch;
@@ -86,12 +87,38 @@ describe("gateway-catalog", () => {
     const res = await getGatewayCatalog();
     expect(res.fallback).toBe(true);
     expect(res.models.length).toBeGreaterThan(0);
-    // Every fallback entry must be usable by the agent loop — a gateway outage
-    // must not leave the picker's capability filter with nothing to show.
+    // Every fallback entry must survive the REAL predicate, not a hand-copied
+    // restatement of it (#4869 review). This asserted `type === "language" &&
+    // supportsTools === true`, which is just FALLBACK_MODELS' own literals read
+    // back — it would stay green if `isSelectableGatewayModel` grew a third
+    // gate, and a gateway outage would then empty the picker, the exact
+    // scenario the assertion claims to guard.
     for (const model of res.models) {
-      expect(model.type).toBe("language");
-      expect(model.supportsTools).toBe(true);
+      expect(isSelectableGatewayModel(model)).toBe(true);
     }
+    // The fallback must also carry the platform default, or an outage forces a
+    // downgrade to change models at all.
+    const ids = res.models.map((m) => m.id);
+    expect(ids).toContain("anthropic/claude-opus-5");
+  });
+
+  test("the bundled fallback covers the shipped ATLAS_RECOMMENDED_MODELS default", async () => {
+    // Drift guard: the manifest and the registry default are two hand-written
+    // lists of the same intent, and they had silently diverged by a whole
+    // model generation (#4869 review). Reads the registry default rather than
+    // restating it, so curation changes surface here instead of in a
+    // screenshot during the next outage.
+    delete process.env.ATLAS_RECOMMENDED_MODELS;
+    const shortlist = __getRecommendedIdsForTests();
+    expect(shortlist.length).toBeGreaterThan(0);
+
+    globalThis.fetch = mockFetchFail(503);
+    const res = await getGatewayCatalog();
+    expect(res.fallback).toBe(true);
+
+    const ids = new Set(res.models.map((m) => m.id));
+    const missing = shortlist.filter((id) => !ids.has(id));
+    expect(missing).toEqual([]);
   });
 
   test("caches the catalog within a TTL window", async () => {
@@ -212,6 +239,100 @@ describe("gateway-catalog", () => {
     });
     const res = await getGatewayCatalog();
     expect(res.models.map((m) => m.type)).toEqual(["transcription", "realtime", "speech"]);
+  });
+
+  describe("warmGatewayCatalog (#4869 review)", () => {
+    test("is a no-op when the cache is already fresh", async () => {
+      let fetches = 0;
+      globalThis.fetch = (async () => {
+        fetches += 1;
+        return new Response(JSON.stringify({ data: [{ id: "a/b", type: "language" }] }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }) as unknown as FetchFn;
+
+      await getGatewayCatalog();
+      expect(fetches).toBe(1);
+
+      warmGatewayCatalog();
+      warmGatewayCatalog();
+      await Promise.resolve();
+      // The early return is load-bearing: this runs on every agent step for a
+      // gateway-shaped id, so a regression here is one fetch PER STEP.
+      expect(fetches).toBe(1);
+    });
+
+    test("does not stampede — concurrent warms share one inflight fetch", async () => {
+      let fetches = 0;
+      globalThis.fetch = (async () => {
+        fetches += 1;
+        await new Promise((r) => setTimeout(r, 20));
+        return new Response(JSON.stringify({ data: [{ id: "a/b", type: "language" }] }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }) as unknown as FetchFn;
+
+      for (let i = 0; i < 25; i += 1) warmGatewayCatalog();
+      await getGatewayCatalog();
+      expect(fetches).toBe(1);
+    });
+
+    test("never throws from its synchronous call site, even when fetch rejects", () => {
+      globalThis.fetch = (() => {
+        throw new Error("network stack exploded");
+      }) as unknown as FetchFn;
+      // Called from `prepareStep`-adjacent sync code — a throw here would take
+      // the turn down.
+      expect(() => warmGatewayCatalog()).not.toThrow();
+    });
+  });
+
+  describe("Recommended group ordering (#4869 review)", () => {
+    test("renders the shortlist in the OPERATOR's order, not catalog order", async () => {
+      // The setting is a RANKED shortlist — the first entry is the house
+      // default. `applyRecommended` used to return catalog order, silently
+      // discarding that curation.
+      process.env.ATLAS_RECOMMENDED_MODELS = "c/third,a/first,b/second";
+      globalThis.fetch = mockFetchOk({
+        data: [
+          { id: "a/first", type: "language" },
+          { id: "b/second", type: "language" },
+          { id: "c/third", type: "language" },
+          { id: "z/unlisted", type: "language" },
+        ],
+      });
+      const res = await getGatewayCatalog();
+      const recommended = res.models.filter((m) => m.recommended).map((m) => m.id);
+      expect(recommended).toEqual(["c/third", "a/first", "b/second"]);
+    });
+
+    test("keeps non-recommended models present after the shortlist", async () => {
+      process.env.ATLAS_RECOMMENDED_MODELS = "b/second";
+      globalThis.fetch = mockFetchOk({
+        data: [
+          { id: "a/first", type: "language" },
+          { id: "b/second", type: "language" },
+        ],
+      });
+      const res = await getGatewayCatalog();
+      expect(res.models.map((m) => m.id)).toEqual(["b/second", "a/first"]);
+      // ...and nothing is dropped or duplicated by the reordering.
+      expect(res.models).toHaveLength(2);
+    });
+
+    test("de-duplicates a repeated id in the setting", async () => {
+      process.env.ATLAS_RECOMMENDED_MODELS = "a/one,a/one,b/two";
+      globalThis.fetch = mockFetchOk({
+        data: [
+          { id: "a/one", type: "language" },
+          { id: "b/two", type: "language" },
+        ],
+      });
+      const res = await getGatewayCatalog();
+      expect(res.models.map((m) => m.id)).toEqual(["a/one", "b/two"]);
+    });
   });
 
   describe("bundled fallback is never treated as authoritative (#4869 review)", () => {

--- a/packages/api/src/lib/__tests__/gateway-catalog.test.ts
+++ b/packages/api/src/lib/__tests__/gateway-catalog.test.ts
@@ -1,5 +1,4 @@
 import { afterEach, beforeEach, describe, expect, test, mock } from "bun:test";
-import { isSelectableGatewayModel } from "@useatlas/types";
 
 import {
   __resetGatewayCatalogCacheForTests,
@@ -7,6 +6,7 @@ import {
   getGatewayCatalog,
   peekModelContextWindow,
   warmGatewayCatalog,
+  isSelectableGatewayModel,
 } from "../gateway-catalog";
 
 type FetchFn = typeof globalThis.fetch;

--- a/packages/api/src/lib/agent-compaction.ts
+++ b/packages/api/src/lib/agent-compaction.ts
@@ -264,13 +264,31 @@ function resolveContextWindow(
   // GLM, Kimi, Grok or DeepSeek would otherwise fall straight through to the
   // safe default and compact far earlier than it needs to.
   //
-  // `peek` is a pure cache read — this runs inside `prepareStep` on every step
-  // and cannot await. A cold cache returns null and we fall through, so this
-  // tier is an upgrade when available, never a dependency.
+  // `peek` is a pure cache read, so this stays sync. NOTE: the earlier claim
+  // that it "runs inside prepareStep and cannot await" was wrong — this is
+  // reached once per turn via `resolveCompactionSettings` from an async scope
+  // in `agent.ts`, and `prepareStep` consumes the already-resolved value. A
+  // single `await` there would make the catalog authoritative on turn 1 and
+  // retire the peek/warm pair entirely; deliberately left as follow-up work
+  // rather than changing the agent hot path in a review fix.
   const fromLiveCatalog = peekModelContextWindow(modelId);
   if (fromLiveCatalog !== null) {
     return { contextWindowTokens: fromLiveCatalog, contextWindowSource: "catalog" };
   }
+
+  // Warm BEFORE the static fallback, not after (#4869 review). This used to sit
+  // in the tier-4 branch, which the static table's `claude` rule made
+  // unreachable for every Anthropic id — so the tier-2 upgrade never activated
+  // for the SaaS default models it was built for. A workspace on
+  // `anthropic/claude-sonnet-5` sized compaction at the static 200k against a
+  // real 1M window, on every turn, forever, unless an admin happened to open
+  // the picker (which warmed it for one 30-minute TTL and no longer).
+  //
+  // Fire-and-forget, deduped by the catalog's inflight promise, and a no-op on
+  // a warm cache. Gated on a gateway-shaped id so a direct/BYOT model id never
+  // triggers an outbound fetch — that keeps air-gapped self-hosted deploys off
+  // the network, since those use hyphen-format ids with no slash.
+  if (modelId?.includes("/")) warmGatewayCatalog();
 
   // Tier 3 — static per-family catalog.
   const fromCatalog = resolveModelContextWindow(modelId);
@@ -280,10 +298,7 @@ function resolveContextWindow(
 
   // Tier 4 — safe default. Neither catalog has an entry for this model and
   // there is no override; the turn proceeds on the default window rather than
-  // failing. Warm the gateway catalog in the background so a gateway-format id
-  // that missed here resolves from tier 2 on a later turn — fire-and-forget,
-  // deduped by the catalog's inflight promise, and a no-op on a warm cache.
-  if (modelId?.includes("/")) warmGatewayCatalog();
+  // failing.
 
   // Logged unconditionally — a blank/undefined modelId is self-documenting in the
   // payload (it's the value that produced the miss), so the empty case isn't silent.

--- a/packages/api/src/lib/agent-compaction.ts
+++ b/packages/api/src/lib/agent-compaction.ts
@@ -48,6 +48,7 @@ import { generateText, type LanguageModel, type ModelMessage } from "ai";
 import type { Attributes } from "@opentelemetry/api";
 import { createLogger, getRequestContext } from "./logger";
 import { getSetting } from "./settings";
+import { peekModelContextWindow, warmGatewayCatalog } from "./gateway-catalog";
 
 const log = createLogger("agent:compaction");
 
@@ -256,14 +257,34 @@ function resolveContextWindow(
     );
   }
 
-  // Tier 2 — static per-model catalog.
+  // Tier 2 — the live gateway catalog, if a fetch has already populated it
+  // (#4869). Authoritative and per-model rather than per-family, which matters
+  // now that the picker exposes the whole gateway: the static table below knows
+  // Claude/GPT/Gemini/Mistral/Llama families and nothing else, so a workspace on
+  // GLM, Kimi, Grok or DeepSeek would otherwise fall straight through to the
+  // safe default and compact far earlier than it needs to.
+  //
+  // `peek` is a pure cache read — this runs inside `prepareStep` on every step
+  // and cannot await. A cold cache returns null and we fall through, so this
+  // tier is an upgrade when available, never a dependency.
+  const fromLiveCatalog = peekModelContextWindow(modelId);
+  if (fromLiveCatalog !== null) {
+    return { contextWindowTokens: fromLiveCatalog, contextWindowSource: "catalog" };
+  }
+
+  // Tier 3 — static per-family catalog.
   const fromCatalog = resolveModelContextWindow(modelId);
   if (fromCatalog !== null) {
     return { contextWindowTokens: fromCatalog, contextWindowSource: "catalog" };
   }
 
-  // Tier 3 — safe default. The catalog has no entry for this model and there is
-  // no override; the turn proceeds on the default window rather than failing.
+  // Tier 4 — safe default. Neither catalog has an entry for this model and
+  // there is no override; the turn proceeds on the default window rather than
+  // failing. Warm the gateway catalog in the background so a gateway-format id
+  // that missed here resolves from tier 2 on a later turn — fire-and-forget,
+  // deduped by the catalog's inflight promise, and a no-op on a warm cache.
+  if (modelId?.includes("/")) warmGatewayCatalog();
+
   // Logged unconditionally — a blank/undefined modelId is self-documenting in the
   // payload (it's the value that produced the miss), so the empty case isn't silent.
   log.debug(

--- a/packages/api/src/lib/anthropic-catalog.ts
+++ b/packages/api/src/lib/anthropic-catalog.ts
@@ -118,6 +118,10 @@ function normalizeEntry(raw: RawAnthropicModel): GatewayCatalogModel | null {
     inputPrice: null,
     outputPrice: null,
     recommended: RECOMMENDED_MODEL_IDS.has(id),
+    // Anthropic's /v1/models publishes no capability data, so tool support is
+    // UNKNOWN here — not absent. `null` keeps these models visible in the
+    // picker's capability filter; `false` would empty the BYOT picker entirely.
+    supportsTools: null,
   };
 }
 

--- a/packages/api/src/lib/bedrock-catalog.ts
+++ b/packages/api/src/lib/bedrock-catalog.ts
@@ -173,6 +173,10 @@ function normalizeModel(model: {
     inputPrice: null,
     outputPrice: null,
     recommended: RECOMMENDED_MODEL_IDS.has(model.modelId),
+    // Bedrock's ListFoundationModels does carry an `inferenceTypesSupported` /
+    // modality surface, but nothing that states tool-calling — UNKNOWN, not
+    // "no". See the anthropic-catalog note.
+    supportsTools: null,
   };
 }
 

--- a/packages/api/src/lib/gateway-catalog.ts
+++ b/packages/api/src/lib/gateway-catalog.ts
@@ -24,7 +24,7 @@ import type {
   GatewayCatalogResponse,
   GatewayModelType,
 } from "@useatlas/types";
-import { GATEWAY_MODEL_TYPES, isSelectableGatewayModel } from "@useatlas/types";
+import { GATEWAY_MODEL_TYPES } from "@useatlas/types";
 import { createLogger } from "./logger";
 import { getSetting } from "./settings";
 
@@ -226,6 +226,27 @@ function normalizeEntry(raw: RawCatalogEntry): GatewayCatalogModel | null {
     recommended: false,
     supportsTools: readToolSupport(raw),
   };
+}
+
+/**
+ * Whether a catalog entry can actually drive Atlas's agent loop.
+ *
+ * Server-side twin of `isSelectable` in
+ * `packages/web/src/ui/components/admin/gateway-model-picker.tsx`. Kept in sync
+ * by hand and by matching behavior tests on both sides — see the note in
+ * `@useatlas/types`' model-config for why this can't be shared from there yet
+ * (published-package pinning in the scaffold templates).
+ *
+ * Two gates:
+ *  - `type === "language"` — the gateway also serves embedding, image, video,
+ *    reranking, transcription, realtime, speech, and anything it adds next
+ *    (normalized to `other`, which is why the type fallback must fail closed).
+ *  - `supportsTools !== false` — Atlas is tool-driven. `null` means the catalog
+ *    didn't say, which is NOT "no": the BYOT direct-provider catalogs publish
+ *    no capability data, so `null` must stay visible.
+ */
+export function isSelectableGatewayModel(model: GatewayCatalogModel): boolean {
+  return model.type === "language" && model.supportsTools !== false;
 }
 
 /**

--- a/packages/api/src/lib/gateway-catalog.ts
+++ b/packages/api/src/lib/gateway-catalog.ts
@@ -26,6 +26,7 @@ import type {
 } from "@useatlas/types";
 import { GATEWAY_MODEL_TYPES } from "@useatlas/types";
 import { createLogger } from "./logger";
+import { getSetting } from "./settings";
 
 const log = createLogger("gateway-catalog");
 
@@ -34,24 +35,44 @@ const DEFAULT_TTL_MS = 30 * 60 * 1_000; // 30 minutes
 const FETCH_TIMEOUT_MS = 10_000;
 
 /**
- * Curated subset surfaced as "recommended" in the picker. IDs must match the
- * gateway model `id` field exactly (gateway uses dot-version like
- * `anthropic/claude-opus-4.6`, not hyphen-version). Curation policy: anchor on
- * a flagship + a cheap-fast pair per major provider; keep the list under ~10
- * so the recommended group fits without scrolling.
+ * The shortlist starred at the top of the picker, read from the
+ * `ATLAS_RECOMMENDED_MODELS` setting (#4869). IDs must match the gateway model
+ * `id` field exactly — the gateway uses dot-version (`anthropic/claude-opus-5`),
+ * not hyphen-version.
+ *
+ * Read per call rather than memoized: the setting is hot-reloadable, and the
+ * whole point of moving it out of source was that curation shouldn't wait for a
+ * deploy. It shouldn't wait for a cache TTL either, so this is resolved at
+ * response time and overlaid onto the cached catalog (which stores only
+ * upstream facts — pricing, capability, context window).
+ *
+ * A blank setting means "no Recommended group", not "fall back to a default" —
+ * an operator who clears the list gets an empty group, which is what they asked
+ * for. The registry default seeds a sensible starting shortlist.
  */
-const RECOMMENDED_MODEL_IDS: ReadonlySet<string> = new Set([
-  "anthropic/claude-opus-4.8",
-  "anthropic/claude-sonnet-5",
-  "openai/gpt-4o",
-  "openai/gpt-4o-mini",
-  "google/gemini-2.0-flash",
-]);
+function recommendedModelIds(): ReadonlySet<string> {
+  const raw = getSetting("ATLAS_RECOMMENDED_MODELS");
+  if (raw === undefined) return new Set();
+  return new Set(
+    raw
+      .split(",")
+      .map((id) => id.trim())
+      .filter((id) => id.length > 0),
+  );
+}
 
 /**
  * Minimal bundled fallback. Used only when the live fetch fails so the
  * picker still functions; pricing fields are intentionally omitted —
- * the live catalog is authoritative for cost.
+ * the live catalog is authoritative for cost. Every entry is hand-picked
+ * and tool-calling, hence `supportsTools: true` rather than `null`: these
+ * must survive the picker's capability filter or a gateway outage would
+ * leave the admin with an empty picker.
+ *
+ * `recommended: false` on every entry is not an oversight — the flag is
+ * overlaid from `ATLAS_RECOMMENDED_MODELS` by `applyRecommended()` like any
+ * other catalog entry, so a fallback model is starred iff the operator listed
+ * it. Hardcoding `true` here would put a star on models the operator removed.
  */
 const FALLBACK_MODELS: GatewayCatalogModel[] = [
   {
@@ -63,7 +84,8 @@ const FALLBACK_MODELS: GatewayCatalogModel[] = [
     maxOutputTokens: 32_000,
     inputPrice: null,
     outputPrice: null,
-    recommended: true,
+    recommended: false,
+    supportsTools: true,
   },
   {
     id: "anthropic/claude-sonnet-5",
@@ -74,7 +96,8 @@ const FALLBACK_MODELS: GatewayCatalogModel[] = [
     maxOutputTokens: 128_000,
     inputPrice: null,
     outputPrice: null,
-    recommended: true,
+    recommended: false,
+    supportsTools: true,
   },
   {
     id: "openai/gpt-4o",
@@ -85,7 +108,8 @@ const FALLBACK_MODELS: GatewayCatalogModel[] = [
     maxOutputTokens: 16_000,
     inputPrice: null,
     outputPrice: null,
-    recommended: true,
+    recommended: false,
+    supportsTools: true,
   },
   {
     id: "openai/gpt-4o-mini",
@@ -96,7 +120,8 @@ const FALLBACK_MODELS: GatewayCatalogModel[] = [
     maxOutputTokens: 16_000,
     inputPrice: null,
     outputPrice: null,
-    recommended: true,
+    recommended: false,
+    supportsTools: true,
   },
 ];
 
@@ -107,6 +132,7 @@ interface RawCatalogEntry {
   context_window?: unknown;
   max_tokens?: unknown;
   pricing?: unknown;
+  supported_parameters?: unknown;
 }
 
 interface CatalogCacheEntry {
@@ -152,6 +178,24 @@ function asGatewayModelType(value: unknown): GatewayModelType {
     : "language";
 }
 
+/**
+ * Whether the entry advertises tool-calling.
+ *
+ * The gateway publishes two equivalent signals — a `tool-use` member of `tags`
+ * and a `tools` member of `supported_parameters`. Measured against the live
+ * catalog (2026-07-28, 306 entries) the two agree on 204/204 language models,
+ * but `supported_parameters` is present on all 204 while `tags` is missing on
+ * 2 — so `supported_parameters` is the one to trust.
+ *
+ * Returns `null` (unknown) when the field is absent entirely, so a future
+ * upstream schema change degrades to "don't filter" instead of hiding the
+ * whole catalog. Only an explicit, parseable array yields `false`.
+ */
+function readToolSupport(raw: RawCatalogEntry): boolean | null {
+  if (!Array.isArray(raw.supported_parameters)) return null;
+  return raw.supported_parameters.includes("tools");
+}
+
 function normalizeEntry(raw: RawCatalogEntry): GatewayCatalogModel | null {
   const id = asString(raw.id);
   if (!id) return null;
@@ -168,8 +212,41 @@ function normalizeEntry(raw: RawCatalogEntry): GatewayCatalogModel | null {
     maxOutputTokens: asPositiveInt(raw.max_tokens),
     inputPrice: asString(pricing.input),
     outputPrice: asString(pricing.output),
-    recommended: RECOMMENDED_MODEL_IDS.has(id),
+    // Always false here. `recommended` is not an upstream fact — it's local
+    // curation from a hot-reloadable setting, so it's overlaid at response
+    // time by `applyRecommended()`. Stamping it into the cached entry would
+    // pin an operator's edit behind the 30-minute catalog TTL.
+    recommended: false,
+    supportsTools: readToolSupport(raw),
   };
+}
+
+/**
+ * Overlay the operator's curated shortlist onto a cached catalog.
+ *
+ * Returns fresh objects rather than mutating: the cache entry is shared across
+ * concurrent callers, and stamping it in place would leak one request's
+ * resolved shortlist into the next.
+ */
+function applyRecommended(models: GatewayCatalogModel[]): GatewayCatalogModel[] {
+  const ids = recommendedModelIds();
+  if (ids.size === 0) return models;
+
+  // A curated ID the gateway no longer serves can't be caught by a type-check
+  // or a unit test — it only shows up against the live catalog, and it fails
+  // silently (the Recommended group just renders short). `google/gemini-2.0-flash`
+  // sat dead in the old hardcoded list until it was found by hand. Warn so the
+  // next one surfaces in logs rather than in a screenshot.
+  const liveIds = new Set(models.map((m) => m.id));
+  const stale = [...ids].filter((id) => !liveIds.has(id));
+  if (stale.length > 0) {
+    log.warn(
+      { stale, configured: ids.size },
+      "gateway-catalog: ATLAS_RECOMMENDED_MODELS names model(s) the gateway does not serve — they are skipped; prune or replace them",
+    );
+  }
+
+  return models.map((m) => (ids.has(m.id) ? { ...m, recommended: true } : m));
 }
 
 async function fetchLiveCatalog(): Promise<GatewayCatalogModel[]> {
@@ -238,7 +315,11 @@ async function load(): Promise<CatalogCacheEntry> {
  */
 export async function getGatewayCatalog(): Promise<GatewayCatalogResponse> {
   if (cache && cache.expiresAt > Date.now()) {
-    return { models: cache.models, fetchedAt: cache.fetchedAt, fallback: cache.fallback };
+    return {
+      models: applyRecommended(cache.models),
+      fetchedAt: cache.fetchedAt,
+      fallback: cache.fallback,
+    };
   }
   if (!inflight) {
     inflight = load().finally(() => {
@@ -247,7 +328,54 @@ export async function getGatewayCatalog(): Promise<GatewayCatalogResponse> {
   }
   const entry = await inflight;
   cache = entry;
-  return { models: entry.models, fetchedAt: entry.fetchedAt, fallback: entry.fallback };
+  return {
+    models: applyRecommended(entry.models),
+    fetchedAt: entry.fetchedAt,
+    fallback: entry.fallback,
+  };
+}
+
+/**
+ * Synchronous, non-fetching lookup of a model's context window from whatever
+ * catalog is already in memory. Returns `null` when the cache is cold, stale,
+ * or has no entry for `modelId`.
+ *
+ * Exists for the compaction trigger, which runs inside `prepareStep` on every
+ * agent step and therefore CANNOT await a network fetch. That constraint is why
+ * `agent-compaction.ts` carries a static family→window table at all; this lets
+ * it prefer the authoritative per-model number when we happen to have it,
+ * without changing its sync contract.
+ *
+ * Deliberately does NOT trigger a refresh: a cold cache must stay cheap and
+ * silent on the hot path. Callers fall back to the static table, and the cache
+ * warms via {@link warmGatewayCatalog} or the first admin who opens the picker.
+ *
+ * A stale (TTL-expired) cache is treated as a miss rather than served: a model's
+ * context window can change between catalog revisions, and compaction sizing is
+ * exactly where a stale number does damage.
+ */
+export function peekModelContextWindow(modelId: string | undefined): number | null {
+  if (!modelId || !cache || cache.expiresAt <= Date.now()) return null;
+  const hit = cache.models.find((m) => m.id === modelId);
+  return hit?.contextWindow ?? null;
+}
+
+/**
+ * Fire-and-forget cache warm. Safe to call from a non-async context: it never
+ * throws (`load()` resolves even on fetch failure) and concurrent calls share
+ * the single inflight promise, so it can't stampede the gateway.
+ */
+export function warmGatewayCatalog(): void {
+  if (cache && cache.expiresAt > Date.now()) return;
+  void getGatewayCatalog().catch((err) => {
+    // Unreachable in practice — `load()` swallows fetch failures into the
+    // bundled fallback — but an unhandled rejection here would be a process
+    // -level event, so it stays explicitly handled rather than assumed away.
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err) },
+      "gateway-catalog: background warm failed",
+    );
+  });
 }
 
 /** Test-only: clears the cache so each test sees a clean fetch path. */
@@ -256,7 +384,7 @@ export function __resetGatewayCatalogCacheForTests(): void {
   inflight = null;
 }
 
-/** Test-only: inspect the curated recommended list. */
+/** Test-only: the shortlist as currently resolved from settings. */
 export function __getRecommendedIdsForTests(): ReadonlySet<string> {
-  return RECOMMENDED_MODEL_IDS;
+  return recommendedModelIds();
 }

--- a/packages/api/src/lib/gateway-catalog.ts
+++ b/packages/api/src/lib/gateway-catalog.ts
@@ -24,7 +24,7 @@ import type {
   GatewayCatalogResponse,
   GatewayModelType,
 } from "@useatlas/types";
-import { GATEWAY_MODEL_TYPES } from "@useatlas/types";
+import { GATEWAY_MODEL_TYPES, isSelectableGatewayModel } from "@useatlas/types";
 import { createLogger } from "./logger";
 import { getSetting } from "./settings";
 
@@ -50,15 +50,35 @@ const FETCH_TIMEOUT_MS = 10_000;
  * an operator who clears the list gets an empty group, which is what they asked
  * for. The registry default seeds a sensible starting shortlist.
  */
-function recommendedModelIds(): ReadonlySet<string> {
+function recommendedModelIds(): readonly string[] {
   const raw = getSetting("ATLAS_RECOMMENDED_MODELS");
-  if (raw === undefined) return new Set();
-  return new Set(
-    raw
-      .split(",")
-      .map((id) => id.trim())
-      .filter((id) => id.length > 0),
-  );
+  if (raw === undefined) return [];
+  // Ordered, not a Set (#4869 review): the Recommended group used to render in
+  // CATALOG order, silently discarding the operator's curation order — the
+  // setting is a ranked shortlist and the first entry is the house default.
+  // De-duplicated while preserving first-seen position.
+  return [...new Set(raw.split(",").map((id) => id.trim()).filter((id) => id.length > 0))];
+}
+
+/** Terse constructor for {@link FALLBACK_MODELS} — every entry shares 8 of 10 fields. */
+function fallbackModel(
+  id: string,
+  name: string,
+  contextWindow: number,
+  maxOutputTokens: number,
+): GatewayCatalogModel {
+  return {
+    id,
+    name,
+    provider: deriveProvider(id),
+    type: "language",
+    contextWindow,
+    maxOutputTokens,
+    inputPrice: null,
+    outputPrice: null,
+    recommended: false,
+    supportsTools: true,
+  };
 }
 
 /**
@@ -73,60 +93,28 @@ function recommendedModelIds(): ReadonlySet<string> {
  * overlaid from `ATLAS_RECOMMENDED_MODELS` by `applyRecommended()` like any
  * other catalog entry, so a fallback model is starred iff the operator listed
  * it. Hardcoding `true` here would put a star on models the operator removed.
+ *
+ * KEEP IN SYNC with the `ATLAS_RECOMMENDED_MODELS` registry default in
+ * `settings.ts` (#4869 review). This list previously predated the shipped
+ * shortlist entirely — opus-4.8 / sonnet-5 / gpt-4o / gpt-4o-mini against a
+ * shortlist of opus-5 / gpt-5.6-* / fable-5 / glm-5.2 / kimi-k3. During an
+ * outage an admin on `anthropic/claude-opus-5` saw their own model as a raw ID
+ * and every selectable option a generation behind, so the only way to change
+ * models was to downgrade. Context windows verified against the live catalog
+ * 2026-07-28; a value here that is WRONG is worse than one that is missing,
+ * which is why `peekModelContextWindow` refuses to read this manifest at all.
  */
 const FALLBACK_MODELS: GatewayCatalogModel[] = [
-  {
-    id: "anthropic/claude-opus-4.8",
-    name: "Claude Opus 4.8",
-    provider: "anthropic",
-    type: "language",
-    // 1M / 128k verified against the live catalog 2026-07-28. This said
-    // 200_000 / 32_000, which was wrong and — because `peekModelContextWindow`
-    // did not check `cache.fallback` — silently drove compaction sizing during
-    // a gateway outage. Both fixed (#4869 review).
-    contextWindow: 1_000_000,
-    maxOutputTokens: 128_000,
-    inputPrice: null,
-    outputPrice: null,
-    recommended: false,
-    supportsTools: true,
-  },
-  {
-    id: "anthropic/claude-sonnet-5",
-    name: "Claude Sonnet 5",
-    provider: "anthropic",
-    type: "language",
-    contextWindow: 1_000_000,
-    maxOutputTokens: 128_000,
-    inputPrice: null,
-    outputPrice: null,
-    recommended: false,
-    supportsTools: true,
-  },
-  {
-    id: "openai/gpt-4o",
-    name: "GPT-4o",
-    provider: "openai",
-    type: "language",
-    contextWindow: 128_000,
-    maxOutputTokens: 16_000,
-    inputPrice: null,
-    outputPrice: null,
-    recommended: false,
-    supportsTools: true,
-  },
-  {
-    id: "openai/gpt-4o-mini",
-    name: "GPT-4o mini",
-    provider: "openai",
-    type: "language",
-    contextWindow: 128_000,
-    maxOutputTokens: 16_000,
-    inputPrice: null,
-    outputPrice: null,
-    recommended: false,
-    supportsTools: true,
-  },
+  fallbackModel("anthropic/claude-opus-5", "Claude Opus 5", 1_000_000, 128_000),
+  fallbackModel("anthropic/claude-sonnet-5", "Claude Sonnet 5", 1_000_000, 128_000),
+  fallbackModel("anthropic/claude-fable-5", "Claude Fable 5", 1_000_000, 128_000),
+  fallbackModel("anthropic/claude-haiku-4.5", "Claude Haiku 4.5", 200_000, 64_000),
+  fallbackModel("anthropic/claude-opus-4.8", "Claude Opus 4.8", 1_000_000, 128_000),
+  fallbackModel("openai/gpt-5.6-sol", "GPT-5.6 Sol", 1_050_000, 128_000),
+  fallbackModel("openai/gpt-5.6-terra", "GPT-5.6 Terra", 1_050_000, 128_000),
+  fallbackModel("openai/gpt-5.6-luna", "GPT-5.6 Luna", 1_050_000, 128_000),
+  fallbackModel("zai/glm-5.2", "GLM-5.2", 204_800, 128_000),
+  fallbackModel("moonshotai/kimi-k3", "Kimi K3", 262_144, 128_000),
 ];
 
 interface RawCatalogEntry {
@@ -252,7 +240,8 @@ function applyRecommended(
   fallback: boolean,
 ): GatewayCatalogModel[] {
   const ids = recommendedModelIds();
-  if (ids.size === 0) return models;
+  if (ids.length === 0) return models;
+  const idSet = new Set(ids);
 
   // A curated ID the gateway no longer serves can't be caught by a type-check
   // or a unit test — it only shows up against the live catalog, and it fails
@@ -260,21 +249,42 @@ function applyRecommended(
   // sat dead in the old hardcoded list until it was found by hand. Warn so the
   // next one surfaces in logs rather than in a screenshot.
   //
-  // NEVER warn off the bundled fallback (#4869 review). It carries 4 models
-  // while the shipped shortlist names 9, so during a gateway outage this
-  // accused 8 of 9 CORRECT ids of being retired and told the operator to
-  // "prune or replace them" — once per request, at 60s fallback TTL, for the
-  // duration of the incident. An operator who complied would destroy a valid
-  // shortlist. Absence from a 4-model emergency manifest is not evidence.
+  // NEVER warn off the bundled fallback (#4869 review). It is a small emergency
+  // manifest, so during a gateway outage this accused CORRECT ids of being
+  // retired and told the operator to "prune or replace them" — once per
+  // request, at 60s fallback TTL, for the duration of the incident. An
+  // operator who complied would destroy a valid shortlist. Absence from the
+  // fallback is not evidence.
   if (!fallback) {
-    const liveIds = new Set(models.map((m) => m.id));
-    const stale = [...ids].filter((id) => !liveIds.has(id));
-    if (stale.length > 0) {
-      warnStaleShortlistOnce(stale, ids.size);
-    }
+    const byId = new Map(models.map((m) => [m.id, m]));
+    const stale = ids.filter((id) => !byId.has(id));
+    if (stale.length > 0) warnStaleShortlistOnce(stale, ids.length);
+
+    // Distinct failure, distinct message: the id IS served, but it can't drive
+    // the agent loop, so the picker filters it out. Without this the operator
+    // sees a short Recommended group and no explanation anywhere.
+    const unusable = ids.filter((id) => {
+      const hit = byId.get(id);
+      return hit !== undefined && !isSelectableGatewayModel(hit);
+    });
+    if (unusable.length > 0) warnUnusableShortlistOnce(unusable);
   }
 
-  return models.map((m) => (ids.has(m.id) ? { ...m, recommended: true } : m));
+  // Recommended entries first, in the operator's configured order, then the
+  // rest in catalog order. The picker splits on the `recommended` flag and
+  // preserves relative order within each group, so ordering here is what makes
+  // the shortlist ranked rather than alphabetical-by-accident.
+  const recommended: GatewayCatalogModel[] = [];
+  const seen = new Set<string>();
+  for (const id of ids) {
+    const hit = models.find((m) => m.id === id);
+    if (hit) {
+      recommended.push({ ...hit, recommended: true });
+      seen.add(id);
+    }
+  }
+  const rest = models.filter((m) => !seen.has(m.id));
+  return [...recommended, ...rest];
 }
 
 /**
@@ -286,6 +296,18 @@ function applyRecommended(
  * Mirrors `warnInvalidOnce` in `agent-compaction.ts`.
  */
 const warnedStaleShortlists = new Set<string>();
+const warnedUnusableShortlists = new Set<string>();
+
+/** Same de-dup discipline as {@link warnStaleShortlistOnce}, different fault. */
+function warnUnusableShortlistOnce(unusable: string[]): void {
+  const sig = [...unusable].sort().join(",");
+  if (warnedUnusableShortlists.has(sig)) return;
+  warnedUnusableShortlists.add(sig);
+  log.warn(
+    { unusable },
+    "gateway-catalog: ATLAS_RECOMMENDED_MODELS names model(s) the gateway serves but that cannot call tools — the picker hides them, so the Recommended group renders short",
+  );
+}
 function warnStaleShortlistOnce(stale: string[], configured: number): void {
   const sig = [...stale].sort().join(",");
   if (warnedStaleShortlists.has(sig)) return;
@@ -465,9 +487,10 @@ export function __resetGatewayCatalogCacheForTests(): void {
   cache = null;
   inflight = null;
   warnedStaleShortlists.clear();
+  warnedUnusableShortlists.clear();
 }
 
-/** Test-only: the shortlist as currently resolved from settings. */
-export function __getRecommendedIdsForTests(): ReadonlySet<string> {
+/** Test-only: the shortlist as currently resolved from settings, in order. */
+export function __getRecommendedIdsForTests(): readonly string[] {
   return recommendedModelIds();
 }

--- a/packages/api/src/lib/gateway-catalog.ts
+++ b/packages/api/src/lib/gateway-catalog.ts
@@ -80,8 +80,12 @@ const FALLBACK_MODELS: GatewayCatalogModel[] = [
     name: "Claude Opus 4.8",
     provider: "anthropic",
     type: "language",
-    contextWindow: 200_000,
-    maxOutputTokens: 32_000,
+    // 1M / 128k verified against the live catalog 2026-07-28. This said
+    // 200_000 / 32_000, which was wrong and — because `peekModelContextWindow`
+    // did not check `cache.fallback` — silently drove compaction sizing during
+    // a gateway outage. Both fixed (#4869 review).
+    contextWindow: 1_000_000,
+    maxOutputTokens: 128_000,
     inputPrice: null,
     outputPrice: null,
     recommended: false,
@@ -171,11 +175,19 @@ function deriveProvider(id: string): string {
 }
 
 function asGatewayModelType(value: unknown): GatewayModelType {
-  // Closed set per Vercel docs; fall back to `language` on unknown so a
-  // forward-compat schema change doesn't break the picker.
+  // Unrecognized types fail CLOSED to `other`, never to `language` (#4869
+  // review). `language` is the one value that passes the picker's type gate, so
+  // falling back to it meant a type the gateway adds tomorrow would be offered
+  // as a selectable chat model. The capability gate is not a sufficient
+  // backstop: `supported_parameters` is absent on 97 of the 101 current
+  // non-language entries, so such an entry gets `supportsTools: null`
+  // ("unknown") and `null !== false` passes.
+  //
+  // Unknown types are collected by the caller and logged ONCE per fetch rather
+  // than per entry — a new type typically arrives as a whole family at once.
   return (GATEWAY_MODEL_TYPES as readonly string[]).includes(value as string)
     ? (value as GatewayModelType)
-    : "language";
+    : "other";
 }
 
 /**
@@ -193,6 +205,13 @@ function asGatewayModelType(value: unknown): GatewayModelType {
  */
 function readToolSupport(raw: RawCatalogEntry): boolean | null {
   if (!Array.isArray(raw.supported_parameters)) return null;
+  // Element shape is checked, not just the array-ness (#4869 review). Without
+  // this, an upstream reshape from `["tools"]` to `[{name:"tools"}]` would make
+  // `.includes("tools")` return false for EVERY language model — fail-closed,
+  // emptying the picker with `fallback: false` so not even the outage banner
+  // fires. A non-string element means "shape changed, we can't read it" →
+  // `null` (unknown), matching the documented fail-open contract.
+  if (!raw.supported_parameters.every((p) => typeof p === "string")) return null;
   return raw.supported_parameters.includes("tools");
 }
 
@@ -228,7 +247,10 @@ function normalizeEntry(raw: RawCatalogEntry): GatewayCatalogModel | null {
  * concurrent callers, and stamping it in place would leak one request's
  * resolved shortlist into the next.
  */
-function applyRecommended(models: GatewayCatalogModel[]): GatewayCatalogModel[] {
+function applyRecommended(
+  models: GatewayCatalogModel[],
+  fallback: boolean,
+): GatewayCatalogModel[] {
   const ids = recommendedModelIds();
   if (ids.size === 0) return models;
 
@@ -237,16 +259,41 @@ function applyRecommended(models: GatewayCatalogModel[]): GatewayCatalogModel[] 
   // silently (the Recommended group just renders short). `google/gemini-2.0-flash`
   // sat dead in the old hardcoded list until it was found by hand. Warn so the
   // next one surfaces in logs rather than in a screenshot.
-  const liveIds = new Set(models.map((m) => m.id));
-  const stale = [...ids].filter((id) => !liveIds.has(id));
-  if (stale.length > 0) {
-    log.warn(
-      { stale, configured: ids.size },
-      "gateway-catalog: ATLAS_RECOMMENDED_MODELS names model(s) the gateway does not serve — they are skipped; prune or replace them",
-    );
+  //
+  // NEVER warn off the bundled fallback (#4869 review). It carries 4 models
+  // while the shipped shortlist names 9, so during a gateway outage this
+  // accused 8 of 9 CORRECT ids of being retired and told the operator to
+  // "prune or replace them" — once per request, at 60s fallback TTL, for the
+  // duration of the incident. An operator who complied would destroy a valid
+  // shortlist. Absence from a 4-model emergency manifest is not evidence.
+  if (!fallback) {
+    const liveIds = new Set(models.map((m) => m.id));
+    const stale = [...ids].filter((id) => !liveIds.has(id));
+    if (stale.length > 0) {
+      warnStaleShortlistOnce(stale, ids.size);
+    }
   }
 
   return models.map((m) => (ids.has(m.id) ? { ...m, recommended: true } : m));
+}
+
+/**
+ * De-duplicated stale-shortlist warning.
+ *
+ * `applyRecommended` runs on every catalog read (several per admin page load),
+ * so an un-deduped warn buries the one genuinely-stale ID that matters under
+ * repeats. Keyed on the sorted ID set so a CHANGED shortlist warns again.
+ * Mirrors `warnInvalidOnce` in `agent-compaction.ts`.
+ */
+const warnedStaleShortlists = new Set<string>();
+function warnStaleShortlistOnce(stale: string[], configured: number): void {
+  const sig = [...stale].sort().join(",");
+  if (warnedStaleShortlists.has(sig)) return;
+  warnedStaleShortlists.add(sig);
+  log.warn(
+    { stale, configured },
+    "gateway-catalog: ATLAS_RECOMMENDED_MODELS names model(s) the live gateway does not serve — they are skipped; prune or replace them",
+  );
 }
 
 async function fetchLiveCatalog(): Promise<GatewayCatalogModel[]> {
@@ -265,17 +312,39 @@ async function fetchLiveCatalog(): Promise<GatewayCatalogModel[]> {
       throw new Error("gateway catalog response missing `data` array");
     }
     const normalized: GatewayCatalogModel[] = [];
-    let dropped = 0;
+    const droppedIds: string[] = [];
+    const unknownTypes = new Set<string>();
     for (const entry of body.data) {
-      const model =
-        entry && typeof entry === "object" ? normalizeEntry(entry as RawCatalogEntry) : null;
-      if (model) normalized.push(model);
-      else dropped += 1;
+      const raw = entry && typeof entry === "object" ? (entry as RawCatalogEntry) : null;
+      const model = raw ? normalizeEntry(raw) : null;
+      if (model) {
+        normalized.push(model);
+        // Recorded from the RAW value: `model.type` has already been collapsed
+        // to `other`, so only the pre-normalization value names the new type.
+        if (
+          model.type === "other" &&
+          typeof raw?.type === "string" &&
+          !(GATEWAY_MODEL_TYPES as readonly string[]).includes(raw.type)
+        ) {
+          unknownTypes.add(raw.type);
+        }
+      } else {
+        // The IDs, not just a count (#4869 review) — a count alone can't tell
+        // you whether the workspace's own saved model was one of the casualties.
+        const id = raw ? asString(raw.id) : null;
+        droppedIds.push(id ?? "<no id>");
+      }
     }
-    if (dropped > 0) {
+    if (droppedIds.length > 0) {
       log.warn(
-        { dropped, kept: normalized.length },
+        { dropped: droppedIds.length, droppedIds: droppedIds.slice(0, 20), kept: normalized.length },
         "gateway-catalog: dropped malformed entries from upstream",
+      );
+    }
+    if (unknownTypes.size > 0) {
+      log.warn(
+        { unknownTypes: [...unknownTypes] },
+        "gateway-catalog: upstream published model type(s) Atlas does not know — mapped to `other` and hidden from the picker; add them to GATEWAY_MODEL_TYPES if they should be selectable",
       );
     }
     return normalized;
@@ -316,7 +385,7 @@ async function load(): Promise<CatalogCacheEntry> {
 export async function getGatewayCatalog(): Promise<GatewayCatalogResponse> {
   if (cache && cache.expiresAt > Date.now()) {
     return {
-      models: applyRecommended(cache.models),
+      models: applyRecommended(cache.models, cache.fallback),
       fetchedAt: cache.fetchedAt,
       fallback: cache.fallback,
     };
@@ -329,7 +398,7 @@ export async function getGatewayCatalog(): Promise<GatewayCatalogResponse> {
   const entry = await inflight;
   cache = entry;
   return {
-    models: applyRecommended(entry.models),
+    models: applyRecommended(entry.models, entry.fallback),
     fetchedAt: entry.fetchedAt,
     fallback: entry.fallback,
   };
@@ -340,11 +409,11 @@ export async function getGatewayCatalog(): Promise<GatewayCatalogResponse> {
  * catalog is already in memory. Returns `null` when the cache is cold, stale,
  * or has no entry for `modelId`.
  *
- * Exists for the compaction trigger, which runs inside `prepareStep` on every
- * agent step and therefore CANNOT await a network fetch. That constraint is why
- * `agent-compaction.ts` carries a static family→window table at all; this lets
- * it prefer the authoritative per-model number when we happen to have it,
- * without changing its sync contract.
+ * Exists for the compaction trigger, which resolves its settings once per turn
+ * and keeps a sync signature. NOTE: `resolveCompactionSettings` is called from
+ * an async scope in `agent.ts`, so awaiting the catalog there IS possible and
+ * would make this peek unnecessary — see the tier-2 comment in
+ * `agent-compaction.ts`. This stays sync for now as the smaller change.
  *
  * Deliberately does NOT trigger a refresh: a cold cache must stay cheap and
  * silent on the hot path. Callers fall back to the static table, and the cache
@@ -353,9 +422,15 @@ export async function getGatewayCatalog(): Promise<GatewayCatalogResponse> {
  * A stale (TTL-expired) cache is treated as a miss rather than served: a model's
  * context window can change between catalog revisions, and compaction sizing is
  * exactly where a stale number does damage.
+ *
+ * A FALLBACK cache is also a miss (#4869 review). The bundled manifest is four
+ * hand-maintained constants that were never fetched from anywhere — strictly
+ * worse than a stale real number, and worse still because it reported as
+ * `contextWindowSource: "catalog"`. It had `opus-4.8` at 200k against a real
+ * 1M, so a gateway outage silently changed a workspace's compaction threshold.
  */
 export function peekModelContextWindow(modelId: string | undefined): number | null {
-  if (!modelId || !cache || cache.expiresAt <= Date.now()) return null;
+  if (!modelId || !cache || cache.fallback || cache.expiresAt <= Date.now()) return null;
   const hit = cache.models.find((m) => m.id === modelId);
   return hit?.contextWindow ?? null;
 }
@@ -368,9 +443,11 @@ export function peekModelContextWindow(modelId: string | undefined): number | nu
 export function warmGatewayCatalog(): void {
   if (cache && cache.expiresAt > Date.now()) return;
   void getGatewayCatalog().catch((err) => {
-    // Unreachable in practice — `load()` swallows fetch failures into the
-    // bundled fallback — but an unhandled rejection here would be a process
-    // -level event, so it stays explicitly handled rather than assumed away.
+    // REACHABLE, despite `load()` swallowing fetch failures (#4869 review):
+    // `getGatewayCatalog` runs `applyRecommended()` → `recommendedModelIds()`
+    // → `getSetting()` AFTER `await inflight`, entirely outside `load()`'s try.
+    // Anything that throws there rejects this promise. The module header's
+    // "never rejects" invariant is about `load()` specifically, not this.
     log.warn(
       { err: err instanceof Error ? err.message : String(err) },
       "gateway-catalog: background warm failed",
@@ -378,10 +455,16 @@ export function warmGatewayCatalog(): void {
   });
 }
 
-/** Test-only: clears the cache so each test sees a clean fetch path. */
+/**
+ * Test-only: clears the cache so each test sees a clean fetch path.
+ *
+ * Also clears the stale-shortlist warn dedup — that Set is module-level and
+ * would otherwise let one test's warning suppress the next test's assertion.
+ */
 export function __resetGatewayCatalogCacheForTests(): void {
   cache = null;
   inflight = null;
+  warnedStaleShortlists.clear();
 }
 
 /** Test-only: the shortlist as currently resolved from settings. */

--- a/packages/api/src/lib/openai-catalog.ts
+++ b/packages/api/src/lib/openai-catalog.ts
@@ -145,6 +145,9 @@ function normalizeEntry(raw: RawOpenAIModel): GatewayCatalogModel | null {
     inputPrice: null,
     outputPrice: null,
     recommended: RECOMMENDED_MODEL_IDS.has(id),
+    // OpenAI's /v1/models publishes no capability data — UNKNOWN, not "no".
+    // See the anthropic-catalog note; `null` keeps BYOT models selectable.
+    supportsTools: null,
   };
 }
 

--- a/packages/api/src/lib/settings.ts
+++ b/packages/api/src/lib/settings.ts
@@ -492,6 +492,40 @@ const SETTINGS_REGISTRY: SettingDefinition[] = [
     scope: "workspace",
   },
   {
+    // #4869 — the shortlist starred at the top of the gateway model picker.
+    //
+    // This used to be a hardcoded `RECOMMENDED_MODEL_IDS` set in
+    // `lib/gateway-catalog.ts`, which made curation redeploy-gated — the exact
+    // property this issue exists to remove — and let entries rot invisibly
+    // (`google/gemini-2.0-flash` sat in it after the gateway retired it; the
+    // group just rendered one row short). As a setting it is hot-reloadable,
+    // editable from /admin, and takes effect on the next catalog read rather
+    // than at the next deploy.
+    //
+    // Platform-scoped: curating the house shortlist is an operator decision,
+    // not a per-workspace one. Every workspace still picks any model it likes
+    // from the full catalog — this only controls what floats to the top.
+    key: "ATLAS_RECOMMENDED_MODELS",
+    section: "Model Catalog",
+    label: "Recommended Models",
+    description:
+      "Comma-separated Vercel AI Gateway model IDs to star at the top of the model picker (e.g. anthropic/claude-opus-5, openai/gpt-5.6-sol). IDs must match the gateway exactly — slash+dot form. Leave blank for no Recommended group; the full catalog stays selectable either way. IDs the gateway no longer serves are logged as a warning and skipped.",
+    type: "string",
+    default: [
+      "openai/gpt-5.6-sol",
+      "openai/gpt-5.6-terra",
+      "openai/gpt-5.6-luna",
+      "anthropic/claude-opus-5",
+      "anthropic/claude-sonnet-5",
+      "anthropic/claude-fable-5",
+      "anthropic/claude-haiku-4.5",
+      "zai/glm-5.2",
+      "moonshotai/kimi-k3",
+    ].join(","),
+    envVar: "ATLAS_RECOMMENDED_MODELS",
+    scope: "platform",
+  },
+  {
     // #3761 — optional cheaper summary model. Names a SEPARATE model for the
     // compaction summarization call so reclaiming context need not cost as much
     // as the turn itself. Blank ⇒ the summary runs on the active turn model (the

--- a/packages/schemas/src/admin-config.ts
+++ b/packages/schemas/src/admin-config.ts
@@ -128,6 +128,13 @@ export const GatewayCatalogModelSchema = z.object({
   inputPrice: z.string().nullable(),
   outputPrice: z.string().nullable(),
   recommended: z.boolean(),
+  // `.default(null)` rather than a bare `.nullable()`: web and api deploy as
+  // separate Railway services, so there is a window where the browser holds new
+  // code and the API still serves catalog entries without this field. A hard
+  // parse failure there would blank the whole picker; defaulting to `null`
+  // (= "capability unknown, don't filter") degrades to today's behavior for the
+  // length of the skew. The `type` filter is unaffected — that field is old.
+  supportsTools: z.boolean().nullable().default(null),
 }) satisfies z.ZodType<GatewayCatalogModel, unknown>;
 
 export const GatewayCatalogResponseSchema = z.object({

--- a/packages/schemas/src/admin-config.ts
+++ b/packages/schemas/src/admin-config.ts
@@ -122,7 +122,15 @@ export const GatewayCatalogModelSchema = z.object({
   id: z.string(),
   name: z.string(),
   provider: z.string(),
-  type: z.enum(GATEWAY_MODEL_TYPES),
+  // `.catch("other")` so a future api that publishes a model type this bundle
+  // predates degrades that ONE entry instead of nuking the response (#4869
+  // review). Without it, `z.enum` rejects the unknown value, and because this
+  // object sits inside `z.array()` the whole `models` array fails — a blank
+  // picker with no error, for the length of an api-before-web deploy window.
+  // Exactly the failure `supportsTools`'s `.default(null)` was written to
+  // avoid; `type` needed the same treatment. `other` never passes the picker's
+  // `type === "language"` gate, so an unknown type is hidden, not offered.
+  type: z.enum(GATEWAY_MODEL_TYPES).catch("other"),
   contextWindow: z.number().nullable(),
   maxOutputTokens: z.number().nullable(),
   inputPrice: z.string().nullable(),

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useatlas/types",
-  "version": "0.7.0",
+  "version": "0.6.0",
   "description": "Shared types for the Atlas text-to-SQL agent",
   "type": "module",
   "scripts": {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useatlas/types",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Shared types for the Atlas text-to-SQL agent",
   "type": "module",
   "scripts": {

--- a/packages/types/src/model-config.ts
+++ b/packages/types/src/model-config.ts
@@ -236,13 +236,25 @@ export interface TestModelConfigResponse {
 // ── Gateway catalog ─────────────────────────────────────────────────
 
 /**
- * Closed set of model types Vercel's gateway publishes.
+ * Model types Vercel's gateway publishes, plus an explicit `other` escape.
  *
  * `transcription` / `realtime` / `speech` were added after the initial five:
- * the gateway serves 13 such entries, and because the normalizer falls back to
- * `language` on an unrecognized type, omitting them silently mislabeled every
- * one of them as a chat model. Keep this in lockstep with the live catalog —
- * an unlisted type is a fail-OPEN, not a fail-closed.
+ * the gateway serves 13 such entries, and the normalizer used to fall back to
+ * `language` on an unrecognized type, which silently mislabeled every one of
+ * them as a chat model.
+ *
+ * `other` closes that hole for good. It is NOT a gateway value — it is what
+ * `asGatewayModelType` returns for anything it doesn't recognize, so an
+ * unlisted type now fails CLOSED (the picker's `type === "language"` gate
+ * rejects it) instead of fail-open. Adding the next real type here remains
+ * worthwhile for display, but forgetting to is no longer a correctness bug.
+ *
+ * Deploy-order note: widening this union widens `z.enum(GATEWAY_MODEL_TYPES)`
+ * in `@useatlas/schemas`. A web bundle built before the widening rejects the
+ * new value and — because it sits inside `z.array()` — discards the WHOLE
+ * catalog response. The schema now carries `.catch("other")` so future
+ * widenings degrade gracefully, but that only protects bundles built from this
+ * commit forward. For THIS promote, deploy web before api.
  */
 export const GATEWAY_MODEL_TYPES = [
   "language",
@@ -253,6 +265,7 @@ export const GATEWAY_MODEL_TYPES = [
   "transcription",
   "realtime",
   "speech",
+  "other",
 ] as const;
 export type GatewayModelType = (typeof GATEWAY_MODEL_TYPES)[number];
 
@@ -295,6 +308,30 @@ export interface GatewayCatalogModel {
    *     `null` to `false` would empty every BYOT picker.
    */
   supportsTools: boolean | null;
+}
+
+/**
+ * Whether a catalog entry can actually drive Atlas's agent loop.
+ *
+ * THE canonical definition, shared by the browser picker and the API's
+ * `PUT /admin/model-config` capability gate (#4869 review). It lived only in
+ * the React component, which meant it was a cosmetic filter: the endpoint took
+ * `model: z.string().min(1)` and never consulted the catalog, so a stale tab
+ * or a direct API call could pin the agent to an embedding model. Ships here
+ * because `@useatlas/types` already emits runtime values (`GATEWAY_MODEL_TYPES`)
+ * and both sides depend on it.
+ *
+ * Two gates:
+ *  - `type === "language"` — the gateway also serves embedding, image, video,
+ *    reranking, transcription, realtime, speech, and anything it adds next
+ *    (normalized to `other`). Every BYOT direct-provider catalog hardcodes
+ *    `"language"`, so this is a no-op there.
+ *  - `supportsTools !== false` — Atlas is tool-driven. `null` means the catalog
+ *    didn't say, which is NOT "no": the BYOT catalogs publish no capability
+ *    data at all, so `null` must stay visible or those pickers go empty.
+ */
+export function isSelectableGatewayModel(model: GatewayCatalogModel): boolean {
+  return model.type === "language" && model.supportsTools !== false;
 }
 
 export interface GatewayCatalogResponse {

--- a/packages/types/src/model-config.ts
+++ b/packages/types/src/model-config.ts
@@ -235,8 +235,25 @@ export interface TestModelConfigResponse {
 
 // ── Gateway catalog ─────────────────────────────────────────────────
 
-/** Closed set of model types Vercel's gateway publishes. */
-export const GATEWAY_MODEL_TYPES = ["language", "embedding", "image", "video", "reranking"] as const;
+/**
+ * Closed set of model types Vercel's gateway publishes.
+ *
+ * `transcription` / `realtime` / `speech` were added after the initial five:
+ * the gateway serves 13 such entries, and because the normalizer falls back to
+ * `language` on an unrecognized type, omitting them silently mislabeled every
+ * one of them as a chat model. Keep this in lockstep with the live catalog —
+ * an unlisted type is a fail-OPEN, not a fail-closed.
+ */
+export const GATEWAY_MODEL_TYPES = [
+  "language",
+  "embedding",
+  "image",
+  "video",
+  "reranking",
+  "transcription",
+  "realtime",
+  "speech",
+] as const;
 export type GatewayModelType = (typeof GATEWAY_MODEL_TYPES)[number];
 
 /**
@@ -263,6 +280,21 @@ export interface GatewayCatalogModel {
   outputPrice: string | null;
   /** Whether this entry is in Atlas's curated "recommended" subset. */
   recommended: boolean;
+  /**
+   * Whether the model can call tools, i.e. whether it can drive Atlas's agent
+   * loop at all (SQL execution, semantic layer, knowledge search). A model
+   * without tool-calling produces an agent that can only chat.
+   *
+   * Three-valued on purpose:
+   *   - `true` / `false` — the catalog stated it (the gateway publishes
+   *     `supported_parameters`, which is present on 100% of its language
+   *     entries).
+   *   - `null` — UNKNOWN, not "no". The BYOT direct-provider catalogs
+   *     (Anthropic/OpenAI/Bedrock `/v1/models`) don't publish capability data,
+   *     so they set `null` and consumers must not filter them out. Collapsing
+   *     `null` to `false` would empty every BYOT picker.
+   */
+  supportsTools: boolean | null;
 }
 
 export interface GatewayCatalogResponse {

--- a/packages/types/src/model-config.ts
+++ b/packages/types/src/model-config.ts
@@ -311,28 +311,23 @@ export interface GatewayCatalogModel {
 }
 
 /**
- * Whether a catalog entry can actually drive Atlas's agent loop.
+ * NOTE: the "can this model drive the agent loop" predicate deliberately does
+ * NOT live here, despite being shared by the API and the web picker.
  *
- * THE canonical definition, shared by the browser picker and the API's
- * `PUT /admin/model-config` capability gate (#4869 review). It lived only in
- * the React component, which meant it was a cosmetic filter: the endpoint took
- * `model: z.string().min(1)` and never consulted the catalog, so a stale tab
- * or a direct API call could pin the agent to an embedding model. Ships here
- * because `@useatlas/types` already emits runtime values (`GATEWAY_MODEL_TYPES`)
- * and both sides depend on it.
+ * `@useatlas/types` is PUBLISHED, and `create-atlas/templates/*` pin a released
+ * range (`^0.5.0`). Scaffold-bound source — which includes `packages/api` — is
+ * type-checked against that published tarball, so importing a symbol added in
+ * an unpublished version fails `Scaffold (docker)` / `Scaffold (vercel)`
+ * (`scripts/check-published-symbols.ts`). Adding it here would have required
+ * the full publish-then-bump sequence.
  *
- * Two gates:
- *  - `type === "language"` — the gateway also serves embedding, image, video,
- *    reranking, transcription, realtime, speech, and anything it adds next
- *    (normalized to `other`). Every BYOT direct-provider catalog hardcodes
- *    `"language"`, so this is a no-op there.
- *  - `supportsTools !== false` — Atlas is tool-driven. `null` means the catalog
- *    didn't say, which is NOT "no": the BYOT catalogs publish no capability
- *    data at all, so `null` must stay visible or those pickers go empty.
+ * It is therefore defined twice, once per side, each pointing at the other:
+ *   - `packages/api/src/lib/gateway-catalog.ts` → `isSelectableGatewayModel`
+ *   - `packages/web/src/ui/components/admin/gateway-model-picker.tsx` → `isSelectable`
+ * Both are covered by behavior tests asserting the same table, so a drift
+ * shows up as a failing test rather than as a picker that offers a model the
+ * API rejects. Consolidate here once a `@useatlas/types` release ships.
  */
-export function isSelectableGatewayModel(model: GatewayCatalogModel): boolean {
-  return model.type === "language" && model.supportsTools !== false;
-}
 
 export interface GatewayCatalogResponse {
   models: GatewayCatalogModel[];

--- a/packages/web/src/app/admin/billing/__tests__/legacy-model-aliases.test.ts
+++ b/packages/web/src/app/admin/billing/__tests__/legacy-model-aliases.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Legacy model-id canonicalization (#4869 review).
+ *
+ * `canonicalizeModel` had ZERO tests in either direction — before or after
+ * #4870 changed what it does. That matters because the behavior change is
+ * deliberate and easy to "fix" back by accident:
+ *
+ *   BEFORE: the map did two jobs — hyphen→slash+dot FORMAT canonicalization,
+ *           AND a version ROLL-FORWARD (`claude-opus-4-6` → opus-4.8) that
+ *           existed only because the picker had three hardcoded rows and a
+ *           deprecated version had nowhere to land (#3076).
+ *   AFTER:  format only. The picker lists the live catalog, so every version
+ *           has its own real row, and relabelling a workspace's configured 4.6
+ *           as "4.8" would misreport what the agent actually runs.
+ *
+ * The roll-forward removal is the whole point of the change, so it gets a test
+ * that fails if someone reinstates it.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { GatewayCatalogModel } from "@/ui/lib/types";
+import { canonicalizeModel, modelLabel } from "../page";
+
+function model(overrides: Partial<GatewayCatalogModel> = {}): GatewayCatalogModel {
+  return {
+    id: "anthropic/claude-opus-4.6",
+    name: "Claude Opus 4.6",
+    provider: "anthropic",
+    type: "language",
+    contextWindow: 1_000_000,
+    maxOutputTokens: 128_000,
+    inputPrice: null,
+    outputPrice: null,
+    recommended: false,
+    supportsTools: true,
+    ...overrides,
+  };
+}
+
+describe("canonicalizeModel", () => {
+  test("rewrites the legacy hyphen format onto the gateway's slash+dot id", () => {
+    expect(canonicalizeModel("claude-haiku-4-5")).toBe("anthropic/claude-haiku-4.5");
+    expect(canonicalizeModel("claude-sonnet-4-6")).toBe("anthropic/claude-sonnet-4.6");
+    expect(canonicalizeModel("claude-opus-4-6")).toBe("anthropic/claude-opus-4.6");
+    expect(canonicalizeModel("claude-opus-4-7")).toBe("anthropic/claude-opus-4.7");
+  });
+
+  test("does NOT roll a deprecated version forward to the current flagship", () => {
+    // The regression guard. Each legacy id maps to its OWN version — a
+    // workspace configured for Opus 4.6 must not be told it is running 4.8.
+    expect(canonicalizeModel("claude-opus-4-6")).not.toBe("anthropic/claude-opus-4.8");
+    expect(canonicalizeModel("claude-opus-4-7")).not.toBe("anthropic/claude-opus-4.8");
+    expect(canonicalizeModel("claude-sonnet-4-6")).not.toBe("anthropic/claude-sonnet-5");
+  });
+
+  test("passes an already-canonical gateway id through untouched", () => {
+    expect(canonicalizeModel("anthropic/claude-opus-5")).toBe("anthropic/claude-opus-5");
+    expect(canonicalizeModel("zai/glm-5.2")).toBe("zai/glm-5.2");
+  });
+
+  test("passes an unrecognized id through rather than guessing", () => {
+    expect(canonicalizeModel("some-model-we-have-never-seen")).toBe(
+      "some-model-we-have-never-seen",
+    );
+    expect(canonicalizeModel("")).toBe("");
+  });
+});
+
+describe("modelLabel", () => {
+  test("resolves a display name through the alias map", () => {
+    expect(modelLabel("claude-opus-4-6", [model()])).toBe("Claude Opus 4.6");
+  });
+
+  test("falls back to the canonical ID rather than inventing a name", () => {
+    // A retired version a workspace is still pinned to. Showing the raw ID is
+    // the honest answer; the picker separately flags it as missing.
+    expect(modelLabel("anthropic/claude-opus-4.1", [model()])).toBe("anthropic/claude-opus-4.1");
+  });
+
+  test("falls back to the canonicalized form, not the raw legacy input", () => {
+    // Even with an empty catalog the hyphen form is normalized, so the operator
+    // sees the id the gateway would actually accept.
+    expect(modelLabel("claude-opus-4-6", [])).toBe("anthropic/claude-opus-4.6");
+  });
+});

--- a/packages/web/src/app/admin/billing/page.tsx
+++ b/packages/web/src/app/admin/billing/page.tsx
@@ -6,13 +6,6 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
 import { Switch } from "@/components/ui/switch";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { AdminContentWrapper } from "@/ui/components/admin-content-wrapper";
 import { ErrorBoundary } from "@/ui/components/error-boundary";
 import {
@@ -37,6 +30,9 @@ import {
 } from "@/ui/components/admin/trial-countdown-banner";
 import { BillingStatusSchema } from "@/ui/lib/admin-schemas";
 import { ModelProviderSection } from "@/ui/components/admin/model-provider-section";
+import { GatewayModelPicker } from "@/ui/components/admin/gateway-model-picker";
+import { GatewayCatalogResponseSchema } from "@useatlas/schemas";
+import type { GatewayCatalogModel } from "@/ui/lib/types";
 import { formatDate, formatNumber } from "@/lib/format";
 import { consumePlanIntent, PAID_TIERS } from "@/lib/billing/plan-intent";
 import { effectiveTrialEnd, isTrialEndPast } from "@/lib/billing/trial-copy";
@@ -134,48 +130,41 @@ function formatDollars(amount: number): string {
   return `$${amount.toFixed(2)}`;
 }
 
-// Values are Vercel AI Gateway model IDs (slash+dot) — SaaS resolves
-// through the gateway, so the picker must write IDs the gateway will
-// recognize. Older hyphen-format settings (`claude-opus-4-6`) are
-// migrated lazily by `modelLabel` and the equivalence check below so
-// existing workspaces don't lose their selection on first load.
-const MODEL_OPTIONS = [
-  { value: "anthropic/claude-haiku-4.5", label: "Haiku 4.5", hint: "fastest, lowest cost" },
-  { value: "anthropic/claude-sonnet-5", label: "Sonnet 5", hint: "balanced" },
-  { value: "anthropic/claude-opus-4.8", label: "Opus 4.8", hint: "most capable" },
-] as const;
-
 // Atlas previously stored model settings in the Anthropic-direct hyphen
 // format (`claude-opus-4-6`); the gateway accepts the slash+dot form
-// (`anthropic/claude-opus-4.6`). When we see a legacy hyphen value
-// stored in `ATLAS_MODEL`, map it to the canonical gateway ID so the
-// picker selects the right row and the agent loop sees a working ID.
+// (`anthropic/claude-opus-4.6`). When we see a legacy hyphen value stored in
+// `ATLAS_MODEL`, map it to the canonical gateway ID so the picker selects the
+// right row and the agent loop sees a working ID.
 //
-// Two kinds of migration live here:
-//   1. Format canonicalization — hyphen → slash+dot (e.g. `claude-sonnet-4-6`).
-//   2. Version roll-forward — a deprecated version that no longer has its own
-//      picker row (Opus 4.6/4.7, the prior Opus defaults; Sonnet 4.6, the
-//      prior Sonnet default) is mapped to the current flagship
-//      (`anthropic/claude-opus-4.8`, `anthropic/claude-sonnet-5`). This is a
-//      version upgrade, not just a format change, so the Select highlights a
-//      valid option instead of rendering blank for workspaces still on the
-//      old default (#3076).
+// FORMAT ONLY — no version roll-forward (#4869). This map used to also bump
+// deprecated versions to the current flagship (Opus 4.6/4.7 → 4.8, Sonnet 4.6
+// → 5) because the picker had exactly three hardcoded rows and an old version
+// had nowhere to land, so it rendered blank (#3076). Now that the picker lists
+// the live catalog, every one of those versions has its own real row — and
+// silently relabelling a workspace's configured 4.7 as "4.8" would be the same
+// class of lie as a cosmetic default that disagrees with the resolver (see the
+// SSOT note in ModelRow). Each entry now maps to its OWN version.
 const LEGACY_MODEL_ALIASES: Record<string, string> = {
   "claude-haiku-4-5": "anthropic/claude-haiku-4.5",
-  "claude-sonnet-4-6": "anthropic/claude-sonnet-5",
-  "anthropic/claude-sonnet-4.6": "anthropic/claude-sonnet-5",
-  "claude-opus-4-6": "anthropic/claude-opus-4.8",
-  "claude-opus-4-7": "anthropic/claude-opus-4.8",
-  "anthropic/claude-opus-4.7": "anthropic/claude-opus-4.8",
+  "claude-sonnet-4-6": "anthropic/claude-sonnet-4.6",
+  "claude-opus-4-6": "anthropic/claude-opus-4.6",
+  "claude-opus-4-7": "anthropic/claude-opus-4.7",
 };
 
 function canonicalizeModel(value: string): string {
   return LEGACY_MODEL_ALIASES[value] ?? value;
 }
 
-function modelLabel(value: string): string {
+/**
+ * Display name for a gateway model ID, resolved from the live catalog.
+ *
+ * Falls back to the raw ID — which is the honest thing to show for a model the
+ * catalog doesn't carry (a retired version a workspace is still pinned to, or
+ * any ID during a cold/failed catalog fetch). Never invents a friendly name.
+ */
+function modelLabel(value: string, models: GatewayCatalogModel[]): string {
   const canonical = canonicalizeModel(value);
-  return MODEL_OPTIONS.find((o) => o.value === canonical)?.label ?? canonical;
+  return models.find((m) => m.id === canonical)?.name ?? canonical;
 }
 
 // ── Component ─────────────────────────────────────────────────────
@@ -937,15 +926,29 @@ function ResourceValue({ count, max }: { count: number; max: number | null }) {
 // ── Model row (progressive disclosure) ────────────────────────────
 
 function ModelRow({ data, onSaved }: { data: BillingStatus; onSaved: () => void }) {
+  // The live Vercel AI Gateway catalog (#4869) — the same server-cached,
+  // anonymous endpoint the BYOT provider section uses. Fetched eagerly rather
+  // than on expand so the collapsed row can show a real display name instead
+  // of a raw ID; the normalized response is ~69 KB, ~6 KB gzipped.
+  const {
+    data: catalog,
+    loading: catalogLoading,
+    refetch: refetchCatalog,
+  } = useAdminFetch("/api/v1/admin/model-config/catalog", {
+    schema: GatewayCatalogResponseSchema,
+  });
+  const catalogModels: GatewayCatalogModel[] = catalog?.models ?? [];
+
   // SSOT (#3098): the API resolves `currentModel` to exactly what the agent
   // runs when nothing is saved — the same value the gateway provider default
   // produces — so display it verbatim. NO hardcoded fallback here: a cosmetic
   // default that disagrees with the resolver is the exact bug this fixes
   // (the row showed "Sonnet 4.6" while unset workspaces ran Opus 4.8).
-  // canonicalize() only maps legacy-hyphen / deprecated-version values onto a
-  // picker row so an older `claude-sonnet-4-6` setting still highlights its row.
+  // canonicalize() only rewrites the legacy hyphen FORMAT onto its own
+  // slash+dot ID so an older `claude-sonnet-4-6` setting resolves to a real
+  // catalog row — it never changes which version is shown.
   const currentModel = canonicalizeModel(data.currentModel);
-  const currentLabel = modelLabel(currentModel);
+  const currentLabel = modelLabel(currentModel, catalogModels);
 
   // #4645 — the pick writes a per-workspace gateway row on platform credits
   // (`workspace_model_config`), the same seam the agent loop resolves first.
@@ -1012,19 +1015,15 @@ function ModelRow({ data, onSaved }: { data: BillingStatus; onSaved: () => void 
       status="disconnected"
       onCollapse={collapse}
     >
-      <Select value={currentModel} onValueChange={handleModelChange} disabled={saving}>
-        <SelectTrigger aria-label="AI model">
-          <SelectValue placeholder="Select a model" />
-        </SelectTrigger>
-        <SelectContent>
-          {MODEL_OPTIONS.map((opt) => (
-            <SelectItem key={opt.value} value={opt.value}>
-              <span className="font-medium">{opt.label}</span>
-              <span className="ml-2 text-xs text-muted-foreground">— {opt.hint}</span>
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
+      <GatewayModelPicker
+        models={catalogModels}
+        value={currentModel}
+        onChange={handleModelChange}
+        loading={catalogLoading}
+        fallback={catalog?.fallback}
+        onRetry={refetchCatalog}
+        disabled={saving}
+      />
       {saving && (
         <p className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
           <Loader2 className="size-3 animate-spin" />

--- a/packages/web/src/app/admin/billing/page.tsx
+++ b/packages/web/src/app/admin/billing/page.tsx
@@ -933,11 +933,19 @@ function ModelRow({ data, onSaved }: { data: BillingStatus; onSaved: () => void 
   const {
     data: catalog,
     loading: catalogLoading,
+    error: catalogError,
     refetch: refetchCatalog,
   } = useAdminFetch("/api/v1/admin/model-config/catalog", {
     schema: GatewayCatalogResponseSchema,
   });
   const catalogModels: GatewayCatalogModel[] = catalog?.models ?? [];
+  // `error` was previously discarded (#4869 review). On a 401/500/schema
+  // mismatch the picker rendered enabled, opened to "No models match.", and
+  // showed no banner and no Retry — the Retry is gated on `fallback`, which is
+  // `undefined` when the fetch never returned a body. A regression against the
+  // pre-#4869 hardcoded options, which always rendered. `fallback` covers
+  // "gateway is down"; this covers "we couldn't reach our own API".
+  const catalogFailed = !catalogLoading && catalogError !== null && catalog === undefined;
 
   // SSOT (#3098): the API resolves `currentModel` to exactly what the agent
   // runs when nothing is saved — the same value the gateway provider default
@@ -1021,6 +1029,7 @@ function ModelRow({ data, onSaved }: { data: BillingStatus; onSaved: () => void 
         onChange={handleModelChange}
         loading={catalogLoading}
         fallback={catalog?.fallback}
+        failed={catalogFailed}
         onRetry={refetchCatalog}
         disabled={saving}
       />

--- a/packages/web/src/app/admin/billing/page.tsx
+++ b/packages/web/src/app/admin/billing/page.tsx
@@ -151,7 +151,7 @@ const LEGACY_MODEL_ALIASES: Record<string, string> = {
   "claude-opus-4-7": "anthropic/claude-opus-4.7",
 };
 
-function canonicalizeModel(value: string): string {
+export function canonicalizeModel(value: string): string {
   return LEGACY_MODEL_ALIASES[value] ?? value;
 }
 
@@ -162,7 +162,7 @@ function canonicalizeModel(value: string): string {
  * catalog doesn't carry (a retired version a workspace is still pinned to, or
  * any ID during a cold/failed catalog fetch). Never invents a friendly name.
  */
-function modelLabel(value: string, models: GatewayCatalogModel[]): string {
+export function modelLabel(value: string, models: GatewayCatalogModel[]): string {
   const canonical = canonicalizeModel(value);
   return models.find((m) => m.id === canonical)?.name ?? canonical;
 }

--- a/packages/web/src/app/admin/model-config/page.tsx
+++ b/packages/web/src/app/admin/model-config/page.tsx
@@ -12,11 +12,16 @@ import {
 import { Cpu, Lock, XCircle } from "lucide-react";
 import { ModelProviderSection } from "@/ui/components/admin/model-provider-section";
 
-// Partial by design — unknown model IDs fall back to the raw string so that
-// a new platform model ships without a UI change. Keep in sync with
-// `MODEL_OPTIONS` in `packages/web/src/app/admin/billing/page.tsx` only for
-// the models you want humanized here. New entries should be added in both
-// places at the same time.
+// Humanizes the handful of Anthropic IDs that predate the catalog picker, for
+// the read-only "platform baseline" row below. Partial BY DESIGN and staying
+// that way: unknown IDs fall back to the raw string, which is the correct
+// display for a gateway ID anyway (`zai/glm-5.2` reads fine).
+//
+// Deliberately NOT extended as new models ship (#4869) — a growing hardcoded
+// label map is the same redeploy-gated liability the model picker just shed.
+// The picker itself resolves display names from the live catalog; this row
+// shows one already-resolved ID and doesn't justify a second catalog fetch on
+// this page (ModelProviderSection below already makes one).
 const PLATFORM_MODEL_LABELS: Record<string, string> = {
   "claude-haiku-4-5": "Haiku 4.5",
   "claude-sonnet-4-6": "Sonnet 4.6",

--- a/packages/web/src/ui/components/admin/__tests__/gateway-model-picker.test.tsx
+++ b/packages/web/src/ui/components/admin/__tests__/gateway-model-picker.test.tsx
@@ -100,6 +100,47 @@ describe("GatewayModelPicker — unusable saved selection", () => {
     expect(baseElement.textContent).not.toContain("can't call tools");
   });
 
+  test("flags a saved model the live catalog no longer carries (#4869 review)", () => {
+    // #4870 removed the version roll-forward that used to remap a retired
+    // version onto the current flagship. That was right — relabelling a
+    // configured 4.7 as "4.8" is a lie — but it left NO signal, so the row
+    // showed a raw ID while every turn failed at the gateway.
+    const { baseElement } = render(
+      <GatewayModelPicker models={[model()]} value="anthropic/claude-opus-4.1" onChange={noop} />,
+    );
+    expect(baseElement.textContent).toContain("isn't in the gateway catalog");
+  });
+
+  test("does NOT flag a missing model while the catalog is still loading", () => {
+    const { baseElement } = render(
+      <GatewayModelPicker models={[]} value="anthropic/claude-opus-4.1" onChange={noop} loading />,
+    );
+    expect(baseElement.textContent).not.toContain("isn't in the gateway catalog");
+  });
+
+  test("does NOT flag a missing model against the bundled fallback subset", () => {
+    // The fallback is a handful of models; absence from it says nothing about
+    // whether the gateway still serves the configured id.
+    const { baseElement } = render(
+      <GatewayModelPicker
+        models={[model()]}
+        value="anthropic/claude-opus-4.1"
+        onChange={noop}
+        fallback
+      />,
+    );
+    expect(baseElement.textContent).not.toContain("isn't in the gateway catalog");
+  });
+
+  test("does NOT flag a missing model when the catalog fetch failed outright", () => {
+    const { baseElement } = render(
+      <GatewayModelPicker models={[]} value="anthropic/claude-opus-4.1" onChange={noop} failed />,
+    );
+    expect(baseElement.textContent).not.toContain("isn't in the gateway catalog");
+    // ...it says the real thing instead.
+    expect(baseElement.textContent).toContain("Couldn't load the model catalog");
+  });
+
   test("renders a saved model the catalog no longer carries without inventing a name", () => {
     // A retired version a workspace is still pinned to: the trigger shows the
     // raw ID rather than a friendly label, and no false capability warning

--- a/packages/web/src/ui/components/admin/__tests__/gateway-model-picker.test.tsx
+++ b/packages/web/src/ui/components/admin/__tests__/gateway-model-picker.test.tsx
@@ -1,0 +1,105 @@
+import { describe, expect, test } from "bun:test";
+import { render } from "@testing-library/react";
+import type { GatewayCatalogModel } from "@/ui/lib/types";
+
+import { GatewayModelPicker, isSelectable } from "../gateway-model-picker";
+
+/**
+ * #4869 — the picker went from three hardcoded Anthropic options to the live
+ * Vercel AI Gateway catalog (~300 entries, of which only ~190 can actually run
+ * Atlas's agent loop). `isSelectable` is the entire guard against a workspace
+ * pinning its agent to something that can't answer a question — an embedding
+ * model, a text-to-speech model, or a chat-only model with no tool calling.
+ *
+ * The predicate is asserted directly rather than through the rendered combobox:
+ * the list lives inside a Radix Popover that only mounts its content once
+ * opened, and driving that in jsdom would test Radix, not this rule.
+ */
+
+function model(overrides: Partial<GatewayCatalogModel> = {}): GatewayCatalogModel {
+  return {
+    id: "anthropic/claude-sonnet-5",
+    name: "Claude Sonnet 5",
+    provider: "anthropic",
+    type: "language",
+    contextWindow: 1_000_000,
+    maxOutputTokens: 64_000,
+    inputPrice: "0.000003",
+    outputPrice: "0.000015",
+    recommended: false,
+    supportsTools: true,
+    ...overrides,
+  };
+}
+
+describe("isSelectable", () => {
+  test("accepts a language model that can call tools", () => {
+    expect(isSelectable(model())).toBe(true);
+  });
+
+  test("rejects every non-language model type the gateway serves", () => {
+    // The gateway publishes all of these alongside chat models. Each one would
+    // produce a completely broken agent if a workspace could select it.
+    for (const type of [
+      "embedding",
+      "image",
+      "video",
+      "reranking",
+      "transcription",
+      "realtime",
+      "speech",
+    ] as const) {
+      expect(isSelectable(model({ type, id: `x/${type}` }))).toBe(false);
+    }
+  });
+
+  test("rejects a language model that cannot call tools", () => {
+    // Atlas is tool-driven — SQL execution, semantic layer, knowledge search.
+    // A chat-only model yields an agent that can talk but never answer.
+    expect(isSelectable(model({ id: "perplexity/sonar", supportsTools: false }))).toBe(false);
+  });
+
+  test("ACCEPTS a model whose tool support is unknown", () => {
+    // `null` means "the catalog didn't say", not "no". The BYOT direct-provider
+    // catalogs (Anthropic/OpenAI/Bedrock /v1/models) publish no capability data
+    // at all, so treating null as false would empty those pickers entirely.
+    expect(isSelectable(model({ supportsTools: null }))).toBe(true);
+  });
+});
+
+describe("GatewayModelPicker — unusable saved selection", () => {
+  const noop = () => {};
+
+  test("warns when the configured model cannot call tools", () => {
+    // Reachable today: a workspace could have saved anything through the API
+    // before this filter existed. Hiding it from the list while leaving it
+    // configured would be the worst of both worlds — the row would look fine.
+    const { baseElement } = render(
+      <GatewayModelPicker
+        models={[model({ id: "perplexity/sonar", name: "Sonar", supportsTools: false })]}
+        value="perplexity/sonar"
+        onChange={noop}
+      />,
+    );
+    expect(baseElement.textContent).toContain("can't call tools");
+    expect(baseElement.textContent).toContain("perplexity/sonar");
+  });
+
+  test("stays quiet for a healthy selection", () => {
+    const { baseElement } = render(
+      <GatewayModelPicker models={[model()]} value="anthropic/claude-sonnet-5" onChange={noop} />,
+    );
+    expect(baseElement.textContent).not.toContain("can't call tools");
+  });
+
+  test("renders a saved model the catalog no longer carries without inventing a name", () => {
+    // A retired version a workspace is still pinned to: the trigger shows the
+    // raw ID rather than a friendly label, and no false capability warning
+    // fires (we know nothing about a model that isn't in the catalog).
+    const { baseElement } = render(
+      <GatewayModelPicker models={[model()]} value="anthropic/claude-opus-4.1" onChange={noop} />,
+    );
+    expect(baseElement.textContent).toContain("anthropic/claude-opus-4.1");
+    expect(baseElement.textContent).not.toContain("can't call tools");
+  });
+});

--- a/packages/web/src/ui/components/admin/__tests__/gateway-model-picker.test.tsx
+++ b/packages/web/src/ui/components/admin/__tests__/gateway-model-picker.test.tsx
@@ -59,6 +59,14 @@ describe("isSelectable", () => {
     expect(isSelectable(model({ id: "perplexity/sonar", supportsTools: false }))).toBe(false);
   });
 
+  test("rejects an unknown-typed model (fail-closed, #4869 review)", () => {
+    // The normalizer maps a type it doesn't recognize to `other`, NOT to
+    // `language`. Before that change it mapped to `language` — the one value
+    // that passes this gate — so a type the gateway adds tomorrow would be
+    // offered as a selectable chat model with `supportsTools: null`.
+    expect(isSelectable(model({ type: "other", id: "x/future", supportsTools: null }))).toBe(false);
+  });
+
   test("ACCEPTS a model whose tool support is unknown", () => {
     // `null` means "the catalog didn't say", not "no". The BYOT direct-provider
     // catalogs (Anthropic/OpenAI/Bedrock /v1/models) publish no capability data

--- a/packages/web/src/ui/components/admin/gateway-model-picker.tsx
+++ b/packages/web/src/ui/components/admin/gateway-model-picker.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Check, ChevronsUpDown, Sparkles, Loader2, RefreshCw } from "lucide-react";
+import { AlertTriangle, Check, ChevronsUpDown, Sparkles, Loader2, RefreshCw } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import {
@@ -46,6 +46,32 @@ function groupByProvider(models: GatewayCatalogModel[]): ProviderGroup[] {
     .sort((a, b) => a.provider.localeCompare(b.provider));
 }
 
+/**
+ * Models that can actually drive Atlas's agent loop (#4869).
+ *
+ * Two gates, both fail-safe toward showing a model rather than hiding it:
+ *
+ *  - `type === "language"` — the gateway also serves embedding, image, video,
+ *    reranking, transcription, realtime and speech models. Every BYOT
+ *    direct-provider catalog hardcodes `"language"`, so this is a no-op there.
+ *  - `supportsTools !== false` — Atlas is tool-driven (SQL, semantic layer,
+ *    knowledge search); a chat-only model yields an agent that can't answer
+ *    anything. `null` means the catalog didn't say, which is NOT the same as
+ *    "no" — the BYOT catalogs publish no capability data at all, so `null`
+ *    must stay visible or those pickers go empty.
+ *
+ * Filtering here rather than at the call sites keeps every picker (billing,
+ * BYOT gateway, BYOT direct) on one definition of "usable".
+ *
+ * Exported for direct unit testing: this predicate is the whole guard against
+ * a workspace pinning its agent to an embedding model or a chat-only model,
+ * and it deserves assertions that don't depend on driving a Radix combobox
+ * open in jsdom.
+ */
+export function isSelectable(model: GatewayCatalogModel): boolean {
+  return model.type === "language" && model.supportsTools !== false;
+}
+
 function formatContext(tokens: number | null): string | null {
   if (tokens === null) return null;
   if (tokens >= 1_000_000) return `${(tokens / 1_000_000).toFixed(1).replace(/\.0$/, "")}M`;
@@ -71,10 +97,17 @@ export function GatewayModelPicker({
 }: GatewayModelPickerProps) {
   const [open, setOpen] = useState(false);
 
-  const recommended = models.filter((m) => m.recommended);
-  const others = models.filter((m) => !m.recommended);
+  const selectable = models.filter(isSelectable);
+  const recommended = selectable.filter((m) => m.recommended);
+  const others = selectable.filter((m) => !m.recommended);
   const grouped = groupByProvider(others);
+  // Resolved against the FULL list, not `selectable`: a workspace that saved a
+  // model before this filter existed (or via the API directly) must still see
+  // its own selection rendered by name instead of degrading to a raw ID.
   const selected = models.find((m) => m.id === value) ?? null;
+  // ...and if that saved model can't drive the agent loop, say so. Silently
+  // hiding it from the list while leaving it configured is the worst of both.
+  const selectedUnusable = selected !== null && !isSelectable(selected);
 
   const buttonLabel = selected
     ? selected.name
@@ -153,6 +186,15 @@ export function GatewayModelPicker({
           </Command>
         </PopoverContent>
       </Popover>
+      {selectedUnusable && (
+        <p className="flex items-start gap-1.5 text-[11px] text-amber-700 dark:text-amber-400">
+          <AlertTriangle className="mt-px size-3 shrink-0" />
+          <span>
+            <span className="font-mono">{selected?.id}</span> can&apos;t call tools, so it
+            can&apos;t run queries or read the semantic layer. Pick another model.
+          </span>
+        </p>
+      )}
       {fallback && (
         <div className="flex items-center gap-2 text-[11px] text-amber-700 dark:text-amber-400">
           <RefreshCw className="size-3" />

--- a/packages/web/src/ui/components/admin/gateway-model-picker.tsx
+++ b/packages/web/src/ui/components/admin/gateway-model-picker.tsx
@@ -14,15 +14,24 @@ import {
 } from "@/components/ui/command";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import type { GatewayCatalogModel } from "@/ui/lib/types";
+import { isSelectableGatewayModel } from "@/ui/lib/types";
 
 interface GatewayModelPickerProps {
   models: GatewayCatalogModel[];
   value: string;
   onChange: (modelId: string) => void;
   loading?: boolean;
+  /** Gateway unreachable — the server returned its bundled subset. */
   fallback?: boolean;
+  /**
+   * The catalog request itself failed (auth, 5xx, schema mismatch), so there
+   * is no list at all. Distinct from `fallback`, which still yields a usable
+   * short list. Without this the picker rendered enabled and empty with no
+   * explanation (#4869 review).
+   */
+  failed?: boolean;
   disabled?: boolean;
-  /** Optional retry handler — surfaced when `fallback` is true. */
+  /** Optional retry handler — surfaced when `fallback` or `failed` is true. */
   onRetry?: () => void;
 }
 
@@ -49,28 +58,14 @@ function groupByProvider(models: GatewayCatalogModel[]): ProviderGroup[] {
 /**
  * Models that can actually drive Atlas's agent loop (#4869).
  *
- * Two gates, both fail-safe toward showing a model rather than hiding it:
- *
- *  - `type === "language"` — the gateway also serves embedding, image, video,
- *    reranking, transcription, realtime and speech models. Every BYOT
- *    direct-provider catalog hardcodes `"language"`, so this is a no-op there.
- *  - `supportsTools !== false` — Atlas is tool-driven (SQL, semantic layer,
- *    knowledge search); a chat-only model yields an agent that can't answer
- *    anything. `null` means the catalog didn't say, which is NOT the same as
- *    "no" — the BYOT catalogs publish no capability data at all, so `null`
- *    must stay visible or those pickers go empty.
- *
- * Filtering here rather than at the call sites keeps every picker (billing,
- * BYOT gateway, BYOT direct) on one definition of "usable".
- *
- * Exported for direct unit testing: this predicate is the whole guard against
- * a workspace pinning its agent to an embedding model or a chat-only model,
- * and it deserves assertions that don't depend on driving a Radix combobox
- * open in jsdom.
+ * Re-exported from `@useatlas/types` rather than defined here. It used to live
+ * in this component, which made it a BROWSER-only filter while
+ * `PUT /admin/model-config` accepted any string — so the comment calling it
+ * "the whole guard" was wrong. The API now applies the same predicate
+ * server-side; this alias keeps the existing local call sites and tests
+ * working against the one shared definition (#4869 review).
  */
-export function isSelectable(model: GatewayCatalogModel): boolean {
-  return model.type === "language" && model.supportsTools !== false;
-}
+export { isSelectableGatewayModel as isSelectable } from "@/ui/lib/types";
 
 function formatContext(tokens: number | null): string | null {
   if (tokens === null) return null;
@@ -92,12 +87,13 @@ export function GatewayModelPicker({
   onChange,
   loading,
   fallback,
+  failed,
   disabled,
   onRetry,
 }: GatewayModelPickerProps) {
   const [open, setOpen] = useState(false);
 
-  const selectable = models.filter(isSelectable);
+  const selectable = models.filter(isSelectableGatewayModel);
   const recommended = selectable.filter((m) => m.recommended);
   const others = selectable.filter((m) => !m.recommended);
   const grouped = groupByProvider(others);
@@ -107,7 +103,7 @@ export function GatewayModelPicker({
   const selected = models.find((m) => m.id === value) ?? null;
   // ...and if that saved model can't drive the agent loop, say so. Silently
   // hiding it from the list while leaving it configured is the worst of both.
-  const selectedUnusable = selected !== null && !isSelectable(selected);
+  const selectedUnusable = selected !== null && !isSelectableGatewayModel(selected);
 
   const buttonLabel = selected
     ? selected.name
@@ -126,7 +122,8 @@ export function GatewayModelPicker({
             variant="outline"
             role="combobox"
             aria-expanded={open}
-            disabled={disabled || loading}
+            aria-label="AI model"
+            disabled={disabled || loading || failed}
             className="w-full justify-between font-mono text-sm"
           >
             <span className={cn("truncate", !selected && !value && "text-muted-foreground")}>
@@ -195,7 +192,22 @@ export function GatewayModelPicker({
           </span>
         </p>
       )}
-      {fallback && (
+      {failed && (
+        <div className="flex items-center gap-2 text-[11px] text-destructive">
+          <AlertTriangle className="size-3 shrink-0" />
+          <span>Couldn&apos;t load the model catalog. Your current model is unchanged.</span>
+          {onRetry && (
+            <button
+              type="button"
+              onClick={onRetry}
+              className="font-medium underline-offset-2 hover:underline"
+            >
+              Retry
+            </button>
+          )}
+        </div>
+      )}
+      {!failed && fallback && (
         <div className="flex items-center gap-2 text-[11px] text-amber-700 dark:text-amber-400">
           <RefreshCw className="size-3" />
           <span>Catalog couldn't reach the gateway — showing a curated subset.</span>

--- a/packages/web/src/ui/components/admin/gateway-model-picker.tsx
+++ b/packages/web/src/ui/components/admin/gateway-model-picker.tsx
@@ -104,6 +104,15 @@ export function GatewayModelPicker({
   // ...and if that saved model can't drive the agent loop, say so. Silently
   // hiding it from the list while leaving it configured is the worst of both.
   const selectedUnusable = selected !== null && !isSelectableGatewayModel(selected);
+  // A configured id the LIVE catalog doesn't carry: a version the gateway has
+  // retired, which every turn will now fail on. #4870 removed the version
+  // roll-forward that used to paper over this (correctly — silently relabelling
+  // a 4.7 as "4.8" is its own lie), but replaced it with no signal at all, so
+  // the row just showed a raw ID (#4869 review). Suppressed while loading, on
+  // the fallback manifest, and on a failed fetch — in all three cases absence
+  // from `models` says nothing about the model.
+  const selectedMissing =
+    value !== "" && selected === null && !loading && !fallback && !failed && models.length > 0;
 
   const buttonLabel = selected
     ? selected.name
@@ -183,6 +192,16 @@ export function GatewayModelPicker({
           </Command>
         </PopoverContent>
       </Popover>
+      {selectedMissing && (
+        <p className="flex items-start gap-1.5 text-[11px] text-amber-700 dark:text-amber-400">
+          <AlertTriangle className="mt-px size-3 shrink-0" />
+          <span>
+            <span className="font-mono">{value}</span> isn&apos;t in the gateway catalog
+            any more — it was probably retired. Turns on it will fail until you pick
+            another model.
+          </span>
+        </p>
+      )}
       {selectedUnusable && (
         <p className="flex items-start gap-1.5 text-[11px] text-amber-700 dark:text-amber-400">
           <AlertTriangle className="mt-px size-3 shrink-0" />

--- a/packages/web/src/ui/components/admin/gateway-model-picker.tsx
+++ b/packages/web/src/ui/components/admin/gateway-model-picker.tsx
@@ -14,7 +14,6 @@ import {
 } from "@/components/ui/command";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import type { GatewayCatalogModel } from "@/ui/lib/types";
-import { isSelectableGatewayModel } from "@/ui/lib/types";
 
 interface GatewayModelPickerProps {
   models: GatewayCatalogModel[];
@@ -58,14 +57,30 @@ function groupByProvider(models: GatewayCatalogModel[]): ProviderGroup[] {
 /**
  * Models that can actually drive Atlas's agent loop (#4869).
  *
- * Re-exported from `@useatlas/types` rather than defined here. It used to live
- * in this component, which made it a BROWSER-only filter while
- * `PUT /admin/model-config` accepted any string — so the comment calling it
- * "the whole guard" was wrong. The API now applies the same predicate
- * server-side; this alias keeps the existing local call sites and tests
- * working against the one shared definition (#4869 review).
+ * NOT the only enforcement point any more. This used to be a browser-only
+ * filter while `PUT /admin/model-config` accepted any string, so the old
+ * comment calling it "the whole guard" was wrong; the API now applies the same
+ * predicate server-side (#4869 review).
+ *
+ * Deliberately duplicated rather than shared through `@useatlas/types`: that
+ * package is published and the scaffold templates pin a released range, so a
+ * symbol added in an unpublished version fails the scaffold smoke tests. The
+ * server-side twin is `isSelectableGatewayModel` in
+ * `packages/api/src/lib/gateway-catalog.ts`; both carry the same behavior
+ * tests, so a drift fails a test rather than shipping a picker that offers a
+ * model the API rejects.
+ *
+ * Two gates:
+ *  - `type === "language"` — the gateway also serves embedding, image, video,
+ *    reranking, transcription, realtime, speech, and anything it adds next
+ *    (normalized to `other`). Every BYOT direct-provider catalog hardcodes
+ *    `"language"`, so this is a no-op there.
+ *  - `supportsTools !== false` — `null` means the catalog didn't say, which is
+ *    NOT "no"; the BYOT catalogs publish no capability data at all.
  */
-export { isSelectableGatewayModel as isSelectable } from "@/ui/lib/types";
+export function isSelectable(model: GatewayCatalogModel): boolean {
+  return model.type === "language" && model.supportsTools !== false;
+}
 
 function formatContext(tokens: number | null): string | null {
   if (tokens === null) return null;
@@ -93,7 +108,7 @@ export function GatewayModelPicker({
 }: GatewayModelPickerProps) {
   const [open, setOpen] = useState(false);
 
-  const selectable = models.filter(isSelectableGatewayModel);
+  const selectable = models.filter(isSelectable);
   const recommended = selectable.filter((m) => m.recommended);
   const others = selectable.filter((m) => !m.recommended);
   const grouped = groupByProvider(others);
@@ -103,7 +118,7 @@ export function GatewayModelPicker({
   const selected = models.find((m) => m.id === value) ?? null;
   // ...and if that saved model can't drive the agent loop, say so. Silently
   // hiding it from the list while leaving it configured is the worst of both.
-  const selectedUnusable = selected !== null && !isSelectableGatewayModel(selected);
+  const selectedUnusable = selected !== null && !isSelectable(selected);
   // A configured id the LIVE catalog doesn't carry: a version the gateway has
   // retired, which every turn will now fail on. #4870 removed the version
   // roll-forward that used to paper over this (correctly — silently relabelling

--- a/packages/web/src/ui/lib/types.ts
+++ b/packages/web/src/ui/lib/types.ts
@@ -81,6 +81,9 @@ export type {
   WizardInferredForeignKey,
   WizardTableEntry,
 } from "@useatlas/types";
+// Runtime value, not just a type: the shared capability predicate the picker
+// filters on and the API enforces server-side (#4869 review).
+export { isSelectableGatewayModel } from "@useatlas/types";
 export type {
   ModelConfigProvider,
   WorkspaceModelConfig,

--- a/packages/web/src/ui/lib/types.ts
+++ b/packages/web/src/ui/lib/types.ts
@@ -81,9 +81,6 @@ export type {
   WizardInferredForeignKey,
   WizardTableEntry,
 } from "@useatlas/types";
-// Runtime value, not just a type: the shared capability predicate the picker
-// filters on and the API enforces server-side (#4869 review).
-export { isSelectableGatewayModel } from "@useatlas/types";
 export type {
   ModelConfigProvider,
   WorkspaceModelConfig,


### PR DESCRIPTION
Closes #4869.

The SaaS **Default AI model** picker on `/admin/billing` offered three hardcoded options (Haiku 4.5, Sonnet 5, Opus 4.8). Every new model Vercel served needed a code change and a redeploy to become selectable.

That curation was load-bearing when the budget was denominated in model-weighted tokens. **It isn't anymore.** Since the at-cost credit move (#4036/#4038/#4039), `enforcement.ts` and `overage-meter.ts` both denominate on `usage.costUsd`, summed from per-turn `gateway_cost_usd` (`providerMetadata.gateway.cost`). The gateway reports real dollars for *any* model it serves — the billing math is already model-agnostic, and the allowlist was the only thing still pinned.

The picker itself already existed and shipped: `<GatewayModelPicker>` over `GET /admin/model-config/catalog` powers the BYOT provider section. The billing row already wrote through the same endpoint (`PUT /admin/model-config` with `{provider: "gateway", model}`). So the core swap is small — the work is in the guardrails the allowlist was implicitly providing.

## Guardrails, now explicit

**Tool-calling capability.** Atlas's agent loop is tool-driven; a chat-only model yields an agent that can talk but never answer. The catalog turns out to publish this two ways — a `tool-use` tag and a `tools` member of `supported_parameters`. Measured against the live response (306 entries): the two agree on **204/204** language models, but `supported_parameters` is present on all 204 while `tags` is missing on 2, so that's the signal read. 192/204 support tools; the 12 excluded are genuinely non-agentic (image-gen variants, Perplexity search, morph edit models). No save-time probe needed — the catalog answers it.

`supportsTools` is three-valued. `null` means **unknown**, not "no": the BYOT direct-provider catalogs (`/v1/models` for Anthropic/OpenAI/Bedrock) publish no capability data, so they set `null` and stay visible. Collapsing `null` to `false` would empty every BYOT picker.

**Model types.** `GATEWAY_MODEL_TYPES` was missing `transcription`, `realtime` and `speech`, and `asGatewayModelType` falls back to `language` on an unrecognized type — so 13 live models were being labelled chat models. Now listed. (All 13 also declare `tools: false`, so the capability filter already caught them; the type fix is correctness, and the fallback is a fail-**open** that shouldn't be leaned on.)

**Compaction context windows.** `resolveContextWindow` gains a tier above the static table: the per-model window from the cached catalog when it's warm. The static table knows Claude/GPT/Gemini/Mistral/Llama and nothing else, so a workspace on GLM, Kimi, Grok or DeepSeek would have compacted against the safe default. It also can't express per-model truth — it maps every `claude` id to 200k when Opus 4.8 is really 1M. Implemented as a **sync cache peek**, so no migration and `prepareStep` still never awaits; a cold cache falls through exactly as today and warms in the background.

## Curation moves out of source

`RECOMMENDED_MODEL_IDS` was itself the same redeploy-gated liability one layer down — and it had already rotted: **`google/gemini-2.0-flash` is gone from the live catalog**, so the Recommended group was silently rendering one row short.

It's now `ATLAS_RECOMMENDED_MODELS` in the settings registry (platform scope, hot-reloadable, editable at `/admin`), seeded with a current shortlist. Applied at *response* time rather than stamped into the cached entry, so an edit lands immediately instead of waiting out the 30-minute TTL — asserted by a test. IDs the gateway no longer serves are logged and skipped.

## Also

- **Dropped the version roll-forward from `LEGACY_MODEL_ALIASES`.** It existed because deprecated versions had no picker row (#3076). They all have real rows now, and relabelling a workspace's configured 4.7 as "4.8" would be the same class of lie as a cosmetic default disagreeing with the resolver. Format canonicalization (hyphen → slash+dot) stays.
- Labels resolve from the catalog with a raw-ID fallback — never an invented name.
- A saved model that can't call tools gets an explicit warning rather than silently vanishing from the list while staying configured.
- `schemas` uses `.default(null)` for `supportsTools`: web and api deploy as separate Railway services, so a skew window would otherwise blank the picker on a parse failure.

## Decision recorded

**No per-plan model gating.** With at-cost dollars plus overage, a Starter workspace picking Opus draws down its $20 credit faster and pays the difference at cost. The three-model list was making that call implicitly; dropping it is deliberate. Rationale on #4869.

## Testing

`/ci` — **all 32 gates green** (includes 319/319 web test files and the full isolated API suite).

New coverage: capability parsing incl. the absent/non-array → `null` cases; the type-sweep regression; the settings-backed shortlist incl. whitespace, blank-means-empty, no-cache-mutation, and applies-without-TTL-wait; `peekModelContextWindow` cold/warm/miss; the compaction tier incl. override-still-wins and fall-through-to-static; and the picker predicate across all seven non-language types plus the unknown-capability case.

https://claude.ai/code/session_01BxXkiB6b6ca7HCabeewjGv