### PR TITLE
chore(brain): e2e temporal-loop proof — conflict → correct → supersede → asOf (#4917)

### DIFF
--- a/packages/api/src/lib/brain/__tests__/temporal-loop-pg.test.ts
+++ b/packages/api/src/lib/brain/__tests__/temporal-loop-pg.test.ts
@@ -1,0 +1,903 @@
+/**
+ * The M2 temporal stack, proven end to end (#4917, ADR-0036 §Temporal,
+ * conflict & provenance) — the temporal counterpart of `wedge-loop-pg.test.ts`.
+ *
+ * ## Why this file exists when every temporal verb already has a suite
+ *
+ * Each M2 stage suite injects the previous stage's output as a literal — a
+ * draft row the test INSERTed, a tension edge the test wrote, a validity
+ * window the fixture posed. What none of them can observe is the HANDOFF:
+ * whether the edge reconcile actually writes is the edge both read surfaces
+ * actually cluster, whether the `valid_to` the publish gate actually stamps is
+ * the boundary the `asOf` branch actually reads, and whether the tombstone
+ * `correct_fact` actually stamps is hidden by every read that promised to hide
+ * it. Five PRs (#4912–#4916) each held one end of those seams. The assertions
+ * below are claims about the boundaries:
+ *
+ *   1. **Does the tension edge RECONCILE writes reach both surfaces?** The
+ *      advisory `in-tension-with` edge is written by `reconcile.ts` for a
+ *      `single`-cardinality rival and read back by `loadTensionClusters`
+ *      behind BOTH the review queue and `searchBrain` — three modules, one
+ *      edge row, and the failure mode is a conflict that silently reads as
+ *      "nothing contradicts this".
+ *   2. **Does the gate's stamp close the window the reads open?** The
+ *      `SUPERSEDE_STAMP_SQL` write and `supersedes` edge come from the row
+ *      version the promote transaction saw; the default read hides the loser
+ *      through `brainFactCurrentClause` and the `asOf` branch re-admits it —
+ *      the two branches of `buildFactQuery` against a stamp neither wrote.
+ *   3. **Does `correct_fact` retract hide history from EVERY read?** The
+ *      tombstone is stamped by `RETRACT_FACT_SQL` inside the correction
+ *      transaction; `invalidated_at IS NULL` survives in BOTH temporal
+ *      branches of the fact read (#4916 — retraction is the one verb whose
+ *      job is hiding history), and the `derives-from` dependents are flagged
+ *      through a provenance marker that must not touch any gated column.
+ *
+ * ## What is faked, precisely
+ *
+ * Exactly what `wedge-loop-pg.test.ts` fakes, for the reasons its header
+ * records: Slack's HTTP surface (the REAL `createSlackHistoryClient` runs on
+ * top of a fixture `SlackHistoryApi`) and the extraction model (a
+ * `MockLanguageModelV3` returning fixed JSON under the real `generateObject`
+ * parse). Everything else — ingest, extraction, reconcile with its tension
+ * pass, the publish gate with its supersession collision, the audience sync,
+ * `correct_fact`, and both read surfaces — is production code against real
+ * Postgres.
+ *
+ * ## Fixture discipline (inherited from #4775)
+ *
+ *   - Reader contexts come from `resolvePrincipalContext` against the real
+ *     `fact_audience_member` table — a hand-built context would make every ACL
+ *     assertion a statement about the fixture rather than the code.
+ *   - NO `workspace_plugins` install row is seeded, so
+ *     `upsertConnectorSyncState` silently no-ops and every sync reads a null
+ *     cursor. The premise is PINNED per sync (see `syncHistory`), because the
+ *     re-sync `duplicate` counts below rest on it.
+ *   - The clock is injected (`CLOCK`): the 7-day backfill floor would exclude
+ *     every fixture message against the real clock.
+ *   - `GRANT_UNUSABLE` remains the only gate refusal reachable from the
+ *     database; this file never exercises gate refusals — `wedge-loop-pg`
+ *     owns that arm.
+ *
+ * ## Three deliberate pins that are easy to misread as bugs
+ *
+ *   - **The gate-superseding winner has an UNRECORDED start.** The extraction
+ *     schema carries no `validFrom`, so a winner promoted at the gate lands
+ *     with `valid_from NULL` — and #4916 admits an unrecorded start at ANY
+ *     `asOf`. A reader entitled to both sides therefore sees BOTH claims on a
+ *     point read before the publish; only the loser's closed window, not the
+ *     winner's open one, encodes the arbitration. Pinned below rather than
+ *     "fixed" in the fixture.
+ *   - **Supersession is grant-blind.** The collision join never reads
+ *     `visible_to`, so an audience-granted winner retires an org-granted
+ *     loser for readers who will never see the winner: the org reader's
+ *     current belief simply ends. The frozen grant still serves them
+ *     yesterday's truth under `asOf` — that asymmetry IS the T5 design.
+ *   - **The correction episode never reaches the extraction queue.**
+ *     `extracted_at` is stamped at INSERT (#4915), so the drain after a
+ *     correction inspects nothing — a human's exact words are never re-derived
+ *     into a second, machine-produced claim.
+ *
+ * The `derives-from` fact→fact edge behind the flag-not-cascade arm is
+ * INSERTed by hand: ADR-0036 §M5's write-back is the producer that will mint
+ * those edges, and `DEPENDENT_FACTS_SQL` (the retraction's reader) is already
+ * live against the shape migration 0180 admits. Same posture as the wedge
+ * suite's import-shaped INSERT.
+ *
+ * Opt in locally with:
+ *   bun run db:up && export TEST_DATABASE_URL=postgresql://atlas:atlas@localhost:5432/atlas
+ */
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
+import { Effect } from "effect";
+import { Pool } from "pg";
+import { MockLanguageModelV3 } from "ai/test";
+import { runMigrations } from "@atlas/api/lib/db/migrate";
+import { MANAGED_AUTH_MIGRATIONS, _resetPool } from "@atlas/api/lib/db/internal";
+import { syncBrainEpisodeSource } from "@atlas/api/lib/brain/ingest/episode-sync";
+import {
+  _resetBrainExtractionFailures,
+  llmFactExtractor,
+  runBrainExtractionCycle,
+  type ResolvedExtractionModel,
+} from "@atlas/api/lib/brain/extract";
+import { promoteBrainFacts } from "@atlas/api/lib/content-mode/adapters/brain-facts";
+import { searchBrainCore } from "@atlas/api/lib/brain/search";
+import { loadFactCandidates } from "@atlas/api/lib/brain/candidates";
+import { correctFact } from "@atlas/api/lib/brain/correction";
+import { createSlackHistoryClient, type SlackHistoryApi } from "@atlas/api/lib/brain/ingest/slack/client";
+import { getChatBackfillWindowMs } from "@atlas/api/lib/brain/ingest/slack/connector";
+import { SLACK_HISTORY_SOURCE } from "@atlas/api/lib/brain/ingest/slack/config";
+import { chatChannelAudienceId } from "@atlas/api/lib/brain/ingest/grant";
+import {
+  runAudienceSyncCycle,
+  type AudienceSyncCycleResult,
+  type AudienceSyncDeps,
+} from "@atlas/api/lib/brain/audience/sync";
+import { resolvePrincipals } from "@atlas/api/lib/brain/audience/resolver";
+import { reconcileAudienceMembership } from "@atlas/api/lib/brain/audience/membership";
+import type { SlackDirectoryUser, SlackHistoryMessage } from "@atlas/api/lib/slack/api";
+import {
+  AUDIENCE_PREFIX,
+  resolvePrincipalContext,
+  type BrainPrincipalContext,
+} from "@atlas/api/lib/brain/acl";
+import type { BrainSourceConnector } from "@atlas/api/lib/brain/ingest/types";
+import type { AtlasMode } from "@useatlas/types/auth";
+import type { BrainFactResult, BrainSearchResult } from "@useatlas/types";
+
+const TEST_DB_URL = process.env.TEST_DATABASE_URL;
+const describeIfPg = TEST_DB_URL ? describe : describe.skip;
+const PG_TEST_TIMEOUT_MS = 60_000;
+
+const WORKSPACE = "ws-brain-temporal";
+const INSTALL_ID = "slack-history-temporal";
+const CATALOG_ID = "slack-history-test";
+
+/** The public channel — `isPrivate: false` resolves to `['org']`. */
+const PUBLIC_CHANNEL = "C0PUBLIC";
+/** The private channel — resolves to a single `audience:` token. */
+const EXEC_CHANNEL = "C0EXEC";
+
+/** Built through the real id helper, so the grant grammar cannot drift out from under the assertions. */
+const EXEC_AUDIENCE = chatChannelAudienceId(SLACK_HISTORY_SOURCE, EXEC_CHANNEL);
+const EXEC_GRANT_TOKEN = `${AUDIENCE_PREFIX}${EXEC_AUDIENCE}`;
+
+/**
+ * The injected clock — load-bearing, not decoration: the backfill window is 7
+ * days, so against the real clock every fixture message would fall outside the
+ * floor and the loop would ingest nothing (see `wedge-loop-pg.test.ts`).
+ */
+const CLOCK = () => new Date("2026-06-27T00:00:00.000Z");
+
+/**
+ * When the correction runs, on the same pinned timeline. Only the correction
+ * EPISODE's instants come from this; `invalidated_at` and `valid_to` are
+ * stamped by SQL `now()`, which is the production shape and is why the `asOf`
+ * instants below sit safely before the real test-run time.
+ */
+const CORRECTION_CLOCK = () => new Date("2026-06-27T12:00:00.000Z");
+
+/**
+ * The point-read instant: after both beliefs were ingested and the loser
+ * published, before the publish that superseded it (`valid_to` is stamped at
+ * real run time, far later than this). Past-relative-to-now, as
+ * `parseBrainAsOf` requires.
+ */
+const AS_OF = "2026-06-26T12:00:00Z";
+const AS_OF_ECHO = "2026-06-26T12:00:00.000Z";
+
+/** Message bodies, named so `EXTRACTIONS` cannot silently drift from the history. */
+const BODY = {
+  /** The incumbent belief — public channel, org grant. */
+  thursdays: "the deploy window is Thursdays",
+  /** The claim that will derive from the deploy window — the dependent's source. */
+  freeze: "the release freeze is the day before the deploy window",
+  /** Small talk in the exec channel; extraction yields nothing. */
+  lunch: "lunch?",
+  /** The conflicting rival — exec channel, audience grant, arrives a day later. */
+  fridays: "the deploy window is Fridays",
+} as const;
+
+function message(overrides: Partial<SlackHistoryMessage> & { ts: string; text: string }): SlackHistoryMessage {
+  return { user: "U_ADA", subtype: null, botId: null, ...overrides };
+}
+
+/**
+ * Synthetic Slack history. `ts` values are round instants so a near-miss in
+ * the Slack-ts conversion fails loudly on a provenance assertion.
+ */
+const CHANNEL_HISTORY: Readonly<Record<string, readonly SlackHistoryMessage[]>> = {
+  // 2026-06-25T10:00:00Z and 10:05:00Z
+  [PUBLIC_CHANNEL]: [
+    message({ ts: "1782381600.000100", text: BODY.thursdays, user: "U_ADA" }),
+    message({ ts: "1782381900.000200", text: BODY.freeze, user: "U_ADA" }),
+  ],
+  // 2026-06-25T11:00:00Z
+  [EXEC_CHANNEL]: [message({ ts: "1782385200.000300", text: BODY.lunch, user: "U_ALAN" })],
+};
+
+/** The rival claim, said in the EXEC channel a day later. 2026-06-26T11:00:00Z. */
+const FRIDAYS_MESSAGE = message({ ts: "1782471600.000400", text: BODY.fridays, user: "U_ALAN" });
+
+const PUBLIC_CHANNELS = new Set([PUBLIC_CHANNEL]);
+
+/**
+ * Slack's roster per channel. Only the PRIVATE channel's roster is ever read —
+ * the audience sync skips public channels — and `U_ADMIN` is what makes the
+ * workspace admin a member of the exec audience THROUGH production code
+ * (roster → directory email → Atlas user), not by fixture assertion. The org
+ * member (`user-member`) is deliberately in no roster: they are the reader the
+ * withheld-counterpart and frozen-grant arms below are about.
+ */
+const CHANNEL_ROSTER: Readonly<Record<string, readonly string[]>> = {
+  [PUBLIC_CHANNEL]: ["U_ADA"],
+  [EXEC_CHANNEL]: ["U_ADMIN", "U_ALAN"],
+};
+
+/** Slack's directory. `U_ALAN`'s address matches no Atlas user — logged, never guessed. */
+const SLACK_DIRECTORY: readonly SlackDirectoryUser[] = [
+  { id: "U_ADMIN", email: "admin@temporal.test", deleted: false, isBot: false },
+  { id: "U_ADA", email: "ada@temporal.test", deleted: false, isBot: false },
+  { id: "U_ALAN", email: "nobody@temporal.test", deleted: false, isBot: false },
+];
+
+type Candidate = {
+  readonly subject: string;
+  readonly predicate: string;
+  readonly object: string;
+  readonly cardinality: "single" | "multi";
+};
+
+/**
+ * What the mock model "extracts" from each body. `Partial` + a `BODY`-derived
+ * key type: editing a body then fails to COMPILE here rather than silently
+ * turning an extraction into the empty arm. Both deploy-window claims are
+ * `single` — that cardinality, on both sides, is what arms the tension pass
+ * and the gate's supersession collision.
+ */
+const EXTRACTIONS: Partial<Record<(typeof BODY)[keyof typeof BODY], readonly Candidate[]>> = {
+  [BODY.thursdays]: [
+    { subject: "deploy window", predicate: "is", object: "Thursdays", cardinality: "single" },
+  ],
+  [BODY.fridays]: [
+    { subject: "deploy window", predicate: "is", object: "Fridays", cardinality: "single" },
+  ],
+  [BODY.freeze]: [
+    {
+      subject: "release freeze",
+      predicate: "is",
+      object: "the day before the deploy window",
+      cardinality: "multi",
+    },
+  ],
+};
+
+type FactRow = {
+  readonly id: string;
+  readonly subject: string;
+  readonly object: string;
+  readonly status: string;
+  readonly predicate_cardinality: string;
+  readonly visible_to: string[];
+  readonly valid_from: Date | null;
+  readonly valid_to: Date | null;
+  readonly invalidated_at: Date | null;
+  readonly provenance: Record<string, unknown>;
+};
+
+describeIfPg("brain M2 temporal loop (real Postgres)", () => {
+  let pool: Pool;
+  let priorDatabaseUrl: string | undefined;
+  const schemaName = `brain_4917_${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
+
+  /** Bodies the model was asked about — the "was the seam even exercised" pin. */
+  let modelCalls: string[] = [];
+  /** Extra messages appended to a channel between sync passes (the rival's arrival). */
+  let extraMessages: Readonly<Record<string, readonly SlackHistoryMessage[]>> = {};
+
+  const mockModel = new MockLanguageModelV3({
+    doGenerate: async (options) => {
+      const prompt = JSON.stringify(options.prompt);
+      const body = (Object.keys(EXTRACTIONS) as (keyof typeof EXTRACTIONS)[]).find(
+        (candidate) => prompt.includes(candidate),
+      );
+      modelCalls.push(body ?? "(no match)");
+      return {
+        content: [
+          { type: "text" as const, text: JSON.stringify({ facts: body ? EXTRACTIONS[body] : [] }) },
+        ],
+        finishReason: { unified: "stop" as const, raw: "end_turn" },
+        usage: {
+          inputTokens: { total: 50, noCache: 50, cacheRead: 0, cacheWrite: 0 },
+          outputTokens: { total: 30, text: 30, reasoning: 0 },
+        },
+        warnings: [],
+      };
+    },
+  });
+
+  const EXTRACTION_MODEL = {
+    model: mockModel,
+    modelId: "mock-extractor",
+  } satisfies ResolvedExtractionModel;
+
+  beforeAll(async () => {
+    // `hasInternalDB()` reads `DATABASE_URL`, not the pool — without this the
+    // extraction cycle takes its "no database" path. Set inside the hook per
+    // the test-discipline rule; restored in `afterAll`.
+    priorDatabaseUrl = process.env.DATABASE_URL;
+    process.env.DATABASE_URL = TEST_DB_URL;
+    pool = new Pool({
+      connectionString: TEST_DB_URL,
+      options: `-c search_path="${schemaName}",public`,
+    });
+    const bootstrap = new Pool({ connectionString: TEST_DB_URL });
+    try {
+      await bootstrap.query(`CREATE SCHEMA IF NOT EXISTS "${schemaName}"`);
+    } finally {
+      await bootstrap.end();
+    }
+    await runMigrations(pool, { skip: MANAGED_AUTH_MIGRATIONS });
+    // Better-Auth-owned tables, stubbed for `wedge-loop-pg.test.ts`'s reasons:
+    // `organization` feeds the tier-cap lookup (missing TABLE fails closed and
+    // aborts the sync; missing ROW is the self-hosted "no tier cap" arm), and
+    // `"user"` + `member` feed the audience sync's email resolution.
+    await pool.query(`
+      CREATE TABLE IF NOT EXISTS organization (
+        id TEXT PRIMARY KEY,
+        name TEXT,
+        slug TEXT,
+        workspace_status TEXT,
+        plan_tier TEXT,
+        byot BOOLEAN,
+        "stripeCustomerId" TEXT,
+        trial_ends_at TIMESTAMPTZ,
+        suspended_at TIMESTAMPTZ,
+        suspension_source TEXT,
+        plan_override_until TIMESTAMPTZ,
+        deleted_at TIMESTAMPTZ,
+        region TEXT,
+        region_assigned_at TIMESTAMPTZ,
+        "createdAt" TIMESTAMPTZ NOT NULL DEFAULT now()
+      )
+    `);
+    await pool.query(`
+      CREATE TABLE IF NOT EXISTS "user" (
+        id TEXT PRIMARY KEY,
+        email TEXT NOT NULL
+      )
+    `);
+    await pool.query(`
+      CREATE TABLE IF NOT EXISTS member (
+        id TEXT PRIMARY KEY,
+        "organizationId" TEXT NOT NULL,
+        "userId" TEXT NOT NULL,
+        role TEXT
+      )
+    `);
+    await pool.query(
+      `INSERT INTO "user" (id, email) VALUES ($1, $2) ON CONFLICT (id) DO NOTHING`,
+      ["user-admin", "admin@temporal.test"],
+    );
+    await pool.query(
+      `INSERT INTO member (id, "organizationId", "userId", role)
+       VALUES ($1, $2, $3, $4) ON CONFLICT (id) DO NOTHING`,
+      ["m-admin", WORKSPACE, "user-admin", "admin"],
+    );
+    // The ingest/extraction/correction stages write through the module-level
+    // pool, so it has to BE this schema-scoped one.
+    _resetPool(pool);
+  }, PG_TEST_TIMEOUT_MS);
+
+  afterAll(async () => {
+    _resetPool(null);
+    if (priorDatabaseUrl === undefined) delete process.env.DATABASE_URL;
+    else process.env.DATABASE_URL = priorDatabaseUrl;
+    if (pool) {
+      await pool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+      await pool.end();
+    }
+  }, PG_TEST_TIMEOUT_MS);
+
+  afterEach(async () => {
+    // One atomic statement + a `finally` reset, for `wedge-loop-pg.test.ts`'s
+    // reason: a part-way failure must not cascade into the next test.
+    try {
+      await pool.query(
+        `TRUNCATE brain_edges, brain_facts, brain_episodes, fact_audience_member, knowledge_sync_state, admin_action_log`,
+      );
+    } finally {
+      _resetBrainExtractionFailures();
+      modelCalls = [];
+      extraMessages = {};
+    }
+  });
+
+  // ── stage drivers (the wedge suite's, minus what this loop never uses) ──
+
+  const slackApi: SlackHistoryApi = {
+    getConversationInfo: (_token, channelId) =>
+      Promise.resolve({
+        ok: true as const,
+        channel: {
+          id: channelId,
+          name: channelId.toLowerCase(),
+          isPrivate: !PUBLIC_CHANNELS.has(channelId),
+          isMember: true,
+          isArchived: false,
+        },
+      }),
+    fetchConversationHistoryPage: (_token, params) => {
+      const known = CHANNEL_HISTORY[params.channel];
+      if (known === undefined) {
+        return Promise.resolve({ ok: false as const, error: "channel_not_found" as const, retryAfterSeconds: null });
+      }
+      const all = [...known, ...(extraMessages[params.channel] ?? [])];
+      const oldest = params.oldest === undefined ? null : Number(params.oldest);
+      if (oldest !== null && Number.isNaN(oldest)) {
+        throw new Error(`fixture: non-numeric oldest bound ${params.oldest} — the Slack-ts format changed`);
+      }
+      const messages = oldest === null ? all : all.filter((m) => Number(m.ts) > oldest);
+      return Promise.resolve({ ok: true as const, messages, nextCursor: null, dropped: 0 });
+    },
+  };
+
+  const connector: BrainSourceConnector = {
+    catalogId: CATALOG_ID,
+    source: SLACK_HISTORY_SOURCE,
+    createClient: () =>
+      createSlackHistoryClient({
+        token: "xoxb-test",
+        channels: [PUBLIC_CHANNEL, EXEC_CHANNEL],
+        backfillWindowMs: getChatBackfillWindowMs(),
+        api: slackApi,
+        now: CLOCK,
+      }),
+  };
+
+  /** `syncBrainEpisodeSource` never throws — the outcome is asserted here once. */
+  async function syncHistory() {
+    const outcome = await syncBrainEpisodeSource({
+      connector,
+      workspaceId: WORKSPACE,
+      installId: INSTALL_ID,
+      config: null,
+      now: CLOCK,
+    });
+    expect(outcome).toMatchObject({
+      status: "success",
+      error: null,
+      coverageIncomplete: false,
+      warnings: [],
+    });
+    // The cursor-less premise the `duplicate` counts below rest on — see the
+    // header's fixture-discipline bullet and the wedge suite's fuller note.
+    const { rows: premise } = await pool.query<{ installs: string; state: string }>(
+      `SELECT (SELECT count(*)::text FROM workspace_plugins WHERE workspace_id = $1 AND install_id = $2) AS installs,
+              (SELECT count(*)::text FROM knowledge_sync_state WHERE workspace_id = $1) AS state`,
+      [WORKSPACE, INSTALL_ID],
+    );
+    expect(premise[0]).toEqual({ installs: "0", state: "0" });
+    return outcome;
+  }
+
+  /** The extraction fiber, driving the real `llmFactExtractor`. */
+  async function extract() {
+    const cycle = await Effect.runPromise(
+      runBrainExtractionCycle({
+        extract: llmFactExtractor,
+        resolveModel: async (workspaceId) => {
+          expect(workspaceId).toBe(WORKSPACE);
+          return EXTRACTION_MODEL;
+        },
+      }),
+    );
+    expect(cycle).toMatchObject({
+      status: "success",
+      failed: 0,
+      blockedEpisodes: 0,
+      factsBlocked: 0,
+      outageRefunded: 0,
+    });
+    expect(cycle.skipped).toEqual({ model_unavailable: 0, no_body: 0, quarantined: 0 });
+    return cycle;
+  }
+
+  /** The review gate, in a transaction, as `/admin/publish` runs it. */
+  async function publish() {
+    const client = await pool.connect();
+    try {
+      await client.query("BEGIN");
+      const report = await Effect.runPromise(promoteBrainFacts(client, WORKSPACE));
+      await client.query("COMMIT");
+      client.release();
+      return report;
+    } catch (err) {
+      await client.query("ROLLBACK").catch((rollbackErr: unknown) => {
+        console.debug(
+          "publish(): ROLLBACK failed after a promote error",
+          rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr),
+        );
+      });
+      // Destroyed, not recycled — a client with an open transaction holds the
+      // `FOR UPDATE` locks and would block `afterEach`'s TRUNCATE.
+      client.release(err instanceof Error ? err : new Error(String(err)));
+      throw err;
+    }
+  }
+
+  /** The fused read. `asOf` present ⇒ the bi-temporal point read (#4916). */
+  function search(
+    ctx: BrainPrincipalContext,
+    options: { mode?: AtlasMode; query?: string; asOf?: string } = {},
+  ) {
+    return searchBrainCore(pool, {
+      ctx,
+      mode: options.mode ?? "published",
+      query: options.query,
+      include: ["fact", "raw-episode"],
+      expand: false,
+      limit: 25,
+      ...(options.asOf !== undefined ? { asOf: options.asOf } : {}),
+    });
+  }
+
+  /** Reader contexts, resolved the way production resolves them. */
+  function readerFor(userId: string, role: "admin" | "member"): Promise<BrainPrincipalContext> {
+    return resolvePrincipalContext(pool, {
+      workspaceId: WORKSPACE,
+      mode: "managed",
+      userId,
+      resolvedRole: { role, orgId: WORKSPACE },
+    });
+  }
+
+  /** The reviewer/corrector — a member of the exec audience via the roster sync. */
+  const admin = () => readerFor("user-admin", "admin");
+  /** An org member in no audience — the withheld-arm and frozen-grant reader. */
+  const member = () => readerFor("user-member", "member");
+
+  /** The real audience-membership sync (#4801), on the wedge suite's seams. */
+  async function syncAudiences(): Promise<AudienceSyncCycleResult> {
+    const result = await runAudienceSyncCycle({
+      api: {
+        getConversationInfo: slackApi.getConversationInfo,
+        fetchConversationMembersPage: (_token, params) => {
+          const roster = CHANNEL_ROSTER[params.channel];
+          if (roster === undefined) {
+            return Promise.resolve({
+              ok: false as const,
+              error: "channel_not_found" as const,
+              retryAfterSeconds: null,
+            });
+          }
+          return Promise.resolve({ ok: true as const, memberIds: roster, nextCursor: null });
+        },
+        fetchUsersListPage: () =>
+          Promise.resolve({
+            ok: true as const,
+            users: SLACK_DIRECTORY,
+            nextCursor: null,
+            dropped: 0,
+          }),
+      },
+      query: (<T extends Record<string, unknown>>() =>
+        Promise.resolve([
+          { workspace_id: WORKSPACE, install_id: INSTALL_ID, config: { channels: [PUBLIC_CHANNEL, EXEC_CHANNEL] } },
+        ] as unknown as T[])) as AudienceSyncDeps["query"],
+      resolveToken: () => Promise.resolve("xoxb-test"),
+      resolve: (workspaceId, principals) =>
+        resolvePrincipals(workspaceId, principals, { query: poolQuery }),
+      reconcile: (input) =>
+        reconcileAudienceMembership(input, { withTransaction: poolTransaction }),
+    });
+    expect(result.status).toBe("success");
+    return result;
+  }
+
+  const poolQuery = async <T extends Record<string, unknown>>(
+    sql: string,
+    params?: unknown[],
+  ): Promise<T[]> => {
+    const { rows } = await pool.query(sql, params);
+    return rows as T[];
+  };
+
+  const poolTransaction = async <T>(
+    fn: (tx: { query: (sql: string, params?: unknown[]) => Promise<{ rows: readonly unknown[] }> }) => Promise<T>,
+  ): Promise<T> => {
+    const client = await pool.connect();
+    try {
+      await client.query("BEGIN");
+      const out = await fn({
+        query: async (sql, params) => {
+          const res = await client.query(sql, params);
+          return { rows: res.rows as readonly unknown[] };
+        },
+      });
+      await client.query("COMMIT");
+      return out;
+    } catch (err) {
+      await client.query("ROLLBACK").catch((rbErr: unknown) => {
+        console.debug("fixture rollback failed", rbErr);
+      });
+      throw err;
+    } finally {
+      client.release();
+    }
+  };
+
+  // ── row helpers ─────────────────────────────────────────────────────────
+
+  async function facts(): Promise<readonly FactRow[]> {
+    const { rows } = await pool.query<FactRow>(
+      `SELECT id, subject, object, status, predicate_cardinality, visible_to,
+              valid_from, valid_to, invalidated_at, provenance
+         FROM brain_facts ORDER BY subject, object`,
+    );
+    return rows;
+  }
+
+  /** Named throws, not `!` — a failure must name the row a stage failed to write. */
+  function factByClaim(rows: readonly FactRow[], subject: string, object: string): FactRow {
+    const row = rows.find((f) => f.subject === subject && f.object === object);
+    if (!row) {
+      throw new Error(
+        `no brain_facts row asserting "${subject} … ${object}"; saw [${rows
+          .map((f) => `${f.subject} … ${f.object}`)
+          .join(", ")}]`,
+      );
+    }
+    return row;
+  }
+
+  async function edgeCount(
+    edgeType: string,
+    fromFactId: string,
+    to: { factId?: string; episodeId?: string },
+  ): Promise<number> {
+    const toClause = to.factId !== undefined ? `to_fact_id = $4::uuid` : `to_episode_id = $4::uuid`;
+    const { rows } = await pool.query<{ n: string }>(
+      `SELECT count(*)::text AS n FROM brain_edges
+        WHERE workspace_id = $1 AND edge_type = $2 AND from_fact_id = $3::uuid AND ${toClause}`,
+      [WORKSPACE, edgeType, fromFactId, to.factId ?? to.episodeId],
+    );
+    return Number(rows[0]?.n ?? "0");
+  }
+
+  const isFact = (r: BrainSearchResult): r is BrainFactResult => r.tier === "fact";
+
+  const byText = (a: string, b: string) => a.localeCompare(b);
+  const subjectsOf = (results: readonly BrainSearchResult[]) =>
+    results.filter(isFact).map((f) => f.subject).toSorted(byText);
+  /** The deploy-window objects a read served — the loop's central projection. */
+  const deployObjectsOf = (results: readonly BrainSearchResult[]) =>
+    results
+      .filter(isFact)
+      .filter((f) => f.subject === "deploy window")
+      .map((f) => f.object)
+      .toSorted(byText);
+
+  // ── the loop ────────────────────────────────────────────────────────────
+
+  it(
+    "walks conflict → advisory tension → gate supersession → asOf → correct_fact retract, end to end",
+    async () => {
+      // ---- 1. the incumbent belief, published -----------------------------
+      const sync = await syncHistory();
+      expect(sync.episodes).toMatchObject({ inserted: 3, duplicate: 0 });
+      const cycle = await extract();
+      expect(cycle).toMatchObject({ inspected: 3, extracted: 3, factsCreated: 2 });
+      expect(modelCalls.toSorted(byText)).toEqual(
+        [BODY.thursdays, BODY.freeze, "(no match)"].toSorted(byText),
+      );
+      const firstPublish = await publish();
+      expect(firstPublish.promoted).toBe(2);
+      expect(firstPublish.refused).toEqual([]);
+      // Nothing published before it — the supersession machinery must be inert
+      // on a conflict-free publish, or every later assertion about it is noise.
+      expect(firstPublish.superseded).toEqual([]);
+
+      const synced = await syncAudiences();
+      expect(synced.membersAdded).toBe(1);
+
+      let rows = await facts();
+      const thursdays = factByClaim(rows, "deploy window", "Thursdays");
+      const freeze = factByClaim(rows, "release freeze", "the day before the deploy window");
+      expect(thursdays).toMatchObject({
+        status: "published",
+        predicate_cardinality: "single",
+        visible_to: ["org"],
+        valid_to: null,
+        invalidated_at: null,
+      });
+
+      // ---- 2. the rival arrives — draft + advisory tension edge -----------
+      extraMessages = { [EXEC_CHANNEL]: [FRIDAYS_MESSAGE] };
+      const second = await syncHistory();
+      expect(second.episodes).toMatchObject({ inserted: 1, duplicate: 3 });
+      const rivalCycle = await extract();
+      expect(rivalCycle).toMatchObject({ inspected: 1, extracted: 1, factsCreated: 1, factsCorroborated: 0 });
+
+      rows = await facts();
+      const fridays = factByClaim(rows, "deploy window", "Fridays");
+      // The rival is a DRAFT with the exec channel's derived grant — reconcile
+      // recorded the conflict, it arbitrated nothing.
+      expect(fridays).toMatchObject({
+        status: "draft",
+        predicate_cardinality: "single",
+        visible_to: [EXEC_GRANT_TOKEN],
+        valid_to: null,
+        invalidated_at: null,
+      });
+      expect(factByClaim(rows, "deploy window", "Thursdays").status).toBe("published");
+      // The edge reconcile wrote: newer claim → incumbent, exactly once.
+      expect(await edgeCount("in-tension-with", fridays.id, { factId: thursdays.id })).toBe(1);
+
+      // ---- 3. surfaced-both-with-provenance, on BOTH read surfaces --------
+      // The org member sees the incumbent, and the rival they may not read is
+      // REPORTED rather than dropped — the withheld arm (negative: a reader
+      // who cannot see one side).
+      const memberCtx = await member();
+      const memberView = await search(memberCtx);
+      expect(subjectsOf(memberView.results)).toEqual(["deploy window", "release freeze"]);
+      const memberIncumbent = memberView.results.filter(isFact).find((f) => f.subject === "deploy window");
+      expect(memberIncumbent).toMatchObject({ object: "Thursdays", status: "published" });
+      expect(memberIncumbent?.tensions).toEqual([{ visible: false, withheldCount: 1 }]);
+
+      // The exec-audience admin sees the SAME cluster with the rival's full
+      // claim and provenance — surfaced-both, never ranked.
+      const adminCtx = await admin();
+      const adminView = await search(adminCtx);
+      // The draft rival is not itself served in published mode; it reaches the
+      // reader only as the incumbent's counterpart.
+      expect(deployObjectsOf(adminView.results)).toEqual(["Thursdays"]);
+      const adminIncumbent = adminView.results.filter(isFact).find((f) => f.subject === "deploy window");
+      expect(adminIncumbent?.tensions).toHaveLength(1);
+      expect(adminIncumbent?.tensions[0]).toMatchObject({
+        visible: true,
+        factId: fridays.id,
+        // The edge points newer → incumbent, so from the incumbent's side the
+        // counterpart sits on the `from` end.
+        edgeDirection: "from",
+        object: "Fridays",
+        status: "draft",
+        invalidatedAt: null,
+        provenance: {
+          source: SLACK_HISTORY_SOURCE,
+          attribution: { visible: true, actor: "slack:U_ALAN" },
+        },
+      });
+
+      // The REVIEWER's queue holds the rival with the incumbent as its
+      // counterpart — same edge, other surface, per-rival projection.
+      const queue = await loadFactCandidates(pool, { ctx: adminCtx, limit: 50, offset: 0 });
+      expect(queue.total).toBe(1);
+      expect(queue.candidates[0]).toMatchObject({
+        id: fridays.id,
+        object: "Fridays",
+        provenance: { source: SLACK_HISTORY_SOURCE, attribution: { visible: true, actor: "slack:U_ALAN" } },
+      });
+      expect(queue.candidates[0]?.tensions).toEqual([
+        expect.objectContaining({
+          visible: true,
+          factId: thursdays.id,
+          edgeDirection: "to",
+          object: "Thursdays",
+          status: "published",
+          invalidatedAt: null,
+        }),
+      ]);
+
+      // ---- 4. the reviewer publishes — supersession at the gate -----------
+      const gate = await publish();
+      expect(gate.promoted).toBe(1);
+      expect(gate.refused).toEqual([]);
+      expect(gate.superseded).toEqual([{ rowId: fridays.id, superseded: [thursdays.id] }]);
+
+      rows = await facts();
+      const loser = factByClaim(rows, "deploy window", "Thursdays");
+      const winner = factByClaim(rows, "deploy window", "Fridays");
+      // The stamp closed the loser's window and ONLY its window: still
+      // published (the review verdict stands), still not retracted.
+      expect(loser.valid_to).not.toBeNull();
+      expect(loser).toMatchObject({ status: "published", invalidated_at: null });
+      // The winner is current, with an UNRECORDED start — the extraction
+      // schema carries no validFrom, so only the loser's closed window encodes
+      // the arbitration (see the header pin).
+      expect(winner).toMatchObject({ status: "published", valid_to: null, valid_from: null });
+      // The arbitration record, new → old.
+      expect(await edgeCount("supersedes", winner.id, { factId: loser.id })).toBe(1);
+
+      // ---- 5. default reads: the survivor only ----------------------------
+      const adminNow = await search(adminCtx);
+      expect(deployObjectsOf(adminNow.results)).toEqual(["Fridays"]);
+      expect("asOf" in adminNow).toBe(false);
+      // Supersession is grant-blind (header pin): the org member's belief
+      // simply ENDS — the loser is no longer current and the winner's frozen
+      // audience grant withholds it.
+      const memberNow = await search(memberCtx);
+      expect(subjectsOf(memberNow.results)).toEqual(["release freeze"]);
+
+      // ---- 6. asOf: yesterday's truth under the frozen grant --------------
+      // The org member's point read serves the superseded claim again — gated
+      // by the row's own frozen `['org']` grant, with its provenance intact —
+      // and the winner stays withheld by ITS frozen grant.
+      const memberThen = await search(memberCtx, { asOf: AS_OF });
+      expect(memberThen.asOf).toBe(AS_OF_ECHO);
+      expect(deployObjectsOf(memberThen.results)).toEqual(["Thursdays"]);
+      const memberThenFact = memberThen.results.filter(isFact).find((f) => f.subject === "deploy window");
+      expect(memberThenFact?.validTo).not.toBeNull();
+      expect(memberThenFact?.provenance).toMatchObject({
+        source: SLACK_HISTORY_SOURCE,
+        attribution: { visible: true, actor: "slack:U_ADA" },
+      });
+      // A reader entitled to BOTH sides sees both at the instant: the winner's
+      // unrecorded start is admitted at any `asOf` by design (#4916 — the
+      // point read must not diverge from the default read on NULL
+      // `valid_from`). Pinned, not worked around.
+      const adminThen = await search(adminCtx, { asOf: AS_OF });
+      expect(deployObjectsOf(adminThen.results)).toEqual(["Fridays", "Thursdays"]);
+
+      // ---- 7. correct_fact retract: tombstone + flag, never cascade -------
+      // The write-back-shaped lineage edge (header note): the freeze claim
+      // derives from the deploy-window belief being retracted.
+      await pool.query(
+        `INSERT INTO brain_edges (workspace_id, edge_type, from_fact_id, to_fact_id)
+         VALUES ($1, 'derives-from', $2::uuid, $3::uuid)`,
+        [WORKSPACE, freeze.id, winner.id],
+      );
+
+      const correction = await correctFact(
+        { ctx: adminCtx, factId: winner.id, verb: "retract", reason: "wrong side of the rename" },
+        { now: CORRECTION_CLOCK },
+      );
+      if (correction.kind !== "corrected") {
+        throw new Error(`retract did not apply: ${JSON.stringify(correction)}`);
+      }
+      expect(correction.result).toMatchObject({
+        verb: "retract",
+        factId: winner.id,
+        supersededBy: null,
+        validTo: null,
+        flaggedForReReview: [freeze.id],
+      });
+      expect(correction.result.invalidatedAt).not.toBeNull();
+
+      // The immutable human record: a `human` episode carrying the target's
+      // own grant, pre-stamped off the extraction queue (#4915).
+      const { rows: correctionEpisodes } = await pool.query<{
+        source: string;
+        source_actor: string | null;
+        visible_to: string[];
+        extracted_at: Date | null;
+      }>(
+        `SELECT source, source_actor, visible_to, extracted_at FROM brain_episodes WHERE id = $1::uuid`,
+        [correction.result.correctionEpisodeId],
+      );
+      expect(correctionEpisodes[0]).toMatchObject({
+        source: "human",
+        source_actor: "user-admin",
+        visible_to: [EXEC_GRANT_TOKEN],
+      });
+      expect(correctionEpisodes[0]?.extracted_at).not.toBeNull();
+      // Lineage, fact → correction episode: `derives-from`, not evidence.
+      expect(
+        await edgeCount("derives-from", winner.id, {
+          episodeId: correction.result.correctionEpisodeId,
+        }),
+      ).toBe(1);
+      // …and the drain confirms the pre-stamp: nothing queued, nothing
+      // re-derived from the human's words.
+      const afterCorrection = await extract();
+      expect(afterCorrection).toMatchObject({ inspected: 0, extracted: 0, factsCreated: 0 });
+
+      // The dependent was FLAGGED, not cascaded: marker in provenance, every
+      // gated column untouched, still served.
+      rows = await facts();
+      const flagged = factByClaim(rows, "release freeze", "the day before the deploy window");
+      expect(flagged).toMatchObject({ status: "published", valid_to: null, invalidated_at: null });
+      expect(flagged.provenance.reReview).toMatchObject({
+        reason: "derives-from-retracted",
+        retractedFactId: winner.id,
+        correctionEpisodeId: correction.result.correctionEpisodeId,
+      });
+
+      // ---- 8. the tombstone is hidden from EVERY read ---------------------
+      // Default read: the retracted survivor is gone; the flagged dependent is
+      // not (flag ≠ cascade, through the reader's eyes).
+      const adminAfter = await search(adminCtx);
+      expect(deployObjectsOf(adminAfter.results)).toEqual([]);
+      expect(subjectsOf(adminAfter.results)).toEqual(["release freeze"]);
+      // The point read hides it too — retraction is the one verb whose job is
+      // hiding history (#4916) — while the SUPERSEDED claim's history
+      // survives: retracting the winner does not resurrect or destroy the
+      // loser's window.
+      const adminThenAfter = await search(adminCtx, { asOf: AS_OF });
+      expect(deployObjectsOf(adminThenAfter.results)).toEqual(["Thursdays"]);
+      const memberThenAfter = await search(memberCtx, { asOf: AS_OF });
+      expect(deployObjectsOf(memberThenAfter.results)).toEqual(["Thursdays"]);
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+});

--- a/packages/api/src/lib/brain/__tests__/temporal-loop-pg.test.ts
+++ b/packages/api/src/lib/brain/__tests__/temporal-loop-pg.test.ts
@@ -17,14 +17,17 @@
  *   1. **Does the tension edge RECONCILE writes reach both surfaces?** The
  *      advisory `in-tension-with` edge is written by `reconcile.ts` for a
  *      `single`-cardinality rival and read back by `loadTensionClusters`
- *      behind BOTH the review queue and `searchBrain` — three modules, one
- *      edge row, and the failure mode is a conflict that silently reads as
- *      "nothing contradicts this".
+ *      behind BOTH the review queue and `searchBrain` — one writer, one
+ *      shared walk, two surfaces, one edge row, and the failure mode is a
+ *      conflict that silently reads as "nothing contradicts this".
  *   2. **Does the gate's stamp close the window the reads open?** The
- *      `SUPERSEDE_STAMP_SQL` write and `supersedes` edge come from the row
- *      version the promote transaction saw; the default read hides the loser
- *      through `brainFactCurrentClause` and the `asOf` branch re-admits it —
- *      the two branches of `buildFactQuery` against a stamp neither wrote.
+ *      `SUPERSEDE_STAMP_SQL` write and `supersedes` edge come from the
+ *      collision the promote transaction computed, re-checked at stamp time
+ *      against whatever the published rows have since become (the published
+ *      side is NOT covered by `DRAFT_FACTS_SQL`'s `FOR UPDATE`). The default
+ *      read then hides the loser through `brainFactCurrentClause` and the
+ *      `asOf` branch re-admits it — the two branches of `buildFactQuery`
+ *      against a stamp neither wrote.
  *   3. **Does `correct_fact` retract hide history from EVERY read?** The
  *      tombstone is stamped by `RETRACT_FACT_SQL` inside the correction
  *      transaction; `invalidated_at IS NULL` survives in BOTH temporal
@@ -35,13 +38,23 @@
  * ## What is faked, precisely
  *
  * Exactly what `wedge-loop-pg.test.ts` fakes, for the reasons its header
- * records: Slack's HTTP surface (the REAL `createSlackHistoryClient` runs on
- * top of a fixture `SlackHistoryApi`) and the extraction model (a
- * `MockLanguageModelV3` returning fixed JSON under the real `generateObject`
- * parse). Everything else — ingest, extraction, reconcile with its tension
- * pass, the publish gate with its supersession collision, the audience sync,
- * `correct_fact`, and both read surfaces — is production code against real
- * Postgres.
+ * records:
+ *
+ *   - **Slack's HTTP surface** — a fixture `SlackHistoryApi`, with the REAL
+ *     `createSlackHistoryClient` on top of it. NOT on the path:
+ *     `createSlackHistoryConnector` and its `parseSlackHistoryConfig` /
+ *     `resolveSlackHistoryToken` (`slack-connector.test.ts` owns those), which
+ *     is why the connector below is a test-owned shim.
+ *   - **The extraction model** — a `MockLanguageModelV3` returning fixed JSON
+ *     under the real `generateObject` schema parse.
+ *   - **The audience sync's install scan and token resolution** — this suite
+ *     deliberately seeds no `workspace_plugins` row, so the scan is supplied
+ *     directly. Its staleness sweep, principal resolver, and membership
+ *     reconcile all run for real (see `syncAudiences`).
+ *
+ * Everything else — ingest, extraction, reconcile with its tension pass, the
+ * publish gate with its supersession collision, `correct_fact`, and both read
+ * surfaces — is production code against real Postgres.
  *
  * ## Fixture discipline (inherited from #4775)
  *
@@ -70,18 +83,26 @@
  *   - **Supersession is grant-blind.** The collision join never reads
  *     `visible_to`, so an audience-granted winner retires an org-granted
  *     loser for readers who will never see the winner: the org reader's
- *     current belief simply ends. The frozen grant still serves them
- *     yesterday's truth under `asOf` — that asymmetry IS the T5 design.
+ *     current belief simply ends. That the frozen grant still serves them
+ *     yesterday's truth under `asOf` IS T5, and falls out of grant
+ *     immutability. That the COLLISION is grant-blind is a separate thing
+ *     and a consequence no ADR and no `supersessionCollisionJoin` doc states
+ *     — pinned here so a future change to it has to argue with a test.
  *   - **The correction episode never reaches the extraction queue.**
  *     `extracted_at` is stamped at INSERT (#4915), so the drain after a
  *     correction inspects nothing — a human's exact words are never re-derived
  *     into a second, machine-produced claim.
  *
  * The `derives-from` fact→fact edge behind the flag-not-cascade arm is
- * INSERTed by hand: ADR-0036 §M5's write-back is the producer that will mint
- * those edges, and `DEPENDENT_FACTS_SQL` (the retraction's reader) is already
- * live against the shape migration 0180 admits. Same posture as the wedge
- * suite's import-shaped INSERT.
+ * INSERTed by hand, and the shape is not speculative: it is FORK LINEAGE
+ * (ADR-0036 §T4, migration 0180), and the region import accepts it today —
+ * `admin-migrate.ts`'s validator lets `derives-from` "legitimately reach
+ * either kind" where every other edge type is constrained. So this INSERT
+ * mimics an import bundle, exactly as the wedge suite's does, rather than
+ * standing in for a producer that does not exist yet. (M5's write-back may
+ * also mint these; what it is documented to mint is fact→EPISODE, which is
+ * the shape `DERIVES_FROM_EDGE_SQL` already writes.) `DEPENDENT_FACTS_SQL`,
+ * the retraction's reader, is live against it either way.
  *
  * Opt in locally with:
  *   bun run db:up && export TEST_DATABASE_URL=postgresql://atlas:atlas@localhost:5432/atlas
@@ -109,6 +130,8 @@ import { getChatBackfillWindowMs } from "@atlas/api/lib/brain/ingest/slack/conne
 import { SLACK_HISTORY_SOURCE } from "@atlas/api/lib/brain/ingest/slack/config";
 import { chatChannelAudienceId } from "@atlas/api/lib/brain/ingest/grant";
 import {
+  AUDIENCE_STALENESS_SQL,
+  AUDIENCE_SYNC_INSTALLS_SQL,
   runAudienceSyncCycle,
   type AudienceSyncCycleResult,
   type AudienceSyncDeps,
@@ -122,8 +145,14 @@ import {
   type BrainPrincipalContext,
 } from "@atlas/api/lib/brain/acl";
 import type { BrainSourceConnector } from "@atlas/api/lib/brain/ingest/types";
+import type { BrainEdgeType, PredicateCardinality } from "@atlas/api/lib/brain/types";
 import type { AtlasMode } from "@useatlas/types/auth";
-import type { BrainFactResult, BrainSearchResult } from "@useatlas/types";
+import type {
+  BrainEpisodeResult,
+  BrainFactResult,
+  BrainFactReviewStatus,
+  BrainSearchResult,
+} from "@useatlas/types";
 
 const TEST_DB_URL = process.env.TEST_DATABASE_URL;
 const describeIfPg = TEST_DB_URL ? describe : describe.skip;
@@ -150,18 +179,33 @@ const EXEC_GRANT_TOKEN = `${AUDIENCE_PREFIX}${EXEC_AUDIENCE}`;
 const CLOCK = () => new Date("2026-06-27T00:00:00.000Z");
 
 /**
- * When the correction runs, on the same pinned timeline. Only the correction
- * EPISODE's instants come from this; `invalidated_at` and `valid_to` are
- * stamped by SQL `now()`, which is the production shape and is why the `asOf`
- * instants below sit safely before the real test-run time.
+ * When the correction runs, on the same pinned timeline.
+ *
+ * It supplies the correction EPISODE's instants and the retraction's
+ * `reReview.flaggedAt` marker — both asserted below. It does NOT supply
+ * `invalidated_at` or `valid_to`: those are stamped by SQL `now()`, which is
+ * the production shape and is why the `asOf` instants here sit safely before
+ * the real test-run time.
  */
 const CORRECTION_CLOCK = () => new Date("2026-06-27T12:00:00.000Z");
+const CORRECTION_AT = CORRECTION_CLOCK().toISOString();
 
 /**
- * The point-read instant: after both beliefs were ingested and the loser
- * published, before the publish that superseded it (`valid_to` is stamped at
- * real run time, far later than this). Past-relative-to-now, as
- * `parseBrainAsOf` requires.
+ * The instant the "yesterday's truth" arms read at.
+ *
+ * Be precise about what it does and does not discriminate. Both facts here are
+ * born of the extraction path, whose schema carries no `validFrom`, so both
+ * rows have `valid_from NULL` — and `valid_to` is stamped with SQL `now()` at
+ * real run time, far in this instant's future. So the point read admits both
+ * rows through the `valid_from IS NULL` arm and the far-future upper bound:
+ * ANY past instant would satisfy the assertions that use this constant, and it
+ * is chosen for readability (it sits between the two beliefs' arrival) rather
+ * than because a boundary turns on it.
+ *
+ * The predicates are falsified instead at the one instant where they must
+ * bite — `loser.valid_to` exactly, the value the GATE stamped — in the final
+ * arm of the loop. That is the assertion to keep if this one ever looks
+ * redundant.
  */
 const AS_OF = "2026-06-26T12:00:00Z";
 const AS_OF_ECHO = "2026-06-26T12:00:00.000Z";
@@ -225,15 +269,26 @@ type Candidate = {
   readonly subject: string;
   readonly predicate: string;
   readonly object: string;
-  readonly cardinality: "single" | "multi";
+  /**
+   * The SSOT union, never hand-listed — `extract.ts`'s `ExtractionSchema`
+   * derives the same arm list from `PREDICATE_CARDINALITIES`, and this fixture
+   * feeds the REAL `generateObject` parse. A hand-spelled pair would drift the
+   * first time M2 adds an arm, and the drift would surface as a parse failure
+   * rather than a compile error.
+   */
+  readonly cardinality: PredicateCardinality;
 };
 
 /**
- * What the mock model "extracts" from each body. `Partial` + a `BODY`-derived
- * key type: editing a body then fails to COMPILE here rather than silently
- * turning an extraction into the empty arm. Both deploy-window claims are
- * `single` — that cardinality, on both sides, is what arms the tension pass
- * and the gate's supersession collision.
+ * What the mock model "extracts" from each body.
+ *
+ * The keys are COMPUTED from `BODY`, so editing a body moves both sides in
+ * lockstep. What the `Partial<Record<(typeof BODY)[keyof typeof BODY], …>>`
+ * type adds is the other direction: a hand-spelled key matching no `BODY`
+ * value fails to COMPILE, so an extraction can never be keyed to a body that
+ * no longer exists — which would silently turn that episode into the empty
+ * arm. Both deploy-window claims are `single`: that cardinality, on both
+ * sides, is what arms the tension pass and the gate's supersession collision.
  */
 const EXTRACTIONS: Partial<Record<(typeof BODY)[keyof typeof BODY], readonly Candidate[]>> = {
   [BODY.thursdays]: [
@@ -256,9 +311,9 @@ type FactRow = {
   readonly id: string;
   readonly subject: string;
   readonly object: string;
-  readonly status: string;
-  readonly predicate_cardinality: string;
-  readonly visible_to: string[];
+  readonly status: BrainFactReviewStatus;
+  readonly predicate_cardinality: PredicateCardinality;
+  readonly visible_to: readonly string[];
   readonly valid_from: Date | null;
   readonly valid_to: Date | null;
   readonly invalidated_at: Date | null;
@@ -272,6 +327,8 @@ describeIfPg("brain M2 temporal loop (real Postgres)", () => {
 
   /** Bodies the model was asked about — the "was the seam even exercised" pin. */
   let modelCalls: string[] = [];
+  /** Workspaces the cycle resolved a model for — asserted outside the callback. */
+  let resolveModelCalls: string[] = [];
   /** Extra messages appended to a channel between sync passes (the rival's arrival). */
   let extraMessages: Readonly<Record<string, readonly SlackHistoryMessage[]>> = {};
 
@@ -374,8 +431,21 @@ describeIfPg("brain M2 temporal loop (real Postgres)", () => {
     if (priorDatabaseUrl === undefined) delete process.env.DATABASE_URL;
     else process.env.DATABASE_URL = priorDatabaseUrl;
     if (pool) {
-      await pool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
-      await pool.end();
+      // `DROP SCHEMA … CASCADE` over a fully-migrated schema is slow under a
+      // loaded runner, and a lingering lock can make it throw outright. The
+      // `finally` is what keeps that from ALSO leaking the pool: open handles
+      // would keep the bun process alive, turning a leaked scratch schema into
+      // a hung run. Same discipline the bootstrap pool gets above.
+      try {
+        await pool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+      } catch (err) {
+        console.debug(
+          `afterAll(): DROP SCHEMA "${schemaName}" failed — the scratch schema is leaking`,
+          err instanceof Error ? err.message : String(err),
+        );
+      } finally {
+        await pool.end();
+      }
     }
   }, PG_TEST_TIMEOUT_MS);
 
@@ -389,6 +459,7 @@ describeIfPg("brain M2 temporal loop (real Postgres)", () => {
     } finally {
       _resetBrainExtractionFailures();
       modelCalls = [];
+      resolveModelCalls = [];
       extraMessages = {};
     }
   });
@@ -466,8 +537,15 @@ describeIfPg("brain M2 temporal loop (real Postgres)", () => {
     const cycle = await Effect.runPromise(
       runBrainExtractionCycle({
         extract: llmFactExtractor,
+        // RECORDED here, ASSERTED below — never `expect`-ed inside the
+        // callback. The per-episode apply runs under `Effect.tryPromise`
+        // (`scheduler/periodic-db-job.ts`), which converts any throw into a
+        // counted `failed` outcome — so an `expect` here would have its
+        // "expected X, received Y" message destroyed on the way out and
+        // surface only as `failed: 0` mismatching, naming neither the
+        // assertion nor the wrong workspace.
         resolveModel: async (workspaceId) => {
-          expect(workspaceId).toBe(WORKSPACE);
+          resolveModelCalls.push(workspaceId);
           return EXTRACTION_MODEL;
         },
       }),
@@ -480,6 +558,10 @@ describeIfPg("brain M2 temporal loop (real Postgres)", () => {
       outageRefunded: 0,
     });
     expect(cycle.skipped).toEqual({ model_unavailable: 0, no_body: 0, quarantined: 0 });
+    // The cycle must resolve the model for the EPISODE's workspace — the
+    // BYO-mis-billing class `resolveExtractionModel` exists to prevent. A
+    // `Set` because one cycle resolves once per drained episode.
+    expect(new Set(resolveModelCalls)).toEqual(new Set([WORKSPACE]));
     return cycle;
   }
 
@@ -561,10 +643,29 @@ describeIfPg("brain M2 temporal loop (real Postgres)", () => {
             dropped: 0,
           }),
       },
-      query: (<T extends Record<string, unknown>>() =>
-        Promise.resolve([
-          { workspace_id: WORKSPACE, install_id: INSTALL_ID, config: { channels: [PUBLIC_CHANNEL, EXEC_CHANNEL] } },
-        ] as unknown as T[])) as AudienceSyncDeps["query"],
+      // `deps.query` has TWO consumers — the install scan and the staleness
+      // sweep — so a stub that ignores `sql` hands the sweep an install row,
+      // which it defensively reports as "counters unavailable" and warns
+      // about. That is a production degradation path running silently under a
+      // green test, and it is exactly the plausible-fallback shape the
+      // `oldest` guard above refuses.
+      //
+      // Dispatched on statement IDENTITY (both constants are exported), so a
+      // paraphrase fails loudly instead of falling into the wrong arm — the
+      // same seam `correction.test.ts` uses. Only the INSTALL scan is faked,
+      // and only because this suite deliberately seeds no `workspace_plugins`
+      // row; the sweep runs for real against the scratch schema.
+      query: (async <T extends Record<string, unknown>>(sql: string, params?: unknown[]) => {
+        if (sql === AUDIENCE_SYNC_INSTALLS_SQL) {
+          return [
+            { workspace_id: WORKSPACE, install_id: INSTALL_ID, config: { channels: [PUBLIC_CHANNEL, EXEC_CHANNEL] } },
+          ] as unknown as T[];
+        }
+        if (sql === AUDIENCE_STALENESS_SQL) return poolQuery<T>(sql, params);
+        throw new Error(
+          `fixture: unstubbed AudienceSyncDeps.query — a new consumer appeared: ${sql.slice(0, 120)}`,
+        );
+      }) as AudienceSyncDeps["query"],
       resolveToken: () => Promise.resolve("xoxb-test"),
       resolve: (workspaceId, principals) =>
         resolvePrincipals(workspaceId, principals, { query: poolQuery }),
@@ -596,14 +697,28 @@ describeIfPg("brain M2 temporal loop (real Postgres)", () => {
         },
       });
       await client.query("COMMIT");
+      client.release();
       return out;
     } catch (err) {
+      // Surfaced, not swallowed, and NARROWED: a failed rollback would
+      // otherwise present as the ORIGINAL error over a silently poisoned
+      // connection, and a raw `unknown` names neither the operation nor the
+      // failure (pg can reject with a plain object on a destroyed socket).
+      let rolledBack = true;
       await client.query("ROLLBACK").catch((rbErr: unknown) => {
-        console.debug("fixture rollback failed", rbErr);
+        rolledBack = false;
+        console.debug(
+          "poolTransaction(): ROLLBACK failed after a fixture transaction error",
+          rbErr instanceof Error ? rbErr.message : String(rbErr),
+        );
       });
+      // Destroyed, not recycled, when the rollback itself failed — same hazard
+      // `publish()` documents: a client returned to the pool with an in-doubt
+      // transaction still holds its locks, and `afterEach`'s TRUNCATE would
+      // then block until the hook times out, reporting "timed out after
+      // 60000ms" instead of the reconcile error that actually happened.
+      client.release(rolledBack ? undefined : err instanceof Error ? err : new Error(String(err)));
       throw err;
-    } finally {
-      client.release();
     }
   };
 
@@ -631,25 +746,51 @@ describeIfPg("brain M2 temporal loop (real Postgres)", () => {
     return row;
   }
 
+  /**
+   * Edges of one type between two named endpoints.
+   *
+   * `to` is an exclusive union, not an all-optional pair: the two-optional
+   * shape admits `{}`, which binds `undefined` → SQL NULL → a count of 0. Every
+   * caller today asserts `toBe(1)` so that would fail loudly — but this file's
+   * own discipline is to assert negatives, and the first `toBe(0)` written
+   * against a typo'd key would pass vacuously. The union makes that
+   * unspellable.
+   */
   async function edgeCount(
-    edgeType: string,
+    edgeType: BrainEdgeType,
     fromFactId: string,
-    to: { factId?: string; episodeId?: string },
+    to: { readonly factId: string } | { readonly episodeId: string },
   ): Promise<number> {
-    const toClause = to.factId !== undefined ? `to_fact_id = $4::uuid` : `to_episode_id = $4::uuid`;
+    const [toClause, toId] =
+      "factId" in to
+        ? ([`to_fact_id = $4::uuid`, to.factId] as const)
+        : ([`to_episode_id = $4::uuid`, to.episodeId] as const);
     const { rows } = await pool.query<{ n: string }>(
       `SELECT count(*)::text AS n FROM brain_edges
         WHERE workspace_id = $1 AND edge_type = $2 AND from_fact_id = $3::uuid AND ${toClause}`,
-      [WORKSPACE, edgeType, fromFactId, to.factId ?? to.episodeId],
+      [WORKSPACE, edgeType, fromFactId, toId],
     );
     return Number(rows[0]?.n ?? "0");
   }
 
+  // Typed as the union, not `{ tier: string }`: that is what keeps the
+  // compiler checking the literal against the discriminant, so a tier rename
+  // in `@useatlas/types` is a TS2367 rather than a filter that silently
+  // returns `[]` and satisfies every empty-list assertion in the file.
   const isFact = (r: BrainSearchResult): r is BrainFactResult => r.tier === "fact";
+  const isEpisode = (r: BrainSearchResult): r is BrainEpisodeResult => r.tier === "raw-episode";
 
   const byText = (a: string, b: string) => a.localeCompare(b);
   const subjectsOf = (results: readonly BrainSearchResult[]) =>
     results.filter(isFact).map((f) => f.subject).toSorted(byText);
+  const bodiesOf = (results: readonly BrainSearchResult[]) =>
+    results
+      .filter(isEpisode)
+      // `body` is nullable — a by-reference episode carries none. This loop
+      // never creates one, so a null is a real regression and is surfaced as a
+      // value rather than sorted into an ambiguous slot.
+      .map((e) => e.body ?? "(null body)")
+      .toSorted(byText);
   /** The deploy-window objects a read served — the loop's central projection. */
   const deployObjectsOf = (results: readonly BrainSearchResult[]) =>
     results
@@ -665,9 +806,26 @@ describeIfPg("brain M2 temporal loop (real Postgres)", () => {
     async () => {
       // ---- 1. the incumbent belief, published -----------------------------
       const sync = await syncHistory();
-      expect(sync.episodes).toMatchObject({ inserted: 3, duplicate: 0 });
+      // BY VALUE, not `toMatchObject`: `refused` and `batchDuplicate` are the
+      // ingest core's entire silent-drop-prevention mechanism, and a subset
+      // match discards exactly them (the rule `wedge-loop-pg.test.ts` states).
+      expect(sync.episodes).toEqual({
+        inserted: 3,
+        duplicate: 0,
+        batchDuplicate: 0,
+        refused: { blank_source_id: 0, blank_body: 0, unusable_grant: 0, invalid_occurred_at: 0 },
+      });
       const cycle = await extract();
-      expect(cycle).toMatchObject({ inspected: 3, extracted: 3, factsCreated: 2 });
+      // `factsCorroborated: 0` even on the first cycle, where there is nothing
+      // to corroborate: it is the assertion that catches a conflict silently
+      // merged into an existing claim, and omitting it here would make the
+      // rival cycle's identical pin look like the special case.
+      expect(cycle).toMatchObject({
+        inspected: 3,
+        extracted: 3,
+        factsCreated: 2,
+        factsCorroborated: 0,
+      });
       expect(modelCalls.toSorted(byText)).toEqual(
         [BODY.thursdays, BODY.freeze, "(no match)"].toSorted(byText),
       );
@@ -679,7 +837,15 @@ describeIfPg("brain M2 temporal loop (real Postgres)", () => {
       expect(firstPublish.superseded).toEqual([]);
 
       const synced = await syncAudiences();
-      expect(synced.membersAdded).toBe(1);
+      // `principalsUnresolved` is asserted, not just `membersAdded`: the added
+      // count catches a resolver that MIS-resolves `U_ALAN` (it would become
+      // 2), but only this catches one that silently DROPS an unresolvable
+      // principal without counting it — the "logged, never guessed" arm.
+      expect(synced).toMatchObject({
+        membersAdded: 1,
+        principalsUnresolved: 1,
+        workspacesFailed: 0,
+      });
 
       let rows = await facts();
       const thursdays = factByClaim(rows, "deploy window", "Thursdays");
@@ -695,7 +861,12 @@ describeIfPg("brain M2 temporal loop (real Postgres)", () => {
       // ---- 2. the rival arrives — draft + advisory tension edge -----------
       extraMessages = { [EXEC_CHANNEL]: [FRIDAYS_MESSAGE] };
       const second = await syncHistory();
-      expect(second.episodes).toMatchObject({ inserted: 1, duplicate: 3 });
+      expect(second.episodes).toEqual({
+        inserted: 1,
+        duplicate: 3,
+        batchDuplicate: 0,
+        refused: { blank_source_id: 0, blank_body: 0, unusable_grant: 0, invalid_occurred_at: 0 },
+      });
       const rivalCycle = await extract();
       expect(rivalCycle).toMatchObject({ inspected: 1, extracted: 1, factsCreated: 1, factsCorroborated: 0 });
 
@@ -766,6 +937,15 @@ describeIfPg("brain M2 temporal loop (real Postgres)", () => {
           object: "Thursdays",
           status: "published",
           invalidatedAt: null,
+          // The AC is "surfaced with provenance to reader AND reviewer", and
+          // the review surface re-decides attribution per counterpart through
+          // its OWN projection (`candidates.ts`). Without this, a regression
+          // that dropped provenance from the reviewer's counterpart while
+          // leaving the search surface intact would pass.
+          provenance: expect.objectContaining({
+            source: SLACK_HISTORY_SOURCE,
+            attribution: expect.objectContaining({ visible: true, actor: "slack:U_ADA" }),
+          }),
         }),
       ]);
 
@@ -784,8 +964,16 @@ describeIfPg("brain M2 temporal loop (real Postgres)", () => {
       expect(loser).toMatchObject({ status: "published", invalidated_at: null });
       // The winner is current, with an UNRECORDED start — the extraction
       // schema carries no validFrom, so only the loser's closed window encodes
-      // the arbitration (see the header pin).
-      expect(winner).toMatchObject({ status: "published", valid_to: null, valid_from: null });
+      // the arbitration (see the header pin). `visible_to` asserted directly:
+      // the whole frozen-grant arm below rests on the winner NOT having
+      // widened to `org` through #4823's evidence union, and proving that only
+      // through "the member sees nothing" leaves three possible causes.
+      expect(winner).toMatchObject({
+        status: "published",
+        valid_to: null,
+        valid_from: null,
+        visible_to: [EXEC_GRANT_TOKEN],
+      });
       // The arbitration record, new → old.
       expect(await edgeCount("supersedes", winner.id, { factId: loser.id })).toBe(1);
 
@@ -807,8 +995,15 @@ describeIfPg("brain M2 temporal loop (real Postgres)", () => {
       expect(memberThen.asOf).toBe(AS_OF_ECHO);
       expect(deployObjectsOf(memberThen.results)).toEqual(["Thursdays"]);
       const memberThenFact = memberThen.results.filter(isFact).find((f) => f.subject === "deploy window");
-      expect(memberThenFact?.validTo).not.toBeNull();
-      expect(memberThenFact?.provenance).toMatchObject({
+      // Named throw, not `?.`: `expect(undefined).not.toBeNull()` PASSES, so
+      // the next assertion would be vacuous the moment the read returned
+      // nothing — and "the point read served nothing" is precisely the
+      // regression this arm exists to catch.
+      if (memberThenFact === undefined) {
+        throw new Error("the member's asOf read served no deploy-window fact — the point read is broken");
+      }
+      expect(memberThenFact.validTo).not.toBeNull();
+      expect(memberThenFact.provenance).toMatchObject({
         source: SLACK_HISTORY_SOURCE,
         attribution: { visible: true, actor: "slack:U_ADA" },
       });
@@ -818,6 +1013,39 @@ describeIfPg("brain M2 temporal loop (real Postgres)", () => {
       // `valid_from`). Pinned, not worked around.
       const adminThen = await search(adminCtx, { asOf: AS_OF });
       expect(deployObjectsOf(adminThen.results)).toEqual(["Fridays", "Thursdays"]);
+      // `asOf` leaves the EPISODE store alone (`search.ts`: an episode is
+      // append-only evidence of what was SAID and has no validity window), so
+      // the same reader's evidence is identical either side of the point read.
+      // Without this an `asOf` that accidentally narrowed the episode store
+      // would pass every fact assertion above.
+      expect(bodiesOf(adminThen.results)).toEqual(bodiesOf(adminNow.results));
+
+      // THE UPPER BOUND, falsified by BRACKETING the boundary the GATE
+      // stamped. Every other asOf assertion here is satisfied through the
+      // `valid_from IS NULL` arm and a `valid_to` far in the future of
+      // `AS_OF` — delete both temporal predicates and they all still pass.
+      // This pair cannot: one millisecond either side of the stamp flips
+      // whether the superseded claim answers, and the bound is the value
+      // `SUPERSEDE_STAMP_SQL` wrote rather than one the fixture chose, which
+      // is the handoff this file exists to prove.
+      //
+      // BRACKETED rather than read AT the stamp, and the reason is a real
+      // trap: `timestamptz` keeps MICROseconds, but `parseBrainAsOf` round
+      // trips through a JS `Date` and so can only ever bind millisecond
+      // precision. An `asOf` built from `valid_to.toISOString()` is therefore
+      // the stamp TRUNCATED — strictly less than it — and the loser stays
+      // visible through `valid_to > asOf`. Equality at the half-open bound is
+      // unreachable through this API; ±1ms is exact regardless.
+      // (`search-pg.test.ts` pins the equality semantics directly, against
+      // hand-built rows whose bounds it controls to the microsecond.)
+      if (loser.valid_to === null) {
+        throw new Error("the gate stamped no valid_to — the bracket below would be vacuous");
+      }
+      const stampMs = loser.valid_to.getTime();
+      const justAfter = await search(adminCtx, { asOf: new Date(stampMs + 1).toISOString() });
+      expect(deployObjectsOf(justAfter.results)).toEqual(["Fridays"]);
+      const justBefore = await search(adminCtx, { asOf: new Date(stampMs - 1).toISOString() });
+      expect(deployObjectsOf(justBefore.results)).toEqual(["Fridays", "Thursdays"]);
 
       // ---- 7. correct_fact retract: tombstone + flag, never cascade -------
       // The write-back-shaped lineage edge (header note): the freeze claim
@@ -855,12 +1083,21 @@ describeIfPg("brain M2 temporal loop (real Postgres)", () => {
         `SELECT source, source_actor, visible_to, extracted_at FROM brain_episodes WHERE id = $1::uuid`,
         [correction.result.correctionEpisodeId],
       );
-      expect(correctionEpisodes[0]).toMatchObject({
+      const correctionEpisode = correctionEpisodes[0];
+      // Named throw for the same reason as the asOf arm below: the
+      // `extracted_at` pin two lines on would pass vacuously against an
+      // `undefined` row.
+      if (correctionEpisode === undefined) {
+        throw new Error(
+          `no brain_episodes row for correction episode ${correction.result.correctionEpisodeId}`,
+        );
+      }
+      expect(correctionEpisode).toMatchObject({
         source: "human",
         source_actor: "user-admin",
         visible_to: [EXEC_GRANT_TOKEN],
       });
-      expect(correctionEpisodes[0]?.extracted_at).not.toBeNull();
+      expect(correctionEpisode.extracted_at).not.toBeNull();
       // Lineage, fact → correction episode: `derives-from`, not evidence.
       expect(
         await edgeCount("derives-from", winner.id, {
@@ -869,6 +1106,17 @@ describeIfPg("brain M2 temporal loop (real Postgres)", () => {
       ).toBe(1);
       // …and the drain confirms the pre-stamp: nothing queued, nothing
       // re-derived from the human's words.
+      //
+      // The QUEUE is asserted directly rather than only the cycle counters,
+      // because `{inspected: 0, extracted: 0}` is byte-identical to the
+      // zeroed result `runPeriodicDbCycle` returns when `hasInternalDB()` is
+      // false — the very path `beforeAll`'s `DATABASE_URL` line exists to
+      // avoid. This distinguishes "nothing was queued" from "the drain never
+      // ran", which is the premise-pinning discipline `syncHistory` follows.
+      const { rows: queued } = await pool.query<{ n: string }>(
+        `SELECT count(*)::text AS n FROM brain_episodes WHERE extracted_at IS NULL`,
+      );
+      expect(queued[0]?.n).toBe("0");
       const afterCorrection = await extract();
       expect(afterCorrection).toMatchObject({ inspected: 0, extracted: 0, factsCreated: 0 });
 
@@ -881,6 +1129,9 @@ describeIfPg("brain M2 temporal loop (real Postgres)", () => {
         reason: "derives-from-retracted",
         retractedFactId: winner.id,
         correctionEpisodeId: correction.result.correctionEpisodeId,
+        // The injected clock reaches the marker — without this the clock is
+        // decoration and the human record's instant is unpinned.
+        flaggedAt: CORRECTION_AT,
       });
 
       // ---- 8. the tombstone is hidden from EVERY read ---------------------

--- a/packages/api/src/lib/brain/correction.ts
+++ b/packages/api/src/lib/brain/correction.ts
@@ -15,7 +15,9 @@
  *   - **retract** — the ONLY tombstone path, and the verb a GDPR erasure
  *     ROUTES THROUGH (the ADR's epithet; actual content deletion of the row
  *     and its episodes is a separate operation this verb does not perform —
- *     the claim stays readable to as-of reads by design). Stamps
+ *     the row stays stored, but every read INCLUDING `asOf` hides it: #4916
+ *     keeps `invalidated_at IS NULL` in both temporal branches, because
+ *     hiding history is what this verb is for). Stamps
  *     `invalidated_at` (never `status` — ADR-0036: withdrawal is a tombstone,
  *     not a demotion) and FLAGS every `derives-from` dependent for re-review.
  *     Flagging is a provenance marker (`reReview`), never a cascade: a
@@ -284,8 +286,10 @@ export const CORRECTION_EPISODE_INSERT_SQL = `INSERT INTO brain_episodes
  * `invalidated_at` verbatim — a restore, not a new arbitration, the same
  * distinction the promotion guard's allowlist draws. It never names `status`:
  * withdrawal is a
- * tombstone, not a demotion, and the retracted row stays readable to as-of
- * reads. The ACL already ran at {@link correctionTargetSql}, which also holds
+ * tombstone, not a demotion — and the tombstone hides the row from every fact
+ * read, `asOf` included (#4916); only the tension surfaces still list it,
+ * labelled, as a withdrawn rival. The ACL already ran at
+ * {@link correctionTargetSql}, which also holds
  * the row lock; the residual predicates make the statement correct standalone.
  */
 export const RETRACT_FACT_SQL = `UPDATE brain_facts

--- a/packages/api/src/lib/brain/correction.ts
+++ b/packages/api/src/lib/brain/correction.ts
@@ -14,10 +14,16 @@
  *
  *   - **retract** — the ONLY tombstone path, and the verb a GDPR erasure
  *     ROUTES THROUGH (the ADR's epithet; actual content deletion of the row
- *     and its episodes is a separate operation this verb does not perform —
- *     the row stays stored, but every read INCLUDING `asOf` hides it: #4916
- *     keeps `invalidated_at IS NULL` in both temporal branches, because
- *     hiding history is what this verb is for). Stamps
+ *     and its episodes is a separate operation this verb does not perform).
+ *     The row stays stored, and every FACT-SERVING read hides it, `asOf`
+ *     included — #4916 keeps `invalidated_at IS NULL` in BOTH temporal
+ *     branches, because hiding history is what this verb is for. The one
+ *     exception is the tension cluster: `tensions.ts`'s counterpart SELECT
+ *     deliberately does not filter `invalidated_at`, so a retracted claim is
+ *     still listed — labelled by `invalidatedAt`, with its payload — as a
+ *     withdrawn rival of any live claim it contested. That carve-out is why
+ *     erasure of CONTENT has to be a separate operation and cannot be read
+ *     off this verb. Stamps
  *     `invalidated_at` (never `status` — ADR-0036: withdrawal is a tombstone,
  *     not a demotion) and FLAGS every `derives-from` dependent for re-review.
  *     Flagging is a provenance marker (`reReview`), never a cascade: a
@@ -285,12 +291,11 @@ export const CORRECTION_EPISODE_INSERT_SQL = `INSERT INTO brain_episodes
  * import's INSERT (`admin-migrate.ts`), which restores an existing
  * `invalidated_at` verbatim — a restore, not a new arbitration, the same
  * distinction the promotion guard's allowlist draws. It never names `status`:
- * withdrawal is a
- * tombstone, not a demotion — and the tombstone hides the row from every fact
- * read, `asOf` included (#4916); only the tension surfaces still list it,
- * labelled, as a withdrawn rival. The ACL already ran at
- * {@link correctionTargetSql}, which also holds
- * the row lock; the residual predicates make the statement correct standalone.
+ * withdrawal is a tombstone, not a demotion — and the tombstone hides the row
+ * from every fact-serving read, `asOf` included (#4916); only the tension
+ * surfaces still list it, labelled, as a withdrawn rival. The ACL already ran
+ * at {@link correctionTargetSql}, which also holds the row lock; the residual
+ * predicates make the statement correct standalone.
  */
 export const RETRACT_FACT_SQL = `UPDATE brain_facts
         SET invalidated_at = now(), updated_at = now()


### PR DESCRIPTION
Closes #4917

The M2 counterpart of #4775's wedge-loop proof: one `-pg` e2e over the completed temporal stack (#4912–#4916).

## The loop

Two Slack channels produce conflicting `single`-cardinality claims — *deploy window is Thursdays* in the public channel (`org` grant), *is Fridays* in the exec channel (`audience:` grant) a day later. From there:

1. **Reconcile** writes the advisory `in-tension-with` edge — newer claim → incumbent, arbitrating nothing.
2. **Both surfaces cluster it off that one edge row.** The org member gets `{visible: false, withheldCount: 1}` for the rival they can't read; the exec-audience admin gets the counterpart's full claim *with provenance*; the reviewer's queue shows the mirror-image cluster. That's the "surfaced-both-with-provenance, to reader AND reviewer" AC, plus the withheld negative arm.
3. **The publish gate supersedes** — `valid_to` stamped, `supersedes` edge written, `report.superseded` exact.
4. **Default reads return the survivor only**; `asOf` returns yesterday's truth to the org member under the row's own frozen `['org']` grant.
5. **`correct_fact` retract** tombstones the winner out of *both* temporal branches and flags the `derives-from` dependent rather than cascading to it.

## Three properties pinned rather than papered over

Each is real behaviour of the shipped code that a future reader would otherwise "fix":

- **The gate-promoted winner has an unrecorded start.** `ExtractionSchema` carries no `validFrom`, so a promoted fact lands `valid_from NULL`, which #4916 admits at *any* `asOf`. Only the loser's *closed* window encodes the arbitration.
- **Supersession is grant-blind.** `supersessionCollisionJoin` never reads `visible_to`, so an audience-granted winner retires an org-granted loser for readers who will never see the winner — their current belief simply ends. The frozen grant still serves them history under `asOf`; that half is T5, the collision's grant-blindness is an undocumented consequence, pinned so a change has to argue with a test.
- **The correction episode never reaches the extraction queue** (`extracted_at` stamped at INSERT), so a human's words are never re-derived into a machine claim.

## The asOf upper bound is genuinely load-bearing

Worth calling out because the first version of this file got it wrong. Both facts are extraction-born (`valid_from NULL`) and the loser's `valid_to` sits at wall-clock run time, so every `asOf` assertion passed through the NULL arm and a far-future bound — **deleting both temporal predicates would not have failed the file.** The bound is now bracketed ±1ms around the value the *gate* stamped.

Bracketed rather than read *at* the stamp because `timestamptz` keeps microseconds while `parseBrainAsOf` round-trips through a JS `Date` and can only bind milliseconds — equality at the half-open bound is unreachable through that API.

Mutation-verified: removing `(valid_to IS NULL OR valid_to > asOf)` kills the test at the bracket; removing `invalidated_at IS NULL` kills it at the tombstone arm.

## Also: a comment-drift fix in `correction.ts`

Two `retract` comments claimed the tombstoned row *"stays readable to as-of reads"* — the opposite of what #4916 implemented (`invalidated_at IS NULL` survives in **both** branches of `buildFactQuery`). Corrected, with the carve-out the code actually has: the tension surfaces deliberately don't filter `invalidated_at`, so a retracted claim is still listed — labelled — as a withdrawn rival. That carve-out is why content erasure has to be a separate operation and can't be read off this verb.

## Verification

- `scripts/ci-local.sh` — **33/33 gates PASS**, including `brain-fact-promotion`, `test-discipline`, and the full suite with `TEST_DATABASE_URL` set (`temporal-loop-pg` ran for real, 12s — not silently skipped).
- `test-isolated.ts --affected` — 346/346.
- `/review-panel` — 4 specialists, 21 findings, all addressed; second round CLEAN.

## Note for the reviewer

One panel suggestion declined: splitting the single `it()` into per-arm tests. The arms are sequential stages of one story, so each would replay most of the loop — unlike the wedge suite, whose arms are independent reads off a shared corpus. Flagging it as a stated decision rather than a default.