### PR TITLE
chore(brain): harden wedge-loop-pg fixture helpers

### DIFF
--- a/packages/api/src/lib/brain/__tests__/wedge-loop-pg.test.ts
+++ b/packages/api/src/lib/brain/__tests__/wedge-loop-pg.test.ts
@@ -271,6 +271,8 @@ describeIfPg("brain M1 wedge loop (real Postgres)", () => {
 
   /** Bodies the model was asked about — the "was the seam even exercised" pin. */
   let modelCalls: string[] = [];
+  /** Workspaces the cycle resolved a model for — asserted outside the callback. */
+  let resolveModelCalls: string[] = [];
   /** Extra messages a single test appends to a channel (the corroboration case). */
   let extraMessages: Readonly<Record<string, readonly SlackHistoryMessage[]>> = {};
 
@@ -399,11 +401,22 @@ describeIfPg("brain M1 wedge loop (real Postgres)", () => {
     if (priorDatabaseUrl === undefined) delete process.env.DATABASE_URL;
     else process.env.DATABASE_URL = priorDatabaseUrl;
     if (pool) {
-      await pool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
-      await pool.end();
+      // `DROP SCHEMA … CASCADE` over a fully-migrated schema is slow under a
+      // loaded runner, and a lingering lock can make it throw outright. The
+      // `finally` is what keeps that from ALSO leaking the pool: open handles
+      // would keep the bun process alive, turning a leaked scratch schema into
+      // a hung run. Same discipline the bootstrap pool gets above.
+      try {
+        await pool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+      } catch (err) {
+        console.debug(
+          `afterAll(): DROP SCHEMA "${schemaName}" failed — the scratch schema is leaking`,
+          err instanceof Error ? err.message : String(err),
+        );
+      } finally {
+        await pool.end();
+      }
     }
-    // `DROP SCHEMA … CASCADE` over a fully-migrated schema is slow under a
-    // loaded runner, and a hook timeout here leaves the scratch schema behind.
   }, PG_TEST_TIMEOUT_MS);
 
   afterEach(async () => {
@@ -422,6 +435,7 @@ describeIfPg("brain M1 wedge loop (real Postgres)", () => {
       // becomes a cascade of unrelated ones.
       _resetBrainExtractionFailures();
       modelCalls = [];
+      resolveModelCalls = [];
       extraMessages = {};
       resetRosters();
     }
@@ -546,10 +560,15 @@ describeIfPg("brain M1 wedge loop (real Postgres)", () => {
     const cycle = await Effect.runPromise(
       runBrainExtractionCycle({
         extract: llmFactExtractor,
+        // RECORDED here, ASSERTED below — never `expect`-ed inside the
+        // callback. The per-episode apply runs under `Effect.tryPromise`
+        // (`scheduler/periodic-db-job.ts`), which converts any throw into a
+        // counted `failed` outcome — so an `expect` here would have its
+        // "expected X, received Y" message destroyed on the way out and
+        // surface only as `failed: 0` mismatching, naming neither the
+        // assertion nor the wrong workspace.
         resolveModel: async (workspaceId) => {
-          // The cycle must resolve the model for the EPISODE's workspace — the
-          // BYO-mis-billing class `resolveExtractionModel` exists to prevent.
-          expect(workspaceId).toBe(WORKSPACE);
+          resolveModelCalls.push(workspaceId);
           return EXTRACTION_MODEL;
         },
       }),
@@ -564,6 +583,10 @@ describeIfPg("brain M1 wedge loop (real Postgres)", () => {
       outageRefunded: 0,
     });
     expect(cycle.skipped).toEqual({ model_unavailable: 0, no_body: 0, quarantined: 0 });
+    // The cycle must resolve the model for the EPISODE's workspace — the
+    // BYO-mis-billing class `resolveExtractionModel` exists to prevent. A
+    // `Set` because one cycle resolves once per drained episode.
+    expect(new Set(resolveModelCalls)).toEqual(new Set([WORKSPACE]));
     return cycle;
   }
 
@@ -712,16 +735,28 @@ describeIfPg("brain M1 wedge loop (real Postgres)", () => {
         },
       });
       await client.query("COMMIT");
+      client.release();
       return out;
     } catch (err) {
+      // Surfaced, not swallowed, and NARROWED: a failed rollback would
+      // otherwise present as the ORIGINAL error over a silently poisoned
+      // connection, and a raw `unknown` names neither the operation nor the
+      // failure (pg can reject with a plain object on a destroyed socket).
+      let rolledBack = true;
       await client.query("ROLLBACK").catch((rbErr: unknown) => {
-        // Surfaced, not swallowed: a failed rollback here would otherwise
-        // present as the ORIGINAL error with a silently poisoned connection.
-        console.debug("fixture rollback failed", rbErr);
+        rolledBack = false;
+        console.debug(
+          "poolTransaction(): ROLLBACK failed after a fixture transaction error",
+          rbErr instanceof Error ? rbErr.message : String(rbErr),
+        );
       });
+      // Destroyed, not recycled, when the rollback itself failed — same hazard
+      // `publish()` documents: a client returned to the pool with an in-doubt
+      // transaction still holds its locks, and `afterEach`'s TRUNCATE would
+      // then block until the hook times out, reporting "timed out after
+      // 60000ms" instead of the reconcile error that actually happened.
+      client.release(rolledBack ? undefined : err instanceof Error ? err : new Error(String(err)));
       throw err;
-    } finally {
-      client.release();
     }
   };
 

--- a/packages/api/src/lib/brain/__tests__/wedge-loop-pg.test.ts
+++ b/packages/api/src/lib/brain/__tests__/wedge-loop-pg.test.ts
@@ -271,8 +271,6 @@ describeIfPg("brain M1 wedge loop (real Postgres)", () => {
 
   /** Bodies the model was asked about — the "was the seam even exercised" pin. */
   let modelCalls: string[] = [];
-  /** Workspaces the cycle resolved a model for — asserted outside the callback. */
-  let resolveModelCalls: string[] = [];
   /** Extra messages a single test appends to a channel (the corroboration case). */
   let extraMessages: Readonly<Record<string, readonly SlackHistoryMessage[]>> = {};
 
@@ -403,18 +401,32 @@ describeIfPg("brain M1 wedge loop (real Postgres)", () => {
     if (pool) {
       // `DROP SCHEMA … CASCADE` over a fully-migrated schema is slow under a
       // loaded runner, and a lingering lock can make it throw outright. The
-      // `finally` is what keeps that from ALSO leaking the pool: open handles
-      // would keep the bun process alive, turning a leaked scratch schema into
-      // a hung run. Same discipline the bootstrap pool gets above.
+      // `finally` covers the THROW: `pool.end()` still runs, so a failed drop
+      // leaks only the schema and not the pool's open handles, which would keep
+      // the bun process alive. Same discipline the bootstrap pool gets above.
+      // A genuine hook TIMEOUT is still uncovered — an await that never settles
+      // never reaches the `finally`, and both leak.
+      // Narrowed at the catch site, like `poolTransaction`'s `destroyReason`,
+      // so the rethrow below has a `.message` without re-narrowing.
+      let dropErr: Error | undefined;
       try {
         await pool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
       } catch (err) {
-        console.debug(
-          `afterAll(): DROP SCHEMA "${schemaName}" failed — the scratch schema is leaking`,
-          err instanceof Error ? err.message : String(err),
-        );
+        dropErr = err instanceof Error ? err : new Error(String(err));
       } finally {
         await pool.end();
+      }
+      if (dropErr !== undefined) {
+        // Thrown, not logged. `scripts/test-isolated.ts` prints a file's
+        // captured output ONLY on a non-zero exit, so a `console.debug` here
+        // would be discarded in precisely the case it exists to report: a green
+        // run that leaked a schema. `schemaName` carries a timestamp and a
+        // random suffix, so an unreported leak is an unattributable orphan in a
+        // shared test database — failing the file is the only channel that
+        // survives.
+        throw new Error(
+          `afterAll(): DROP SCHEMA "${schemaName}" failed — scratch schema leaked, drop it by hand: ${dropErr.message}`,
+        );
       }
     }
   }, PG_TEST_TIMEOUT_MS);
@@ -435,7 +447,6 @@ describeIfPg("brain M1 wedge loop (real Postgres)", () => {
       // becomes a cascade of unrelated ones.
       _resetBrainExtractionFailures();
       modelCalls = [];
-      resolveModelCalls = [];
       extraMessages = {};
       resetRosters();
     }
@@ -557,16 +568,23 @@ describeIfPg("brain M1 wedge loop (real Postgres)", () => {
    * design, so nothing else in the file would notice it.
    */
   async function extract() {
+    // Scoped to the CYCLE, not the suite: two tests drive `extract()` twice, and
+    // a suite-lifetime recorder would let the second call's assertion pass on
+    // the first call's entry — silently vacuous for the zero-drain replay at the
+    // bottom of this file, and spuriously red for any future test whose FIRST
+    // cycle drains nothing.
+    const resolveModelCalls: string[] = [];
     const cycle = await Effect.runPromise(
       runBrainExtractionCycle({
         extract: llmFactExtractor,
         // RECORDED here, ASSERTED below — never `expect`-ed inside the
         // callback. The per-episode apply runs under `Effect.tryPromise`
         // (`scheduler/periodic-db-job.ts`), which converts any throw into a
-        // counted `failed` outcome — so an `expect` here would have its
-        // "expected X, received Y" message destroyed on the way out and
-        // surface only as `failed: 0` mismatching, naming neither the
-        // assertion nor the wrong workspace.
+        // counted `failed` outcome — so an `expect` here is diverted into a
+        // scrubbed, truncated `log.warn` line and never reaches the test's
+        // failure diff. It would surface as a counter mismatch (`failed`, plus
+        // `outageRefunded` once every episode fails), naming the assertion
+        // nowhere a reader is looking.
         resolveModel: async (workspaceId) => {
           resolveModelCalls.push(workspaceId);
           return EXTRACTION_MODEL;
@@ -583,10 +601,15 @@ describeIfPg("brain M1 wedge loop (real Postgres)", () => {
       outageRefunded: 0,
     });
     expect(cycle.skipped).toEqual({ model_unavailable: 0, no_body: 0, quarantined: 0 });
-    // The cycle must resolve the model for the EPISODE's workspace — the
-    // BYO-mis-billing class `resolveExtractionModel` exists to prevent. A
-    // `Set` because one cycle resolves once per drained episode.
-    expect(new Set(resolveModelCalls)).toEqual(new Set([WORKSPACE]));
+    // Two claims in one array. WHICH workspace: the cycle must resolve for the
+    // EPISODE's workspace — the BYO-mis-billing class `resolveExtractionModel`
+    // exists to prevent. HOW MANY times: exactly one, because `extract.ts`'s
+    // `modelFor` memoizes per workspace per cycle ("not once per episode: a
+    // decrypt is not free"), so this also pins that cache against a regression
+    // to per-episode resolution. Keyed off `inspected` because a cycle that
+    // drained nothing must resolve nothing — asserting `[WORKSPACE]` there
+    // would blame model resolution for what is really an empty backlog.
+    expect(resolveModelCalls).toEqual(cycle.inspected > 0 ? [WORKSPACE] : []);
     return cycle;
   }
 
@@ -726,6 +749,11 @@ describeIfPg("brain M1 wedge loop (real Postgres)", () => {
     fn: (tx: { query: (sql: string, params?: unknown[]) => Promise<{ rows: readonly unknown[] }> }) => Promise<T>,
   ): Promise<T> => {
     const client = await pool.connect();
+    // `undefined` ⇒ safe to recycle; set ⇒ destroy on release. One binding
+    // rather than a boolean plus a discarded error, so the reason the client is
+    // being destroyed is the ROLLBACK failure that actually poisoned it — not
+    // the original error, which is merely why we rolled back.
+    let destroyReason: Error | undefined;
     try {
       await client.query("BEGIN");
       const out = await fn({
@@ -735,28 +763,29 @@ describeIfPg("brain M1 wedge loop (real Postgres)", () => {
         },
       });
       await client.query("COMMIT");
-      client.release();
       return out;
     } catch (err) {
       // Surfaced, not swallowed, and NARROWED: a failed rollback would
       // otherwise present as the ORIGINAL error over a silently poisoned
       // connection, and a raw `unknown` names neither the operation nor the
-      // failure (pg can reject with a plain object on a destroyed socket).
-      let rolledBack = true;
+      // failure (pg may reject with a plain object on a destroyed socket).
       await client.query("ROLLBACK").catch((rbErr: unknown) => {
-        rolledBack = false;
-        console.debug(
-          "poolTransaction(): ROLLBACK failed after a fixture transaction error",
-          rbErr instanceof Error ? rbErr.message : String(rbErr),
-        );
+        destroyReason = rbErr instanceof Error ? rbErr : new Error(String(rbErr));
+        console.debug("poolTransaction(): ROLLBACK failed after a fixture transaction error", destroyReason.message);
       });
-      // Destroyed, not recycled, when the rollback itself failed — same hazard
-      // `publish()` documents: a client returned to the pool with an in-doubt
-      // transaction still holds its locks, and `afterEach`'s TRUNCATE would
-      // then block until the hook times out, reporting "timed out after
-      // 60000ms" instead of the reconcile error that actually happened.
-      client.release(rolledBack ? undefined : err instanceof Error ? err : new Error(String(err)));
       throw err;
+    } finally {
+      // In a `finally` so EVERY path releases exactly once — including a throw
+      // from inside the catch block itself. A client that never returns to the
+      // pool makes `afterEach`'s TRUNCATE block until the hook times out,
+      // reporting a hook timeout instead of the reconcile error that actually
+      // happened: the same hazard `publish()` documents, and the exact
+      // diagnostic erasure this helper exists to avoid.
+      //
+      // Unlike `publish()`, which destroys unconditionally, a rollback that
+      // SUCCEEDED here leaves no in-doubt transaction, so the client is safe to
+      // recycle and only a failed rollback forces the destroy.
+      client.release(destroyReason);
     }
   };
 


### PR DESCRIPTION
## Summary

Closes #4926.

Four diagnostic-quality defects in `wedge-loop-pg.test.ts`'s fixture helpers, plus corrections to the reference implementation they were copied from.

**None of the original four can make a passing test fail or a failing test pass.** They only bite once something else is already broken, and then they destroy or delay the signal that would tell you what.

1. **`poolTransaction` returned a poisoned client to the pool.** The `finally { client.release() }` handed back a client with an in-doubt transaction when the callback threw *and* the `ROLLBACK` also failed. The held locks then blocked `afterEach`'s TRUNCATE, so the run reported a hook timeout instead of the reconcile error that actually happened. Now destroys rather than recycles in that case — what `publish()` in the same file already did.
2. **Un-narrowed caught error.** `console.debug("fixture rollback failed", rbErr)` handed a raw `unknown` to the log and named no operation. Now narrowed and named, per CLAUDE.md § Error handling.
3. **`afterAll` leaked the pool if `DROP SCHEMA` threw.** `pool.end()` never ran, so open handles kept the bun process alive *and* the scratch `brain_*` schema leaked.
4. **Assertion inside a production-invoked callback.** `expect(workspaceId).toBe(WORKSPACE)` sat in `resolveModel`, which runs under `Effect.tryPromise` in `scheduler/periodic-db-job.ts` — any throw became a counted `failed` outcome, diverting the assertion message out of the test's failure diff. Moved outside as record-then-assert.

Test-only; no production code touched.

### Second commit — review-panel corrections

A four-reviewer panel over the first commit returned **CHANGES REQUESTED**, and the must-fixes were real. Two comments inherited from the reference file state falsehoods about production:

- *"A `Set` because one cycle resolves once per drained episode"* is the **opposite** of `extract.ts:680`, where `modelFor` memoizes through a per-cycle Map: *"Resolved once per WORKSPACE per cycle, not once per episode: a decrypt is not free."* One cycle over four same-workspace episodes records **one** entry. A maintainer trusting the comment would "strengthen" the assertion to a length of 4 and break the suite.
- The rollback comment predicted `timed out after 60000ms`, but `afterEach` takes no timeout argument and no bunfig sets one, so a hung TRUNCATE reports bun's default **5000ms**. `publish()` documents the same hazard and deliberately gives no number.

Consequent tightening:

- **The assertion is now per-cycle and exact.** `resolveModelCalls` moved inside `extract()` (dropping the module-level `let` and its `afterEach` reset), asserted as `toEqual(cycle.inspected > 0 ? [WORKSPACE] : [])`. This pins *which* workspace **and** *how many* resolutions, so it now guards the memoization contract the `Set` was hiding. The zero-drain branch is load-bearing: the idempotence replay drains nothing, and the `Set` previously passed there purely on the prior cycle's leftover entry.
- **`poolTransaction` releases in a `finally` again**, so every path releases exactly once — including a throw from inside the catch, where the two-release-site shape leaked the client and caused the very hook timeout this helper exists to avoid. `rolledBack` plus a discarded rollback error collapse into one `Error | undefined` matching `release()`'s domain, and the destroy reason is now the ROLLBACK failure that actually poisoned the connection. The comment states the deliberate divergence from `publish()` (which destroys unconditionally) instead of implying parity.
- **`afterAll` throws on a failed `DROP SCHEMA` rather than logging** — a deliberate override of the issue's "logging the leak" criterion. `scripts/test-isolated.ts:183` prints captured output only on a non-zero exit, so the log line was discarded in exactly the case it existed to report: a green run that leaked a schema. Schema names carry a timestamp and random suffix, so an unreported leak is an unattributable orphan in a shared database.
- The `Effect.tryPromise` comment no longer says the assertion message is "destroyed" — it survives to a scrubbed, truncated `log.warn`, but is diverted out of the failure diff, which is the real problem.

### Companion commit on `milestone/brain-m2`

All of the above are equally wrong in `temporal-loop-pg.test.ts`, the reference #4926 says to copy from. Fixing only this side would recreate the divergence the issue exists to close, so `5ead11f` on `milestone/brain-m2` ports the same corrections. **The three shared blocks — `poolTransaction`, the `afterAll` pool teardown, and the `resolveModel` assertion — now diff byte-identical between the two files** (acceptance criterion 6).

## Test Plan

The suite is `describe.skip` without `TEST_DATABASE_URL`, so a run without a database proves nothing. There was no Docker or Postgres in the working container, so I installed Postgres 16 and ran against it.

```
wedge-loop-pg.test.ts    10 pass, 0 fail, 131 expect() calls
temporal-loop-pg.test.ts  1 pass, 0 fail,  67 expect() calls   (milestone/brain-m2)
```

Beyond a green run, the two assertion-semantics changes were mutation-checked on **both** files:

| Mutation | Expected | Result |
|---|---|---|
| Push a wrong workspace id | assertion fails, naming the bad value | fails with a readable diff — previously surfaced only as a `failed:` count mismatch |
| Remove the zero-drain branch | replay test fails | wedge 9/10, temporal 0/1 — confirms the old `Set` was passing vacuously there |
| Simulate per-episode resolution | arity pin catches it | wedge 1/10, temporal 0/1 — the `Set` could not catch this at all |

- [x] Manual testing
- [x] Unit tests added/updated — existing suites' fixture helpers hardened; no new cases
- [ ] E2E tests added/updated

## Checklist

- [x] Types pass (`bun run type`) — both branches
- [x] Tests pass (`bun run test`) — full suite exit 0 with `TEST_DATABASE_URL` set; all 38 packages passed
- [x] Lint passes (`bun run lint`) — and `lint:type-aware`, zero errors, zero hits in either changed file
- [ ] Deps consistent (`bun run deps:lint`) — N/A, no dependency changes
- [x] Labels added (type + area) — inherited from #4926: `chore`, `area: api`, `area: testing`
- [ ] CHANGELOG.md updated (if user-facing change) — N/A, test-only

https://claude.ai/code/session_01E7T3XoX1MrmwYbWZ31p1Sd