### PR TITLE
feat(brain): bi-temporal asOf reads in searchBrain (#4916)

### DIFF
--- a/packages/api/src/lib/brain/__tests__/search-pg.test.ts
+++ b/packages/api/src/lib/brain/__tests__/search-pg.test.ts
@@ -141,12 +141,15 @@ describeIfPg("searchBrain against the live schema", () => {
     visibleTo?: readonly string[];
     status?: "draft" | "published";
     invalidated?: boolean;
+    /** Validity window (#4916) — `validTo` set simulates a supersession stamp. */
+    validFrom?: Date;
+    validTo?: Date;
   }): Promise<string> {
     const { rows } = await pool.query<{ id: string }>(
       `INSERT INTO brain_facts
          (workspace_id, subject, predicate, object, source_episode_id, provenance,
-          status, visible_to, invalidated_at)
-       VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7, $8::text[], $9)
+          status, visible_to, invalidated_at, valid_from, valid_to)
+       VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7, $8::text[], $9, $10, $11)
        RETURNING id`,
       [
         WS,
@@ -158,6 +161,8 @@ describeIfPg("searchBrain against the live schema", () => {
         opts.status ?? "published",
         opts.visibleTo ?? ["org"],
         opts.invalidated ? new Date() : null,
+        opts.validFrom ?? null,
+        opts.validTo ?? null,
       ],
     );
     return rows[0]!.id;
@@ -452,6 +457,129 @@ describeIfPg("searchBrain against the live schema", () => {
       expect(rival.provenance.source).toBe("slack");
       expect(rival.provenance.attribution).toMatchObject({ visible: true, actor: "U1" });
       expect(rival.status).toBe("published");
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+
+  // ══════════════════════════════════════════════════════════════════
+  // 7. asOf — the bi-temporal point read (#4916)
+  // ══════════════════════════════════════════════════════════════════
+
+  it(
+    "answers a point read under each version's FROZEN grant — a widening between versions does not reach back",
+    async () => {
+      // The acceptance scenario: the grant CHANGED between versions. Monday's
+      // version was private to `audience:private-channel`; Wednesday's
+      // supersession republished the claim org-wide. "What did we believe
+      // Monday" must use Monday's grant — the org reader gets NOTHING at
+      // Monday even though the CURRENT version is public, because each row is
+      // gated by its own immutable `visible_to`, not by the lineage's newest.
+      const monday = new Date("2026-07-06T09:00:00Z");
+      const tuesday = "2026-07-07T09:00:00Z";
+      const wednesday = new Date("2026-07-08T09:00:00Z");
+      const ep = await seedEpisode({
+        sourceId: "asof-grant",
+        visibleTo: ["audience:private-channel"],
+      });
+      const privateV1 = await seedFact({
+        subject: "Osprey rollout",
+        predicate: "led_by",
+        object: "the skunkworks pod",
+        episodeId: ep,
+        visibleTo: ["audience:private-channel"],
+        validFrom: monday,
+        validTo: wednesday, // superseded at Wednesday's publish
+      });
+      const publicV2 = await seedFact({
+        subject: "Osprey rollout",
+        predicate: "led_by",
+        object: "the platform team",
+        episodeId: ep,
+        visibleTo: ["org"],
+        validFrom: wednesday,
+      });
+
+      // The insider at Tuesday: Monday's belief, through Monday's grant.
+      const insiderAtTuesday = await search(insider(), {
+        query: "Osprey rollout",
+        include: ["fact"],
+        asOf: tuesday,
+      });
+      expect(ids(insiderAtTuesday.results)).toContain(privateV1);
+      // v2's window has not opened at Tuesday — a later belief must not
+      // answer for an earlier instant.
+      expect(ids(insiderAtTuesday.results)).not.toContain(publicV2);
+      expect(insiderAtTuesday.asOf).toBe("2026-07-07T09:00:00.000Z");
+
+      // The org reader at Tuesday: NOTHING. v1's frozen grant excludes them,
+      // and v2 had not begun. The current version being org-visible earns no
+      // historical access.
+      const outsiderAtTuesday = await search(outsider(), {
+        query: "Osprey rollout",
+        include: ["fact"],
+        asOf: tuesday,
+      });
+      expect(ids(outsiderAtTuesday.results)).not.toContain(privateV1);
+      expect(ids(outsiderAtTuesday.results)).not.toContain(publicV2);
+
+      // Default (as-of-now) reads are unchanged by any of the above: the
+      // superseded v1 is hidden, the current v2 serves — for both readers.
+      for (const reader of [insider(), outsider()]) {
+        const nowRead = await search(reader, { query: "Osprey rollout", include: ["fact"] });
+        expect(ids(nowRead.results)).toContain(publicV2);
+        expect(ids(nowRead.results)).not.toContain(privateV1);
+        expect("asOf" in nowRead).toBe(false);
+      }
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "keeps a TOMBSTONED fact hidden at every instant, even one inside its validity window",
+    async () => {
+      // Retraction is the only way to hide history, and hiding is what it
+      // does: a retracted fact whose window covers the asked-about instant
+      // still never answers. Distinct from supersession, which the previous
+      // test proves DOES answer inside its window.
+      const ep = await seedEpisode({ sourceId: "asof-tomb" });
+      const retracted = await seedFact({
+        subject: "Heron pricing",
+        object: "the old tier sheet",
+        episodeId: ep,
+        invalidated: true,
+        validFrom: new Date("2026-07-06T00:00:00Z"),
+        validTo: new Date("2026-07-20T00:00:00Z"),
+      });
+
+      const res = await search(outsider(), {
+        query: "Heron pricing",
+        include: ["fact"],
+        asOf: "2026-07-10T00:00:00Z",
+      });
+      expect(ids(res.results)).not.toContain(retracted);
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "admits a NULL valid_from at any instant — an unrecorded start is not a late one",
+    async () => {
+      // The default read serves NULL-valid_from rows as current belief (it has
+      // no valid_from predicate at all), so the point read must admit them too
+      // or `asOf ≈ now` would diverge from the default read.
+      const ep = await seedEpisode({ sourceId: "asof-nullfrom" });
+      const openStart = await seedFact({
+        subject: "Puffin oncall",
+        object: "the infra rotation",
+        episodeId: ep,
+      });
+
+      const res = await search(outsider(), {
+        query: "Puffin oncall",
+        include: ["fact"],
+        asOf: "2026-01-01T00:00:00Z",
+      });
+      expect(ids(res.results)).toContain(openStart);
     },
     PG_TEST_TIMEOUT_MS,
   );

--- a/packages/api/src/lib/brain/__tests__/search-pg.test.ts
+++ b/packages/api/src/lib/brain/__tests__/search-pg.test.ts
@@ -535,6 +535,87 @@ describeIfPg("searchBrain against the live schema", () => {
   );
 
   it(
+    "hands over exactly at the supersession instant — half-open windows, no gap, no double answer",
+    async () => {
+      // asOf == v1.valid_to == v2.valid_from: the `<=` / `>` pair must compose
+      // against real timestamptz semantics so exactly ONE version answers at
+      // the boundary — v2 (its window is [from, ∞)), never v1 (its window is
+      // [from, to), half-open on the right).
+      const handover = new Date("2026-07-08T12:00:00Z");
+      const ep = await seedEpisode({ sourceId: "asof-boundary" });
+      const v1 = await seedFact({
+        subject: "Gannet migration",
+        object: "the legacy exporter",
+        episodeId: ep,
+        validFrom: new Date("2026-07-01T00:00:00Z"),
+        validTo: handover,
+      });
+      const v2 = await seedFact({
+        subject: "Gannet migration",
+        object: "the streaming exporter",
+        episodeId: ep,
+        validFrom: handover,
+      });
+
+      const atBoundary = await search(outsider(), {
+        query: "Gannet migration",
+        include: ["fact"],
+        asOf: handover.toISOString(),
+      });
+      expect(ids(atBoundary.results)).toContain(v2);
+      expect(ids(atBoundary.results)).not.toContain(v1);
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "a NARROWING between versions leaves the once-public version historically readable — frozen grants cut both ways",
+    async () => {
+      // The converse of the widening scenario, pinned so the disclosure
+      // semantics cannot flip silently: v1 was published org-wide, v2
+      // re-narrowed the claim to a private audience. Under frozen per-version
+      // grants the org reader RETAINS historical access to the version that
+      // was public while it held — narrowing the current belief does not
+      // rewrite who was allowed to see the old one — and sees nothing current.
+      const monday = new Date("2026-07-06T09:00:00Z");
+      const wednesday = new Date("2026-07-08T09:00:00Z");
+      const ep = await seedEpisode({ sourceId: "asof-narrow" });
+      const publicV1 = await seedFact({
+        subject: "Skua incident review",
+        object: "published to all-hands",
+        episodeId: ep,
+        visibleTo: ["org"],
+        validFrom: monday,
+        validTo: wednesday,
+      });
+      const privateV2 = await seedFact({
+        subject: "Skua incident review",
+        object: "restricted to legal",
+        episodeId: ep,
+        visibleTo: ["audience:private-channel"],
+        validFrom: wednesday,
+      });
+
+      const outsiderAtTuesday = await search(outsider(), {
+        query: "Skua incident review",
+        include: ["fact"],
+        asOf: "2026-07-07T09:00:00Z",
+      });
+      expect(ids(outsiderAtTuesday.results)).toContain(publicV1);
+      expect(ids(outsiderAtTuesday.results)).not.toContain(privateV2);
+
+      const outsiderNow = await search(outsider(), {
+        query: "Skua incident review",
+        include: ["fact"],
+      });
+      // As of now: v1 is superseded, v2 is granted elsewhere — nothing serves.
+      expect(ids(outsiderNow.results)).not.toContain(publicV1);
+      expect(ids(outsiderNow.results)).not.toContain(privateV2);
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+
+  it(
     "keeps a TOMBSTONED fact hidden at every instant, even one inside its validity window",
     async () => {
       // Retraction is the only way to hide history, and hiding is what it

--- a/packages/api/src/lib/brain/__tests__/search.test.ts
+++ b/packages/api/src/lib/brain/__tests__/search.test.ts
@@ -25,8 +25,10 @@
 
 import { describe, expect, it } from "bun:test";
 import {
+  BrainAsOfInvalidError,
   buildEpisodeQuery,
   buildFactQuery,
+  parseBrainAsOf,
   searchBrainCore,
   TENSION_FANOUT_CAP,
   type BrainSearchReader,
@@ -226,6 +228,150 @@ describe("buildFactQuery — push-down and the tombstone trap", () => {
     expect(sql).toContain("f.fts @@ websearch_to_tsquery('english', $3)");
     expect(sql).toContain("ts_rank(f.fts,");
     expect(sql).not.toContain("to_tsvector(");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// asOf — the bi-temporal point read (#4916)
+// ---------------------------------------------------------------------------
+
+describe("asOf — the bi-temporal point read (#4916)", () => {
+  const AS_OF = "2026-07-01T00:00:00.000Z";
+
+  it("switches the temporal predicate to the validity window, both bounds off ONE parameter", () => {
+    const { sql, params } = buildFactQuery("published", {
+      limit: 10,
+      asOf: AS_OF,
+      ...acl(ctx(), "brain_facts"),
+    });
+    // `valid_from <= asOf < COALESCE(valid_to, ∞)` — a NULL `valid_from`
+    // (an unrecorded start) is admitted, matching the default read.
+    expect(sql).toContain("(f.valid_from IS NULL OR f.valid_from <= $3::timestamptz)");
+    expect(sql).toContain("(f.valid_to IS NULL OR f.valid_to > $3::timestamptz)");
+    // The as-of-now supersession clause is REPLACED, not composed: composing
+    // both would hide every superseded fact from the historical read — the
+    // exact rows the point read exists to serve.
+    expect(sql).not.toContain("now()");
+    expect(params).toContain(AS_OF);
+  });
+
+  it("keeps the tombstone filter under asOf — retraction hides history at EVERY instant", () => {
+    // The boundary rule cut both ways in the ADR: superseded facts DO appear
+    // inside their window (previous test); tombstoned facts NEVER do, because
+    // retraction (the review gate's reject verb, and the GDPR-erasure path) is
+    // the one verb whose job is hiding.
+    const { sql } = buildFactQuery("published", {
+      limit: 10,
+      asOf: AS_OF,
+      ...acl(ctx(), "brain_facts"),
+    });
+    expect(sql).toContain("f.invalidated_at IS NULL");
+  });
+
+  it("leaves the default read byte-identical — the regression pin", () => {
+    // Not "still contains the old clauses" — BYTE-identical, so any reordering
+    // or reformatting the asOf branch leaks into the default arm fails here.
+    const withBranch = buildFactQuery("published", {
+      query: "billing",
+      limit: 10,
+      ...acl(ctx(), "brain_facts"),
+    });
+    expect(withBranch.sql).toContain("(f.valid_to IS NULL OR f.valid_to > now())");
+    expect(withBranch.sql).not.toContain("valid_from IS NULL OR");
+    expect(withBranch.sql).not.toContain("timestamptz");
+    // Predicate order unchanged: ACL → mode → tombstone → supersession.
+    const order = [
+      "visible_to &&",
+      "f.status = 'published'",
+      "f.invalidated_at IS NULL",
+      "f.valid_to IS NULL OR f.valid_to > now()",
+    ].map((clause) => withBranch.sql.indexOf(clause));
+    expect(order.every((i) => i >= 0)).toBe(true);
+    expect([...order].sort((a, b) => a - b)).toEqual(order);
+  });
+
+  it("rejects a malformed asOf loudly, naming the value — never falls through to as-of-now", () => {
+    expect(() => parseBrainAsOf("last tuesday")).toThrow(BrainAsOfInvalidError);
+    expect(() => parseBrainAsOf("last tuesday")).toThrow(/"last tuesday"/);
+    expect(() => parseBrainAsOf("last tuesday")).toThrow(/ISO-8601/);
+  });
+
+  it("rejects a BLANK asOf rather than treating it as absent", () => {
+    // '   '.trim() || undefined is the sibling params' normalization, and it
+    // is exactly the silent fall-through #4916 forbids on this one.
+    expect(() => parseBrainAsOf("")).toThrow(BrainAsOfInvalidError);
+    expect(() => parseBrainAsOf("   ")).toThrow(BrainAsOfInvalidError);
+  });
+
+  it("rejects a FUTURE asOf — beliefs not yet held are not a point this surface answers", () => {
+    const now = () => Date.parse("2026-07-30T00:00:00Z");
+    expect(() => parseBrainAsOf("2026-08-01T00:00:00Z", now)).toThrow(BrainAsOfInvalidError);
+    expect(() => parseBrainAsOf("2026-08-01T00:00:00Z", now)).toThrow(/future/);
+    // The boundary itself is admitted: `asOf === now` is a valid past-or-present instant.
+    expect(parseBrainAsOf("2026-07-30T00:00:00Z", now)).toBe("2026-07-30T00:00:00.000Z");
+  });
+
+  it("normalizes the instant to canonical ISO-8601 UTC", () => {
+    // Bound as `timestamptz` and echoed on the response, so both carry the
+    // canonical spelling rather than the caller's local-offset one.
+    expect(parseBrainAsOf(" 2026-07-01T02:00:00+02:00 ")).toBe(AS_OF);
+  });
+
+  it("echoes the normalized asOf on the response — a historical page must say it is one", async () => {
+    const db = reader([{ match: SQL.factPage, rows: [factRow()] }]);
+    const res = await searchBrainCore(db, {
+      ctx: ctx(),
+      mode: "published",
+      include: ["fact"],
+      asOf: "2026-07-01T02:00:00+02:00",
+      limit: 10,
+      expand: false,
+    });
+    expect(res.asOf).toBe(AS_OF);
+    const factCall = db.calls.find((c) => c.sql.includes(SQL.factPage))!;
+    expect(factCall.params).toContain(AS_OF);
+  });
+
+  it("omits the field entirely on a default read — absence IS the 'current belief' statement", async () => {
+    const db = reader([{ match: SQL.factPage, rows: [factRow()] }]);
+    const res = await searchBrainCore(db, {
+      ctx: ctx(),
+      mode: "published",
+      include: ["fact"],
+      limit: 10,
+      expand: false,
+    });
+    expect("asOf" in res).toBe(false);
+  });
+
+  it("refuses an unusable asOf BEFORE any store runs", async () => {
+    const db = reader();
+    await expect(
+      searchBrainCore(db, {
+        ctx: ctx(),
+        mode: "published",
+        asOf: "garbage",
+        limit: 10,
+        expand: false,
+      }),
+    ).rejects.toBeInstanceOf(BrainAsOfInvalidError);
+    expect(db.calls).toHaveLength(0);
+  });
+
+  it("does NOT leak the temporal predicate into the episode store — episodes have no validity window", async () => {
+    const db = reader();
+    await searchBrainCore(db, {
+      ctx: ctx(),
+      mode: "published",
+      include: ["fact", "raw-episode"],
+      asOf: AS_OF,
+      limit: 10,
+      expand: false,
+    });
+    const episodeCall = db.calls.find((c) => c.sql.includes(SQL.episodePage))!;
+    expect(episodeCall.sql).not.toContain("valid_from");
+    expect(episodeCall.sql).not.toContain("valid_to");
+    expect(episodeCall.params).not.toContain(AS_OF);
   });
 });
 

--- a/packages/api/src/lib/brain/__tests__/search.test.ts
+++ b/packages/api/src/lib/brain/__tests__/search.test.ts
@@ -241,7 +241,7 @@ describe("asOf — the bi-temporal point read (#4916)", () => {
   it("switches the temporal predicate to the validity window, both bounds off ONE parameter", () => {
     const { sql, params } = buildFactQuery("published", {
       limit: 10,
-      asOf: AS_OF,
+      asOf: parseBrainAsOf(AS_OF),
       ...acl(ctx(), "brain_facts"),
     });
     // `valid_from <= asOf < COALESCE(valid_to, ∞)` — a NULL `valid_from`
@@ -262,38 +262,107 @@ describe("asOf — the bi-temporal point read (#4916)", () => {
     // the one verb whose job is hiding.
     const { sql } = buildFactQuery("published", {
       limit: 10,
-      asOf: AS_OF,
+      asOf: parseBrainAsOf(AS_OF),
       ...acl(ctx(), "brain_facts"),
     });
     expect(sql).toContain("f.invalidated_at IS NULL");
   });
 
   it("leaves the default read byte-identical — the regression pin", () => {
-    // Not "still contains the old clauses" — BYTE-identical, so any reordering
-    // or reformatting the asOf branch leaks into the default arm fails here.
-    const withBranch = buildFactQuery("published", {
+    // A GOLDEN pin, not a contains-check: the literal below is the statement
+    // the pre-#4916 builder emitted (captured from it verbatim), so any
+    // reordering, reformatting, or new clause the asOf branch leaks into the
+    // default arm fails byte-for-byte. If this fails because you CHANGED the
+    // default fact read on purpose, re-capture the literal — that is the
+    // deliberate act this pin exists to force.
+    const { sql, params } = buildFactQuery("published", {
       query: "billing",
       limit: 10,
       ...acl(ctx(), "brain_facts"),
     });
-    expect(withBranch.sql).toContain("(f.valid_to IS NULL OR f.valid_to > now())");
-    expect(withBranch.sql).not.toContain("valid_from IS NULL OR");
-    expect(withBranch.sql).not.toContain("timestamptz");
-    // Predicate order unchanged: ACL → mode → tombstone → supersession.
-    const order = [
-      "visible_to &&",
-      "f.status = 'published'",
-      "f.invalidated_at IS NULL",
-      "f.valid_to IS NULL OR f.valid_to > now()",
-    ].map((clause) => withBranch.sql.indexOf(clause));
-    expect(order.every((i) => i >= 0)).toBe(true);
-    expect([...order].sort((a, b) => a - b)).toEqual(order);
+    expect(sql).toBe(`SELECT f.id::text AS id,
+         f.subject,
+         f.predicate,
+         f.object,
+         f.status,
+         f.predicate_cardinality,
+         f.visible_to,
+         f.pre_widening_visible_to,
+         f.provenance,
+         f.source_episode_id::text AS source_episode_id,
+         f.valid_from,
+         f.valid_to,
+         f.invalidated_at,
+         f.ingested_at,
+         (
+    SELECT COUNT(DISTINCT ed.to_episode_id)
+      FROM brain_edges ed
+     WHERE ed.workspace_id = f.workspace_id
+       AND ed.edge_type = 'provenance'
+       AND ed.from_fact_id = f.id
+  )::int AS corroboration_count,
+         (
+    SELECT MAX(COALESCE(ep.occurred_at, ep.ingested_at))
+      FROM brain_edges ed
+      JOIN brain_episodes ep
+        ON ep.workspace_id = ed.workspace_id
+       AND ep.id = ed.to_episode_id
+     WHERE ed.workspace_id = f.workspace_id
+       AND ed.edge_type = 'provenance'
+       AND ed.from_fact_id = f.id
+  ) AS last_observed_at,
+         ts_headline('english', f.subject || ' ' || f.predicate || ' ' || f.object, websearch_to_tsquery('english', $3),
+        'StartSel=**, StopSel=**, MaxFragments=1, MaxWords=28, MinWords=4') AS snippet,
+         ts_rank(f.fts, websearch_to_tsquery('english', $3)) AS rank
+    FROM brain_facts f
+   WHERE (f.workspace_id = $1 AND f.visible_to && $2::text[])
+     AND f.status = 'published'
+     AND f.invalidated_at IS NULL
+     AND (f.valid_to IS NULL OR f.valid_to > now())
+     AND f.fts @@ websearch_to_tsquery('english', $3)
+   ORDER BY rank DESC NULLS LAST, f.ingested_at DESC, f.id DESC
+   LIMIT $4`);
+    expect(params).toEqual([WS, ["org", "role:member", "user:user-1"], "billing", 10]);
   });
 
   it("rejects a malformed asOf loudly, naming the value — never falls through to as-of-now", () => {
     expect(() => parseBrainAsOf("last tuesday")).toThrow(BrainAsOfInvalidError);
     expect(() => parseBrainAsOf("last tuesday")).toThrow(/"last tuesday"/);
     expect(() => parseBrainAsOf("last tuesday")).toThrow(/ISO-8601/);
+    // `new Date()` would happily parse these; the ISO shape gate must not.
+    expect(() => parseBrainAsOf("July 1 2026")).toThrow(BrainAsOfInvalidError);
+    expect(() => parseBrainAsOf("07/01/2026")).toThrow(BrainAsOfInvalidError);
+  });
+
+  it("rejects a zone-less time — it would be read in the SERVER's timezone", () => {
+    // `new Date("2026-07-01T02:00:00")` is interpreted in the process's local
+    // zone (ECMA-262), so the same call would answer a different instant per
+    // deployment — a silent hours-scale shift of the point read. Malformed.
+    expect(() => parseBrainAsOf("2026-07-01T02:00:00")).toThrow(BrainAsOfInvalidError);
+    expect(() => parseBrainAsOf("2026-07-01T02:00:00")).toThrow(/zone/);
+    // A bare DATE is fine: ECMA-262 reads it as UTC midnight, deterministically.
+    const dateOnly: string = parseBrainAsOf("2026-07-01");
+    expect(dateOnly).toBe(AS_OF);
+  });
+
+  it("rejects instants below the timestamptz floor instead of failing the bind as an internal fault", () => {
+    // JS parses year zero; Postgres has no year zero. Without the floor this
+    // would surface at the bind as a retryable `search_failed` — the wrong
+    // recovery signal for a caller-argument problem.
+    expect(() => parseBrainAsOf("0000-01-05T00:00:00Z")).toThrow(BrainAsOfInvalidError);
+    expect(() => parseBrainAsOf("0000-01-05T00:00:00Z")).toThrow(/0001-01-01/);
+  });
+
+  it("caps the echoed value in the rejection message — caller input is unbounded", () => {
+    const huge = `${"9".repeat(500)}!`;
+    try {
+      parseBrainAsOf(huge);
+      throw new Error("expected a rejection");
+    } catch (err) {
+      if (!(err instanceof BrainAsOfInvalidError)) throw err;
+      expect(err.message.length).toBeLessThan(400);
+      expect(err.message).toContain("…");
+    }
   });
 
   it("rejects a BLANK asOf rather than treating it as absent", () => {
@@ -308,13 +377,15 @@ describe("asOf — the bi-temporal point read (#4916)", () => {
     expect(() => parseBrainAsOf("2026-08-01T00:00:00Z", now)).toThrow(BrainAsOfInvalidError);
     expect(() => parseBrainAsOf("2026-08-01T00:00:00Z", now)).toThrow(/future/);
     // The boundary itself is admitted: `asOf === now` is a valid past-or-present instant.
-    expect(parseBrainAsOf("2026-07-30T00:00:00Z", now)).toBe("2026-07-30T00:00:00.000Z");
+    const atNow: string = parseBrainAsOf("2026-07-30T00:00:00Z", now);
+    expect(atNow).toBe("2026-07-30T00:00:00.000Z");
   });
 
   it("normalizes the instant to canonical ISO-8601 UTC", () => {
     // Bound as `timestamptz` and echoed on the response, so both carry the
     // canonical spelling rather than the caller's local-offset one.
-    expect(parseBrainAsOf(" 2026-07-01T02:00:00+02:00 ")).toBe(AS_OF);
+    const normalized: string = parseBrainAsOf(" 2026-07-01T02:00:00+02:00 ");
+    expect(normalized).toBe(AS_OF);
   });
 
   it("echoes the normalized asOf on the response — a historical page must say it is one", async () => {
@@ -351,6 +422,24 @@ describe("asOf — the bi-temporal point read (#4916)", () => {
         ctx: ctx(),
         mode: "published",
         asOf: "garbage",
+        limit: 10,
+        expand: false,
+      }),
+    ).rejects.toBeInstanceOf(BrainAsOfInvalidError);
+    expect(db.calls).toHaveLength(0);
+  });
+
+  it("refuses asOf when `include` excludes the fact store — a temporal ask of atemporal stores", async () => {
+    // Echoing `asOf` over current-only documents/episodes would label
+    // as-of-now content as a historical page; dropping the parameter silently
+    // is the fall-through #4916 forbids. So it is a refusal, before any store.
+    const db = reader();
+    await expect(
+      searchBrainCore(db, {
+        ctx: ctx(),
+        mode: "published",
+        include: ["document", "raw-episode"],
+        asOf: AS_OF,
         limit: 10,
         expand: false,
       }),

--- a/packages/api/src/lib/brain/search.ts
+++ b/packages/api/src/lib/brain/search.ts
@@ -90,11 +90,46 @@
  *
  * FTS-first, per the M1 cut. Embeddings, RRF over dense lists, and rerank are
  * M4 — `fusion.ts` is the seam they extend, and there is no disabled embedding
- * path here to switch on. `asOf` bi-temporal point reads are M2's; this read is
- * as-of-now. `in-tension-with` is surfaced as a conflict CLUSTER (#4913): both
- * directions, each visible counterpart with its own provenance, invisible ones
- * as a withheld count — and never ranked; arbitration belongs to the human
- * gate.
+ * path here to switch on. `in-tension-with` is surfaced as a conflict CLUSTER
+ * (#4913): both directions, each visible counterpart with its own provenance,
+ * invisible ones as a withheld count — and never ranked; arbitration belongs
+ * to the human gate.
+ *
+ * ## `asOf` — the bi-temporal point read (#4916, ADR-0036 §Temporal)
+ *
+ * T4/T7's "what did we believe Monday": an optional `asOf` instant switches the
+ * FACT store's temporal predicate from as-of-now to the point read
+ * `valid_from <= asOf < COALESCE(valid_to, ∞)`, so a fact a later promotion
+ * superseded answers again inside its own validity window — that is the point
+ * of keeping superseded rows readable. Four boundary rules, all deliberate:
+ *
+ *   - **Tombstones stay hidden under ANY `asOf`.** Retraction is the only verb
+ *     that hides history, and hiding history is what it is FOR (it is also the
+ *     GDPR-erasure path) — so `invalidated_at IS NULL` survives in both
+ *     branches, unconditionally.
+ *   - **The ACL is the row's own frozen grant against as-of-NOW membership.**
+ *     Each version carries the immutable `visible_to` it was published with,
+ *     and `aclVisibilityClause` evaluates exactly that column per row — so
+ *     "Monday's belief" is gated by Monday's grant with no code here doing
+ *     anything: the bi-temporal ACL (T5) falls out of grant immutability. The
+ *     reader's tokens, by contrast, are always resolved as of now — a member
+ *     who since left an audience does not keep historical access through the
+ *     read; membership is the live half and the revocation path.
+ *   - **A NULL `valid_from` is an unrecorded start, not a late one.** The
+ *     as-of-now read has no `valid_from` predicate at all — a fact with no
+ *     recorded start IS served as current belief — so the point read must
+ *     admit it too, or `asOf ≈ now()` would diverge from the default read.
+ *   - **The default read is byte-identical to before #4916** — same clauses,
+ *     same order, regression-pinned — and a malformed or future `asOf` is
+ *     REJECTED with {@link BrainAsOfInvalidError}, never silently ignored: a
+ *     caller who asked for history and silently got current belief would
+ *     attribute today's claims to Monday.
+ *
+ * The episode and document stores are untouched by `asOf`: an episode is
+ * append-only evidence of what was SAID (it has no validity window to point
+ * into), and a KB document is deliberately outside the truth ordering. Only
+ * the fact store makes claims about what was BELIEVED, so it is the only store
+ * with a temporal axis to read against.
  */
 
 import { createLogger } from "@atlas/api/lib/logger";
@@ -198,10 +233,75 @@ export interface BrainSearchOptions {
   readonly tags?: readonly string[];
   readonly collection?: string;
   readonly since?: string;
+  /**
+   * Bi-temporal point read (#4916): the ISO-8601 instant to answer for.
+   * Fact store only — see the module header. Validated by
+   * {@link parseBrainAsOf}; malformed or future values THROW rather than fall
+   * through to as-of-now. Absent ⇒ current belief, unchanged.
+   */
+  readonly asOf?: string;
   /** Include the 1-hop KB link-graph expansion of matched documents. */
   readonly expand: boolean;
   readonly limit: number;
   readonly requestId?: string;
+}
+
+// ---------------------------------------------------------------------------
+// asOf validation (#4916)
+// ---------------------------------------------------------------------------
+
+/**
+ * A caller-supplied `asOf` this read refuses to honor.
+ *
+ * A dedicated class rather than a bare `Error` so the tool wrapper can map it
+ * to its machine-readable reason (`invalid_as_of`) by `instanceof`, the same
+ * seam `BrainReaderIdentityError` rides — never by matching the prose, which
+ * is user-facing and free to change.
+ */
+export class BrainAsOfInvalidError extends Error {
+  override readonly name = "BrainAsOfInvalidError";
+  constructor(message: string) {
+    super(message);
+  }
+}
+
+/**
+ * Validate and normalize a caller-supplied `asOf`, or throw
+ * {@link BrainAsOfInvalidError}.
+ *
+ * FAIL CLOSED, per the issue's boundary rule: a value the caller plainly meant
+ * as a point-read instant but that cannot be honored must never degrade to the
+ * as-of-now read — the caller would attribute today's beliefs to the instant
+ * they asked about, silently. So blank, unparseable, and FUTURE values are all
+ * refusals with a message naming the value and the fix. Future bounds are
+ * refused rather than clamped because `valid_from` can legitimately sit in the
+ * future (a region import restores it verbatim), so a future point read is not
+ * "the same as now" — it is a question about beliefs not yet held, which this
+ * surface does not answer.
+ *
+ * Returns the instant normalized to ISO-8601 UTC: it is bound as a
+ * `timestamptz` parameter and echoed on the response, and both should carry
+ * the canonical spelling rather than whatever the caller typed.
+ */
+export function parseBrainAsOf(raw: string, now: () => number = Date.now): string {
+  const trimmed = raw.trim();
+  if (trimmed === "") {
+    throw new BrainAsOfInvalidError(
+      "asOf was blank. Pass an ISO-8601 instant (e.g. 2026-07-27T09:00:00Z) for a historical read, or omit asOf entirely for current beliefs.",
+    );
+  }
+  const parsed = new Date(trimmed);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new BrainAsOfInvalidError(
+      `asOf ${JSON.stringify(trimmed)} is not a parseable timestamp. Pass an ISO-8601 instant (e.g. 2026-07-27T09:00:00Z), or omit asOf for current beliefs.`,
+    );
+  }
+  if (parsed.getTime() > now()) {
+    throw new BrainAsOfInvalidError(
+      `asOf ${parsed.toISOString()} is in the future. As-of reads answer what was believed at a past instant; omit asOf for current beliefs.`,
+    );
+  }
+  return parsed.toISOString();
 }
 
 // ---------------------------------------------------------------------------
@@ -309,21 +409,46 @@ const FACT_COLUMNS = `f.id::text AS id,
  */
 export function buildFactQuery(
   mode: AtlasMode,
-  options: { query?: string; limit: number; aclSql: string; aclParams: readonly unknown[] },
+  options: {
+    query?: string;
+    limit: number;
+    aclSql: string;
+    aclParams: readonly unknown[];
+    /** A VALIDATED point-read instant off {@link parseBrainAsOf}, or absent. */
+    asOf?: string;
+  },
 ): { sql: string; params: unknown[] } {
   const params: unknown[] = [...options.aclParams];
   const where: string[] = [
     options.aclSql,
     brainFactStatusClause(mode, "f"),
     // NOT redundant with the mode clause — see the module header. Without it
-    // the agent is served retracted claims as current belief.
+    // the agent is served retracted claims as current belief. Deliberately in
+    // BOTH temporal branches: a tombstone is hidden under any `asOf`, because
+    // retraction is the one verb whose JOB is hiding history (#4916).
     "f.invalidated_at IS NULL",
+  ];
+  if (options.asOf !== undefined) {
+    // The bi-temporal point read (#4916): the facts valid AT the instant —
+    // `valid_from <= asOf < COALESCE(valid_to, ∞)`. A superseded fact answers
+    // again inside its window (that is the point of keeping it readable); a
+    // NULL `valid_from` is an unrecorded start and is admitted, matching the
+    // default read's treatment of the same rows — see the module header.
+    // One bound parameter, referenced by both bounds, so the two sides of the
+    // window cannot be handed different instants.
+    params.push(options.asOf);
+    const asOfParam = `$${params.length}::timestamptz`;
+    where.push(
+      `(f.valid_from IS NULL OR f.valid_from <= ${asOfParam})`,
+      `(f.valid_to IS NULL OR f.valid_to > ${asOfParam})`,
+    );
+  } else {
     // The FOURTH predicate (#4912): a fact whose `valid_to` has passed was
     // superseded at the publish gate and is no longer current belief. Hidden
-    // exactly as tombstones are — the row stays readable to the as-of reads M2
-    // adds, and this default read is as-of-now.
-    brainFactCurrentClause("f"),
-  ];
+    // exactly as tombstones are — the row stays readable to the `asOf` branch
+    // above, and this default read is as-of-now.
+    where.push(brainFactCurrentClause("f"));
+  }
 
   const trimmed = options.query?.trim();
   let tsq: string | null = null;
@@ -712,6 +837,8 @@ function queriedStore(matched: number, limit: number): BrainSearchStoreReport {
  *   principals. Deliberately not degraded to an empty result set: an agent told
  *   "the brain holds nothing about this" answers from the model's priors, which
  *   is the failure a trust-labeled surface exists to prevent.
+ * @throws {BrainAsOfInvalidError} when `asOf` is malformed or in the future —
+ *   fail closed, never fall through to as-of-now (#4916).
  */
 export async function searchBrainCore(
   db: BrainSearchReader,
@@ -720,6 +847,10 @@ export async function searchBrainCore(
   const { ctx, mode, requestId } = options;
   const limit = Math.min(Math.max(1, Math.trunc(options.limit)), MAX_SEARCH_LIMIT);
   const include = new Set(options.include ?? BRAIN_RESULT_TIERS);
+  // Validated FIRST, before any store runs: an unusable point-read instant is
+  // the caller's input problem and must be reported as such, not spent a
+  // fan-out on. Throws — see parseBrainAsOf on why it never degrades.
+  const asOf = options.asOf === undefined ? undefined : parseBrainAsOf(options.asOf);
 
   const wantFacts = include.has("fact");
   const wantEpisodes = include.has("raw-episode");
@@ -764,6 +895,7 @@ export async function searchBrainCore(
             limit,
             aclSql: acl.sql,
             aclParams: acl.params,
+            asOf,
           });
           const result = await db.query(built.sql, built.params);
           return result.rows as FactRow[];
@@ -909,5 +1041,9 @@ export async function searchBrainCore(
         : UNQUERIED_STORE,
     },
     tensionsTruncated: tensions.truncated,
+    // Echoed ONLY on an as-of read — spreading rather than `asOf: asOf` keeps
+    // the default response byte-identical to pre-#4916, and makes the field's
+    // absence itself the "these are current beliefs" statement.
+    ...(asOf !== undefined ? { asOf } : {}),
   };
 }

--- a/packages/api/src/lib/brain/search.ts
+++ b/packages/api/src/lib/brain/search.ts
@@ -129,7 +129,17 @@
  * append-only evidence of what was SAID (it has no validity window to point
  * into), and a KB document is deliberately outside the truth ordering. Only
  * the fact store makes claims about what was BELIEVED, so it is the only store
- * with a temporal axis to read against.
+ * with a temporal axis to read against — and an `asOf` read that EXCLUDES the
+ * fact store is refused outright, because echoing `asOf` over current-only
+ * content would label it historical.
+ *
+ * One scope limit, stated so nobody reads more into the point read than it
+ * does: metadata computed AT READ TIME — the decay signal, the corroboration
+ * count, and the tension cluster — is evaluated as of NOW even on a historical
+ * page. Those are advisory framing about the row as it stands today (how stale
+ * it has since become, what has since come to contradict it), not part of the
+ * belief being reported, and rewinding them would require versioned edges the
+ * substrate does not keep.
  */
 
 import { createLogger } from "@atlas/api/lib/logger";
@@ -265,6 +275,41 @@ export class BrainAsOfInvalidError extends Error {
   }
 }
 
+declare const brainAsOfBrand: unique symbol;
+/**
+ * An instant that has been through {@link parseBrainAsOf} — normalized
+ * ISO-8601 UTC, in the past, inside `timestamptz` range. The brand makes
+ * "validated" a compile-time property of {@link buildFactQuery}'s input rather
+ * than a doc-comment precondition, and keeps the UNVALIDATED sibling params
+ * (`since`, the documents filter) unpassable where `asOf` belongs.
+ */
+export type BrainAsOfInstant = string & { readonly [brainAsOfBrand]: true };
+
+/**
+ * The accepted spellings: a bare ISO date (`YYYY-MM-DD`, read as UTC midnight
+ * per ECMA-262 — deterministic), or a timestamp with an EXPLICIT zone.
+ *
+ * Deliberately stricter than `new Date()`, which this feeds: bare `Date`
+ * parsing admits `"July 2026"` and — worse — reads a zone-less
+ * `"2026-07-27T09:00"` in the SERVER's local timezone, so the same call would
+ * answer a different instant per deployment. A silent hours-scale shift of the
+ * point read is the same class of failure as the silent fall-through this
+ * function exists to refuse, so a time without a zone is malformed here.
+ */
+const AS_OF_SHAPE =
+  /^\d{4}-\d{2}-\d{2}([T ]\d{2}:\d{2}(:\d{2}(\.\d{1,9})?)?(Z|z|[+-]\d{2}:?\d{2}))?$/;
+
+/**
+ * Everything `timestamptz` can hold starts here: Postgres admits no year zero
+ * (and no negative years in ISO input), so a JS-parseable instant below this
+ * would pass validation only to fail the bind at query time — surfacing as a
+ * retryable internal fault when it is really the caller's argument.
+ */
+const AS_OF_FLOOR_MS = Date.parse("0001-01-01T00:00:00Z");
+
+/** Longest slice of a rejected value echoed back — a bound on message/log size, not a policy. */
+const AS_OF_ECHO_CAP = 64;
+
 /**
  * Validate and normalize a caller-supplied `asOf`, or throw
  * {@link BrainAsOfInvalidError}.
@@ -272,28 +317,44 @@ export class BrainAsOfInvalidError extends Error {
  * FAIL CLOSED, per the issue's boundary rule: a value the caller plainly meant
  * as a point-read instant but that cannot be honored must never degrade to the
  * as-of-now read — the caller would attribute today's beliefs to the instant
- * they asked about, silently. So blank, unparseable, and FUTURE values are all
- * refusals with a message naming the value and the fix. Future bounds are
- * refused rather than clamped because `valid_from` can legitimately sit in the
- * future (a region import restores it verbatim), so a future point read is not
- * "the same as now" — it is a question about beliefs not yet held, which this
- * surface does not answer.
+ * they asked about, silently. So blank, non-ISO, zone-less, out-of-range, and
+ * FUTURE values are all refusals with a message naming the value and the fix.
+ * Future bounds are refused rather than clamped because `valid_from` can
+ * legitimately sit in the future (a region import restores it verbatim), so a
+ * future point read is not "the same as now" — it is a question about beliefs
+ * not yet held, which this surface does not answer.
  *
  * Returns the instant normalized to ISO-8601 UTC: it is bound as a
  * `timestamptz` parameter and echoed on the response, and both should carry
  * the canonical spelling rather than whatever the caller typed.
  */
-export function parseBrainAsOf(raw: string, now: () => number = Date.now): string {
+export function parseBrainAsOf(raw: string, now: () => number = Date.now): BrainAsOfInstant {
   const trimmed = raw.trim();
+  // The caller's own input, so echoing it back is safe — but it is unbounded,
+  // so the echo is capped rather than pasted verbatim into an error message
+  // and a warn line.
+  const shown =
+    trimmed.length > AS_OF_ECHO_CAP ? `${trimmed.slice(0, AS_OF_ECHO_CAP)}…` : trimmed;
   if (trimmed === "") {
     throw new BrainAsOfInvalidError(
       "asOf was blank. Pass an ISO-8601 instant (e.g. 2026-07-27T09:00:00Z) for a historical read, or omit asOf entirely for current beliefs.",
     );
   }
+  if (!AS_OF_SHAPE.test(trimmed)) {
+    throw new BrainAsOfInvalidError(
+      `asOf ${JSON.stringify(shown)} is not an ISO-8601 instant. Pass a date (2026-07-27) or a timestamp with an explicit zone (2026-07-27T09:00:00Z) — a time without a zone would be read in the server's timezone, so it is rejected. Omit asOf for current beliefs.`,
+    );
+  }
   const parsed = new Date(trimmed);
   if (Number.isNaN(parsed.getTime())) {
+    // Shape-valid but field-invalid — a 13th month, a 25th hour.
     throw new BrainAsOfInvalidError(
-      `asOf ${JSON.stringify(trimmed)} is not a parseable timestamp. Pass an ISO-8601 instant (e.g. 2026-07-27T09:00:00Z), or omit asOf for current beliefs.`,
+      `asOf ${JSON.stringify(shown)} is not a real instant — a field is out of range. Pass a valid ISO-8601 instant (e.g. 2026-07-27T09:00:00Z), or omit asOf for current beliefs.`,
+    );
+  }
+  if (parsed.getTime() < AS_OF_FLOOR_MS) {
+    throw new BrainAsOfInvalidError(
+      `asOf ${JSON.stringify(shown)} is before 0001-01-01, which the database cannot represent. Pass an instant on or after 0001-01-01T00:00:00Z.`,
     );
   }
   if (parsed.getTime() > now()) {
@@ -301,7 +362,7 @@ export function parseBrainAsOf(raw: string, now: () => number = Date.now): strin
       `asOf ${parsed.toISOString()} is in the future. As-of reads answer what was believed at a past instant; omit asOf for current beliefs.`,
     );
   }
-  return parsed.toISOString();
+  return parsed.toISOString() as BrainAsOfInstant;
 }
 
 // ---------------------------------------------------------------------------
@@ -414,8 +475,12 @@ export function buildFactQuery(
     limit: number;
     aclSql: string;
     aclParams: readonly unknown[];
-    /** A VALIDATED point-read instant off {@link parseBrainAsOf}, or absent. */
-    asOf?: string;
+    /**
+     * A point-read instant, or absent for the as-of-now read. The brand means
+     * it can only come from {@link parseBrainAsOf} — "validated" is a
+     * compile-time property here, not a doc-comment plea.
+     */
+    asOf?: BrainAsOfInstant;
   },
 ): { sql: string; params: unknown[] } {
   const params: unknown[] = [...options.aclParams];
@@ -847,14 +912,26 @@ export async function searchBrainCore(
   const { ctx, mode, requestId } = options;
   const limit = Math.min(Math.max(1, Math.trunc(options.limit)), MAX_SEARCH_LIMIT);
   const include = new Set(options.include ?? BRAIN_RESULT_TIERS);
-  // Validated FIRST, before any store runs: an unusable point-read instant is
-  // the caller's input problem and must be reported as such, not spent a
-  // fan-out on. Throws — see parseBrainAsOf on why it never degrades.
-  const asOf = options.asOf === undefined ? undefined : parseBrainAsOf(options.asOf);
 
   const wantFacts = include.has("fact");
   const wantEpisodes = include.has("raw-episode");
   const wantDocuments = include.has("document");
+
+  // Validated FIRST, before any store runs: an unusable point-read instant is
+  // the caller's input problem and must be reported as such, not spent a
+  // fan-out on. Throws — see parseBrainAsOf on why it never degrades.
+  const asOf = options.asOf === undefined ? undefined : parseBrainAsOf(options.asOf);
+  if (asOf !== undefined && !wantFacts) {
+    // A temporal question aimed only at stores with no temporal axis. Serving
+    // the current documents/episodes under an echoed `asOf` would label
+    // as-of-now content as a historical page — mislabeling on the one surface
+    // whose labels are the product — and silently dropping the parameter is
+    // the fall-through this module refuses. Same fail-closed verb as every
+    // other unusable asOf.
+    throw new BrainAsOfInvalidError(
+      'asOf was passed but `include` excludes "fact" — only reviewed facts have a validity window to read against. Add "fact" to include, or omit asOf.',
+    );
+  }
 
   // Resolved UNCONDITIONALLY, before any store runs, and the refusal is the
   // single gate for the whole read. Deliberately not scoped to

--- a/packages/api/src/lib/tools/__tests__/search-brain-tool.test.ts
+++ b/packages/api/src/lib/tools/__tests__/search-brain-tool.test.ts
@@ -234,6 +234,35 @@ describe("searchBrain tool.execute", () => {
     expect(loggedError).toBeDefined();
   });
 
+  it("threads a valid asOf into the fact read and echoes it — the historical page says so (#4916)", async () => {
+    const res = await run({ query: "x", include: ["fact"], asOf: "2026-07-01T00:00:00Z", expand: false });
+    const factCall = queryCalls.find((c) => c.sql.includes("brain_facts"))!;
+    expect(factCall.sql).toContain("f.valid_from IS NULL OR f.valid_from <=");
+    expect(factCall.params).toContain("2026-07-01T00:00:00.000Z");
+    expect(res.asOf).toBe("2026-07-01T00:00:00.000Z");
+    expect(res.error).toBeUndefined();
+  });
+
+  it("rejects a malformed asOf with its own machine-readable reason — never answers as-of-now (#4916)", async () => {
+    const res = await run({ query: "x", asOf: "yesterday-ish" });
+    expect(res.error).toContain("yesterday-ish");
+    expect(res.error).toContain("ISO-8601");
+    expect(res.reason).toBe("invalid_as_of");
+    expect(res.results).toBeUndefined();
+    // Fail closed: nothing was searched — a page of CURRENT beliefs under a
+    // rejected historical ask would be attributed to the asked-about instant.
+    expect(queryCalls).toHaveLength(0);
+  });
+
+  it("rejects a BLANK asOf rather than normalizing it away like the document filters", async () => {
+    // `since: '  '` becomes absent; `asOf: '  '` must NOT — an explicit
+    // point-read argument that silently degrades to as-of-now is the exact
+    // fall-through #4916 forbids.
+    const res = await run({ query: "x", asOf: "   " });
+    expect(res.reason).toBe("invalid_as_of");
+    expect(queryCalls).toHaveLength(0);
+  });
+
   it("logs and returns a generic, secret-free error when the query throws", async () => {
     queryImpl = async () => {
       throw new Error("connection to postgres://user:pw@host failed");

--- a/packages/api/src/lib/tools/__tests__/search-brain-tool.test.ts
+++ b/packages/api/src/lib/tools/__tests__/search-brain-tool.test.ts
@@ -63,11 +63,14 @@ void mock.module("@atlas/api/lib/auth/detect", () => ({
 }));
 
 let loggedError: unknown;
+let loggedWarn: unknown;
 // Mock all value exports of the logger module (mock.module is file-global; a
 // partial stub would hand `undefined` to any importer reaching an unmocked one).
 const noopLogger = {
   info: () => {},
-  warn: () => {},
+  warn: (obj: unknown) => {
+    loggedWarn = obj;
+  },
   debug: () => {},
   error: (obj: unknown) => {
     loggedError = obj;
@@ -126,6 +129,7 @@ beforeEach(() => {
   queryCalls.length = 0;
   queryImpl = async () => [];
   loggedError = undefined;
+  loggedWarn = undefined;
 });
 
 describe("searchBrain tool.execute", () => {
@@ -252,6 +256,9 @@ describe("searchBrain tool.execute", () => {
     // Fail closed: nothing was searched — a page of CURRENT beliefs under a
     // rejected historical ask would be attributed to the asked-about instant.
     expect(queryCalls).toHaveLength(0);
+    // Logged at warn (a caller mistake, not a server fault), with correlation.
+    expect(loggedWarn).toMatchObject({ workspaceId: "ws-1", requestId: "req-1" });
+    expect(loggedError).toBeUndefined();
   });
 
   it("rejects a BLANK asOf rather than normalizing it away like the document filters", async () => {

--- a/packages/api/src/lib/tools/descriptions.ts
+++ b/packages/api/src/lib/tools/descriptions.ts
@@ -62,9 +62,9 @@ Use this whenever a metric exists for what the user asked — never re-derive me
 
 Don't use this when no metric id matches; fall back to \`executeSQL\` with a query pattern from \`describeEntity\`. Avoid passing \`filters\` — pass-through is reserved for future work and is rejected today.`;
 
-export const SEARCH_BRAIN_TOOL_DESCRIPTION = `Search the company brain — a trust-labeled read over three stores. \`tier: "fact"\` is human-reviewed; \`tier: "raw-episode"\` is its source record; \`tier: "document"\` is hosted knowledge — ${KNOWLEDGE_TRUST_FRAMING}. When \`provenance.attribution\` is \`{ "visible": false }\`, author, source id and timestamp are withheld: use the claim, say attribution is restricted; never call it anonymous, undated, unsourced; never infer the author. Retracted claims are excluded. Unextracted episodes carry \`extraction: "pending"\`. Age metadata (\`validFrom\`, \`corroborationCount\`, \`decay\`): present a stale fact's age, never assert it as current or drop it. \`tensions\` lists rival claims+provenance (\`withheldCount\` = unseen rivals), unranked: never pick winners. \`unavailable\` = the search failed, not "nothing known". Example: \`{ "query": "who owns billing" }\`.
+export const SEARCH_BRAIN_TOOL_DESCRIPTION = `Search the company brain — trust-labeled results across three stores. \`tier: "fact"\` is human-reviewed; \`tier: "raw-episode"\` its source record; \`tier: "document"\` hosted knowledge — ${KNOWLEDGE_TRUST_FRAMING}. \`provenance.attribution\` \`{ "visible": false }\`: author, source id, timestamp withheld — use the claim, say attribution restricted, never call it anonymous, undated, unsourced, nor infer the author. Unextracted episodes carry \`extraction: "pending"\`. Age (\`validFrom\`, \`corroborationCount\`, \`decay\`): present a stale fact's age; never assert it as current or drop it. \`tensions\` lists rival claims+provenance (\`withheldCount\` = unseen rivals), unranked: never pick winners. \`unavailable\` = search failed, not "nothing known". \`asOf\` (past ISO-8601) reads facts valid then — superseded included, retracted never; frame as "as of <time>". Example: \`{ "query": "who owns billing", "asOf": "2026-07-01T00:00:00Z" }\`.
 
-Use this when asking about decisions, rationale, ownership, or policy — what people wrote down, not what a warehouse counts.
+Use this when asking about decisions, rationale, ownership, or policy — recorded knowledge.
 
 Don't use this for quantitative current state (\`executeSQL\`) or the semantic layer (\`explore\`).`;
 
@@ -139,8 +139,12 @@ export const RUN_METRIC_ERROR_CODES = [
 // the fail-closed ACL deny, which is an upstream defect and must NOT read to
 // the agent as "the brain knows nothing" — and, independently, from the
 // dispatch gate's own `minRole` denial, which never reaches the tool body.
+// `validation_failed` for a malformed/future `asOf` (#4916) — the caller's own
+// argument, refused rather than silently answered as-of-now, and distinct from
+// `internal_error` because the recovery is "fix the argument", not "retry".
 // Plus the per-client rate limit and the catch-all.
 export const SEARCH_BRAIN_ERROR_CODES = [
+  "validation_failed",
   "forbidden",
   "rate_limited",
   "internal_error",

--- a/packages/api/src/lib/tools/search-brain.ts
+++ b/packages/api/src/lib/tools/search-brain.ts
@@ -272,7 +272,7 @@ export const searchBrain = tool({
       .string()
       .optional()
       .describe(
-        "Facts only: ISO-8601 instant for a historical point read — returns the reviewed facts that were valid at that moment (later-superseded versions included; retracted facts never). Must be in the past; malformed or future values are rejected. Omit for current beliefs.",
+        "Facts only: historical point read — returns the reviewed facts valid at that moment (later-superseded versions included; retracted facts never). An ISO-8601 date (2026-07-27) or a timestamp with an EXPLICIT zone (2026-07-27T09:00:00Z); zone-less times, non-ISO forms, and future instants are rejected. Requires the fact store in `include`. Omit for current beliefs.",
       ),
     limit: z
       .number()

--- a/packages/api/src/lib/tools/search-brain.ts
+++ b/packages/api/src/lib/tools/search-brain.ts
@@ -66,7 +66,12 @@ import { createLogger, getRequestContext } from "@atlas/api/lib/logger";
 import { getInternalDB, hasInternalDB } from "@atlas/api/lib/db/internal";
 import { detectAuthMode } from "@atlas/api/lib/auth/detect";
 import { rootCauseMessage } from "@atlas/api/lib/error-cause";
-import { searchBrainCore, DEFAULT_SEARCH_LIMIT, MAX_SEARCH_LIMIT } from "@atlas/api/lib/brain/search";
+import {
+  searchBrainCore,
+  BrainAsOfInvalidError,
+  DEFAULT_SEARCH_LIMIT,
+  MAX_SEARCH_LIMIT,
+} from "@atlas/api/lib/brain/search";
 import {
   BrainReaderIdentityError,
   resolveBrainReaderContext,
@@ -94,6 +99,13 @@ export const BRAIN_TOOL_REASONS = {
   noWorkspace: "no_workspace",
   readerUnresolved: "reader_unresolved",
   searchFailed: "search_failed",
+  /**
+   * The caller's `asOf` could not be honored (#4916) — malformed or in the
+   * future. Its own reason rather than `search_failed` because the recovery is
+   * different: fix the argument, don't retry — and the MCP edge maps it to
+   * `validation_failed`, not `internal_error`.
+   */
+  invalidAsOf: "invalid_as_of",
 } as const;
 
 export type BrainToolReason = (typeof BRAIN_TOOL_REASONS)[keyof typeof BRAIN_TOOL_REASONS];
@@ -154,6 +166,7 @@ Use the searchBrain tool for decisions, rationale, ownership, policy, and histor
 - A fact whose \`provenance.attribution\` is \`{ "visible": false }\` is one you may read but whose author, source id, and original timestamp are withheld from this reader. Use the claim; say attribution is restricted if asked who said it. Do NOT report it as anonymous, undated, or unsourced — and never infer the author from anything else in the response
 - Every fact carries its age: \`validFrom\`, \`corroborationCount\`, \`provenance.attribution.occurredAt\` (when visible), and a read-time \`decay\` signal (\`fresh\`/\`aging\`/\`stale\`/\`unknown\`). Staleness is advisory — a \`stale\` fact is still the reviewed record. Present its age ("as of March…") instead of asserting it as current, and never discard or overrule a fact because of age
 - \`tensions\` is the fact's conflict cluster, listed in both directions and deliberately unranked — each visible counterpart carries its own claim and provenance, so surface both sides with their evidence and never pick a winner; recency and corroboration are context for the reader, not a verdict. A \`{ "visible": false, "withheldCount": N }\` entry means N conflicting claims exist that you cannot see — treat the claim as contested, never as settled
+- To answer "what did we believe at <time>", pass \`asOf\` (ISO-8601, in the past): facts are then the versions valid AT that instant, including ones since superseded. A response carrying \`asOf\` is HISTORICAL — frame every fact in it as "as of <time>", never as current; a response without \`asOf\` is current belief. Retracted facts never appear, at any time
 - If the response carries \`unavailable\`, the brain could NOT be searched (e.g. no workspace is bound). Say so — do NOT report it as "nothing is known"
 - Read-only, and never the SQL whitelist, metrics, or glossary. For quantitative current state use \`executeSQL\`; for the on-disk semantic layer use \`explore\``;
 
@@ -175,6 +188,7 @@ export interface SearchBrainInput {
   tags?: string[];
   collection?: string;
   since?: string;
+  asOf?: string;
   limit?: number;
   expand?: boolean;
 }
@@ -194,6 +208,7 @@ export function normalizeSearchInput(input: SearchBrainInput): {
   tags?: readonly string[];
   collection?: string;
   since?: string;
+  asOf?: string;
   limit: number;
   expand: boolean;
 } {
@@ -214,6 +229,11 @@ export function normalizeSearchInput(input: SearchBrainInput): {
     tags: tags && tags.length > 0 ? tags : undefined,
     collection: input.collection?.trim() || undefined,
     since: input.since?.trim() || undefined,
+    // Passed through VERBATIM, deliberately unlike `since` above: `'   '.trim()
+    // || undefined` would silently turn an explicit-but-blank asOf into the
+    // as-of-now read — exactly the fall-through #4916 forbids. The core's
+    // parseBrainAsOf owns the judgment and REJECTS a blank instead.
+    asOf: input.asOf,
     limit,
     expand: input.expand ?? true,
   };
@@ -248,6 +268,12 @@ export const searchBrain = tool({
       .string()
       .optional()
       .describe("Documents only: ISO-8601 date; documents at or after this timestamp."),
+    asOf: z
+      .string()
+      .optional()
+      .describe(
+        "Facts only: ISO-8601 instant for a historical point read — returns the reviewed facts that were valid at that moment (later-superseded versions included; retracted facts never). Must be in the past; malformed or future values are rejected. Omit for current beliefs.",
+      ),
     limit: z
       .number()
       .int()
@@ -307,6 +333,20 @@ export const searchBrain = tool({
       });
     } catch (err) {
       const requestId = reqCtx?.requestId;
+      // The caller's own argument, refused (#4916) — warn, not error: nothing
+      // is wrong server-side, and the message already tells the agent the fix.
+      // The core's prose IS the user-facing message; it names the offending
+      // value and the recovery, per the no-generic-errors rule.
+      if (err instanceof BrainAsOfInvalidError) {
+        log.warn(
+          { err: err.message, workspaceId, requestId },
+          "searchBrain rejected an unusable asOf — refusing rather than answering as-of-now",
+        );
+        return {
+          error: withRequestId(err.message, requestId),
+          reason: BRAIN_TOOL_REASONS.invalidAsOf,
+        };
+      }
       // Identity failures are reported as a REFUSAL, distinctly from a generic
       // search failure — see the module header on why an empty result set would
       // be the dangerous answer here. ONE `instanceof` against the shared base,

--- a/packages/mcp/src/__tests__/tools.test.ts
+++ b/packages/mcp/src/__tests__/tools.test.ts
@@ -1045,7 +1045,7 @@ describe("MCP tools", () => {
       // the agent to retry the identical call; `validation_failed` tells it
       // the argument is the problem, which the message then names.
       mockSearchBrainExecute.mockResolvedValueOnce({
-        error: 'asOf "yesterday-ish" is not a parseable timestamp.',
+        error: 'asOf "yesterday-ish" is not an ISO-8601 instant.',
         reason: REAL_BRAIN_TOOL_REASONS.invalidAsOf,
       });
       const { client } = await createTestClient();
@@ -1056,6 +1056,41 @@ describe("MCP tools", () => {
       expect(result.isError).toBe(true);
       const envelope = parseAtlasMcpToolError(getContentText(result.content));
       expect(envelope?.code).toBe("validation_failed");
+      // The MCP input schema is a strip-unknown z.object: if the `asOf` entry
+      // were dropped from the registration, the argument would be silently
+      // stripped and the tool would answer as-of-now — the exact fall-through
+      // #4916 forbids, invisible to every other assertion in this block.
+      expect(mockSearchBrainExecute).toHaveBeenCalledWith(
+        expect.objectContaining({ asOf: "yesterday-ish" }),
+        expect.anything(),
+      );
+    });
+
+    it("forwards asOf and passes the historical page's echo through untouched (#4916)", async () => {
+      mockSearchBrainExecute.mockResolvedValueOnce({
+        results: [],
+        neighbors: [],
+        stores: {
+          fact: { queried: true, matched: 0, truncated: false },
+          "raw-episode": { queried: false },
+          document: { queried: false },
+        },
+        tensionsTruncated: false,
+        asOf: "2026-07-01T00:00:00.000Z",
+      });
+      const { client } = await createTestClient();
+      const result = await client.callTool({
+        name: "searchBrain",
+        arguments: { query: "x", asOf: "2026-07-01T00:00:00Z" },
+      });
+      expect(result.isError).toBeFalsy();
+      expect(mockSearchBrainExecute).toHaveBeenCalledWith(
+        expect.objectContaining({ asOf: "2026-07-01T00:00:00Z" }),
+        expect.anything(),
+      );
+      // The echo is the page's only "this is historical" marker; the MCP edge
+      // must not strip it on the way to the agent.
+      expect(JSON.parse(getContentText(result.content)).asOf).toBe("2026-07-01T00:00:00.000Z");
     });
 
     it("maps every other degraded reason to `internal_error`", async () => {

--- a/packages/mcp/src/__tests__/tools.test.ts
+++ b/packages/mcp/src/__tests__/tools.test.ts
@@ -1040,6 +1040,24 @@ describe("MCP tools", () => {
       expect(envelope?.request_id).toBeTruthy();
     });
 
+    it("maps a rejected asOf to `validation_failed` — fix the argument, don't retry (#4916)", async () => {
+      // The caller's own timestamp refused. `internal_error` here would tell
+      // the agent to retry the identical call; `validation_failed` tells it
+      // the argument is the problem, which the message then names.
+      mockSearchBrainExecute.mockResolvedValueOnce({
+        error: 'asOf "yesterday-ish" is not a parseable timestamp.',
+        reason: REAL_BRAIN_TOOL_REASONS.invalidAsOf,
+      });
+      const { client } = await createTestClient();
+      const result = await client.callTool({
+        name: "searchBrain",
+        arguments: { query: "x", asOf: "yesterday-ish" },
+      });
+      expect(result.isError).toBe(true);
+      const envelope = parseAtlasMcpToolError(getContentText(result.content));
+      expect(envelope?.code).toBe("validation_failed");
+    });
+
     it("maps every other degraded reason to `internal_error`", async () => {
       mockSearchBrainExecute.mockResolvedValueOnce({
         error: "Company-brain search failed.",

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -377,6 +377,12 @@ export function registerTools(server: McpServer, opts: RegisterToolsOptions): vo
           .string()
           .optional()
           .describe("Documents only: ISO-8601 date; documents at or after this timestamp."),
+        asOf: z
+          .string()
+          .optional()
+          .describe(
+            "Facts only: ISO-8601 instant for a historical point read — the reviewed facts valid at that moment (superseded versions included; retracted never). Must be in the past. Omit for current beliefs.",
+          ),
         limit: z
           .number()
           .int()
@@ -433,14 +439,22 @@ export function registerTools(server: McpServer, opts: RegisterToolsOptions): vo
           // refusal to `internal_error` with nothing catching it.
           const obj = result as Record<string, unknown>;
           if (typeof obj.error === "string") {
-            // `reader_unresolved` is the ACL boundary; everything else is an
-            // Atlas-side fault. `request_id` rides on BOTH — the refusal is
-            // documented as an upstream defect deserving log correlation, and
-            // dropping the id there would leave an operator with nothing to
-            // grep for the one failure this surface most wants reported.
-            const refused = obj.reason === BRAIN_TOOL_REASONS.readerUnresolved;
+            // `reader_unresolved` is the ACL boundary; `invalid_as_of` (#4916)
+            // is the caller's own argument refused — `validation_failed`, so an
+            // agent fixes the timestamp instead of retrying an "internal"
+            // fault. Everything else is an Atlas-side fault. `request_id` rides
+            // on ALL of them — the refusal is documented as an upstream defect
+            // deserving log correlation, and dropping the id there would leave
+            // an operator with nothing to grep for the one failure this
+            // surface most wants reported.
+            const code =
+              obj.reason === BRAIN_TOOL_REASONS.readerUnresolved
+                ? "forbidden"
+                : obj.reason === BRAIN_TOOL_REASONS.invalidAsOf
+                  ? "validation_failed"
+                  : "internal_error";
             return toEnvelopeResult(
-              envelope(refused ? "forbidden" : "internal_error", obj.error, {
+              envelope(code, obj.error, {
                 request_id: requestId,
               }),
             );

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -27,7 +27,12 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { explore } from "@atlas/api/lib/tools/explore";
 import { executeSQL } from "@atlas/api/lib/tools/sql";
-import { BRAIN_TOOL_REASONS, searchBrain } from "@atlas/api/lib/tools/search-brain";
+import {
+  BRAIN_TOOL_REASONS,
+  searchBrain,
+  type BrainToolReason,
+} from "@atlas/api/lib/tools/search-brain";
+import type { AtlasMcpToolErrorCode } from "@useatlas/types/mcp";
 import { DEFAULT_SEARCH_LIMIT, MAX_SEARCH_LIMIT } from "@atlas/api/lib/brain/search";
 import {
   EXECUTE_SQL_ERROR_CODES,
@@ -381,7 +386,7 @@ export function registerTools(server: McpServer, opts: RegisterToolsOptions): vo
           .string()
           .optional()
           .describe(
-            "Facts only: ISO-8601 instant for a historical point read — the reviewed facts valid at that moment (superseded versions included; retracted never). Must be in the past. Omit for current beliefs.",
+            "Facts only: historical point read — the reviewed facts valid at that moment (superseded versions included; retracted never). ISO-8601 date (2026-07-27) or timestamp with an explicit zone (2026-07-27T09:00:00Z); zone-less times and future instants are rejected. Omit for current beliefs.",
           ),
         limit: z
           .number()
@@ -442,17 +447,32 @@ export function registerTools(server: McpServer, opts: RegisterToolsOptions): vo
             // `reader_unresolved` is the ACL boundary; `invalid_as_of` (#4916)
             // is the caller's own argument refused — `validation_failed`, so an
             // agent fixes the timestamp instead of retrying an "internal"
-            // fault. Everything else is an Atlas-side fault. `request_id` rides
-            // on ALL of them — the refusal is documented as an upstream defect
-            // deserving log correlation, and dropping the id there would leave
-            // an operator with nothing to grep for the one failure this
-            // surface most wants reported.
-            const code =
-              obj.reason === BRAIN_TOOL_REASONS.readerUnresolved
-                ? "forbidden"
-                : obj.reason === BRAIN_TOOL_REASONS.invalidAsOf
-                  ? "validation_failed"
-                  : "internal_error";
+            // fault. Everything else is an Atlas-side fault. `request_id`
+            // rides on ALL of them — the `reader_unresolved` refusal in
+            // particular is documented as an upstream defect deserving log
+            // correlation, and dropping the id there would leave an operator
+            // with nothing to grep for the one failure this surface most
+            // wants reported.
+            //
+            // A `satisfies`-checked map, not an if-chain: the next reason
+            // added to `BRAIN_TOOL_REASONS` is a COMPILE error here until
+            // somebody decides its envelope code — the silent-`internal_error`
+            // default is exactly the misclassification #4916 fixed for
+            // `invalid_as_of`. (`no_workspace` never accompanies `error` — it
+            // rides `unavailable` on a shaped response — but it still needs a
+            // row so the exhaustiveness check covers the whole vocabulary.)
+            const codeByReason = {
+              [BRAIN_TOOL_REASONS.readerUnresolved]: "forbidden",
+              [BRAIN_TOOL_REASONS.invalidAsOf]: "validation_failed",
+              [BRAIN_TOOL_REASONS.noInternalDb]: "internal_error",
+              [BRAIN_TOOL_REASONS.noWorkspace]: "internal_error",
+              [BRAIN_TOOL_REASONS.searchFailed]: "internal_error",
+            } as const satisfies Record<BrainToolReason, AtlasMcpToolErrorCode>;
+            const reason = obj.reason;
+            const code: AtlasMcpToolErrorCode =
+              typeof reason === "string" && reason in codeByReason
+                ? codeByReason[reason as BrainToolReason]
+                : "internal_error";
             return toEnvelopeResult(
               envelope(code, obj.error, {
                 request_id: requestId,

--- a/packages/types/src/brain.ts
+++ b/packages/types/src/brain.ts
@@ -935,6 +935,15 @@ export interface BrainSearchResponse {
    * stdio MCP actor has no workspace and takes this path on every call.
    */
   readonly unavailable?: BrainSearchUnavailable | null;
+  /**
+   * The bi-temporal point-read instant this page answered for (#4916), echoed
+   * back normalized to ISO-8601. Present ONLY on an as-of read — an as-of-now
+   * page omits it, so its absence is the statement "these are current beliefs".
+   * Carried because a historical fact page read WITHOUT this framing is
+   * indistinguishable from current belief, which is exactly the confusion a
+   * trust-labeled surface must not permit.
+   */
+  readonly asOf?: string;
 }
 
 /**


### PR DESCRIPTION
Closes #4916 (milestone-branch PR — will not auto-close; closed by hand after merge).

## What

T4/T7's bi-temporal read: `searchBrain` gains an optional `asOf` parameter — a point read returning the facts valid at that instant (`valid_from <= asOf < COALESCE(valid_to, ∞)`), each row gated by **that version's frozen `visible_to`** evaluated against **as-of-now membership**. "What did we believe Monday" uses Monday's grant.

## Boundary rules (all test-pinned)

- **Tombstoned facts stay hidden under any `asOf`** — retraction is the only verb that hides history. Superseded facts DO appear inside their window; that is the point of keeping them readable (#4912).
- **Default reads are byte-identical** — pinned by a golden full-SQL snapshot of the default fact statement.
- **Frozen grants cut both ways** — a widening between versions does not reach back (org reader sees nothing at Monday), and a narrowing does not rewrite history (once-public v1 stays historically readable). Both proven in `-pg` tests where the grant changed between versions.
- **Fail closed, never fall through**: blank, non-ISO, zone-less-time, sub-`timestamptz`-range, and future `asOf` values are rejected with context-specific errors (`BrainAsOfInvalidError` → tool reason `invalid_as_of` → MCP `validation_failed`). A zone-less time would be read in the *server's* timezone — silently shifting the point read per deployment — so it is malformed by definition. `asOf` with `include` excluding `"fact"` is refused too: only facts have a temporal axis.

## Surfaces

- Agent tool + MCP `searchBrain` input schemas expose `asOf` additively; results stay trust-tier + provenance labeled.
- Response echoes the normalized instant (`BrainSearchResponse.asOf`, additive in `@useatlas/types`) — a historical page must say it is one; absence is the "current beliefs" statement.
- MCP reason→envelope-code mapping is now a `satisfies`-checked exhaustive map (next reason added = compile error, not a silent `internal_error`).
- No REST route change: OpenAPI drift gate green (searchBrain is an agent/MCP tool, not a REST surface). `@useatlas/schemas` needs no mirror — it deliberately carries no searchBrain response parse (documented in `schemas/src/brain.ts`).

## Review + CI

- Internal 4-agent review panel run pre-PR: no blocking findings; all advisory items (strict ISO gate, `timestamptz` floor, echo scoping, branded `BrainAsOfInstant`, exhaustive MCP map, golden regression pin, MCP arg-forwarding tests, pg boundary-handoff + grant-narrowing tests) addressed in the second commit.
- `scripts/ci-local.sh`: 33 gates, 32 PASS; the one `test` failure was `plugins/mcp/__tests__/cli.test.ts` SIGTERM shutdown (untouched package, subprocess-timing flake under parallel load — passes in isolation).
- `-pg` suites ran locally against real Postgres (`TEST_DATABASE_URL` set): 13/13 pass.