### PR TITLE
fix(chat): detect @-mentions that arrive as plain message events (#4909)

### DIFF
--- a/docs/architecture/chat-plugin-atlas-contract.md
+++ b/docs/architecture/chat-plugin-atlas-contract.md
@@ -97,6 +97,34 @@ stays the self-host fallback unchanged. ⚠ row to watch: any change to the shap
 overlay (e.g. nesting, or a non-string value) breaks the `{ ...process.env, ...overlay }`
 merge contract — the overlay must stay a flat `Record<string, string>`.
 
+### Adapter identity — `SlackAdapterConfig.userName` / `Chat.userName` (#4909)
+
+The bot's own handle at the `@chat-adapter/slack` construction boundary. Not
+cosmetic: it is the **only** working input to `detectMention`, the fallback the
+SDK uses when `isMention` wasn't set from the event type.
+
+| Boundary field | Owner | Atlas wiring | Adapter behaviour without it | Status |
+|---|---|---|---|---|
+| `SlackAdapterConfig.userName` | chat-adapter | `plugins/chat/src/adapters/slack.ts` passes `DEFAULT_BOT_USER_NAME` (`config.ts`), overridable per deploy | defaults to the literal `"bot"`; replaced from `auth.test` **only** inside `initialize()`, which runs solely on the single-workspace `defaultBotToken` path | ✓ verified |
+| `Chat.userName` | chat SDK | `bridge.ts` `new Chat({ userName: DEFAULT_BOT_USER_NAME })` — same constant | — | ✓ verified |
+
+**Boundary contract.** `detectMention` resolves the handle as
+`adapter.userName || chat.userName`. Because the adapter's default `"bot"` is
+**truthy, it shadows `chat.userName`** — setting only the `Chat` side looks correct
+and silently does nothing. Both must come from one constant, which is why
+`DEFAULT_BOT_USER_NAME` exists rather than two literals.
+
+The id-based patterns in `detectMention` are **not** a backstop here: the async
+parse path runs `resolveInlineMentions`, which rewrites `<@U0BOT…>` to the bot's
+display name, so no user id survives in `message.text`. (That rewrite is meant to be
+suppressed for the bot itself via `skipSelfMention`, but that guard reads the
+adapter's instance `_botUserId`, which is null in multi-workspace — see the
+`botUserId` row above.) Name matching is the only route.
+
+⚠ row to watch: this is **single-workspace-safe and multi-workspace-broken** by
+default — the class that produced both #4907 and #4909. Anything that relies on
+`initialize()` having populated adapter instance state is dead in SaaS/BYOT.
+
 ### Durable approval-park resume delivery — `ChatPluginConfig.onBridgeReady` + `chat:resume-pending:<conversationId>` (#3750)
 
 Durable sessions (#3742 family) let an agent turn **park** on an approval rule and

--- a/plugins/chat/src/adapters/slack.test.ts
+++ b/plugins/chat/src/adapters/slack.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Mention-detection regression tests for the Slack adapter wrapper (#4909).
+ *
+ * The bug: in multi-workspace deploys an @-mention that arrives as a plain
+ * `message` event (which happens whenever `message.channels` /
+ * `message.groups` are subscribed alongside `app_mention` — Slack sends
+ * BOTH, and the SDK dedupes them by shared `ts`, so only the first-processed
+ * one survives) was never recognised as a mention, and fell through to the
+ * pattern handlers instead of the mention handler.
+ *
+ * These drive the REAL `Chat` dispatch rather than reimplementing
+ * `detectMention`, so they fail if the SDK changes how `isMention` is
+ * resolved — which is the thing worth knowing about.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { createSlackAdapter } from "./slack";
+import { DEFAULT_BOT_USER_NAME } from "../config";
+
+const BASE = {
+  signingSecret: "x".repeat(32),
+  clientId: "cid",
+  clientSecret: "csec",
+  encryptionKey: Buffer.alloc(32).toString("base64"),
+};
+
+describe("createSlackAdapter — mention detection wiring", () => {
+  it("sets userName so it does not fall back to the adapter's 'bot' default", () => {
+    const a = createSlackAdapter(BASE) as unknown as { userName: string };
+    // "bot" is `@chat-adapter/slack`'s ctor default, replaced only inside
+    // initialize() from auth.test — which multi-workspace never runs. It is
+    // truthy, so it SHADOWS chat.userName in `adapter.userName ||
+    // chat.userName` and makes name matching impossible.
+    expect(a.userName).not.toBe("bot");
+    expect(a.userName).toBe(DEFAULT_BOT_USER_NAME);
+  });
+
+  it("honours an explicit userName override for a renamed bot", () => {
+    const a = createSlackAdapter({ ...BASE, userName: "datapal" }) as unknown as {
+      userName: string;
+    };
+    expect(a.userName).toBe("datapal");
+  });
+});
+
+describe("Chat dispatch — @-mention arriving as a plain message event", () => {
+  /**
+   * Build a real `Chat` around the real Slack adapter and record which
+   * handler chain a message lands in.
+   */
+  async function dispatch(text: string) {
+    const { Chat } = await import("chat");
+    const { createStateAdapter } = await import("../state");
+    const state = createStateAdapter({ backend: "memory" }, null);
+    await state.connect();
+
+    const adapter = createSlackAdapter(BASE);
+    const chat = new Chat({
+      userName: DEFAULT_BOT_USER_NAME,
+      adapters: { slack: adapter },
+      state,
+    });
+
+    const hits: string[] = [];
+    chat.onNewMention(async () => { hits.push("mention"); });
+    chat.onNewMessage(/.+/, async () => { hits.push("pattern"); });
+
+    // A plain `message` event — `isMention` unset, exactly what Slack
+    // delivers for message.channels. The bot's own <@id> has already been
+    // rewritten to its display name by resolveInlineMentions, so no user
+    // id survives in the text; name matching is the only route left.
+    const msg = (adapter as unknown as {
+      parseSlackMessageSync: (e: unknown, t: string) => unknown;
+    }).parseSlackMessageSync(
+      { ts: "1700000000.0001", text, user: "U0HUMAN", channel: "C1" },
+      "slack:C1:1700000000.0001",
+    );
+
+    chat.processMessage(
+      adapter as never,
+      "slack:C1:1700000000.0001",
+      msg as never,
+    );
+    // processMessage is fire-and-forget; let its async chain settle.
+    await new Promise((r) => setTimeout(r, 150));
+    await chat.shutdown?.();
+    return hits;
+  }
+
+  it("routes a display-name mention to the mention handler, not the pattern chain", async () => {
+    // What production actually sees post-resolveInlineMentions.
+    expect(await dispatch("@Atlas what is MRR?")).toContain("mention");
+  });
+
+  it("still routes an unrelated message to the pattern chain", async () => {
+    // The negative: proactive must keep seeing ordinary channel chatter,
+    // or this "fix" would silently swallow the proactive pillar's input.
+    const hits = await dispatch("deploy went out this morning");
+    expect(hits).toContain("pattern");
+    expect(hits).not.toContain("mention");
+  });
+});

--- a/plugins/chat/src/adapters/slack.ts
+++ b/plugins/chat/src/adapters/slack.ts
@@ -8,7 +8,7 @@
  */
 
 import { createSlackAdapter as createChatSlackAdapter } from "@chat-adapter/slack";
-import type { SlackAdapterConfig } from "../config";
+import { DEFAULT_BOT_USER_NAME, type SlackAdapterConfig } from "../config";
 
 /**
  * Create a Chat SDK Slack adapter from Atlas plugin config.
@@ -23,6 +23,12 @@ export function createSlackAdapter(config: SlackAdapterConfig) {
     signingSecret: config.signingSecret,
     clientId: config.clientId,
     clientSecret: config.clientSecret,
+    // Without this the adapter defaults to the literal "bot" and, being
+    // truthy, shadows `chat.userName` in `detectMention` — so @-mentions
+    // that arrive as a plain `message` event (rather than `app_mention`)
+    // are never recognised and fall through to the pattern handlers.
+    // See DEFAULT_BOT_USER_NAME for the full chain (#4909).
+    userName: config.userName ?? DEFAULT_BOT_USER_NAME,
     // Per-tenant AES-GCM envelope for installation bot tokens (#2634).
     // Pass-through when configured; the chat-adapter falls back to its
     // own `SLACK_ENCRYPTION_KEY` env lookup when undefined.

--- a/plugins/chat/src/bridge.ts
+++ b/plugins/chat/src/bridge.ts
@@ -35,6 +35,7 @@ import type {
   ChatMessage,
   PendingAction,
 } from "./config";
+import { DEFAULT_BOT_USER_NAME } from "./config";
 import { buildQueryResultCard } from "./cards/query-result-card";
 import { buildErrorCard } from "./cards/error-card";
 import { buildApprovalCardJSX } from "./cards/approval-card";
@@ -864,7 +865,10 @@ export function createChatBridge(
   }
 
   const chat = new Chat({
-    userName: "atlas",
+    // Same constant the Slack adapter gets. `detectMention` reads
+    // `adapter.userName || chat.userName`, so these drifting apart would
+    // silently change which handle counts as a mention (#4909).
+    userName: DEFAULT_BOT_USER_NAME,
     adapters,
     state: stateAdapter,
     ...(config.streaming?.chunkIntervalMs != null && {

--- a/plugins/chat/src/config.ts
+++ b/plugins/chat/src/config.ts
@@ -199,9 +199,42 @@ export interface ChatResumeBridge {
 export type OnBridgeReady = (bridge: ChatResumeBridge | null) => void;
 
 /** Adapter-specific credential configuration. */
+/**
+ * The bot's own handle, used for @-mention detection.
+ *
+ * Load-bearing in MULTI-WORKSPACE deploys (#4909). The chat SDK decides
+ * `isMention` two ways: from the Slack event TYPE (`app_mention`), and —
+ * when that isn't set — by text-matching `@<botUserName>` in
+ * `detectMention`, where the name is `adapter.userName || chat.userName`.
+ *
+ * `@chat-adapter/slack` defaults its own `userName` to the literal
+ * `"bot"` and only replaces it inside `initialize()` from `auth.test`,
+ * which runs solely on the single-workspace `defaultBotToken` path. So in
+ * multi-workspace the adapter's name stays `"bot"`, and because it is
+ * truthy it SHADOWS `chat.userName` — the fallback can never match.
+ *
+ * The id-based patterns can't rescue it either: the async parse path runs
+ * `resolveInlineMentions`, which rewrites `<@U0BOT…>` to the bot's
+ * display name, so no user id survives in `message.text` to match against.
+ * Name matching is the only route left, which is why this constant is
+ * passed to BOTH the adapter and the `Chat` instance from one place.
+ *
+ * Matching is case-insensitive and `\b`-anchored, so this also matches a
+ * display name that merely starts with it (`@Atlas Bot`). A workspace
+ * that renames the bot to something not prefixed by this needs
+ * {@link SlackAdapterConfig.userName}.
+ */
+export const DEFAULT_BOT_USER_NAME = "atlas";
+
 export interface SlackAdapterConfig {
   /** Single-workspace bot token (`xoxb-…`). Omit in multi-workspace deploys. */
   botToken?: string;
+  /**
+   * Override for the bot's @-handle used in mention detection. Defaults
+   * to {@link DEFAULT_BOT_USER_NAME}; set it when a workspace has renamed
+   * the bot's Slack display name to something that doesn't start with it.
+   */
+  userName?: string;
   signingSecret: string;
   /** Client ID for multi-workspace OAuth. */
   clientId?: string;


### PR DESCRIPTION
Fixes #4909.

Atlas stopped answering @-mentions in prod immediately after Slack was re-enabled post-#4907. This is a **separate bug** — same multi-workspace-only class, different mechanism.

## Root cause

With `app_mention` **and** `message.channels`/`message.groups` all subscribed, Slack sends **two** events for one @-mention sharing a `ts`. The SDK dedupes on that (`chat/dist/index.js:2871`), so only the first-processed survives — and in prod the plain `message` event won every time (three attempts, three identical outcomes, all landing on `proactive.classify`, never on the mention handler).

`isMention` comes from the event **type** (`@chat-adapter/slack` dist:1487), so the survivor arrives `isMention = false` and falls back to `detectMention` — which **could never match**:

| Pattern | Why it's dead |
|---|---|
| `@${adapter.userName \|\| chat.userName}` | adapter defaults `userName` to the literal `"bot"` (dist:778), replaced from `auth.test` only inside `initialize()` (dist:821) — the single-workspace `defaultBotToken` path. `"bot"` is truthy so it **shadows** `chat.userName` |
| `@${botUserId}`, `<@!?${botUserId}>` | the async parse path runs `resolveInlineMentions`, rewriting `<@U0BOT…>` to the display name — no id survives in `message.text` |

Verified against the vendored adapter rather than reasoned about:

```
ASYNC parsed .text : "@Atlas what is MRR?"
detect(text, 'bot',  undefined)  : false
detect(text, 'bot',  'U0BOTXYZ') : false   ← id already gone
detect(text, 'Atlas', undefined) : "name"  ← only the name can match
```

## Why it only surfaced now

Before the Company Brain reinstall only `app_mention` was subscribed — one event, `isMention` always set from the type. Adding the `message.*` subscriptions introduced the second event that now wins the dedup. The fallback has been broken in multi-workspace the whole time; nothing had ever needed it.

## The fix

Pass the bot handle to the adapter. It comes from one shared `DEFAULT_BOT_USER_NAME` given to **both** the adapter and the `Chat` instance — two literals could drift and silently change what counts as a mention, and because the adapter's value shadows Chat's, setting only one side looks correct and does nothing. Overridable via `SlackAdapterConfig.userName` for a workspace that renamed the bot.

This **keeps** `message.channels`/`message.groups` working, so proactive chat (`proactive/listener.ts:1044`, `onNewMessage(/.+/)`) keeps its input. The alternative — dropping those subscriptions — would have fixed mentions by disabling the proactive pillar.

## Verification

- `bun run type` clean, `bun run lint` exit 0
- `plugins/chat`: 4 new + 138 bridge + 24 adapter-registry + 8 resolve-adapter-env, all pass
- Tests drive **real `Chat` dispatch** via `processMessage` rather than reimplementing `detectMention`, so they break if the SDK changes how `isMention` resolves
- Asserts the negative: ordinary chatter must still reach the pattern handlers, or the fix would silently swallow proactive's input
- **Three of the four fail without the fix**, including the end-to-end dispatch case

## Note on the contract doc

Added an "Adapter identity" section. The shadowing behaviour is the kind of thing that reads as a no-op change and isn't, and this is now the third entry in that doc's recurring class: *anything relying on `initialize()` having populated adapter instance state is dead in multi-workspace.* Both #4907 and #4909 are instances.

## Follow-up (not this PR)

`resolveInlineMentions`' `skipSelfMention` is also dead in multi-workspace — it guards on the adapter's instance `_botUserId`, null without a single-workspace token. Fixing that upstream would restore id-based matching as a second, name-independent route.
