### PR TITLE
test(brain): fix an inverted negation in the corroboration comment

### DIFF
--- a/packages/api/src/lib/brain/__tests__/wedge-loop-pg.test.ts
+++ b/packages/api/src/lib/brain/__tests__/wedge-loop-pg.test.ts
@@ -1033,7 +1033,8 @@ describeIfPg("brain M1 wedge loop (real Postgres)", () => {
       // disappearing at the moment it was reinforced. The precision matters:
       // liveness is `valid_to IS NULL OR valid_to > now()`, so a FUTURE-dated
       // stamp is still a live fact (#4942). What this asserts is the stronger
-      // claim that re-observation stamps the column at all — neither direction.
+      // claim that re-observation NEVER stamps the column at all — so it holds
+      // whichever direction a stamp would have gone.
       const { rows: validity } = await pool.query<{
         valid_to: Date | null;
         invalidated_at: Date | null;


### PR DESCRIPTION
Follow-up to #4946 (which carried #4938's six criteria and is already merged into `chore/brain-m2-to-main`).

#4946 correctly sharpened this comment against #4935/#4942's predicate correction — non-null `valid_to` does **not** mean retired, since liveness is `valid_to IS NULL OR valid_to > now()` and a future-dated stamp is still served as current.

But its closing sentence dropped a negation and states the inverse of what the assertion does:

> What this asserts is the stronger claim that re-observation stamps the column at all — neither direction.

The assertion is `expect(validity[0]).toEqual({ valid_to: null, invalidated_at: null })`. Re-observation must **never** stamp the column. As written, the comment tells the next reader that corroboration is *expected* to write `valid_to` — which would make a real regression here read as intended behaviour.

Comment-only; no assertion changes. `wedge-loop-pg.test.ts` 10/10 green.

An inverted comment on a test whose entire subject is precision is the rot class #4938 exists to eliminate, so it shouldn't sit on the branch until M2 lands.

Refs #4938.