### PR TITLE
chore(create-atlas): repin @useatlas/types to ^0.7.0

### DIFF
--- a/create-atlas/templates/docker/package.json
+++ b/create-atlas/templates/docker/package.json
@@ -26,7 +26,7 @@
     "@useatlas/react": "^0.2.0",
     "@useatlas/sdk": "^0.1.0",
     "@useatlas/twenty": "^0.0.6",
-    "@useatlas/types": "^0.5.0",
+    "@useatlas/types": "^0.7.0",
     "@useatlas/webhook-publisher": "^0.0.1",
     "@better-auth/agent-auth": "0.6.2",
     "@better-auth/api-key": "^1.6.25",

--- a/create-atlas/templates/nextjs-standalone/package.json
+++ b/create-atlas/templates/nextjs-standalone/package.json
@@ -23,7 +23,7 @@
     "@useatlas/react": "^0.2.0",
     "@useatlas/sdk": "^0.1.0",
     "@useatlas/twenty": "^0.0.6",
-    "@useatlas/types": "^0.5.0",
+    "@useatlas/types": "^0.7.0",
     "@useatlas/webhook-publisher": "^0.0.1",
     "ai": "^6.0.208",
     "@better-auth/agent-auth": "0.6.2",


### PR DESCRIPTION
Step 4 of the publish-then-bump sequence for #4869.

`@useatlas/types@0.7.0` is live on npm (tag `types-v0.7.0`, published from
`46e29b2cf` — the #4870 squash merge). The scaffold templates can now move off
`^0.5.0`.

## Why this is a separate PR

`scripts/check-published-symbols.ts` resolves these pinned ranges against the
**registry**. Repinning to a version that isn't published yet fails the very
gate the pin exists to enforce, so the order is: bump → merge → tag → publish →
**repin**. Doing it in #4870 is what broke `Deploy Validation` there.

## What's in 0.7.0

- `GatewayModelType` gains an `other` member — unknown gateway model types now
  fail CLOSED instead of being mislabelled `language` (the one value that passed
  the picker's type gate)
- `GatewayCatalogModel` gains a required `supportsTools` field
- exports `isSelectableGatewayModel`

## Follow-up this unblocks (intentionally not done here)

Because 0.7.0 exports `isSelectableGatewayModel`, the "can this model drive the
agent loop" predicate can be consolidated. It is currently defined twice:

- `packages/api/src/lib/gateway-catalog.ts`
- `packages/web/src/ui/components/admin/gateway-model-picker.tsx`

That duplication exists only because the symbol couldn't be imported from a
published package that didn't have it yet. It is guarded by matching behavior
tests on both sides, so it is safe as-is; consolidating is a behavior-neutral
refactor that deserves its own review rather than riding along with a dependency
repin.

## Verification

- `check-published-symbols` — `@useatlas/types@^0.7.0 → 0.7.0... ok`
- `check-template-drift` — pass
- `type` — pass

https://claude.ai/code/session_01BxXkiB6b6ca7HCabeewjGv