### PR TITLE
chore(ci): stop Dependabot re-floating the pinned @typescript/native-preview (#4878)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -70,3 +70,9 @@ updates:
       - dependency-name: "*"
         update-types:
           - version-update:semver-major
+      # Pinned EXACTLY on purpose by #4882 — the `type` gate was running against a
+      # floating preview, so the whole point of that change was to stop this
+      # version from moving on its own. Dependabot's first run after #4884 opened
+      # exactly that bump (#4887), which would have re-floated the gate every
+      # week. Bump it deliberately or not at all.
+      - dependency-name: "@typescript/native-preview"


### PR DESCRIPTION
Caught by watching #4884's first Dependabot run. Refs #4882, #4884.

## The defect

#4882 pinned `@typescript/native-preview` to an **exact** version two days ago, for a specific reason — *"the type gate was on a floating preview."* Root `package.json` declares it with no range:

```json
"@typescript/native-preview": "7.0.0-dev.20260623.1"
```

Enabling version updates in #4884 meant Dependabot's very first run opened **#4887**, bumping it to `7.0.0-dev.20260707.2` across `package.json` and four published packages. Left alone that re-floats the type gate **every Monday**, silently undoing #4882 on a schedule.

## Why the existing guard missed it

`.github/dependabot.yml` already ignores `"*"` for `version-update:semver-major`. That doesn't apply here: these are `7.0.0-dev.*` prerelease builds, so moving between them is not a semver major. It slipped through as a minor/patch and got swept into the grouped PR logic.

Fix is an explicit per-package `ignore`, with the reasoning inline so the next person doesn't "helpfully" remove it.

## Verification

- `.github/dependabot.yml` parses; `ignore` now has both entries
- `bash scripts/ci-local.sh` — **33/33 PASS**
- #4887 will be closed as superseded

## Two things worth your judgement, not silently decided

1. **#4886** — `bump the bun-minor-patch group with 66 updates`. The grouping worked exactly as configured (one PR, not 66) and the `open-pull-requests-limit: 3` held. But it is a 66-package sweep and I have not merged it — that is a deliberate call for you.

2. **Overlap with `/deps-update`.** That skill already owns "Group A = all minors/patches in one PR." This config now does the same thing automatically every Monday, so the two mechanisms overlap. I left majors to Group B as documented, but Group A is now double-covered. Worth deciding whether Dependabot's weekly cadence replaces the manual sweep or whether the ecosystem block should be narrowed further — flagging rather than picking for you, since it changes an established workflow.