### PR TITLE
ci: drop the chore/ exception — the arc is on milestone/brain-m2 now

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main, "milestone/**", "hotfix/**"]
   pull_request:
-    branches: [main, "milestone/**", chore/brain-m2-to-main]
+    branches: [main, "milestone/**"]
   # Manual lever: lets an operator/agent re-create required check runs when
   # GitHub drops pull_request event deliveries (observed 2026-06-10 on #3358).
   workflow_dispatch:
@@ -17,19 +17,15 @@ on:
 # post-merge integration signal, which is what catches a semantic conflict
 # between two stacked PRs that were each green in isolation.
 #
-# `chore/brain-m2-to-main` is a NAMED, TEMPORARY exception — delete it when #4932
-# merges. Brain M2 was reverted from `main` (`0bb5d9130`), so its re-landing arc
-# needed an integration branch, and it was cut as `chore/**` instead of
-# `milestone/**`. That put it outside the filter above, which is exactly the
-# failure this block exists to prevent: PRs #4942/#4944/#4945/#4946/#4947 all
-# merged onto it with `fork-pr-gate` as their ONLY check. Nothing was bypassed —
-# branch protection is `main`-only, so there was no gate to override — but the
-# safety of the whole arc rested on each author's local `/ci` run.
-#
-# The real fix is the naming convention, not this line: a long-running
-# integration branch belongs in `milestone/**`, which is already gated and needs
-# no config change. (`milestone/brain-m2` existed the whole time; the arc simply
-# branched from the wrong namespace.) Prefer that over adding another name here.
+# Precedent, Brain M2 (2026-07-31): M2 was reverted from `main` (`0bb5d9130`) and
+# its re-landing arc was cut as `chore/brain-m2-to-main` — outside this filter.
+# PRs #4942/#4944/#4945/#4946/#4947 each merged onto it with `fork-pr-gate` as
+# their ONLY check, and three of four authors independently fired a
+# `workflow_dispatch` to compensate. Nothing was bypassed (branch protection is
+# `main`-only, so there was no gate to override), but the arc's safety rested
+# entirely on local `/ci` runs. The arc was moved back onto `milestone/brain-m2`
+# rather than adding the branch name here. Do that, not this — an integration
+# branch in this namespace is gated with no config change at all.
 #
 # Caveat, by design: `Analyze (javascript-typescript)` (CodeQL default setup) is
 # `main`-only and cannot be branch-filtered here, so milestone-branch PRs are


### PR DESCRIPTION
#4948 added `chore/brain-m2-to-main` to `ci.yml`'s `pull_request` filter to gate the Brain M2 arc. **The arc has been moved onto `milestone/brain-m2`**, which that filter already covers — so the exception is dead weight and this removes it.

The precedent stays as a comment, because the lesson is worth keeping: the failure was the *namespace*, not a missing capability. An integration branch in `milestone/**` is gated with no config change at all.

## Why the move

Five PRs (#4942/#4944/#4945/#4946/#4947) merged onto `chore/brain-m2-to-main` with `fork-pr-gate` as their only check, and three of four authors independently fired a `workflow_dispatch` to compensate. Adding the branch name to the filter treated the symptom. `milestone/brain-m2` already existed — the arc had simply branched from the wrong namespace.

`milestone/brain-m2` was fast-forwarded `153d8c634 → 8e445bbf4`: 12 commits gained, **0 lost**, no force needed.

## This PR is also the verification

It targets `milestone/brain-m2`, so its own check set proves the gating works. If this shows the full battery — `api-tests` shards, `type`, `lint`, `drift`, `build` — rather than `fork-pr-gate` alone, the move did what it was supposed to and the remaining P2s (#4933/#4934/#4939) are covered.

That was the one unchecked box on #4948.

## Test plan

- [x] YAML parses; `on.pull_request.branches` is back to `[main, "milestone/**"]`
- [x] Diff is exactly one file
- [x] `milestone/brain-m2` fast-forward verified as ancestor-only (0 commits lost)
- [ ] **This PR's own check set is the proof** — expecting the full battery, not `fork-pr-gate` alone