### PR TITLE
fix(brain): label the retracted rival on the tool-schema and MCP descriptions (#4933)

### DIFF
--- a/packages/api/src/lib/tools/__tests__/search-brain-tool.test.ts
+++ b/packages/api/src/lib/tools/__tests__/search-brain-tool.test.ts
@@ -17,6 +17,7 @@
  */
 
 import { describe, expect, it, beforeEach, mock } from "bun:test";
+import { z } from "zod";
 import { buildInternalDbMockDefaults } from "@atlas/api/testing/api-test-mocks";
 import type { AuthMode } from "@useatlas/types";
 
@@ -427,6 +428,43 @@ describe.each([
 });
 
 /**
+ * The one rule every agent-facing string about retraction has to obey (#4933):
+ * a sentence may state that a retracted fact NEVER comes back only if that same
+ * sentence names the exception. `invalidatedAt` alone does not count — naming
+ * the label without naming where it is read is what the pre-#4933 prose already
+ * did on the surfaces that had it.
+ *
+ * Two predicates rather than one, because only the absolute claim is policed.
+ * The label-defining sentences ("a non-null `invalidatedAt` is a rival since
+ * RETRACTED") mention retraction without promising anything about reachability,
+ * and a rule that demanded a carve-out from those would push the whole clause
+ * out of the 150-word rubric for no truth gained.
+ *
+ * `ABSOLUTE` is deliberately broader than the two wordings that actually
+ * shipped, and `CARVE_OUT` deliberately requires an exception marker next to
+ * `tensions` rather than the bare word: a rewrite that merely mentions
+ * `tensions` earlier in the sentence ("`tensions` unranked; superseded
+ * included, retracted never returned") restates the exact defect and must not
+ * buy immunity with a token.
+ */
+const RETRACTION_ABSOLUTE =
+  /retract\w*\s+(?:facts?\s+)?(?:is |are )?never|never\s+(?:returned|surfaces?|appears?|as a RESULT)/i;
+const RETRACTION_CARVE_OUT = /(only|except|still appears?|the one place)[^.]{0,80}tensions/i;
+
+/** Sentences that promise retracted facts are unreachable without naming the exception. */
+function unqualifiedRetractionSentences(description: string): readonly string[] {
+  return (
+    description
+      // Naive on purpose: prose with "e.g." fragments mid-sentence, which can
+      // only ever SPLIT an offender into smaller chunks that are still tested.
+      .split(/(?<=\.)\s+/)
+      .filter((s) => /retract/i.test(s))
+      .filter((s) => RETRACTION_ABSOLUTE.test(s))
+      .filter((s) => !RETRACTION_CARVE_OUT.test(s))
+  );
+}
+
+/**
  * The tension-counterpart lifecycle labels (#4935), pinned for the reason the
  * base commit exists: this block's `asOf` sentence claimed "Retracted facts
  * never appear, at any time" until #4913 made it false, and NOTHING failed.
@@ -438,8 +476,9 @@ describe.each([
  *
  * BOTH surfaces, as of #4933. The block shipped with #4935 covering only
  * `SEARCH_BRAIN_DESCRIPTION` and said so, because `SEARCH_BRAIN_TOOL_DESCRIPTION`
- * — and through it `packages/mcp/src/tools.ts`, which registers that exact
- * string — had to trade words against the 80–150 rubric
+ * — the description served to the in-process agent AND, via
+ * `searchBrain.description` wrapped in `withErrorContract`, to every external
+ * MCP client — had to trade words against the 80–150 rubric
  * (`description-rubric.test.ts`) before it could carry any of this. #4933 paid
  * that price, so the parameterisation is now the assertion.
  *
@@ -451,7 +490,10 @@ describe.each([
  */
 describe.each([
   ["SEARCH_BRAIN_DESCRIPTION (in-process agent system prompt)", SEARCH_BRAIN_DESCRIPTION],
-  ["SEARCH_BRAIN_TOOL_DESCRIPTION (MCP tool description)", SEARCH_BRAIN_TOOL_DESCRIPTION],
+  [
+    "SEARCH_BRAIN_TOOL_DESCRIPTION (tool description — in-process agent and MCP)",
+    SEARCH_BRAIN_TOOL_DESCRIPTION,
+  ],
 ])("%s — a retired tension counterpart is labelled, not re-litigated (#4935, #4933)", (_label, description) => {
   it("names BOTH wire fields, so neither axis can be dropped in a rewrite", () => {
     expect(description).toContain("invalidatedAt");
@@ -504,42 +546,50 @@ describe.each([
     // cannot tell which from the prose, so it reports a settled retraction as
     // a live contradiction.
     //
-    // Sentence-scoped rather than a blocklist of the two exact wordings that
-    // shipped: any future sentence that mentions retraction has to say, in
-    // that same sentence, where a retracted fact still surfaces. A blocklist
-    // would pass the moment someone rephrased the absolute.
-    const offenders = description
-      .split(/(?<=\.)\s+/)
-      .filter((s) => /retract/i.test(s))
-      .filter((s) => !s.includes("tensions") && !s.includes("invalidatedAt"));
+    // Rule-shaped rather than a blocklist of the two wordings that shipped: a
+    // blocklist goes green the moment someone rephrases the absolute.
     expect(
-      offenders,
-      "every sentence mentioning retraction must name `tensions` or `invalidatedAt` — an unqualified absolute teaches the model retracted facts are unreachable",
+      unqualifiedRetractionSentences(description),
+      "a sentence promising retracted facts never come back must name the `tensions` carve-out in that same sentence",
     ).toEqual([]);
   });
 });
 
 /**
- * The third agent-facing string, and the one neither block above reaches: the
- * `asOf` ARGUMENT description on the tool's input schema (#4933). A model
- * deciding whether to pass `asOf` reads the argument prose, not the tool
- * prose, and this one shipped promising "retracted facts never" — the same
- * absolute, in the same place, on a surface with its own reader.
+ * The third of FOUR agent-facing strings, and the one neither block above
+ * reaches: the `asOf` ARGUMENT description on this tool's input schema
+ * (#4933). The four are the system prompt (`SEARCH_BRAIN_DESCRIPTION`), the
+ * tool prose (`SEARCH_BRAIN_TOOL_DESCRIPTION`, both blocks above), this
+ * argument, and its re-declared MCP twin. A model deciding whether to PASS
+ * `asOf` reads the argument, not the tool prose, and this one shipped
+ * promising "retracted facts never" — the same absolute, on a surface with its
+ * own reader.
  *
- * `packages/mcp/src/tools.ts` re-declares this argument rather than importing
- * it, so the MCP half is pinned there (`__tests__/tools.test.ts`, via
- * `listTools()`). Two assertions, two files, because there are genuinely two
- * strings.
+ * `packages/mcp/src/tools.ts` re-declares the whole input schema rather than
+ * importing it — `asOf` is only the argument where that drift is
+ * correctness-bearing, and `query` has already drifted harmlessly — so the
+ * fourth string is pinned there (`__tests__/tools.test.ts`, through
+ * `listTools()`). Two files because there are genuinely two strings.
  */
 describe("searchBrain `asOf` argument description — the carve-out travels with the promise (#4933)", () => {
   const asOfDescription = ((): string => {
-    // The AI SDK keeps the zod object it was handed, so the argument prose an
-    // LLM is served is readable straight off the shape. Narrowed rather than
-    // cast blind: a schema reshape should fail loudly here, not silently pin
-    // an empty string.
-    const shape = (searchBrain.inputSchema as unknown as { shape?: Record<string, unknown> }).shape;
-    const asOf = shape?.asOf as { description?: string } | undefined;
-    return asOf?.description ?? "";
+    // Read what the model is SERVED, not what the builder was handed: the AI
+    // SDK hands the LLM a JSON Schema, and zod resolves `.describe()` into it
+    // wherever in the chain it was called. Reading `.shape.asOf.description`
+    // instead would go red on a harmless `.describe()`/`.optional()` reorder
+    // while the model still saw the right prose.
+    //
+    // The narrowing throws rather than falling back, so an AI SDK reshape
+    // reports itself instead of collapsing to `""` and reading as a prose
+    // regression in the three assertions below.
+    const schema = searchBrain.inputSchema;
+    if (!(schema instanceof z.ZodObject)) {
+      throw new Error(
+        "searchBrain.inputSchema is no longer a ZodObject — re-point this read at whatever now carries the argument prose, or the retraction pins below pass vacuously",
+      );
+    }
+    const asOf = z.toJSONSchema(schema).properties?.asOf;
+    return typeof asOf === "object" ? (asOf.description ?? "") : "";
   })();
 
   it("is readable at all — a reshape must fail here, not silently pass", () => {
@@ -555,5 +605,15 @@ describe("searchBrain `asOf` argument description — the carve-out travels with
     // The carve-out is what makes the sentence true; this is what makes it
     // useful. Drop it and the model has no reason to trust an `asOf` read.
     expect(asOfDescription).toMatch(/never as a RESULT/);
+  });
+
+  it("obeys the same absolute rule as the two descriptions above", () => {
+    // The positive pins above all survive a rewrite that keeps the three
+    // tokens and re-adds an unqualified absolute in a neighbouring sentence.
+    // This is the arm that does not.
+    expect(
+      unqualifiedRetractionSentences(asOfDescription),
+      "a sentence promising retracted facts never come back must name the `tensions` carve-out in that same sentence",
+    ).toEqual([]);
   });
 });

--- a/packages/api/src/lib/tools/__tests__/search-brain-tool.test.ts
+++ b/packages/api/src/lib/tools/__tests__/search-brain-tool.test.ts
@@ -359,18 +359,22 @@ describe("searchBrain tool.execute", () => {
  *     guidance injected into the in-process agent's SYSTEM PROMPT via
  *     `registry.ts`'s `describe()`.
  *   - `SEARCH_BRAIN_TOOL_DESCRIPTION` (`lib/tools/descriptions.ts`) — the
- *     LLM-facing tool description `packages/mcp/src/tools.ts` registers, i.e.
- *     what an external MCP client's model reads.
+ *     LLM-facing TOOL description, served both to the in-process agent (as
+ *     `searchBrain.description`) and, via `withErrorContract`, to every
+ *     external MCP client.
  *
  * They are NOT the same string and neither is derived from the other, so
- * guidance added to one reaches only half the agents. The MCP half is the one
- * Atlas does not control the model of, which makes it the half where an
- * unguided `{ "visible": false }` is most likely to be narrated as "nobody
+ * guidance added to the system prompt alone never reaches an external MCP
+ * client — the one reader whose model Atlas does not control, and so the one
+ * most likely to narrate an unguided `{ "visible": false }` as "nobody
  * recorded who said this".
  */
 describe.each([
   ["SEARCH_BRAIN_DESCRIPTION (in-process agent system prompt)", SEARCH_BRAIN_DESCRIPTION],
-  ["SEARCH_BRAIN_TOOL_DESCRIPTION (MCP tool description)", SEARCH_BRAIN_TOOL_DESCRIPTION],
+  [
+    "SEARCH_BRAIN_TOOL_DESCRIPTION (tool description — in-process agent and MCP)",
+    SEARCH_BRAIN_TOOL_DESCRIPTION,
+  ],
 ])("%s — withheld attribution is explained to the model", (_label, description) => {
   it("names the wire shape the model will actually see", () => {
     // A rule keyed on prose the response does not contain is unactionable.
@@ -400,11 +404,14 @@ describe.each([
  * Same two-surface pin, for #4914's staleness guidance — and for the same
  * reason the attribution block states: a description is a string nobody would
  * notice deleting, the two surfaces are not derived from each other, and
- * guidance added to one reaches only half the agents.
+ * guidance added to the system prompt alone never reaches an MCP client.
  */
 describe.each([
   ["SEARCH_BRAIN_DESCRIPTION (in-process agent system prompt)", SEARCH_BRAIN_DESCRIPTION],
-  ["SEARCH_BRAIN_TOOL_DESCRIPTION (MCP tool description)", SEARCH_BRAIN_TOOL_DESCRIPTION],
+  [
+    "SEARCH_BRAIN_TOOL_DESCRIPTION (tool description — in-process agent and MCP)",
+    SEARCH_BRAIN_TOOL_DESCRIPTION,
+  ],
 ])("%s — staleness is presented, never arbitrated (#4914)", (_label, description) => {
   it("names the temporal wire fields the model will actually see", () => {
     for (const field of ["decay", "validFrom", "corroborationCount"]) {
@@ -448,16 +455,21 @@ describe.each([
  * buy immunity with a token.
  */
 const RETRACTION_ABSOLUTE =
-  /retract\w*\s+(?:facts?\s+)?(?:is |are )?never|never\s+(?:returned|surfaces?|appears?|as a RESULT)/i;
+  /retract\w*\s+(?:facts?\s+)?(?:is |are )?never|never\s+(?:returned|surfaces?|appears?|as a RESULT)|retract\w*[^.]{0,40}\b(?:excluded|omitted)\b/i;
 const RETRACTION_CARVE_OUT = /(only|except|still appears?|the one place)[^.]{0,80}tensions/i;
 
 /** Sentences that promise retracted facts are unreachable without naming the exception. */
 function unqualifiedRetractionSentences(description: string): readonly string[] {
   return (
     description
-      // Naive on purpose: prose with "e.g." fragments mid-sentence, which can
-      // only ever SPLIT an offender into smaller chunks that are still tested.
-      .split(/(?<=\.)\s+/)
+      // Two delimiters, and the bullet arm is the load-bearing one. Splitting
+      // on `. ` alone under-splits the system prompt, whose markdown bullets
+      // have no terminal period: bullet N's tail glues to bullet N+1's head,
+      // and an offender could then borrow a NEIGHBOUR's carve-out — the same
+      // "buy immunity with a token" hole this predicate exists to close, one
+      // level up. Over-splitting (an "e.g." mid-sentence) is the safe
+      // direction: it can only ever hand a smaller chunk to the same filters.
+      .split(/(?<=\.)\s+|\n(?=[-*] )/)
       .filter((s) => /retract/i.test(s))
       .filter((s) => RETRACTION_ABSOLUTE.test(s))
       .filter((s) => !RETRACTION_CARVE_OUT.test(s))
@@ -556,14 +568,16 @@ describe.each([
 });
 
 /**
- * The third of FOUR agent-facing strings, and the one neither block above
- * reaches: the `asOf` ARGUMENT description on this tool's input schema
- * (#4933). The four are the system prompt (`SEARCH_BRAIN_DESCRIPTION`), the
- * tool prose (`SEARCH_BRAIN_TOOL_DESCRIPTION`, both blocks above), this
- * argument, and its re-declared MCP twin. A model deciding whether to PASS
- * `asOf` reads the argument, not the tool prose, and this one shipped
- * promising "retracted facts never" — the same absolute, on a surface with its
- * own reader.
+ * The third of the four strings that CARRY THE RETRACTION PROMISE, and the one
+ * neither block above reaches: the `asOf` ARGUMENT description on this tool's
+ * input schema (#4933). The four are the system prompt
+ * (`SEARCH_BRAIN_DESCRIPTION`), the tool prose (`SEARCH_BRAIN_TOOL_DESCRIPTION`,
+ * both blocks above), this argument, and its re-declared MCP twin. (searchBrain
+ * has a dozen-odd other `.describe()` strings; none of them say anything about
+ * retraction, which is why the count here is four and not twenty.) A model
+ * deciding whether to PASS `asOf` reads the argument, not the tool prose, and
+ * this one shipped promising "retracted facts never" — the same absolute, on a
+ * surface with its own reader.
  *
  * `packages/mcp/src/tools.ts` re-declares the whole input schema rather than
  * importing it — `asOf` is only the argument where that drift is
@@ -579,21 +593,35 @@ describe("searchBrain `asOf` argument description — the carve-out travels with
     // instead would go red on a harmless `.describe()`/`.optional()` reorder
     // while the model still saw the right prose.
     //
-    // The narrowing throws rather than falling back, so an AI SDK reshape
-    // reports itself instead of collapsing to `""` and reading as a prose
-    // regression in the three assertions below.
+    // BOTH shape failures throw rather than falling back, so an AI SDK or zod
+    // reshape reports itself instead of collapsing to `""` and reading as a
+    // prose regression in the assertions below. Only a dropped `.describe()`
+    // returns `""`, which is the one case where an empty string IS the honest
+    // signal — that genuinely is a prose regression.
     const schema = searchBrain.inputSchema;
     if (!(schema instanceof z.ZodObject)) {
       throw new Error(
         "searchBrain.inputSchema is no longer a ZodObject — re-point this read at whatever now carries the argument prose, or the retraction pins below pass vacuously",
       );
     }
-    const asOf = z.toJSONSchema(schema).properties?.asOf;
-    return typeof asOf === "object" ? (asOf.description ?? "") : "";
+    const properties = z.toJSONSchema(schema).properties;
+    const asOf = properties?.asOf;
+    if (typeof asOf !== "object") {
+      throw new Error(
+        `searchBrain's input schema no longer exposes an \`asOf\` object property (saw: ${Object.keys(properties ?? {}).join(", ") || "none"}) — re-point this read, or the retraction pins below pass vacuously`,
+      );
+    }
+    return asOf.description ?? "";
   })();
 
   it("is readable at all — a reshape must fail here, not silently pass", () => {
-    expect(asOfDescription).toContain("historical point read");
+    // Deliberately not keyed on a phrase: a reworded-but-intact description
+    // ("point-in-time read") is not a failure of THIS pin, and the shape
+    // failures it used to stand in for now throw above.
+    expect(
+      asOfDescription,
+      "the `asOf` argument lost its `.describe()` — the retraction pins below would pass vacuously",
+    ).toBeTruthy();
   });
 
   it("names where a retracted fact still surfaces, and the field that labels it", () => {

--- a/packages/api/src/lib/tools/__tests__/search-brain-tool.test.ts
+++ b/packages/api/src/lib/tools/__tests__/search-brain-tool.test.ts
@@ -436,27 +436,34 @@ describe.each([
  * winner" — which is precisely the instruction that turns an arbitrated
  * conflict into a live one.
  *
- * ONE surface, deliberately, unlike the `describe.each` pins above:
- * `SEARCH_BRAIN_TOOL_DESCRIPTION` — and through it `packages/mcp/src/tools.ts`
- * — is #4933's, which owns the same omission and has to trade words against
- * the 80–150 rubric to fit any of it. Note #4933's acceptance criteria PREDATE
- * `validTo` and name only `invalidatedAt`: those two surfaces now lag on BOTH
- * axes, so closing #4933 as literally written would leave the MCP model still
- * unable to tell a superseded rival from a live one. Widening this block to
- * `describe.each` over both strings is the assertion that actually closes it.
+ * BOTH surfaces, as of #4933. The block shipped with #4935 covering only
+ * `SEARCH_BRAIN_DESCRIPTION` and said so, because `SEARCH_BRAIN_TOOL_DESCRIPTION`
+ * — and through it `packages/mcp/src/tools.ts`, which registers that exact
+ * string — had to trade words against the 80–150 rubric
+ * (`description-rubric.test.ts`) before it could carry any of this. #4933 paid
+ * that price, so the parameterisation is now the assertion.
+ *
+ * Note #4933's acceptance criteria PREDATE `validTo` and name only
+ * `invalidatedAt`. Closing it that literally would have left the MCP model
+ * able to spot a retracted rival and still unable to tell a superseded one
+ * from a live one — half a fix on the surface Atlas does not control the model
+ * of. Both axes are pinned on both strings for that reason.
  */
-describe("SEARCH_BRAIN_DESCRIPTION — a retired tension counterpart is labelled, not re-litigated (#4935)", () => {
+describe.each([
+  ["SEARCH_BRAIN_DESCRIPTION (in-process agent system prompt)", SEARCH_BRAIN_DESCRIPTION],
+  ["SEARCH_BRAIN_TOOL_DESCRIPTION (MCP tool description)", SEARCH_BRAIN_TOOL_DESCRIPTION],
+])("%s — a retired tension counterpart is labelled, not re-litigated (#4935, #4933)", (_label, description) => {
   it("names BOTH wire fields, so neither axis can be dropped in a rewrite", () => {
-    expect(SEARCH_BRAIN_DESCRIPTION).toContain("invalidatedAt");
-    expect(SEARCH_BRAIN_DESCRIPTION).toContain("validTo");
+    expect(description).toContain("invalidatedAt");
+    expect(description).toContain("validTo");
   });
 
   it("distinguishes the two verbs rather than merging them into one label", () => {
     // Retracted means "should never have been served"; superseded means "was
     // true, then stopped being". A prompt that says only "retired" loses the
     // ability to tell a reader which happened.
-    expect(SEARCH_BRAIN_DESCRIPTION).toMatch(/RETRACTED/);
-    expect(SEARCH_BRAIN_DESCRIPTION).toMatch(/SUPERSEDED/);
+    expect(description).toMatch(/RETRACTED/);
+    expect(description).toMatch(/SUPERSEDED/);
   });
 
   it("tells the model a retired rival is SETTLED, which is the actionable half", () => {
@@ -466,7 +473,7 @@ describe("SEARCH_BRAIN_DESCRIPTION — a retired tension counterpart is labelled
     // Anchored to the INSTRUCTION, not to the word: a bare /settled/i passes
     // on the pre-#4935 string, which already says "never as settled" about
     // withheld rivals. Deleting this whole clause would have left it green.
-    expect(SEARCH_BRAIN_DESCRIPTION).toMatch(/report (those|them) as settled/i);
+    expect(description).toMatch(/report (those|them) as settled/i);
   });
 
   it("qualifies `validTo` by the clock, so a future window is not called settled", () => {
@@ -479,14 +486,74 @@ describe("SEARCH_BRAIN_DESCRIPTION — a retired tension counterpart is labelled
     // is matched by the pre-existing `asOf` bullet ("ISO-8601, in the past"),
     // and `/future/` alone would accept a prompt that called a future window
     // settled too — so the future arm has to carry its VERDICT.
-    expect(SEARCH_BRAIN_DESCRIPTION).toMatch(/ALREADY IN THE PAST/);
-    expect(SEARCH_BRAIN_DESCRIPTION).toMatch(/still in the future[^.]*\b(LIVE|contested)/);
+    expect(description).toMatch(/ALREADY IN THE PAST/);
+    expect(description).toMatch(/still in the future[^.]*\b(LIVE|contested)/);
   });
 
   it("keeps the never-arm that a labelling clause could plausibly displace", () => {
     // Labelling lifecycle state is not ranking. The moment this ban goes, the
     // model is free to read the labels as a verdict and pick a side on the
     // pair that is still genuinely live.
-    expect(SEARCH_BRAIN_DESCRIPTION).toMatch(/never pick a winner/i);
+    expect(description).toMatch(/never pick a winner/i);
+  });
+
+  it("never states the absolute the wire does not keep (#4933)", () => {
+    // The defect both #4932 and #4933 fixed was not a missing clause, it was a
+    // PRESENT one: "retracted never", unqualified, in a sentence about what
+    // `asOf` returns. True of results, false of the response — and a model
+    // cannot tell which from the prose, so it reports a settled retraction as
+    // a live contradiction.
+    //
+    // Sentence-scoped rather than a blocklist of the two exact wordings that
+    // shipped: any future sentence that mentions retraction has to say, in
+    // that same sentence, where a retracted fact still surfaces. A blocklist
+    // would pass the moment someone rephrased the absolute.
+    const offenders = description
+      .split(/(?<=\.)\s+/)
+      .filter((s) => /retract/i.test(s))
+      .filter((s) => !s.includes("tensions") && !s.includes("invalidatedAt"));
+    expect(
+      offenders,
+      "every sentence mentioning retraction must name `tensions` or `invalidatedAt` — an unqualified absolute teaches the model retracted facts are unreachable",
+    ).toEqual([]);
+  });
+});
+
+/**
+ * The third agent-facing string, and the one neither block above reaches: the
+ * `asOf` ARGUMENT description on the tool's input schema (#4933). A model
+ * deciding whether to pass `asOf` reads the argument prose, not the tool
+ * prose, and this one shipped promising "retracted facts never" — the same
+ * absolute, in the same place, on a surface with its own reader.
+ *
+ * `packages/mcp/src/tools.ts` re-declares this argument rather than importing
+ * it, so the MCP half is pinned there (`__tests__/tools.test.ts`, via
+ * `listTools()`). Two assertions, two files, because there are genuinely two
+ * strings.
+ */
+describe("searchBrain `asOf` argument description — the carve-out travels with the promise (#4933)", () => {
+  const asOfDescription = ((): string => {
+    // The AI SDK keeps the zod object it was handed, so the argument prose an
+    // LLM is served is readable straight off the shape. Narrowed rather than
+    // cast blind: a schema reshape should fail loudly here, not silently pin
+    // an empty string.
+    const shape = (searchBrain.inputSchema as unknown as { shape?: Record<string, unknown> }).shape;
+    const asOf = shape?.asOf as { description?: string } | undefined;
+    return asOf?.description ?? "";
+  })();
+
+  it("is readable at all — a reshape must fail here, not silently pass", () => {
+    expect(asOfDescription).toContain("historical point read");
+  });
+
+  it("names where a retracted fact still surfaces, and the field that labels it", () => {
+    expect(asOfDescription).toContain("tensions");
+    expect(asOfDescription).toContain("invalidatedAt");
+  });
+
+  it("keeps the never-arm: retracted is still never a RESULT", () => {
+    // The carve-out is what makes the sentence true; this is what makes it
+    // useful. Drop it and the model has no reason to trust an `asOf` read.
+    expect(asOfDescription).toMatch(/never as a RESULT/);
   });
 });

--- a/packages/api/src/lib/tools/descriptions.ts
+++ b/packages/api/src/lib/tools/descriptions.ts
@@ -71,20 +71,26 @@ Don't use this when no metric id matches; fall back to \`executeSQL\` with a que
 // Without them a model reads the whole cluster as unresolved and re-opens a
 // conflict a human already settled.
 //
-// This string is the tool description for BOTH readers — the in-process agent
-// (`defaultRegistry`) and any external MCP client — so a gap here is not an
-// MCP-only gap.
+// This string is the tool description for BOTH readers — it reaches the
+// in-process agent as `searchBrain.description` (the AI SDK tool object that
+// `defaultRegistry` registers; `registry.ts`'s own `description:` field is the
+// SYSTEM-PROMPT constant, a different string) and every external MCP client via
+// `withErrorContract`. A gap here is not an MCP-only gap.
 //
 // The lifecycle labels are trades, not additions: the string sat at 149 of the
 // rubric's 150 words (`__tests__/description-rubric.test.ts`), and the budget
-// came out of the tier, attribution, age and `asOf` clauses, the JSON example,
-// and both routing paragraphs. It now sits at 148 — two words of headroom, and
-// `KNOWLEDGE_TRUST_FRAMING` is interpolated, so growing that shared constant
-// spends this description's margin too.
+// came out of the opening sentence, the attribution and age clauses, the
+// folded-in `extraction: "pending"` sentence, the JSON example, and both
+// routing paragraphs. The `asOf` clause was restructured, not squeezed — it
+// still costs what it did, so it is not the place to look for slack. The
+// string now sits at 148: two words of headroom, and `KNOWLEDGE_TRUST_FRAMING`
+// is interpolated, so growing that shared constant spends this margin too.
 //
-// The system-prompt twin in `lib/tools/search-brain.ts` is a superset, not a
-// copy: uncapped, it also carries the as-of-NOW clarifier and the withheld-arm
-// rule, which do not fit here. Parity is on the labels only, and is pinned in
+// The system-prompt twin in `lib/tools/search-brain.ts` is longer and uncapped,
+// not a copy and not a strict superset (it carries the as-of-NOW clarifier and
+// the withheld-arm rule, which do not fit here; it does not carry
+// `KNOWLEDGE_TRUST_FRAMING`, which the prompt gets from the collection ToC).
+// Parity is on the labels only, and is pinned in
 // `__tests__/search-brain-tool.test.ts` — the never-arms are assertions, not
 // decoration, so trim anything here and re-run that suite.
 export const SEARCH_BRAIN_TOOL_DESCRIPTION = `Search the company brain. Trust-labeled results: \`tier: "fact"\` human-reviewed, \`"raw-episode"\` its source (maybe \`extraction: "pending"\`), \`"document"\` hosted knowledge — ${KNOWLEDGE_TRUST_FRAMING}. \`provenance.attribution\` \`{ "visible": false }\`: use the claim, say attribution restricted; never anonymous, undated, unsourced, nor infer the author. Age (\`validFrom\`, \`corroborationCount\`, \`decay\`): present a stale fact's age, never assert as current or drop. \`tensions\` lists rival claims+provenance (\`withheldCount\` = unseen), unranked: never pick a winner. Report those as settled once retired: \`invalidatedAt\` non-null = RETRACTED, \`validTo\` ALREADY IN THE PAST = SUPERSEDED; \`validTo\` still in the future = LIVE. \`unavailable\` = search failed, not "nothing known". \`asOf\` (past ISO-8601) reads facts valid then, framed "as of <time>": superseded included, retracted only in \`tensions\`. Example: \`{ "query": "billing owner", "asOf": "2026-07-01" }\`.

--- a/packages/api/src/lib/tools/descriptions.ts
+++ b/packages/api/src/lib/tools/descriptions.ts
@@ -62,11 +62,23 @@ Use this whenever a metric exists for what the user asked — never re-derive me
 
 Don't use this when no metric id matches; fall back to \`executeSQL\` with a query pattern from \`describeEntity\`. Avoid passing \`filters\` — pass-through is reserved for future work and is rejected today.`;
 
-export const SEARCH_BRAIN_TOOL_DESCRIPTION = `Search the company brain — trust-labeled results across three stores. \`tier: "fact"\` is human-reviewed; \`tier: "raw-episode"\` its source record; \`tier: "document"\` hosted knowledge — ${KNOWLEDGE_TRUST_FRAMING}. \`provenance.attribution\` \`{ "visible": false }\`: author, source id, timestamp withheld — use the claim, say attribution restricted, never call it anonymous, undated, unsourced, nor infer the author. Unextracted episodes carry \`extraction: "pending"\`. Age (\`validFrom\`, \`corroborationCount\`, \`decay\`): present a stale fact's age; never assert it as current or drop it. \`tensions\` lists rival claims+provenance (\`withheldCount\` = unseen rivals), unranked: never pick winners. \`unavailable\` = search failed, not "nothing known". \`asOf\` (past ISO-8601) reads facts valid then — superseded included, retracted never; frame as "as of <time>". Example: \`{ "query": "who owns billing", "asOf": "2026-07-01T00:00:00Z" }\`.
+// The `tensions` clause is the one place in this file where prose is load-
+// bearing for correctness rather than routing (#4933). `invalidatedAt` and
+// `validTo` are carried on every counterpart precisely so a withdrawn or
+// replaced rival is distinguishable from a live one; without the labels here
+// an MCP model reads the whole cluster as unresolved and re-opens a conflict a
+// human already settled. The two lifecycle words are trades, not additions —
+// the string sat at 149/150 rubric words, so the retraction guidance was paid
+// for by compressing the tier, attribution, age, and `asOf` clauses. The
+// system-prompt twin in `lib/tools/search-brain.ts` carries the same semantics
+// at full length because it is not rubric-capped; the two are pinned together
+// in `__tests__/search-brain-tool.test.ts`. Trim anything here and re-run that
+// suite — the never-arms are assertions, not decoration.
+export const SEARCH_BRAIN_TOOL_DESCRIPTION = `Search the company brain. Trust-labeled results: \`tier: "fact"\` human-reviewed, \`"raw-episode"\` its source (maybe \`extraction: "pending"\`), \`"document"\` hosted knowledge — ${KNOWLEDGE_TRUST_FRAMING}. \`provenance.attribution\` \`{ "visible": false }\`: use the claim, say attribution restricted; never anonymous, undated, unsourced, nor infer the author. Age (\`validFrom\`, \`corroborationCount\`, \`decay\`): present a stale fact's age, never assert as current or drop. \`tensions\` lists rival claims+provenance (\`withheldCount\` = unseen), unranked: never pick a winner. Report those as settled once retired: \`invalidatedAt\` non-null = RETRACTED, \`validTo\` ALREADY IN THE PAST = SUPERSEDED; \`validTo\` still in the future = LIVE. \`unavailable\` = search failed, not "nothing known". \`asOf\` (past ISO-8601) reads facts valid then, framed "as of <time>": superseded included, retracted only in \`tensions\`. Example: \`{ "query": "billing owner", "asOf": "2026-07-01" }\`.
 
-Use this when asking about decisions, rationale, ownership, or policy — recorded knowledge.
+Use this when asked about decisions, rationale, ownership, or policy.
 
-Don't use this for quantitative current state (\`executeSQL\`) or the semantic layer (\`explore\`).`;
+Don't use this for quantitative state (\`executeSQL\`) or the semantic layer (\`explore\`).`;
 
 export const QUERY_TOOL_DESCRIPTION = `Ask Atlas's server-side analyst agent a natural-language question; it explores the semantic layer, writes and runs the SELECTs itself, and returns a prose \`answer\` plus every SQL statement it ran and the result rows. This is the recommended path for question-answering — the agent knows the catalog, glossary, canonical metrics, joins, and RLS, so it composes better SQL than a generic client writing raw SQL blind. It runs a second server-side LLM and spends Atlas plan tokens; prefer it when answer quality matters. Example call: \`{ "question": "top 5 products by revenue last quarter" }\`. Example response: \`{ "answer": "...", "sql": ["SELECT ..."], "data": [...] }\`.
 

--- a/packages/api/src/lib/tools/descriptions.ts
+++ b/packages/api/src/lib/tools/descriptions.ts
@@ -62,18 +62,31 @@ Use this whenever a metric exists for what the user asked — never re-derive me
 
 Don't use this when no metric id matches; fall back to \`executeSQL\` with a query pattern from \`describeEntity\`. Avoid passing \`filters\` — pass-through is reserved for future work and is rejected today.`;
 
-// The `tensions` clause is the one place in this file where prose is load-
-// bearing for correctness rather than routing (#4933). `invalidatedAt` and
-// `validTo` are carried on every counterpart precisely so a withdrawn or
-// replaced rival is distinguishable from a live one; without the labels here
-// an MCP model reads the whole cluster as unresolved and re-opens a conflict a
-// human already settled. The two lifecycle words are trades, not additions —
-// the string sat at 149/150 rubric words, so the retraction guidance was paid
-// for by compressing the tier, attribution, age, and `asOf` clauses. The
-// system-prompt twin in `lib/tools/search-brain.ts` carries the same semantics
-// at full length because it is not rubric-capped; the two are pinned together
-// in `__tests__/search-brain-tool.test.ts`. Trim anything here and re-run that
-// suite — the never-arms are assertions, not decoration.
+// The `tensions` clause is load-bearing for correctness rather than routing
+// (#4933) — like the attribution and age never-arms beside it. `invalidatedAt`
+// and `validTo` are carried on every VISIBLE counterpart precisely so a
+// withdrawn or replaced rival is distinguishable from a live one; the withheld
+// arm is a bare `withheldCount` and stays contested by construction, which is
+// why the labels are stated as a carve-out and not as a verdict on the cluster.
+// Without them a model reads the whole cluster as unresolved and re-opens a
+// conflict a human already settled.
+//
+// This string is the tool description for BOTH readers — the in-process agent
+// (`defaultRegistry`) and any external MCP client — so a gap here is not an
+// MCP-only gap.
+//
+// The lifecycle labels are trades, not additions: the string sat at 149 of the
+// rubric's 150 words (`__tests__/description-rubric.test.ts`), and the budget
+// came out of the tier, attribution, age and `asOf` clauses, the JSON example,
+// and both routing paragraphs. It now sits at 148 — two words of headroom, and
+// `KNOWLEDGE_TRUST_FRAMING` is interpolated, so growing that shared constant
+// spends this description's margin too.
+//
+// The system-prompt twin in `lib/tools/search-brain.ts` is a superset, not a
+// copy: uncapped, it also carries the as-of-NOW clarifier and the withheld-arm
+// rule, which do not fit here. Parity is on the labels only, and is pinned in
+// `__tests__/search-brain-tool.test.ts` — the never-arms are assertions, not
+// decoration, so trim anything here and re-run that suite.
 export const SEARCH_BRAIN_TOOL_DESCRIPTION = `Search the company brain. Trust-labeled results: \`tier: "fact"\` human-reviewed, \`"raw-episode"\` its source (maybe \`extraction: "pending"\`), \`"document"\` hosted knowledge — ${KNOWLEDGE_TRUST_FRAMING}. \`provenance.attribution\` \`{ "visible": false }\`: use the claim, say attribution restricted; never anonymous, undated, unsourced, nor infer the author. Age (\`validFrom\`, \`corroborationCount\`, \`decay\`): present a stale fact's age, never assert as current or drop. \`tensions\` lists rival claims+provenance (\`withheldCount\` = unseen), unranked: never pick a winner. Report those as settled once retired: \`invalidatedAt\` non-null = RETRACTED, \`validTo\` ALREADY IN THE PAST = SUPERSEDED; \`validTo\` still in the future = LIVE. \`unavailable\` = search failed, not "nothing known". \`asOf\` (past ISO-8601) reads facts valid then, framed "as of <time>": superseded included, retracted only in \`tensions\`. Example: \`{ "query": "billing owner", "asOf": "2026-07-01" }\`.
 
 Use this when asked about decisions, rationale, ownership, or policy.

--- a/packages/api/src/lib/tools/search-brain.ts
+++ b/packages/api/src/lib/tools/search-brain.ts
@@ -272,7 +272,7 @@ export const searchBrain = tool({
       .string()
       .optional()
       .describe(
-        "Facts only: historical point read — returns the reviewed facts valid at that moment (later-superseded versions included; retracted facts never). An ISO-8601 date (2026-07-27) or a timestamp with an EXPLICIT zone (2026-07-27T09:00:00Z); zone-less times, non-ISO forms, and future instants are rejected. Requires the fact store in `include`. Omit for current beliefs.",
+        "Facts only: historical point read — returns the reviewed facts valid at that moment (later-superseded versions included; a retracted fact never as a RESULT, only as a `tensions` counterpart labelled by `invalidatedAt`). An ISO-8601 date (2026-07-27) or a timestamp with an EXPLICIT zone (2026-07-27T09:00:00Z); zone-less times, non-ISO forms, and future instants are rejected. Requires the fact store in `include`. Omit for current beliefs.",
       ),
     limit: z
       .number()

--- a/packages/mcp/src/__tests__/tools.test.ts
+++ b/packages/mcp/src/__tests__/tools.test.ts
@@ -1024,10 +1024,17 @@ describe("MCP tools", () => {
       // The stub text comes from the module mock at the top of this file, so
       // this asserts the WIRING, not the prose — which is the only half that
       // can be checked here without duplicating a 148-word string.
+      //
+      // Exact-match on the pre-contract paragraph, not `toContain`: the stub
+      // ("Search the company brain") is a PREFIX of the real constant, so a
+      // hand-written literal copied from `descriptions.ts` would satisfy a
+      // substring check and `withErrorContract` would still append its section
+      // — i.e. both assertions would go green on the exact decoupling this
+      // test exists to catch.
       const { client } = await createTestClient();
       const { tools } = await client.listTools();
       const description = tools.find((t) => t.name === "searchBrain")?.description;
-      expect(description).toContain("Search the company brain");
+      expect(description?.split("\n\n")[0]).toBe("Search the company brain");
       expect(description).toContain("Error contract:");
     });
 
@@ -1047,10 +1054,15 @@ describe("MCP tools", () => {
       // REGISTERED schema.
       const { client } = await createTestClient();
       const { tools } = await client.listTools();
-      const asOf = tools.find((t) => t.name === "searchBrain")?.inputSchema.properties?.asOf as
-        | { description?: string }
-        | undefined;
-      const description = asOf?.description;
+      // Narrowed, not asserted: the MCP SDK types `properties` as
+      // `Record<string, object>`, so a cast here would re-introduce on this
+      // side exactly the blind widening the api-side twin was rewritten to
+      // avoid.
+      const asOf = tools.find((t) => t.name === "searchBrain")?.inputSchema.properties?.asOf;
+      const description =
+        asOf && "description" in asOf && typeof asOf.description === "string"
+          ? asOf.description
+          : undefined;
       expect(
         description,
         "searchBrain's registered inputSchema has no `asOf` description — the registration in src/tools.ts changed shape, so the retraction pins below would pass vacuously",
@@ -1064,15 +1076,20 @@ describe("MCP tools", () => {
       // is still never a RESULT, which is what makes `asOf` safe to trust.
       expect(description).toMatch(/never as a RESULT/);
       // And the arm the three pins above survive: a rewrite that keeps every
-      // token and re-adds the absolute in a neighbouring sentence. Mirrors
-      // `unqualifiedRetractionSentences` in the api suite; four short lines
-      // rather than a shared helper because the two packages do not share test
-      // utilities and the rule is stated in full at its api-side definition.
+      // token and re-adds the absolute in a neighbouring sentence.
+      //
+      // A deliberate second copy of `unqualifiedRetractionSentences` from the
+      // api suite, not a forced one — `@atlas/api` does export a `./testing/*`
+      // entrypoint these four lines could live behind. The rule is OWNED
+      // there, where it is stated in full; a tightening there has to be
+      // mirrored here by hand, which is the cost of not adding a cross-package
+      // test-utility export to a scoped fix. The `\n(?=[-*] )` bullet arm is
+      // omitted because this string is prose, not markdown.
       const unqualified = (description ?? "")
         .split(/(?<=\.)\s+/)
         .filter((s) => /retract/i.test(s))
         .filter((s) =>
-          /retract\w*\s+(?:facts?\s+)?(?:is |are )?never|never\s+(?:returned|surfaces?|appears?|as a RESULT)/i.test(
+          /retract\w*\s+(?:facts?\s+)?(?:is |are )?never|never\s+(?:returned|surfaces?|appears?|as a RESULT)|retract\w*[^.]{0,40}\b(?:excluded|omitted)\b/i.test(
             s,
           ),
         )

--- a/packages/mcp/src/__tests__/tools.test.ts
+++ b/packages/mcp/src/__tests__/tools.test.ts
@@ -1011,6 +1011,38 @@ describe("MCP tools", () => {
   // --- searchBrain dispatch (#4773) ---
 
   describe("searchBrain", () => {
+    it("the advertised `asOf` argument does not promise retracted facts are unreachable (#4933)", async () => {
+      // This string is written HERE, not imported from the api package, so it
+      // is the one half of the searchBrain description that a fix in
+      // `lib/tools/descriptions.ts` cannot reach — and it shipped saying
+      // "retracted never", full stop. #4913 kept a retracted rival in
+      // `tensions` precisely so it stays distinguishable, so the absolute was
+      // false of the response and true only of `results`; a model reading it
+      // reports a settled retraction as a live contradiction.
+      //
+      // Asserted through `listTools()` rather than against the source constant
+      // because what an external client's model actually reads is the
+      // REGISTERED schema. `searchBrain.description` is module-mocked at the
+      // top of this file, so the tool-level prose is pinned in the api package
+      // (`lib/tools/__tests__/search-brain-tool.test.ts`); the argument prose
+      // has no other home.
+      const { client } = await createTestClient();
+      const { tools } = await client.listTools();
+      const asOf = tools.find((t) => t.name === "searchBrain")?.inputSchema.properties?.asOf as
+        | { description?: string }
+        | undefined;
+      expect(asOf?.description).toBeTruthy();
+      const description = asOf?.description ?? "";
+      // Both arms, so neither half can be dropped: the carve-out has to be
+      // stated (`tensions`) AND the field that labels it has to be nameable
+      // (`invalidatedAt`), or the guidance is unactionable.
+      expect(description).toContain("tensions");
+      expect(description).toContain("invalidatedAt");
+      // The never-arm the carve-out could plausibly displace: a retracted fact
+      // is still never a RESULT, which is what makes `asOf` safe to trust.
+      expect(description).toMatch(/never as a RESULT/);
+    });
+
     it("returns the fused payload as JSON on success", async () => {
       const { client } = await createTestClient();
       const result = await client.callTool({ name: "searchBrain", arguments: { query: "x" } });

--- a/packages/mcp/src/__tests__/tools.test.ts
+++ b/packages/mcp/src/__tests__/tools.test.ts
@@ -1011,28 +1011,50 @@ describe("MCP tools", () => {
   // --- searchBrain dispatch (#4773) ---
 
   describe("searchBrain", () => {
-    it("the advertised `asOf` argument does not promise retracted facts are unreachable (#4933)", async () => {
-      // This string is written HERE, not imported from the api package, so it
-      // is the one half of the searchBrain description that a fix in
-      // `lib/tools/descriptions.ts` cannot reach — and it shipped saying
-      // "retracted never", full stop. #4913 kept a retracted rival in
-      // `tensions` precisely so it stays distinguishable, so the absolute was
-      // false of the response and true only of `results`; a model reading it
-      // reports a settled retraction as a live contradiction.
+    it("advertises the tool prose the api package owns, not a local copy (#4933)", async () => {
+      // The link that makes #4933's api-side fix reach an MCP client at all:
+      // `registerTools` must keep deriving this description from
+      // `searchBrain.description` (wrapped by `withErrorContract`) rather than
+      // growing a hand-written literal here. The retraction labels are pinned
+      // on the constant in the api package
+      // (`lib/tools/__tests__/search-brain-tool.test.ts`); nothing there would
+      // notice this file re-declaring the prose, and every retraction
+      // assertion in this suite would still be green.
       //
-      // Asserted through `listTools()` rather than against the source constant
+      // The stub text comes from the module mock at the top of this file, so
+      // this asserts the WIRING, not the prose — which is the only half that
+      // can be checked here without duplicating a 148-word string.
+      const { client } = await createTestClient();
+      const { tools } = await client.listTools();
+      const description = tools.find((t) => t.name === "searchBrain")?.description;
+      expect(description).toContain("Search the company brain");
+      expect(description).toContain("Error contract:");
+    });
+
+    it("the advertised `asOf` argument does not promise retracted facts are unreachable (#4933)", async () => {
+      // Unlike the tool prose above, the whole input schema is re-declared in
+      // `src/tools.ts` rather than imported — `query` has already drifted from
+      // its api-side twin — so `asOf` is the argument where that drift is
+      // correctness-bearing and a fix in `lib/tools/descriptions.ts`
+      // structurally cannot reach it. It shipped saying "retracted never",
+      // full stop. #4913 kept a retracted rival in `tensions` precisely so it
+      // stays distinguishable, so the absolute was false of the response and
+      // true only of `results`; a model reading it reports a settled
+      // retraction as a live contradiction.
+      //
+      // Asserted through `listTools()` rather than against the source string
       // because what an external client's model actually reads is the
-      // REGISTERED schema. `searchBrain.description` is module-mocked at the
-      // top of this file, so the tool-level prose is pinned in the api package
-      // (`lib/tools/__tests__/search-brain-tool.test.ts`); the argument prose
-      // has no other home.
+      // REGISTERED schema.
       const { client } = await createTestClient();
       const { tools } = await client.listTools();
       const asOf = tools.find((t) => t.name === "searchBrain")?.inputSchema.properties?.asOf as
         | { description?: string }
         | undefined;
-      expect(asOf?.description).toBeTruthy();
-      const description = asOf?.description ?? "";
+      const description = asOf?.description;
+      expect(
+        description,
+        "searchBrain's registered inputSchema has no `asOf` description — the registration in src/tools.ts changed shape, so the retraction pins below would pass vacuously",
+      ).toBeTruthy();
       // Both arms, so neither half can be dropped: the carve-out has to be
       // stated (`tensions`) AND the field that labels it has to be nameable
       // (`invalidatedAt`), or the guidance is unactionable.
@@ -1041,6 +1063,24 @@ describe("MCP tools", () => {
       // The never-arm the carve-out could plausibly displace: a retracted fact
       // is still never a RESULT, which is what makes `asOf` safe to trust.
       expect(description).toMatch(/never as a RESULT/);
+      // And the arm the three pins above survive: a rewrite that keeps every
+      // token and re-adds the absolute in a neighbouring sentence. Mirrors
+      // `unqualifiedRetractionSentences` in the api suite; four short lines
+      // rather than a shared helper because the two packages do not share test
+      // utilities and the rule is stated in full at its api-side definition.
+      const unqualified = (description ?? "")
+        .split(/(?<=\.)\s+/)
+        .filter((s) => /retract/i.test(s))
+        .filter((s) =>
+          /retract\w*\s+(?:facts?\s+)?(?:is |are )?never|never\s+(?:returned|surfaces?|appears?|as a RESULT)/i.test(
+            s,
+          ),
+        )
+        .filter((s) => !/(only|except|still appears?|the one place)[^.]{0,80}tensions/i.test(s));
+      expect(
+        unqualified,
+        "a sentence promising retracted facts never come back must name the `tensions` carve-out in that same sentence",
+      ).toEqual([]);
     });
 
     it("returns the fused payload as JSON on success", async () => {

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -382,16 +382,16 @@ export function registerTools(server: McpServer, opts: RegisterToolsOptions): vo
           .string()
           .optional()
           .describe("Documents only: ISO-8601 date; documents at or after this timestamp."),
+        // "retracted never" was true of RESULTS and false of the response as a
+        // whole (#4933): #4913 kept a retracted rival in `tensions` precisely
+        // so it stays distinguishable, and an unqualified absolute here taught
+        // the MCP model the opposite. The wording names which field carries
+        // the label, so the guidance is actionable rather than a promise the
+        // wire does not keep.
         asOf: z
           .string()
           .optional()
           .describe(
-            // "retracted never" was true of RESULTS and false of the response
-            // as a whole (#4933): #4913 kept a retracted rival in `tensions`
-            // precisely so it stays distinguishable, and an unqualified
-            // absolute here taught the MCP model the opposite. Says which
-            // field carries the label, so the guidance is actionable rather
-            // than a promise the wire does not keep.
             "Facts only: historical point read — the reviewed facts valid at that moment (superseded versions included; a retracted fact never as a RESULT, only as a `tensions` counterpart labelled by `invalidatedAt`). ISO-8601 date (2026-07-27) or timestamp with an explicit zone (2026-07-27T09:00:00Z); zone-less times and future instants are rejected. Omit for current beliefs.",
           ),
         limit: z

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -386,7 +386,13 @@ export function registerTools(server: McpServer, opts: RegisterToolsOptions): vo
           .string()
           .optional()
           .describe(
-            "Facts only: historical point read — the reviewed facts valid at that moment (superseded versions included; retracted never). ISO-8601 date (2026-07-27) or timestamp with an explicit zone (2026-07-27T09:00:00Z); zone-less times and future instants are rejected. Omit for current beliefs.",
+            // "retracted never" was true of RESULTS and false of the response
+            // as a whole (#4933): #4913 kept a retracted rival in `tensions`
+            // precisely so it stays distinguishable, and an unqualified
+            // absolute here taught the MCP model the opposite. Says which
+            // field carries the label, so the guidance is actionable rather
+            // than a promise the wire does not keep.
+            "Facts only: historical point read — the reviewed facts valid at that moment (superseded versions included; a retracted fact never as a RESULT, only as a `tensions` counterpart labelled by `invalidatedAt`). ISO-8601 date (2026-07-27) or timestamp with an explicit zone (2026-07-27T09:00:00Z); zone-less times and future instants are rejected. Omit for current beliefs.",
           ),
         limit: z
           .number()


### PR DESCRIPTION
Closes #4933.

Base is `milestone/brain-m2`, not `main` — Brain M2 is currently reverted from `main`, so the code this touches only exists on the integration branch.

## The gap

#4932 fixed the `searchBrain` **system prompt**, which claimed *"Retracted facts never appear, at any time"* — false since #4913, which deliberately keeps a retracted rival in `tensions` so a human's resolution stays visible. The same absolute survived on three other agent-facing strings, all of them out of that PR's scope:

| Surface | Before |
|---|---|
| `SEARCH_BRAIN_TOOL_DESCRIPTION` (`lib/tools/descriptions.ts`) | `tensions` clause documented `withheldCount` and nothing else — no lifecycle label at all; `asOf` clause said "retracted never" |
| `searchBrain` `asOf` argument (`lib/tools/search-brain.ts`) | "retracted facts never" |
| MCP `searchBrain` `asOf` argument (`packages/mcp/src/tools.ts`) | "retracted never" |

Consequence: an agent reads a `tensions` counterpart a human already retracted and presents it as a live, unresolved contradiction — on the surface that reaches end users.

## What changed

**`SEARCH_BRAIN_TOOL_DESCRIPTION`** now carries the full lifecycle label, not just the retraction half:

> `tensions` lists rival claims+provenance (`withheldCount` = unseen), unranked: never pick a winner. Report those as settled once retired: `invalidatedAt` non-null = RETRACTED, `validTo` ALREADY IN THE PAST = SUPERSEDED; `validTo` still in the future = LIVE.

The issue's acceptance criteria predate `validTo` and name only `invalidatedAt`; closing it that literally would have left the MCP model able to spot a retracted rival and still unable to tell a superseded one from a live one. Both axes are in.

**The word budget was traded, not raised.** The string sat at **149 of the rubric's 150 words** and now sits at **148** — the ~35 words of lifecycle prose were paid for by compressing the opening sentence, the attribution and age clauses, the `extraction: "pending"` sentence (folded into the tier list), the JSON example, and both routing paragraphs. Every pre-existing pin — #4913 attribution, #4914 staleness, the `unavailable` never-arm — still passes, which is the evidence the squeeze didn't quietly drop a guarantee.

⚠️ **Two words of headroom, and `KNOWLEDGE_TRUST_FRAMING` is interpolated into this string.** Growing that shared constant (`lib/knowledge/framing.ts`) by three words breaks `description-rubric.test.ts` for `searchBrain` *and* `explore`. Noted in a comment above the constant.

**Both `asOf` arguments** now say a retracted fact is never a RESULT *and* where it does still surface.

## Tests

Five acceptance criteria, all pinned at `expect` level:

- The #4935 `describe` block is **widened to `describe.each` over both descriptions** — the tool description now inherits every never-arm the system prompt had (`invalidatedAt`/`validTo`, RETRACTED/SUPERSEDED, "report those as settled", the past/future `validTo` qualifier, "never pick a winner").
- A new **rule-shaped negative guard**, `unqualifiedRetractionSentences()`: a sentence may promise retracted facts never come back only if that same sentence names the `tensions` carve-out. Applied to all four strings. Deliberately not a blocklist of the two wordings that shipped — a blocklist goes green the moment someone rephrases.
- A new MCP test asserts, through `listTools()`, that `registerTools` still **derives** the tool description from `searchBrain.description` rather than growing a local literal — the link on which "the api-side fix reaches an MCP client" rests, and which nothing held before.
- The `asOf` argument prose is read from the **served JSON Schema** (`z.toJSONSchema`), not from `.shape`, so the pin tracks what the model actually receives; both shape-failure modes throw with an actionable message rather than collapsing to `""`.

### Mutation verification

21 mutations, each applied to a **real source file**, seen failing, and reverted. Baseline re-verified clean afterwards (`git status` empty).

| # | Mutation | Caught by |
|---|---|---|
| 1 | drop `invalidatedAt` label from the tool description | names BOTH wire fields; distinguishes the two verbs |
| 2 | drop both `validTo` clauses | names BOTH wire fields; two verbs; clock qualifier |
| 3 | merge RETRACTED/SUPERSEDED into "retired" | distinguishes the two verbs |
| 4 | name the fields, drop the instruction | tells the model a retired rival is SETTLED |
| 5 | `ALREADY IN THE PAST` → `non-null` | clock qualifier |
| 6 | drop the future-window LIVE carve-out | clock qualifier |
| 7 | "never pick a winner" → the pre-#4935 plural | never-arm |
| 8 | restore "retracted never" on the tool description | negative guard |
| 9 | restore "Retracted facts never appear, at any time" on the system prompt | negative guard |
| 10 | drop the carve-out from the AI SDK `asOf` argument | names the carve-out; negative guard |
| 11 | drop "never as a RESULT" from the AI SDK `asOf` argument | never-arm |
| 12 | restore "retracted never" on the MCP `asOf` argument | MCP `asOf` pin |
| 13 | push the description past 150 words | `description-rubric.test.ts` |
| 14 | token-immunity regression: keep `tensions` in the sentence, re-add the absolute | negative guard (this passed the first draft of the guard — the review panel found it) |
| 15 | AI SDK `asOf`: keep all three tokens, absolute in a neighbouring sentence | negative guard |
| 16 | MCP rewires the description to a different local literal | derivation pin |
| 17 | MCP `asOf`: keep all tokens, absolute alongside | negative guard (MCP) |
| 18 | MCP decouples by **copying** the api constant's opening verbatim | derivation pin (exact prefix-paragraph match; a `toContain` would have passed) |
| 19 | absolute at the tail of a periodless bullet whose *next* bullet carries the carve-out | negative guard (bullet-aware splitter; the naive `. ` splitter merged them and let it borrow) |
| 20 | rename `asOf` out of the input schema | the read throws with the property list; suite exits 1 |
| 21 | paraphrase the absolute as "retracted facts excluded" | negative guard (broadened `ABSOLUTE`) |

Mutations 14, 18, 19 and 21 exist because the internal review panel demonstrated each as a false-pass against an earlier draft of the guards.

## Scope note

`packages/mcp/src/tools.ts` re-declares the whole `searchBrain` input schema rather than importing it — `query` has already drifted harmlessly from its api-side twin. Collapsing that to one shared constant would make this class of divergence structurally impossible, but it changes MCP-advertised argument prose beyond the retraction fix, so it is deliberately out of scope here (#4939 is sequenced behind this PR and touches the same files). The divergence is pinned on both sides instead.
