### PR TITLE
security(agent): stop runAgent defaulting to a write-carrying tool registry (#4936)

### DIFF
--- a/ee/src/proactive/__tests__/answer-adapter.test.ts
+++ b/ee/src/proactive/__tests__/answer-adapter.test.ts
@@ -41,7 +41,15 @@ interface ObservedRunAgentCall {
   orgId?: string | null;
   agentOrigin?: string;
   requestId?: string;
-  hasCustomToolRegistry: boolean;
+  /**
+   * #4936 — the tool NAMES the adapter handed this run. This used to be a
+   * boolean (`params.tools !== undefined`), which only discriminated the two
+   * branches while the linked branch passed no registry at all. Now that BOTH
+   * branches name one, the boolean is true either way — so it is replaced with
+   * the names, which say what each branch actually got and keep the
+   * unlinked-asker assertion (AC #2614) from going vacuous.
+   */
+  toolNames: readonly string[] | undefined;
   /** #4299 — the answer style the adapter resolved for this run. */
   answerStyle?: string;
 }
@@ -91,10 +99,9 @@ mock.module("@atlas/api/lib/agent", () => ({
       orgId: ctx?.user?.activeOrganizationId ?? null,
       agentOrigin: ctx?.agentOrigin,
       requestId: ctx?.requestId,
-      // Non-null when the adapter built a restricted registry for the
-      // unlinked-asker path. The unlinked path test asserts truthy;
-      // linked path tests assert falsy.
-      hasCustomToolRegistry: params.tools !== undefined,
+      toolNames: params.tools
+        ? Object.keys((params.tools as { getAll(): Record<string, unknown> }).getAll())
+        : undefined,
       ...(params.answerStyle !== undefined ? { answerStyle: params.answerStyle } : {}),
     });
 
@@ -230,9 +237,23 @@ describe("createProactiveAnswerAdapter — linked path", () => {
     expect(observedRunAgentCalls[0].orgId).toBe("org-linked");
     expect(observedRunAgentCalls[0].agentOrigin).toBe("slack");
     expect(observedRunAgentCalls[0].question).toBe("how many customers?");
-    // Linked askers get the default ToolRegistry — no `tools` arg
-    // passed through to runAgent.
-    expect(observedRunAgentCalls[0].hasCustomToolRegistry).toBe(false);
+    // #4936 — the linked branch names `nonDashboardRegistry`. It used to pass
+    // no `tools` at all and inherit `runAgent`'s then-default `defaultRegistry`,
+    // which carries the brain-mutating `correct_fact`: a proactive Slack answer
+    // is autonomous and has no confirmation UI, so the write verb must not be
+    // on the surface however well execute-time gating holds.
+    const linkedTools = observedRunAgentCalls[0].toolNames;
+    expect(linkedTools, "the linked branch must name a registry").toBeDefined();
+    expect(linkedTools).not.toContain("correct_fact");
+    expect(linkedTools).not.toContain("createDashboard");
+    // Not vacuous — a linked asker still gets full data access under their own
+    // identity, which is the whole point of the linked branch.
+    expect(linkedTools).toContain("executeSQL");
+    expect(linkedTools).toContain("explore");
+    // `searchBrain` also separates this from the unlinked branch's
+    // two-tool public-dataset registry, so the two assertions can't both be
+    // satisfied by the same registry.
+    expect(linkedTools).toContain("searchBrain");
     // #4299 — no presentationMode on the context: the adapter resolves the
     // analyst fallback (successor of the retired addendum-free "developer"
     // posture for hosts predating #2705).
@@ -371,11 +392,26 @@ describe("createProactiveAnswerAdapter — unlinked path", () => {
     // model routing both branch on `activeOrganizationId`, so an empty
     // string here is the unlinked-asker fingerprint.
     expect(observedRunAgentCalls[0].orgId === null || observedRunAgentCalls[0].orgId === "").toBe(true);
-    // AC #2614 belt-and-braces: agent runs with a restricted registry,
-    // not the default workspace toolset. The listener's post-filter is
-    // a backstop — the adapter-side gate prevents the agent from
-    // reading sensitive entities in the first place.
-    expect(observedRunAgentCalls[0].hasCustomToolRegistry).toBe(true);
+    // AC #2614 belt-and-braces: agent runs with the restricted PUBLIC-DATASET
+    // registry, not a workspace toolset. The listener's post-filter is a
+    // backstop — the adapter-side gate prevents the agent from reading
+    // sensitive entities in the first place.
+    //
+    // #4936 — asserted on the tool NAMES, not on "a registry was passed". Now
+    // that the linked branch also names one, "passed something" no longer
+    // discriminates: a regression that dropped `createPublicDatasetToolRegistry`
+    // and fell through to a warehouse-wide registry would satisfy it. The
+    // public-dataset registry is defined by what it does NOT carry.
+    // Pinned as an EXACT set, not a subset: `explore`/`executeSQL` here are the
+    // public-dataset REIMPLEMENTATIONS (`public-dataset-tools.ts`), so matching
+    // on their names alone cannot tell this registry from a workspace one. What
+    // distinguishes it is everything it does NOT also carry — `searchBrain`,
+    // `sendEmail`, `createLinearIssue`, `correct_fact`, `createDashboard`. A
+    // regression that fell through to `nonDashboardRegistry` or
+    // `defaultRegistry` fails on the extra names.
+    const unlinkedTools = observedRunAgentCalls[0].toolNames;
+    expect(unlinkedTools, "the unlinked branch must name a registry").toBeDefined();
+    expect([...unlinkedTools!].sort()).toEqual(["executeSQL", "explore"]);
     await runtime.dispose();
   });
 

--- a/ee/src/proactive/__tests__/answer-adapter.test.ts
+++ b/ee/src/proactive/__tests__/answer-adapter.test.ts
@@ -411,7 +411,11 @@ describe("createProactiveAnswerAdapter — unlinked path", () => {
     // `defaultRegistry` fails on the extra names.
     const unlinkedTools = observedRunAgentCalls[0].toolNames;
     expect(unlinkedTools, "the unlinked branch must name a registry").toBeDefined();
-    expect([...unlinkedTools!].sort()).toEqual(["executeSQL", "explore"]);
+    expect(
+      [...unlinkedTools!].sort(),
+      "the public-dataset registry is defined by what it does NOT carry — an extra name " +
+        "means the unlinked asker reached a workspace registry",
+    ).toEqual(["executeSQL", "explore"]);
     await runtime.dispose();
   });
 

--- a/ee/src/proactive/answer-adapter.ts
+++ b/ee/src/proactive/answer-adapter.ts
@@ -16,8 +16,12 @@
  * Identity binding:
  *   - **Linked asker** (`context.atlasUserId` non-null) — resolve the
  *     user's active org via the `member` table, build a real
- *     {@link AtlasUser} via {@link loadActorUser}, run the agent with
- *     the full workspace toolset (default {@link ToolRegistry}).
+ *     {@link AtlasUser} via {@link loadActorUser}, run the agent on the
+ *     headless core toolset ({@link nonDashboardRegistry}) — full data
+ *     access under the user's real identity, but no `createDashboard`
+ *     (no dashboards route to hand off to) and no `correct_fact` (#4936:
+ *     a brain-mutating write does not belong on an autonomous surface
+ *     with no confirmation UI, whatever the asker's org role).
  *   - **Unlinked asker** (`context.atlasUserId === null`) — synthesize
  *     an anonymous chat-bot actor with no `activeOrganizationId`, and
  *     restrict the agent at the tool boundary via
@@ -71,6 +75,7 @@ import {
 } from "@atlas/api/lib/db/internal";
 import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
 import type { ToolRegistry } from "@atlas/api/lib/tools/registry";
+import { nonDashboardRegistry } from "@atlas/api/lib/tools/registry";
 import { createPublicDatasetToolRegistry } from "./public-dataset-tools";
 import type { PublicDatasetEntry } from "./public-dataset";
 
@@ -177,9 +182,20 @@ export function createProactiveAnswerAdapter(
     const { threadId, asker, atlasUserId, workspaceId } = context;
     const askerId = describeAskerId(asker);
 
-    // 1. Resolve identity + (unlinked) restricted tool registry ----------
+    // 1. Resolve identity + this turn's tool registry --------------------
+    // #4936 — BOTH branches assign a registry. `toolRegistry` used to be left
+    // `undefined` on the linked-asker branch and spread away at the call site
+    // (`...(toolRegistry ? { tools: toolRegistry } : {})`), so a linked asker
+    // fell through to whatever `runAgent` defaulted to — then the dashboards-
+    // owning `defaultRegistry`, which carries the brain-mutating `correct_fact`.
+    // `resolveLinkedActor` returns a REAL user with a real
+    // `activeOrganizationId` and `resolveBrainReaderContext` re-resolves their
+    // real `member.role`, so for an org owner/admin a proactive Slack answer
+    // could retract or supersede brain facts — autonomously, with no
+    // confirmation UI, guarded only by prose in `CORRECT_FACT_DESCRIPTION`.
+    // No `undefined` state now exists to fall through.
     let actor: AtlasUser;
-    let toolRegistry: ToolRegistry | undefined;
+    let toolRegistry: ToolRegistry;
     try {
       if (atlasUserId) {
         actor = await resolveLinkedActor(
@@ -187,6 +203,11 @@ export function createProactiveAnswerAdapter(
           resolveOrgForUser,
           resolveActor,
         );
+        // Linked asker — full identity, but still a HEADLESS surface: a
+        // proactive Slack answer owns no dashboards route and has no human in
+        // the loop, exactly like the `executeAgentQuery` turns the chat plugin
+        // drives. Same registry, named explicitly.
+        toolRegistry = nonDashboardRegistry;
       } else {
         // Unlinked asker — MUST resolve the workspace's public dataset
         // and bind the adapter-side tool gate before invoking the
@@ -303,7 +324,11 @@ export function createProactiveAnswerAdapter(
               },
             ],
             aiModel,
-            ...(toolRegistry ? { tools: toolRegistry } : {}),
+            // #4936 — unconditional: the linked branch pins
+            // `nonDashboardRegistry`, the unlinked branch pins the
+            // public-dataset registry. Neither can be `undefined`, so there is
+            // no path left that inherits `runAgent`'s default.
+            tools: toolRegistry,
             // #2705/#4299 — the proactive seam still speaks the legacy
             // presentation-mode signal; resolve it through the answer-style
             // registry so the system prompt carries that style's addendum.

--- a/ee/src/proactive/answer-adapter.ts
+++ b/ee/src/proactive/answer-adapter.ts
@@ -188,12 +188,19 @@ export function createProactiveAnswerAdapter(
     // (`...(toolRegistry ? { tools: toolRegistry } : {})`), so a linked asker
     // fell through to whatever `runAgent` defaulted to — then the dashboards-
     // owning `defaultRegistry`, which carries the brain-mutating `correct_fact`.
-    // `resolveLinkedActor` returns a REAL user with a real
-    // `activeOrganizationId` and `resolveBrainReaderContext` re-resolves their
-    // real `member.role`, so for an org owner/admin a proactive Slack answer
-    // could retract or supersede brain facts — autonomously, with no
-    // confirmation UI, guarded only by prose in `CORRECT_FACT_DESCRIPTION`.
-    // No `undefined` state now exists to fall through.
+    // `resolveLinkedActor` returns a REAL user, with a real
+    // `activeOrganizationId` whenever they have a member row, and
+    // `resolveBrainReaderContext` re-resolves their real `member.role` — so for
+    // an org owner/admin a proactive Slack answer could retract or supersede
+    // brain facts, autonomously, with no confirmation UI, guarded only by prose
+    // in `CORRECT_FACT_DESCRIPTION`.
+    //
+    // LATENT rather than live today: the wired SaaS resolver
+    // (`createSlackProactiveUserResolver`) returns `unlinked` for every asker
+    // until a Slack-user link table lands (#2624), so this branch is unreachable
+    // in production. That is exactly why it must be closed BEFORE that branch
+    // goes live — the type now makes the `undefined` state unrepresentable, so
+    // there is no path left to fall through.
     let actor: AtlasUser;
     let toolRegistry: ToolRegistry;
     try {
@@ -204,9 +211,17 @@ export function createProactiveAnswerAdapter(
           resolveActor,
         );
         // Linked asker — full identity, but still a HEADLESS surface: a
-        // proactive Slack answer owns no dashboards route and has no human in
-        // the loop, exactly like the `executeAgentQuery` turns the chat plugin
-        // drives. Same registry, named explicitly.
+        // proactive Slack answer owns no dashboards route and has no
+        // confirmation UI, like the `executeAgentQuery` turns the chat plugin
+        // drives.
+        //
+        // Deliberately the STATIC core set, not `buildHeadlessRegistry()`.
+        // They are not the same registry: the dynamic builder adds the operator
+        // action tools (`sendEmailReport`, `createJiraTicket`) under
+        // `ATLAS_ACTIONS_ENABLED`, plus `executePython`. Handing external-write
+        // verbs to the most autonomous, least supervised surface in the product,
+        // under a real linked user's identity, is the widening this issue is
+        // about — so do NOT "dedupe" these two into one call.
         toolRegistry = nonDashboardRegistry;
       } else {
         // Unlinked asker — MUST resolve the workspace's public dataset
@@ -324,10 +339,7 @@ export function createProactiveAnswerAdapter(
               },
             ],
             aiModel,
-            // #4936 — unconditional: the linked branch pins
-            // `nonDashboardRegistry`, the unlinked branch pins the
-            // public-dataset registry. Neither can be `undefined`, so there is
-            // no path left that inherits `runAgent`'s default.
+            // #4936 — unconditional; see the branch comment above.
             tools: toolRegistry,
             // #2705/#4299 — the proactive seam still speaks the legacy
             // presentation-mode signal; resolve it through the answer-style

--- a/ee/src/proactive/answer-adapter.ts
+++ b/ee/src/proactive/answer-adapter.ts
@@ -195,10 +195,10 @@ export function createProactiveAnswerAdapter(
     // brain facts, autonomously, with no confirmation UI, guarded only by prose
     // in `CORRECT_FACT_DESCRIPTION`.
     //
-    // LATENT rather than live today: the wired SaaS resolver
+    // LATENT rather than live on the SaaS wiring today: the wired resolver
     // (`createSlackProactiveUserResolver`) returns `unlinked` for every asker
-    // until a Slack-user link table lands (#2624), so this branch is unreachable
-    // in production. That is exactly why it must be closed BEFORE that branch
+    // until a Slack-user link table exists, so this branch is unreachable there.
+    // A self-hosted host may still supply its own `userResolver`. That is exactly why it must be closed BEFORE that branch
     // goes live — the type now makes the `undefined` state unrepresentable, so
     // there is no path left to fall through.
     let actor: AtlasUser;
@@ -218,10 +218,15 @@ export function createProactiveAnswerAdapter(
         // Deliberately the STATIC core set, not `buildHeadlessRegistry()`.
         // They are not the same registry: the dynamic builder adds the operator
         // action tools (`sendEmailReport`, `createJiraTicket`) under
-        // `ATLAS_ACTIONS_ENABLED`, plus `executePython`. Handing external-write
-        // verbs to the most autonomous, least supervised surface in the product,
-        // under a real linked user's identity, is the widening this issue is
-        // about — so do NOT "dedupe" these two into one call.
+        // `ATLAS_ACTIONS_ENABLED`, and `executePython` under
+        // `ATLAS_PYTHON_ENABLED`. Adding OPERATOR-configured write verbs to the
+        // most autonomous, least supervised surface in the product, under a real
+        // linked user's identity, is the widening this issue is about — so do
+        // NOT "dedupe" these two into one call.
+        //
+        // This set is lesser-privileged, not side-effect-free: `sendEmail` and
+        // `createLinearIssue` are core tools here too, gated at execute time on
+        // the workspace install.
         toolRegistry = nonDashboardRegistry;
       } else {
         // Unlinked asker — MUST resolve the workspace's public dataset

--- a/ee/src/proactive/answer-adapter.ts
+++ b/ee/src/proactive/answer-adapter.ts
@@ -198,9 +198,10 @@ export function createProactiveAnswerAdapter(
     // LATENT rather than live on the SaaS wiring today: the wired resolver
     // (`createSlackProactiveUserResolver`) returns `unlinked` for every asker
     // until a Slack-user link table exists, so this branch is unreachable there.
-    // A self-hosted host may still supply its own `userResolver`. That is exactly why it must be closed BEFORE that branch
-    // goes live — the type now makes the `undefined` state unrepresentable, so
-    // there is no path left to fall through.
+    // A self-hosted host may still supply its own `userResolver`. That is
+    // exactly why it must be closed BEFORE the branch goes live — the type now
+    // makes the `undefined` state unrepresentable, so there is no path left to
+    // fall through.
     let actor: AtlasUser;
     let toolRegistry: ToolRegistry;
     try {

--- a/packages/api/src/api/__tests__/chat-resume.test.ts
+++ b/packages/api/src/api/__tests__/chat-resume.test.ts
@@ -258,6 +258,30 @@ describe("POST /api/v1/chat/:conversationId/resume", () => {
     expect(arg.resume?.priorStepIndex).toBe(2);
   });
 
+  it("#4936 — resumes on the WORKSPACE registry, keeping both write verbs", async () => {
+    // The web resume is the dashboards-owning twin of the chat-PLATFORM resume
+    // (`lib/chat-plugin/resume-turn.ts`, which resolves `buildHeadlessRegistry()`).
+    // `runAgent` now defaults to the least-privileged registry, so this route
+    // must name `defaultRegistry` — and over-correcting it to
+    // `nonDashboardRegistry` would silently strip dashboards and fact
+    // correction from a resumed web turn. The structural guard pins the
+    // variable NAME at this call site, not the registry it resolves to, so only
+    // this assertion catches that.
+    const res = await app.fetch(resumeRequest());
+    expect(res.status).toBe(200);
+    expect(mockRunAgent).toHaveBeenCalledTimes(1);
+
+    const arg = (mockRunAgent.mock.calls as unknown as Array<
+      [{ tools?: { getAll(): Record<string, unknown> } }]
+    >)[0]![0];
+    expect(arg.tools, "the web resume must pass `tools` explicitly").toBeDefined();
+
+    const names = Object.keys(arg.tools!.getAll());
+    expect(names).toContain("createDashboard");
+    expect(names).toContain("correct_fact");
+    expect(names).toContain("executeSQL");
+  });
+
   // #4302 — a resumed turn rebuilds its system prompt live (the checkpoint
   // stores the transcript, not the system param), so the conversation's
   // pinned answer style must be re-threaded from the row loaded for the

--- a/packages/api/src/api/__tests__/chat.test.ts
+++ b/packages/api/src/api/__tests__/chat.test.ts
@@ -1642,14 +1642,34 @@ describe("POST /api/v1/chat", () => {
     expect(response.status).toBe(422);
   });
 
+  // #4936 — these three used to read `call.tools === undefined` as the proxy for
+  // "no action tools", which only worked because the chat route omitted `tools`
+  // and let `runAgent` default. The route now names its registry explicitly (it
+  // is the one surface that OWNS `/dashboards/[id]`, so it opts in to the
+  // workspace set), and `undefined` is no longer reachable. Assert on the tool
+  // NAMES instead — that is what the tests were always trying to say, and it
+  // survives any future change to how the route resolves its registry.
+  function toolNamesFromRunAgentCall(): string[] {
+    const calls = mockRunAgent.mock.calls as unknown as unknown[][];
+    const call = calls[0]![0] as { tools?: { getAll(): Record<string, unknown> } };
+    expect(call.tools, "the chat route must pass `tools` explicitly (#4936)").toBeDefined();
+    return Object.keys(call.tools!.getAll());
+  }
+
+  /**
+   * An operator-env ACTION tool (`lib/tools/actions/`) — registered only when
+   * `buildRegistry({ includeActions: true })` runs. Not to be confused with the
+   * integration tools `sendEmail` / `createLinearIssue`, which are core (always
+   * registered, gated at execute time on the workspace install).
+   */
+  const ACTION_TOOL = "sendEmailReport";
+
   it("passes action tools to runAgent when ATLAS_ACTIONS_ENABLED=true", async () => {
     process.env.ATLAS_ACTIONS_ENABLED = "true";
     const response = await app.fetch(makeRequest());
     expect(response.status).toBe(200);
     expect(mockRunAgent).toHaveBeenCalledTimes(1);
-    const calls = mockRunAgent.mock.calls as unknown as unknown[][];
-    const call = calls[0]![0] as { tools?: unknown };
-    expect(call.tools).toBeDefined();
+    expect(toolNamesFromRunAgentCall()).toContain(ACTION_TOOL);
   });
 
   it("does not pass action tools when ATLAS_ACTIONS_ENABLED is unset", async () => {
@@ -1657,9 +1677,10 @@ describe("POST /api/v1/chat", () => {
     const response = await app.fetch(makeRequest());
     expect(response.status).toBe(200);
     expect(mockRunAgent).toHaveBeenCalledTimes(1);
-    const calls = mockRunAgent.mock.calls as unknown as unknown[][];
-    const call = calls[0]![0] as { tools?: unknown };
-    expect(call.tools).toBeUndefined();
+    const names = toolNamesFromRunAgentCall();
+    expect(names).not.toContain(ACTION_TOOL);
+    // Not vacuous — the core surface is intact, only the actions are absent.
+    expect(names).toContain("executeSQL");
   });
 
   it("does not pass action tools when ATLAS_ACTIONS_ENABLED=false", async () => {
@@ -1667,9 +1688,9 @@ describe("POST /api/v1/chat", () => {
     const response = await app.fetch(makeRequest());
     expect(response.status).toBe(200);
     expect(mockRunAgent).toHaveBeenCalledTimes(1);
-    const calls = mockRunAgent.mock.calls as unknown as unknown[][];
-    const call = calls[0]![0] as { tools?: unknown };
-    expect(call.tools).toBeUndefined();
+    const names = toolNamesFromRunAgentCall();
+    expect(names).not.toContain(ACTION_TOOL);
+    expect(names).toContain("executeSQL");
   });
 
   it("passes warnings to runAgent when buildRegistry throws", async () => {

--- a/packages/api/src/api/__tests__/chat.test.ts
+++ b/packages/api/src/api/__tests__/chat.test.ts
@@ -1681,6 +1681,13 @@ describe("POST /api/v1/chat", () => {
     expect(names).not.toContain(ACTION_TOOL);
     // Not vacuous — the core surface is intact, only the actions are absent.
     expect(names).toContain("executeSQL");
+    // #4936 — and the web surface must KEEP the workspace write verbs. It owns
+    // `/dashboards/[id]` and has a human in the loop, so it is the one place
+    // they belong. Without this, over-correcting the route's fallback to
+    // `nonDashboardRegistry` would silently strip dashboards and fact
+    // correction from web chat and every test in the fix would stay green.
+    expect(names).toContain("createDashboard");
+    expect(names).toContain("correct_fact");
   });
 
   it("does not pass action tools when ATLAS_ACTIONS_ENABLED=false", async () => {

--- a/packages/api/src/api/__tests__/cors.test.ts
+++ b/packages/api/src/api/__tests__/cors.test.ts
@@ -62,10 +62,14 @@ void mock.module("@atlas/api/lib/tools/explore", () => ({
   // ordinary path (this file mocks `lib/agent`, which used to be the only thing
   // pulling it in). A partial mock of a module that registry's graph imports
   // fails the whole import, which surfaces here as a JSON error instead of the
-  // SSE stream under test — so these mocks must cover the real export surface.
+  // SSE stream under test — so this and the `lib/settings` mock below cover
+  // their modules' full named-export surface, not just the names that broke.
   invalidateOrgExploreBackends: mock(() => {}),
   markNsjailFailed: mock(() => {}),
   markSidecarFailed: mock(() => {}),
+  snapshotExploreSandboxEnv: () => ({}),
+  _formatSandboxPriorityFailureForTest: () => "",
+  _resetSandboxFailureFlagsForTest: () => {},
 }));
 
 void mock.module("@atlas/api/lib/auth/detect", () => ({
@@ -78,6 +82,12 @@ void mock.module("@atlas/api/lib/settings", () => ({
   getSettingAuto: () => undefined,
   // #4936 — same cause as the `lib/tools/explore` mock above.
   getSettingOverride: () => undefined,
+  isSaasModeForGuard: () => false,
+  refreshSettingsTick: async () => {},
+  isHotReloadedKey: () => false,
+  HOT_RELOADED_KEYS: new Set<string>(),
+  SECURITY_SENSITIVE_KEYS: new Set<string>(),
+  securitySensitiveAuditFields: () => ({}),
   getSettingLive: async () => undefined,
   setSetting: async () => {},
   deleteSetting: async () => {},

--- a/packages/api/src/api/__tests__/cors.test.ts
+++ b/packages/api/src/api/__tests__/cors.test.ts
@@ -76,6 +76,7 @@ void mock.module("@atlas/api/lib/auth/detect", () => ({
 void mock.module("@atlas/api/lib/settings", () => ({
   getSetting: () => undefined,
   getSettingAuto: () => undefined,
+  // #4936 — same cause as the `lib/tools/explore` mock above.
   getSettingOverride: () => undefined,
   getSettingLive: async () => undefined,
   setSetting: async () => {},

--- a/packages/api/src/api/__tests__/cors.test.ts
+++ b/packages/api/src/api/__tests__/cors.test.ts
@@ -57,6 +57,13 @@ void mock.module("@atlas/api/lib/tools/explore", () => ({
   getActiveSandboxPluginId: () => null,
   explore: { type: "function" },
   invalidateExploreBackend: mock(() => {}),
+  // #4936 — the chat route now resolves its tool registry explicitly instead of
+  // inheriting `runAgent`'s default, so `lib/tools/registry` is loaded on the
+  // ordinary path (this file mocks `lib/agent`, which used to be the only thing
+  // pulling it in). A partial mock of a module that registry's graph imports
+  // fails the whole import, which surfaces here as a JSON error instead of the
+  // SSE stream under test — so these mocks must cover the real export surface.
+  invalidateOrgExploreBackends: mock(() => {}),
   markNsjailFailed: mock(() => {}),
   markSidecarFailed: mock(() => {}),
 }));
@@ -69,6 +76,7 @@ void mock.module("@atlas/api/lib/auth/detect", () => ({
 void mock.module("@atlas/api/lib/settings", () => ({
   getSetting: () => undefined,
   getSettingAuto: () => undefined,
+  getSettingOverride: () => undefined,
   getSettingLive: async () => undefined,
   setSetting: async () => {},
   deleteSetting: async () => {},

--- a/packages/api/src/api/routes/chat.ts
+++ b/packages/api/src/api/routes/chat.ts
@@ -1567,7 +1567,20 @@ chat.openapi(chatRoute, async (c) => {
             );
             toolRegistry = buildBoundDashboardRegistry(boundDashboardForAgent.toolContext);
           }
-  
+
+          // #4936 — the web chat surface OWNS `/dashboards/[id]` and has a human
+          // in the loop, so it is one of the two callers that opts IN to the
+          // dashboards-owning `defaultRegistry` (`createDashboard`,
+          // `correct_fact`). `runAgent` now defaults to the least-privileged
+          // `nonDashboardRegistry`, so the fallback is resolved HERE rather than
+          // inherited: the workspace tool set stays attached to the surface that
+          // can actually reach it, instead of leaking to every headless caller
+          // that happened to omit `tools`. `toolRegistry` is still undefined on
+          // the ordinary path (actions off, no plugin tools, not bound), which is
+          // exactly why this cannot be left implicit.
+          const { defaultRegistry } = await import("@atlas/api/lib/tools/registry");
+          const resolvedToolRegistry = toolRegistry ?? defaultRegistry;
+
           // #1988 B5 — out-array the agent's preflight loaders push into
           // when the org semantic layer or learned-patterns lookup fail.
           // We forward each as an SSE `data-context-warning` frame below
@@ -1681,7 +1694,7 @@ chat.openapi(chatRoute, async (c) => {
             () =>
               runAgent({
                 messages,
-                ...(toolRegistry && { tools: toolRegistry }),
+                tools: resolvedToolRegistry,
                 conversationId,
                 ...(warnings.length > 0 && { warnings }),
                 contextWarnings,
@@ -2164,6 +2177,19 @@ chat.openapi(chatResumeRoute, async (c) => {
             log.error({ err: err instanceof Error ? err : new Error(String(err)) }, "Failed to merge plugin tools on resume — continuing without");
           }
 
+          // #4936 — same opt-in as the chat route above: this is the WEB resume,
+          // on the dashboards-owning workspace surface, so it names
+          // `defaultRegistry` explicitly rather than inheriting a default that
+          // `runAgent` now points at the least-privileged registry. (The
+          // chat-PLATFORM resume — `lib/chat-plugin/resume-turn.ts` — is the
+          // headless twin and resolves `buildHeadlessRegistry()` instead; the
+          // two resume paths must not share one implicit default, which is how
+          // the widening went unnoticed.)
+          const { defaultRegistry: workspaceRegistry } = await import(
+            "@atlas/api/lib/tools/registry"
+          );
+          const resolvedToolRegistry = toolRegistry ?? workspaceRegistry;
+
           // Re-enter the agent loop from the checkpoint. `messages: []` is inert
           // — the `resume.transcript` is the model input; the loop continues from
           // the last completed step. The resumed step accounting counts against
@@ -2182,7 +2208,7 @@ chat.openapi(chatResumeRoute, async (c) => {
 
           const agentResult = await runAgent({
             messages: [],
-            ...(toolRegistry && { tools: toolRegistry }),
+            tools: resolvedToolRegistry,
             conversationId,
             // #4302 — a resumed turn rebuilds its system prompt live (the
             // checkpoint stores the message transcript, not the system

--- a/packages/api/src/api/routes/chat.ts
+++ b/packages/api/src/api/routes/chat.ts
@@ -1570,14 +1570,11 @@ chat.openapi(chatRoute, async (c) => {
 
           // #4936 — the web chat surface OWNS `/dashboards/[id]` and has a human
           // in the loop, so it is one of the two callers that opts IN to the
-          // dashboards-owning `defaultRegistry` (`createDashboard`,
-          // `correct_fact`). `runAgent` now defaults to the least-privileged
-          // `nonDashboardRegistry`, so the fallback is resolved HERE rather than
-          // inherited: the workspace tool set stays attached to the surface that
-          // can actually reach it, instead of leaking to every headless caller
-          // that happened to omit `tools`. `toolRegistry` is still undefined on
-          // the ordinary path (actions off, no plugin tools, not bound), which is
-          // exactly why this cannot be left implicit.
+          // dashboards-owning `defaultRegistry`. Resolved HERE rather than
+          // inherited: `toolRegistry` is still undefined on the ordinary path
+          // (actions off, no plugin tools, not bound), which is exactly why it
+          // cannot be left implicit. Rationale: the `correct_fact` gate comment
+          // in lib/tools/registry.ts.
           const { defaultRegistry } = await import("@atlas/api/lib/tools/registry");
           const resolvedToolRegistry = toolRegistry ?? defaultRegistry;
 
@@ -2177,14 +2174,12 @@ chat.openapi(chatResumeRoute, async (c) => {
             log.error({ err: err instanceof Error ? err : new Error(String(err)) }, "Failed to merge plugin tools on resume — continuing without");
           }
 
-          // #4936 — same opt-in as the chat route above: this is the WEB resume,
-          // on the dashboards-owning workspace surface, so it names
-          // `defaultRegistry` explicitly rather than inheriting a default that
-          // `runAgent` now points at the least-privileged registry. (The
-          // chat-PLATFORM resume — `lib/chat-plugin/resume-turn.ts` — is the
-          // headless twin and resolves `buildHeadlessRegistry()` instead; the
-          // two resume paths must not share one implicit default, which is how
-          // the widening went unnoticed.)
+          // #4936 — same opt-in as the chat route above: the WEB resume, on the
+          // dashboards-owning workspace surface. Its headless twin is the
+          // chat-PLATFORM resume (`lib/chat-plugin/resume-turn.ts`), which
+          // resolves `buildHeadlessRegistry()`. The two resume paths must not
+          // share one implicit default — that is how the widening went
+          // unnoticed.
           const { defaultRegistry: workspaceRegistry } = await import(
             "@atlas/api/lib/tools/registry"
           );

--- a/packages/api/src/api/routes/demo.ts
+++ b/packages/api/src/api/routes/demo.ts
@@ -649,8 +649,10 @@ demo.openapi(demoChatRoute, async (c) => {
         // zero-signup demo is anonymous and owns no `/dashboards/[id]` route,
         // so `createDashboard` proposes a draft the visitor can't open and
         // `correct_fact` advertises an admin write verb the demo actor can
-        // never satisfy (`createAtlasUser` sets no `activeOrganizationId`, so
-        // the verb refuses with `no_workspace`). Both were reaching the demo
+        // never satisfy (the demo's `createAtlasUser` call passes no
+        // `activeOrganizationId`, so the verb refuses with `no_workspace` —
+        // or `no_internal_db`, checked first, on a deploy without one). Both
+        // were reaching the demo
         // purely because `runAgent` used to default to the workspace registry.
         const { nonDashboardRegistry } = await import("@atlas/api/lib/tools/registry");
         const agentResult = await runAgent({

--- a/packages/api/src/api/routes/demo.ts
+++ b/packages/api/src/api/routes/demo.ts
@@ -644,9 +644,18 @@ demo.openapi(demoChatRoute, async (c) => {
         // non-gateway deploy so runAgent resolves the platform default.
         // Passing `aiModel` makes the demo model authoritative, so
         // `token_usage.model`/`provider` reflect it.
-        // Demo uses default tools only — no actions, no plugin tools
+        // Demo uses the core tools only — no actions, no plugin tools.
+        // #4936 — named explicitly, and named `nonDashboardRegistry`: the
+        // zero-signup demo is anonymous and owns no `/dashboards/[id]` route,
+        // so `createDashboard` proposes a draft the visitor can't open and
+        // `correct_fact` advertises an admin write verb the demo actor can
+        // never satisfy (`createAtlasUser` sets no `activeOrganizationId`, so
+        // the verb refuses with `no_workspace`). Both were reaching the demo
+        // purely because `runAgent` used to default to the workspace registry.
+        const { nonDashboardRegistry } = await import("@atlas/api/lib/tools/registry");
         const agentResult = await runAgent({
           messages,
+          tools: nonDashboardRegistry,
           conversationId,
           maxSteps: getDemoMaxSteps(),
           ...demoRunAgentModelParams(),

--- a/packages/api/src/lib/__tests__/agent-query.test.ts
+++ b/packages/api/src/lib/__tests__/agent-query.test.ts
@@ -159,6 +159,12 @@ describe("executeAgentQuery actor binding", () => {
     expect(observedToolNames).toHaveLength(1);
     const names = observedToolNames[0];
     expect(names).not.toContain("createDashboard");
+    // #4936 — `correct_fact` is the other half of the same policy: both are
+    // gated on the SAME `dashboardUrlResolver` signal in `registerCoreTools`,
+    // so a change that re-globalizes one re-globalizes both. Pinned here
+    // because `buildHeadlessRegistry()` is now the shared seam these surfaces
+    // and the chat-plugin approval resume all route through.
+    expect(names).not.toContain("correct_fact");
     // The core query capability is untouched — the surface stays useful.
     expect(names).toContain("executeSQL");
     expect(names).toContain("explore");

--- a/packages/api/src/lib/__tests__/agent-runagent-call-sites.test.ts
+++ b/packages/api/src/lib/__tests__/agent-runagent-call-sites.test.ts
@@ -24,11 +24,16 @@
  *      called `tools`": `EXPECTED_REGISTRY` pins the actual expression per
  *      file, because "passed a registry" is satisfied just as well by passing
  *      the WRONG one, and a text match for `tools:` is satisfied by a
- *      CONDITIONAL spread — which is the exact shape two of the three
- *      pre-fix call sites had (`...(toolRegistry ? { tools: toolRegistry } :
- *      {})`). A guard that misses the spelling the bug actually used is
- *      theatre, so `SCANNER_FIXTURES` below pins the scanner against the
- *      historical spellings.
+ *      CONDITIONAL spread — `...(toolRegistry ? { tools: toolRegistry } : {})`,
+ *      which is what `ee/.../answer-adapter.ts` and `api/routes/chat.ts`
+ *      contained (the latter inheriting the default harmlessly, being the
+ *      surface that wants it — which is why the shape survived review). A guard
+ *      that misses the spelling the bug actually used is theatre, so
+ *      `SCANNER_FIXTURES` below pins the scanner against it.
+ *
+ *      Where an entry in `EXPECTED_REGISTRY` pins a LOCAL IDENTIFIER rather
+ *      than a registry name, the identifier's value is guaranteed only by that
+ *      surface's behavioural test — named per entry.
  *
  * The safe default is the backstop for anything the scan cannot see (an
  * untyped caller, a plugin compiled separately); naming the registry at the
@@ -38,7 +43,7 @@
  * axis (F-54/F-55), but over a DIFFERENT set — its roots are
  * `packages/api/src/api/routes` + `packages/api/src/lib/scheduler` only, so it
  * covers neither `ee/**` nor `lib/chat-plugin/**`. The two files overlap on
- * three call sites; they are complementary, not co-extensive.
+ * three FILES; they are complementary, not co-extensive.
  */
 
 import { describe, expect, it, mock } from "bun:test";
@@ -232,7 +237,9 @@ const REPO_ROOT = resolve(import.meta.dir, "..", "..", "..", "..", "..");
  * included deliberately: the proactive answer adapter — the call site with the
  * most authority (a real linked user, resolved to their real `member.role`)
  * and the least supervision (autonomous Slack answer, no confirmation UI) —
- * lives there, and an audit that stops at `packages/` misses it entirely.
+ * lives there, and an audit that stops at `packages/` misses it entirely. That
+ * branch is latent on the SaaS wiring today (see the adapter), which is why it
+ * needs a guard rather than a fix-on-report.
  *
  * This is an allowlist, so it can rot silently as packages are added.
  * `no runAgent call site lives outside SCAN_ROOTS` below is the drift guard.
@@ -284,39 +291,131 @@ function findRunAgentCalls(file: string, source: string): CallSite[] {
         if (depth === 0) break;
       }
     }
+    if (depth !== 0) {
+      // Never found the closing paren. `slice(start, i)` would return the rest
+      // of the FILE as the "arguments" — which almost certainly contains a
+      // `tools:` somewhere, so the call site would be silently ACCEPTED. Same
+      // rule as the sweep's read-fault handling: a degraded scan fails loudly.
+      throw new Error(
+        `unbalanced runAgent(...) at ${file} offset ${match.index} — the comment ` +
+          `stripper likely ate a paren; an unterminated scan silently ACCEPTS the call site`,
+      );
+    }
     out.push({ file, args: source.slice(start, i) });
   }
   return out;
 }
 
+type ToolsProp =
+  /** An unconditional `tools: <expr>` at the top level of the options object. */
+  | { readonly kind: "value"; readonly text: string }
+  /** An unconditional `tools` shorthand property. */
+  | { readonly kind: "shorthand" }
+  /** `tools` appears, but only inside a spread element. */
+  | { readonly kind: "spread-only" }
+  | { readonly kind: "absent" };
+
 /**
- * A call site is an offender if it does not name `tools` UNCONDITIONALLY.
+ * Locate the `tools` property of a `runAgent(...)` options object.
  *
- * The three rejected shapes are not hypothetical — the first two are verbatim
- * what `ee/src/proactive/answer-adapter.ts` and `packages/api/src/api/routes/
- * chat.ts` contained before this fix. A predicate that only asks "does the
- * substring `tools:` appear?" passes both, i.e. would have reported #4936 as
- * clean. `SCANNER_FIXTURES` pins that it does not.
+ * Deliberately a small brace-depth scanner rather than a regex. Every regex
+ * spelling of this check has a blind spot that matters:
+ *
+ *   - `/tools\s*:/` alone accepts a CONDITIONAL spread — and
+ *     `...(toolRegistry ? { tools: toolRegistry } : {})` is verbatim what
+ *     `ee/src/proactive/answer-adapter.ts` contained before this fix. A guard
+ *     that misses the spelling the bug actually used is theatre.
+ *   - narrowing the spread to `/\.\.\.\s*\([^)]*tools\s*:/` then misses any
+ *     condition containing a paren (`...(hasTools() ? … : {})`).
+ *   - either way, a `tools:` nested in `resume: { tools }` counts as a hit.
+ *
+ * Splitting on top-level commas has none of those holes: spread elements are
+ * identified as elements and skipped wholesale however they are spelled, and
+ * nesting is excluded by construction.
  */
-function offenceFor(args: string): string | undefined {
-  if (/\.\.\.\s*\([^)]*\btools\s*:/.test(args)) {
-    return "passes `tools` through a CONDITIONAL spread — the surface inherits the default whenever the condition is false";
+function inspectToolsProp(args: string): ToolsProp {
+  const open = args.indexOf("{");
+  // `runAgent(opts)` — no literal to inspect, so the surface's posture is not
+  // visible here. Treated as absent: fail closed and make the author inline it.
+  if (open === -1) return { kind: "absent" };
+
+  const props: string[] = [];
+  let depth = 0;
+  let start = open + 1;
+  for (let i = open; i < args.length; i++) {
+    const ch = args[i];
+    if (ch === "{" || ch === "(" || ch === "[") {
+      depth++;
+    } else if (ch === "}" || ch === ")" || ch === "]") {
+      depth--;
+      if (depth === 0) {
+        props.push(args.slice(start, i));
+        break;
+      }
+    } else if (ch === "," && depth === 1) {
+      props.push(args.slice(start, i));
+      start = i + 1;
+    }
   }
-  if (/(^|[\s{,])tools\s*:\s*undefined\b/.test(args)) {
-    return "passes `tools: undefined`, which is the same as omitting it";
+
+  let sawToolsInSpread = false;
+  for (const raw of props) {
+    const prop = raw.trim();
+    if (prop.startsWith("...")) {
+      if (/\btools\b/.test(prop)) sawToolsInSpread = true;
+      continue;
+    }
+    const match = /^(?:"tools"|'tools'|tools)\s*(:?)/.exec(prop);
+    if (!match) continue;
+    if (match[1] !== ":") {
+      // Guard against `toolsFoo` matching the bare-identifier arm.
+      if (prop !== "tools") continue;
+      return { kind: "shorthand" };
+    }
+    return { kind: "value", text: prop.slice(match[0].length).trim() };
   }
-  if (!/(^|[\s{,])tools\s*:/.test(args)) {
-    return "omits `tools`";
-  }
-  return undefined;
+
+  return sawToolsInSpread ? { kind: "spread-only" } : { kind: "absent" };
 }
 
 /**
- * The registry each production surface must resolve to. Pinning the EXPRESSION,
- * not just the presence of a `tools` key, is what makes this a security guard
- * rather than a style check: "passed a registry" is satisfied equally well by
- * passing the wrong one, and `tools: defaultRegistry` on a new headless surface
- * is precisely the regression #4936 is about.
+ * A call site is an offender if it does not name `tools` UNCONDITIONALLY, with
+ * a value that cannot be `undefined`.
+ *
+ * The last clause matters because `exactOptionalPropertyTypes` is off, so
+ * `tools: ToolRegistry | undefined` typechecks against `tools?: ToolRegistry`:
+ * `tools: cond ? registry : undefined` reads as explicit and behaves as
+ * omission. `SCANNER_FIXTURES` pins every one of these shapes.
+ */
+function offenceFor(args: string): string | undefined {
+  const prop = inspectToolsProp(args);
+  switch (prop.kind) {
+    case "absent":
+      return "omits `tools`";
+    case "spread-only":
+      return "names `tools` only inside a SPREAD — the surface inherits the default whenever the spread's condition is false";
+    case "shorthand":
+      return undefined;
+    case "value":
+      return /\bundefined\b/.test(prop.text)
+        ? "passes a `tools` value that can be `undefined`, which is the same as omitting it"
+        : undefined;
+  }
+}
+
+/**
+ * The registry each production surface must resolve to. Pinning what is PASSED,
+ * not just that something called `tools` is passed, is what makes this a
+ * security guard rather than a style check: "passed a registry" is satisfied
+ * equally well by passing the wrong one, and `tools: defaultRegistry` on a new
+ * headless surface is precisely the regression #4936 is about.
+ *
+ * Where the pin is a REGISTRY NAME (`demo.ts`, `resume-turn.ts`) it is exact.
+ * Where it is a LOCAL IDENTIFIER (`chat.ts`, `agent-query.ts`,
+ * `answer-adapter.ts`) it only proves the surface chose deliberately — what the
+ * identifier resolves to is pinned by that surface's behavioural test, named in
+ * the `why` string. A text scan cannot close that gap; the behavioural layer is
+ * not optional decoration.
  *
  * A call-site file absent from this map fails. That is the point — a new
  * `runAgent` surface must make its tool posture a reviewed decision here, not
@@ -326,7 +425,7 @@ const EXPECTED_REGISTRY: ReadonlyArray<readonly [file: string, expected: RegExp,
   [
     "packages/api/src/api/routes/chat.ts",
     /tools:\s*(resolvedToolRegistry|workspaceRegistry)\b/,
-    "web chat + web resume OWN /dashboards/[id] and have a human in the loop — the two surfaces that opt IN to defaultRegistry",
+    "web chat + web resume OWN /dashboards/[id] and have a human in the loop — the two surfaces that opt IN to defaultRegistry. Identity backstopped by chat.test.ts + chat-resume.test.ts",
   ],
   [
     "packages/api/src/api/routes/demo.ts",
@@ -341,7 +440,7 @@ const EXPECTED_REGISTRY: ReadonlyArray<readonly [file: string, expected: RegExp,
   [
     "packages/api/src/lib/agent-query.ts",
     /tools:\s*toolRegistry\b/,
-    "the canonical headless surface — resolves buildHeadlessRegistry() just above",
+    "the canonical headless surface — resolves buildHeadlessRegistry() just above. Identity backstopped by agent-query.test.ts",
   ],
   [
     "packages/api/src/lib/chat-plugin/resume-turn.ts",
@@ -351,7 +450,7 @@ const EXPECTED_REGISTRY: ReadonlyArray<readonly [file: string, expected: RegExp,
   [
     "ee/src/proactive/answer-adapter.ts",
     /tools:\s*toolRegistry\b/,
-    "both proactive branches assign toolRegistry: nonDashboardRegistry (linked) / public-dataset (unlinked)",
+    "both proactive branches assign toolRegistry: nonDashboardRegistry (linked) / public-dataset (unlinked). Identity backstopped by ee answer-adapter.test.ts",
   ],
 ];
 
@@ -421,10 +520,12 @@ const REQUIRED_CALL_SITE_FILES = [...EXPECTED_REGISTRY_FILES];
 
 describe("#4936 — the call-site scanner detects the shapes the bug actually had", () => {
   /**
-   * Fixtures are the VERBATIM pre-fix argument text of the three regressed call
-   * sites, plus the shapes a reasonable person might reach for next. Without
-   * these, the scanner's own correctness is untested and it can silently
-   * degrade into a check that nothing can fail.
+   * Fixtures reproduce the exact offending SPELLINGS the pre-fix call sites
+   * used (condensed to the relevant argument shape), plus the variants a
+   * reasonable person reaches for next — several of which escaped an earlier,
+   * regex-based version of `offenceFor`. Without these the scanner's own
+   * correctness is untested and it can silently degrade into a check nothing
+   * can fail.
    */
   const SCANNER_FIXTURES: ReadonlyArray<readonly [label: string, args: string, isOffender: boolean]> = [
     [
@@ -442,10 +543,42 @@ describe("#4936 — the call-site scanner detects the shapes the bug actually ha
       `{ messages: [], conversationId, resume }`,
       true,
     ],
+    // A condition containing a paren — the shape that escaped the first,
+    // regex-based version of this predicate.
+    [
+      "conditional spread whose condition contains a paren",
+      `{ messages, ...(hasTools() ? { tools: toolRegistry } : {}), conversationId }`,
+      true,
+    ],
+    [
+      "conditional spread, && with a call in the condition",
+      `{ messages, ...(isEnabled(ctx) && { tools: toolRegistry }) }`,
+      true,
+    ],
+    [
+      "conditional spread across several lines",
+      `{\n  messages,\n  ...(toolRegistry\n    ? { tools: toolRegistry }\n    : {}),\n}`,
+      true,
+    ],
     ["explicit undefined", `{ messages, tools: undefined }`, true],
+    // `exactOptionalPropertyTypes` is off, so a value that MAY be undefined
+    // typechecks against `tools?: ToolRegistry` and behaves as an omission.
+    ["ternary that can yield undefined", `{ messages, tools: cond ? reg : undefined }`, true],
+    ["nullish-coalescing to undefined", `{ messages, tools: reg ?? undefined }`, true],
+    // A nested `tools` is not the options-object property.
+    ["tools nested under another key", `{ messages, resume: { runId, tools: r } }`, true],
+    ["a pre-built options bag hides the posture", `opts`, true],
     ["unconditional — the fixed shape", `{ messages, tools: resolvedToolRegistry }`, false],
     ["unconditional, first key", `{ tools: nonDashboardRegistry, messages }`, false],
     ["unconditional await", `{ messages: [], tools: await buildHeadlessRegistry() }`, false],
+    ["shorthand property", `{ messages, tools }`, false],
+    // A legitimate conditional spread of something OTHER than tools must not
+    // be flagged — the real chat.ts call site contains one.
+    [
+      "unconditional tools beside an unrelated conditional spread",
+      `{ messages, tools: resolvedToolRegistry, ...(warnings.length > 0 && { warnings }) }`,
+      false,
+    ],
   ];
 
   for (const [label, args, isOffender] of SCANNER_FIXTURES) {
@@ -560,11 +693,14 @@ describe("#4936 — SCAN_ROOTS has not rotted", () => {
     // calling `runAgent` would otherwise be invisible to every check above,
     // forever, with no signal. Grep the whole repo and assert every production
     // hit is inside a declared root.
+    // `--untracked` matters locally: without it the file a developer just wrote
+    // — exactly the one at risk — is invisible to this guard until it is staged.
     const proc = Bun.spawn(
       [
         "git",
         "grep",
         "-l",
+        "--untracked",
         "-E",
         String.raw`\brunAgent\s*\(`,
         "--",
@@ -573,20 +709,32 @@ describe("#4936 — SCAN_ROOTS has not rotted", () => {
       ],
       { cwd: REPO_ROOT, stdout: "pipe", stderr: "pipe" },
     );
-    const stdout = await new Response(proc.stdout).text();
-    expect(await proc.exited, "git grep failed").toBe(0);
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+    expect(exitCode, `git grep failed: ${stderr}`).toBe(0);
 
-    const outside = stdout
+    const hits = stdout
       .split("\n")
       .filter(Boolean)
-      .filter((f) => !f.endsWith(".test.ts") && f !== AGENT_MODULE)
-      .filter((f) => !SCAN_ROOTS.some((root) => f.startsWith(`${root}/`)));
+      .filter((f) => !f.endsWith(".test.ts") && f !== AGENT_MODULE);
 
     expect(
-      outside,
+      hits.filter((f) => !SCAN_ROOTS.some((root) => f.startsWith(`${root}/`))),
       "file(s) reference runAgent outside SCAN_ROOTS, so no call-site guard above can see " +
         "them. Add the package's src root to SCAN_ROOTS (and the call site to " +
         "EXPECTED_REGISTRY).",
+    ).toEqual([]);
+
+    // The walker reads `.ts` only, so a `.tsx` call site INSIDE a scan root
+    // would satisfy the assertion above and still be unscanned. None exists
+    // today; this fails the moment one does, rather than covering it silently.
+    expect(
+      hits.filter((f) => f.endsWith(".tsx")),
+      "a .tsx file references runAgent — `walk()` only reads .ts, so every call-site check " +
+        "above is blind to it. Widen the extension filter in `walk()`.",
     ).toEqual([]);
   });
 });

--- a/packages/api/src/lib/__tests__/agent-runagent-call-sites.test.ts
+++ b/packages/api/src/lib/__tests__/agent-runagent-call-sites.test.ts
@@ -1,0 +1,354 @@
+/**
+ * #4936 — the `runAgent` tool-surface guardrail.
+ *
+ * #4915 keeps `correct_fact` — a brain-mutating WRITE — off the read-safe
+ * agent surface by registering it only when a `dashboardUrlResolver` is
+ * present (`lib/tools/registry.ts`). That gate decides what each REGISTRY
+ * contains. It says nothing about which registry a given turn actually gets —
+ * and `runAgent` used to answer that question with a default parameter
+ * (`tools: toolRegistry = defaultRegistry`), so every caller that omitted
+ * `tools` silently received the dashboards-owning, write-carrying registry.
+ * Three live surfaces did: the proactive linked-asker branch, the chat-plugin
+ * approval resume, and the zero-signup demo.
+ *
+ * `registry.test.ts` pins WHICH REGISTRY CONTAINS THE TOOL. Nothing pinned
+ * WHICH REGISTRY EACH CALL SITE RESOLVES TO — which is why no per-slice
+ * reviewer of the Brain M2 diff could have caught it: the gate was correct,
+ * the bypass lived in a default parameter and in call sites the milestone
+ * never touched. This file closes that axis from both ends:
+ *
+ *   1. BEHAVIOURAL — a real `runAgent` turn with no `tools` hands the model a
+ *      tool set with no brain-write and no dashboard-write verb. The same turn
+ *      with `defaultRegistry` passed explicitly DOES carry them, so the
+ *      assertion is a real gate and not a tautology about an empty tool set.
+ *   2. STRUCTURAL — every production `runAgent(...)` call site, across
+ *      `packages/**` AND `ee/**`, passes `tools` explicitly. The safe default
+ *      is the backstop; naming the registry at the surface is the contract.
+ *      A new headless surface can therefore neither inherit nor omit its way
+ *      into a write-carrying tool set.
+ *
+ * Sibling guardrail: `agent-surface-registry.test.ts` pins the ACTOR-binding
+ * axis (F-54/F-55) over the same call sites.
+ */
+
+import { describe, expect, it, mock } from "bun:test";
+import { readFile, readdir } from "node:fs/promises";
+import { resolve } from "node:path";
+import {
+  MockLanguageModelV3,
+  convertArrayToReadableStream,
+} from "ai/test";
+import type { LanguageModelV3StreamPart } from "@ai-sdk/provider";
+import type { UIMessage } from "ai";
+import { createConnectionMock } from "@atlas/api/testing/connection";
+
+// ---------------------------------------------------------------------------
+// 1. Behavioural — what tool set does the model actually receive?
+// ---------------------------------------------------------------------------
+
+// Same mock floor as the other mock-LLM seam tests (agent-dialect-specialist-
+// seam.test.ts): runAgent runs with NO request context, so every org-scoped
+// loader must be stubbed or the turn reaches a DB.
+void mock.module("@atlas/api/lib/db/connection", () =>
+  createConnectionMock({
+    connections: {
+      describe: () => [{ id: "default", dbType: "postgres" }],
+    },
+  }),
+);
+
+void mock.module("@atlas/api/lib/semantic", () => ({
+  getOrgWhitelistedTables: () => new Set(),
+  loadOrgWhitelist: async () => new Map(),
+  invalidateOrgWhitelist: () => {},
+  getOrgSemanticIndex: async () => "",
+  invalidateOrgSemanticIndex: () => {},
+  _resetOrgWhitelists: () => {},
+  _resetOrgSemanticIndexes: () => {},
+  getWhitelistedTables: () => new Set(["orders"]),
+  _resetWhitelists: () => {},
+  getCrossSourceJoins: () => [],
+}));
+
+void mock.module("@atlas/api/lib/plugins/tools", () => ({
+  getContextFragments: () => [],
+  getDialectHints: () => [],
+  pluginDialectModules: () => [],
+  setContextFragments: () => {},
+  setDialectHints: () => {},
+  setPluginTools: () => {},
+  getPluginTools: () => undefined,
+}));
+
+void mock.module("@atlas/api/lib/learn/pattern-cache", () => ({
+  buildLearnedPatternsSection: async () => "",
+  getRelevantPatterns: async () => [],
+  buildRetrievalQuery: () => "",
+  getRetrievalTurns: () => 3,
+  invalidatePatternCache: () => {},
+  extractKeywords: () => new Set(),
+  _resetPatternCache: () => {},
+}));
+
+void mock.module("@atlas/api/lib/learn/org-knowledge-section", () => ({
+  resolveOrgKnowledgeSection: async () => "",
+}));
+
+const { runAgent } = await import("@atlas/api/lib/agent");
+const { defaultRegistry } = await import("@atlas/api/lib/tools/registry");
+
+let lastToolNames: string[] | undefined;
+
+/**
+ * Pull the tool names out of the provider-level call options. The AI SDK has
+ * carried these as an array of `{ name }` and as a keyed record across
+ * versions, so read both shapes rather than pinning one — a silently empty
+ * list would make every `not.toContain` below vacuously pass, which the
+ * positive-control test guards against.
+ */
+function extractToolNames(opts: unknown): string[] | undefined {
+  const tools = (opts as { tools?: unknown })?.tools;
+  if (Array.isArray(tools)) {
+    return tools.map((t) => String((t as { name?: unknown })?.name ?? ""));
+  }
+  if (tools && typeof tools === "object") return Object.keys(tools);
+  return undefined;
+}
+
+function makeSpyingModel(): InstanceType<typeof MockLanguageModelV3> {
+  const parts: LanguageModelV3StreamPart[] = [
+    { type: "text-delta", id: "text-0", delta: "ok" },
+    {
+      type: "finish",
+      usage: {
+        inputTokens: { total: 10, noCache: 10, cacheRead: undefined, cacheWrite: undefined },
+        outputTokens: { total: 20, text: 20, reasoning: undefined },
+      },
+      finishReason: { unified: "stop", raw: "end_turn" },
+    },
+  ];
+  return new MockLanguageModelV3({
+    doStream: async (opts: unknown) => {
+      const names = extractToolNames(opts);
+      if (names) lastToolNames = names;
+      return { stream: convertArrayToReadableStream(parts) };
+    },
+  });
+}
+
+function userMessages(text: string): UIMessage[] {
+  return [{ id: "msg-1", role: "user" as const, parts: [{ type: "text" as const, text }] }];
+}
+
+async function toolNamesForTurn(
+  extra: Parameters<typeof runAgent>[0] extends infer _ ? Record<string, unknown> : never,
+): Promise<string[]> {
+  lastToolNames = undefined;
+  const result = await runAgent({
+    messages: userMessages("How many orders last month?"),
+    aiModel: {
+      model: makeSpyingModel(),
+      providerType: "openai",
+      modelId: "mock-runagent-call-sites",
+    },
+    ...extra,
+  });
+  await result.text;
+  expect(lastToolNames, "the spying model never received a tool set").toBeDefined();
+  return lastToolNames ?? [];
+}
+
+/** Tools that WRITE — none may reach a turn that didn't ask for them. */
+const BRAIN_WRITE_TOOL = "correct_fact";
+const DASHBOARD_WRITE_TOOL = "createDashboard";
+
+describe("#4936 — runAgent's default tool surface fails closed", () => {
+  it("a turn that omits `tools` gets no brain-write and no dashboard-write verb", async () => {
+    const names = await toolNamesForTurn({});
+
+    // The whole point of the issue: omitting `tools` used to yield
+    // `defaultRegistry`, which carries both of these.
+    expect(names).not.toContain(BRAIN_WRITE_TOOL);
+    expect(names).not.toContain(DASHBOARD_WRITE_TOOL);
+    // Not vacuous — the read tools are still there, so this is a narrowed
+    // surface, not a broken one.
+    expect(names).toContain("executeSQL");
+    expect(names).toContain("explore");
+    expect(names).toContain("searchBrain");
+  });
+
+  it("positive control: passing `defaultRegistry` explicitly DOES carry both write verbs", async () => {
+    // Without this the assertions above would pass just as happily against a
+    // model that never receives tools at all, or against a registry rename
+    // that made both names unreachable. The workspace surface is the one place
+    // these tools belong, and it must still get them.
+    const names = await toolNamesForTurn({ tools: defaultRegistry });
+
+    expect(names).toContain(BRAIN_WRITE_TOOL);
+    expect(names).toContain(DASHBOARD_WRITE_TOOL);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Structural — every production call site names its registry
+// ---------------------------------------------------------------------------
+
+const REPO_ROOT = resolve(import.meta.dir, "..", "..", "..", "..", "..");
+
+/**
+ * Source trees that may contain a production `runAgent` call. `ee/` is
+ * included deliberately: the proactive answer adapter — the call site with the
+ * most authority (a real linked user, resolved to their real `member.role`)
+ * and the least supervision (autonomous Slack answer, no confirmation UI) —
+ * lives there, and an audit that stops at `packages/` misses it entirely.
+ */
+const SCAN_ROOTS = [
+  "packages/api/src",
+  "packages/mcp/src",
+  "packages/sdk/src",
+  "ee/src",
+];
+
+/** The definition itself, not a call site. */
+const AGENT_MODULE = "packages/api/src/lib/agent.ts";
+
+interface CallSite {
+  readonly file: string;
+  readonly args: string;
+}
+
+/**
+ * Strip line and block comments so a doc comment that mentions
+ * `runAgent({ resume })` — several modules narrate the seam that way — isn't
+ * mistaken for a call site. Deliberately naive about comment-like sequences
+ * inside string literals: over-stripping can only ever HIDE a call site, and
+ * the non-vacuity assertion below fails if the known ones stop being found.
+ */
+function stripComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/^[ \t]*\/\/.*$/gm, "");
+}
+
+/** Extract the balanced `(...)` argument text for each `runAgent(` in `source`. */
+function findRunAgentCalls(file: string, source: string): CallSite[] {
+  const out: CallSite[] = [];
+  const pattern = /\brunAgent\s*\(/g;
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(source)) !== null) {
+    let depth = 0;
+    let i = match.index + match[0].length - 1;
+    const start = i + 1;
+    for (; i < source.length; i++) {
+      const ch = source[i];
+      if (ch === "(") depth++;
+      else if (ch === ")") {
+        depth--;
+        if (depth === 0) break;
+      }
+    }
+    out.push({ file, args: source.slice(start, i) });
+  }
+  return out;
+}
+
+async function collectCallSites(): Promise<CallSite[]> {
+  const out: CallSite[] = [];
+  for (const root of SCAN_ROOTS) {
+    await walk(resolve(REPO_ROOT, root), root, out);
+  }
+  return out;
+}
+
+async function walk(absDir: string, relDir: string, out: CallSite[]): Promise<void> {
+  let entries: Array<{ name: string; isDirectory: () => boolean; isFile: () => boolean }>;
+  try {
+    entries = (await readdir(absDir, { withFileTypes: true })) as unknown as Array<{
+      name: string;
+      isDirectory: () => boolean;
+      isFile: () => boolean;
+    }>;
+  } catch (err) {
+    // A root that isn't checked out in this tree is not a failure — but it
+    // must not pass silently either, or the scan degrades to a no-op.
+    // eslint-disable-next-line no-console
+    console.debug(
+      `[agent-runagent-call-sites] skipping unreadable scan root ${relDir}: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+    return;
+  }
+  for (const entry of entries) {
+    if (entry.name === "__tests__" || entry.name === "node_modules") continue;
+    const childRel = `${relDir}/${entry.name}`;
+    const childAbs = resolve(absDir, entry.name);
+    if (entry.isDirectory()) {
+      await walk(childAbs, childRel, out);
+    } else if (
+      entry.isFile() &&
+      entry.name.endsWith(".ts") &&
+      !entry.name.endsWith(".test.ts") &&
+      childRel !== AGENT_MODULE
+    ) {
+      const source = stripComments(await readFile(childAbs, "utf8"));
+      if (!source.includes("runAgent")) continue;
+      out.push(...findRunAgentCalls(childRel, source));
+    }
+  }
+}
+
+/**
+ * Call sites that MUST exist. If the scan stops finding these — a rename, a
+ * moved file, a regex that quietly matches nothing — the guard has become a
+ * no-op and this test says so instead of reporting a clean sweep of zero
+ * files.
+ */
+const REQUIRED_CALL_SITE_FILES = [
+  "packages/api/src/api/routes/chat.ts",
+  "packages/api/src/api/routes/demo.ts",
+  "packages/api/src/api/routes/admin-semantic-improve.ts",
+  "packages/api/src/lib/agent-query.ts",
+  "packages/api/src/lib/chat-plugin/resume-turn.ts",
+  "ee/src/proactive/answer-adapter.ts",
+];
+
+describe("#4936 — every production runAgent call site names its registry", () => {
+  it("scans a non-vacuous set of call sites (guard against a silently dead sweep)", async () => {
+    const sites = await collectCallSites();
+    const files = new Set(sites.map((s) => s.file));
+    for (const required of REQUIRED_CALL_SITE_FILES) {
+      expect(
+        files.has(required),
+        `expected a runAgent call site in ${required}; the scan found: ${[...files].sort().join(", ")}`,
+      ).toBe(true);
+    }
+  });
+
+  it("no call site omits `tools` (an omission inherits a default the surface never chose)", async () => {
+    const sites = await collectCallSites();
+    const offenders = sites
+      .filter((s) => !/(^|[\s{,])tools\s*:/.test(s.args))
+      .map((s) => `${s.file}: runAgent(${s.args.trim().slice(0, 120)}…)`);
+
+    expect(
+      offenders,
+      "runAgent call site(s) without an explicit `tools`. The default is fail-closed " +
+        "(`nonDashboardRegistry`), so this is not an open door — but the surface's tool " +
+        "posture must be declared AT the surface. Pass `defaultRegistry` if it owns " +
+        "`/dashboards/[id]` and has a human in the loop; `buildHeadlessRegistry()` if it " +
+        "is an SDK / chat-platform / MCP / scheduler surface; a purpose-built registry " +
+        "otherwise. See #4936 and the gating comment in lib/tools/registry.ts.",
+    ).toEqual([]);
+  });
+});
+
+describe("#4936 — the fail-closed default is pinned in source", () => {
+  it("runAgent defaults `tools` to nonDashboardRegistry, never a write-carrying registry", async () => {
+    const source = await readFile(resolve(REPO_ROOT, AGENT_MODULE), "utf8");
+
+    expect(
+      source,
+      "runAgent's `tools` default must stay the least-privileged registry — reverting it " +
+        "to `defaultRegistry` re-opens #4936 for every caller that omits `tools`.",
+    ).toMatch(/tools:\s*toolRegistry\s*=\s*nonDashboardRegistry/);
+  });
+});

--- a/packages/api/src/lib/__tests__/agent-runagent-call-sites.test.ts
+++ b/packages/api/src/lib/__tests__/agent-runagent-call-sites.test.ts
@@ -8,30 +8,41 @@
  * and `runAgent` used to answer that question with a default parameter
  * (`tools: toolRegistry = defaultRegistry`), so every caller that omitted
  * `tools` silently received the dashboards-owning, write-carrying registry.
- * Three live surfaces did: the proactive linked-asker branch, the chat-plugin
+ * Three surfaces did: the proactive linked-asker branch, the chat-plugin
  * approval resume, and the zero-signup demo.
  *
  * `registry.test.ts` pins WHICH REGISTRY CONTAINS THE TOOL. Nothing pinned
- * WHICH REGISTRY EACH CALL SITE RESOLVES TO — which is why no per-slice
- * reviewer of the Brain M2 diff could have caught it: the gate was correct,
- * the bypass lived in a default parameter and in call sites the milestone
- * never touched. This file closes that axis from both ends:
+ * WHICH REGISTRY EACH CALL SITE RESOLVES TO. This file closes that axis from
+ * both ends:
  *
  *   1. BEHAVIOURAL — a real `runAgent` turn with no `tools` hands the model a
  *      tool set with no brain-write and no dashboard-write verb. The same turn
  *      with `defaultRegistry` passed explicitly DOES carry them, so the
  *      assertion is a real gate and not a tautology about an empty tool set.
- *   2. STRUCTURAL — every production `runAgent(...)` call site, across
- *      `packages/**` AND `ee/**`, passes `tools` explicitly. The safe default
- *      is the backstop; naming the registry at the surface is the contract.
- *      A new headless surface can therefore neither inherit nor omit its way
- *      into a write-carrying tool set.
+ *   2. STRUCTURAL — every production `runAgent(...)` call site resolves to the
+ *      registry its surface is supposed to have. Not merely "passes something
+ *      called `tools`": `EXPECTED_REGISTRY` pins the actual expression per
+ *      file, because "passed a registry" is satisfied just as well by passing
+ *      the WRONG one, and a text match for `tools:` is satisfied by a
+ *      CONDITIONAL spread — which is the exact shape two of the three
+ *      pre-fix call sites had (`...(toolRegistry ? { tools: toolRegistry } :
+ *      {})`). A guard that misses the spelling the bug actually used is
+ *      theatre, so `SCANNER_FIXTURES` below pins the scanner against the
+ *      historical spellings.
+ *
+ * The safe default is the backstop for anything the scan cannot see (an
+ * untyped caller, a plugin compiled separately); naming the registry at the
+ * surface is the contract.
  *
  * Sibling guardrail: `agent-surface-registry.test.ts` pins the ACTOR-binding
- * axis (F-54/F-55) over the same call sites.
+ * axis (F-54/F-55), but over a DIFFERENT set — its roots are
+ * `packages/api/src/api/routes` + `packages/api/src/lib/scheduler` only, so it
+ * covers neither `ee/**` nor `lib/chat-plugin/**`. The two files overlap on
+ * three call sites; they are complementary, not co-extensive.
  */
 
 import { describe, expect, it, mock } from "bun:test";
+import type { Dirent } from "node:fs";
 import { readFile, readdir } from "node:fs/promises";
 import { resolve } from "node:path";
 import {
@@ -49,6 +60,13 @@ import { createConnectionMock } from "@atlas/api/testing/connection";
 // Same mock floor as the other mock-LLM seam tests (agent-dialect-specialist-
 // seam.test.ts): runAgent runs with NO request context, so every org-scoped
 // loader must be stubbed or the turn reaches a DB.
+//
+// Each mock covers its module's FULL named-export surface, not just the names
+// this file's import graph happens to reach today. bun's `mock.module` replaces
+// the module wholesale, so a missing name fails the whole import with "Export
+// named 'X' not found" the moment some other module in the graph wants it —
+// surfacing as an unrelated, opaque error. This PR had to repair two such
+// mocks already (`cors.test.ts`, `chat-plugin/__tests__/resume-turn.test.ts`).
 void mock.module("@atlas/api/lib/db/connection", () =>
   createConnectionMock({
     connections: {
@@ -58,39 +76,47 @@ void mock.module("@atlas/api/lib/db/connection", () =>
 );
 
 void mock.module("@atlas/api/lib/semantic", () => ({
-  getOrgWhitelistedTables: () => new Set(),
-  loadOrgWhitelist: async () => new Map(),
-  invalidateOrgWhitelist: () => {},
-  getOrgSemanticIndex: async () => "",
-  invalidateOrgSemanticIndex: () => {},
-  _resetOrgWhitelists: () => {},
-  _resetOrgSemanticIndexes: () => {},
   getWhitelistedTables: () => new Set(["orders"]),
-  _resetWhitelists: () => {},
+  getWhitelistedTablesStrict: () => new Set(["orders"]),
+  SemanticLayerScanError: class SemanticLayerScanError extends Error {},
   getCrossSourceJoins: () => [],
+  registerPluginEntities: () => {},
+  _resetWhitelists: () => {},
+  loadOrgWhitelist: async () => new Map(),
+  getOrgWhitelistedTables: () => new Set(),
+  invalidateOrgWhitelist: () => {},
+  invalidateOrgSemanticIndex: () => {},
+  getOrgSemanticIndex: async () => "",
 }));
 
 void mock.module("@atlas/api/lib/plugins/tools", () => ({
-  getContextFragments: () => [],
-  getDialectHints: () => [],
-  pluginDialectModules: () => [],
-  setContextFragments: () => {},
-  setDialectHints: () => {},
   setPluginTools: () => {},
   getPluginTools: () => undefined,
+  setContextFragments: () => {},
+  getContextFragments: () => [],
+  setDialectHints: () => {},
+  getDialectHints: () => [],
+  pluginDialectModules: () => [],
 }));
 
 void mock.module("@atlas/api/lib/learn/pattern-cache", () => ({
-  buildLearnedPatternsSection: async () => "",
-  getRelevantPatterns: async () => [],
-  buildRetrievalQuery: () => "",
+  DEFAULT_RETRIEVAL_TURNS: 3,
+  DEFAULT_LATENCY_BUDGET_MS: 1000,
   getRetrievalTurns: () => 3,
-  invalidatePatternCache: () => {},
+  getConfidenceThreshold: () => 0,
+  getLatencyBudgetMs: () => 1000,
   extractKeywords: () => new Set(),
+  perfWeight: () => 0,
+  rankPatterns: () => [],
+  invalidatePatternCache: () => {},
   _resetPatternCache: () => {},
+  buildRetrievalQuery: () => "",
+  getRelevantPatterns: async () => [],
+  buildLearnedPatternsSection: async () => "",
 }));
 
 void mock.module("@atlas/api/lib/learn/org-knowledge-section", () => ({
+  buildOrgKnowledgeSection: () => "",
   resolveOrgKnowledgeSection: async () => "",
 }));
 
@@ -140,8 +166,14 @@ function userMessages(text: string): UIMessage[] {
   return [{ id: "msg-1", role: "user" as const, parts: [{ type: "text" as const, text }] }];
 }
 
+/**
+ * `Partial<…>` rather than a hand-written bag: it is tied to `runAgent`'s real
+ * signature, so a misspelled option (`tolls:`) is a compile error instead of a
+ * silently ignored key that would turn the negative assertions below into a
+ * tautology about a default-tools turn.
+ */
 async function toolNamesForTurn(
-  extra: Parameters<typeof runAgent>[0] extends infer _ ? Record<string, unknown> : never,
+  extra: Partial<Parameters<typeof runAgent>[0]>,
 ): Promise<string[]> {
   lastToolNames = undefined;
   const result = await runAgent({
@@ -190,7 +222,7 @@ describe("#4936 — runAgent's default tool surface fails closed", () => {
 });
 
 // ---------------------------------------------------------------------------
-// 2. Structural — every production call site names its registry
+// 2. Structural — every production call site names the RIGHT registry
 // ---------------------------------------------------------------------------
 
 const REPO_ROOT = resolve(import.meta.dir, "..", "..", "..", "..", "..");
@@ -201,6 +233,9 @@ const REPO_ROOT = resolve(import.meta.dir, "..", "..", "..", "..", "..");
  * most authority (a real linked user, resolved to their real `member.role`)
  * and the least supervision (autonomous Slack answer, no confirmation UI) —
  * lives there, and an audit that stops at `packages/` misses it entirely.
+ *
+ * This is an allowlist, so it can rot silently as packages are added.
+ * `no runAgent call site lives outside SCAN_ROOTS` below is the drift guard.
  */
 const SCAN_ROOTS = [
   "packages/api/src",
@@ -218,14 +253,18 @@ interface CallSite {
 }
 
 /**
- * Strip line and block comments so a doc comment that mentions
- * `runAgent({ resume })` — several modules narrate the seam that way — isn't
- * mistaken for a call site. Deliberately naive about comment-like sequences
- * inside string literals: over-stripping can only ever HIDE a call site, and
- * the non-vacuity assertion below fails if the known ones stop being found.
+ * Strip comments so a doc comment that mentions `runAgent({ resume })` — several
+ * modules narrate the seam that way — isn't mistaken for a call site, and so a
+ * commented-out `// tools: defaultRegistry` can't satisfy the checks below.
+ *
+ * The line-comment pattern deliberately requires the `//` not be preceded by
+ * `:`, which leaves `https://` inside string literals intact. Otherwise
+ * deliberately naive about comment-like sequences in strings: over-stripping
+ * can only ever HIDE a call site, and the non-vacuity assertion below fails if
+ * the known ones stop being found.
  */
 function stripComments(source: string): string {
-  return source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/^[ \t]*\/\/.*$/gm, "");
+  return source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/(^|[^:])\/\/.*$/gm, "$1");
 }
 
 /** Extract the balanced `(...)` argument text for each `runAgent(` in `source`. */
@@ -250,31 +289,107 @@ function findRunAgentCalls(file: string, source: string): CallSite[] {
   return out;
 }
 
+/**
+ * A call site is an offender if it does not name `tools` UNCONDITIONALLY.
+ *
+ * The three rejected shapes are not hypothetical — the first two are verbatim
+ * what `ee/src/proactive/answer-adapter.ts` and `packages/api/src/api/routes/
+ * chat.ts` contained before this fix. A predicate that only asks "does the
+ * substring `tools:` appear?" passes both, i.e. would have reported #4936 as
+ * clean. `SCANNER_FIXTURES` pins that it does not.
+ */
+function offenceFor(args: string): string | undefined {
+  if (/\.\.\.\s*\([^)]*\btools\s*:/.test(args)) {
+    return "passes `tools` through a CONDITIONAL spread — the surface inherits the default whenever the condition is false";
+  }
+  if (/(^|[\s{,])tools\s*:\s*undefined\b/.test(args)) {
+    return "passes `tools: undefined`, which is the same as omitting it";
+  }
+  if (!/(^|[\s{,])tools\s*:/.test(args)) {
+    return "omits `tools`";
+  }
+  return undefined;
+}
+
+/**
+ * The registry each production surface must resolve to. Pinning the EXPRESSION,
+ * not just the presence of a `tools` key, is what makes this a security guard
+ * rather than a style check: "passed a registry" is satisfied equally well by
+ * passing the wrong one, and `tools: defaultRegistry` on a new headless surface
+ * is precisely the regression #4936 is about.
+ *
+ * A call-site file absent from this map fails. That is the point — a new
+ * `runAgent` surface must make its tool posture a reviewed decision here, not
+ * inherit one.
+ */
+const EXPECTED_REGISTRY: ReadonlyArray<readonly [file: string, expected: RegExp, why: string]> = [
+  [
+    "packages/api/src/api/routes/chat.ts",
+    /tools:\s*(resolvedToolRegistry|workspaceRegistry)\b/,
+    "web chat + web resume OWN /dashboards/[id] and have a human in the loop — the two surfaces that opt IN to defaultRegistry",
+  ],
+  [
+    "packages/api/src/api/routes/demo.ts",
+    /tools:\s*nonDashboardRegistry\b/,
+    "anonymous zero-signup demo — no dashboards route, no workspace",
+  ],
+  [
+    "packages/api/src/api/routes/admin-semantic-improve.ts",
+    /tools:\s*expertRegistry\b/,
+    "the expert-agent chat runs a purpose-built registry (proposeAmendment, no analyst write verbs)",
+  ],
+  [
+    "packages/api/src/lib/agent-query.ts",
+    /tools:\s*toolRegistry\b/,
+    "the canonical headless surface — resolves buildHeadlessRegistry() just above",
+  ],
+  [
+    "packages/api/src/lib/chat-plugin/resume-turn.ts",
+    /tools:\s*await buildHeadlessRegistry\(\)/,
+    "approval resume must rebuild the SAME headless set the parked turn ran under",
+  ],
+  [
+    "ee/src/proactive/answer-adapter.ts",
+    /tools:\s*toolRegistry\b/,
+    "both proactive branches assign toolRegistry: nonDashboardRegistry (linked) / public-dataset (unlinked)",
+  ],
+];
+
+const EXPECTED_REGISTRY_FILES = new Set(EXPECTED_REGISTRY.map(([file]) => file));
+
+/**
+ * Roots that could not be read. A root missing from a partial checkout is
+ * tolerable; a read fault anywhere else is not, because it silently shrinks the
+ * sweep and the suite reports "no offenders" — the same false negative as
+ * `catch { return false }` on a security check, one level up.
+ */
+const skippedRoots: string[] = [];
+
 async function collectCallSites(): Promise<CallSite[]> {
+  skippedRoots.length = 0;
   const out: CallSite[] = [];
   for (const root of SCAN_ROOTS) {
-    await walk(resolve(REPO_ROOT, root), root, out);
+    await walk(resolve(REPO_ROOT, root), root, out, true);
   }
   return out;
 }
 
-async function walk(absDir: string, relDir: string, out: CallSite[]): Promise<void> {
-  let entries: Array<{ name: string; isDirectory: () => boolean; isFile: () => boolean }>;
+async function walk(
+  absDir: string,
+  relDir: string,
+  out: CallSite[],
+  isRoot = false,
+): Promise<void> {
+  let entries: Dirent[];
   try {
-    entries = (await readdir(absDir, { withFileTypes: true })) as unknown as Array<{
-      name: string;
-      isDirectory: () => boolean;
-      isFile: () => boolean;
-    }>;
+    entries = await readdir(absDir, { withFileTypes: true });
   } catch (err) {
-    // A root that isn't checked out in this tree is not a failure — but it
-    // must not pass silently either, or the scan degrades to a no-op.
-    // eslint-disable-next-line no-console
-    console.debug(
-      `[agent-runagent-call-sites] skipping unreadable scan root ${relDir}: ${
-        err instanceof Error ? err.message : String(err)
-      }`,
-    );
+    const code = (err as NodeJS.ErrnoException)?.code;
+    // Only a declared ROOT may be absent (a partial checkout). A mid-tree read
+    // fault — EACCES, ELOOP, EMFILE — must fail loudly rather than quietly
+    // remove a subtree from a security sweep.
+    if (!isRoot || code !== "ENOENT") throw err;
+    skippedRoots.push(relDir);
     return;
   }
   for (const entry of entries) {
@@ -302,16 +417,54 @@ async function walk(absDir: string, relDir: string, out: CallSite[]): Promise<vo
  * no-op and this test says so instead of reporting a clean sweep of zero
  * files.
  */
-const REQUIRED_CALL_SITE_FILES = [
-  "packages/api/src/api/routes/chat.ts",
-  "packages/api/src/api/routes/demo.ts",
-  "packages/api/src/api/routes/admin-semantic-improve.ts",
-  "packages/api/src/lib/agent-query.ts",
-  "packages/api/src/lib/chat-plugin/resume-turn.ts",
-  "ee/src/proactive/answer-adapter.ts",
-];
+const REQUIRED_CALL_SITE_FILES = [...EXPECTED_REGISTRY_FILES];
 
-describe("#4936 — every production runAgent call site names its registry", () => {
+describe("#4936 — the call-site scanner detects the shapes the bug actually had", () => {
+  /**
+   * Fixtures are the VERBATIM pre-fix argument text of the three regressed call
+   * sites, plus the shapes a reasonable person might reach for next. Without
+   * these, the scanner's own correctness is untested and it can silently
+   * degrade into a check that nothing can fail.
+   */
+  const SCANNER_FIXTURES: ReadonlyArray<readonly [label: string, args: string, isOffender: boolean]> = [
+    [
+      "pre-fix ee/answer-adapter — ternary conditional spread",
+      `{ messages, aiModel, ...(toolRegistry ? { tools: toolRegistry } : {}), answerStyle }`,
+      true,
+    ],
+    [
+      "pre-fix routes/chat.ts — && conditional spread",
+      `{ messages, ...(toolRegistry && { tools: toolRegistry }), conversationId }`,
+      true,
+    ],
+    [
+      "pre-fix resume-turn.ts / demo.ts — omitted entirely",
+      `{ messages: [], conversationId, resume }`,
+      true,
+    ],
+    ["explicit undefined", `{ messages, tools: undefined }`, true],
+    ["unconditional — the fixed shape", `{ messages, tools: resolvedToolRegistry }`, false],
+    ["unconditional, first key", `{ tools: nonDashboardRegistry, messages }`, false],
+    ["unconditional await", `{ messages: [], tools: await buildHeadlessRegistry() }`, false],
+  ];
+
+  for (const [label, args, isOffender] of SCANNER_FIXTURES) {
+    it(`${isOffender ? "flags" : "accepts"}: ${label}`, () => {
+      expect(offenceFor(args) !== undefined, `args: ${args}`).toBe(isOffender);
+    });
+  }
+
+  it("strips a commented-out `tools:` but keeps a `https://` URL intact", () => {
+    // A trailing `// tools: defaultRegistry` must not satisfy the predicate…
+    const commented = stripComments(`runAgent({ messages, // tools: defaultRegistry\n});`);
+    expect(offenceFor(commented)).toBeDefined();
+    // …while the `//` in a URL must not eat the rest of the line, which would
+    // truncate real call sites out of the sweep.
+    expect(stripComments(`const u = "https://x.dev/a"; const t = 1;`)).toContain("const t = 1");
+  });
+});
+
+describe("#4936 — every production runAgent call site names the right registry", () => {
   it("scans a non-vacuous set of call sites (guard against a silently dead sweep)", async () => {
     const sites = await collectCallSites();
     const files = new Set(sites.map((s) => s.file));
@@ -321,27 +474,65 @@ describe("#4936 — every production runAgent call site names its registry", () 
         `expected a runAgent call site in ${required}; the scan found: ${[...files].sort().join(", ")}`,
       ).toBe(true);
     }
+    expect(
+      skippedRoots,
+      "a skipped scan root means this guard covered less than it claims to",
+    ).toEqual([]);
   });
 
-  it("no call site omits `tools` (an omission inherits a default the surface never chose)", async () => {
+  it("no call site inherits the default (omitted, conditional, or explicitly undefined)", async () => {
     const sites = await collectCallSites();
     const offenders = sites
-      .filter((s) => !/(^|[\s{,])tools\s*:/.test(s.args))
-      .map((s) => `${s.file}: runAgent(${s.args.trim().slice(0, 120)}…)`);
+      .map((s) => ({ s, offence: offenceFor(s.args) }))
+      .filter((x) => x.offence !== undefined)
+      .map((x) => `${x.s.file}: ${x.offence} — runAgent(${x.s.args.trim().slice(0, 120)}…)`);
 
     expect(
       offenders,
-      "runAgent call site(s) without an explicit `tools`. The default is fail-closed " +
-        "(`nonDashboardRegistry`), so this is not an open door — but the surface's tool " +
-        "posture must be declared AT the surface. Pass `defaultRegistry` if it owns " +
-        "`/dashboards/[id]` and has a human in the loop; `buildHeadlessRegistry()` if it " +
-        "is an SDK / chat-platform / MCP / scheduler surface; a purpose-built registry " +
-        "otherwise. See #4936 and the gating comment in lib/tools/registry.ts.",
+      "runAgent call site(s) that inherit the default tool registry. The default is " +
+        "fail-closed (`nonDashboardRegistry`), so this is not an open door — but the " +
+        "surface's tool posture must be declared AT the surface, unconditionally. Pass " +
+        "`defaultRegistry` if it owns `/dashboards/[id]` and has a human in the loop; " +
+        "`buildHeadlessRegistry()` if it is an SDK / chat-platform / MCP / scheduler " +
+        "surface; a purpose-built registry otherwise. See #4936 and the gating comment " +
+        "in lib/tools/registry.ts.",
+    ).toEqual([]);
+  });
+
+  it("each call site resolves to the registry its surface is supposed to have", async () => {
+    const sites = await collectCallSites();
+    const wrong: string[] = [];
+
+    for (const [file, expected, why] of EXPECTED_REGISTRY) {
+      for (const site of sites.filter((s) => s.file === file)) {
+        if (!expected.test(site.args)) {
+          wrong.push(`${file}: expected ${expected} (${why}) — got runAgent(${site.args.trim().slice(0, 120)}…)`);
+        }
+      }
+    }
+
+    expect(
+      wrong,
+      "a call site passes `tools`, but not the registry its surface is supposed to have. " +
+        "Passing the WRONG registry is the same class of bug as passing none.",
+    ).toEqual([]);
+  });
+
+  it("a new call-site file must declare its expected registry here", async () => {
+    const sites = await collectCallSites();
+    const undeclared = [...new Set(sites.map((s) => s.file))].filter(
+      (f) => !EXPECTED_REGISTRY_FILES.has(f),
+    );
+
+    expect(
+      undeclared,
+      "a production runAgent call site with no entry in EXPECTED_REGISTRY. Add one — a " +
+        "new agent surface's tool posture is a decision to review, not to inherit.",
     ).toEqual([]);
   });
 });
 
-describe("#4936 — the fail-closed default is pinned in source", () => {
+describe("#4936 — the fail-closed defaults are pinned in source", () => {
   it("runAgent defaults `tools` to nonDashboardRegistry, never a write-carrying registry", async () => {
     const source = await readFile(resolve(REPO_ROOT, AGENT_MODULE), "utf8");
 
@@ -350,5 +541,52 @@ describe("#4936 — the fail-closed default is pinned in source", () => {
       "runAgent's `tools` default must stay the least-privileged registry — reverting it " +
         "to `defaultRegistry` re-opens #4936 for every caller that omits `tools`.",
     ).toMatch(/tools:\s*toolRegistry\s*=\s*nonDashboardRegistry/);
+  });
+
+  it("buildSystemParam defaults `registry` to nonDashboardRegistry too", async () => {
+    // The prompt half of the same invariant. Reverting only this one would
+    // re-advertise `createDashboard` / `correct_fact` GUIDANCE to a surface
+    // whose tool set doesn't carry them — the model is told to use a verb it
+    // hasn't got. The `tools` pin above does not cover it.
+    const source = await readFile(resolve(REPO_ROOT, AGENT_MODULE), "utf8");
+
+    expect(source).toMatch(/registry\s*=\s*nonDashboardRegistry,/);
+  });
+});
+
+describe("#4936 — SCAN_ROOTS has not rotted", () => {
+  it("no runAgent call site lives outside SCAN_ROOTS", async () => {
+    // SCAN_ROOTS is a hand-maintained allowlist. A new package that starts
+    // calling `runAgent` would otherwise be invisible to every check above,
+    // forever, with no signal. Grep the whole repo and assert every production
+    // hit is inside a declared root.
+    const proc = Bun.spawn(
+      [
+        "git",
+        "grep",
+        "-l",
+        "-E",
+        String.raw`\brunAgent\s*\(`,
+        "--",
+        "*.ts",
+        "*.tsx",
+      ],
+      { cwd: REPO_ROOT, stdout: "pipe", stderr: "pipe" },
+    );
+    const stdout = await new Response(proc.stdout).text();
+    expect(await proc.exited, "git grep failed").toBe(0);
+
+    const outside = stdout
+      .split("\n")
+      .filter(Boolean)
+      .filter((f) => !f.endsWith(".test.ts") && f !== AGENT_MODULE)
+      .filter((f) => !SCAN_ROOTS.some((root) => f.startsWith(`${root}/`)));
+
+    expect(
+      outside,
+      "file(s) reference runAgent outside SCAN_ROOTS, so no call-site guard above can see " +
+        "them. Add the package's src root to SCAN_ROOTS (and the call site to " +
+        "EXPECTED_REGISTRY).",
+    ).toEqual([]);
   });
 });

--- a/packages/api/src/lib/__tests__/agent-runagent-call-sites.test.ts
+++ b/packages/api/src/lib/__tests__/agent-runagent-call-sites.test.ts
@@ -33,7 +33,8 @@
  *
  *      Where an entry in `EXPECTED_REGISTRY` pins a LOCAL IDENTIFIER rather
  *      than a registry name, the identifier's value is guaranteed only by that
- *      surface's behavioural test — named per entry.
+ *      surface's behavioural test — named per entry, including the one entry
+ *      (`admin-semantic-improve.ts`) whose route test mocks its builder.
  *
  * The safe default is the backstop for anything the scan cannot see (an
  * untyped caller, a plugin compiled separately); naming the registry at the
@@ -313,6 +314,8 @@ type ToolsProp =
   | { readonly kind: "shorthand" }
   /** `tools` appears, but only inside a spread element. */
   | { readonly kind: "spread-only" }
+  /** `tools` is named unconditionally, then RE-ASSIGNED by a LATER spread. */
+  | { readonly kind: "overridden" }
   | { readonly kind: "absent" };
 
 /**
@@ -358,23 +361,40 @@ function inspectToolsProp(args: string): ToolsProp {
     }
   }
 
+  // Scan ALL properties, never returning early. Object spread is
+  // LAST-WRITE-WINS, so a `tools`-carrying spread that appears AFTER the
+  // property is what the turn actually runs with — the named registry is then
+  // decoration, and every downstream check (including `EXPECTED_REGISTRY`,
+  // whose pinned spelling is still literally present) passes while the surface
+  // silently runs on the spread's registry. This is the one escape shape whose
+  // failure direction is UPWARD: it re-adds `correct_fact`, rather than
+  // resolving to `undefined` and landing on the fail-closed default. Stacked
+  // conditional spreads are the house idiom at exactly these call sites, so it
+  // is a one-line diff away. A spread BEFORE the property is harmless.
   let sawToolsInSpread = false;
+  let found: ToolsProp | undefined;
   for (const raw of props) {
     const prop = raw.trim();
     if (prop.startsWith("...")) {
-      if (/\btools\b/.test(prop)) sawToolsInSpread = true;
+      if (/\btools\b/.test(prop)) {
+        if (found) return { kind: "overridden" };
+        sawToolsInSpread = true;
+      }
       continue;
     }
+    if (found) continue;
     const match = /^(?:"tools"|'tools'|tools)\s*(:?)/.exec(prop);
     if (!match) continue;
     if (match[1] !== ":") {
       // Guard against `toolsFoo` matching the bare-identifier arm.
       if (prop !== "tools") continue;
-      return { kind: "shorthand" };
+      found = { kind: "shorthand" };
+      continue;
     }
-    return { kind: "value", text: prop.slice(match[0].length).trim() };
+    found = { kind: "value", text: prop.slice(match[0].length).trim() };
   }
 
+  if (found) return found;
   return sawToolsInSpread ? { kind: "spread-only" } : { kind: "absent" };
 }
 
@@ -394,6 +414,8 @@ function offenceFor(args: string): string | undefined {
       return "omits `tools`";
     case "spread-only":
       return "names `tools` only inside a SPREAD — the surface inherits the default whenever the spread's condition is false";
+    case "overridden":
+      return "names `tools` unconditionally and then RE-ASSIGNS it from a later spread — object spread is last-write-wins, so the named registry is not what the turn runs with";
     case "shorthand":
       return undefined;
     case "value":
@@ -412,10 +434,11 @@ function offenceFor(args: string): string | undefined {
  *
  * Where the pin is a REGISTRY NAME (`demo.ts`, `resume-turn.ts`) it is exact.
  * Where it is a LOCAL IDENTIFIER (`chat.ts`, `agent-query.ts`,
- * `answer-adapter.ts`) it only proves the surface chose deliberately — what the
- * identifier resolves to is pinned by that surface's behavioural test, named in
- * the `why` string. A text scan cannot close that gap; the behavioural layer is
- * not optional decoration.
+ * `answer-adapter.ts`, `admin-semantic-improve.ts`) it only proves the surface
+ * chose deliberately — what the identifier resolves to is pinned by that
+ * surface's behavioural test, named in the `why` string. A text scan cannot
+ * close that gap; the behavioural layer is not optional decoration, and where
+ * it is thin the `why` string says so.
  *
  * A call-site file absent from this map fails. That is the point — a new
  * `runAgent` surface must make its tool posture a reviewed decision here, not
@@ -435,7 +458,7 @@ const EXPECTED_REGISTRY: ReadonlyArray<readonly [file: string, expected: RegExp,
   [
     "packages/api/src/api/routes/admin-semantic-improve.ts",
     /tools:\s*expertRegistry\b/,
-    "the expert-agent chat runs a purpose-built registry (proposeAmendment, no analyst write verbs)",
+    "the expert-agent chat runs a purpose-built registry (proposeAmendment, no analyst write verbs). Contents pinned by lib/tools/__tests__/expert-registry.test.ts; the route's own test MOCKS buildExpertRegistry, so the identifier->registry edge is scanner-only",
   ],
   [
     "packages/api/src/lib/agent-query.ts",
@@ -572,10 +595,21 @@ describe("#4936 — the call-site scanner detects the shapes the bug actually ha
     ["unconditional, first key", `{ tools: nonDashboardRegistry, messages }`, false],
     ["unconditional await", `{ messages: [], tools: await buildHeadlessRegistry() }`, false],
     ["shorthand property", `{ messages, tools }`, false],
-    // A legitimate conditional spread of something OTHER than tools must not
-    // be flagged — the real chat.ts call site contains one.
+    // Last-write-wins escalation — the only escape shape that fails UPWARD.
     [
-      "unconditional tools beside an unrelated conditional spread",
+      "a later spread re-assigns tools",
+      `{ messages, tools: nonDashboardRegistry, ...(isInternal && { tools: defaultRegistry }) }`,
+      true,
+    ],
+    [
+      "a spread BEFORE tools is harmless — the literal wins",
+      `{ messages, ...(x && { tools: defaultRegistry }), tools: nonDashboardRegistry }`,
+      false,
+    ],
+    // A conditional spread of something OTHER than tools must not be flagged —
+    // the real chat.ts call site stacks three of them.
+    [
+      "unconditional tools beside a conditional spread of something ELSE",
       `{ messages, tools: resolvedToolRegistry, ...(warnings.length > 0 && { warnings }) }`,
       false,
     ],

--- a/packages/api/src/lib/__tests__/agent-scope-prompt.test.ts
+++ b/packages/api/src/lib/__tests__/agent-scope-prompt.test.ts
@@ -254,6 +254,7 @@ function makeSpyingModel(toolCallArgs: Record<string, unknown>): InstanceType<ty
 const { runAgent } = await import("@atlas/api/lib/agent");
 const { buildSystemParam, buildRestDatasourceScopeNote } = await import("@atlas/api/lib/agent");
 const { withRequestContext } = await import("@atlas/api/lib/logger");
+const { defaultRegistry } = await import("@atlas/api/lib/tools/registry");
 
 function userMessages(content: string): UIMessage[] {
   return [
@@ -559,6 +560,15 @@ describe("agent loop — REST datasource scope threading (#3044)", () => {
 });
 
 describe("agent loop — REST-only focus suspends executeSQL (#3067)", () => {
+  // #4936 — these turns name `defaultRegistry` explicitly. The assertions below
+  // are about what the FOCUS STRIP removes, so they need a registry that has
+  // `createDashboard` to begin with: `runAgent`'s default is now the
+  // least-privileged `nonDashboardRegistry`, under which every
+  // `not.toContain("createDashboard")` would pass without the strip running at
+  // all. `defaultRegistry` is what the web chat surface passes in production,
+  // so this also keeps the test on the path the strip actually serves.
+  const focusTurnRegistry = defaultRegistry;
+
   // Text-only model: emits no tool call, so the agent just builds the prompt +
   // tool set (captured via doStream opts) and finishes.
   function makeCapturingTextModel(): InstanceType<typeof MockLanguageModelV3> {
@@ -607,7 +617,7 @@ describe("agent loop — REST-only focus suspends executeSQL (#3067)", () => {
     restOrThrowResult = [restDatasourceStub("stripe")];
     const result = await withRequestContext(
       { requestId: "focus-1", user: focusUser, restFocusDatasourceId: "stripe" },
-      () => runAgent({ messages: userMessages("ask stripe only") }),
+      () => runAgent({ messages: userMessages("ask stripe only"), tools: focusTurnRegistry }),
     );
     await result.steps; // consume the stream so doStream captures tools + prompt
     // Resolved via the THROWING resolver, focus only (group + exclude inert).
@@ -635,7 +645,7 @@ describe("agent loop — REST-only focus suspends executeSQL (#3067)", () => {
         restExcludedDatasourceIds: ["other"],
         connectionGroupId: "prod",
       },
-      () => runAgent({ messages: userMessages("ask stripe only") }),
+      () => runAgent({ messages: userMessages("ask stripe only"), tools: focusTurnRegistry }),
     );
     // No `excluded` / `activeGroupId` key — focus short-circuits both.
     expect(capturedOrThrowArgs!.deps).toEqual({ focus: "stripe" });
@@ -652,7 +662,7 @@ describe("agent loop — REST-only focus suspends executeSQL (#3067)", () => {
         connectionGroupId: "prod",
         restExcludedDatasourceIds: ["x"],
       },
-      () => runAgent({ messages: userMessages("hello") }),
+      () => runAgent({ messages: userMessages("hello"), tools: focusTurnRegistry }),
     );
     await result.steps; // consume the stream so doStream captures tools + prompt
     // The focus resolve (empty), THEN the default-scope never-rejects fallback.
@@ -673,7 +683,7 @@ describe("agent loop — REST-only focus suspends executeSQL (#3067)", () => {
     const contextWarnings: ChatContextWarning[] = [];
     const result = await withRequestContext(
       { requestId: "focus-4", user: focusUser, restFocusDatasourceId: "stripe" },
-      () => runAgent({ messages: userMessages("ask stripe only"), contextWarnings }),
+      () => runAgent({ messages: userMessages("ask stripe only"), contextWarnings, tools: focusTurnRegistry }),
     );
     await result.steps; // consume the stream so doStream captures tools + prompt
     expect(lastToolNames).not.toContain("executeSQL");

--- a/packages/api/src/lib/agent-query.ts
+++ b/packages/api/src/lib/agent-query.ts
@@ -268,20 +268,14 @@ export async function executeAgentQuery(
     // non-web programmatic surfaces — the SDK query route, chat-platform
     // adapters (Slack), the MCP query tool, and the scheduler. None of them own
     // a dashboards route and none has a confirmation UI in the surface itself
-    // (the approval park/resume flow is out-of-band), so this is the
-    // canonical HEADLESS surface: `buildHeadlessRegistry` omits `createDashboard`
-    // (#4566, PRD #4553 L2 — a `/dashboards/[id]` handoff is unreachable from
-    // Slack or a scheduled digest) and `correct_fact` (#4915), keeps action
-    // tools opt-in via ATLAS_ACTIONS_ENABLED, and falls back to
-    // `nonDashboardRegistry` (NOT the dashboards-owning `defaultRegistry`) on a
-    // build failure so both omissions hold on the error path too.
+    // (the approval park/resume flow is out-of-band), so this is the canonical
+    // HEADLESS surface. What that registry contains and why is
+    // `buildHeadlessRegistry`'s docstring — not restated here.
     //
     // #4936 — that construction moved into `registry.ts` so the chat-plugin
     // approval RESUME of a turn started here rebuilds from the identical POLICY
     // instead of re-deriving it (or, as it did, omitting `tools` and inheriting
-    // the workspace registry). Policy, not set: `ATLAS_ACTIONS_ENABLED` is
-    // re-read at resume time, so a turn parked across an operator flag flip
-    // resumes on a different set. We still pass `tools` explicitly: `runAgent`'s
+    // the workspace registry). We still pass `tools` explicitly: `runAgent`'s
     // default now fails closed, but the surface's choice belongs in the surface.
     const { buildHeadlessRegistry } = await import("@atlas/api/lib/tools/registry");
     const toolRegistry = await buildHeadlessRegistry();

--- a/packages/api/src/lib/agent-query.ts
+++ b/packages/api/src/lib/agent-query.ts
@@ -267,7 +267,8 @@ export async function executeAgentQuery(
     // Build the tool registry for this surface. `executeAgentQuery` serves the
     // non-web programmatic surfaces — the SDK query route, chat-platform
     // adapters (Slack), the MCP query tool, and the scheduler. None of them own
-    // a dashboards route and none has a human in the loop, so this is the
+    // a dashboards route and none has a confirmation UI in the surface itself
+    // (the approval park/resume flow is out-of-band), so this is the
     // canonical HEADLESS surface: `buildHeadlessRegistry` omits `createDashboard`
     // (#4566, PRD #4553 L2 — a `/dashboards/[id]` handoff is unreachable from
     // Slack or a scheduled digest) and `correct_fact` (#4915), keeps action
@@ -276,9 +277,11 @@ export async function executeAgentQuery(
     // build failure so both omissions hold on the error path too.
     //
     // #4936 — that construction moved into `registry.ts` so the chat-plugin
-    // approval RESUME of a turn started here rebuilds the identical set instead
-    // of re-deriving it (or, as it did, omitting `tools` and inheriting the
-    // workspace registry). We still pass `tools` explicitly: `runAgent`'s
+    // approval RESUME of a turn started here rebuilds from the identical POLICY
+    // instead of re-deriving it (or, as it did, omitting `tools` and inheriting
+    // the workspace registry). Policy, not set: `ATLAS_ACTIONS_ENABLED` is
+    // re-read at resume time, so a turn parked across an operator flag flip
+    // resumes on a different set. We still pass `tools` explicitly: `runAgent`'s
     // default now fails closed, but the surface's choice belongs in the surface.
     const { buildHeadlessRegistry } = await import("@atlas/api/lib/tools/registry");
     const toolRegistry = await buildHeadlessRegistry();

--- a/packages/api/src/lib/agent-query.ts
+++ b/packages/api/src/lib/agent-query.ts
@@ -267,31 +267,21 @@ export async function executeAgentQuery(
     // Build the tool registry for this surface. `executeAgentQuery` serves the
     // non-web programmatic surfaces — the SDK query route, chat-platform
     // adapters (Slack), the MCP query tool, and the scheduler. None of them own
-    // a dashboards route, so we pass `dashboardUrlResolver: null` to omit
-    // `createDashboard` entirely (#4566, PRD #4553 L2): a handoff link to
-    // `/dashboards/[id]` is unreachable from Slack or a scheduled digest, so the
-    // agent must never be offered the tool here. Action tools stay opt-in via
-    // ATLAS_ACTIONS_ENABLED. On a build failure we fall back to
-    // `nonDashboardRegistry` (NOT the dashboards-owning `defaultRegistry`) so the
-    // createDashboard omission holds on the error path too — and we always pass
-    // `tools` so `runAgent` never defaults to `defaultRegistry`.
-    const { buildRegistry, nonDashboardRegistry } = await import(
-      "@atlas/api/lib/tools/registry"
-    );
-    let toolRegistry = nonDashboardRegistry;
-    const includeActions = process.env.ATLAS_ACTIONS_ENABLED === "true";
-    try {
-      const result = await buildRegistry({
-        includeActions,
-        dashboardUrlResolver: null,
-      });
-      toolRegistry = result.registry;
-    } catch (err) {
-      log.error(
-        { err: err instanceof Error ? err : new Error(String(err)) },
-        "Failed to build tool registry — falling back to the non-dashboard core registry",
-      );
-    }
+    // a dashboards route and none has a human in the loop, so this is the
+    // canonical HEADLESS surface: `buildHeadlessRegistry` omits `createDashboard`
+    // (#4566, PRD #4553 L2 — a `/dashboards/[id]` handoff is unreachable from
+    // Slack or a scheduled digest) and `correct_fact` (#4915), keeps action
+    // tools opt-in via ATLAS_ACTIONS_ENABLED, and falls back to
+    // `nonDashboardRegistry` (NOT the dashboards-owning `defaultRegistry`) on a
+    // build failure so both omissions hold on the error path too.
+    //
+    // #4936 — that construction moved into `registry.ts` so the chat-plugin
+    // approval RESUME of a turn started here rebuilds the identical set instead
+    // of re-deriving it (or, as it did, omitting `tools` and inheriting the
+    // workspace registry). We still pass `tools` explicitly: `runAgent`'s
+    // default now fails closed, but the surface's choice belongs in the surface.
+    const { buildHeadlessRegistry } = await import("@atlas/api/lib/tools/registry");
+    const toolRegistry = await buildHeadlessRegistry();
 
     const result = await runAgent({
       messages,

--- a/packages/api/src/lib/agent.ts
+++ b/packages/api/src/lib/agent.ts
@@ -1087,7 +1087,8 @@ function wrapToolsWithDurableState(toolSet: ToolSet, store: DurableStateStore): 
  *   a new package can reach `runAgent`.
  *
  *   The parameter stays optional for TESTS; production callers are required to
- *   name a registry. The default is now {@link nonDashboardRegistry}, not the
+ *   name a registry. Making it required outright — so the compiler enforces this
+ *   instead of a source scanner — is #4943. The default is now {@link nonDashboardRegistry}, not the
  *   dashboards-owning `defaultRegistry` (#4936). The old default was
  *   write-carrying: any caller that omitted `tools` silently received
  *   `createDashboard` AND `correct_fact` — re-opening, from the outside, the

--- a/packages/api/src/lib/agent.ts
+++ b/packages/api/src/lib/agent.ts
@@ -1088,7 +1088,9 @@ function wrapToolsWithDurableState(toolSet: ToolSet, store: DurableStateStore): 
  *
  *   The parameter stays optional for TESTS; production callers are required to
  *   name a registry. Making it required outright — so the compiler enforces this
- *   instead of a source scanner — is #4943. The default is now {@link nonDashboardRegistry}, not the
+ *   instead of a source scanner — is #4943.
+ *
+ *   The default is now {@link nonDashboardRegistry}, not the
  *   dashboards-owning `defaultRegistry` (#4936). The old default was
  *   write-carrying: any caller that omitted `tools` silently received
  *   `createDashboard` AND `correct_fact` — re-opening, from the outside, the

--- a/packages/api/src/lib/agent.ts
+++ b/packages/api/src/lib/agent.ts
@@ -27,7 +27,7 @@ import { Effect, Duration } from "effect";
 import type { ChatContextWarning } from "@useatlas/types";
 import { normalizeError } from "./effect/errors";
 import { getModel, getProviderType, getModelFromWorkspaceConfig, getWorkspaceProviderType, getSummaryModel, isGatewayAnthropicModel, type ProviderType } from "./providers";
-import { defaultRegistry, ToolRegistry } from "./tools/registry";
+import { nonDashboardRegistry, ToolRegistry } from "./tools/registry";
 import { resolveWorkspaceRestDatasources, resolveWorkspaceRestDatasourcesOrThrow } from "./openapi/workspace-datasource";
 import type { RestDatasource } from "./openapi/datasource";
 import { buildAgentRepresentation } from "./openapi/representation";
@@ -667,7 +667,14 @@ When a question spans more than one source in the catalog above — several SQL 
 - **Never silently fall back to an unrelated source.** If the source that actually holds the answer is empty or errors, say so plainly and state the gap — do not answer from a different source and imply it is equivalent.`;
 
 export interface BuildSystemParamOptions {
-  /** Tool registry the prompt's tool-guidance sections are built from. Defaults to `defaultRegistry`. */
+  /**
+   * Tool registry the prompt's tool-guidance sections are built from.
+   * Defaults to `nonDashboardRegistry` — the least-privileged core set (#4936).
+   * `runAgent` always passes its resolved `activeRegistry`, so the default only
+   * serves callers that build a prompt outside a turn; it fails closed so such
+   * a caller can't advertise `createDashboard`/`correct_fact` guidance to a
+   * surface whose tool set doesn't carry them.
+   */
   readonly registry?: ToolRegistry;
   /** Startup/context warnings surfaced to the agent under a `## Warnings` section. */
   readonly warnings?: readonly string[];
@@ -785,7 +792,7 @@ export function buildSystemParam(
   options: BuildSystemParamOptions = {},
 ): string | SystemModelMessage {
   const {
-    registry = defaultRegistry,
+    registry = nonDashboardRegistry,
     warnings,
     persona,
     briefing,
@@ -1072,16 +1079,29 @@ function wrapToolsWithDurableState(toolSet: ToolSet, store: DurableStateStore): 
  * Run the Atlas agent loop.
  *
  * @param messages - The conversation history from the chat UI.
- * @param tools - Optional custom {@link ToolRegistry}. Defaults to
- *   {@link defaultRegistry} (explore + executeSQL). The loop terminates
- *   when the step limit is reached (configurable via `ATLAS_AGENT_MAX_STEPS`,
- *   default 25) or the model stops issuing tool calls.
+ * @param tools - The surface's {@link ToolRegistry}. **Every production call
+ *   site passes it explicitly** — `agent-runagent-call-sites.test.ts` is the
+ *   tripwire that keeps that true across `packages/**` and `ee/**`.
+ *
+ *   It stays optional for tests and for callers that legitimately want the
+ *   read-safe core set, but the default is now
+ *   {@link nonDashboardRegistry}, not the dashboards-owning
+ *   `defaultRegistry` (#4936). The old default was write-carrying: any caller
+ *   that omitted `tools` silently received `createDashboard` AND `correct_fact`
+ *   — re-opening, from the outside, the surface gate `registry.ts` applies from
+ *   the inside (#4915). Defaulting to the least-privileged registry makes
+ *   forgetting fail CLOSED. A surface that owns `/dashboards/[id]` must now
+ *   opt in by passing `defaultRegistry`; a headless one should pass
+ *   `buildHeadlessRegistry()`.
+ *
+ *   The loop terminates when the step limit is reached (configurable via
+ *   `ATLAS_AGENT_MAX_STEPS`, default 25) or the model stops issuing tool calls.
  * @param conversationId - Optional conversation ID for token usage tracking.
  *   When provided, the recorded token usage row links to this conversation.
  */
 export async function runAgent({
   messages,
-  tools: toolRegistry = defaultRegistry,
+  tools: toolRegistry = nonDashboardRegistry,
   conversationId,
   warnings,
   persona,

--- a/packages/api/src/lib/agent.ts
+++ b/packages/api/src/lib/agent.ts
@@ -669,7 +669,8 @@ When a question spans more than one source in the catalog above — several SQL 
 export interface BuildSystemParamOptions {
   /**
    * Tool registry the prompt's tool-guidance sections are built from.
-   * Defaults to `nonDashboardRegistry` — the least-privileged core set (#4936).
+   * Defaults to `nonDashboardRegistry` — the lesser-privileged of the two core
+   * registries (#4936).
    * `runAgent` always passes its resolved `activeRegistry`, so the default only
    * serves callers that build a prompt outside a turn; it fails closed so such
    * a caller can't advertise `createDashboard`/`correct_fact` guidance to a
@@ -1079,20 +1080,26 @@ function wrapToolsWithDurableState(toolSet: ToolSet, store: DurableStateStore): 
  * Run the Atlas agent loop.
  *
  * @param messages - The conversation history from the chat UI.
- * @param tools - The surface's {@link ToolRegistry}. **Every production call
- *   site passes it explicitly** — `agent-runagent-call-sites.test.ts` is the
- *   tripwire that keeps that true across `packages/**` and `ee/**`.
+ * @param tools - The surface's {@link ToolRegistry}. Every production call site
+ *   passes it explicitly, and `agent-runagent-call-sites.test.ts` pins WHICH
+ *   registry each one must resolve to. That guard scans the roots listed in its
+ *   `SCAN_ROOTS` (`packages/api|mcp|sdk/src` + `ee/src`) — add a root there when
+ *   a new package can reach `runAgent`.
  *
- *   It stays optional for tests and for callers that legitimately want the
- *   read-safe core set, but the default is now
- *   {@link nonDashboardRegistry}, not the dashboards-owning
- *   `defaultRegistry` (#4936). The old default was write-carrying: any caller
- *   that omitted `tools` silently received `createDashboard` AND `correct_fact`
- *   — re-opening, from the outside, the surface gate `registry.ts` applies from
- *   the inside (#4915). Defaulting to the least-privileged registry makes
- *   forgetting fail CLOSED. A surface that owns `/dashboards/[id]` must now
- *   opt in by passing `defaultRegistry`; a headless one should pass
- *   `buildHeadlessRegistry()`.
+ *   The parameter stays optional for TESTS; production callers are required to
+ *   name a registry. The default is now {@link nonDashboardRegistry}, not the
+ *   dashboards-owning `defaultRegistry` (#4936). The old default was
+ *   write-carrying: any caller that omitted `tools` silently received
+ *   `createDashboard` AND `correct_fact` — re-opening, from the outside, the
+ *   surface gate `registry.ts` applies from the inside (#4915). Defaulting to
+ *   the lesser-privileged registry makes forgetting fail CLOSED. A surface that
+ *   owns `/dashboards/[id]` opts in by passing `defaultRegistry`; a headless one
+ *   passes `buildHeadlessRegistry()`.
+ *
+ *   `nonDashboardRegistry` is lesser-privileged, not side-effect-free: `sendEmail`
+ *   / `createLinearIssue` / `querySalesforce` are core tools, gated at execute
+ *   time on the workspace install. Rationale: the `correct_fact` gate comment in
+ *   `lib/tools/registry.ts`.
  *
  *   The loop terminates when the step limit is reached (configurable via
  *   `ATLAS_AGENT_MAX_STEPS`, default 25) or the model stops issuing tool calls.

--- a/packages/api/src/lib/chat-plugin/__tests__/resume-turn.test.ts
+++ b/packages/api/src/lib/chat-plugin/__tests__/resume-turn.test.ts
@@ -40,8 +40,14 @@ void mock.module("@atlas/api/lib/durable-resume", () => ({
 void mock.module("@atlas/api/lib/billing/agent-gate", () => ({
   checkAgentBillingGate: mockBillingGate,
 }));
+// `getRequestContext` is not used by `resume-turn` itself — it is pulled in by
+// the tool-registry module graph that `buildHeadlessRegistry()` reaches (#4936).
+// A partial mock of a module the graph imports fails the whole import with
+// "Export named 'getRequestContext' not found", which `resume-turn`'s catch
+// would then report as an opaque `agent_run_error`.
 void mock.module("@atlas/api/lib/logger", () => ({
   createLogger: () => ({ info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }),
+  getRequestContext: () => undefined,
   withRequestContext: async (ctx: Record<string, unknown>, fn: () => Promise<unknown>) => {
     capturedContext = ctx;
     return fn();
@@ -87,6 +93,25 @@ describe("resumeChatTurn (#3750)", () => {
     expect(runArgs.resume?.runId).toBe("run_1");
     // Lease released.
     expect(mockFinishResume).toHaveBeenCalledTimes(1);
+  });
+
+  it("#4936 — resumes on the headless tool set, not the workspace one", async () => {
+    // The parked turn ran through `executeAgentQuery` → `buildHeadlessRegistry()`.
+    // Resume used to omit `tools` entirely and inherit `runAgent`'s default, so
+    // the surface WIDENED across the approval boundary — picking up the
+    // brain-mutating `correct_fact` on an autonomous Slack turn with no
+    // confirmation UI. The registry must now be named here, and be the same one.
+    await resumeChatTurn({ ...BASE, externalUserId: "U999" });
+
+    const runArgs = mockRunAgent.mock.calls[0]![0] as { tools?: { getAll(): Record<string, unknown> } };
+    expect(runArgs.tools, "resume must pass `tools` explicitly").toBeDefined();
+
+    const names = Object.keys(runArgs.tools!.getAll());
+    expect(names).not.toContain("correct_fact");
+    expect(names).not.toContain("createDashboard");
+    // Not vacuous — the read surface the parked turn had is intact.
+    expect(names).toContain("executeSQL");
+    expect(names).toContain("explore");
   });
 
   it("blocks (does not resume) when billing re-resolution refuses", async () => {

--- a/packages/api/src/lib/chat-plugin/__tests__/resume-turn.test.ts
+++ b/packages/api/src/lib/chat-plugin/__tests__/resume-turn.test.ts
@@ -40,14 +40,22 @@ void mock.module("@atlas/api/lib/durable-resume", () => ({
 void mock.module("@atlas/api/lib/billing/agent-gate", () => ({
   checkAgentBillingGate: mockBillingGate,
 }));
-// `getRequestContext` is not used by `resume-turn` itself — it is pulled in by
-// the tool-registry module graph that `buildHeadlessRegistry()` reaches (#4936).
-// A partial mock of a module the graph imports fails the whole import with
-// "Export named 'getRequestContext' not found", which `resume-turn`'s catch
-// would then report as an opaque `agent_run_error`.
+// Mocked at its FULL named-export surface, not just the names `resume-turn`
+// itself uses. `buildHeadlessRegistry()` (#4936) pulls the tool-registry module
+// graph in here, and a partial `mock.module` fails the whole import with
+// "Export named 'X' not found" — which `resume-turn`'s catch then reports as an
+// opaque `agent_run_error`. Mocking only the name that breaks today guarantees
+// the next unrelated PR re-hits this.
 void mock.module("@atlas/api/lib/logger", () => ({
+  ACTOR_KINDS: ["human", "agent", "mcp", "scheduler", "api_key"],
   createLogger: () => ({ info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }),
+  getLogger: () => ({ info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }),
   getRequestContext: () => undefined,
+  hashShareToken: (t: string) => t,
+  redactPaths: [],
+  scrubErrSerializer: (v: unknown) => v,
+  scrubLogFormatter: (o: unknown) => o,
+  setLogLevel: () => true,
   withRequestContext: async (ctx: Record<string, unknown>, fn: () => Promise<unknown>) => {
     capturedContext = ctx;
     return fn();
@@ -100,7 +108,8 @@ describe("resumeChatTurn (#3750)", () => {
     // Resume used to omit `tools` entirely and inherit `runAgent`'s default, so
     // the surface WIDENED across the approval boundary — picking up the
     // brain-mutating `correct_fact` on an autonomous Slack turn with no
-    // confirmation UI. The registry must now be named here, and be the same one.
+    // confirmation UI. The registry must now be named here, and rebuilt from the
+    // same policy.
     await resumeChatTurn({ ...BASE, externalUserId: "U999" });
 
     const runArgs = mockRunAgent.mock.calls[0]![0] as { tools?: { getAll(): Record<string, unknown> } };

--- a/packages/api/src/lib/chat-plugin/resume-turn.ts
+++ b/packages/api/src/lib/chat-plugin/resume-turn.ts
@@ -147,8 +147,21 @@ export async function resumeChatTurn(input: ResumeChatTurnInput): Promise<Resume
         // Re-enter the loop from the checkpoint. `messages: []` is inert — the
         // rewritten transcript (carrying the "approved, re-run now" result) is
         // the model input. The tools re-resolve connection/whitelist/RLS live.
+        //
+        // #4936 — the registry is named explicitly, and it is the SAME one the
+        // parked turn ran under: the original chat-platform turn went through
+        // `executeAgentQuery` → `buildHeadlessRegistry()`. Omitting `tools`
+        // here used to hand the resume the workspace registry instead, so the
+        // tool surface silently WIDENED across the approval boundary — adding
+        // `correct_fact` to an autonomous Slack turn with no confirmation UI.
+        // (Execute time still refused: the actor is `botActorUser`, role
+        // `member` with no member row, so the owner/admin gate said no. The
+        // posture is that a brain-mutating tool must not be on this surface at
+        // all, however well execute-time gating held.)
+        const { buildHeadlessRegistry } = await import("@atlas/api/lib/tools/registry");
         const agentResult = await runAgent({
           messages: [],
+          tools: await buildHeadlessRegistry(),
           conversationId,
           resume: {
             runId: handle.runId,

--- a/packages/api/src/lib/chat-plugin/resume-turn.ts
+++ b/packages/api/src/lib/chat-plugin/resume-turn.ts
@@ -154,10 +154,16 @@ export async function resumeChatTurn(input: ResumeChatTurnInput): Promise<Resume
         // here used to hand the resume the workspace registry instead, so the
         // tool surface silently WIDENED across the approval boundary — adding
         // `correct_fact` to an autonomous Slack turn with no confirmation UI.
-        // (Execute time still refused: the actor is `botActorUser`, role
-        // `member` with no member row, so the owner/admin gate said no. The
-        // posture is that a brain-mutating tool must not be on this surface at
-        // all, however well execute-time gating held.)
+        // Execute time did NOT uniformly refuse. In authenticated modes it did
+        // — `botActorUser` is role `member` with no member row, so
+        // `correction.ts`'s owner/admin gate said no. But under
+        // `ATLAS_AUTH_MODE=none` the principal resolves to
+        // `origin: "unauthenticated-local"`, which that gate deliberately lets
+        // through ("the local operator is the only identity there is"), so on a
+        // self-hosted no-auth deploy running the Slack plugin the widened
+        // resume could actually have mutated the brain. Even where the gate did
+        // hold, the posture is that a brain-mutating tool must not be on this
+        // surface at all.
         const { buildHeadlessRegistry } = await import("@atlas/api/lib/tools/registry");
         const agentResult = await runAgent({
           messages: [],

--- a/packages/api/src/lib/chat-plugin/resume-turn.ts
+++ b/packages/api/src/lib/chat-plugin/resume-turn.ts
@@ -148,15 +148,21 @@ export async function resumeChatTurn(input: ResumeChatTurnInput): Promise<Resume
         // rewritten transcript (carrying the "approved, re-run now" result) is
         // the model input. The tools re-resolve connection/whitelist/RLS live.
         //
-        // #4936 — the registry is named explicitly, and it is the SAME one the
-        // parked turn ran under: the original chat-platform turn went through
-        // `executeAgentQuery` → `buildHeadlessRegistry()`. Omitting `tools`
+        // #4936 — the registry is named explicitly, and it is rebuilt from the
+        // SAME POLICY the parked turn ran under: the original chat-platform turn
+        // went through `executeAgentQuery` → `buildHeadlessRegistry()`. Policy,
+        // not set — `ATLAS_ACTIONS_ENABLED` / `ATLAS_PYTHON_ENABLED` are re-read
+        // here, so a turn parked across an operator flag flip resumes on a
+        // different set. Omitting `tools`
         // here used to hand the resume the workspace registry instead, so the
         // tool surface silently WIDENED across the approval boundary — adding
         // `correct_fact` to an autonomous Slack turn with no confirmation UI.
-        // Execute time did NOT uniformly refuse. In authenticated modes it did
-        // — `botActorUser` is role `member` with no member row, so
-        // `correction.ts`'s owner/admin gate said no. But under
+        // Execute time did NOT uniformly refuse. In authenticated modes it did:
+        // the role is re-resolved from the `member` table and the session role
+        // is discarded by design (`reader-context.ts`), the bot has no member
+        // row, so `ctx.role` is null and `correction.ts`'s owner/admin gate said
+        // no. Note the bot's synthetic `role: "member"` is NOT what refuses —
+        // raising it would change nothing. But under
         // `ATLAS_AUTH_MODE=none` the principal resolves to
         // `origin: "unauthenticated-local"`, which that gate deliberately lets
         // through ("the local operator is the only identity there is"), so on a

--- a/packages/api/src/lib/tools/__tests__/registry.test.ts
+++ b/packages/api/src/lib/tools/__tests__/registry.test.ts
@@ -41,6 +41,7 @@ const {
   defaultRegistry,
   nonDashboardRegistry,
   buildRegistry,
+  buildHeadlessRegistry,
   WORKSPACE_DASHBOARD_URL_RESOLVER,
   INTENTIONAL_TOOL_SHADOWS,
   TOOL_SHADOW_REMEDIATIONS,
@@ -444,5 +445,77 @@ describe("tool-shadow policy (#3326)", () => {
   it("remediation copy exists for the known querySalesforce collision", () => {
     expect(TOOL_SHADOW_REMEDIATIONS.querySalesforce).toContain("SALESFORCE_CLIENT_ID");
     expect(TOOL_SHADOW_REMEDIATIONS.querySalesforce).toContain("salesforce://");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #4936 — buildHeadlessRegistry
+// ---------------------------------------------------------------------------
+
+/** Run `fn` with the given env keys set/cleared, restoring them afterwards. */
+async function withEnv(
+  overrides: Record<string, string | undefined>,
+  fn: () => Promise<void>,
+): Promise<void> {
+  const saved = new Map(Object.keys(overrides).map((k) => [k, process.env[k]]));
+  try {
+    for (const [k, v] of Object.entries(overrides)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+    await fn();
+  } finally {
+    for (const [k, v] of saved) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  }
+}
+
+describe("buildHeadlessRegistry (#4936)", () => {
+  // The named seam three surfaces now share — `executeAgentQuery` (SDK / Slack
+  // / MCP / scheduler) and the chat-plugin approval RESUME of a turn started
+  // there. It exists so resume rebuilds the same policy the parked turn ran
+  // under instead of re-deriving it, which is how the surface silently widened
+  // across the approval boundary before this fix.
+  it("omits both write verbs but keeps the core query tools", async () => {
+    const names = Object.keys((await buildHeadlessRegistry()).getAll());
+
+    expect(names).not.toContain("createDashboard");
+    expect(names).not.toContain("correct_fact");
+    // Not vacuous — a headless surface is still a full read surface.
+    for (const core of ["explore", "executeSQL", "searchBrain"]) {
+      expect(names).toContain(core);
+    }
+  });
+
+  it("keeps operator action tools opt-in behind ATLAS_ACTIONS_ENABLED", async () => {
+    await withEnv({ ATLAS_ACTIONS_ENABLED: undefined }, async () => {
+      expect(Object.keys((await buildHeadlessRegistry()).getAll())).not.toContain("sendEmailReport");
+    });
+    await withEnv({ ATLAS_ACTIONS_ENABLED: "true" }, async () => {
+      expect(Object.keys((await buildHeadlessRegistry()).getAll())).toContain("sendEmailReport");
+    });
+  });
+
+  it("falls back to nonDashboardRegistry — NOT defaultRegistry — when buildRegistry throws", async () => {
+    // The security-relevant branch, and the one the pre-refactor inline version
+    // in agent-query.ts never had a test for. `ATLAS_PYTHON_ENABLED` without
+    // `ATLAS_SANDBOX_URL` is the fatal misconfiguration buildRegistry throws on
+    // (pinned above). Both omissions must hold on the error path too, or a
+    // misconfigured box quietly hands every headless surface the write verbs.
+    await withEnv(
+      { ATLAS_PYTHON_ENABLED: "true", ATLAS_SANDBOX_URL: undefined },
+      async () => {
+        await expect(buildRegistry()).rejects.toThrow("ATLAS_SANDBOX_URL");
+
+        const registry = await buildHeadlessRegistry();
+        expect(registry).toBe(nonDashboardRegistry);
+        const names = Object.keys(registry.getAll());
+        expect(names).not.toContain("createDashboard");
+        expect(names).not.toContain("correct_fact");
+        expect(names).toContain("executeSQL");
+      },
+    );
   });
 });

--- a/packages/api/src/lib/tools/__tests__/registry.test.ts
+++ b/packages/api/src/lib/tools/__tests__/registry.test.ts
@@ -473,9 +473,9 @@ async function withEnv(
 }
 
 describe("buildHeadlessRegistry (#4936)", () => {
-  // The named seam three surfaces now share — `executeAgentQuery` (SDK / Slack
-  // / MCP / scheduler) and the chat-plugin approval RESUME of a turn started
-  // there. It exists so resume rebuilds the same policy the parked turn ran
+  // The named seam two call sites now share — `executeAgentQuery` (serving the
+  // SDK / Slack / MCP / scheduler surfaces) and the chat-plugin approval RESUME
+  // of a turn started there. It exists so resume rebuilds the same policy the parked turn ran
   // under instead of re-deriving it, which is how the surface silently widened
   // across the approval boundary before this fix.
   it("omits both write verbs but keeps the core query tools", async () => {

--- a/packages/api/src/lib/tools/__tests__/registry.test.ts
+++ b/packages/api/src/lib/tools/__tests__/registry.test.ts
@@ -475,9 +475,9 @@ async function withEnv(
 describe("buildHeadlessRegistry (#4936)", () => {
   // The named seam two call sites now share — `executeAgentQuery` (serving the
   // SDK / Slack / MCP / scheduler surfaces) and the chat-plugin approval RESUME
-  // of a turn started there. It exists so resume rebuilds the same policy the parked turn ran
-  // under instead of re-deriving it, which is how the surface silently widened
-  // across the approval boundary before this fix.
+  // of a turn started there. It exists so resume rebuilds from the same policy
+  // the parked turn ran under instead of re-deriving it, which is how the
+  // surface silently widened across the approval boundary before this fix.
   it("omits both write verbs but keeps the core query tools", async () => {
     const names = Object.keys((await buildHeadlessRegistry()).getAll());
 

--- a/packages/api/src/lib/tools/registry.ts
+++ b/packages/api/src/lib/tools/registry.ts
@@ -295,7 +295,8 @@ function registerCoreTools(
   // own spelling (`correct_fact`). Workspace, identity, and the owner/admin
   // authority gate all run at execute time inside the verb machinery — but
   // unlike `searchBrain` it is NOT registered globally, because it WRITES:
-  // `nonDashboardRegistry` is the surface `POST /api/v1/query` reaches, and
+  // `nonDashboardRegistry` is the policy `POST /api/v1/query` reaches (via
+  // `buildHeadlessRegistry()`; this singleton is that path's fallback), and
   // that operation is admitted to READ-SAFE Agent-Auth keys on a read-only-
   // engine guarantee (#4707, pinned by `agent-auth-read-safe-engine.test.ts`'s
   // tool-surface tripwire). A brain-mutating tool on that surface would break
@@ -313,8 +314,8 @@ function registerCoreTools(
   // gate from the outside). The default now fails CLOSED to
   // `nonDashboardRegistry`, and `agent-runagent-call-sites.test.ts` pins the
   // registry each production call site must resolve to. This is the canonical
-  // account of that fix; the other touched files carry a one-line pointer here
-  // rather than restating it.
+  // account of the GATE; each call site narrates only its own surface-specific
+  // exposure rather than restating this.
   if (dashboardUrlResolver) {
     registry.register({
       name: "correct_fact",
@@ -379,9 +380,9 @@ defaultRegistry.freeze();
 // Core tools MINUS createDashboard AND correct_fact (both gate on the same
 // `dashboardUrlResolver` signal), for surfaces that own no dashboards route
 // (SDK / Slack / MCP / scheduler via `executeAgentQuery`). Also the
-// guaranteed-safe fallback when `buildRegistry` throws — so the createDashboard
-// omission holds even on the error path instead of falling through to the
-// dashboards-owning `defaultRegistry`.
+// guaranteed-safe fallback when `buildRegistry` throws — so BOTH omissions hold
+// even on the error path instead of falling through to the dashboards-owning
+// `defaultRegistry`.
 const nonDashboardRegistry = new ToolRegistry();
 registerCoreTools(nonDashboardRegistry, null);
 nonDashboardRegistry.freeze();
@@ -544,7 +545,8 @@ export async function buildRegistry(options?: {
  * route and has no human in the loop (#4936).
  *
  * This is `executeAgentQuery`'s registry construction, lifted to a named seam
- * so the surfaces that re-enter the SAME turn get the SAME tool set. Chat
+ * so the surfaces that re-enter the SAME turn rebuild from the SAME POLICY
+ * (not necessarily the same SET — the env flags below are re-read). Chat
  * resume (`lib/chat-plugin/resume-turn.ts`) was the case that forced it: the
  * original Slack turn ran through `executeAgentQuery`, but the approval-resume
  * of that turn called `runAgent` with no `tools` at all — so the tool surface
@@ -560,6 +562,13 @@ export async function buildRegistry(options?: {
  *
  * A build failure falls back to `nonDashboardRegistry`, NOT the dashboards-
  * owning `defaultRegistry`, so both omissions hold on the error path too.
+ *
+ * Two known limits, deliberately out of #4936's scope and tracked separately:
+ * this catch also swallows `buildRegistry`'s DELIBERATE fatal throws (#4940 —
+ * every caller in the repo already does, and the fallback preserves the
+ * isolation invariant by not carrying `executePython`), and the return type has
+ * nowhere for `BuildRegistryResult.warnings` to go, so a degraded action-tool
+ * load is invisible to the user on every headless surface (#4941).
  */
 export async function buildHeadlessRegistry(): Promise<ToolRegistry> {
   try {

--- a/packages/api/src/lib/tools/registry.ts
+++ b/packages/api/src/lib/tools/registry.ts
@@ -311,10 +311,10 @@ function registerCoreTools(
   // site passes. That used to be a silent decision (`runAgent` defaulted to
   // the write-carrying `defaultRegistry`, so an omitted `tools` re-opened this
   // gate from the outside). The default now fails CLOSED to
-  // `nonDashboardRegistry`, and `agent-runagent-call-sites.test.ts` requires
-  // every production call site — `packages/**` and `ee/**` — to pass `tools`
-  // explicitly, so a new headless surface can neither inherit nor omit its way
-  // into a brain-mutating tool set.
+  // `nonDashboardRegistry`, and `agent-runagent-call-sites.test.ts` pins the
+  // registry each production call site must resolve to. This is the canonical
+  // account of that fix; the other touched files carry a one-line pointer here
+  // rather than restating it.
   if (dashboardUrlResolver) {
     registry.register({
       name: "correct_fact",
@@ -376,7 +376,8 @@ registerCoreTools(defaultRegistry, WORKSPACE_DASHBOARD_URL_RESOLVER);
 defaultRegistry.freeze();
 
 // --- Non-dashboard registry (#4566) ---
-// Core tools MINUS createDashboard, for surfaces that own no dashboards route
+// Core tools MINUS createDashboard AND correct_fact (both gate on the same
+// `dashboardUrlResolver` signal), for surfaces that own no dashboards route
 // (SDK / Slack / MCP / scheduler via `executeAgentQuery`). Also the
 // guaranteed-safe fallback when `buildRegistry` throws — so the createDashboard
 // omission holds even on the error path instead of falling through to the

--- a/packages/api/src/lib/tools/registry.ts
+++ b/packages/api/src/lib/tools/registry.ts
@@ -305,6 +305,16 @@ function registerCoreTools(
   // surface with a human in the loop), and today those classes coincide
   // exactly with where a correction verb belongs — if they ever diverge,
   // split the signal rather than re-globalizing this tool.
+  //
+  // #4936 — this gate only decides what each REGISTRY contains; the surface a
+  // given turn actually gets is decided by which registry its `runAgent` call
+  // site passes. That used to be a silent decision (`runAgent` defaulted to
+  // the write-carrying `defaultRegistry`, so an omitted `tools` re-opened this
+  // gate from the outside). The default now fails CLOSED to
+  // `nonDashboardRegistry`, and `agent-runagent-call-sites.test.ts` requires
+  // every production call site — `packages/**` and `ee/**` — to pass `tools`
+  // explicitly, so a new headless surface can neither inherit nor omit its way
+  // into a brain-mutating tool set.
   if (dashboardUrlResolver) {
     registry.register({
       name: "correct_fact",
@@ -526,6 +536,45 @@ export async function buildRegistry(options?: {
 
   registry.freeze();
   return { registry, warnings };
+}
+
+/**
+ * The registry for a HEADLESS agent surface — one that owns no dashboards
+ * route and has no human in the loop (#4936).
+ *
+ * This is `executeAgentQuery`'s registry construction, lifted to a named seam
+ * so the surfaces that re-enter the SAME turn get the SAME tool set. Chat
+ * resume (`lib/chat-plugin/resume-turn.ts`) was the case that forced it: the
+ * original Slack turn ran through `executeAgentQuery`, but the approval-resume
+ * of that turn called `runAgent` with no `tools` at all — so the tool surface
+ * silently widened across the resume boundary. Rebuilding it here keeps resume
+ * faithful (an approved action tool is still executable) without either caller
+ * re-deriving the policy.
+ *
+ * `dashboardUrlResolver: null` is the whole policy: it drops `createDashboard`
+ * (a `/dashboards/[id]` handoff is unreachable from Slack or a scheduled
+ * digest, #4566) and `correct_fact` (a brain-mutating write has no place on an
+ * autonomous surface with no confirmation UI, #4915). Action tools stay opt-in
+ * via `ATLAS_ACTIONS_ENABLED`.
+ *
+ * A build failure falls back to `nonDashboardRegistry`, NOT the dashboards-
+ * owning `defaultRegistry`, so both omissions hold on the error path too.
+ */
+export async function buildHeadlessRegistry(): Promise<ToolRegistry> {
+  try {
+    const { registry } = await buildRegistry({
+      includeActions: process.env.ATLAS_ACTIONS_ENABLED === "true",
+      dashboardUrlResolver: null,
+    });
+    return registry;
+  } catch (err) {
+    const { createLogger } = await import("@atlas/api/lib/logger");
+    createLogger("registry").error(
+      { err: err instanceof Error ? err : new Error(String(err)) },
+      "Failed to build headless tool registry — falling back to the non-dashboard core registry",
+    );
+    return nonDashboardRegistry;
+  }
 }
 
 export { defaultRegistry, nonDashboardRegistry };

--- a/packages/api/src/lib/tools/registry.ts
+++ b/packages/api/src/lib/tools/registry.ts
@@ -546,7 +546,9 @@ export async function buildRegistry(options?: {
  *
  * This is `executeAgentQuery`'s registry construction, lifted to a named seam
  * so the surfaces that re-enter the SAME turn rebuild from the SAME POLICY
- * (not necessarily the same SET — the env flags below are re-read). Chat
+ * (not necessarily the same SET — the env this seam and `buildRegistry` read
+ * are re-read: `ATLAS_ACTIONS_ENABLED`, `ATLAS_PYTHON_ENABLED`, and the
+ * Salesforce OAuth pair that gates `querySalesforce`). Chat
  * resume (`lib/chat-plugin/resume-turn.ts`) was the case that forced it: the
  * original Slack turn ran through `executeAgentQuery`, but the approval-resume
  * of that turn called `runAgent` with no `tools` at all — so the tool surface


### PR DESCRIPTION
Closes #4936. Targets `chore/brain-m2-to-main` (#4932), not `main` — `correction.ts` and the #4915 surface gate only exist there after the Brain M2 revert (`0bb5d9130`).

## The bug

#4915 keeps `correct_fact` — a brain-mutating WRITE — off the read-safe agent surface by registering it only when a `dashboardUrlResolver` is present. That gate decides what each **registry** contains. It said nothing about which registry a given **turn** gets, and `runAgent` answered that with a default parameter:

```ts
tools: toolRegistry = defaultRegistry   // carries createDashboard AND correct_fact
```

Three surfaces omitted `tools` and silently inherited it — the proactive linked-asker branch (`ee/`), the chat-plugin approval resume, and the zero-signup demo. The gate was correct where it was applied; it was re-opened from the outside.

## The fix

- **`runAgent`'s default is now `nonDashboardRegistry`** — forgetting fails CLOSED. `buildSystemParam`'s `registry` default moves with it, so the prompt's tool guidance can't advertise verbs the tool set doesn't carry.
- **Every production call site names its registry.** The two workspace surfaces (web chat, web resume) opt IN to `defaultRegistry`; the headless ones resolve `buildHeadlessRegistry()`.
- **`buildHeadlessRegistry()`** lifts `executeAgentQuery`'s registry construction into a named seam, so chat resume rebuilds from the same policy the parked turn ran under instead of widening across the approval boundary.
- **`agent-runagent-call-sites.test.ts`** pins the call-site axis: behavioural (a real turn's tool set) plus structural (which registry each site resolves to), scanning `packages/api|mcp|sdk/src` and `ee/src`.

Follow-ups filed, and referenced from the code: **#4940** (`buildRegistry`'s fatal throws are swallowed by all five callers — pre-existing and repo-wide), **#4941** (headless surfaces discard `buildRegistry` warnings), **#4943** (make `tools` required so the compiler is primary — see below).

## On scope: `agent-query.ts` and `chat.ts` are consequences, not creep

Neither is named in the issue. Both are forced by removing the default:

- **`chat.ts`** — the web chat surface legitimately wants `createDashboard` + `correct_fact`; it owns `/dashboards/[id]` and has a human in the loop. It had been getting them *by inheriting the default*. Flipping the default without this change would silently strip both from web chat. `toolRegistry` is still `undefined` on the ordinary path, which is exactly why it can't stay implicit.
- **`agent-query.ts`** — net −2 lines. Its inline registry construction moved into `buildHeadlessRegistry()` so `resume-turn.ts` reuses the identical policy rather than re-deriving it. Re-deriving is how the two paths diverged in the first place.

## On the security bar: why `tools` is not required (yet)

The strongest fix makes `tools` a required parameter so the compiler enforces the gate. The type-design reviewer proved with `tsc --noEmit` that a required param rejects all five bug shapes — including both conditional spreads that were the actual pre-fix source. That is real, and it is filed as **#4943**.

It is deferred rather than skipped because 86 `runAgent(` call sites across 22 test files omit `tools`, and the migration is not purely mechanical: this PR twice found that naming the registry at a call site drags `lib/tools/registry`'s module graph into a test that previously only mocked `lib/agent`, breaking its partial `mock.module` (`cors.test.ts`, `chat-plugin/__tests__/resume-turn.test.ts`). Both were repaired here, and they are the grounded estimate for what a codemod would hit.

What ships instead is defence in depth the required param alone would not give: a **fail-closed runtime default** covering callers the type system never sees (an `any`-typed bag, a separately compiled plugin), plus a **structural guard** covering `runAgent(opts)` where the choice is laundered through a bag — which compiles clean under a required param. #4943 recommends both together.

## Three review rounds, and what they cost

The panel found real defects each round; recording them because two were in the guard itself, which is the part most likely to be trusted on sight.

1. **The `ee` suite was RED and I hadn't run it** — `--affected` only covers `packages/api`. `answer-adapter.test.ts`'s `hasCustomToolRegistry` boolean inverted once the linked branch named a registry. Fixed by capturing tool *names*, which also rescued the unlinked-asker assertion (AC #2614) from going vacuous: with both branches now passing a registry, "passed something" no longer discriminates.
2. **The guard did not catch the shape the bug actually had.** Its predicate was a text match for `tools:`, which a conditional spread satisfies — and `...(toolRegistry ? { tools: toolRegistry } : {})` is verbatim what two call sites contained. It would have reported #4936 clean. Replaced with a brace-depth scanner; fixtures pin the historical spellings.
3. **A `tools`-carrying spread placed *after* the property was invisible.** Object spread is last-write-wins, so the turn runs on the spread's registry while the pinned spelling is still literally present and every gate passes. The only escape shape that fails **upward** — it re-adds `correct_fact` rather than resolving to `undefined` and landing on the fail-closed default. Stacked conditional spreads are the house idiom at these exact call sites (`chat.ts` has three).

Every guard in this PR was verified by mutation — reverting the default, omitting `tools`, passing the wrong registry, both spread shapes, and the source pins each go red on a real call site.

## Verification

- `bun run type` clean; `bun run lint` exit 0
- `packages/api` isolated runner `--affected`: **427/427**
- `ee`: **52/52**
- `/ci`: **32 of 33 gates PASS**. The one failure is `@atlas/mcp`'s `canonical-mcp-auth.test.ts` on a 5s `beforeEach` hook timeout under concurrent local load; it passes in isolation in 2.21s, and `packages/mcp` is untouched by this diff.

## Test changes

Three assertions encoded the old default and were updated with their reasoning:
- `chat.test.ts` read `call.tools === undefined` as the proxy for "no action tools" — a proxy that only worked *because of the bug*. Now asserts tool names, and additionally that web chat KEEPS both write verbs (over-correcting the route would otherwise be silent).
- `agent-scope-prompt.test.ts`'s focus-strip assertions would have gone vacuous under the new default; they now name `defaultRegistry`, which is what the strip actually serves.
- `chat-resume.test.ts` gained the web-resume mirror of the same check.

New: `buildHeadlessRegistry` including its previously untested fallback branch, `correct_fact` pinned on the headless surface, `buildSystemParam`'s default pinned, and a drift guard that fails if a `runAgent` call site appears outside `SCAN_ROOTS`.