### PR TITLE
ci: gate PRs onto the Brain M2 integration branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main, "milestone/**", "hotfix/**"]
   pull_request:
-    branches: [main, "milestone/**"]
+    branches: [main, "milestone/**", chore/brain-m2-to-main]
   # Manual lever: lets an operator/agent re-create required check runs when
   # GitHub drops pull_request event deliveries (observed 2026-06-10 on #3358).
   workflow_dispatch:
@@ -16,6 +16,20 @@ on:
 # merge. The `push:` half is deliberate too: it gives the milestone branch a
 # post-merge integration signal, which is what catches a semantic conflict
 # between two stacked PRs that were each green in isolation.
+#
+# `chore/brain-m2-to-main` is a NAMED, TEMPORARY exception — delete it when #4932
+# merges. Brain M2 was reverted from `main` (`0bb5d9130`), so its re-landing arc
+# needed an integration branch, and it was cut as `chore/**` instead of
+# `milestone/**`. That put it outside the filter above, which is exactly the
+# failure this block exists to prevent: PRs #4942/#4944/#4945/#4946/#4947 all
+# merged onto it with `fork-pr-gate` as their ONLY check. Nothing was bypassed —
+# branch protection is `main`-only, so there was no gate to override — but the
+# safety of the whole arc rested on each author's local `/ci` run.
+#
+# The real fix is the naming convention, not this line: a long-running
+# integration branch belongs in `milestone/**`, which is already gated and needs
+# no config change. (`milestone/brain-m2` existed the whole time; the arc simply
+# branched from the wrong namespace.) Prefer that over adding another name here.
 #
 # Caveat, by design: `Analyze (javascript-typescript)` (CodeQL default setup) is
 # `main`-only and cannot be branch-filtered here, so milestone-branch PRs are


### PR DESCRIPTION
## The gap

`ci.yml` triggers `pull_request` on `[main, "milestone/**"]`. Brain M2 was reverted from `main` (`0bb5d9130`), so its re-landing arc needed an integration branch — and it was cut as **`chore/brain-m2-to-main`**, outside that filter.

Result: **PRs #4942, #4944, #4945, #4946 and #4947 all merged onto it with `fork-pr-gate` as their only check.** No `api-tests` shards, no `type`, no `lint`, no drift gates.

Nothing was bypassed and no `--admin` was used — branch protection is `main`-only, so there was literally no gate to override. But the safety of the whole arc rested on each author's local `/ci` run. One of those PRs (#4945) was a security fix.

The tell that the *lane* was wrong rather than the discipline: **three of the four agents independently fired a `workflow_dispatch` of this same workflow** to get real coverage — runs [`30660952141`](https://github.com/AtlasDevHQ/atlas/actions/runs/30660952141), [`30661206680`](https://github.com/AtlasDevHQ/atlas/actions/runs/30661206680), [`30661729635`](https://github.com/AtlasDevHQ/atlas/actions/runs/30661729635), all green. Four manual workarounds for a one-line filter is the wrong trade.

The irony is that this block's own comment already describes the failure exactly — *"Without it, a PR stacked onto a milestone branch would run ZERO required checks"* — it just names one namespace, and this arc landed outside it.

## The change

Adds `chore/brain-m2-to-main` to the `pull_request` filter, plus a comment explaining the exception and its expiry.

**This PR targets `chore/brain-m2-to-main`, not `main`** — deliberately. The whole M2 arc lands on one branch and reaches `main` as a single merge via #4932. Putting this on the integration branch means the remaining P2s (#4933/#4934/#4939) are gated by it immediately, with no separate propagation step and no second merge to `main` to keep track of.

## This is deliberately temporary

The branch name is hardcoded and the comment says to **delete it when #4932 merges**. I did not invent a broader pattern:

- `chore/**` would put the full battery on every chore PR — far too wide.
- A `chore/*-to-main` convention would be inventing a naming rule with n=1.

**The durable fix is the naming convention, not this line.** A long-running integration branch belongs in `milestone/**`, which is already gated and needs no config change at all. `milestone/brain-m2` existed on the remote the entire time — the arc simply branched from the wrong namespace. The comment says to prefer that over adding another name here.

## Scope

`push:` is deliberately unchanged. The post-merge integration signal that `milestone/**` gets is valuable, but this branch is short-lived and about to be deleted; adding it would leave more to clean up for a signal that only matters across a few remaining PRs.

CodeQL remains `main`-only by design and cannot be branch-filtered — it runs on #4932's own PR into `main`, which is the merge that matters for that gate. Unchanged here.

## Test plan

- [x] YAML parses; `on.pull_request.branches` is `[main, milestone/**, chore/brain-m2-to-main]`
- [x] Diff is exactly one file, `.github/workflows/ci.yml`
- [x] Merge-base with `main` is `0bb5d9130`, so retargeting onto the integration branch left the diff unchanged
- [ ] Effect is verified by the next PR onto this branch (#4933/#4934/#4939) showing the full check set rather than `fork-pr-gate` alone