### PR TITLE
refactor(api): await the gateway catalog once per turn, retire the peek/warm pair (#4872)

### DIFF
--- a/ee/src/platform/model-routing.test.ts
+++ b/ee/src/platform/model-routing.test.ts
@@ -37,10 +37,11 @@ const getGatewayCatalogMock = mock(async () => ({
 // review).
 mock.module("@atlas/api/lib/gateway-catalog", () => ({
   getGatewayCatalog: getGatewayCatalogMock,
-  peekModelContextWindow: () => null,
+  lookupModelContextWindow: async () => null,
   isSelectableGatewayModel: (m: { type: string; supportsTools: boolean | null }) =>
     m.type === "language" && m.supportsTools !== false,
-  warmGatewayCatalog: () => {},
+  peekModelPricing: () => null,
+  primeGatewayCatalog: async () => {},
   __resetGatewayCatalogCacheForTests: () => {},
   __getRecommendedIdsForTests: () => [] as readonly string[],
 }));

--- a/packages/api/src/api/__tests__/admin-model-config.test.ts
+++ b/packages/api/src/api/__tests__/admin-model-config.test.ts
@@ -454,11 +454,11 @@ const mockGetGatewayCatalog: Mock<() => unknown> = mock(async () => ({
 
 // mock.module replaces the WHOLE module — every export the real file has must
 // be listed here or an unrelated importer (agent-compaction imports
-// peekModelContextWindow/warmGatewayCatalog) dies with a link-time
-// "Export named 'x' not found". Add new gateway-catalog exports here too.
+// lookupModelContextWindow) dies with a link-time "Export named 'x' not
+// found". Add new gateway-catalog exports here too.
 void mock.module("@atlas/api/lib/gateway-catalog", () => ({
   getGatewayCatalog: mockGetGatewayCatalog,
-  peekModelContextWindow: mock(() => null),
+  lookupModelContextWindow: mock(async () => null),
   // Real implementation, not a stub: the route's capability gate is the thing
   // under test in the PUT cases, and a stubbed predicate would assert the mock
   // rather than the rule (#4869 review).
@@ -469,7 +469,7 @@ void mock.module("@atlas/api/lib/gateway-catalog", () => ({
   // fails at CALL time, far from the cause. The in-file note below says to keep
   // this list complete — it wasn't.
   peekModelPricing: mock(() => null),
-  warmGatewayCatalog: mock(() => {}),
+  primeGatewayCatalog: mock(async () => {}),
   __resetGatewayCatalogCacheForTests: mock(() => {}),
   __getRecommendedIdsForTests: mock((): readonly string[] => []),
 }));

--- a/packages/api/src/api/routes/__tests__/platform-demo.test.ts
+++ b/packages/api/src/api/routes/__tests__/platform-demo.test.ts
@@ -51,6 +51,52 @@ interface CapturedAudit {
 }
 let auditCalls: CapturedAudit[] = [];
 
+/**
+ * Gateway-catalog stub state (#4872).
+ *
+ * The `/leads` and `/metrics` handlers now `await primeGatewayCatalog(...)`
+ * before folding usage rows, and `token-pricing`'s `resolveRate` reads the
+ * primed catalog synchronously per row. Without this mock the suite makes a
+ * REAL outbound call to `ai-gateway.vercel.sh` and prices its assertions off
+ * Anthropic's live published rates — green today only because the live haiku
+ * price happens to equal the static `FAMILY_RATES.haiku` entry, and red the day
+ * the vendor reprices.
+ *
+ * The two halves are deliberately COUPLED: `peekModelPricing` answers only once
+ * `primeGatewayCatalog` has been called with a gateway-shaped id. That makes the
+ * prime-before-fold contract testable — drop the `yield* Effect.promise(...)`
+ * line from EITHER handler and that handler's catalog-priced test below goes
+ * red. `primeRejects` additionally exercises the path `Effect.promise` cannot
+ * recover from.
+ */
+let catalogPrimed = false;
+let primeRejects = false;
+interface StubRate {
+  inputPerMTok: number;
+  outputPerMTok: number;
+  cacheReadPerMTok: number | null;
+  cacheWritePerMTok: number | null;
+}
+let stubCatalogPrices: Record<string, StubRate> = {};
+
+// mock.module replaces the WHOLE module — list every export of the real file or
+// an unrelated importer in this graph dies with a link-time
+// "Export named 'x' not found".
+void mock.module("@atlas/api/lib/gateway-catalog", () => ({
+  primeGatewayCatalog: async (ids: readonly (string | null | undefined)[]) => {
+    if (primeRejects) throw new Error("gateway catalog exploded");
+    if (ids.some((id) => typeof id === "string" && id.includes("/"))) catalogPrimed = true;
+  },
+  peekModelPricing: (id: string | null | undefined) =>
+    catalogPrimed && id ? (stubCatalogPrices[id] ?? null) : null,
+  lookupModelContextWindow: async () => null,
+  getGatewayCatalog: async () => ({ models: [], fetchedAt: "", fallback: false }),
+  isSelectableGatewayModel: (m: { type: string; supportsTools: boolean | null }) =>
+    m.type === "language" && m.supportsTools !== false,
+  __resetGatewayCatalogCacheForTests: () => {},
+  __getRecommendedIdsForTests: (): readonly string[] => [],
+}));
+
 // Real demoUserId hash so the leads/usage JS join keys line up.
 function realDemoUserId(email: string): string {
   const normalized = email.toLowerCase().trim();
@@ -235,6 +281,9 @@ beforeEach(() => {
   queryCalls = [];
   setSettingCalls = [];
   auditCalls = [];
+  catalogPrimed = false;
+  primeRejects = false;
+  stubCatalogPrices = {};
   demoConfig = {
     model: "",
     maxSteps: 10,
@@ -409,8 +458,64 @@ describe("GET /leads", () => {
     expect(lead.usage.promptTokens).toBe(1000);
     expect(lead.usage.completionTokens).toBe(200);
     expect(lead.usage.avgLatencyMs).toBe(1500);
+    // No catalog price stubbed ⇒ the static family table answers.
     // Haiku: 1000 input * $1/MTok + 200 output * $5/MTok = $0.002.
     expect(lead.usage.estimatedCostUsd).toBeCloseTo(0.002, 9);
+  });
+
+  test("prices from the LIVE catalog, which means priming it before the fold (#4872)", async () => {
+    // The regression guard for the new `primeGatewayCatalog` call site. The
+    // catalog rate is deliberately DIFFERENT from `FAMILY_RATES.haiku`
+    // ($1/$5) — so if the prime is removed, reordered below the fold, or the
+    // handler stops awaiting it, the response falls back to $0.002 and this
+    // goes red. Asserting the resolved DOLLAR figure rather than "a prime
+    // happened" is the lesson from #4869: the earlier shape proved a warm
+    // fired while the value it produced was never actually used.
+    stubCatalogPrices["anthropic/claude-haiku-4.5"] = {
+      inputPerMTok: 10,
+      outputPerMTok: 50,
+      cacheReadPerMTok: null,
+      cacheWritePerMTok: null,
+    };
+    wireLeads();
+
+    const res = await app.request(`${BASE}/leads`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      leads: Array<{ usage: { estimatedCostUsd: number | null } }>;
+    };
+    // 1000 input * $10/MTok + 200 output * $50/MTok = $0.02 — 10x the family
+    // rate, so the two tiers can't be confused for one another.
+    expect(body.leads[0]!.usage.estimatedCostUsd).toBeCloseTo(0.02, 9);
+    expect(catalogPrimed).toBe(true);
+  });
+
+  test("a REJECTING prime still returns the page, priced from the static family table", async () => {
+    // `primeGatewayCatalog` is invoked through `Effect.promise`, which turns a
+    // rejection into an unrecoverable defect — a 500 on the whole spend page
+    // over a pricing tier that has a designed fallback. It cannot reject today
+    // (`catalogWithinBudget` catches), so the route wraps it defensively; this
+    // is the test that the wrapper is actually there. A stubbed rejection, not
+    // just an unprimed cache — those are different paths and only this one
+    // reaches the Effect boundary.
+    primeRejects = true;
+    // A catalog rate IS stubbed, so a passing test can't be explained by the
+    // fold having nothing to read: the assertion below is the family rate,
+    // which only appears because the prime failed.
+    stubCatalogPrices["anthropic/claude-haiku-4.5"] = {
+      inputPerMTok: 10,
+      outputPerMTok: 50,
+      cacheReadPerMTok: null,
+      cacheWritePerMTok: null,
+    };
+    wireLeads();
+
+    const res = await app.request(`${BASE}/leads`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      leads: Array<{ usage: { estimatedCostUsd: number | null } }>;
+    };
+    expect(body.leads[0]!.usage.estimatedCostUsd).toBeCloseTo(0.002, 9);
   });
 
   test("a lead with no demo turns reports a zeroed rollup", async () => {
@@ -485,6 +590,52 @@ describe("GET /metrics", () => {
     expect(body.totals.estimatedCostUsd).not.toBeNull();
     expect(body.perModel).toHaveLength(1);
     expect(body.perModel[0]!.model).toBe("anthropic/claude-haiku-4.5");
+  });
+
+  test("prices from the LIVE catalog, which means priming it before the fold (#4872)", async () => {
+    // The `/metrics` twin of the `/leads` guard. Both handlers got their own
+    // `primeCatalogForPricing` call, so both need their own regression test —
+    // without this one, deleting the metrics prime leaves the suite green
+    // (the assertions above only check `estimatedCostUsd` is non-null, which
+    // the static family table satisfies just as well).
+    stubCatalogPrices["anthropic/claude-haiku-4.5"] = {
+      inputPerMTok: 10,
+      outputPerMTok: 50,
+      cacheReadPerMTok: null,
+      cacheWritePerMTok: null,
+    };
+    queryStub = async (sql: string) => {
+      if (sql.includes("GROUP BY tu.model, tu.provider")) {
+        return [
+          {
+            user_id: "",
+            model: "anthropic/claude-haiku-4.5",
+            provider: "gateway",
+            turns: 4,
+            prompt_tokens: "2000",
+            completion_tokens: "400",
+            cache_read_tokens: "0",
+            cache_write_tokens: "0",
+            avg_latency_ms: 1200,
+            latency_count: 4,
+          },
+        ];
+      }
+      if (sql.includes("lead_count")) return [{ lead_count: 2, session_count: 7 }];
+      return [];
+    };
+
+    const res = await app.request(`${BASE}/metrics`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      totals: { estimatedCostUsd: number | null; costEstimated: boolean };
+    };
+    // Catalog: 2000 * $10/MTok + 400 * $50/MTok = $0.04.
+    // Family table would be 2000 * $1 + 400 * $5 = $0.004 — a 10x gap, so the
+    // two tiers can't be confused for one another.
+    expect(body.totals.estimatedCostUsd).toBeCloseTo(0.04, 9);
+    // Priced entirely from the live catalog ⇒ no offline-table disclaimer.
+    expect(body.totals.costEstimated).toBe(false);
   });
 
   test("flags costComplete=false when a model is unpriced", async () => {

--- a/packages/api/src/api/routes/platform-demo.ts
+++ b/packages/api/src/api/routes/platform-demo.ts
@@ -28,6 +28,7 @@ import { RequestContext } from "@atlas/api/lib/effect/services";
 import { hasInternalDB, queryEffect } from "@atlas/api/lib/db/internal";
 import { setSetting } from "@atlas/api/lib/settings";
 import { demoUserId, getDemoConfig } from "@atlas/api/lib/demo";
+import { primeGatewayCatalog } from "@atlas/api/lib/gateway-catalog";
 import {
   LEADS_LIMIT,
   TRANSCRIPT_CONVERSATION_LIMIT,
@@ -56,6 +57,43 @@ import { ErrorSchema, AuthErrorSchema } from "./shared-schemas";
 import { createPlatformRouter } from "./admin-router";
 
 const log = createLogger("platform-demo");
+
+/**
+ * Load the live gateway catalog into memory before a rollup folds its rows
+ * (#4872).
+ *
+ * `token-pricing`'s `resolveRate` is sync and runs per ROW inside `foldUsage`,
+ * so priming here is what makes the catalog authoritative on the FIRST render
+ * rather than the second. It is bounded by the catalog's hot-path budget and a
+ * miss is not an error: the rollup falls back to the static family table and
+ * flags `costEstimated`, which the page already explains.
+ *
+ * Failure is swallowed on purpose, and this is the one place in the file where
+ * that's right. `primeGatewayCatalog` cannot reject today (`catalogWithinBudget`
+ * catches internally), but the bare `Effect.promise` this started as would
+ * convert any future rejection into an unrecoverable DEFECT — a 500 on the whole
+ * operator spend page over an optional pricing refinement that has a designed
+ * fallback. `tryPromise` + `catchAll` keeps the page rendering; the failure is
+ * logged with the requestId, never rethrown.
+ */
+function primeCatalogForPricing(
+  modelIds: readonly (string | null | undefined)[],
+  requestId: string,
+): Effect.Effect<void> {
+  return Effect.tryPromise({
+    try: () => primeGatewayCatalog(modelIds),
+    catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+  }).pipe(
+    Effect.catchAll((err) =>
+      Effect.sync(() => {
+        log.warn(
+          { requestId, err: err.message },
+          "gateway catalog prime failed; pricing this rollup from the static family table",
+        );
+      }),
+    ),
+  );
+}
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -360,6 +398,12 @@ platformDemo.openapi(leadsRoute, async (c) => {
         { concurrency: "unbounded" },
       );
 
+      // Fetch the live catalog ONCE before the fold (#4872). `resolveRate` is
+      // sync and runs per usage row inside `foldUsage`, so this is where the
+      // spend page pays for a cold catalog — bounded, and a miss just means the
+      // rollup prices off the static family table and flags `costEstimated`.
+      yield* primeCatalogForPricing(usageRows.map((r) => r.model), requestId);
+
       return c.json({ leads: assembleLeads(leadRows, usageRows, convCountRows) }, 200);
     }),
     { label: "list demo leads" },
@@ -411,6 +455,9 @@ platformDemo.openapi(metricsRoute, async (c) => {
         ],
         { concurrency: "unbounded" },
       );
+
+      // Same prime-once-then-fold contract as GET /leads above (#4872).
+      yield* primeCatalogForPricing(perModelRows.map((r) => r.model), requestId);
 
       return c.json(assembleMetrics(perModelRows, leadCountRows), 200);
     }),

--- a/packages/api/src/lib/__tests__/agent-compaction-integration.test.ts
+++ b/packages/api/src/lib/__tests__/agent-compaction-integration.test.ts
@@ -195,6 +195,7 @@ const { runAgent } = await import("@atlas/api/lib/agent");
 const { invalidateExploreBackend } = await import("@atlas/api/lib/tools/explore");
 const { COMPACTION_SUMMARY_PREFIX, COMPACTION_STREAM_PART_TYPE } = await import("@atlas/api/lib/agent-compaction");
 const { _resetSettingsCache } = await import("@atlas/api/lib/settings");
+const { __resetGatewayCatalogCacheForTests } = await import("@atlas/api/lib/gateway-catalog");
 const { withRequestContext } = await import("@atlas/api/lib/logger");
 const { setStreamWriter, clearStreamWriter } = await import("@atlas/api/lib/tools/python-stream");
 
@@ -528,6 +529,49 @@ describe("agent compaction — per-model context window at the runAgent seam (#3
     // 1000-token override pins the budget low enough that it does.
     expect(summarizerCalls).toBeGreaterThanOrEqual(1);
     expect(JSON.stringify(capturedPrompts)).toContain(COMPACTION_SUMMARY_PREFIX);
+  });
+
+  it("resolves the gateway catalog ONCE PER TURN, not once per step (#4872)", async () => {
+    // The acceptance criterion with no other coverage: the await added in #4872
+    // must stay in `runAgent`'s setup and never migrate into `prepareStep`,
+    // which re-runs on every step of every turn.
+    //
+    // Discriminated via a 1ms catalog TTL. Per-step lookups are SEQUENTIAL
+    // awaits, so the inflight-promise dedup never applies to them — what would
+    // otherwise collapse five of them into one fetch is the 30-minute TTL
+    // cache. Expiring it immediately makes every RESOLUTION a fresh fetch, so
+    // the fetch count IS the resolution count. This turn runs 5 steps.
+    const origTtl = process.env.ATLAS_GATEWAY_CATALOG_TTL_MS;
+    const realFetch = globalThis.fetch;
+    process.env.ATLAS_GATEWAY_CATALOG_TTL_MS = "1";
+    __resetGatewayCatalogCacheForTests();
+
+    let catalogFetches = 0;
+    globalThis.fetch = (async () => {
+      catalogFetches += 1;
+      return new Response(
+        JSON.stringify({
+          data: [{ id: "anthropic/claude-opus-4.8", type: "language", context_window: 1_000_000 }],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }) as unknown as typeof globalThis.fetch;
+
+    try {
+      enablePerModelCompaction();
+      // Gateway-shaped id, so the air-gap gate lets the lookup through.
+      mockModel = buildModel("anthropic/claude-opus-4.8");
+      const result = await runAgent({ messages: userMessages(BIG_QUESTION) });
+      const steps = await result.steps;
+
+      expect(steps.length).toBe(5);
+      expect(catalogFetches).toBe(1);
+    } finally {
+      globalThis.fetch = realFetch;
+      if (origTtl === undefined) delete process.env.ATLAS_GATEWAY_CATALOG_TTL_MS;
+      else process.env.ATLAS_GATEWAY_CATALOG_TTL_MS = origTtl;
+      __resetGatewayCatalogCacheForTests();
+    }
   });
 });
 

--- a/packages/api/src/lib/__tests__/agent-compaction.test.ts
+++ b/packages/api/src/lib/__tests__/agent-compaction.test.ts
@@ -26,10 +26,7 @@ import {
   COMPACTION_STREAM_PART_TYPE,
   type CompactionSettings,
 } from "@atlas/api/lib/agent-compaction";
-import {
-  getGatewayCatalog,
-  __resetGatewayCatalogCacheForTests,
-} from "@atlas/api/lib/gateway-catalog";
+import { __resetGatewayCatalogCacheForTests } from "@atlas/api/lib/gateway-catalog";
 import { setSetting, _resetSettingsCache } from "@atlas/api/lib/settings";
 import { _resetPool, type InternalPool } from "@atlas/api/lib/db/internal";
 
@@ -284,8 +281,8 @@ describe("resolveCompactionSettings — registry precedence + hot-reload", () =>
     _resetSettingsCache();
   });
 
-  it("defaults to OFF with sane defaults when nothing is set", () => {
-    const s = resolveCompactionSettings();
+  it("defaults to OFF with sane defaults when nothing is set", async () => {
+    const s = await resolveCompactionSettings();
     expect(s.enabled).toBe(false);
     expect(s.fillFraction).toBe(0.85);
     expect(s.pinnedRecentSteps).toBe(6);
@@ -294,11 +291,11 @@ describe("resolveCompactionSettings — registry precedence + hot-reload", () =>
     expect(s.contextWindowSource).toBe("default");
   });
 
-  it("reads the env-var tier (Tier 3)", () => {
+  it("reads the env-var tier (Tier 3)", async () => {
     process.env.ATLAS_COMPACTION_ENABLED = "true";
     process.env.ATLAS_COMPACTION_FILL_FRACTION = "0.5";
     process.env.ATLAS_COMPACTION_PINNED_RECENT_STEPS = "3";
-    const s = resolveCompactionSettings();
+    const s = await resolveCompactionSettings();
     expect(s.enabled).toBe(true);
     expect(s.fillFraction).toBe(0.5);
     expect(s.pinnedRecentSteps).toBe(3);
@@ -309,20 +306,20 @@ describe("resolveCompactionSettings — registry precedence + hot-reload", () =>
     await setSetting("ATLAS_COMPACTION_PINNED_RECENT_STEPS", "10"); // platform
     await setSetting("ATLAS_COMPACTION_PINNED_RECENT_STEPS", "20", "tester", ORG); // workspace
 
-    expect(resolveCompactionSettings(undefined, ORG).pinnedRecentSteps).toBe(20); // workspace wins
-    expect(resolveCompactionSettings().pinnedRecentSteps).toBe(10); // platform wins over env
+    expect((await resolveCompactionSettings(undefined, ORG)).pinnedRecentSteps).toBe(20); // workspace wins
+    expect((await resolveCompactionSettings()).pinnedRecentSteps).toBe(10); // platform wins over env
   });
 
   it("hot-reloads — a new override is visible without restart", async () => {
-    expect(resolveCompactionSettings(undefined, ORG).enabled).toBe(false);
+    expect((await resolveCompactionSettings(undefined, ORG)).enabled).toBe(false);
     await setSetting("ATLAS_COMPACTION_ENABLED", "true", "tester", ORG);
-    expect(resolveCompactionSettings(undefined, ORG).enabled).toBe(true);
+    expect((await resolveCompactionSettings(undefined, ORG)).enabled).toBe(true);
   });
 
-  it("falls back to defaults for out-of-range / unparseable values", () => {
+  it("falls back to defaults for out-of-range / unparseable values", async () => {
     process.env.ATLAS_COMPACTION_FILL_FRACTION = "2"; // > 1
     process.env.ATLAS_COMPACTION_PINNED_RECENT_STEPS = "0"; // < min
-    const s = resolveCompactionSettings();
+    const s = await resolveCompactionSettings();
     expect(s.fillFraction).toBe(0.85);
     expect(s.pinnedRecentSteps).toBe(6);
   });
@@ -378,7 +375,7 @@ describe("resolveModelContextWindow — static catalog (#3760)", () => {
   });
 });
 
-describe("resolveCompactionSettings — per-model window + override (#3760)", () => {
+describe("resolveCompactionSettings — static per-family window + override (#3760)", () => {
   const origDbUrl = process.env.DATABASE_URL;
 
   beforeEach(() => {
@@ -396,16 +393,16 @@ describe("resolveCompactionSettings — per-model window + override (#3760)", ()
     _resetSettingsCache();
   });
 
-  it("resolves the window from the catalog per model (200k vs 128k for the SAME fraction)", () => {
+  it("resolves the window from the static table per family (200k vs 128k for the SAME fraction)", async () => {
     process.env.ATLAS_COMPACTION_FILL_FRACTION = "0.9";
 
-    const opus = resolveCompactionSettings("claude-opus-4-8");
-    const gpt = resolveCompactionSettings("gpt-4o");
+    const opus = await resolveCompactionSettings("claude-opus-4-8");
+    const gpt = await resolveCompactionSettings("gpt-4o");
 
     expect(opus.contextWindowTokens).toBe(200_000);
-    expect(opus.contextWindowSource).toBe("catalog");
+    expect(opus.contextWindowSource).toBe("static");
     expect(gpt.contextWindowTokens).toBe(128_000);
-    expect(gpt.contextWindowSource).toBe("catalog");
+    expect(gpt.contextWindowSource).toBe("static");
 
     // Same fill fraction ⇒ DIFFERENT absolute trigger point per model. This is
     // the whole point of #3760: 0.9 means 180k tokens on Opus but 115.2k on
@@ -427,23 +424,23 @@ describe("resolveCompactionSettings — per-model window + override (#3760)", ()
     delete process.env.ATLAS_COMPACTION_FILL_FRACTION;
   });
 
-  it("falls back to the safe default window for a model absent from the catalog (no throw)", () => {
-    const s = resolveCompactionSettings("some-bespoke-local-model");
+  it("falls back to the safe default window for a model absent from the static table (no throw)", async () => {
+    const s = await resolveCompactionSettings("some-bespoke-local-model");
     expect(s.contextWindowTokens).toBe(200_000);
     expect(s.contextWindowSource).toBe("default");
   });
 
-  it("override knob pins the window and takes precedence over the catalog", async () => {
-    // Catalog would give Opus 200k; the explicit override wins.
+  it("override knob pins the window and takes precedence over every catalog tier", async () => {
+    // The static table would give Opus 200k; the explicit override wins.
     await setSetting("ATLAS_COMPACTION_CONTEXT_WINDOW_TOKENS", "50000");
-    const s = resolveCompactionSettings("claude-opus-4-8");
+    const s = await resolveCompactionSettings("claude-opus-4-8");
     expect(s.contextWindowTokens).toBe(50_000);
     expect(s.contextWindowSource).toBe("override");
   });
 
-  it("override knob covers a model the catalog can't resolve", async () => {
+  it("override knob covers a model no catalog tier can resolve", async () => {
     await setSetting("ATLAS_COMPACTION_CONTEXT_WINDOW_TOKENS", "64000");
-    const s = resolveCompactionSettings("some-bespoke-local-model");
+    const s = await resolveCompactionSettings("some-bespoke-local-model");
     expect(s.contextWindowTokens).toBe(64_000);
     expect(s.contextWindowSource).toBe("override");
   });
@@ -453,63 +450,90 @@ describe("resolveCompactionSettings — per-model window + override (#3760)", ()
     await setSetting("ATLAS_COMPACTION_CONTEXT_WINDOW_TOKENS", "80000"); // platform
     await setSetting("ATLAS_COMPACTION_CONTEXT_WINDOW_TOKENS", "90000", "tester", ORG); // workspace
 
-    expect(resolveCompactionSettings("claude-opus-4-8", ORG).contextWindowTokens).toBe(90_000);
-    expect(resolveCompactionSettings("claude-opus-4-8").contextWindowTokens).toBe(80_000);
+    expect((await resolveCompactionSettings("claude-opus-4-8", ORG)).contextWindowTokens).toBe(90_000);
+    expect((await resolveCompactionSettings("claude-opus-4-8")).contextWindowTokens).toBe(80_000);
   });
 
-  it("ignores an invalid override and resolves from the catalog instead", () => {
+  it("ignores an invalid override and resolves from the static table instead", async () => {
     process.env.ATLAS_COMPACTION_CONTEXT_WINDOW_TOKENS = "not-a-number";
-    const s = resolveCompactionSettings("gpt-4o");
+    const s = await resolveCompactionSettings("gpt-4o");
     expect(s.contextWindowTokens).toBe(128_000);
-    expect(s.contextWindowSource).toBe("catalog");
+    expect(s.contextWindowSource).toBe("static");
   });
 
-  it("ignores a numeric-but-too-small override and falls through to the catalog (F4)", () => {
+  it("ignores a numeric-but-too-small override and falls through to the static table (F4)", async () => {
     // A real number below MIN_CONTEXT_WINDOW_TOKENS is distinct from not-a-number:
-    // it parses fine but is out of range, so it must fall through to the catalog.
+    // it parses fine but is out of range, so it must fall through to the static table.
     process.env.ATLAS_COMPACTION_CONTEXT_WINDOW_TOKENS = "500";
-    const s = resolveCompactionSettings("gpt-4o");
+    const s = await resolveCompactionSettings("gpt-4o");
     expect(s.contextWindowTokens).toBe(128_000);
-    expect(s.contextWindowSource).toBe("catalog");
+    expect(s.contextWindowSource).toBe("static");
   });
 
-  it("ignores an absurdly-large override and falls through to the catalog (F2 ceiling)", () => {
+  it("ignores an absurdly-large override and falls through to the static table (F2 ceiling)", async () => {
     // No upper bound once let an absurd value silently disable compaction (the
     // trigger never crosses). An out-of-range-HIGH override now falls through to
-    // the catalog like the too-small / not-a-number cases.
+    // the static table like the too-small / not-a-number cases.
     process.env.ATLAS_COMPACTION_CONTEXT_WINDOW_TOKENS = "999999999999";
-    const s = resolveCompactionSettings("gpt-4o");
+    const s = await resolveCompactionSettings("gpt-4o");
     expect(s.contextWindowTokens).toBe(128_000);
-    expect(s.contextWindowSource).toBe("catalog");
+    expect(s.contextWindowSource).toBe("static");
   });
 
-  it("treats a blank override as 'use the catalog' (the registry default)", () => {
-    // Default is "" — unset knob ⇒ catalog resolution, never a pinned 0/empty.
-    const s = resolveCompactionSettings("claude-opus-4-8");
-    expect(s.contextWindowSource).toBe("catalog");
+  it("treats a blank override as 'resolve it for me' (the registry default)", async () => {
+    // Default is "" — unset knob ⇒ tier-2/3 resolution, never a pinned 0/empty.
+    const s = await resolveCompactionSettings("claude-opus-4-8");
+    expect(s.contextWindowSource).toBe("static");
     expect(s.contextWindowTokens).toBe(200_000);
   });
 });
 
 // ---------------------------------------------------------------------------
-// Live gateway catalog tier (#4869)
+// Live gateway catalog tier (#4869), awaited once per turn (#4872)
 // ---------------------------------------------------------------------------
 
-describe("resolveCompactionSettings — live gateway catalog tier (#4869)", () => {
+describe("resolveCompactionSettings — live gateway catalog tier (#4869, #4872)", () => {
   const origDbUrl = process.env.DATABASE_URL;
   const realFetch = globalThis.fetch;
+  let fetches = 0;
 
-  function warmCatalogWith(entries: unknown[]): Promise<unknown> {
-    globalThis.fetch = (async () =>
-      new Response(JSON.stringify({ data: entries }), {
+  const origEnabled = process.env.ATLAS_COMPACTION_ENABLED;
+  /** Resolves the pending slow fetch, if the test armed one. */
+  let releaseSlowFetch: (() => void) | undefined;
+
+  /**
+   * Serve `entries` from the gateway WITHOUT pre-warming the cache. Every test
+   * below starts cold on purpose: since #4872 the resolver fetches for itself,
+   * so "cold cache" is the state under test, not a setup step to get past.
+   *
+   * `slow: true` holds the response until `releaseSlowFetch` — a deferred gate
+   * rather than a wall-clock delay, so the test decides when the fetch is
+   * allowed to proceed instead of leaving a real timer pending past its own
+   * `afterEach` (#4872 review).
+   */
+  function serveCatalog(entries: unknown[], opts: { slow?: boolean } = {}): void {
+    globalThis.fetch = (async () => {
+      fetches += 1;
+      if (opts.slow) {
+        await new Promise<void>((resolve) => {
+          releaseSlowFetch = resolve;
+        });
+      }
+      return new Response(JSON.stringify({ data: entries }), {
         status: 200,
         headers: { "content-type": "application/json" },
-      })) as unknown as typeof globalThis.fetch;
-    return getGatewayCatalog();
+      });
+    }) as unknown as typeof globalThis.fetch;
   }
 
   beforeEach(() => {
+    fetches = 0;
+    releaseSlowFetch = undefined;
     delete process.env.ATLAS_COMPACTION_CONTEXT_WINDOW_TOKENS;
+    // Tier 2 is gated on compaction being ENABLED (#4872 review) — the window
+    // only sizes the trigger, so a disabled turn never pays for the network.
+    // Every test in this block is about that tier, so turn it on.
+    process.env.ATLAS_COMPACTION_ENABLED = "true";
     process.env.DATABASE_URL = "postgresql://test:test@localhost:5432/test";
     _resetPool(mockPool);
     _resetSettingsCache();
@@ -517,8 +541,17 @@ describe("resolveCompactionSettings — live gateway catalog tier (#4869)", () =
   });
 
   afterEach(() => {
+    // Unblock any gated fetch so its promise can settle rather than dangling to
+    // process exit. This does NOT wait for the load to land — it has several
+    // more ticks of JSON parsing and normalizing to go, and will almost
+    // certainly finish after the reset below. What actually stops it writing
+    // into the next test is `cacheGeneration`, bumped by
+    // `__resetGatewayCatalogCacheForTests`.
+    releaseSlowFetch?.();
     globalThis.fetch = realFetch;
     delete process.env.ATLAS_COMPACTION_CONTEXT_WINDOW_TOKENS;
+    if (origEnabled !== undefined) process.env.ATLAS_COMPACTION_ENABLED = origEnabled;
+    else delete process.env.ATLAS_COMPACTION_ENABLED;
     if (origDbUrl !== undefined) process.env.DATABASE_URL = origDbUrl;
     else delete process.env.DATABASE_URL;
     _resetPool(null);
@@ -526,92 +559,123 @@ describe("resolveCompactionSettings — live gateway catalog tier (#4869)", () =
     __resetGatewayCatalogCacheForTests();
   });
 
-  it("resolves a real window for a family the static table has never heard of", async () => {
-    // The point of the whole change: the picker now exposes the full gateway,
-    // and the static table only knows Claude/GPT/Gemini/Mistral/Llama. Before
-    // this tier, a GLM workspace silently compacted against the safe default.
-    const cold = resolveCompactionSettings("zai/glm-5.2");
-    expect(cold.contextWindowSource).toBe("default");
-
-    await warmCatalogWith([{ id: "zai/glm-5.2", type: "language", context_window: 1_040_000 }]);
-
-    const warm = resolveCompactionSettings("zai/glm-5.2");
-    expect(warm.contextWindowTokens).toBe(1_040_000);
-    expect(warm.contextWindowSource).toBe("catalog");
-  });
-
-  it("prefers the per-model live window over the per-family static guess", async () => {
-    // The static table maps every `claude` id to 200k. Opus 4.8 is really 1M —
-    // a per-family table cannot express that, so compaction fired ~5x too early.
-    expect(resolveCompactionSettings("anthropic/claude-opus-4.8").contextWindowTokens).toBe(
-      200_000,
-    );
-
-    await warmCatalogWith([
-      { id: "anthropic/claude-opus-4.8", type: "language", context_window: 1_000_000 },
-    ]);
-
-    expect(resolveCompactionSettings("anthropic/claude-opus-4.8").contextWindowTokens).toBe(
-      1_000_000,
-    );
-  });
-
-  it("still lets an explicit operator override win over the live catalog", async () => {
-    await warmCatalogWith([{ id: "zai/glm-5.2", type: "language", context_window: 1_040_000 }]);
-    process.env.ATLAS_COMPACTION_CONTEXT_WINDOW_TOKENS = "50000";
-    const s = resolveCompactionSettings("zai/glm-5.2");
-    expect(s.contextWindowTokens).toBe(50_000);
-    expect(s.contextWindowSource).toBe("override");
-  });
-
-  it("WARMS the catalog for a Claude id, whose static-table hit used to skip the warm", async () => {
-    // The regression this guards (#4869 review): `warmGatewayCatalog()` sat in
-    // the tier-4 branch, below the static family table. The table's `claude`
-    // rule matches every Anthropic id, so tier 4 was unreachable for them and
-    // the warm never fired — meaning tier 2 never populated for the SaaS
-    // DEFAULT models and `anthropic/claude-sonnet-5` sized compaction at the
-    // static 200k against a real 1M window, on every turn, indefinitely.
+  it("resolves the live window on the FIRST turn, from a cold cache", async () => {
+    // The #4872 acceptance criterion, and the guard against the tier-ordering
+    // hazard silently coming back. Before this, tier 2 read a cache some EARLIER
+    // turn had to have warmed, so turn 1 always answered from the static table
+    // (or the safe default) — and when the warm call drifted below the static
+    // tier there was no turn 2 either.
     //
-    // Asserted via the outbound fetch because that IS the observable effect of
-    // the warm; asserting the returned window would pass either way on a cold
-    // cache (both paths return 200k on turn 1 — the bug is that turn 2 also
-    // returns 200k, forever).
-    let fetches = 0;
-    globalThis.fetch = (async () => {
-      fetches += 1;
-      return new Response(JSON.stringify({ data: [] }), {
-        status: 200,
-        headers: { "content-type": "application/json" },
-      });
-    }) as unknown as typeof globalThis.fetch;
+    // GLM is the sharpest case: the static table knows Claude/GPT/Gemini/
+    // Mistral/Llama and nothing else, so without the catalog this workspace
+    // compacts against the 200k safe default instead of its real 1.04M window.
+    serveCatalog([{ id: "zai/glm-5.2", type: "language", context_window: 1_040_000 }]);
 
-    const s = resolveCompactionSettings("anthropic/claude-sonnet-5");
-    // Still 200k on THIS turn — the peek is sync and the cache was cold.
-    expect(s.contextWindowTokens).toBe(200_000);
-    // ...but the warm fired, so a later turn resolves from tier 2.
-    await Promise.resolve();
+    const first = await resolveCompactionSettings("zai/glm-5.2");
+    expect(first.contextWindowTokens).toBe(1_040_000);
+    expect(first.contextWindowSource).toBe("gateway");
     expect(fetches).toBe(1);
   });
 
-  it("does NOT warm for a slashless BYOT/self-hosted id", async () => {
-    // Air-gapped self-hosted deploys use hyphen-format ids. They must never
-    // trigger an outbound call to the gateway.
-    let fetches = 0;
-    globalThis.fetch = (async () => {
-      fetches += 1;
-      return new Response(JSON.stringify({ data: [] }), { status: 200 });
-    }) as unknown as typeof globalThis.fetch;
+  it("beats the per-family static guess on turn 1 for the SaaS default models", async () => {
+    // The bug #4872 retires the mechanism behind (#4869 review): the static
+    // table maps EVERY `claude` id to 200k, so the tier-4 warm was unreachable
+    // for Anthropic ids and `anthropic/claude-sonnet-5` sized compaction at
+    // 200k against a real 1M window, on every turn, indefinitely.
+    //
+    // Asserted on the returned WINDOW, not on the fetch count: an assertion
+    // that only proves "a fetch happened" is what let the previous shape look
+    // covered while the value it produced was never used.
+    serveCatalog([{ id: "anthropic/claude-sonnet-5", type: "language", context_window: 1_000_000 }]);
 
-    resolveCompactionSettings("claude-opus-4-8");
-    await Promise.resolve();
+    const s = await resolveCompactionSettings("anthropic/claude-sonnet-5");
+    expect(s.contextWindowTokens).toBe(1_000_000);
+    expect(s.contextWindowSource).toBe("gateway");
+  });
+
+  it("still lets an explicit operator override win over the live catalog", async () => {
+    serveCatalog([{ id: "zai/glm-5.2", type: "language", context_window: 1_040_000 }]);
+    process.env.ATLAS_COMPACTION_CONTEXT_WINDOW_TOKENS = "50000";
+    const s = await resolveCompactionSettings("zai/glm-5.2");
+    expect(s.contextWindowTokens).toBe(50_000);
+    expect(s.contextWindowSource).toBe("override");
+    // Tier 1 short-circuits above the catalog, so the pinned turn doesn't even
+    // reach the network.
     expect(fetches).toBe(0);
   });
 
+  it("makes NO outbound call for a slashless BYOT/self-hosted id", async () => {
+    // Air-gapped self-hosted deploys use hyphen-format ids. They must never
+    // trigger an outbound call to the gateway — the id-shape gate is what
+    // keeps the awaited tier 2 safe for them.
+    serveCatalog([]);
+    const s = await resolveCompactionSettings("claude-opus-4-8");
+    expect(fetches).toBe(0);
+    // ...and they still get a window, from the static table.
+    expect(s.contextWindowTokens).toBe(200_000);
+    expect(s.contextWindowSource).toBe("static");
+  });
+
   it("falls through to the static table when the live catalog lacks the id", async () => {
-    await warmCatalogWith([{ id: "some/other-model", type: "language", context_window: 999 }]);
-    const s = resolveCompactionSettings("gpt-4o");
+    serveCatalog([{ id: "some/other-model", type: "language", context_window: 999 }]);
+    const s = await resolveCompactionSettings("openai/gpt-4o");
     expect(s.contextWindowTokens).toBe(128_000);
-    expect(s.contextWindowSource).toBe("catalog");
+    expect(s.contextWindowSource).toBe("static");
+  });
+
+  it("does not stall the turn on a slow gateway — bounded, then static fallback", async () => {
+    // The failure story (#4872 AC). The catalog fetch's OWN ceiling is 10s,
+    // which must never be spent in the turn path; the resolver bounds its wait
+    // to `HOT_PATH_BUDGET_MS` and degrades to the static table. This gateway
+    // would answer with the real 1M window, so a static-table result can only
+    // mean the turn stopped waiting.
+    serveCatalog(
+      [{ id: "anthropic/claude-sonnet-5", type: "language", context_window: 1_000_000 }],
+      { slow: true },
+    );
+
+    const started = Date.now();
+    const s = await resolveCompactionSettings("anthropic/claude-sonnet-5");
+    const elapsed = Date.now() - started;
+
+    // Two-sided on purpose. The upper bound alone would also pass with the
+    // budget set to 0 or the await deleted — i.e. it can't tell "bounded wait"
+    // from "no wait at all", which is half the contract.
+    expect(elapsed).toBeGreaterThanOrEqual(1_000);
+    expect(elapsed).toBeLessThan(4_000);
+    expect(s.contextWindowTokens).toBe(200_000);
+    expect(s.contextWindowSource).toBe("static");
+  });
+
+  it("does not fail the turn when the gateway is unreachable", async () => {
+    globalThis.fetch = (async () => {
+      fetches += 1;
+      throw new Error("ECONNREFUSED");
+    }) as unknown as typeof globalThis.fetch;
+
+    const s = await resolveCompactionSettings("anthropic/claude-sonnet-5");
+    // Static table, not an error and not the bundled fallback manifest.
+    expect(s.contextWindowTokens).toBe(200_000);
+    expect(s.contextWindowSource).toBe("static");
+    expect(fetches).toBe(1);
+  });
+
+  it("skips the network entirely when compaction is DISABLED (the shipped default)", async () => {
+    // The window exists only to size the fill-fraction trigger, and compaction
+    // ships off — so a default SaaS deploy must not spend up to
+    // `HOT_PATH_BUDGET_MS` on the agent hot path computing a number that
+    // `shouldCompact` will short-circuit past anyway (#4872 review).
+    process.env.ATLAS_COMPACTION_ENABLED = "false";
+    _resetSettingsCache();
+    serveCatalog([{ id: "zai/glm-5.2", type: "language", context_window: 1_040_000 }]);
+
+    const s = await resolveCompactionSettings("zai/glm-5.2");
+    expect(s.enabled).toBe(false);
+    expect(fetches).toBe(0);
+    // Falls to the safe default — the static table has no `zai` rule — which is
+    // exactly what a disabled turn resolved to before #4872.
+    expect(s.contextWindowTokens).toBe(200_000);
+    expect(s.contextWindowSource).toBe("default");
   });
 });
 
@@ -650,16 +714,16 @@ describe("Compaction 1 invariants are unchanged (#3759 regression)", () => {
     _resetSettingsCache();
   });
 
-  it("default-off: resolution is disabled regardless of model (no behavior change)", () => {
-    expect(resolveCompactionSettings("claude-opus-4-8").enabled).toBe(false);
-    expect(resolveCompactionSettings("gpt-4o").enabled).toBe(false);
-    expect(resolveCompactionSettings().enabled).toBe(false);
+  it("default-off: resolution is disabled regardless of model (no behavior change)", async () => {
+    expect((await resolveCompactionSettings("claude-opus-4-8")).enabled).toBe(false);
+    expect((await resolveCompactionSettings("gpt-4o")).enabled).toBe(false);
+    expect((await resolveCompactionSettings()).enabled).toBe(false);
   });
 
-  it("the coarse default window (200k) is preserved for a model the catalog can't resolve", () => {
+  it("the coarse default window (200k) is preserved for a model no tier can resolve", async () => {
     // #3759 used a flat 200k; an uncatalogued model still resolves to exactly
     // that, so the trigger point for unknown models is byte-for-byte unchanged.
-    const s = resolveCompactionSettings("totally-unknown-model");
+    const s = await resolveCompactionSettings("totally-unknown-model");
     expect(s.contextWindowTokens).toBe(DEFAULT_WINDOW_3759);
   });
 
@@ -671,7 +735,7 @@ describe("Compaction 1 invariants are unchanged (#3759 regression)", () => {
       fillFraction: 0.85,
       pinnedRecentSteps: 6,
       contextWindowTokens: 200_000,
-      contextWindowSource: "catalog",
+      contextWindowSource: "static",
     };
     const threshold = 0.85 * 200_000; // 170k
     expect(shouldCompact(threshold - 1, s)).toBe(false);

--- a/packages/api/src/lib/__tests__/gateway-catalog.test.ts
+++ b/packages/api/src/lib/__tests__/gateway-catalog.test.ts
@@ -4,8 +4,8 @@ import {
   __resetGatewayCatalogCacheForTests,
   __getRecommendedIdsForTests,
   getGatewayCatalog,
-  peekModelContextWindow,
-  warmGatewayCatalog,
+  lookupModelContextWindow,
+  primeGatewayCatalog,
   isSelectableGatewayModel,
   peekModelPricing,
 } from "../gateway-catalog";
@@ -242,7 +242,7 @@ describe("gateway-catalog", () => {
     expect(res.models.map((m) => m.type)).toEqual(["transcription", "realtime", "speech"]);
   });
 
-  describe("warmGatewayCatalog (#4869 review)", () => {
+  describe("primeGatewayCatalog (#4872)", () => {
     test("is a no-op when the cache is already fresh", async () => {
       let fetches = 0;
       globalThis.fetch = (async () => {
@@ -256,15 +256,12 @@ describe("gateway-catalog", () => {
       await getGatewayCatalog();
       expect(fetches).toBe(1);
 
-      warmGatewayCatalog();
-      warmGatewayCatalog();
-      await Promise.resolve();
-      // The early return is load-bearing: this runs on every agent step for a
-      // gateway-shaped id, so a regression here is one fetch PER STEP.
+      await primeGatewayCatalog(["a/b"]);
+      await primeGatewayCatalog(["a/b"]);
       expect(fetches).toBe(1);
     });
 
-    test("does not stampede — concurrent warms share one inflight fetch", async () => {
+    test("does not stampede — concurrent primes share one inflight fetch", async () => {
       let fetches = 0;
       globalThis.fetch = (async () => {
         fetches += 1;
@@ -275,18 +272,64 @@ describe("gateway-catalog", () => {
         });
       }) as unknown as FetchFn;
 
-      for (let i = 0; i < 25; i += 1) warmGatewayCatalog();
+      await Promise.all(Array.from({ length: 25 }, () => primeGatewayCatalog(["a/b"])));
       await getGatewayCatalog();
       expect(fetches).toBe(1);
     });
 
-    test("never throws from its synchronous call site, even when fetch rejects", () => {
+    test("never rejects, even when fetch throws synchronously", async () => {
       globalThis.fetch = (() => {
         throw new Error("network stack exploded");
       }) as unknown as FetchFn;
-      // Called from `prepareStep`-adjacent sync code — a throw here would take
-      // the turn down.
-      expect(() => warmGatewayCatalog()).not.toThrow();
+      // A rejection here would 500 the operator spend page over a gateway
+      // outage that has a perfectly good static fallback.
+      expect(await primeGatewayCatalog(["a/b"]).then(() => "resolved")).toBe("resolved");
+    });
+
+    test("makes NO outbound call when no id is gateway-shaped (air gap)", async () => {
+      // Air-gapped self-hosted deploys use hyphen-format ids with no slash. The
+      // gate is per-CALL, not per-id: one gateway-shaped row is enough to
+      // justify the fetch, none at all means the network is never touched.
+      const fetchMock = mock(async () => new Response("{}", { status: 200 }));
+      globalThis.fetch = fetchMock as unknown as FetchFn;
+      await primeGatewayCatalog(["claude-opus-4-8", "gpt-4o", null, undefined]);
+      expect(fetchMock).toHaveBeenCalledTimes(0);
+
+      await primeGatewayCatalog(["claude-opus-4-8", "anthropic/claude-opus-5"]);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    test("gives up at the budget and leaves the load running for the next caller", async () => {
+      let resolveFetch: ((r: Response) => void) | undefined;
+      const gate = new Promise<Response>((r) => {
+        resolveFetch = r;
+      });
+      let fetches = 0;
+      globalThis.fetch = (async () => {
+        fetches += 1;
+        return gate;
+      }) as unknown as FetchFn;
+
+      const started = Date.now();
+      await primeGatewayCatalog(["zai/glm-5.2"], 25);
+      // Returned on the budget, NOT on the 10s fetch timeout.
+      expect(Date.now() - started).toBeLessThan(1_000);
+      expect(peekModelPricing("zai/glm-5.2")).toBeNull();
+
+      // The abandoned load was not cancelled: when it lands it populates the
+      // shared cache, so the next caller reads it for free.
+      resolveFetch?.(
+        new Response(
+          JSON.stringify({
+            data: [{ id: "zai/glm-5.2", type: "language", pricing: { input: "0.000001", output: "0.000002" } }],
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+      );
+      await primeGatewayCatalog(["zai/glm-5.2"], 5_000);
+      expect(peekModelPricing("zai/glm-5.2")?.inputPerMTok).toBeCloseTo(1, 10);
+      // Re-used the SAME inflight load rather than starting a second one.
+      expect(fetches).toBe(1);
     });
   });
 
@@ -342,16 +385,31 @@ describe("gateway-catalog", () => {
       return getGatewayCatalog();
     }
 
-    test("peekModelContextWindow returns null off a fallback cache", async () => {
+    test("lookupModelContextWindow returns null off a fallback cache", async () => {
       const res = await forceFallback();
       expect(res.fallback).toBe(true);
-      // sonnet-5 IS in FALLBACK_MODELS with a contextWindow, so a naive peek
-      // would happily return it. Four hand-maintained constants must not size
+      // sonnet-5 IS in FALLBACK_MODELS with a contextWindow, so a naive read
+      // would happily return it. Hand-maintained constants must not size
       // compaction — the manifest had opus-4.8 at 200k against a real 1M.
-      expect(peekModelContextWindow("anthropic/claude-sonnet-5")).toBeNull();
-      expect(peekModelContextWindow("anthropic/claude-opus-4.8")).toBeNull();
+      expect(await lookupModelContextWindow("anthropic/claude-sonnet-5")).toBeNull();
+      expect(await lookupModelContextWindow("anthropic/claude-opus-4.8")).toBeNull();
     });
 
+    test("a fresh fallback cache short-circuits — no retry storm while the gateway is down", async () => {
+      const fetchMock = mock(async () => new Response("down", { status: 503 }));
+      globalThis.fetch = fetchMock as unknown as FetchFn;
+
+      await lookupModelContextWindow("anthropic/claude-sonnet-5");
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+
+      // The fallback entry carries a short (60s) TTL precisely so we retry
+      // sooner than a healthy cycle — but WITHIN it, every turn must read the
+      // cached failure instead of paying the hot-path budget again.
+      for (let i = 0; i < 5; i += 1) {
+        expect(await lookupModelContextWindow("anthropic/claude-sonnet-5")).toBeNull();
+      }
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe("tool-calling capability (#4869)", () => {
@@ -466,28 +524,109 @@ describe("gateway-catalog", () => {
     });
   });
 
-  describe("peekModelContextWindow (#4869)", () => {
-    test("returns null on a cold cache and never fetches", () => {
+  describe("lookupModelContextWindow (#4869, #4872)", () => {
+    test("FETCHES on a cold cache and answers from it — no prior warm needed", async () => {
+      // The #4872 premise: this is awaited once per turn from an async scope,
+      // so turn 1 gets the live window. The predecessor (`peekModelContextWindow`)
+      // could only ever answer from turn 2 onward.
+      const fetchMock = mock(
+        async () =>
+          new Response(
+            JSON.stringify({ data: [{ id: "zai/glm-5.2", type: "language", context_window: 1_040_000 }] }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          ),
+      );
+      globalThis.fetch = fetchMock as unknown as FetchFn;
+
+      expect(await lookupModelContextWindow("zai/glm-5.2")).toBe(1_040_000);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    test("serves the per-model window from a warm catalog without re-fetching", async () => {
+      const fetchMock = mock(
+        async () =>
+          new Response(
+            JSON.stringify({
+              data: [
+                { id: "zai/glm-5.2", type: "language", context_window: 1_040_000 },
+                { id: "a/no-window", type: "language" },
+              ],
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          ),
+      );
+      globalThis.fetch = fetchMock as unknown as FetchFn;
+
+      await getGatewayCatalog();
+      expect(await lookupModelContextWindow("zai/glm-5.2")).toBe(1_040_000);
+      // Present in the catalog but with no window published → still a miss, so
+      // the caller falls through to its static table rather than to `0`.
+      expect(await lookupModelContextWindow("a/no-window")).toBeNull();
+      expect(await lookupModelContextWindow("not/in-catalog")).toBeNull();
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    test("REFRESHES a TTL-expired entry instead of serving the stale window", async () => {
+      // The opposite contract to the pricing path's "expired ⇒ miss": here an
+      // expired entry must be re-fetched and the NEW window returned. A model's
+      // window changes between catalog revisions and compaction sizing is where
+      // a stale number does damage — so deleting the freshness check would pin
+      // a workspace to whatever the window was at process start, forever.
+      // Driven through the real TTL knob rather than a clock mock.
+      const origTtl = process.env.ATLAS_GATEWAY_CATALOG_TTL_MS;
+      process.env.ATLAS_GATEWAY_CATALOG_TTL_MS = "1";
+      let windows = [200_000, 1_000_000];
+      let fetches = 0;
+      globalThis.fetch = (async () => {
+        const contextWindow = windows[Math.min(fetches, windows.length - 1)];
+        fetches += 1;
+        return new Response(
+          JSON.stringify({
+            data: [{ id: "anthropic/claude-sonnet-5", type: "language", context_window: contextWindow }],
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }) as unknown as FetchFn;
+
+      try {
+        expect(await lookupModelContextWindow("anthropic/claude-sonnet-5")).toBe(200_000);
+        await new Promise((r) => setTimeout(r, 25)); // outlive the 1ms TTL
+        expect(await lookupModelContextWindow("anthropic/claude-sonnet-5")).toBe(1_000_000);
+        expect(fetches).toBe(2);
+      } finally {
+        if (origTtl === undefined) delete process.env.ATLAS_GATEWAY_CATALOG_TTL_MS;
+        else process.env.ATLAS_GATEWAY_CATALOG_TTL_MS = origTtl;
+        windows = [];
+      }
+    });
+
+    test("never fetches for a slashless BYOT id, warm or cold (air gap)", async () => {
       const fetchMock = mock(async () => new Response("{}", { status: 200 }));
       globalThis.fetch = fetchMock as unknown as FetchFn;
-      expect(peekModelContextWindow("a/one")).toBeNull();
+      expect(await lookupModelContextWindow("claude-opus-4-8")).toBeNull();
+      expect(await lookupModelContextWindow(undefined)).toBeNull();
+      expect(await lookupModelContextWindow("")).toBeNull();
       expect(fetchMock).toHaveBeenCalledTimes(0);
     });
 
-    test("serves the per-model window once the catalog is warm", async () => {
-      globalThis.fetch = mockFetchOk({
-        data: [
-          { id: "zai/glm-5.2", type: "language", context_window: 1_040_000 },
-          { id: "a/no-window", type: "language" },
-        ],
-      });
-      await getGatewayCatalog();
-      expect(peekModelContextWindow("zai/glm-5.2")).toBe(1_040_000);
-      // Present in the catalog but with no window published → still a miss, so
-      // the caller falls through to its static table rather than to `0`.
-      expect(peekModelContextWindow("a/no-window")).toBeNull();
-      expect(peekModelContextWindow("not/in-catalog")).toBeNull();
-      expect(peekModelContextWindow(undefined)).toBeNull();
+    test("returns null at the budget rather than waiting out the slow fetch", async () => {
+      // A slow gateway must not hold a turn open. The fetch below eventually
+      // succeeds WITH the real window — the assertion is that the turn didn't
+      // wait for it, so a passing test can't be explained by the fetch failing.
+      globalThis.fetch = (async () => {
+        await new Promise((r) => setTimeout(r, 400));
+        return new Response(
+          JSON.stringify({ data: [{ id: "zai/glm-5.2", type: "language", context_window: 1_040_000 }] }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }) as unknown as FetchFn;
+
+      const started = Date.now();
+      expect(await lookupModelContextWindow("zai/glm-5.2", 25)).toBeNull();
+      expect(Date.now() - started).toBeLessThan(300);
+
+      // ...and the abandoned load still lands, so the next turn gets it.
+      expect(await lookupModelContextWindow("zai/glm-5.2", 5_000)).toBe(1_040_000);
     });
   });
 

--- a/packages/api/src/lib/__tests__/token-pricing.test.ts
+++ b/packages/api/src/lib/__tests__/token-pricing.test.ts
@@ -6,6 +6,7 @@ import {
 } from "@atlas/api/lib/token-pricing";
 import {
   getGatewayCatalog,
+  primeGatewayCatalog,
   __resetGatewayCatalogCacheForTests,
 } from "@atlas/api/lib/gateway-catalog";
 
@@ -333,35 +334,56 @@ describe("resolveRate — catalog tier", () => {
     expect(Number(rate?.outputPerMTok)).toBe(25);
   });
 
-  it("WARMS the catalog for an Anthropic id, which used to skip the warm", async () => {
-    // The regression: the warm sat inside the `!family` branch, and
-    // `resolveModelFamily` substring-matches haiku/sonnet/opus — so every
-    // Anthropic id resolved a family and never warmed. The catalog tier never
-    // activated for them and the static table answered forever, which is what
-    // turned a stale rate into a PERMANENT over-report rather than a
-    // one-turn cold-start artifact.
+  it("never fetches — the catalog tier is a pure memory read (#4872)", async () => {
+    // `resolveRate` runs per ROW inside `foldUsage`, so it stays sync and must
+    // never reach the network itself. It used to fire a fire-and-forget warm
+    // from this line; that moved to an awaited `primeGatewayCatalog` in the
+    // `/platform/demo` handlers, which is what makes the catalog tier
+    // authoritative on the FIRST render instead of the second.
     let fetches = 0;
     globalThis.fetch = (async () => {
       fetches += 1;
-      return new Response(JSON.stringify({ data: [] }), {
-        status: 200,
-        headers: { "content-type": "application/json" },
-      });
+      return new Response(
+        JSON.stringify({
+          data: [
+            {
+              id: "anthropic/claude-opus-4.8",
+              type: "language",
+              pricing: { input: "0.000004", output: "0.00002" },
+            },
+          ],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
     }) as unknown as typeof globalThis.fetch;
 
+    // Cold: the static family table answers, and nothing is fetched.
     expect(resolveRate("anthropic/claude-opus-4.8")?.source).toBe("family");
     await Promise.resolve();
+    expect(fetches).toBe(0);
+
+    // Primed: the SAME sync call now resolves from the live catalog. The
+    // regression this replaces (#4869 review): `resolveModelFamily`
+    // substring-matches haiku/sonnet/opus, so every Anthropic id resolved a
+    // family and skipped the warm — the catalog tier never activated for them
+    // and the static table answered forever, turning a stale rate into a
+    // PERMANENT over-report rather than a cold-start artifact.
+    await primeGatewayCatalog(["anthropic/claude-opus-4.8"]);
+    const primed = resolveRate("anthropic/claude-opus-4.8");
+    expect(primed?.source).toBe("catalog");
+    expect(Number(primed?.inputPerMTok)).toBeCloseTo(4, 10);
     expect(fetches).toBe(1);
   });
 
-  it("does NOT warm for a slashless direct/BYOT id", () => {
+  it("primes NOTHING for a slashless direct/BYOT id (air gap)", async () => {
     let fetches = 0;
     globalThis.fetch = (async () => {
       fetches += 1;
       return new Response(JSON.stringify({ data: [] }), { status: 200 });
     }) as unknown as typeof globalThis.fetch;
 
-    resolveRate("claude-opus-4-8");
+    await primeGatewayCatalog(["claude-opus-4-8"]);
+    expect(resolveRate("claude-opus-4-8")?.source).toBe("family");
     expect(fetches).toBe(0);
   });
 

--- a/packages/api/src/lib/agent-compaction.ts
+++ b/packages/api/src/lib/agent-compaction.ts
@@ -16,12 +16,21 @@
  *
  * Scope:
  * - #3759: the fill-fraction trigger + summarize-older-history pass. Default OFF.
- * - #3760 (this slice): the context window is resolved PER MODEL from a static
- *   catalog (Anthropic 200k vs OpenAI 128k vs …), so the same fill fraction means
- *   the same thing on a 128k model as on a 200k one. A model the catalog doesn't
+ * - #3760: the context window is resolved PER MODEL from a static per-family
+ *   table (Anthropic 200k vs OpenAI 128k vs …), so the same fill fraction means
+ *   the same thing on a 128k model as on a 200k one. A model the table doesn't
  *   cover falls back to a safe default (never errors the turn). An admin can pin
  *   the window explicitly via the `ATLAS_COMPACTION_CONTEXT_WINDOW_TOKENS`
- *   settings knob, which takes precedence over the catalog.
+ *   settings knob, which takes precedence over every catalog.
+ *
+ * - #4869 / #4872: the LIVE gateway catalog sits above that static table, so the
+ *   window is per-MODEL rather than per-family — which the static table cannot
+ *   express (it maps every `claude` id to 200k against Sonnet 5's real 1M) and
+ *   which matters now that the model picker exposes the whole gateway. #4872
+ *   made the lookup an `await`, taken ONCE PER TURN in `agent.ts` and bounded by
+ *   a hot-path budget, retiring a sync-peek + fire-and-forget-warm pair that
+ *   could only answer from turn 2 onward. See {@link ContextWindowSource} for
+ *   the four tiers and `resolveContextWindow` for the ordering.
  *
  * - #3761: an optional cheaper summary model (the `ATLAS_COMPACTION_SUMMARY_MODEL`
  *   knob names a SEPARATE model for the summarization call, resolved on the same
@@ -48,7 +57,7 @@ import { generateText, type LanguageModel, type ModelMessage } from "ai";
 import type { Attributes } from "@opentelemetry/api";
 import { createLogger, getRequestContext } from "./logger";
 import { getSetting } from "./settings";
-import { peekModelContextWindow, warmGatewayCatalog } from "./gateway-catalog";
+import { lookupModelContextWindow } from "./gateway-catalog";
 
 const log = createLogger("agent:compaction");
 
@@ -65,12 +74,35 @@ export interface CompactionSettings {
   /**
    * Context-window size in tokens the fill-fraction trigger computes against.
    * Resolved per model (#3760): the operator override knob if set, else the
-   * static catalog value for the active model, else a safe default.
+   * LIVE gateway catalog (#4869), else the static per-family table, else a safe
+   * default. The gateway tier is skipped entirely when {@link enabled} is false,
+   * so a disabled turn never reports `gateway` — the value is inert anyway.
    */
   readonly contextWindowTokens: number;
-  /** How {@link contextWindowTokens} was resolved — for observability/tests. */
-  readonly contextWindowSource: "override" | "catalog" | "default";
+  /** How {@link contextWindowTokens} was resolved. */
+  readonly contextWindowSource: ContextWindowSource;
 }
+
+/**
+ * Which tier produced {@link CompactionSettings.contextWindowTokens}.
+ *
+ * `gateway` and `static` used to share one `"catalog"` label (#4872 review) —
+ * which meant the same model could resolve 1M on one turn and 200k on the next
+ * and report identically both times, so neither telemetry nor a test could tell
+ * whether the live tier had fired at all. That ambiguity is what let the tier
+ * ordering regress unnoticed in the first place. Draws the same live-vs-offline
+ * distinction as `ResolvedRate.source` in `token-pricing.ts`, under different
+ * labels (`catalog`/`family` there).
+ */
+export type ContextWindowSource =
+  /** The `ATLAS_COMPACTION_CONTEXT_WINDOW_TOKENS` knob. */
+  | "override"
+  /** The live gateway catalog — per-model and authoritative. */
+  | "gateway"
+  /** {@link CONTEXT_WINDOW_RULES}, the offline per-family floor. */
+  | "static"
+  /** {@link DEFAULT_CONTEXT_WINDOW_TOKENS} — no tier knew this model. */
+  | "default";
 
 const DEFAULT_FILL_FRACTION = 0.85;
 const DEFAULT_PINNED_RECENT_STEPS = 6;
@@ -96,14 +128,15 @@ const MAX_CONTEXT_WINDOW_TOKENS = 10_000_000;
 
 // ── Per-model context-window catalog (#3760) ─────────────────────────
 //
-// The live provider catalogs (`gateway-catalog`, `anthropic-catalog`,
-// `bedrock-catalog`, `openai-catalog`) carry a `contextWindow` field, but it is
-// either network-backed + async (gateway) or `null` from the upstream
-// discovery endpoint (the BYOT providers' `/v1/models` responses don't return
-// it). The compaction trigger runs synchronously inside `prepareStep` on every
-// step, so it can't await a network fetch. This static table is the synchronous
-// source of truth: a model-family → window map matched by substring against the
-// resolved model id, which is robust across the id shapes the providers use
+// The live gateway catalog is authoritative and IS consulted first (tier 2 in
+// `resolveContextWindow`, awaited once per turn since #4872). This table is the
+// OFFLINE floor underneath it: the BYOT provider catalogs (`anthropic-catalog`,
+// `bedrock-catalog`, `openai-catalog`) return `null` for `contextWindow` from
+// their upstream discovery endpoints, an air-gapped deploy never reaches the
+// gateway at all, and a gateway that is slow or down must not stall a turn. In
+// all three cases the turn still needs a number, and this is it: a
+// model-family → window map matched by substring against the resolved model id,
+// robust across the id shapes the providers use
 // (`claude-opus-4-8`, `anthropic/claude-opus-4.8`, `us.anthropic.claude-…`,
 // `gpt-4o`, `gemini-2.0-flash`, …) without an exact-id table that goes stale on
 // every model release. First match wins, so order most-specific first.
@@ -129,7 +162,11 @@ const CONTEXT_WINDOW_RULES: readonly ContextWindowRule[] = [
   { match: ["gpt-4"], windowTokens: 8_192 },
   { match: ["gpt-3.5-turbo-16k"], windowTokens: 16_384 },
   { match: ["gpt-3.5"], windowTokens: 16_385 },
-  // Anthropic — Claude 2.x through the 4.x line are all 200k.
+  // Anthropic — a deliberate 200k FLOOR for every `claude` id, not a claim that
+  // 200k is right. It is wrong-low for the 5.x line and for opus-4.8, which are
+  // really 1M (verified against the live catalog 2026-07-28); the gateway tier
+  // above is what corrects them. Low is the safe direction here — the trigger
+  // fires early, never late.
   { match: ["claude"], windowTokens: 200_000 },
   // Google Gemini — 1.5/2.x long context.
   { match: ["gemini-1.5-pro", "gemini-2"], windowTokens: 2_000_000 },
@@ -143,8 +180,8 @@ const CONTEXT_WINDOW_RULES: readonly ContextWindowRule[] = [
 /**
  * Resolve the active model's context-window size (tokens) from the static
  * catalog by family-substring match. Returns `null` when no rule matches — the
- * caller falls back to the safe default rather than erroring. Pure + sync so the
- * per-step compaction trigger can call it without awaiting a network fetch.
+ * caller falls back to the safe default rather than erroring. Pure + sync: it
+ * is the offline floor, so it must be answerable with no network and no wait.
  *
  * @param modelId provider model id (any shape: `claude-opus-4-8`,
  *   `anthropic/claude-opus-4.8`, `us.anthropic.claude-…`, `gpt-4o`, …).
@@ -175,15 +212,28 @@ function parseBoolean(raw: string | undefined, fallback: boolean): boolean {
  * Resolve the compaction knobs for a turn.
  *
  * `modelId` selects the per-model context window (#3760): the override knob
- * wins if set, else the static catalog value for the model, else a safe
- * default. `orgId` threads the workspace tier (the keys are workspace-scoped);
- * when omitted resolution falls back through platform override > env var >
- * registry default, matching `getAgentMaxSteps`.
+ * wins if set, else the live gateway catalog, else the static family table,
+ * else a safe default. `orgId` threads the workspace tier (the keys are
+ * workspace-scoped); when omitted resolution falls back through platform
+ * override > env var > registry default, matching `getAgentMaxSteps`.
+ *
+ * ASYNC, and called exactly ONCE PER TURN (#4872) — from `runAgent`'s setup in
+ * `agent.ts`, never from `prepareStep`, which consumes the already-resolved
+ * value. The single await is what lets the live catalog answer on turn 1 rather
+ * than from turn 2 onward. It is bounded and fail-soft: see
+ * `HOT_PATH_BUDGET_MS` in `gateway-catalog.ts` — a slow or unreachable gateway
+ * costs at most that budget, once per cache fill, and degrades to the static
+ * table rather than failing the turn.
+ *
+ * It costs NOTHING when compaction is off, which is the shipped default: the
+ * window only exists to size the fill-fraction trigger, so a disabled turn skips
+ * the network tier entirely rather than awaiting a budget for a number nothing
+ * will read (#4872 review).
  */
-export function resolveCompactionSettings(
+export async function resolveCompactionSettings(
   modelId?: string,
   orgId?: string,
-): CompactionSettings {
+): Promise<CompactionSettings> {
   // Fall back to the request-context org when the caller omits it, matching
   // getAgentMaxSteps — so a future caller that forgets to thread orgId still
   // hits the workspace tier instead of silently resolving platform-wide.
@@ -216,29 +266,43 @@ export function resolveCompactionSettings(
     pinnedRecentSteps = DEFAULT_PINNED_RECENT_STEPS;
   }
 
-  // Context window (#3760): override knob > static per-model catalog > default.
-  // The knob's registry default is empty, so an unset/blank value means "resolve
-  // from the catalog"; only an explicit operator value pins the window.
-  const { contextWindowTokens, contextWindowSource } = resolveContextWindow(
+  // Context window (#3760, #4869): override knob > live gateway catalog >
+  // static per-family table > safe default. The knob's registry default is
+  // empty, so an unset/blank value means "resolve from a catalog"; only an
+  // explicit operator value pins the window.
+  const { contextWindowTokens, contextWindowSource } = await resolveContextWindow(
     modelId,
     getSetting("ATLAS_COMPACTION_CONTEXT_WINDOW_TOKENS", effectiveOrgId),
+    enabled,
   );
 
   return { enabled, fillFraction, pinnedRecentSteps, contextWindowTokens, contextWindowSource };
 }
 
 /**
- * Resolve the context window the trigger computes against: an explicit, valid
- * operator override pins it; otherwise the static per-model catalog
- * ({@link resolveModelContextWindow}); otherwise a safe default. A blank/unset
- * override and a catalog miss both fall through cleanly — never throws, so a
- * model the catalog doesn't cover degrades to the default instead of erroring
- * the turn (logged at debug).
+ * Resolve the context window the trigger computes against, in four tiers:
+ * an explicit, valid operator override pins it; otherwise the LIVE gateway
+ * catalog ({@link lookupModelContextWindow}, awaited and budget-bounded since
+ * #4872); otherwise the static per-family table
+ * ({@link resolveModelContextWindow}); otherwise a safe default.
+ *
+ * Every tier falls through cleanly — a blank/unset override, an unreachable
+ * gateway, a family the static table doesn't know. Never throws, so a model no
+ * tier covers degrades to the default instead of erroring the turn.
+ *
+ * `compactionEnabled` gates the NETWORK tier only. The window is meaningless on
+ * a turn that will never compact, and compaction ships off, so a disabled turn
+ * resolves from the sync tiers alone and never waits on the gateway (#4872
+ * review). The tiers it does reach behave identically either way.
  */
-function resolveContextWindow(
+async function resolveContextWindow(
   modelId: string | undefined,
   overrideRaw: string | undefined,
-): { contextWindowTokens: number; contextWindowSource: CompactionSettings["contextWindowSource"] } {
+  compactionEnabled: boolean,
+): Promise<{
+  contextWindowTokens: number;
+  contextWindowSource: ContextWindowSource;
+}> {
   // Tier 1 — explicit operator override (settings registry already applied
   // workspace > platform > env precedence). Blank string ⇒ "use the catalog".
   if (overrideRaw !== undefined && overrideRaw.trim() !== "") {
@@ -257,48 +321,39 @@ function resolveContextWindow(
     );
   }
 
-  // Tier 2 — the live gateway catalog, if a fetch has already populated it
-  // (#4869). Authoritative and per-model rather than per-family, which matters
-  // now that the picker exposes the whole gateway: the static table below knows
-  // Claude/GPT/Gemini/Mistral/Llama families and nothing else, so a workspace on
-  // GLM, Kimi, Grok or DeepSeek would otherwise fall straight through to the
-  // safe default and compact far earlier than it needs to.
+  // Tier 2 — the live gateway catalog (#4869), fetched here if it isn't already
+  // in memory (#4872). Authoritative and per-model rather than per-family, which
+  // matters now that the picker exposes the whole gateway: the static table
+  // below knows Claude/GPT/Gemini/Mistral/Llama families and nothing else, so a
+  // workspace on GLM, Kimi, Grok or DeepSeek would otherwise fall straight
+  // through to the safe default and compact far earlier than it needs to. Even
+  // within a family it knows, the per-family guess can be badly wrong: it maps
+  // every `claude` id to 200k, against Sonnet 5's real 1M.
   //
-  // `peek` is a pure cache read, so this stays sync. NOTE: the earlier claim
-  // that it "runs inside prepareStep and cannot await" was wrong — this is
-  // reached once per turn via `resolveCompactionSettings` from an async scope
-  // in `agent.ts`, and `prepareStep` consumes the already-resolved value. A
-  // single `await` there would make the catalog authoritative on turn 1 and
-  // retire the peek/warm pair entirely; deliberately left as follow-up work
-  // rather than changing the agent hot path in a review fix.
-  const fromLiveCatalog = peekModelContextWindow(modelId);
-  if (fromLiveCatalog !== null) {
-    return { contextWindowTokens: fromLiveCatalog, contextWindowSource: "catalog" };
+  // ONE await, once per turn — never per step. `lookupModelContextWindow` owns
+  // the whole "is the gateway reachable, and how long may we wait" question:
+  // it's air-gap gated on the id shape, bounded by a hot-path budget well under
+  // the fetch timeout, logs the operator-actionable misses, and returns null
+  // instead of throwing on every failure mode. So the tiers below are reached by
+  // a plain fall-through, with no separate warm call that a reordering could
+  // strand (#4869 review: the warm used to sit BELOW the static table, whose
+  // `claude` rule matches every Anthropic id, so the tier this feeds never
+  // activated for the SaaS default models at all).
+  if (compactionEnabled) {
+    const fromLiveCatalog = await lookupModelContextWindow(modelId);
+    if (fromLiveCatalog !== null) {
+      return { contextWindowTokens: fromLiveCatalog, contextWindowSource: "gateway" };
+    }
   }
 
-  // Warm BEFORE the static fallback, not after (#4869 review). This used to sit
-  // in the tier-4 branch, which the static table's `claude` rule made
-  // unreachable for every Anthropic id — so the tier-2 upgrade never activated
-  // for the SaaS default models it was built for. A workspace on
-  // `anthropic/claude-sonnet-5` sized compaction at the static 200k against a
-  // real 1M window, on every turn, forever, unless an admin happened to open
-  // the picker (which warmed it for one 30-minute TTL and no longer).
-  //
-  // Fire-and-forget, deduped by the catalog's inflight promise, and a no-op on
-  // a warm cache. Gated on a gateway-shaped id so a direct/BYOT model id never
-  // triggers an outbound fetch — that keeps air-gapped self-hosted deploys off
-  // the network, since those use hyphen-format ids with no slash.
-  if (modelId?.includes("/")) warmGatewayCatalog();
-
-  // Tier 3 — static per-family catalog.
-  const fromCatalog = resolveModelContextWindow(modelId);
-  if (fromCatalog !== null) {
-    return { contextWindowTokens: fromCatalog, contextWindowSource: "catalog" };
+  // Tier 3 — static per-family table.
+  const fromStaticTable = resolveModelContextWindow(modelId);
+  if (fromStaticTable !== null) {
+    return { contextWindowTokens: fromStaticTable, contextWindowSource: "static" };
   }
 
-  // Tier 4 — safe default. Neither catalog has an entry for this model and
-  // there is no override; the turn proceeds on the default window rather than
-  // failing.
+  // Tier 4 — safe default. No tier has an entry for this model and there is no
+  // override; the turn proceeds on the default window rather than failing.
 
   // Logged unconditionally — a blank/undefined modelId is self-documenting in the
   // payload (it's the value that produced the miss), so the empty case isn't silent.

--- a/packages/api/src/lib/agent.ts
+++ b/packages/api/src/lib/agent.ts
@@ -1794,7 +1794,13 @@ export async function runAgent({
   // identical older slice is reused verbatim, and a grown one folds only the
   // newly-aged-out delta into the prior summary (rolling summary) — keeping the
   // per-step summarization cost bounded instead of O(full older slice).
-  const compactionSettings = resolveCompactionSettings(resolvedModelId, orgId);
+  // Awaited (#4872): tier 2 of the window resolution is the live gateway
+  // catalog, so this is where the turn pays for a cold catalog — bounded by
+  // `HOT_PATH_BUDGET_MS`, once per cache fill, degrading to the static family
+  // table rather than failing. Free when compaction is off (the default), which
+  // skips the network tier outright. `prepareStep` below reads the resolved
+  // value; nothing new is awaited per STEP.
+  const compactionSettings = await resolveCompactionSettings(resolvedModelId, orgId);
   let compactionSummaryMemo: { olderCount: number; text: string } | undefined;
 
   // #3761 — optional cheaper summary model. When `ATLAS_COMPACTION_SUMMARY_MODEL`
@@ -2118,6 +2124,11 @@ export async function runAgent({
                     pinnedMessages: compacted.pinnedMessageCount,
                     fillFraction: compactionSettings.fillFraction,
                     contextWindowTokens: compactionSettings.contextWindowTokens,
+                    // Which tier produced that window (#4872). Without it a
+                    // logged `200000` can't be told apart from the coarse
+                    // static floor — which is exactly how the live tier stayed
+                    // silently dead for the SaaS default models.
+                    contextWindowSource: compactionSettings.contextWindowSource,
                   },
                   "context compaction pass ran",
                 );

--- a/packages/api/src/lib/gateway-catalog.ts
+++ b/packages/api/src/lib/gateway-catalog.ts
@@ -25,7 +25,7 @@ import type {
   GatewayModelType,
 } from "@useatlas/types";
 import { GATEWAY_MODEL_TYPES } from "@useatlas/types";
-import { createLogger } from "./logger";
+import { createLogger, getRequestContext } from "./logger";
 import { getSetting } from "./settings";
 
 const log = createLogger("gateway-catalog");
@@ -33,6 +33,30 @@ const log = createLogger("gateway-catalog");
 const GATEWAY_CATALOG_URL = "https://ai-gateway.vercel.sh/v1/models";
 const DEFAULT_TTL_MS = 30 * 60 * 1_000; // 30 minutes
 const FETCH_TIMEOUT_MS = 10_000;
+
+/**
+ * How long a HOT PATH (an agent turn, an operator page load) will wait for a
+ * cold catalog before giving up and proceeding on its own static fallback.
+ *
+ * Deliberately far below {@link FETCH_TIMEOUT_MS} (#4872). The 10s fetch ceiling
+ * is the right bound for the ADMIN picker, which has nothing to render without
+ * the catalog and a spinner to show meanwhile; it is much too long to sit in
+ * front of an agent turn. So hot-path callers race the load against this budget:
+ * whichever finishes first wins, and losing the race is never an error — the
+ * caller falls through to its static table exactly as if the cache were cold.
+ *
+ * The abandoned load is NOT cancelled. It keeps running against the full 10s
+ * fetch timeout and populates the shared cache, so the next caller reads it for
+ * free.
+ *
+ * The cost is therefore once per CACHE FILL, not once per turn: once per cold
+ * start, once per TTL expiry (30 minutes by default, `ATLAS_GATEWAY_CATALOG_TTL_MS`),
+ * and — during a sustained outage — once per 60s fallback TTL (`load()` shortens
+ * the TTL on failure so it retries sooner). Note the cache is only written when a load LANDS, so every turn that
+ * starts while a cold load is still in flight pays its own budget; on a busy
+ * process with a slow gateway that is every turn in the window, not one.
+ */
+const HOT_PATH_BUDGET_MS = 1_500;
 
 /**
  * The shortlist starred at the top of the picker, read from the
@@ -102,7 +126,7 @@ function fallbackModel(
  * and every selectable option a generation behind, so the only way to change
  * models was to downgrade. Context windows verified against the live catalog
  * 2026-07-28; a value here that is WRONG is worse than one that is missing,
- * which is why `peekModelContextWindow` refuses to read this manifest at all.
+ * which is why `lookupModelContextWindow` refuses to read this manifest at all.
  */
 const FALLBACK_MODELS: GatewayCatalogModel[] = [
   fallbackModel("anthropic/claude-opus-5", "Claude Opus 5", 1_000_000, 128_000),
@@ -533,25 +557,168 @@ async function load(): Promise<CatalogCacheEntry> {
   }
 }
 
+/** The cached entry if it hasn't aged past its TTL, else `null`. */
+function unexpiredEntry(): CatalogCacheEntry | null {
+  return cache && cache.expiresAt > Date.now() ? cache : null;
+}
+
 /**
- * Return the cached catalog if fresh; refresh asynchronously when stale.
- * Concurrent callers during a refresh share a single inflight promise.
+ * Bumped by {@link __resetGatewayCatalogCacheForTests}. An abandoned load (see
+ * {@link catalogWithinBudget}) keeps running after the caller walked away, so
+ * without this its `cache = entry` write can land AFTER a reset and resurrect a
+ * previous test's catalog into the next one. Racing the load made abandoned
+ * loads routine where they used to be rare, so the hazard is real rather than
+ * theoretical (#4872 review).
  */
-export async function getGatewayCatalog(): Promise<GatewayCatalogResponse> {
-  if (cache && cache.expiresAt > Date.now()) {
-    return {
-      models: applyRecommended(cache.models, cache.fallback),
-      fetchedAt: cache.fetchedAt,
-      fallback: cache.fallback,
-    };
-  }
+let cacheGeneration = 0;
+
+/**
+ * Resolve the cache entry, fetching only when it's cold or stale. Concurrent
+ * callers during a refresh share the single inflight promise.
+ *
+ * Never rejects — `load()` resolves even on fetch failure, and this function
+ * adds nothing that can throw. That is what lets hot-path callers race it
+ * without an error branch. Note this is strictly narrower than
+ * {@link getGatewayCatalog}, which additionally runs `applyRecommended()` →
+ * `getSetting()` and therefore CAN reject. Callers on the agent turn path must
+ * use this one; routing them through `getGatewayCatalog` would put a settings
+ * fault on the critical path of every turn.
+ */
+async function ensureCatalogEntry(): Promise<CatalogCacheEntry> {
+  const fresh = unexpiredEntry();
+  if (fresh) return fresh;
+  const generation = cacheGeneration;
   if (!inflight) {
-    inflight = load().finally(() => {
-      inflight = null;
+    const started = load();
+    inflight = started;
+    // `if (inflight === started)` rather than a bare `inflight = null` (#4872
+    // review): an abandoned load's `finally` can fire AFTER a reset has already
+    // cleared the slot and a successor has claimed it, and would otherwise null
+    // out that successor — breaking the dedup and letting a third fetch start.
+    void started.finally(() => {
+      if (inflight === started) inflight = null;
     });
   }
   const entry = await inflight;
-  cache = entry;
+  if (generation === cacheGeneration) cache = entry;
+  return entry;
+}
+
+/** How {@link catalogWithinBudget} resolved — distinguishable so callers can log. */
+type CatalogOutcome =
+  | { readonly kind: "entry"; readonly entry: CatalogCacheEntry }
+  /** The budget elapsed before a cold load landed. Normal, but worth a warn. */
+  | { readonly kind: "budget-elapsed" }
+  /** The load rejected — the "never rejects" invariant is broken. */
+  | { readonly kind: "broken" };
+
+/**
+ * The load whose budget-elapsed warn has already been emitted.
+ *
+ * Deduped per CACHE-FILL ATTEMPT, not per caller (#4872 review). Every turn that
+ * starts while a cold load is in flight loses its own race, so an undeduped warn
+ * is one line per turn — and because a failed fill gets a 60s TTL, that repeats
+ * every 60s for the length of an outage. The operator wants one line per failed
+ * fill. Keyed on the promise identity so the NEXT attempt warns again; mirrors
+ * the warn-once discipline of {@link warnStaleShortlistOnce}.
+ */
+let warnedBudgetForLoad: Promise<CatalogCacheEntry> | null = null;
+
+/**
+ * The cache entry, waiting at most `budgetMs` for a cold one.
+ *
+ * Distinguishes the abnormal outcomes rather than collapsing them to `null`
+ * (#4872 review). Retiring `warmGatewayCatalog` left this path — the CALLER side
+ * of the load, as opposed to `load()`'s own catch — with no warn at all, and a
+ * gateway that is merely SLOW (healthy enough that `load()` never warns, slow
+ * enough to lose every race) would otherwise reinstate the exact bug this change
+ * fixes with no signal anywhere.
+ */
+async function catalogWithinBudget(budgetMs: number): Promise<CatalogOutcome> {
+  const fresh = unexpiredEntry();
+  // The common (warm) path touches neither the network nor a timer; the
+  // caller's `await` costs one microtask tick and nothing more.
+  if (fresh) return { kind: "entry", entry: fresh };
+
+  // Normalized for `setTimeout`, which coerces a negative delay to 0 and NaN to
+  // 0 — either of which would make every call return `budget-elapsed` on the
+  // next tick, i.e. the fire-and-forget semantics #4872 retired. No caller
+  // computes this today; the guard is for the first one that does.
+  const wait = Number.isFinite(budgetMs) ? Math.max(1, budgetMs) : HOT_PATH_BUDGET_MS;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const budget = new Promise<null>((resolve) => {
+    timer = setTimeout(() => resolve(null), wait);
+  });
+  const pending = ensureCatalogEntry();
+  // Read AFTER the call, BEFORE the first await: `ensureCatalogEntry` runs
+  // synchronously up to its own `await inflight`, so the slot is populated by
+  // now — and it is cleared again once the load settles, so reading it after
+  // the race would give null or already the next attempt.
+  const attempt = inflight;
+  try {
+    // `Promise.race` subscribes to the load even when the budget wins, so
+    // abandoning it can never surface as an unhandled rejection.
+    const won = await Promise.race([pending, budget]);
+    if (won === null) {
+      if (attempt !== warnedBudgetForLoad) {
+        warnedBudgetForLoad = attempt;
+        const ctx = getRequestContext();
+        log.warn(
+          {
+            budgetMs: wait,
+            requestId: ctx?.requestId,
+            // Whether a TTL-EXPIRED entry was available and deliberately not
+            // served. That trade (refresh rather than serve stale, so compaction
+            // is never sized off a superseded window) is invisible otherwise,
+            // and it is the one worth revisiting if these warns are frequent.
+            discardedExpiredEntry: cache !== null && !cache.fallback,
+          },
+          "gateway-catalog: hot-path budget elapsed before the catalog landed; callers fall back to their static tables until this fill completes. Repeated warns mean the gateway is slow enough to defeat the live tier on every cache fill",
+        );
+      }
+      return { kind: "budget-elapsed" };
+    }
+    return { kind: "entry", entry: won };
+  } catch (err) {
+    // Defence in depth. `ensureCatalogEntry` is documented never to reject and
+    // doesn't today — but this now sits on the agent turn path, outside every
+    // `try` in `runAgent`, so a future break of that invariant would fail live
+    // turns for a tier whose entire contract is "degrade to the static table".
+    // An unenforced invariant on a hot path is worth one catch block.
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err) },
+      "gateway-catalog: catalog resolution rejected — the never-rejects invariant is broken; falling back to the static table",
+    );
+    return { kind: "broken" };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Whether an id is gateway-shaped (`provider/model`) and so worth a catalog
+ * lookup at all.
+ *
+ * This is the air-gap gate (#4869 review, #4872). Direct/BYOT and self-hosted
+ * deploys use hyphen-format ids with no slash, so gating every catalog entry
+ * point on it means an air-gapped install never makes an outbound call no
+ * matter which hot path runs.
+ */
+function isGatewayModelId(modelId: string | null | undefined): boolean {
+  return typeof modelId === "string" && modelId.includes("/");
+}
+
+/**
+ * Return the cached catalog if fresh; refresh when stale. Concurrent callers
+ * during a refresh share a single inflight promise.
+ *
+ * This is the ADMIN-picker entry point: it waits for the full
+ * {@link FETCH_TIMEOUT_MS} because the picker has nothing to render without a
+ * catalog. Hot paths must use {@link lookupModelContextWindow} /
+ * {@link primeGatewayCatalog}, which bound their wait.
+ */
+export async function getGatewayCatalog(): Promise<GatewayCatalogResponse> {
+  const entry = await ensureCatalogEntry();
   return {
     models: applyRecommended(entry.models, entry.fallback),
     fetchedAt: entry.fetchedAt,
@@ -560,34 +727,97 @@ export async function getGatewayCatalog(): Promise<GatewayCatalogResponse> {
 }
 
 /**
- * Synchronous, non-fetching lookup of a model's context window from whatever
- * catalog is already in memory. Returns `null` when the cache is cold, stale,
- * or has no entry for `modelId`.
+ * A model's context window from the live catalog, fetching it if needed but
+ * never waiting longer than `budgetMs`. Returns `null` when the id isn't
+ * gateway-shaped, the budget elapsed, the gateway is unreachable, or the
+ * catalog carries no window for `modelId` — the caller falls back to its own
+ * static table in every one of those cases. The operator-actionable ones are
+ * logged before the `null`: the budget elapsing (in `catalogWithinBudget`), and
+ * the active model being absent from the live catalog entirely.
  *
- * Exists for the compaction trigger, which resolves its settings once per turn
- * and keeps a sync signature. NOTE: `resolveCompactionSettings` is called from
- * an async scope in `agent.ts`, so awaiting the catalog there IS possible and
- * would make this peek unnecessary — see the tier-2 comment in
- * `agent-compaction.ts`. This stays sync for now as the smaller change.
+ * The compaction trigger's tier 2 (#3760, #4869), called ONCE PER TURN from
+ * `resolveCompactionSettings` (`agent-compaction.ts`) — which `agent.ts` awaits
+ * in the turn setup, well outside `prepareStep`. This replaces the sync
+ * `peekModelContextWindow` + fire-and-forget `warmGatewayCatalog` pair (#4872):
+ * that pair only ever answered from turn 2 onward, made the live value depend on
+ * whether some earlier turn happened to warm the cache, and put the warm and the
+ * read in two different places — so it was possible (and it happened) for a
+ * static-table tier to sit between them and make the warm unreachable.
  *
- * Deliberately does NOT trigger a refresh: a cold cache must stay cheap and
- * silent on the hot path. Callers fall back to the static table, and the cache
- * warms via {@link warmGatewayCatalog} or the first admin who opens the picker.
+ * A TTL-EXPIRED entry is refreshed rather than served, even though it is sitting
+ * right there and the refresh costs up to `budgetMs`: a model's context window
+ * changes between catalog revisions, and compaction sizing is exactly where a
+ * stale number does damage. Losing the race just falls through to the static
+ * table, which is the same floor an air-gapped deploy runs on permanently.
  *
- * A stale (TTL-expired) cache is treated as a miss rather than served: a model's
- * context window can change between catalog revisions, and compaction sizing is
- * exactly where a stale number does damage.
- *
- * A FALLBACK cache is also a miss (#4869 review). The bundled manifest is four
- * hand-maintained constants that were never fetched from anywhere — strictly
- * worse than a stale real number, and worse still because it reported as
- * `contextWindowSource: "catalog"`. It had `opus-4.8` at 200k against a real
- * 1M, so a gateway outage silently changed a workspace's compaction threshold.
+ * A FALLBACK catalog reads as a miss (#4869 review). The bundled manifest is a
+ * handful of hand-maintained constants that were never fetched from anywhere,
+ * and unlike the static family table nothing marks them as a floor — so a
+ * gateway OUTAGE would silently change a workspace's compaction threshold to
+ * whatever this file was last edited to say. It once had `opus-4.8` at 200k
+ * against a real 1M.
  */
-export function peekModelContextWindow(modelId: string | undefined): number | null {
-  if (!modelId || !cache || cache.fallback || cache.expiresAt <= Date.now()) return null;
-  const hit = cache.models.find((m) => m.id === modelId);
-  return hit?.contextWindow ?? null;
+export async function lookupModelContextWindow(
+  modelId: string | null | undefined,
+  budgetMs: number = HOT_PATH_BUDGET_MS,
+): Promise<number | null> {
+  if (!isGatewayModelId(modelId)) return null;
+  const outcome = await catalogWithinBudget(budgetMs);
+  // `budget-elapsed` and `broken` already warned inside `catalogWithinBudget`;
+  // a `fallback` entry already warned inside `load()`.
+  if (outcome.kind !== "entry" || outcome.entry.fallback) return null;
+
+  const hit = outcome.entry.models.find((m) => m.id === modelId);
+  if (hit === undefined) {
+    // The workspace's CONFIGURED, active model is not in the live catalog at
+    // all — a typo, a retired id, or an entry `normalizeEntry` dropped. That is
+    // permanent and silent: every turn thereafter sizes compaction off the
+    // coarse static floor. Warn (deduped on the id, since it repeats per turn),
+    // matching how the shortlist treats the same fault.
+    warnUncataloguedModelOnce(modelId as string);
+    return null;
+  }
+  if (hit.contextWindow === null) {
+    // Distinct, milder fault: the gateway serves this model but publishes no
+    // window for it. Nothing for an operator to fix, so debug rather than warn.
+    log.debug(
+      { modelId },
+      "gateway-catalog: live catalog serves the active model but publishes no context window; falling back to the static family table",
+    );
+    return null;
+  }
+  return hit.contextWindow;
+}
+
+/** Same warn-once discipline as {@link warnStaleShortlistOnce}, different fault. */
+const warnedUncataloguedModels = new Set<string>();
+function warnUncataloguedModelOnce(modelId: string): void {
+  if (warnedUncataloguedModels.has(modelId)) return;
+  warnedUncataloguedModels.add(modelId);
+  log.warn(
+    { modelId },
+    "gateway-catalog: the active model is absent from the live gateway catalog — compaction is sized from the coarse static family table instead; check the configured model id",
+  );
+}
+
+/**
+ * Fetch the catalog into memory for a caller that is about to read it
+ * synchronously many times, waiting at most `budgetMs`. A no-op unless at least
+ * one of `modelIds` is gateway-shaped, so an air-gapped deploy still never
+ * reaches the network. Never throws.
+ *
+ * `readonly []` rather than `Iterable` on purpose: the scan below returns on the
+ * first gateway-shaped id, which would leave a generator partially drained for a
+ * caller that has no way to know how far.
+ *
+ * Pairs with {@link peekModelPricing}: await this once, then read per row.
+ */
+export async function primeGatewayCatalog(
+  modelIds: readonly (string | null | undefined)[],
+  budgetMs: number = HOT_PATH_BUDGET_MS,
+): Promise<void> {
+  if (!modelIds.some(isGatewayModelId)) return;
+  await catalogWithinBudget(budgetMs);
 }
 
 /**
@@ -595,37 +825,36 @@ export function peekModelContextWindow(modelId: string | undefined): number | nu
  * already in memory. Returns `null` when the cache is cold, stale, or has no
  * priced entry for `modelId`.
  *
- * Same contract and rationale as {@link peekModelContextWindow}: sync so the
- * caller keeps its own sync signature, and a stale cache reads as a miss
- * because a price that moved between catalog revisions is worse than no price.
+ * Deliberately left SYNC where the context-window lookup was made async
+ * (#4872), because it has the opposite profile: `resolveRate` runs per ROW
+ * inside `foldUsage`'s loop over the operator spend page's usage rows, so an
+ * async reader would mean either an await per row or restructuring a pure fold
+ * into an async one. Its caller awaits {@link primeGatewayCatalog} ONCE before
+ * the loop instead, which buys the same "authoritative on the first render"
+ * property with one await rather than hundreds.
+ *
+ * That leaves a prime-then-read seam a future caller could forget, which the
+ * context-window path no longer has. It is a deliberate trade, not an
+ * oversight — but see {@link resolveRate} for the honest failure story: a
+ * forgotten prime costs precision for Anthropic ids and the whole figure for
+ * everything else. Both are visible; neither is a wrong number presented as
+ * right. If a third consumer appears, close the seam with a reader closure
+ * rather than adding a third place to remember.
+ *
+ * A stale cache reads as a miss because a price that moved between catalog
+ * revisions is worse than no price. `cache.fallback` is checked explicitly even
+ * though the fallback's `prices` map is empty today, so it already returns
+ * null: stating it stops a future "let's ship prices in the fallback too" from
+ * silently pricing off redeploy-gated constants (#4869 review).
  */
-export function peekModelPricing(modelId: string | undefined): CatalogModelPricing | null {
-  // `cache.fallback` is checked explicitly even though the fallback's `prices`
-  // map is empty today, so it already returns null. Stating it keeps the two
-  // peeks symmetric and stops a future "let's ship prices in the fallback too"
-  // from silently pricing off redeploy-gated constants (#4869 review).
-  if (!modelId || !cache || cache.fallback || cache.expiresAt <= Date.now()) return null;
-  return cache.prices.get(modelId) ?? null;
-}
-
-/**
- * Fire-and-forget cache warm. Safe to call from a non-async context: it never
- * throws (`load()` resolves even on fetch failure) and concurrent calls share
- * the single inflight promise, so it can't stampede the gateway.
- */
-export function warmGatewayCatalog(): void {
-  if (cache && cache.expiresAt > Date.now()) return;
-  void getGatewayCatalog().catch((err) => {
-    // REACHABLE, despite `load()` swallowing fetch failures (#4869 review):
-    // `getGatewayCatalog` runs `applyRecommended()` → `recommendedModelIds()`
-    // → `getSetting()` AFTER `await inflight`, entirely outside `load()`'s try.
-    // Anything that throws there rejects this promise. The module header's
-    // "never rejects" invariant is about `load()` specifically, not this.
-    log.warn(
-      { err: err instanceof Error ? err.message : String(err) },
-      "gateway-catalog: background warm failed",
-    );
-  });
+export function peekModelPricing(modelId: string | null | undefined): CatalogModelPricing | null {
+  if (!modelId) return null;
+  // Shares `unexpiredEntry` with the context-window path rather than
+  // re-implementing the freshness predicate, so a future change to what counts
+  // as fresh can't silently diverge the two (#4872 review).
+  const entry = unexpiredEntry();
+  if (!entry || entry.fallback) return null;
+  return entry.prices.get(modelId) ?? null;
 }
 
 /**
@@ -635,10 +864,15 @@ export function warmGatewayCatalog(): void {
  * would otherwise let one test's warning suppress the next test's assertion.
  */
 export function __resetGatewayCatalogCacheForTests(): void {
+  // Invalidates in-flight loads too, so a load abandoned at the budget by an
+  // earlier test can't write its entry into a later one (#4872 review).
+  cacheGeneration += 1;
   cache = null;
   inflight = null;
+  warnedBudgetForLoad = null;
   warnedStaleShortlists.clear();
   warnedUnusableShortlists.clear();
+  warnedUncataloguedModels.clear();
 }
 
 /** Test-only: the shortlist as currently resolved from settings, in order. */

--- a/packages/api/src/lib/token-pricing.ts
+++ b/packages/api/src/lib/token-pricing.ts
@@ -22,13 +22,12 @@
  * this module knew three families and returned `null` for everything else — so
  * the operator spend page went blank the moment a workspace ran a non-Anthropic
  * model, which is exactly the set the model picker now exposes.
+ *
+ * The catalog tier reads from memory and does NOT fetch — see {@link resolveRate}
+ * for why this stays sync and who is responsible for priming it (#4872).
  */
 
-import {
-  peekModelPricing,
-  warmGatewayCatalog,
-  type UsdPerMTok,
-} from "@atlas/api/lib/gateway-catalog";
+import { peekModelPricing, type UsdPerMTok } from "@atlas/api/lib/gateway-catalog";
 
 export interface TokenCounts {
   /** Total input tokens (AI-SDK `inputTokens`, inclusive of the cache split). */
@@ -116,6 +115,26 @@ export interface ResolvedRate {
  *
  * Order matters: catalog wins even for Anthropic models, because it tracks
  * price changes and the static table does not.
+ *
+ * SYNC on purpose (#4872). This runs per ROW inside `foldUsage`'s loop, so the
+ * catalog is fetched by ONE awaited `primeGatewayCatalog(models)` in the
+ * `/platform/demo` route handlers before the fold, and read from memory here.
+ * It replaced a fire-and-forget `warmGatewayCatalog()` call that used to sit on
+ * this line: correct, but authoritative only from the SECOND page load, and
+ * split across two call sites in a way that let a tier reordering strand it
+ * (#4869 review — an earlier iteration had the warm inside the `!family` branch
+ * below, which `resolveModelFamily`'s haiku/sonnet/opus substring match made
+ * unreachable for every Anthropic gateway id).
+ *
+ * A forgotten prime never yields a confidently-wrong number, but it does NOT
+ * degrade uniformly — the two halves land in different places:
+ *  - Anthropic ids fall to `FAMILY_RATES`; the rollup flags `costEstimated`,
+ *    and the spend page explains the figure came from the offline table.
+ *  - Everything else (GLM, Kimi, Grok, DeepSeek — the models #4869 added the
+ *    catalog tier FOR) returns `null` here, so those rows drop out of the total
+ *    and `costComplete` goes false. On an all-non-Anthropic workspace
+ *    `estimatedCostUsd` is null, and BOTH banners are gated on it being
+ *    non-null, so the page renders a bare "—+" with no explanation at all.
  */
 export function resolveRate(model: string | null | undefined): ResolvedRate | null {
   const fromCatalog = peekModelPricing(model ?? undefined);
@@ -128,18 +147,6 @@ export function resolveRate(model: string | null | undefined): ResolvedRate | nu
       source: "catalog",
     };
   }
-
-  // Warm BEFORE the family lookup, not inside the `!family` branch (#4869
-  // review). `resolveModelFamily` substring-matches haiku/sonnet/opus, so every
-  // Anthropic gateway id resolved a family and skipped the warm entirely — the
-  // catalog tier never activated for them, and the static table below answered
-  // forever. That's what made the stale `opus` rate a permanent 3x over-report
-  // rather than a one-turn cold-start artifact.
-  //
-  // Fire-and-forget, deduped by the catalog's inflight promise, no-op when
-  // already warm. Gated on a gateway-shaped id so a direct/BYOT model id never
-  // triggers an outbound fetch.
-  if (model?.includes("/")) warmGatewayCatalog();
 
   const family = resolveModelFamily(model);
   if (!family) return null;


### PR DESCRIPTION
Closes #4872.

## The premise that was false

`agent-compaction.ts` carried this claim:

> `peek` is a pure cache read — this runs inside `prepareStep` on every step and cannot await.

`resolveCompactionSettings` is called **once per turn** from `runAgent`, in an already-`async` scope; `prepareStep` only consumes the already-resolved value. There was never a sync constraint.

That premise was the entire justification for the `peekModelContextWindow` / `warmGatewayCatalog` pair, and it produced a real bug: the warm sat below the static family table, whose `claude` rule matches every Anthropic id, so the live-catalog tier never activated for the SaaS default models. `anthropic/claude-sonnet-5` sized compaction at the static 200k against a real 1M window, indefinitely.

## One await replaces four moving parts

- **`lookupModelContextWindow(modelId, budgetMs)`** — fetches on a cold cache, so the live window answers on **turn 1** instead of turn 2+. Air-gap gated on the `/` id shape, so a BYOT/self-hosted deploy still makes no outbound call. Races the load against a **1.5s `HOT_PATH_BUDGET_MS`** — the fetch's own 10s ceiling is right for the admin picker (which has a spinner) and far too long in front of an agent turn. Losing that race is never an error: it falls through to the static table, and the abandoned load still populates the cache, so the budget is paid **once per cache fill**, not per turn.
- **`primeGatewayCatalog(modelIds)`** serves the pricing path. `resolveRate` stays sync because it runs per row inside `foldUsage`; the two `/platform/demo` handlers await one prime before folding instead of hundreds of awaits.
- **`peekModelContextWindow` and `warmGatewayCatalog` are deleted.**

## Also addressed, from review

- **`contextWindowSource` split `"catalog"` into `"gateway"` vs `"static"`.** One label for both tiers meant the same model could resolve 1M on one turn and 200k on the next and report identically — the ambiguity the issue names, and the reason the tier ordering could regress unnoticed. Now logged on the compaction line in `agent.ts`.
- **The network tier is skipped when compaction is disabled** (the shipped default). Otherwise every default deploy would pay up to 1.5s on the hot path for a number `shouldCompact` short-circuits past.
- **Operator signal restored.** Retiring the warm removed the only `log.warn` on the caller side of the load, so a merely *slow* gateway would have reinstated this exact bug invisibly. Budget-elapsed is now warned (deduped per cache-fill attempt, with `requestId` and whether an expired entry was discarded), and an active model absent from the live catalog warns once per id.
- **`catalogWithinBudget` catches defensively.** The "never rejects" invariant now sits on the agent turn path, outside every `try` in `runAgent`.
- **`platform-demo.test.ts` was making a live call to `ai-gateway.vercel.sh`** and pricing an assertion off Anthropic's published rate — green only because the live haiku price happened to equal the static family rate. Now mocked, with the stub coupled so dropping either prime call fails a test.

## Acceptance criteria

- [x] Catalog awaited once per turn; a cold cache resolves the live window on the **first** turn
- [x] Failure/timeout story explicit — bounded budget, races the static fallback, never fails a turn
- [x] Air-gapped self-hosted still makes no outbound call
- [x] `peekModelContextWindow` / `warmGatewayCatalog` removed
- [x] `peekModelPricing` / `resolveRate` explicitly left sync, with the reason and the honest failure story
- [x] Tier ordering can't regress silently — a cold cache yields the live value, asserted on the resolved window rather than on "a fetch happened"
- [x] No new await on a per-STEP path

## Verification

`/ci` — **32/32 gates PASS**, full suite included.

Every new guard was checked by breaking the implementation and confirming the specific test goes red:

| Break | Result |
|---|---|
| Remove the budget race | 3 fail |
| Revert to peek semantics (no fetch on cold) | 3 fail |
| Drop the air-gap gate | 3 fail |
| Remove the `/leads` prime | 1 fail |
| Remove the `/metrics` prime | 1 fail |
| Remove the prime rejection guard | 1 fail |
| Remove the compaction-disabled gate | 1 fail |
| Move the resolve into `prepareStep` | 1 fail (6 fetches vs 1) |

## Deliberately not in scope

Three review suggestions are behavior changes rather than defects in this refactor, so they are left out: serving a TTL-expired window as a distinct `gateway-stale` tier; returning prime success as a new `pricingCatalogAvailable` wire field; and a periodic catalog-refresh fiber. The first is made *observable* instead — the budget-elapsed warn reports `discardedExpiredEntry` — so it surfaces in logs if it turns out to matter.

https://claude.ai/code/session_01BxXkiB6b6ca7HCabeewjGv