### PR TITLE
chore(deps): npm advisory remediation — fix the Dependabot handoff that never worked (#4878)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,72 @@
+version: 2
+
+# Dependabot configuration (#4878).
+#
+# ── What this can and cannot do ───────────────────────────────────────────────
+#
+# Atlas uses bun, and `bun` is a SEPARATE Dependabot ecosystem from `npm`, with a
+# different support matrix:
+#
+#   version updates    supported      <- this file drives them
+#   security updates   NOT supported  <- planned upstream, no timeline
+#
+# So this file delivers dependency *freshness*, not advisory remediation. It
+# cannot open a fix PR for a vulnerable package, and nothing in it makes the
+# GitHub dependency graph read `bun.lock`: the graph parses only
+# package-lock.json / yarn.lock / pnpm-lock.yaml, so bun.lock's transitive
+# closure is invisible to it. Measured on this repo — the graph held 150 unique
+# packages as unresolved caret RANGES read off the 53 package.json manifests,
+# against 2133 resolved packages in bun.lock.
+#
+# Transitive visibility is supplied separately by
+# .github/workflows/dependency-graph.yml, which submits the resolved bun.lock
+# closure through the Dependency Submission API. Alerts fire on submitted
+# dependencies; fix PRs still do not, per the matrix above.
+#
+# Remediation of npm advisories is therefore Trivy-on-image (image-scan.yml)
+# plus hand-authored `overrides` in the root package.json. See #4878.
+#
+# ── Why the limit is low, and majors are ignored ──────────────────────────────
+#
+# The workspace has 53 manifests and ~150 unique direct deps, so enabling
+# version updates opens a batch on the first run. Non-major updates are grouped
+# into a single PR and the open-PR ceiling is deliberately small.
+#
+# Majors are ignored on purpose: `/deps-update` already owns them as "Group B",
+# one deliberate PR per major, because this repo has several majors that need
+# coupled bumps (fumadocs-core/openapi lockstep, zod x @modelcontextprotocol/sdk).
+# An unattended major PR would be noise at best and a red CI lane at worst.
+#
+# ── Two things to know before merging a Dependabot PR here ────────────────────
+#
+# 1. bunfig.toml sets `minimumReleaseAge = 172800` (48h). Dependabot does not
+#    know about that gate, so it can propose a version younger than 48h that a
+#    local `bun install` will decline to resolve. If a PR's lockfile looks
+#    unreproducible, check the release age before hunting for a real cause.
+#
+# 2. Any PR touching bun.lock or package.json DEPLOYS docs.useatlas.dev on merge
+#    (deploy/docs/railway.json watchPatterns), direct from main to production
+#    with no staging twin. Verify the docs site after merging, not before.
+
+updates:
+  - package-ecosystem: bun
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 3
+    labels:
+      - dependencies
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      bun-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-major

--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -1,0 +1,77 @@
+name: Dependency Graph
+
+# Submits the resolved `bun.lock` closure to the GitHub dependency graph (#4878).
+#
+# ── The gap this closes ───────────────────────────────────────────────────────
+#
+# The dependency graph parses package-lock.json, yarn.lock and pnpm-lock.yaml.
+# It does NOT parse bun.lock. On this repo that meant the graph held 150 unique
+# packages — read off the 53 package.json manifests as unresolved caret RANGES —
+# against 2133 resolved packages in the lockfile. Every transitive-only package
+# was invisible, so Dependabot produced no alerts for them and `image-scan.yml`
+# handed npm advisories to a Dependabot that could not see them.
+#
+# Storing ranges rather than resolved versions also made the graph unable to
+# distinguish a vulnerable build from a fixed one: `next: ^16.2.9` reads as
+# already-satisfiable while the lockfile pins the vulnerable version.
+#
+# ── What submitting buys, and what it does not ────────────────────────────────
+#
+# Buys:      Dependabot ALERTS on the full transitive closure.
+# Does not:  automatic fix PRs. `bun` is a separate Dependabot ecosystem from
+#            `npm` and does not support security updates (planned upstream, no
+#            timeline). Remediation stays with Trivy-on-image (image-scan.yml)
+#            plus hand-authored `overrides` in the root package.json.
+#
+# The snapshot is regenerated from the committed lockfile on every run and never
+# committed. That is deliberate: a checked-in package-lock.json would give the
+# same visibility but drift from bun.lock permanently, and would invite
+# Dependabot to open "fix" PRs against a file bun never reads — a green PR that
+# changes nothing about the build is worse than no PR.
+#
+# ── Why it runs on main only ──────────────────────────────────────────────────
+#
+# Dependabot alerts are keyed to the default branch, so a snapshot submitted from
+# a feature branch produces nothing actionable. Snapshots supersede per
+# (correlator, ref), so re-running is safe and idempotent.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "bun.lock"
+      - "**/package.json"
+      - "scripts/submit-dependency-snapshot.ts"
+      - ".github/workflows/dependency-graph.yml"
+  workflow_dispatch:
+
+# `contents: write` is what the Dependency Submission API requires to write a
+# snapshot. It is the only elevated scope here and the job runs no build steps.
+permissions:
+  contents: write
+
+env:
+  BUN_VERSION: "1.3.13"
+
+concurrency:
+  group: dependency-graph-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  submit:
+    name: Submit bun.lock closure
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+
+      - uses: oven-sh/setup-bun@e3914758a49697077f7bcd190d36582a61667aad # v2 + node24 (pending release)
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      # No `bun install`: the converter reads the committed lockfile as text and
+      # needs no node_modules, which keeps this job off the dependency tree it is
+      # reporting on.
+      - name: Submit dependency snapshot
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bun run scripts/submit-dependency-snapshot.ts

--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -26,12 +26,35 @@ name: Image Scan
 #   Unfixed CVEs, because a gate that is red for something nobody can action
 #   gets ignored, and an ignored gate reads as coverage while providing none.
 #
-#   Library findings (npm, Go modules) inside the images, because Dependabot
-#   already owns them and can open the fix PR. Gating here too would put two
-#   red surfaces on one problem and block unrelated PRs on a dependency bump.
-#   #4822 scoped dependency scanning out for exactly this reason. They are
-#   still reported — the image's resolved node_modules is not identical to the
-#   manifest Dependabot reads.
+#   Library findings (npm, Go modules) inside the images. #4822 scoped these out
+#   on the premise that "Dependabot already owns them and can open the fix PR."
+#   That premise was false and is corrected here (#4878): Atlas uses bun, and
+#   `bun` is a SEPARATE Dependabot ecosystem from `npm` that does NOT support
+#   security updates. Dependabot will not open a fix PR for an npm advisory in
+#   this repo, no matter how it is configured — so for the whole window between
+#   #4822 and #4878 this scanner was the only thing looking, while its own header
+#   said something else owned it.
+#
+#   The handoff that actually exists now:
+#
+#     detection      Trivy here, against the image's resolved node_modules —
+#                    the authoritative surface, since that is what ships
+#     visibility     .github/workflows/dependency-graph.yml submits the resolved
+#                    bun.lock closure via the Dependency Submission API, which
+#                    is what makes Dependabot ALERTS fire on transitive packages.
+#                    The dependency graph does not parse bun.lock on its own
+#     remediation    hand-authored `overrides` in the root package.json, plus
+#                    parent bumps where a parent pins a vulnerable version
+#     freshness      .github/dependabot.yml — version updates only, not security
+#
+#   They still do not block, but for a different reason than #4822 gave: the
+#   remediation path is manual, and part of the residual set has no expressible
+#   fix. bun supports only TOP-LEVEL overrides, so a package present at two
+#   majors (undici 6.x + 7.x, brace-expansion 2.x + 5.x, protobufjs 7.x + 8.x)
+#   cannot be pinned per-major — a single global override silently forces every
+#   consumer onto one version. Gating on findings nobody can action is the same
+#   trap as gating on unfixed CVEs, one bullet up. The residual set and the
+#   reason each entry is declined are recorded on #4878.
 #
 # ── Where it runs, and why ────────────────────────────────────────────────────
 #

--- a/bun.lock
+++ b/bun.lock
@@ -944,6 +944,17 @@
   "patchedDependencies": {
     "bun-types@1.3.14": "patches/bun-types@1.3.14.patch",
   },
+  "overrides": {
+    "@discordjs/rest": "^2.6.3",
+    "axios": "^1.18.0",
+    "body-parser": "^2.3.0",
+    "discord.js": "^14.27.0",
+    "fast-uri": "^3.1.3",
+    "form-data": "^4.0.6",
+    "hono": "^4.12.27",
+    "shell-quote": "^1.9.0",
+    "tar": "^7.5.17",
+  },
   "packages": {
     "@ai-sdk/amazon-bedrock": ["@ai-sdk/amazon-bedrock@4.0.119", "", { "dependencies": { "@ai-sdk/anthropic": "3.0.85", "@ai-sdk/openai": "3.0.73", "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.30", "@smithy/eventstream-codec": "^4.0.1", "@smithy/util-utf8": "^4.0.0", "aws4fetch": "^1.0.20" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-DgJugGl0Euja2g+60p3eV+2k4kQvtLtJFeYskVrAlt0KgpVGYot0XEPCOBgjDsn6aAEuyibWDSIddxJU8k9wug=="],
 
@@ -1243,7 +1254,7 @@
 
     "@discordjs/formatters": ["@discordjs/formatters@0.6.2", "", { "dependencies": { "discord-api-types": "^0.38.33" } }, "sha512-y4UPwWhH6vChKRkGdMB4odasUbHOUwy7KL+OVwF86PvT6QVOwElx+TiI1/6kcmcEe+g5YRXJFiXSXUdabqZOvQ=="],
 
-    "@discordjs/rest": ["@discordjs/rest@2.6.1", "", { "dependencies": { "@discordjs/collection": "^2.1.1", "@discordjs/util": "^1.2.0", "@sapphire/async-queue": "^1.5.3", "@sapphire/snowflake": "^3.5.5", "@vladfrangu/async_event_emitter": "^2.4.6", "discord-api-types": "^0.38.40", "magic-bytes.js": "^1.13.0", "tslib": "^2.6.3", "undici": "6.24.1" } }, "sha512-wwQdgjeaoYFiaG+atbqx6aJDpqW7JHAo0HrQkBTbYzM3/PJ3GweQIpgElNcGZ26DCUOXMyawYd0YF7vtr+fZXg=="],
+    "@discordjs/rest": ["@discordjs/rest@2.6.3", "", { "dependencies": { "@discordjs/collection": "^2.1.1", "@discordjs/util": "^1.2.0", "@sapphire/async-queue": "^1.5.3", "@sapphire/snowflake": "^3.5.5", "@vladfrangu/async_event_emitter": "^2.4.6", "discord-api-types": "^0.38.50", "magic-bytes.js": "^1.13.0", "tslib": "^2.6.3", "undici": "^6.27.0" } }, "sha512-wvOylxNYJkwKjctS/Mn5GP1w9r3/rzyH+ThD1JlAca6zEdlHs8QWBBUQJpU5Q+W6DoIj/Ljh1IPlZs7hTU+UAg=="],
 
     "@discordjs/util": ["@discordjs/util@1.2.0", "", { "dependencies": { "discord-api-types": "^0.38.33" } }, "sha512-3LKP7F2+atl9vJFhaBjn4nOaSWahZ/yWjOvA4e5pnXkt2qyXRCHLxoBQy81GFtLGCq7K9lPm9R517M1U+/90Qg=="],
 
@@ -1943,7 +1954,7 @@
 
     "@sapphire/shapeshift": ["@sapphire/shapeshift@4.0.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "lodash": "^4.17.21" } }, "sha512-d9dUmWVA7MMiKobL3VpLF8P2aeanRTu6ypG2OIaEv/ZHH/SUQ2iHOVyi5wAPjQ+HmnMuL0whK9ez8I/raWbtIg=="],
 
-    "@sapphire/snowflake": ["@sapphire/snowflake@3.5.3", "", {}, "sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ=="],
+    "@sapphire/snowflake": ["@sapphire/snowflake@3.5.5", "", {}, "sha512-xzvBr1Q1c4lCe7i6sRnrofxeO1QTP/LKQ6A6qy0iB4x5yfiSfARMEQEghojzTNALDTcv8En04qYNIco9/K9eZQ=="],
 
     "@sec-ant/readable-stream": ["@sec-ant/readable-stream@0.4.1", "", {}, "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg=="],
 
@@ -2301,7 +2312,7 @@
 
     "axe-core": ["axe-core@4.11.4", "", {}, "sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA=="],
 
-    "axios": ["axios@1.17.0", "", { "dependencies": { "follow-redirects": "^1.16.0", "form-data": "^4.0.5", "https-proxy-agent": "^5.0.1", "proxy-from-env": "^2.1.0" } }, "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw=="],
+    "axios": ["axios@1.18.1", "", { "dependencies": { "follow-redirects": "^1.16.0", "form-data": "^4.0.5", "https-proxy-agent": "^5.0.1", "proxy-from-env": "^2.1.0" } }, "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g=="],
 
     "b4a": ["b4a@1.8.1", "", { "peerDependencies": { "react-native-b4a": "*" }, "optionalPeers": ["react-native-b4a"] }, "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw=="],
 
@@ -2339,7 +2350,7 @@
 
     "bn.js": ["bn.js@4.12.3", "", {}, "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g=="],
 
-    "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
+    "body-parser": ["body-parser@2.3.0", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^2.0.0", "debug": "^4.4.3", "http-errors": "^2.0.1", "iconv-lite": "^0.7.2", "on-finished": "^2.4.1", "qs": "^6.15.2", "raw-body": "^3.0.2", "type-is": "^2.1.0" } }, "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw=="],
 
     "botbuilder": ["botbuilder@4.23.3", "", { "dependencies": { "@azure/core-rest-pipeline": "^1.18.1", "@azure/msal-node": "^2.13.1", "axios": "^1.8.2", "botbuilder-core": "4.23.3", "botbuilder-stdlib": "4.23.3-internal", "botframework-connector": "4.23.3", "botframework-schema": "4.23.3", "botframework-streaming": "4.23.3", "dayjs": "^1.11.13", "filenamify": "^6.0.0", "fs-extra": "^11.2.0", "htmlparser2": "^9.0.1", "uuid": "^10.0.0", "zod": "^3.23.8" } }, "sha512-1gDIQHHYosYBHGXMjvZEJDrcp3NGy3lzHBml5wn9PFqVuIk/cbsCDZs3KJ3g+aH/GGh4CH/ij9iQ2KbQYHAYKA=="],
 
@@ -2609,7 +2620,7 @@
 
     "discord-interactions": ["discord-interactions@4.4.0", "", {}, "sha512-jjJx8iwAeJcj8oEauV43fue9lNqkf38fy60aSs2+G8D1nJmDxUIrk08o3h0F3wgwuBWWJUZO+X/VgfXsxpCiJA=="],
 
-    "discord.js": ["discord.js@14.26.4", "", { "dependencies": { "@discordjs/builders": "^1.14.1", "@discordjs/collection": "1.5.3", "@discordjs/formatters": "^0.6.2", "@discordjs/rest": "^2.6.1", "@discordjs/util": "^1.2.0", "@discordjs/ws": "^1.2.3", "@sapphire/snowflake": "3.5.3", "discord-api-types": "^0.38.40", "fast-deep-equal": "3.1.3", "lodash.snakecase": "4.1.1", "magic-bytes.js": "^1.13.0", "tslib": "^2.6.3", "undici": "6.24.1" } }, "sha512-4oBp8tc6Kf8IDBwAHhbsMaAqx1b5fob9SNasZT7V6yyyUydoO5i5fGuX7TmvRtR+q/WgKRnRViRoAWnG7fNyvA=="],
+    "discord.js": ["discord.js@14.27.0", "", { "dependencies": { "@discordjs/builders": "^1.14.1", "@discordjs/collection": "1.5.3", "@discordjs/formatters": "^0.6.2", "@discordjs/rest": "^2.6.2", "@discordjs/util": "^1.2.0", "@discordjs/ws": "^1.2.3", "@sapphire/snowflake": "3.5.5", "discord-api-types": "^0.38.49", "fast-deep-equal": "3.1.3", "lodash.snakecase": "4.1.1", "magic-bytes.js": "^1.13.0", "tslib": "^2.6.3", "undici": "^6.27.0" } }, "sha512-qHbFlFG2N7y3LjPySYsL6A1+BnX6bkTVgo842EX0CqVPk/KTMwZkojPHEXKsQUpWZNyz5BISNHK1cPpQw0+m4A=="],
 
     "dockerfile-ast": ["dockerfile-ast@0.7.1", "", { "dependencies": { "vscode-languageserver-textdocument": "^1.0.8", "vscode-languageserver-types": "^3.17.3" } }, "sha512-oX/A4I0EhSkGqrFv0YuvPkBUSYp1XiY8O8zAKc8Djglx8ocz+JfOr8gP0ryRMC2myqvDLagmnZaU9ot1vG2ijw=="],
 
@@ -2755,7 +2766,7 @@
 
     "fast-string-width": ["fast-string-width@3.0.2", "", { "dependencies": { "fast-string-truncated-width": "^3.0.2" } }, "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg=="],
 
-    "fast-uri": ["fast-uri@3.1.2", "", {}, "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ=="],
+    "fast-uri": ["fast-uri@3.1.4", "", {}, "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw=="],
 
     "fast-wrap-ansi": ["fast-wrap-ansi@0.2.2", "", { "dependencies": { "fast-string-width": "^3.0.2" } }, "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q=="],
 
@@ -2803,7 +2814,7 @@
 
     "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
 
-    "form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
+    "form-data": ["form-data@4.0.6", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.4", "mime-types": "^2.1.35" } }, "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ=="],
 
     "format": ["format@0.2.2", "", {}, "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww=="],
 
@@ -3801,7 +3812,7 @@
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
-    "shell-quote": ["shell-quote@1.8.4", "", {}, "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ=="],
+    "shell-quote": ["shell-quote@1.10.0", "", {}, "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA=="],
 
     "shiki": ["shiki@4.2.0", "", { "dependencies": { "@shikijs/core": "4.2.0", "@shikijs/engine-javascript": "4.2.0", "@shikijs/engine-oniguruma": "4.2.0", "@shikijs/langs": "4.2.0", "@shikijs/themes": "4.2.0", "@shikijs/types": "4.2.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-hjNax6o/ylDy9lefQEaSDtzaT3iVNtZ3WmpQnbuQNoG4xvnSKf2kSKbihZVO4JRG1TTMejs7CmNRYlWgAL66pQ=="],
 
@@ -3925,7 +3936,7 @@
 
     "tapable": ["tapable@2.3.3", "", {}, "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A=="],
 
-    "tar": ["tar@7.5.16", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w=="],
+    "tar": ["tar@7.5.22", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA=="],
 
     "tar-fs": ["tar-fs@2.1.4", "", { "dependencies": { "chownr": "^1.1.1", "mkdirp-classic": "^0.5.2", "pump": "^3.0.0", "tar-stream": "^2.1.4" } }, "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ=="],
 
@@ -4233,11 +4244,9 @@
 
     "@discordjs/rest/@discordjs/collection": ["@discordjs/collection@2.1.1", "", {}, "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg=="],
 
-    "@discordjs/rest/@sapphire/snowflake": ["@sapphire/snowflake@3.5.5", "", {}, "sha512-xzvBr1Q1c4lCe7i6sRnrofxeO1QTP/LKQ6A6qy0iB4x5yfiSfARMEQEghojzTNALDTcv8En04qYNIco9/K9eZQ=="],
+    "@discordjs/rest/discord-api-types": ["discord-api-types@0.38.52", "", {}, "sha512-uwe9EKfbjsmgWc2fdFjvDbj+dQqx3lp7wqDCmIha0jInuU+xeQjkCK9tMMn+p7RXfdVQORCInq4cD3U2ymDmyg=="],
 
-    "@discordjs/rest/discord-api-types": ["discord-api-types@0.38.48", "", {}, "sha512-WFUE/2o0lBlLeCQonQ+Pu2RqHAqbytBJ2RlXR91gzk05InSS6k9ShzzLYoymrA4c2oRgRKGE7/VqQJNNdGWSxQ=="],
-
-    "@discordjs/rest/undici": ["undici@6.24.1", "", {}, "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA=="],
+    "@discordjs/rest/undici": ["undici@6.28.0", "", {}, "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA=="],
 
     "@discordjs/util/discord-api-types": ["discord-api-types@0.38.48", "", {}, "sha512-WFUE/2o0lBlLeCQonQ+Pu2RqHAqbytBJ2RlXR91gzk05InSS6k9ShzzLYoymrA4c2oRgRKGE7/VqQJNNdGWSxQ=="],
 
@@ -4266,8 +4275,6 @@
     "@fast-csv/parse/@types/node": ["@types/node@14.18.63", "", {}, "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ=="],
 
     "@grpc/proto-loader/protobufjs": ["protobufjs@7.6.2", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.5", "@protobufjs/eventemitter": "^1.1.1", "@protobufjs/fetch": "^1.1.1", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.2", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.1", "@types/node": ">=13.7.0", "long": "^5.3.2" } }, "sha512-N9EiLovGEQOJSPF26Ij7qUGvahfEnq0eeYZ02aigIedkmz1qZSwjnP9SBITHJuF/6MYbIW4HDN8zdYjsjqJKXQ=="],
-
-    "@modelcontextprotocol/sdk/hono": ["hono@4.12.23", "", {}, "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA=="],
 
     "@mongodb-js/zstd/node-addon-api": ["node-addon-api@8.8.0", "", {}, "sha512-c5Ko1fZJIJmzhFIkhRN76WTq+fC6tWnGy9CXA0fA+XygsWZmEwG8vmbkNqxMyoaa0Tin4djul49NzdVcJJcjeA=="],
 
@@ -4397,6 +4404,8 @@
 
     "bl/buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
 
+    "body-parser/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
+
     "botbuilder/@azure/msal-node": ["@azure/msal-node@2.16.3", "", { "dependencies": { "@azure/msal-common": "14.16.1", "jsonwebtoken": "^9.0.0", "uuid": "^8.3.0" } }, "sha512-CO+SE4weOsfJf+C5LM8argzvotrXw252/ZU6SM2Tz63fEblhH1uuVaaO4ISYFuN4Q6BhTo7I3qIdi8ydUQCqhw=="],
 
     "botbuilder/uuid": ["uuid@10.0.0", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="],
@@ -4439,9 +4448,9 @@
 
     "cosmiconfig/js-yaml": ["js-yaml@4.2.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw=="],
 
-    "discord.js/discord-api-types": ["discord-api-types@0.38.48", "", {}, "sha512-WFUE/2o0lBlLeCQonQ+Pu2RqHAqbytBJ2RlXR91gzk05InSS6k9ShzzLYoymrA4c2oRgRKGE7/VqQJNNdGWSxQ=="],
+    "discord.js/discord-api-types": ["discord-api-types@0.38.52", "", {}, "sha512-uwe9EKfbjsmgWc2fdFjvDbj+dQqx3lp7wqDCmIha0jInuU+xeQjkCK9tMMn+p7RXfdVQORCInq4cD3U2ymDmyg=="],
 
-    "discord.js/undici": ["undici@6.24.1", "", {}, "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA=="],
+    "discord.js/undici": ["undici@6.28.0", "", {}, "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA=="],
 
     "drizzle-kit/esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
 

--- a/package.json
+++ b/package.json
@@ -148,6 +148,17 @@
     "tailwindcss": "^4.3.1",
     "zustand": "^5.0.14"
   },
+  "overrides": {
+    "@discordjs/rest": "^2.6.3",
+    "axios": "^1.18.0",
+    "body-parser": "^2.3.0",
+    "discord.js": "^14.27.0",
+    "fast-uri": "^3.1.3",
+    "form-data": "^4.0.6",
+    "hono": "^4.12.27",
+    "shell-quote": "^1.9.0",
+    "tar": "^7.5.17"
+  },
   "patchedDependencies": {
     "bun-types@1.3.14": "patches/bun-types@1.3.14.patch"
   }

--- a/scripts/submit-dependency-snapshot.ts
+++ b/scripts/submit-dependency-snapshot.ts
@@ -1,0 +1,301 @@
+#!/usr/bin/env bun
+/**
+ * Converts `bun.lock` into a GitHub dependency snapshot and submits it through
+ * the Dependency Submission API.
+ *
+ * Why this exists: the GitHub dependency graph does not parse `bun.lock`. It
+ * parses package-lock.json, yarn.lock and pnpm-lock.yaml only, so on this repo
+ * the graph held 150 unique packages — read off the 53 `package.json` manifests
+ * as unresolved caret RANGES — against 2133 resolved packages in the lockfile.
+ * Every transitive-only package (undici, tar, axios, sharp, form-data,
+ * shell-quote, postcss, brace-expansion, uuid, protobufjs, fast-uri) was
+ * therefore invisible to Dependabot, which is why `image-scan.yml` could hand
+ * npm advisories to Dependabot and have nothing whatsoever happen. See #4878.
+ *
+ * Because the graph stored RANGES rather than resolved versions, it also could
+ * not tell a vulnerable build from a fixed one: `next: ^16.2.9` reads as
+ * already-satisfiable even when the lockfile pins a vulnerable 16.2.9.
+ *
+ * Submitting the resolved closure fixes visibility — alerts do fire on
+ * submitted dependencies. It does NOT buy automatic fix PRs: `bun` is a
+ * separate Dependabot ecosystem from `npm` and does not support security
+ * updates. Remediation stays with Trivy-on-image plus root `overrides`.
+ *
+ * The snapshot is generated from the committed lockfile on every run and never
+ * itself committed, so it cannot drift the way a checked-in package-lock.json
+ * would — a second lockfile would also invite Dependabot to "fix" a file bun
+ * never reads.
+ *
+ * Usage:
+ *   bun run scripts/submit-dependency-snapshot.ts --out snapshot.json   # local, no network
+ *   bun run scripts/submit-dependency-snapshot.ts                       # submit (CI)
+ */
+
+type LockEntry = [id: string, registry: unknown, meta?: unknown, hash?: string];
+type DepMap = Record<string, string>;
+type WorkspaceEntry = {
+  name?: string;
+  dependencies?: DepMap;
+  devDependencies?: DepMap;
+  optionalDependencies?: DepMap;
+  peerDependencies?: DepMap;
+};
+type Lockfile = {
+  lockfileVersion?: number;
+  workspaces?: Record<string, WorkspaceEntry>;
+  packages?: Record<string, LockEntry>;
+};
+
+type Scope = "runtime" | "development";
+type Relationship = "direct" | "indirect";
+
+const RUNTIME_DEP_KINDS = ["dependencies", "optionalDependencies", "peerDependencies"] as const;
+
+/**
+ * bun.lock is JSON with `//` comments and trailing commas permitted. Strip both
+ * rather than pulling in a JSON5 dependency for one file.
+ */
+function parseLockfile(text: string): Lockfile {
+  const stripped = text.replace(/^\s*\/\/.*$/gm, "").replace(/,(\s*[}\]])/g, "$1");
+  return JSON.parse(stripped) as Lockfile;
+}
+
+/**
+ * Split a lock path into package-name segments. Scoped names contain a `/`
+ * themselves, so `@discordjs/rest/undici` is TWO segments
+ * (`@discordjs/rest`, `undici`), not three — a naive split corrupts every
+ * scoped nesting in the tree.
+ */
+function pathSegments(key: string): string[] {
+  const parts = key.split("/");
+  const out: string[] = [];
+  for (let i = 0; i < parts.length; i++) {
+    const part = parts[i];
+    if (part === undefined) continue;
+    const next = parts[i + 1];
+    if (part.startsWith("@") && next !== undefined) {
+      out.push(`${part}/${next}`);
+      i++;
+    } else {
+      out.push(part);
+    }
+  }
+  return out;
+}
+
+/** Split a lock entry id (`name@version`) on the LAST `@` so scopes survive. */
+function splitId(id: string): { name: string; version: string } | undefined {
+  const at = id.lastIndexOf("@");
+  if (at <= 0) return undefined;
+  return { name: id.slice(0, at), version: id.slice(at + 1) };
+}
+
+/** purl for an npm package; the scope's `@` must be percent-encoded. */
+function packageUrl(name: string, version: string): string {
+  const encoded = name.startsWith("@")
+    ? `%40${name.slice(1).split("/").map(encodeURIComponent).join("/")}`
+    : encodeURIComponent(name);
+  return `pkg:npm/${encoded}@${encodeURIComponent(version)}`;
+}
+
+function declaredDeps(meta: unknown, kinds: readonly string[]): DepMap {
+  if (!meta || typeof meta !== "object") return {};
+  const record = meta as Record<string, unknown>;
+  const out: DepMap = {};
+  for (const kind of kinds) {
+    const group = record[kind];
+    if (!group || typeof group !== "object") continue;
+    for (const [name, range] of Object.entries(group as Record<string, unknown>)) {
+      if (typeof range === "string") out[name] = range;
+    }
+  }
+  return out;
+}
+
+export function buildSnapshotManifest(lock: Lockfile) {
+  const packages = lock.packages ?? {};
+  const workspaces = lock.workspaces ?? {};
+
+  /**
+   * Resolve a dependency edge the way bun's hoisting does: prefer the most
+   * deeply nested entry, then walk up toward the bare (hoisted) name.
+   */
+  const resolveFrom = (fromKey: string, depName: string): string | undefined => {
+    const segs = fromKey === "" ? [] : pathSegments(fromKey);
+    for (let i = segs.length; i >= 0; i--) {
+      const candidate = [...segs.slice(0, i), depName].join("/");
+      if (packages[candidate]) return candidate;
+    }
+    return undefined;
+  };
+
+  // Workspace packages are first-party and carry no registry version; they are
+  // edges into the graph, not nodes of it.
+  const workspaceNames = new Set(
+    Object.values(workspaces)
+      .map((w) => w.name)
+      .filter((n): n is string => typeof n === "string"),
+  );
+
+  const directKeys = new Set<string>();
+  const runtimeRoots: string[] = [];
+  const devRoots: string[] = [];
+  for (const ws of Object.values(workspaces)) {
+    for (const [name] of Object.entries(declaredDeps(ws, RUNTIME_DEP_KINDS))) {
+      const key = resolveFrom("", name);
+      if (key) { directKeys.add(key); runtimeRoots.push(key); }
+    }
+    for (const [name] of Object.entries(declaredDeps(ws, ["devDependencies"]))) {
+      const key = resolveFrom("", name);
+      if (key) { directKeys.add(key); devRoots.push(key); }
+    }
+  }
+
+  // Reachability decides scope: a package is `development` only if nothing in
+  // the runtime closure reaches it. Marking every transitive package "runtime"
+  // would overstate the production surface.
+  const scopeOf = new Map<string, Scope>();
+  const walk = (roots: string[], scope: Scope) => {
+    const queue = [...roots];
+    while (queue.length > 0) {
+      const key = queue.pop();
+      if (key === undefined) continue;
+      if (scopeOf.get(key) === "runtime") continue;
+      if (scopeOf.get(key) === scope) continue;
+      scopeOf.set(key, scope);
+      const entry = packages[key];
+      if (!entry) continue;
+      for (const depName of Object.keys(declaredDeps(entry[2], RUNTIME_DEP_KINDS))) {
+        const next = resolveFrom(key, depName);
+        if (next) queue.push(next);
+      }
+    }
+  };
+  walk(runtimeRoots, "runtime");
+  walk(devRoots, "development");
+
+  const resolved: Record<string, {
+    package_url: string;
+    relationship: Relationship;
+    scope: Scope;
+    dependencies?: string[];
+  }> = {};
+
+  let skipped = 0;
+  for (const [key, entry] of Object.entries(packages)) {
+    const id = typeof entry?.[0] === "string" ? entry[0] : "";
+    const split = splitId(id);
+    if (!split) { skipped++; continue; }
+    const { name, version } = split;
+    // `workspace:`-versioned and first-party entries are not registry packages.
+    if (version.startsWith("workspace:") || version === "" || workspaceNames.has(name)) {
+      skipped++;
+      continue;
+    }
+    const deps: string[] = [];
+    for (const depName of Object.keys(declaredDeps(entry[2], RUNTIME_DEP_KINDS))) {
+      const target = resolveFrom(key, depName);
+      if (target && target !== key) deps.push(target);
+    }
+    resolved[key] = {
+      package_url: packageUrl(name, version),
+      relationship: directKeys.has(key) ? "direct" : "indirect",
+      scope: scopeOf.get(key) ?? "runtime",
+      ...(deps.length > 0 ? { dependencies: deps } : {}),
+    };
+  }
+
+  return { resolved, skipped };
+}
+
+function requiredEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`${name} is required to submit a snapshot (set --out to run offline)`);
+  return value;
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const outIndex = args.indexOf("--out");
+  const outFile = outIndex >= 0 ? args[outIndex + 1] : undefined;
+
+  const lockPath = "bun.lock";
+  const lock = parseLockfile(await Bun.file(lockPath).text());
+  const { resolved, skipped } = buildSnapshotManifest(lock);
+  const count = Object.keys(resolved).length;
+
+  // A snapshot that silently resolved almost nothing would replace real graph
+  // data with an empty picture, which reads as "no vulnerabilities" — the exact
+  // failure this script exists to end. Refuse instead.
+  if (count < 500) {
+    throw new Error(
+      `refusing to submit: only ${count} packages resolved from ${lockPath} ` +
+        `(expected >500). Lockfile format may have changed.`,
+    );
+  }
+
+  const snapshot = {
+    version: 0,
+    job: {
+      correlator: `${process.env.GITHUB_WORKFLOW ?? "local"}-${process.env.GITHUB_JOB ?? "local"}`,
+      id: process.env.GITHUB_RUN_ID ?? "local",
+    },
+    sha: process.env.GITHUB_SHA ?? "0000000000000000000000000000000000000000",
+    ref: process.env.GITHUB_REF ?? "refs/heads/main",
+    detector: {
+      name: "atlas-bun-lock-to-snapshot",
+      version: "1.0.0",
+      url: "https://github.com/AtlasDevHQ/atlas/blob/main/scripts/submit-dependency-snapshot.ts",
+    },
+    scanned: new Date().toISOString(),
+    manifests: {
+      [lockPath]: {
+        name: lockPath,
+        file: { source_location: lockPath },
+        resolved,
+      },
+    },
+  };
+
+  console.log(
+    `bun.lock -> snapshot: ${count} packages ` +
+      `(${Object.values(resolved).filter((r) => r.relationship === "direct").length} direct, ` +
+      `${Object.values(resolved).filter((r) => r.scope === "development").length} development-scoped; ` +
+      `${skipped} non-registry entries skipped)`,
+  );
+
+  if (outFile) {
+    await Bun.write(outFile, JSON.stringify(snapshot, null, 2));
+    console.log(`wrote ${outFile} (not submitted)`);
+    return;
+  }
+
+  const repository = requiredEnv("GITHUB_REPOSITORY");
+  const token = requiredEnv("GITHUB_TOKEN");
+  const response = await fetch(
+    `https://api.github.com/repos/${repository}/dependency-graph/snapshots`,
+    {
+      method: "POST",
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${token}`,
+        "X-GitHub-Api-Version": "2022-11-28",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(snapshot),
+    },
+  );
+
+  const body = await response.text();
+  if (!response.ok) {
+    throw new Error(`snapshot submission failed: ${response.status} ${response.statusText} — ${body}`);
+  }
+  console.log(`submitted: ${response.status} ${body}`);
+}
+
+if (import.meta.main) {
+  main().catch((err: unknown) => {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
Closes #4878. Refs #4822.

## The spike came first, and it changed the plan

AC1 was a real unknown, so it was verified empirically before anything was built. Two findings, both measured:

**1. The dependency graph does not parse `bun.lock` — and it never resolved versions at all.** The graph's 568 npm entries collapse to **150 unique names**, duplicated once per workspace manifest that declares them (`zod` ×34, `ai` ×27, `hono` ×25), and the versions are stored as **unresolved caret ranges**:

```
picocolors@^1.1.1   @clack/prompts@^1.1.0   react-grid-layout@^2.2.3
```

Against **2133** resolved packages in `bun.lock`. No other lockfile exists in the repo. This *explains* root cause #3 in the issue rather than restating it: the graph holds `next: ^16.2.9` as a range, so GitHub reads it as already-satisfiable. It isn't that caret ranges mask the problem — the graph has no idea what is installed. GitHub documents the parsed formats as package-lock.json / yarn.lock / pnpm-lock.yaml only.

**2. The handoff is structurally impossible, not misconfigured.** `bun` is a **separate Dependabot ecosystem** from `npm`:

| ecosystem | version updates | security updates |
|---|---|---|
| `npm` | ✓ | ✓ |
| `bun` (≥v1.1.39) | ✓ | **✗** |

So `image-scan.yml`'s "Dependabot already owns them and *can open the fix PR*" cannot be repaired by configuration. For the whole window between #4822 and now, this scanner was the only thing looking while its own header said otherwise.

**The `package-lock.json` fallback was rejected deliberately.** It doesn't just risk drift — it would make Dependabot open fix PRs against a file bun never reads. A merged, green PR that fixes nothing is worse than no PR, and it is the same "reads as coverage while providing none" trap the header warns about one bullet up.

## What shipped instead

| concern | mechanism |
|---|---|
| detection | Trivy on the image (`image-scan.yml`) — the authoritative surface, since that is what ships |
| **visibility** | `scripts/submit-dependency-snapshot.ts` + `.github/workflows/dependency-graph.yml` — submits the resolved closure (**2085 packages**) via the Dependency Submission API. Regenerated from the committed lockfile each run, never committed, so it cannot drift |
| **remediation** | root `package.json` `overrides` (+ one parent bump) |
| freshness | `.github/dependabot.yml` — bun ecosystem, version updates only |

`open-pull-requests-limit: 3`, non-majors grouped into one PR. Majors are **ignored on purpose**: `/deps-update` owns them as Group B because several need coupled bumps (fumadocs lockstep, zod × MCP sdk).

## AC3 — measured, not asserted

Trivy **0.72.0** (the version pinned in `image-scan.yml`), `--scanners vuln`, no ignorefile, two locally built api images. The 66 baseline reproduced exactly (67 raw, minus the dismissed `@better-auth/scim` HIGH).

```
node-pkg          66 -> 34      C1 H24 M36 L5  ->  C0 H16 M16 L2
gobinary           0 ->  0      already cleared by #4881
os-pkgs/debian   325 -> 325     out of scope, separate baseline
```

**The only CRITICAL is gone** (CVE-2026-59873, `tar`). HIGH 24 → 16. **No new findings introduced.**

Cleared: `axios` −10 · `hono` −8 · `tar` −5 · `undici@6.24.1` −4 · `fast-uri` −2 · `body-parser` −1 · `form-data` −1 · `shell-quote` −1

Every override was checked with semver against **every** declared consumer range, so none forces a consumer off-range. `undici@6.24.1` was cleared by a **parent bump expressed as an override**: `discord.js@14.27.0` moved from the exact pin `6.24.1` to `^6.27.0`, which is itself the fixed version, and it satisfies `@chat-adapter/discord`'s `^14.25.1`.

## The 34 that remain, and why they are not expressible

**bun supports only TOP-LEVEL overrides.** Path-scoped keys are **silently ignored** — asking for `minimatch/brace-expansion: 1.1.15` yielded `1.1.17`, no error. And a global override that violates a declared range is installed **silently**: declared `^6.0.0` + override `7.28.0` → installed 7.28.0, exit 0, no warning.

So any package present at two majors cannot be pinned per-major without forcing every consumer onto one version:

| remaining | n | why declined |
|---|---|---|
| `protobufjs@8.0.1` / `@7.6.2` | 13 | `otlp-transformer` pins 8.0.1 **exactly**; `@grpc/proto-loader` wants `^7.5.5`. Cleared only by the OTel `0.218 → 0.221` bump, which drops protobufjs entirely |
| `undici@7.27.2` | 7 | hoisted for `@vercel/sandbox` (`^7.27.1`, still latest at 2.9.0). Refreshing the entry cascaded a repo-wide re-resolve (tailwindcss, zustand, undici→8.9.0) — a Group A sweep, not a security fix |
| `postcss@8.4.31` | 3 | `next@16.2.12` pins it **exactly** and is already latest |
| `brace-expansion@2.1.1` / `@5.0.6` | 4 | three majors coexist under `minimatch` 3/5/9/10 (`^1.1.7`, `^2.0.x`, `^5.0.5`) |
| `uuid@8.3.2` / `@10.0.0` | 2 | `^8.3.0` + `^10.0.0` consumers; uuid 11 is a breaking API change |
| `sharp@0.34.5` | 1 | `next` optional peer `^0.34.5`; 0.35.0 is out of range and next is latest |
| `@opentelemetry/core` / `propagator-jaeger` | 2 | exact-pinned (core by ~74 packages); cleared by the same OTel bump |
| `@hono/node-server@1.19.14` | 1 | major cross for a server adapter, 1 MEDIUM — poor risk/reward |
| `@better-auth/oauth-provider@1.6.25` | 1 | fix is `1.7.0-beta.4`, the breaking beta already declined for `@better-auth/scim` |

**Deliberately not in this PR:** the OTel `0.218 → 0.221` bump would clear 13 more (incl. 5 HIGH), but it spans 5 manifests including `packages/web`, and OTel breakage tends to surface as *telemetry silently stopping* — the silent-failure class this repo forbids. It needs its own soak, not a ride-along on a security PR. Same for an `e2b` bump, which I tried and reverted: it moved e2b's own undici to 7.29.0 but left the hoisted 7.27.2 for `@vercel/sandbox` and **added a third copy** (`"undici8": "npm:undici@8.8.0"`), clearing nothing.

## Test the negative

**Overrides:** proven by the Trivy re-scan above, not by green CI.

**Visibility — half proven now, half gated on merge.** The submission pipeline was run for real against this branch: **`201 ACCEPTED`**, validating the payload format end-to-end. GitHub's own response states the rest:

> The snapshot was accepted, but it is not for the default branch. It will not update dependency results for the repository.

which is exactly why the workflow is `main`-only. Alerts therefore cannot be observed until this merges.

Pre-merge baseline is recorded so the post-merge check is a real before/after — **0 open Dependabot alerts** while every residual package is invisible to the graph:

```
INVISIBLE   undici          INVISIBLE   uuid
INVISIBLE   protobufjs      INVISIBLE   sharp
INVISIBLE   postcss         INVISIBLE   @hono/node-server
INVISIBLE   brace-expansion INVISIBLE   @opentelemetry/core
```

Trivy flags 34 findings across exactly those packages while Dependabot shows 0 alerts. **The residual set is the deliberately-outdated transitive dep the AC asks for** — real, known-vulnerable, and currently unseen — so no synthetic package is needed, and it is a stronger probe than one.

## Verification checklist for merge

- [ ] `Dependency Graph` workflow succeeds on `main`
- [ ] Dependabot alerts become non-zero for the residual set (`undici@7.27.2`, `protobufjs@8.0.1`, `postcss@8.4.31`) — **this is the AC2 negative test**
- [ ] **docs.useatlas.dev** healthy — `deploy/docs/railway.json` watches `bun.lock` **and** `package.json`, both touched here
- [ ] **www.useatlas.dev** healthy — watches `apps/www/**` (untouched here, so `No deployment needed` is the expected status)

Both deploy direct from `main` to production with no staging twin, so this ships unsoaked on merge. The v0.2.0 hold is satisfied (tagged @ `ba98acad6`, live in all 3 regions) but the hazard is permanent.

## Local gates

`bash scripts/ci-local.sh` — **33/33 PASS**. Real-Postgres (`*-pg.test.ts`) tests were **skipped locally** (`TEST_DATABASE_URL` unset, deliberately — a shared PG container is in use by parallel sessions and this change is dependency-only); CI's `api-tests (1/4)`–`(4/4)` shards run them against real Postgres.

`scripts/` is excluded from `tsconfig.json`, so the new script is not covered by `bun run type` — type-checked separately with `tsgo --noEmit --strict`, clean.