### PR TITLE
fix(brain): correct_fact's agent-tool path writes the admin-actions row (#4934)

### DIFF
--- a/packages/api/src/api/routes/__tests__/admin-brain-facts.test.ts
+++ b/packages/api/src/api/routes/__tests__/admin-brain-facts.test.ts
@@ -18,9 +18,13 @@ import { beforeEach, describe, expect, it, mock } from "bun:test";
 import { OpenAPIHono } from "@hono/zod-openapi";
 import { Effect, Layer } from "effect";
 import { buildInternalDbMockDefaults } from "@atlas/api/testing/api-test-mocks";
+import { ADMIN_ACTIONS as REAL_ADMIN_ACTIONS } from "@atlas/api/lib/audit/actions";
 // Type-only: erased at compile time, so it does not evaluate the module this
 // file `mock.module`s below.
-import type { CorrectionOutcome } from "@atlas/api/lib/brain/correction";
+import type {
+  CorrectionOutcome,
+  CorrectionRefusalReason,
+} from "@atlas/api/lib/brain/correction";
 
 const CURRENT_ORG = "org-1";
 
@@ -51,9 +55,11 @@ void mock.module("@atlas/api/lib/audit", () => ({
   logAdminActionAwait: async (entry: Record<string, unknown>) => {
     auditRows.push(entry);
   },
-  ADMIN_ACTIONS: {
-    brainFact: { retract: "brain_fact.retract", correct: "brain_fact.correct" },
-  },
+  // The REAL catalog rather than a hand-copy, for `correction-audit.test.ts`'s
+  // reason: a copy drifts silently through a rename. `lib/audit/actions.ts` is
+  // a zero-import constant module, so reaching past the mocked barrel into it
+  // pulls nothing back in and the factory stays synchronous.
+  ADMIN_ACTIONS: REAL_ADMIN_ACTIONS,
   errorMessage: (err: unknown) => (err instanceof Error ? err.message : String(err)),
   causeToError: (cause: unknown) => (cause instanceof Error ? cause : new Error(String(cause))),
 }));
@@ -141,7 +147,14 @@ const REFUSAL_REASONS = {
   replacementUnpublishable: "REPLACEMENT_UNPUBLISHABLE",
 } as const;
 let correctCalls: Array<Record<string, unknown>> = [];
-let correctionOutcome: Record<string, unknown> = {
+/**
+ * Typed as the real union rather than `Record<string, unknown>`, so a reshape of
+ * the machinery's contract breaks every fixture in this file at compile time
+ * instead of leaving hand-written literals asserting against a shape that moved.
+ * The one exception below (`invalidatedAt: 42`) is a DELIBERATE violation and
+ * says so at its site.
+ */
+let correctionOutcome: CorrectionOutcome = {
   kind: "corrected",
   result: {
     verb: "retract",
@@ -871,10 +884,28 @@ describe("POST /{id}/correct", () => {
         message: "tier-1 has no correction path",
       },
     ];
-    for (const outcome of outcomes) {
+    // Statuses asserted per iteration, not just the final row count. Without
+    // them a request that 500s BEFORE reaching the line where the deleted
+    // `logAdminAction` used to sit leaves this green while proving nothing — and
+    // one fixture does exactly that: `/retract` rejects a `corrected` outcome
+    // whose `invalidatedAt` is null (the `pin` shape), so it never traverses the
+    // handler's tail. Pinning the expected status is what makes each iteration a
+    // statement about a path that was actually walked.
+    const expected: Array<{ retract: number; correct: number }> = [
+      { retract: 200, correct: 200 },
+      // `pin` through `/retract`: no tombstone in the outcome ⇒ the route's own
+      // shape guard 500s. Deliberately kept — it is the one path that stops
+      // early, and naming it here is cheaper than a fixture that avoids it.
+      { retract: 500, correct: 200 },
+      { retract: 404, correct: 404 },
+      { retract: 409, correct: 409 },
+    ];
+    for (const [i, outcome] of outcomes.entries()) {
       correctionOutcome = outcome;
-      await adminBrainFacts.request(`/${FACT_ID}/retract`, { method: "POST" });
-      await correct({ verb: "pin" });
+      const retractRes = await adminBrainFacts.request(`/${FACT_ID}/retract`, { method: "POST" });
+      expect(retractRes.status, `outcome ${i} via /retract`).toBe(expected[i]?.retract);
+      const correctRes = await correct({ verb: "pin" });
+      expect(correctRes.status, `outcome ${i} via /correct`).toBe(expected[i]?.correct);
     }
     expect(auditRows).toHaveLength(0);
   });
@@ -896,7 +927,7 @@ describe("POST /{id}/correct", () => {
   });
 
   it("maps refusals onto their HTTP classes: 403 authority, 400 request shape, 409 target state", async () => {
-    const cases: Array<{ reason: string; status: number }> = [
+    const cases: Array<{ reason: CorrectionRefusalReason; status: number }> = [
       { reason: REFUSAL_REASONS.notAuthorized, status: 403 },
       { reason: REFUSAL_REASONS.replacementMissing, status: 400 },
       { reason: REFUSAL_REASONS.replacementIdentical, status: 400 },
@@ -926,6 +957,11 @@ describe("POST /{id}/correct", () => {
   it("refuses to ship a correction payload that violates its own wire schema", async () => {
     // Same `checked()` posture as the list route: a machinery result the
     // schema refuses must become a 500, never reach the browser.
+    //
+    // The one fixture in this file that is deliberately ILL-TYPED — `42` where
+    // the contract says `string | null` — because the whole point is a producer
+    // that broke the contract. Cast at this site only, so every other fixture
+    // stays compile-checked against the real union.
     correctionOutcome = {
       kind: "corrected",
       result: {
@@ -937,7 +973,7 @@ describe("POST /{id}/correct", () => {
         supersededBy: null,
         validTo: null,
       },
-    };
+    } as unknown as CorrectionOutcome;
     const res = await correct({ verb: "pin" });
     expect(res.status).toBe(500);
     expect(await res.text()).not.toContain("ep-corr-3");

--- a/packages/api/src/api/routes/__tests__/admin-brain-facts.test.ts
+++ b/packages/api/src/api/routes/__tests__/admin-brain-facts.test.ts
@@ -3,8 +3,9 @@
  *
  * The read model's behaviour is pinned in `lib/brain/__tests__/candidates.test.ts`;
  * here the assertions are about THIS router — the filter guard, the deliberately
- * ambiguous retract 404, the audit row, and the two seams that would be silent
- * if they broke:
+ * ambiguous retract 404, the ABSENCE of a router-level audit row (#4934 moved it
+ * into `correctFact` so both entry points get one), and the two seams that would
+ * be silent if they broke:
  *
  *   - the reviewer's principal context is built from `resolveEffectiveRole`,
  *     never a back-filled auth-mode default (which mints `role:admin` for every
@@ -110,10 +111,11 @@ void mock.module("@atlas/api/lib/brain/candidates", () => ({
 
 /**
  * The verb machinery (#4915), stubbed on the same terms as the read model: the
- * route's own obligations — the UUID guard, outcome→HTTP mapping, the audit
- * row, the wire parse — are what these tests exercise. The verbs' semantics
- * are pinned in `lib/brain/__tests__/correction.test.ts` against a fake store
- * and in `candidates-pg.test.ts` §7 against the live schema.
+ * route's own obligations — the UUID guard, outcome→HTTP mapping, the wire
+ * parse — are what these tests exercise. The verbs' semantics are pinned in
+ * `lib/brain/__tests__/correction.test.ts` against a fake store and in
+ * `candidates-pg.test.ts` §7 against the live schema; the audit row they emit
+ * is pinned in `lib/brain/__tests__/correction-audit.test.ts` (#4934).
  */
 const REFUSAL_REASONS = {
   notAuthorized: "NOT_AUTHORIZED",
@@ -689,7 +691,7 @@ describe("GET /oversight", () => {
 });
 
 describe("POST /{id}/retract", () => {
-  it("runs the retract CORRECTION verb and records the decision in the admin action log", async () => {
+  it("runs the retract CORRECTION verb and emits NO audit row of its own", async () => {
     correctionOutcome = {
       kind: "corrected",
       result: {
@@ -712,20 +714,14 @@ describe("POST /{id}/retract", () => {
     expect(correctCalls).toHaveLength(1);
     expect(correctCalls[0]).toMatchObject({ factId: FACT_ID, verb: "retract" });
 
-    expect(auditRows).toHaveLength(1);
-    expect(auditRows[0]).toMatchObject({
-      actionType: "brain_fact.retract",
-      targetType: "brainFact",
-      targetId: FACT_ID,
-      // The tombstone pointer. A retraction is never a delete, so the row this
-      // names is still there to be read as-of.
-      metadata: {
-        invalidatedAt: "2026-07-01T00:00:00.000Z",
-        workspaceId: CURRENT_ORG,
-        correctionEpisodeId: "ep-corr-9",
-        flaggedForReReview: ["dep-1"],
-      },
-    });
+    // #4934 moved the `admin_action_log` row DOWN into `correctFact`, so the
+    // agent tool's corrections are audited on the same terms as these routes.
+    // `correctFact` is stubbed here, so zero rows is the correct expectation —
+    // and a non-zero count means a route-level call came back and every
+    // correction is now double-logged. The row's own shape and the
+    // both-entry-points claim are pinned in
+    // `lib/brain/__tests__/correction-audit.test.ts`.
+    expect(auditRows).toHaveLength(0);
   });
 
   it("400s a malformed id instead of letting Postgres 500 on the uuid cast", async () => {
@@ -810,25 +806,54 @@ describe("POST /{id}/correct", () => {
       replacement: { object: "Bo" },
     });
 
-    // The non-retract verbs share the `correct` audit action, verb in metadata.
-    expect(auditRows[0]).toMatchObject({
-      actionType: "brain_fact.correct",
-      targetType: "brainFact",
-      targetId: FACT_ID,
-      metadata: {
-        verb: "supersede",
-        workspaceId: CURRENT_ORG,
-        correctionEpisodeId: "ep-corr-2",
-        supersededBy: "fact-new-1",
-        validTo: "2026-07-30T12:00:00.000Z",
-      },
-    });
+    // The audit row is `correctFact`'s (#4934), and `correctFact` is stubbed.
+    expect(auditRows).toHaveLength(0);
   });
 
-  it("a retract through /correct audits as brain_fact.retract — one verb, one audit vocabulary", async () => {
-    const res = await correct({ verb: "retract" });
-    expect(res.status).toBe(200);
-    expect(auditRows[0]).toMatchObject({ actionType: "brain_fact.retract" });
+  it("emits NO audit row on ANY path — the correction machinery owns it (#4934)", async () => {
+    // The double-logging guard, swept rather than enumerated: whatever this
+    // router does, it must not write an `admin_action_log` row, because
+    // `correctFact` already writes exactly one for every entry point. Re-adding
+    // a `logAdminAction` call to either handler turns one human decision into
+    // two forensic rows, and this fails.
+    const outcomes: Array<Record<string, unknown>> = [
+      {
+        kind: "corrected",
+        result: {
+          verb: "retract",
+          factId: FACT_ID,
+          correctionEpisodeId: "ep-corr-a",
+          invalidatedAt: "2026-07-01T00:00:00.000Z",
+          flaggedForReReview: ["dep-1"],
+          supersededBy: null,
+          validTo: null,
+        },
+      },
+      {
+        kind: "corrected",
+        result: {
+          verb: "pin",
+          factId: FACT_ID,
+          correctionEpisodeId: "ep-corr-b",
+          invalidatedAt: null,
+          flaggedForReReview: [],
+          supersededBy: null,
+          validTo: null,
+        },
+      },
+      { kind: "not-found" },
+      {
+        kind: "refused",
+        reason: REFUSAL_REASONS.warehouseTarget,
+        message: "tier-1 has no correction path",
+      },
+    ];
+    for (const outcome of outcomes) {
+      correctionOutcome = outcome;
+      await adminBrainFacts.request(`/${FACT_ID}/retract`, { method: "POST" });
+      await correct({ verb: "pin" });
+    }
+    expect(auditRows).toHaveLength(0);
   });
 
   it("400s an unknown verb at the schema, before the machinery runs", async () => {

--- a/packages/api/src/api/routes/__tests__/admin-brain-facts.test.ts
+++ b/packages/api/src/api/routes/__tests__/admin-brain-facts.test.ts
@@ -18,6 +18,9 @@ import { beforeEach, describe, expect, it, mock } from "bun:test";
 import { OpenAPIHono } from "@hono/zod-openapi";
 import { Effect, Layer } from "effect";
 import { buildInternalDbMockDefaults } from "@atlas/api/testing/api-test-mocks";
+// Type-only: erased at compile time, so it does not evaluate the module this
+// file `mock.module`s below.
+import type { CorrectionOutcome } from "@atlas/api/lib/brain/correction";
 
 const CURRENT_ORG = "org-1";
 
@@ -36,12 +39,23 @@ void mock.module("@atlas/api/lib/logger", () => {
   return { createLogger: () => logger, getRequestContext: () => ({ requestId: "test-req" }) };
 });
 
+// BOTH audit helpers land in one array, so the "this router emits nothing"
+// guard below is true for whichever one a re-added call reaches for — a partial
+// factory would fail it with `undefined is not a function` instead, which reads
+// as a broken test rather than a double-log. Mock-all-exports besides: since
+// #4934 `lib/brain/correction.ts` imports `logAdminActionAwait`, so a partial
+// factory here link-fails the moment that module is un-stubbed.
 const auditRows: Array<Record<string, unknown>> = [];
 void mock.module("@atlas/api/lib/audit", () => ({
   logAdminAction: (entry: Record<string, unknown>) => auditRows.push(entry),
+  logAdminActionAwait: async (entry: Record<string, unknown>) => {
+    auditRows.push(entry);
+  },
   ADMIN_ACTIONS: {
     brainFact: { retract: "brain_fact.retract", correct: "brain_fact.correct" },
   },
+  errorMessage: (err: unknown) => (err instanceof Error ? err.message : String(err)),
+  causeToError: (cause: unknown) => (cause instanceof Error ? cause : new Error(String(cause))),
 }));
 
 // Records the role lookup so a test can prove the ROLE SOURCE, which is
@@ -810,13 +824,22 @@ describe("POST /{id}/correct", () => {
     expect(auditRows).toHaveLength(0);
   });
 
-  it("emits NO audit row on ANY path — the correction machinery owns it (#4934)", async () => {
+  it("emits NO audit row on ANY path of EITHER route — the machinery owns it (#4934)", async () => {
     // The double-logging guard, swept rather than enumerated: whatever this
     // router does, it must not write an `admin_action_log` row, because
     // `correctFact` already writes exactly one for every entry point. Re-adding
-    // a `logAdminAction` call to either handler turns one human decision into
-    // two forensic rows, and this fails.
-    const outcomes: Array<Record<string, unknown>> = [
+    // either audit helper to either handler turns one human decision into two
+    // forensic rows, and this fails — both are captured into `auditRows`.
+    //
+    // Deliberately reaches `/retract` as well as `/correct` despite living in
+    // the `/correct` block: the two handlers are the pair that has to stay in
+    // step, and splitting the sweep across two describes is how one of them
+    // stops being swept.
+    //
+    // Typed as the real `CorrectionOutcome` union, so a reshape of the
+    // machinery's contract breaks these fixtures at compile time rather than
+    // leaving four hand-written literals asserting against a shape that moved.
+    const outcomes: CorrectionOutcome[] = [
       {
         kind: "corrected",
         result: {

--- a/packages/api/src/api/routes/admin-brain-facts.ts
+++ b/packages/api/src/api/routes/admin-brain-facts.ts
@@ -71,7 +71,6 @@ import {
   type CorrectionRefusalReason,
 } from "@atlas/api/lib/brain/correction";
 import { loadFactOversight, loadSupersessionPreview } from "@atlas/api/lib/brain/oversight";
-import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
 import type { AtlasUser } from "@atlas/api/lib/auth/types";
 import type { AuthMode } from "@useatlas/types";
 import {
@@ -528,22 +527,10 @@ adminBrainFacts.openapi(retractRoute, async (c) => {
         );
       }
 
-      // Durable record of a human trust decision. The `log.info` inside
-      // `correctFact` is operational; this is the forensic trail.
-      // `logAdminAction` is fire-and-forget by design and handles its own
-      // failures — a lost audit row must never roll back a retraction that
-      // already committed, since the caller would then retract again.
-      logAdminAction({
-        actionType: ADMIN_ACTIONS.brainFact.retract,
-        targetType: "brainFact",
-        targetId: factId,
-        metadata: {
-          invalidatedAt: result.invalidatedAt,
-          workspaceId: orgId,
-          correctionEpisodeId: result.correctionEpisodeId,
-          flaggedForReReview: result.flaggedForReReview,
-        },
-      });
+      // No `logAdminAction` here on purpose: `correctFact` emits the
+      // `admin_action_log` row for every entry point onto the correction write,
+      // so the agent tool's corrections are audited too (#4934). Adding a call
+      // back here would double-log. See `lib/brain/correction.ts`'s header.
 
       return c.json(
         checked(BrainFactRetractResponseSchema, {
@@ -607,30 +594,8 @@ adminBrainFacts.openapi(correctRoute, async (c) => {
       }
 
       const { result } = outcome;
-      // The forensic trail beside the in-brain record. Retract keeps its
-      // dedicated action type so existing audit consumers see one vocabulary
-      // for one semantics; the other verbs share `correct` with the verb in
-      // metadata.
-      logAdminAction({
-        actionType:
-          result.verb === "retract"
-            ? ADMIN_ACTIONS.brainFact.retract
-            : ADMIN_ACTIONS.brainFact.correct,
-        targetType: "brainFact",
-        targetId: factId,
-        metadata: {
-          verb: result.verb,
-          workspaceId: orgId,
-          correctionEpisodeId: result.correctionEpisodeId,
-          ...(result.invalidatedAt !== null ? { invalidatedAt: result.invalidatedAt } : {}),
-          ...(result.flaggedForReReview.length > 0
-            ? { flaggedForReReview: result.flaggedForReReview }
-            : {}),
-          ...(result.supersededBy !== null ? { supersededBy: result.supersededBy } : {}),
-          ...(result.validTo !== null ? { validTo: result.validTo } : {}),
-        },
-      });
-
+      // The forensic trail is `correctFact`'s, not this route's — see the
+      // retract handler above and `lib/brain/correction.ts`'s header.
       return c.json(checked(BrainFactCorrectionResponseSchema, result), 200);
     }),
     { label: "apply brain fact correction verb" },

--- a/packages/api/src/lib/audit/actions.ts
+++ b/packages/api/src/lib/audit/actions.ts
@@ -993,16 +993,22 @@ export const ADMIN_ACTIONS = {
    * `metadata.invalidatedAt` is the tombstone timestamp. A retraction is never
    * a delete (ADR-0036: supersession is not deletion), so the row it points at
    * is still there to be read as-of.
+   *
+   * BOTH rows are emitted by `lib/brain/correction.ts`, whichever entry point
+   * asked for the correction — the admin HTTP routes or the `correct_fact`
+   * agent tool. Neither entry point emits one of its own; see that module's
+   * header for why the machinery owns the row (#4934).
    */
   brainFact: {
     retract: "brain_fact.retract",
     /**
-     * A `correct_fact` verb applied over the admin API (#4915) — retract via
-     * the correction machinery still records `retract` above (one retract
-     * semantics, one audit vocabulary); this row covers `supersede`,
-     * `re-authority`, and `pin`, with the verb in `metadata.verb` and the
-     * correction episode id beside it. The correction episode itself is the
-     * durable in-brain record; this is the admin-actions trail's copy.
+     * A `correct_fact` verb applied over EITHER entry point — the admin API or
+     * the agent tool (#4915, #4934). Retract via the correction machinery still
+     * records `retract` above (one retract semantics, one audit vocabulary);
+     * this row covers `supersede`, `re-authority`, and `pin`, with the verb in
+     * `metadata.verb` and the correction episode id beside it. The correction
+     * episode itself is the durable in-brain record; this is the admin-actions
+     * trail's copy.
      */
     correct: "brain_fact.correct",
   },

--- a/packages/api/src/lib/audit/actions.ts
+++ b/packages/api/src/lib/audit/actions.ts
@@ -998,6 +998,14 @@ export const ADMIN_ACTIONS = {
    * asked for the correction — the admin HTTP routes or the `correct_fact`
    * agent tool. Neither entry point emits one of its own; see that module's
    * header for why the machinery owns the row (#4934).
+   *
+   * `metadata` shape, one rule for both action types: `verb`, `workspaceId` and
+   * `correctionEpisodeId` always; `invalidatedAt`, `flaggedForReReview`,
+   * `supersededBy` and `validTo` only when the verb actually produced them. A
+   * consumer must read an ABSENT key as "this verb decided nothing there", not
+   * as missing data — a `pin` row carrying `invalidatedAt: null` would read as
+   * a tombstone decision that was made and came back empty. This unified two
+   * shapes: pre-#4934 `/retract` emitted `flaggedForReReview` even when empty.
    */
   brainFact: {
     retract: "brain_fact.retract",

--- a/packages/api/src/lib/audit/actions.ts
+++ b/packages/api/src/lib/audit/actions.ts
@@ -1004,8 +1004,13 @@ export const ADMIN_ACTIONS = {
    * `supersededBy` and `validTo` only when the verb actually produced them. A
    * consumer must read an ABSENT key as "this verb decided nothing there", not
    * as missing data — a `pin` row carrying `invalidatedAt: null` would read as
-   * a tombstone decision that was made and came back empty. This unified two
-   * shapes: pre-#4934 `/retract` emitted `flaggedForReReview` even when empty.
+   * a tombstone decision that was made and came back empty.
+   *
+   * This unified two divergent shapes, so there is a discontinuity at the #4934
+   * boundary in both directions: pre-#4934 `/retract` rows emitted
+   * `flaggedForReReview` even when empty, and carried NO `metadata.verb` at all.
+   * A consumer pivoting on `metadata.verb` sees it only on rows from #4934
+   * onward.
    */
   brainFact: {
     retract: "brain_fact.retract",

--- a/packages/api/src/lib/brain/__tests__/correction-audit-pg.test.ts
+++ b/packages/api/src/lib/brain/__tests__/correction-audit-pg.test.ts
@@ -151,6 +151,10 @@ describeIfPg("correction audit row (real Postgres)", () => {
     } catch (err) {
       await client.query("ROLLBACK").catch((rbErr: unknown) => {
         rollbackErr = rbErr instanceof Error ? rbErr : new Error(String(rbErr));
+        // Logged, not just captured: without this a failed ROLLBACK is
+        // invisible and the fixture's real problem is a destroyed connection
+        // with no stated reason.
+        console.warn(`correction-audit-pg: ROLLBACK failed — ${rollbackErr.message}`);
       });
       throw err;
     } finally {

--- a/packages/api/src/lib/brain/__tests__/correction-audit-pg.test.ts
+++ b/packages/api/src/lib/brain/__tests__/correction-audit-pg.test.ts
@@ -1,0 +1,370 @@
+/**
+ * The correction's `admin_action_log` row against LIVE Postgres (#4934).
+ *
+ * `correction-audit.test.ts` pins the row the machinery ASKS for, against a
+ * mocked `lib/audit`. That is the wrong instrument for three claims, all of
+ * which this file owns:
+ *
+ *   1. **The resolved row.** `logAdminActionAwait` → `resolveEntry` derives
+ *      `actor_id`, `actor_email`, `org_id` and `request_id` from the
+ *      AsyncLocalStorage request context, and the mocked suite stubs that away.
+ *      #4934's whole point is that a chat-initiated correction lands an
+ *      ATTRIBUTED forensic row; a test that never resolves the actor cannot
+ *      say whether it does.
+ *   2. **That the INSERT lands at all.** The write's failure is swallowed at
+ *      ERROR by design (a committed correction must not be reported as
+ *      failed), so a broken column, a renamed table, or a CHECK the metadata
+ *      violates would leave every other gate in the repo green. The swallow is
+ *      correct; it just means nothing above this file can notice.
+ *   3. **`supersede`'s `supersededBy` / `validTo` metadata.** Those two keys
+ *      are conditional spreads no other verb can produce — every fixture in
+ *      the mocked suite leaves them null, so only the OMISSION branch is
+ *      exercised there. They are also the keys an auditor pivots on to answer
+ *      "what replaced this belief", and driving `supersede` needs the whole
+ *      reconcile path, which is exactly what a live schema gives for free.
+ *
+ * Its own bootstrap rather than a ride on `candidates-pg.test.ts` §7 for one
+ * reason: this file must set `DATABASE_URL` and `_resetPool` the internal pool
+ * so `hasInternalDB()` is true and `internalQuery` reaches the test schema.
+ * That is a file-global change of posture — every correction in the suite then
+ * writes a real audit row — and imposing it on a suite written against the
+ * `hasInternalDB() === false` short-circuit would change what those 20 tests
+ * mean without changing a line of them.
+ *
+ * Opt in locally with:
+ *   bun run db:up && export TEST_DATABASE_URL=postgresql://atlas:atlas@localhost:5432/atlas
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { Pool } from "pg";
+import { runMigrations } from "@atlas/api/lib/db/migrate";
+import { MANAGED_AUTH_MIGRATIONS, _resetPool } from "@atlas/api/lib/db/internal";
+import { withRequestContext } from "@atlas/api/lib/logger";
+import { CORRECTION_REFUSAL_REASONS, correctFact } from "@atlas/api/lib/brain/correction";
+import type { ReconcileTransactionRunner } from "@atlas/api/lib/brain/reconcile";
+import type { BrainPrincipalContext } from "@atlas/api/lib/brain/acl";
+
+const TEST_DB_URL = process.env.TEST_DATABASE_URL;
+const describeIfPg = TEST_DB_URL ? describe : describe.skip;
+const PG_TEST_TIMEOUT_MS = 60_000;
+
+const WS = "ws-correction-audit-pg";
+const ACTOR_ID = "user-admin-1";
+const ACTOR_EMAIL = "admin@example.test";
+
+function reviewer(): BrainPrincipalContext {
+  return {
+    origin: "authenticated",
+    workspaceId: WS,
+    userId: ACTOR_ID,
+    role: "admin",
+    audienceIds: [],
+  };
+}
+
+interface AuditRow {
+  readonly action_type: string;
+  readonly target_type: string;
+  readonly target_id: string;
+  readonly actor_id: string;
+  readonly actor_email: string;
+  readonly org_id: string | null;
+  readonly request_id: string;
+  readonly scope: string;
+  readonly status: string;
+  readonly metadata: Record<string, unknown> | null;
+}
+
+describeIfPg("correction audit row (real Postgres)", () => {
+  let pool: Pool;
+  let priorDatabaseUrl: string | undefined;
+  const schemaName = `brain_corr_audit_${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
+
+  beforeAll(async () => {
+    // `hasInternalDB()` reads `DATABASE_URL`, not the pool — without this the
+    // audit write takes its "no internal database" early return and this whole
+    // file asserts nothing. Set inside the hook per the test-discipline rule;
+    // restored in `afterAll`. `search_path` is baked into the connection
+    // string, not SET from an unawaited `pool.on("connect")` handler.
+    priorDatabaseUrl = process.env.DATABASE_URL;
+    process.env.DATABASE_URL = TEST_DB_URL;
+    pool = new Pool({
+      connectionString: TEST_DB_URL,
+      options: `-c search_path="${schemaName}",public`,
+    });
+    const bootstrap = new Pool({ connectionString: TEST_DB_URL });
+    try {
+      await bootstrap.query(`CREATE SCHEMA IF NOT EXISTS "${schemaName}"`);
+    } finally {
+      await bootstrap.end();
+    }
+    await runMigrations(pool, { skip: MANAGED_AUTH_MIGRATIONS });
+    // `internalQuery` — which is the only path `logAdminActionAwait` takes —
+    // resolves the module-level internal pool, so it has to BE this
+    // schema-scoped pool or the rows land in `public`.
+    _resetPool(pool);
+  }, PG_TEST_TIMEOUT_MS);
+
+  afterAll(async () => {
+    _resetPool(null);
+    if (priorDatabaseUrl === undefined) delete process.env.DATABASE_URL;
+    else process.env.DATABASE_URL = priorDatabaseUrl;
+    if (pool) {
+      await pool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+      await pool.end();
+    }
+  }, PG_TEST_TIMEOUT_MS);
+
+  /** One transaction on the test pool — the runner `correctFact` injects. */
+  const poolTx: ReconcileTransactionRunner = async (fn) => {
+    const client = await pool.connect();
+    try {
+      await client.query("BEGIN");
+      const result = await fn({
+        query: async (sql: string, params?: unknown[]) => {
+          const res = await client.query(sql, params);
+          return { rows: res.rows as readonly unknown[] };
+        },
+      });
+      await client.query("COMMIT");
+      return result;
+    } catch (err) {
+      await client.query("ROLLBACK");
+      throw err;
+    } finally {
+      client.release();
+    }
+  };
+
+  async function seedPublishedFact(opts: {
+    subject: string;
+    predicate: string;
+    object: string;
+    sourceId: string;
+  }): Promise<string> {
+    const { rows: episodes } = await pool.query<{ id: string }>(
+      `INSERT INTO brain_episodes (workspace_id, source, source_id, source_actor, body, occurred_at, visible_to)
+       VALUES ($1, 'slack', $2, 'U1', 'evidence', now(), ARRAY['org'])
+       RETURNING id`,
+      [WS, opts.sourceId],
+    );
+    const episodeId = episodes[0]?.id;
+    if (episodeId === undefined) throw new Error("seed: episode insert returned no id");
+    const { rows } = await pool.query<{ id: string }>(
+      `INSERT INTO brain_facts
+         (workspace_id, subject, predicate, object, source_episode_id, provenance,
+          status, visible_to, predicate_cardinality)
+       VALUES ($1, $2, $3, $4, $5, $6::jsonb, 'published', ARRAY['org'], 'single')
+       RETURNING id`,
+      [
+        WS,
+        opts.subject,
+        opts.predicate,
+        opts.object,
+        episodeId,
+        JSON.stringify({ source: "slack", actor: "U1" }),
+      ],
+    );
+    const factId = rows[0]?.id;
+    if (factId === undefined) throw new Error("seed: fact insert returned no id");
+    return factId;
+  }
+
+  async function auditRowsFor(targetId: string): Promise<AuditRow[]> {
+    const { rows } = await pool.query<AuditRow>(
+      `SELECT action_type, target_type, target_id, actor_id, actor_email, org_id,
+              request_id, scope, status, metadata
+         FROM admin_action_log
+        WHERE target_id = $1
+     ORDER BY timestamp`,
+      [targetId],
+    );
+    return rows;
+  }
+
+  /**
+   * Both entry points run the correction inside a request context — the HTTP
+   * routes through `createAdminRouter`'s middleware, the agent tool through the
+   * chat route's `withRequestContext`. Modelling that here is the point: it is
+   * what turns the row from "an event happened" into "this admin, in this org,
+   * on this request".
+   */
+  function asRequest<T>(requestId: string, fn: () => Promise<T>): Promise<T> {
+    return withRequestContext(
+      {
+        requestId,
+        user: {
+          id: ACTOR_ID,
+          mode: "managed",
+          label: ACTOR_EMAIL,
+          role: "admin",
+          activeOrganizationId: WS,
+        },
+      },
+      fn,
+    );
+  }
+
+  it(
+    "a retract lands an ATTRIBUTED brain_fact.retract row in admin_action_log",
+    async () => {
+      const factId = await seedPublishedFact({
+        subject: "Deploys",
+        predicate: "happen on",
+        object: "Thursdays",
+        sourceId: "audit-pg-retract",
+      });
+
+      const outcome = await asRequest("req-retract-1", () =>
+        correctFact(
+          { ctx: reviewer(), factId, verb: "retract", reason: "wrong on arrival" },
+          { withTransaction: poolTx },
+        ),
+      );
+      if (outcome.kind !== "corrected") throw new Error(`expected corrected, got ${outcome.kind}`);
+
+      const rows = await auditRowsFor(factId);
+      expect(rows).toHaveLength(1);
+      const row = rows[0];
+      // Named throw rather than `rows[0]?.x`: an optional-chained assertion
+      // against a missing row compares `undefined` to `undefined` and passes.
+      if (row === undefined) throw new Error("no admin_action_log row for the retract");
+
+      expect(row.action_type).toBe("brain_fact.retract");
+      expect(row.target_type).toBe("brainFact");
+      expect(row.target_id).toBe(factId);
+      expect(row.status).toBe("success");
+      expect(row.scope).toBe("workspace");
+      // The half `correction-audit.test.ts` structurally cannot see: every one
+      // of these comes from `resolveEntry` reading the request context, and a
+      // row that exists but says `actor_id = 'unknown'` is a worse artifact
+      // than the missing row #4934 fixed.
+      expect(row.actor_id).toBe(ACTOR_ID);
+      expect(row.actor_email).toBe(ACTOR_EMAIL);
+      expect(row.org_id).toBe(WS);
+      expect(row.request_id).toBe("req-retract-1");
+
+      expect(row.metadata).toMatchObject({
+        verb: "retract",
+        workspaceId: WS,
+        correctionEpisodeId: outcome.result.correctionEpisodeId,
+        invalidatedAt: outcome.result.invalidatedAt,
+      });
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "a supersede records WHAT replaced the belief and when the window closed",
+    async () => {
+      const factId = await seedPublishedFact({
+        subject: "Billing",
+        predicate: "is owned by",
+        object: "Ana",
+        sourceId: "audit-pg-supersede",
+      });
+
+      const outcome = await asRequest("req-supersede-1", () =>
+        correctFact(
+          {
+            ctx: reviewer(),
+            factId,
+            verb: "supersede",
+            reason: "Ana left; Bo took over",
+            replacement: { object: "Bo" },
+          },
+          { withTransaction: poolTx },
+        ),
+      );
+      if (outcome.kind !== "corrected") throw new Error(`expected corrected, got ${outcome.kind}`);
+      expect(outcome.result.supersededBy).toBeTruthy();
+      expect(outcome.result.validTo).toBeTruthy();
+
+      const rows = await auditRowsFor(factId);
+      expect(rows).toHaveLength(1);
+      const row = rows[0];
+      if (row === undefined) throw new Error("no admin_action_log row for the supersede");
+
+      // The non-retract verbs share ONE action type, so `metadata.verb` is the
+      // only thing distinguishing a supersession from a pin in the trail.
+      expect(row.action_type).toBe("brain_fact.correct");
+      expect(row.actor_id).toBe(ACTOR_ID);
+      expect(row.request_id).toBe("req-supersede-1");
+      // The two conditional keys no other verb can produce, and the reason this
+      // file drives `supersede` at all: without them the row records that a
+      // belief was retired and not what replaced it.
+      expect(row.metadata).toMatchObject({
+        verb: "supersede",
+        workspaceId: WS,
+        correctionEpisodeId: outcome.result.correctionEpisodeId,
+        supersededBy: outcome.result.supersededBy,
+        validTo: outcome.result.validTo,
+      });
+      // …and a supersession is not a tombstone, so the retract-only key stays
+      // off. `toMatchObject` above would happily ignore an extra `invalidatedAt`.
+      expect(row.metadata).not.toHaveProperty("invalidatedAt");
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "a pin records the verb and nothing it did not decide",
+    async () => {
+      const factId = await seedPublishedFact({
+        subject: "Oncall",
+        predicate: "rotates",
+        object: "weekly",
+        sourceId: "audit-pg-pin",
+      });
+
+      const outcome = await asRequest("req-pin-1", () =>
+        correctFact({ ctx: reviewer(), factId, verb: "pin" }, { withTransaction: poolTx }),
+      );
+      if (outcome.kind !== "corrected") throw new Error(`expected corrected, got ${outcome.kind}`);
+
+      const rows = await auditRowsFor(factId);
+      expect(rows).toHaveLength(1);
+      const row = rows[0];
+      if (row === undefined) throw new Error("no admin_action_log row for the pin");
+      expect(row.action_type).toBe("brain_fact.correct");
+      // Exactly the three unconditional keys — a `pin` neither tombstones,
+      // supersedes, nor closes a validity window, and a row asserting
+      // `invalidatedAt: null` reads as a decision that was made.
+      expect(row.metadata).toEqual({
+        verb: "pin",
+        workspaceId: WS,
+        correctionEpisodeId: outcome.result.correctionEpisodeId,
+      });
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "a REFUSED correction writes no row — the rollback takes the audit with it",
+    async () => {
+      const factId = await seedPublishedFact({
+        subject: "Revenue",
+        predicate: "was",
+        object: "$1M",
+        sourceId: "audit-pg-refused",
+      });
+      // Tier-1: refused from INSIDE the transaction, through the rollback
+      // catch — the return path a test that only exercises the pre-transaction
+      // authority refusal never reaches.
+      await pool.query(
+        `UPDATE brain_facts SET provenance = jsonb_set(provenance, '{source}', '"warehouse"') WHERE id = $1`,
+        [factId],
+      );
+
+      const outcome = await asRequest("req-refused-1", () =>
+        correctFact({ ctx: reviewer(), factId, verb: "pin" }, { withTransaction: poolTx }),
+      );
+      expect(outcome).toMatchObject({
+        kind: "refused",
+        reason: CORRECTION_REFUSAL_REASONS.warehouseTarget,
+      });
+      expect(await auditRowsFor(factId)).toHaveLength(0);
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+});

--- a/packages/api/src/lib/brain/__tests__/correction-audit-pg.test.ts
+++ b/packages/api/src/lib/brain/__tests__/correction-audit-pg.test.ts
@@ -31,6 +31,11 @@
  * `hasInternalDB() === false` short-circuit would change what those 20 tests
  * mean without changing a line of them.
  *
+ * One limit worth knowing: `_resetPool` nulls the `@effect/sql` client too, so
+ * `internalQuery` here takes its raw-pool branch. This proves the row lands and
+ * what it contains; it does not exercise the `PgClient` path production uses
+ * once the InternalDB Layer has booted.
+ *
  * Opt in locally with:
  *   bun run db:up && export TEST_DATABASE_URL=postgresql://atlas:atlas@localhost:5432/atlas
  */
@@ -115,9 +120,24 @@ describeIfPg("correction audit row (real Postgres)", () => {
     }
   }, PG_TEST_TIMEOUT_MS);
 
-  /** One transaction on the test pool — the runner `correctFact` injects. */
-  const poolTx: ReconcileTransactionRunner = async (fn) => {
+  /**
+   * One transaction on the test pool, handed to `correctFact` through
+   * `deps.withTransaction`.
+   *
+   * Deliberately the same shape as production's `withBrainTransaction`, down to
+   * the `.catch` on the ROLLBACK and the `client.release(rollbackErr)`. A naive
+   * `await client.query("ROLLBACK"); throw err;` would let a rollback-time
+   * failure REPLACE the original cause — which in the refusal test below would
+   * swap the `CorrectionRefusedError` for a pg error and fail the assertion
+   * naming the wrong thing — and an unconditional `release()` would hand a
+   * client still inside an aborted transaction back to the pool, where
+   * `auditRowsFor`'s next query fails with "current transaction is aborted".
+   */
+  const poolTx: ReconcileTransactionRunner = async <T,>(
+    fn: (tx: { query: (sql: string, params?: unknown[]) => Promise<{ rows: readonly unknown[] }> }) => Promise<T>,
+  ): Promise<T> => {
     const client = await pool.connect();
+    let rollbackErr: Error | undefined;
     try {
       await client.query("BEGIN");
       const result = await fn({
@@ -129,10 +149,12 @@ describeIfPg("correction audit row (real Postgres)", () => {
       await client.query("COMMIT");
       return result;
     } catch (err) {
-      await client.query("ROLLBACK");
+      await client.query("ROLLBACK").catch((rbErr: unknown) => {
+        rollbackErr = rbErr instanceof Error ? rbErr : new Error(String(rbErr));
+      });
       throw err;
     } finally {
-      client.release();
+      client.release(rollbackErr);
     }
   };
 
@@ -308,7 +330,7 @@ describeIfPg("correction audit row (real Postgres)", () => {
   );
 
   it(
-    "a pin records the verb and nothing it did not decide",
+    "a pin records the verb and nothing it did not decide, under the CANONICAL fact id",
     async () => {
       const factId = await seedPublishedFact({
         subject: "Oncall",
@@ -317,8 +339,17 @@ describeIfPg("correction audit row (real Postgres)", () => {
         sourceId: "audit-pg-pin",
       });
 
+      // Upper-cased on the way in, and that is the point. Postgres canonicalizes
+      // on the `::uuid` cast so the correction succeeds either way, but the
+      // agent tool takes `factId` as a bare `z.string()` with no normalization —
+      // so an LLM echoing a differently-cased id would, if the row used the
+      // CALLER's string, produce a `target_id` that does not string-join to
+      // `brain_facts.id`. The emitter uses `result.factId` for exactly this.
       const outcome = await asRequest("req-pin-1", () =>
-        correctFact({ ctx: reviewer(), factId, verb: "pin" }, { withTransaction: poolTx }),
+        correctFact(
+          { ctx: reviewer(), factId: factId.toUpperCase(), verb: "pin" },
+          { withTransaction: poolTx },
+        ),
       );
       if (outcome.kind !== "corrected") throw new Error(`expected corrected, got ${outcome.kind}`);
 
@@ -327,9 +358,16 @@ describeIfPg("correction audit row (real Postgres)", () => {
       const row = rows[0];
       if (row === undefined) throw new Error("no admin_action_log row for the pin");
       expect(row.action_type).toBe("brain_fact.correct");
-      // Exactly the three unconditional keys — a `pin` neither tombstones,
-      // supersedes, nor closes a validity window, and a row asserting
-      // `invalidatedAt: null` reads as a decision that was made.
+      // Lower-case, i.e. the DB's spelling — not the upper-cased string the
+      // caller passed. `auditRowsFor` queried on the canonical id and found it,
+      // which is the join this pins.
+      expect(row.target_id).toBe(factId);
+      // Exactly the three unconditional keys FROM THIS CALL SITE — a `pin`
+      // neither tombstones, supersedes, nor closes a validity window, and a row
+      // asserting `invalidatedAt: null` reads as a decision that was made.
+      // (`resolveEntry` also merges `trustDeviceIdentifier` / `origin` when the
+      // context carries them; this context carries neither, so a strict
+      // `toEqual` is right and forces a deliberate decision if that changes.)
       expect(row.metadata).toEqual({
         verb: "pin",
         workspaceId: WS,

--- a/packages/api/src/lib/brain/__tests__/correction-audit.test.ts
+++ b/packages/api/src/lib/brain/__tests__/correction-audit.test.ts
@@ -1,0 +1,533 @@
+/**
+ * The `admin_action_log` row a correction emits (#4934).
+ *
+ * `correct_fact` has two entry points onto one write — the admin HTTP routes
+ * and the agent tool — and #4915 wired the audit vocabulary to only the first.
+ * An owner correcting a fact through chat therefore produced the immutable
+ * in-brain correction episode and NO row in the forensic trail, while the same
+ * verb through the console produced both. #4934 moved the write down into
+ * `correctFact`, so the row is emitted once, by the machinery, for every entry
+ * point present or future.
+ *
+ * Split from `correction.test.ts` for the reason `acl-logging.test.ts` and
+ * `grant-sweep-logging.test.ts` are split from theirs: it needs
+ * `mock.module("@atlas/api/lib/logger")` and `mock.module("@atlas/api/lib/audit")`
+ * installed before the module under test is imported, and the sibling suite
+ * deliberately runs with no module mocking at all.
+ *
+ * What is pinned here, and why each half is load-bearing:
+ *
+ *   - the ROW: emitted exactly once for a `corrected` outcome, with retract's
+ *     dedicated action type and the other verbs riding `correct` with the verb
+ *     in metadata; NOT emitted for a refusal or a not-found (#4934's recorded
+ *     non-goal — `admin_action_log` consumers may read the table as
+ *     success-only);
+ *   - AWAITED, not fire-and-forget. `logAdminAction` posts its insert into the
+ *     internal-DB circuit breaker and returns, so an open breaker discards the
+ *     row with nothing but a counter — the silent gap #4937 found on the
+ *     adjacent publish path, and here it would silently reproduce the exact bug
+ *     #4934 fixes. Both halves are pinned: that the write completes before
+ *     `correctFact` resolves, and that a FAILED write is surfaced at ERROR
+ *     rather than swallowed;
+ *   - BOUNDED. `logAdminActionAwait` goes through `internalQuery`, which
+ *     bypasses the breaker on purpose, and the internal pool sets no statement
+ *     timeout — so an awaited-but-unbounded write lets a degraded internal DB
+ *     hold a chat turn open indefinitely;
+ *   - and a SOURCE-LEVEL guard that discovers every `correctFact` caller and
+ *     pins that none of them writes an audit row of its own. That is the half
+ *     that makes "a third entry point cannot land uncovered" true by
+ *     construction rather than by review diligence — the failure mode #4934
+ *     was, at one entry point, exactly this.
+ */
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { beforeEach, describe, expect, test, mock } from "bun:test";
+
+// --- logger: every VALUE export stubbed (mock-all-exports) -----------------
+type LogCall = { level: "error" | "warn" | "info" | "debug"; payload: unknown; message: string };
+const logCalls: LogCall[] = [];
+const recorder = {
+  error: (payload: unknown, message: string) => logCalls.push({ level: "error", payload, message }),
+  warn: (payload: unknown, message: string) => logCalls.push({ level: "warn", payload, message }),
+  info: (payload: unknown, message: string) => logCalls.push({ level: "info", payload, message }),
+  debug: (payload: unknown, message: string) => logCalls.push({ level: "debug", payload, message }),
+};
+void mock.module("@atlas/api/lib/logger", () => ({
+  createLogger: () => recorder,
+  getLogger: () => ({ ...recorder, level: "info" }),
+  setLogLevel: () => true,
+  getRequestContext: () => undefined,
+  ACTOR_KINDS: ["human", "agent", "mcp", "scheduler", "api_key"] as const,
+  withRequestContext: <T,>(_ctx: unknown, fn: () => T): T => fn(),
+  redactPaths: [] as string[],
+  scrubErrSerializer: (value: unknown) => value,
+  scrubLogFormatter: (obj: unknown) => obj,
+  hashShareToken: (token: string) => token,
+}));
+
+// --- audit: the seam under test -------------------------------------------
+interface AuditRow {
+  readonly actionType: string;
+  readonly targetType: string;
+  readonly targetId: string;
+  readonly metadata?: Record<string, unknown>;
+}
+/** Rows that COMMITTED — pushed only after the write's promise settles. */
+const committed: AuditRow[] = [];
+/** Every call, recorded on entry — lets a test see a write that never landed. */
+const attempted: AuditRow[] = [];
+/** Swap to make the awaited write hang or reject. Default: commits promptly. */
+let auditBehaviour: (row: AuditRow) => Promise<void> = async () => {};
+/** Set if anything calls the FIRE-AND-FORGET variant — nothing here may. */
+let fireAndForgetCalls = 0;
+
+void mock.module("@atlas/api/lib/audit", () => ({
+  ADMIN_ACTIONS: {
+    brainFact: { retract: "brain_fact.retract", correct: "brain_fact.correct" },
+  },
+  logAdminAction: () => {
+    fireAndForgetCalls += 1;
+  },
+  logAdminActionAwait: async (row: AuditRow) => {
+    attempted.push(row);
+    await auditBehaviour(row);
+    committed.push(row);
+  },
+  errorMessage: (err: unknown) => (err instanceof Error ? err.message : String(err)),
+  causeToError: (cause: unknown) => (cause instanceof Error ? cause : new Error(String(cause))),
+}));
+
+const {
+  CORRECTION_EPISODE_INSERT_SQL,
+  DEPENDENT_FACTS_SQL,
+  DERIVES_FROM_EDGE_SQL,
+  MERGE_PROVENANCE_MARKER_SQL,
+  RETRACT_FACT_SQL,
+  correctFact,
+} = await import("@atlas/api/lib/brain/correction");
+const { INSERT_PROVENANCE_EDGE_SQL } = await import("@atlas/api/lib/brain/reconcile");
+const { SLACK_SOURCE, WAREHOUSE_SOURCE } = await import("@atlas/api/lib/brain/sources");
+type CorrectionDeps = Parameters<typeof correctFact>[1];
+
+const WS = "ws-audit";
+const FACT = "11111111-1111-4111-8111-111111111111";
+const EPISODE = "22222222-2222-4222-8222-222222222222";
+const NOW = new Date("2026-07-31T09:00:00.000Z");
+
+const admin = {
+  origin: "authenticated",
+  workspaceId: WS,
+  userId: "admin-1",
+  role: "admin",
+  audienceIds: [] as string[],
+} as const;
+
+/**
+ * The narrowest store the two audited verbs need: a statement dispatcher, the
+ * same identity-not-paraphrase idea as `correction.test.ts`'s fake, trimmed to
+ * `retract` and the vouch verbs. `supersede` runs the whole reconcile path and
+ * is pinned there; its audit row rides the SAME expression as `pin`'s (every
+ * non-retract verb maps to `brain_fact.correct`), so what is left untested here
+ * is reconcile, not the audit mapping.
+ */
+function fakeTransaction(
+  options: { dependents?: readonly string[]; warehouseDerived?: boolean } = {},
+): CorrectionDeps {
+  const dependents = options.dependents ?? [];
+  const source = options.warehouseDerived === true ? WAREHOUSE_SOURCE : SLACK_SOURCE;
+  return {
+    now: () => NOW,
+    newCorrectionId: () => "corr-1",
+    withTransaction: async <T,>(
+      fn: (tx: { query: (sql: string, params?: unknown[]) => Promise<{ rows: unknown[] }> }) => Promise<T>,
+    ): Promise<T> =>
+      fn({
+        query: async (sql: string) => {
+          if (sql.startsWith("SELECT f.id::text")) {
+            return {
+              rows: [
+                {
+                  id: FACT,
+                  subject: "Ana",
+                  predicate: "leads",
+                  object: "Platform",
+                  status: "published",
+                  predicate_cardinality: "single",
+                  provenance: { source },
+                  visible_to: ["org"],
+                  valid_to: null,
+                  source_episode_id: "ep-src",
+                },
+              ],
+            };
+          }
+          if (sql === CORRECTION_EPISODE_INSERT_SQL) return { rows: [{ id: EPISODE }] };
+          if (sql === RETRACT_FACT_SQL) {
+            return { rows: [{ id: FACT, invalidated_at: NOW.toISOString() }] };
+          }
+          if (sql === DERIVES_FROM_EDGE_SQL) return { rows: [] };
+          if (sql === INSERT_PROVENANCE_EDGE_SQL) return { rows: [] };
+          if (sql === DEPENDENT_FACTS_SQL) return { rows: dependents.map((id) => ({ id })) };
+          if (sql === MERGE_PROVENANCE_MARKER_SQL) {
+            const ids = dependents.length > 0 ? dependents : [FACT];
+            return { rows: ids.map((id) => ({ id })) };
+          }
+          throw new Error(`fake store: unexpected statement ${sql.slice(0, 60)}`);
+        },
+      }),
+  } satisfies CorrectionDeps;
+}
+
+beforeEach(() => {
+  logCalls.length = 0;
+  committed.length = 0;
+  attempted.length = 0;
+  fireAndForgetCalls = 0;
+  auditBehaviour = async () => {};
+});
+
+// ---------------------------------------------------------------------------
+// The row
+// ---------------------------------------------------------------------------
+
+describe("the correction audit row", () => {
+  test("retract emits exactly one brain_fact.retract row, from the machinery", async () => {
+    const outcome = await correctFact(
+      { ctx: admin, factId: FACT, verb: "retract", requestId: "req-1" },
+      fakeTransaction({ dependents: ["dep-1"] }),
+    );
+
+    expect(outcome.kind).toBe("corrected");
+    expect(committed).toHaveLength(1);
+    expect(committed[0]).toEqual({
+      actionType: "brain_fact.retract",
+      targetType: "brainFact",
+      targetId: FACT,
+      metadata: {
+        verb: "retract",
+        workspaceId: WS,
+        correctionEpisodeId: EPISODE,
+        invalidatedAt: NOW.toISOString(),
+        flaggedForReReview: ["dep-1"],
+      },
+    });
+    // The FIRE-AND-FORGET variant is the one that silently drops rows when the
+    // internal-DB breaker is open. Nothing on this path may reach for it.
+    expect(fireAndForgetCalls).toBe(0);
+  });
+
+  test("the non-retract verbs ride brain_fact.correct with the verb in metadata", async () => {
+    for (const verb of ["pin", "re-authority"] as const) {
+      committed.length = 0;
+      const outcome = await correctFact(
+        { ctx: admin, factId: FACT, verb, requestId: "req-2" },
+        fakeTransaction(),
+      );
+      expect(outcome.kind).toBe("corrected");
+      expect(committed).toHaveLength(1);
+      expect(committed[0]).toEqual({
+        actionType: "brain_fact.correct",
+        targetType: "brainFact",
+        targetId: FACT,
+        // The conditional keys stay OFF when there is nothing to say — a `pin`
+        // neither tombstones, supersedes, nor closes a validity window, and a
+        // row asserting `invalidatedAt: null` reads as a decision that was made.
+        metadata: { verb, workspaceId: WS, correctionEpisodeId: EPISODE },
+      });
+    }
+  });
+
+  test("a retract with no dependents omits flaggedForReReview rather than logging an empty list", async () => {
+    await correctFact(
+      { ctx: admin, factId: FACT, verb: "retract", requestId: "req-3" },
+      fakeTransaction(),
+    );
+    expect(committed).toHaveLength(1);
+    expect(committed[0]?.metadata).not.toHaveProperty("flaggedForReReview");
+    expect(committed[0]?.metadata).toMatchObject({ invalidatedAt: NOW.toISOString() });
+  });
+
+  test("BOTH refusal shapes go unaudited — nothing happened to record", async () => {
+    // Two structurally different refusals, and covering only one is how a
+    // widening slips in: the AUTHORITY refusal returns before the transaction
+    // is ever opened, while the tier-1 refusal throws `CorrectionRefusedError`
+    // from INSIDE it — a separate return path, through the rollback catch,
+    // where an audit call would go unnoticed by a test that only exercises the
+    // early return.
+    const outcome = await correctFact(
+      {
+        ctx: { ...admin, userId: "member-1", role: "member" },
+        factId: FACT,
+        verb: "pin",
+        requestId: "req-4a",
+      },
+      fakeTransaction(),
+    );
+    expect(outcome.kind).toBe("refused");
+
+    const rolledBack = await correctFact(
+      { ctx: admin, factId: FACT, verb: "pin", requestId: "req-4b" },
+      fakeTransaction({ warehouseDerived: true }),
+    );
+    expect(rolledBack.kind).toBe("refused");
+
+    expect(attempted).toHaveLength(0);
+    expect(fireAndForgetCalls).toBe(0);
+  });
+
+  test("a NOT-FOUND correction is not audited", async () => {
+    const deps: CorrectionDeps = {
+      ...fakeTransaction(),
+      withTransaction: async <T,>(
+        fn: (tx: { query: () => Promise<{ rows: unknown[] }> }) => Promise<T>,
+      ): Promise<T> => fn({ query: async () => ({ rows: [] }) }),
+    };
+    const outcome = await correctFact(
+      { ctx: admin, factId: FACT, verb: "pin", requestId: "req-5" },
+      deps,
+    );
+    expect(outcome.kind).toBe("not-found");
+    expect(attempted).toHaveLength(0);
+    expect(fireAndForgetCalls).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Awaited, bounded, and loud — the #4937 swallow class
+// ---------------------------------------------------------------------------
+
+describe("the write is awaited, bounded, and never swallowed", () => {
+  test("the row has COMMITTED by the time correctFact resolves", async () => {
+    // The mutation this catches: `void emitCorrectionAudit(...)` instead of
+    // `await`. A fire-and-forget write still records an ATTEMPT synchronously,
+    // so asserting on `attempted` would pass either way — only the settled
+    // `committed` list can tell the difference.
+    let release: (() => void) | undefined;
+    auditBehaviour = () =>
+      new Promise<void>((resolve) => {
+        release = resolve;
+        // Resolve on a later microtask+macrotask so a non-awaiting caller
+        // returns first and the assertion below sees an empty list.
+        setTimeout(() => resolve(), 5);
+      });
+
+    const outcome = await correctFact(
+      { ctx: admin, factId: FACT, verb: "pin", requestId: "req-6" },
+      fakeTransaction(),
+    );
+
+    expect(outcome.kind).toBe("corrected");
+    expect(committed).toHaveLength(1);
+    release?.();
+  });
+
+  test("a FAILED write is logged at ERROR — never swallowed — and the correction still stands", async () => {
+    auditBehaviour = async () => {
+      throw new Error("internal DB circuit breaker is open");
+    };
+
+    const outcome = await correctFact(
+      { ctx: admin, factId: FACT, verb: "retract", requestId: "req-7" },
+      fakeTransaction(),
+    );
+
+    // The correction committed; reporting failure would invite a retry that
+    // mints a SECOND correction episode for one human decision.
+    expect(outcome.kind).toBe("corrected");
+    expect(committed).toHaveLength(0);
+
+    const errors = logCalls.filter((c) => c.level === "error");
+    expect(errors).toHaveLength(1);
+    const [failure] = errors;
+    // The underlying cause must reach the line — an `err`-less "audit failed"
+    // is not actionable, and CLAUDE.md requires the caught error be narrowed
+    // and logged rather than dropped.
+    expect(failure?.payload).toMatchObject({
+      workspaceId: WS,
+      factId: FACT,
+      verb: "retract",
+      correctionEpisodeId: EPISODE,
+      requestId: "req-7",
+      err: "internal DB circuit breaker is open",
+    });
+    // The message is a recovery instruction: it must name what SURVIVES, or an
+    // operator reads it as "the correction was lost".
+    expect(failure?.message).toContain("brain_episodes");
+    expect(failure?.message).toContain("admin_action");
+  });
+
+  test("a HUNG write is bounded — a degraded internal DB cannot hold the turn open", async () => {
+    // Without the deadline this never settles: `logAdminActionAwait` goes
+    // through `internalQuery`, which bypasses the circuit breaker, and the
+    // internal pool sets no statement timeout.
+    auditBehaviour = () => new Promise<void>(() => {});
+
+    const outcome = await correctFact(
+      { ctx: admin, factId: FACT, verb: "pin", requestId: "req-8" },
+      { ...fakeTransaction(), auditWriteTimeoutMs: 20 },
+    );
+
+    expect(outcome.kind).toBe("corrected");
+    expect(committed).toHaveLength(0);
+    const errors = logCalls.filter((c) => c.level === "error");
+    expect(errors).toHaveLength(1);
+    expect((errors[0]?.payload as { err?: string } | undefined)?.err).toContain("timed out");
+  });
+
+  test("a prompt write CLEARS its deadline timer instead of leaving it armed", async () => {
+    // The timer is cleared in a `finally`. Left armed, a 5s timer holds the
+    // event loop open on EVERY correction — on the agent-tool path that is a
+    // per-chat-turn cost, and it is invisible to every other assertion in this
+    // file because the race has already settled on the winning branch.
+    // `process.getActiveResourcesInfo()` does NOT see it (verified: the leak
+    // mutation stays green through that lens), so the timer functions
+    // themselves are what gets observed.
+    type SetTimeoutFn = typeof globalThis.setTimeout;
+    type ClearTimeoutFn = typeof globalThis.clearTimeout;
+    const realSetTimeout: SetTimeoutFn = globalThis.setTimeout;
+    const realClearTimeout: ClearTimeoutFn = globalThis.clearTimeout;
+    const created = new Set<ReturnType<SetTimeoutFn>>();
+    const cleared = new Set<unknown>();
+    globalThis.setTimeout = ((...args: Parameters<SetTimeoutFn>) => {
+      const handle = realSetTimeout(...args);
+      created.add(handle);
+      return handle;
+    }) as SetTimeoutFn;
+    globalThis.clearTimeout = ((handle: Parameters<ClearTimeoutFn>[0]) => {
+      cleared.add(handle);
+      realClearTimeout(handle);
+    }) as ClearTimeoutFn;
+
+    try {
+      await correctFact(
+        { ctx: admin, factId: FACT, verb: "pin", requestId: "req-9" },
+        fakeTransaction(),
+      );
+    } finally {
+      globalThis.setTimeout = realSetTimeout;
+      globalThis.clearTimeout = realClearTimeout;
+    }
+
+    // The deadline timer is the only one this path arms; if that ever stops
+    // being true the assertion is still the right one — every timer armed
+    // during a correction must be disarmed by the time it returns.
+    expect(created.size).toBeGreaterThan(0);
+    expect([...created].filter((h) => !cleared.has(h))).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Source guard: one call site, discovered rather than enumerated
+// ---------------------------------------------------------------------------
+
+/**
+ * Roots walked by the caller sweep. ASSERTED, not `existsSync`-filtered, for
+ * `publish-caller-supersession-wiring.test.ts`'s reason: a root that silently
+ * filters away shrinks the guarded surface, which is the same failure shape as
+ * the bug being guarded. Criterion for membership: a plausible surface for a
+ * new `correct_fact` entry point that can reach `@atlas/api/lib/**` — the API
+ * package itself, the MCP server, the enterprise seams, the CLI, and the
+ * plugin tree.
+ */
+const ROOTS = [
+  "packages/api/src",
+  "packages/mcp/src",
+  "packages/cli/src",
+  "ee",
+  "plugins",
+];
+
+/** `packages/api/src/lib/brain/__tests__` → repo root: six levels up. */
+const REPO_ROOT = join(import.meta.dir, "../../../../../..");
+
+function walk(dir: string, out: string[]): void {
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    // A root that vanished is a shrunken guard, not a pass — the ROOTS
+    // assertion below turns this into a failure rather than silence.
+    return;
+  }
+  for (const entry of entries) {
+    if (entry === "node_modules" || entry === "dist" || entry === ".next") continue;
+    const full = join(dir, entry);
+    const stat = statSync(full);
+    if (stat.isDirectory()) {
+      walk(full, out);
+      continue;
+    }
+    if (!entry.endsWith(".ts") && !entry.endsWith(".tsx")) continue;
+    // Tests routinely stub both sides; they are not entry points.
+    if (entry.includes(".test.")) continue;
+    if (full.includes(`${"__tests__"}/`)) continue;
+    out.push(full);
+  }
+}
+
+/**
+ * Comments and string literals stripped, strings FIRST so a `//` inside a URL
+ * cannot eat the rest of its line. Both matter here: this file's own prose
+ * names `logAdminAction` repeatedly, and a log message naming its own helper is
+ * an ordinary thing to write.
+ */
+function strip(source: string): string {
+  return source
+    .replace(/`(?:\\.|[^`\\])*`/gs, '""')
+    .replace(/'(?:\\.|[^'\\\n])*'/g, '""')
+    .replace(/"(?:\\.|[^"\\\n])*"/g, '""')
+    .replace(/\/\*[\s\S]*?\*\//g, " ")
+    .replace(/\/\/[^\n]*/g, " ");
+}
+
+describe("source guard: the machinery is the ONLY audit-writing layer for corrections", () => {
+  const MACHINERY = join(REPO_ROOT, "packages/api/src/lib/brain/correction.ts");
+
+  test("every walked root exists — a filtered-away root is a shrunken guard", () => {
+    for (const root of ROOTS) {
+      const full = join(REPO_ROOT, root);
+      expect(() => statSync(full), `walked root missing: ${root}`).not.toThrow();
+    }
+  });
+
+  test("no caller of correctFact writes an audit row of its own", () => {
+    const files: string[] = [];
+    for (const root of ROOTS) walk(join(REPO_ROOT, root), files);
+
+    const callers = files.filter((file) => {
+      if (file === MACHINERY) return false;
+      return /\bcorrectFact\s*\(/.test(strip(readFileSync(file, "utf8")));
+    });
+
+    // Discovery must actually find the known entry points, or the sweep is
+    // vacuous and would pass on an empty result set.
+    const relative = callers.map((f) => f.slice(REPO_ROOT.length + 1));
+    expect(relative).toContain("packages/api/src/api/routes/admin-brain-facts.ts");
+    expect(relative).toContain("packages/api/src/lib/tools/correct-fact.ts");
+
+    const offenders = callers.filter((file) =>
+      /\blogAdminAction(Await)?\s*\(/.test(strip(readFileSync(file, "utf8"))),
+    );
+    expect(
+      offenders.map((f) => f.slice(REPO_ROOT.length + 1)),
+      "an entry point onto correctFact writes its own admin_action_log row — that is either the #4934 " +
+        "double-log or a second metadata shape for one decision. The row belongs to lib/brain/correction.ts",
+    ).toEqual([]);
+  });
+
+  test("the machinery reaches for the AWAITED audit helper, never the fire-and-forget one", () => {
+    // The regression this exists for: swapping `logAdminActionAwait` back to
+    // `logAdminAction` compiles, passes every outcome test above that only
+    // counts rows in the happy path, and silently drops the row whenever the
+    // internal-DB circuit breaker is open — reproducing #4934 in the one
+    // condition where the forensic trail matters most.
+    const source = strip(readFileSync(MACHINERY, "utf8"));
+    expect(source).toMatch(/\blogAdminActionAwait\s*\(/);
+    expect(source).not.toMatch(/\blogAdminAction\s*\(/);
+    // …and the deadline is on it. An awaited write with no bound is worse than
+    // a fire-and-forget one: it converts a dropped row into a hung chat turn.
+    expect(source).toMatch(/Promise\.race\s*\(/);
+    expect(source).toMatch(/AUDIT_WRITE_TIMEOUT_MS/);
+  });
+});

--- a/packages/api/src/lib/brain/__tests__/correction-audit.test.ts
+++ b/packages/api/src/lib/brain/__tests__/correction-audit.test.ts
@@ -253,6 +253,20 @@ function errOf(call: LogCall | undefined): Error {
   return err;
 }
 
+/**
+ * Poll until `predicate` holds, or throw. Generous cap because the bound is
+ * only there to turn "never happens" into a failure rather than a hang — it is
+ * not the thing being measured, so it costs nothing to make it far larger than
+ * any plausible scheduling delay.
+ */
+async function waitFor(predicate: () => boolean, capMs = 2_000): Promise<void> {
+  const deadline = Date.now() + capMs;
+  while (!predicate()) {
+    if (Date.now() > deadline) throw new Error(`condition did not hold within ${capMs}ms`);
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
 /** `JSON.stringify` that cannot itself throw on a circular ref or a BigInt. */
 function describe_(value: unknown): string {
   try {
@@ -483,10 +497,12 @@ describe("the write is awaited, bounded, and never swallowed", () => {
       { ctx: admin, factId: FACT, verb: "pin", requestId: "req-late" },
       { ...fakeTransaction(), auditWriteTimeoutMs: 10 },
     );
-    // No intermediate count assertion: under an event-loop stall the late
-    // rejection can land before it, which would fail the test for a scheduling
-    // reason rather than a behavioural one. The message content is what matters.
-    await new Promise((resolve) => setTimeout(resolve, 120));
+    // Polled, not slept. A fixed sleep couples the assertion to the scheduler:
+    // under a 4-way-sharded CI runner or a WSL2 stall the second line can land
+    // after the sleep expires, and the test then fails for a timing reason
+    // rather than a behavioural one. There is also no intermediate count
+    // assertion, for the mirror-image reason — the rejection can land EARLY.
+    await waitFor(() => logCalls.filter((c) => c.level === "error").length === 2);
 
     const errors = logCalls.filter((c) => c.level === "error");
     expect(errors).toHaveLength(2);
@@ -593,6 +609,12 @@ describe("the write is awaited, bounded, and never swallowed", () => {
 
       expect(committed, `deadline ${label} dropped the row`).toHaveLength(1);
       expect(logCalls.filter((c) => c.level === "error")).toHaveLength(0);
+      // Falling back SILENTLY would be the CLAUDE.md silent-fallback shape and,
+      // practically, a mis-specified seam that turns into a five-second mystery.
+      // The rejected value has to appear, or the line cannot say what was wrong.
+      const warns = logCalls.filter((c) => c.level === "warn" && c.message.includes("out of range"));
+      expect(warns, `deadline ${label} was substituted silently`).toHaveLength(1);
+      expect(warns[0]?.payload).toMatchObject({ requested: ms, using: 5_000 });
     }
   });
 
@@ -632,6 +654,31 @@ describe("the write is awaited, bounded, and never swallowed", () => {
       { ctx: admin, factId: FACT, verb: "pin", requestId: "req-ok" },
       fakeTransaction(),
     );
+    expect(logCalls.filter((c) => c.level === "warn")).toHaveLength(0);
+  });
+
+  test("the LOCAL OPERATOR is exempt — `actor unknown` is the correct row there", async () => {
+    // `unauthenticated-local` is a deployment that has DECLARED it has no ids to
+    // record; `correctFact`'s authority gate lets it through for exactly that
+    // reason. Warning on it would fire on every correction in a
+    // correctly-configured self-hosted deployment, and a guard that cries wolf
+    // on the happy path is a guard someone deletes.
+    requestContext = undefined;
+    const localOperator = {
+      origin: "unauthenticated-local",
+      workspaceId: WS,
+      userId: null,
+      role: null,
+      audienceIds: [],
+    } as const;
+
+    const outcome = await correctFact(
+      { ctx: localOperator, factId: FACT, verb: "pin", requestId: "req-local" },
+      fakeTransaction(),
+    );
+
+    expect(outcome.kind).toBe("corrected");
+    expect(committed).toHaveLength(1);
     expect(logCalls.filter((c) => c.level === "warn")).toHaveLength(0);
   });
 
@@ -853,8 +900,10 @@ describe("source guard: the machinery is the ONLY audit-writing layer for correc
 
     expect(
       offenders,
-      "a second file reaches for the correction audit vocabulary — that is either the #4934 double-log " +
-        "or a second metadata shape for one decision. The row belongs to lib/brain/correction.ts",
+      "a second file reaches for the correction audit vocabulary. If it WRITES a row, that is the #4934 " +
+        "double-log or a second metadata shape for one decision — the row belongs to " +
+        "lib/brain/correction.ts. If it only READS the vocabulary (an audit-log filter, a console label " +
+        "map), add it to this test's exemption list beside lib/audit/actions.ts. Do not delete the sweep",
     ).toEqual([]);
   });
 

--- a/packages/api/src/lib/brain/__tests__/correction-audit.test.ts
+++ b/packages/api/src/lib/brain/__tests__/correction-audit.test.ts
@@ -19,9 +19,11 @@
  *
  *   - the ROW: emitted exactly once for a `corrected` outcome, with retract's
  *     dedicated action type and the other verbs riding `correct` with the verb
- *     in metadata; NOT emitted for a refusal or a not-found (#4934's recorded
- *     non-goal — `admin_action_log` consumers may read the table as
- *     success-only);
+ *     in metadata; NOT emitted for a refusal or a not-found. That is a SCOPE
+ *     call, not a semantic one (#4934 non-goal) — the table is not success-only
+ *     (`AdminActionEntry.status` takes `"failure"`, and `sso.enforcement_block`
+ *     audits a refusal that way), so auditing refused corrections is legitimate
+ *     and can be added later with its own decision about volume;
  *   - AWAITED, not fire-and-forget. `logAdminAction` posts its insert into the
  *     internal-DB circuit breaker and returns, so an open breaker discards the
  *     row with nothing but a counter — the silent gap #4937 found on the
@@ -62,11 +64,18 @@ const recorder = {
   info: (payload: unknown, message: string) => logCalls.push({ level: "info", payload, message }),
   debug: (payload: unknown, message: string) => logCalls.push({ level: "debug", payload, message }),
 };
+/**
+ * What `getRequestContext()` returns. `undefined` models a caller outside any
+ * request; a context WITHOUT a `user` models the canonical scheduler shape,
+ * which resolves to `actor_id: "unknown"` just as an absent context does.
+ */
+let requestContext: { requestId: string; user?: { id: string } } | undefined;
+
 void mock.module("@atlas/api/lib/logger", () => ({
   createLogger: () => recorder,
   getLogger: () => ({ ...recorder, level: "info" }),
   setLogLevel: () => true,
-  getRequestContext: () => undefined,
+  getRequestContext: () => requestContext,
   ACTOR_KINDS: ["human", "agent", "mcp", "scheduler", "api_key"] as const,
   withRequestContext: <T,>(_ctx: unknown, fn: () => T): T => fn(),
   redactPaths: [] as string[],
@@ -91,20 +100,34 @@ let auditBehaviour: (row: AuditRow) => Promise<void> = async () => {};
 /** How many times anything called the FIRE-AND-FORGET variant — must stay 0. */
 let fireAndForgetCalls = 0;
 /**
- * Makes every read of `ADMIN_ACTIONS` throw, modelling a partial
- * `mock.module("@atlas/api/lib/audit")` somewhere else in the repo (there are
- * a dozen) that omits the export `correction.ts` now needs. That throw happens
- * while BUILDING the audit entry, which is the one way the emitter's
- * never-throws contract can be broken by a change outside it.
+ * Makes every read of `ADMIN_ACTIONS` throw, so the emitter's never-throws
+ * contract is exercised on a SYNCHRONOUS throw raised while BUILDING the audit
+ * entry — before any write is attempted. Moving the entry literal out of the
+ * `try` turns the test that uses this red, which is what it is for.
+ *
+ * NOT a model of a partial `mock.module` (66 files mock
+ * `@atlas/api/lib/audit`): an omitted named export fails at LINK time in bun
+ * with `SyntaxError: Export named 'X' not found`, before any test body runs, so
+ * no `try` could catch it and no correction is in flight to be affected. The
+ * hazard this guards is the general one — any synchronous throw in entry
+ * construction landing on an already-committed correction.
+ *
+ * The trap fires on the FIRST property read (`.brainFact`), which is enough
+ * because `correction.ts` reads the catalog at emit time. A future module-scope
+ * `const { brainFact } = ADMIN_ACTIONS` would move the throw to import time and
+ * turn this into a load failure instead of a contract test.
  */
 let breakAdminActions = false;
 
 // The REAL catalog, not a hand-written copy. A copy would keep this suite green
 // through a rename of `ADMIN_ACTIONS.brainFact.retract` while production emitted
 // a new vocabulary — the exact drift a forensic-trail test exists to catch.
-// `lib/audit/actions.ts` is a constant catalog with zero imports, so a static
-// import here keeps the `mock.module` factory synchronous (an async factory
-// deadlocks bun's loader).
+//
+// Reaching past the mocked `@atlas/api/lib/audit` barrel into its submodule is
+// safe because `lib/audit/actions.ts` is a constant catalog with ZERO imports:
+// it cannot cycle back through the mock or drag a transitive graph in. Static
+// rather than dynamic because an async `mock.module` factory deadlocks bun's
+// loader.
 void mock.module("@atlas/api/lib/audit", () => ({
   ADMIN_ACTIONS: new Proxy(REAL_ADMIN_ACTIONS, {
     get(target, key, receiver: unknown) {
@@ -217,11 +240,28 @@ function fakeTransaction(
  */
 function errOf(call: LogCall | undefined): Error {
   if (call === undefined) throw new Error("expected a log line, got none");
-  const { err } = call.payload as { err?: unknown };
+  // A real narrow, not an assertion: `payload as { err?: unknown }` would throw
+  // `Cannot destructure property 'err' of null` on a null payload — the
+  // confusing failure this helper exists to replace.
+  const err =
+    typeof call.payload === "object" && call.payload !== null && "err" in call.payload
+      ? call.payload.err
+      : undefined;
   if (!(err instanceof Error)) {
-    throw new Error(`log line carried no Error in \`err\`: ${JSON.stringify(call.payload)}`);
+    throw new Error(`log line carried no Error in \`err\`: ${describe_(call.payload)}`);
   }
   return err;
+}
+
+/** `JSON.stringify` that cannot itself throw on a circular ref or a BigInt. */
+function describe_(value: unknown): string {
+  try {
+    return JSON.stringify(value) ?? String(value);
+  } catch {
+    // intentionally ignored: this is a diagnostic for an assertion that is
+    // already failing; a serializer error must not replace the real message.
+    return String(value);
+  }
 }
 
 beforeEach(() => {
@@ -230,6 +270,7 @@ beforeEach(() => {
   attempted.length = 0;
   fireAndForgetCalls = 0;
   breakAdminActions = false;
+  requestContext = { requestId: "req-ctx", user: { id: "admin-1" } };
   auditBehaviour = async () => {};
 });
 
@@ -442,15 +483,24 @@ describe("the write is awaited, bounded, and never swallowed", () => {
       { ctx: admin, factId: FACT, verb: "pin", requestId: "req-late" },
       { ...fakeTransaction(), auditWriteTimeoutMs: 10 },
     );
-    // The deadline line fires first; the cause arrives after.
-    expect(logCalls.filter((c) => c.level === "error")).toHaveLength(1);
-    await new Promise((resolve) => setTimeout(resolve, 80));
+    // No intermediate count assertion: under an event-loop stall the late
+    // rejection can land before it, which would fail the test for a scheduling
+    // reason rather than a behavioural one. The message content is what matters.
+    await new Promise((resolve) => setTimeout(resolve, 120));
 
     const errors = logCalls.filter((c) => c.level === "error");
     expect(errors).toHaveLength(2);
-    const late = errors[1];
-    expect(late?.message).toContain("after its deadline");
+    const late = errors.find((c) => c.message.includes("after its deadline"));
+    expect(late).toBeDefined();
     expect(errOf(late).message).toContain("admin_action_log");
+    // The line that reports DEFINITIVE loss must carry the same reconstruction
+    // fields as the uncertain one — it is the more important of the two.
+    expect(late?.payload).toMatchObject({
+      actorId: "admin-1",
+      verb: "pin",
+      correctionEpisodeId: EPISODE,
+      requestId: "req-late",
+    });
   });
 
   test("a throw while BUILDING the entry cannot escape onto a committed correction", async () => {
@@ -471,42 +521,118 @@ describe("the write is awaited, bounded, and never swallowed", () => {
 
     expect(outcome.kind).toBe("corrected");
     expect(attempted).toHaveLength(0);
-    expect(errOf(logCalls.filter((c) => c.level === "error")[0]).message).toContain(
-      "ADMIN_ACTIONS",
-    );
+
+    const errors = logCalls.filter((c) => c.level === "error");
+    expect(errors).toHaveLength(1);
+    // The recovery instruction has to branch. On this path the writer was never
+    // called, so `logAdminActionAwait`'s pre-insert `admin_action` pino line was
+    // never emitted either — telling an operator to go look for it, or to check
+    // `admin_action_log`, sends them after records that do not exist and invites
+    // a hand-inserted duplicate row.
+    expect(errors[0]?.message).toContain("could not even be BUILT");
+    expect(errors[0]?.message).not.toContain("Check admin_action_log");
+    expect(errors[0]?.payload).toMatchObject({ writeAttempted: false, actorId: "admin-1" });
+    expect(errOf(errors[0]).message).toContain("ADMIN_ACTIONS");
   });
 
-  test("a non-positive deadline falls back to the real bound instead of timing out instantly", async () => {
-    // `??` only catches nullish, so a `0` (or negative, or NaN) seam value would
-    // mean "every audit write times out immediately" — a deadline that drops
-    // every row while looking like a configured one. The invariant the type
-    // cannot express is "a positive number of milliseconds".
-    auditBehaviour = () =>
-      new Promise<void>((resolve) => {
-        setTimeout(resolve, 5);
+  test("a WRITE failure gets the other recovery instruction — the pino line does exist", async () => {
+    // The counterpart to the test above: once `logAdminActionAwait` has been
+    // called its pre-insert pino line exists, and the write may still land, so
+    // the operator is told to check before re-creating anything.
+    auditBehaviour = async () => {
+      const pgish = Object.assign(new Error("relation does not exist"), {
+        code: "42P01",
+        constraint: "pk_admin_action_log",
       });
+      throw pgish;
+    };
 
     await correctFact(
-      { ctx: admin, factId: FACT, verb: "pin", requestId: "req-zero" },
-      { ...fakeTransaction(), auditWriteTimeoutMs: 0 },
-    );
-
-    expect(committed).toHaveLength(1);
-    expect(logCalls.filter((c) => c.level === "error")).toHaveLength(0);
-  });
-
-  test("a write with no request context WARNS — an unattributed row is worse than none", async () => {
-    // `resolveEntry` falls back to the literal `"unknown"` actor with no
-    // complaint, so the module header's "a third entry point inherits the audit
-    // trail" is true of the ROW and not of its attribution. This file's logger
-    // mock returns no context, which is exactly the future-scheduler case.
-    await correctFact(
-      { ctx: admin, factId: FACT, verb: "pin", requestId: "req-noctx" },
+      { ctx: admin, factId: FACT, verb: "pin", requestId: "req-pg" },
       fakeTransaction(),
     );
-    const warns = logCalls.filter((c) => c.level === "warn" && c.message.includes("actor 'unknown'"));
-    expect(warns).toHaveLength(1);
-    expect(warns[0]?.message).toContain("withRequestContext");
+
+    const errors = logCalls.filter((c) => c.level === "error");
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.message).toContain("may not have been committed");
+    // `scrubErrSerializer` rebuilds the error into `{ type, message, stack }`
+    // and DROPS everything else, so a pg rejection's diagnostics only reach an
+    // operator if they are lifted onto the payload as their own fields.
+    expect(errors[0]?.payload).toMatchObject({
+      writeAttempted: true,
+      pgCode: "42P01",
+      pgConstraint: "pk_admin_action_log",
+    });
+  });
+
+  test("an out-of-range deadline falls back to the real bound instead of timing out instantly", async () => {
+    // Both ends, and they fail the SAME way. `??` only catches nullish, so `0`,
+    // a negative or `NaN` would mean "time out immediately". And `Infinity` —
+    // the natural spelling of "no deadline for this test" — is worse than it
+    // looks: `setTimeout` clamps anything past 2^31-1 to ONE millisecond, with
+    // nothing but a `TimeoutOverflowWarning` on stderr. A deadline that silently
+    // drops every audit row while looking configured is the failure this guards.
+    for (const [label, ms] of [
+      ["zero", 0],
+      ["negative", -1],
+      ["NaN", Number.NaN],
+      ["Infinity", Number.POSITIVE_INFINITY],
+      ["past the 32-bit timer ceiling", 3_000_000_000],
+    ] as const) {
+      committed.length = 0;
+      logCalls.length = 0;
+      auditBehaviour = () =>
+        new Promise<void>((resolve) => {
+          setTimeout(resolve, 5);
+        });
+
+      await correctFact(
+        { ctx: admin, factId: FACT, verb: "pin", requestId: `req-${label}` },
+        { ...fakeTransaction(), auditWriteTimeoutMs: ms },
+      );
+
+      expect(committed, `deadline ${label} dropped the row`).toHaveLength(1);
+      expect(logCalls.filter((c) => c.level === "error")).toHaveLength(0);
+    }
+  });
+
+  test("a write with no resolvable ACTOR warns — an unattributed row is worse than none", async () => {
+    // `resolveEntry` falls back to the literal `"unknown"` actor with no
+    // complaint, so the module header's "a third entry point inherits the audit
+    // trail" is true of the ROW and not of its attribution.
+    //
+    // Both shapes, because the second is the one that actually happens: a
+    // scheduler fiber or a background session resume runs inside
+    // `withRequestContext({ requestId })` with NO user, and a guard that only
+    // checked for a missing context would wave it through — producing a row that
+    // exists and lies, which is a worse artifact than the missing row #4934
+    // fixed.
+    for (const ctxShape of [undefined, { requestId: "req-sched" }] as const) {
+      logCalls.length = 0;
+      requestContext = ctxShape;
+      await correctFact(
+        { ctx: admin, factId: FACT, verb: "pin", requestId: "req-noactor" },
+        fakeTransaction(),
+      );
+      const warns = logCalls.filter(
+        (c) => c.level === "warn" && c.message.includes("actor 'unknown'"),
+      );
+      expect(warns, `no warning for context ${JSON.stringify(ctxShape)}`).toHaveLength(1);
+      expect(warns[0]?.message).toContain("withRequestContext");
+      // The warn is a finding an operator has to act on, so it carries the same
+      // reconstruction fields as the failure lines.
+      expect(warns[0]?.payload).toMatchObject({ actorId: "admin-1", factId: FACT, verb: "pin" });
+    }
+  });
+
+  test("a resolvable actor produces NO warning — the guard is not always-on noise", async () => {
+    // Without this the warn test above passes on a guard that fires
+    // unconditionally, which would be alert fatigue on every single correction.
+    await correctFact(
+      { ctx: admin, factId: FACT, verb: "pin", requestId: "req-ok" },
+      fakeTransaction(),
+    );
+    expect(logCalls.filter((c) => c.level === "warn")).toHaveLength(0);
   });
 
   test("a prompt write CLEARS its deadline timer instead of leaving it armed", async () => {
@@ -567,13 +693,25 @@ describe("the write is awaited, bounded, and never swallowed", () => {
 const ROOTS = [
   "packages/api/src",
   "packages/mcp/src",
+  // The CLI's TypeScript is split across three trees and ten-plus files under
+  // `lib`/`bin` import `@atlas/api/lib` — walking only `src` would have left
+  // the criterion above claiming coverage it did not have.
   "packages/cli/src",
+  "packages/cli/lib",
+  "packages/cli/bin",
   "ee",
   "plugins",
 ];
 
 /** `packages/api/src/lib/brain/__tests__` → repo root: six levels up. */
 const REPO_ROOT = join(import.meta.dir, "../../../../../..");
+
+/**
+ * Held in a constant so THIS file's own path — which contains the segment —
+ * cannot be rewritten by a careless find-and-replace over the literal, and so
+ * the exclusion reads as a rule rather than a magic string.
+ */
+const TEST_DIR = "__tests__";
 
 function walk(dir: string, out: string[]): void {
   // Deliberately UNGUARDED. A swallowed `readdirSync` — EACCES, ELOOP, a
@@ -593,7 +731,7 @@ function walk(dir: string, out: string[]): void {
     if (!entry.endsWith(".ts") && !entry.endsWith(".tsx")) continue;
     // Tests routinely stub both sides; they are not entry points.
     if (entry.includes(".test.")) continue;
-    if (full.includes(`${"__tests__"}/`)) continue;
+    if (full.includes(`${TEST_DIR}/`)) continue;
     out.push(full);
   }
 }
@@ -601,11 +739,12 @@ function walk(dir: string, out: string[]): void {
 /**
  * Comments and string literals stripped.
  *
- * Both halves are load-bearing, and each has a real in-tree case:
- * `packages/api/src/lib/brain/candidates.ts` names `correctFact({ verb: … })`
- * inside a doc comment, so without comment-stripping the sweep enrols a phantom
- * caller; and a log message naming its own helper is an ordinary thing to write,
- * so without string-stripping a `"...logAdminAction..."` literal reads as a call.
+ * The comment half has a real in-tree case: `lib/brain/candidates.ts` names
+ * `correctFact({ verb: … })` in a `//` line comment, so without it the sweep
+ * enrols a phantom caller. The string half is prophylactic — nothing in-tree
+ * exercises it today, but an `ADMIN_ACTIONS.brainFact` mention inside a log
+ * message is an ordinary thing to write and would read as a reach for the
+ * vocabulary.
  *
  * Strings go first so a `//` inside a URL cannot eat the rest of its line. That
  * ordering has a cost the {@link STRIP_ALLOWLIST} canary exists to pay: a lone
@@ -671,38 +810,51 @@ describe("source guard: the machinery is the ONLY audit-writing layer for correc
     ).toEqual([]);
   });
 
-  test("no caller of correctFact writes a CORRECTION audit row of its own", () => {
+  test("correctFact's DIRECT callers are discovered, and the known two are among them", () => {
     const files: string[] = [];
     for (const root of ROOTS) walk(join(REPO_ROOT, root), files);
 
-    const callers = files.filter((file) => {
-      if (file === MACHINERY) return false;
-      return CALLS_CORRECT_FACT.test(strip(readFileSync(file, "utf8")));
-    });
+    const callers = files
+      .filter((file) => file !== MACHINERY)
+      .filter((file) => CALLS_CORRECT_FACT.test(strip(readFileSync(file, "utf8"))))
+      .map((f) => f.slice(REPO_ROOT.length + 1));
 
     // Discovery must actually find the known entry points, or the sweep is
     // vacuous and would pass on an empty result set.
-    const relative = callers.map((f) => f.slice(REPO_ROOT.length + 1));
-    expect(relative).toContain("packages/api/src/api/routes/admin-brain-facts.ts");
-    expect(relative).toContain("packages/api/src/lib/tools/correct-fact.ts");
+    expect(callers).toContain("packages/api/src/api/routes/admin-brain-facts.ts");
+    expect(callers).toContain("packages/api/src/lib/tools/correct-fact.ts");
+  });
 
-    // Scoped to the brainFact vocabulary rather than any `logAdminAction(`:
-    // `admin-brain-facts.ts` may legitimately grow an unrelated admin action
-    // one day, and a guard that fails on it — with a message about
-    // double-logging — teaches the next author to weaken the test.
+  test("lib/brain/correction.ts is the ONLY file that reaches for the correction vocabulary", () => {
+    // Swept over EVERY walked file, not just `correctFact`'s callers. The
+    // header's promise is "two entry points cannot drift into two metadata
+    // shapes", and a bulk-import path or a migration backfill that emitted
+    // `ADMIN_ACTIONS.brainFact.correct` WITHOUT calling `correctFact` produces
+    // exactly that second shape while never appearing in the caller set.
     //
-    // The CATALOG reference, not the string value, and that is not a weaker
+    // The CATALOG reference, not the string value, and that is not the weaker
     // check: `AdminActionType` is the union of `ADMIN_ACTIONS`' values, so a
-    // hand-written `"brain_fact.correct"` does not type-check. Matching the
-    // identifier also survives `strip`, which removes string literals.
-    const offenders = callers.filter((file) =>
-      /\bADMIN_ACTIONS\.brainFact\b/.test(strip(readFileSync(file, "utf8"))),
-    );
+    // hand-written `"brain_fact.correct"` does not type-check.
+    //
+    // On RAW source, deliberately. `strip` exists to stop prose enrolling a
+    // phantom caller, but here the cost/benefit inverts: over-stripping (the
+    // unbalanced-backtick defeat the canary above documents) would hide a real
+    // second emitter, while a comment merely MENTIONING the vocabulary is a
+    // fair thing to have to explain. There are none today.
+    const files: string[] = [];
+    for (const root of ROOTS) walk(join(REPO_ROOT, root), files);
+
+    const offenders = files
+      .filter((file) => file !== MACHINERY)
+      .filter((file) => /\bADMIN_ACTIONS\.brainFact\b/.test(readFileSync(file, "utf8")))
+      .map((f) => f.slice(REPO_ROOT.length + 1))
+      // The catalog defines the vocabulary; it is not an emitter.
+      .filter((f) => f !== "packages/api/src/lib/audit/actions.ts");
+
     expect(
-      offenders.map((f) => f.slice(REPO_ROOT.length + 1)),
-      "an entry point onto correctFact reaches for the correction audit vocabulary — that is either the " +
-        "#4934 double-log or a second metadata shape for one decision. The row belongs to " +
-        "lib/brain/correction.ts",
+      offenders,
+      "a second file reaches for the correction audit vocabulary — that is either the #4934 double-log " +
+        "or a second metadata shape for one decision. The row belongs to lib/brain/correction.ts",
     ).toEqual([]);
   });
 

--- a/packages/api/src/lib/brain/__tests__/correction-audit.test.ts
+++ b/packages/api/src/lib/brain/__tests__/correction-audit.test.ts
@@ -33,16 +33,25 @@
  *     bypasses the breaker on purpose, and the internal pool sets no statement
  *     timeout — so an awaited-but-unbounded write lets a degraded internal DB
  *     hold a chat turn open indefinitely;
- *   - and a SOURCE-LEVEL guard that discovers every `correctFact` caller and
- *     pins that none of them writes an audit row of its own. That is the half
- *     that makes "a third entry point cannot land uncovered" true by
+ *   - and a SOURCE-LEVEL guard that discovers every DIRECT `correctFact(` call
+ *     site and pins that none of them writes an audit row of its own. That is
+ *     the half that makes "a third entry point cannot land uncovered" true by
  *     construction rather than by review diligence — the failure mode #4934
- *     was, at one entry point, exactly this.
+ *     was, at one entry point, exactly this. Its reach is direct call sites in
+ *     five roots: an aliased import (`const fn = correctFact`), a re-export, or
+ *     a thin wrapper module is invisible to it. Broaden the regexes if one
+ *     appears; do not delete the guard.
+ *
+ * The RESOLVED row — `actor_id`, `actor_email`, `org_id`, `request_id`, which
+ * `resolveEntry` derives from the request context this file stubs away — and
+ * `supersede`'s metadata live in `correction-audit-pg.test.ts`, against live
+ * Postgres. Neither is knowable through a mocked `lib/audit`.
  */
 
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { beforeEach, describe, expect, test, mock } from "bun:test";
+import { ADMIN_ACTIONS as REAL_ADMIN_ACTIONS } from "@atlas/api/lib/audit/actions";
 
 // --- logger: every VALUE export stubbed (mock-all-exports) -----------------
 type LogCall = { level: "error" | "warn" | "info" | "debug"; payload: unknown; message: string };
@@ -79,13 +88,30 @@ const committed: AuditRow[] = [];
 const attempted: AuditRow[] = [];
 /** Swap to make the awaited write hang or reject. Default: commits promptly. */
 let auditBehaviour: (row: AuditRow) => Promise<void> = async () => {};
-/** Set if anything calls the FIRE-AND-FORGET variant — nothing here may. */
+/** How many times anything called the FIRE-AND-FORGET variant — must stay 0. */
 let fireAndForgetCalls = 0;
+/**
+ * Makes every read of `ADMIN_ACTIONS` throw, modelling a partial
+ * `mock.module("@atlas/api/lib/audit")` somewhere else in the repo (there are
+ * a dozen) that omits the export `correction.ts` now needs. That throw happens
+ * while BUILDING the audit entry, which is the one way the emitter's
+ * never-throws contract can be broken by a change outside it.
+ */
+let breakAdminActions = false;
 
+// The REAL catalog, not a hand-written copy. A copy would keep this suite green
+// through a rename of `ADMIN_ACTIONS.brainFact.retract` while production emitted
+// a new vocabulary — the exact drift a forensic-trail test exists to catch.
+// `lib/audit/actions.ts` is a constant catalog with zero imports, so a static
+// import here keeps the `mock.module` factory synchronous (an async factory
+// deadlocks bun's loader).
 void mock.module("@atlas/api/lib/audit", () => ({
-  ADMIN_ACTIONS: {
-    brainFact: { retract: "brain_fact.retract", correct: "brain_fact.correct" },
-  },
+  ADMIN_ACTIONS: new Proxy(REAL_ADMIN_ACTIONS, {
+    get(target, key, receiver: unknown) {
+      if (breakAdminActions) throw new TypeError("partial mock: ADMIN_ACTIONS is not defined");
+      return Reflect.get(target, key, receiver) as unknown;
+    },
+  }),
   logAdminAction: () => {
     fireAndForgetCalls += 1;
   },
@@ -126,10 +152,15 @@ const admin = {
 /**
  * The narrowest store the two audited verbs need: a statement dispatcher, the
  * same identity-not-paraphrase idea as `correction.test.ts`'s fake, trimmed to
- * `retract` and the vouch verbs. `supersede` runs the whole reconcile path and
- * is pinned there; its audit row rides the SAME expression as `pin`'s (every
- * non-retract verb maps to `brain_fact.correct`), so what is left untested here
- * is reconcile, not the audit mapping.
+ * `retract` and the vouch verbs.
+ *
+ * `supersede` is deliberately NOT here — it runs the whole reconcile path, and
+ * faking that would be a second, drifting copy of `correction.test.ts`'s store.
+ * Its `actionType` rides the same expression as `pin`'s, but its
+ * `supersededBy` / `validTo` metadata are conditional spreads no other verb can
+ * produce, so "same expression" does NOT cover them. They are pinned in
+ * `correction-audit-pg.test.ts`, against the live schema, where reconcile runs
+ * for real.
  */
 function fakeTransaction(
   options: { dependents?: readonly string[]; warehouseDerived?: boolean } = {},
@@ -179,11 +210,26 @@ function fakeTransaction(
   } satisfies CorrectionDeps;
 }
 
+/**
+ * The `err` field off a recorded log line, as an `Error`. A named throw rather
+ * than `call?.payload?.err`, which would compare `undefined` to `undefined` and
+ * pass on a line that never fired.
+ */
+function errOf(call: LogCall | undefined): Error {
+  if (call === undefined) throw new Error("expected a log line, got none");
+  const { err } = call.payload as { err?: unknown };
+  if (!(err instanceof Error)) {
+    throw new Error(`log line carried no Error in \`err\`: ${JSON.stringify(call.payload)}`);
+  }
+  return err;
+}
+
 beforeEach(() => {
   logCalls.length = 0;
   committed.length = 0;
   attempted.length = 0;
   fireAndForgetCalls = 0;
+  breakAdminActions = false;
   auditBehaviour = async () => {};
 });
 
@@ -303,13 +349,12 @@ describe("the write is awaited, bounded, and never swallowed", () => {
     // `await`. A fire-and-forget write still records an ATTEMPT synchronously,
     // so asserting on `attempted` would pass either way — only the settled
     // `committed` list can tell the difference.
-    let release: (() => void) | undefined;
     auditBehaviour = () =>
+      // A macrotask, not a microtask: an `await`-less caller drains the
+      // microtask queue before returning, so a resolved-on-a-tick write would
+      // land in `committed` either way and the assertion would be vacuous.
       new Promise<void>((resolve) => {
-        release = resolve;
-        // Resolve on a later microtask+macrotask so a non-awaiting caller
-        // returns first and the assertion below sees an empty list.
-        setTimeout(() => resolve(), 5);
+        setTimeout(resolve, 5);
       });
 
     const outcome = await correctFact(
@@ -319,7 +364,6 @@ describe("the write is awaited, bounded, and never swallowed", () => {
 
     expect(outcome.kind).toBe("corrected");
     expect(committed).toHaveLength(1);
-    release?.();
   });
 
   test("a FAILED write is logged at ERROR — never swallowed — and the correction still stands", async () => {
@@ -340,21 +384,30 @@ describe("the write is awaited, bounded, and never swallowed", () => {
     const errors = logCalls.filter((c) => c.level === "error");
     expect(errors).toHaveLength(1);
     const [failure] = errors;
-    // The underlying cause must reach the line — an `err`-less "audit failed"
-    // is not actionable, and CLAUDE.md requires the caught error be narrowed
-    // and logged rather than dropped.
+    // Everything needed to reconstruct the lost row BY HAND has to be on the
+    // line that says it is gone — the row was the actor-attributed record, so
+    // `actorId` in particular is not decoration.
     expect(failure?.payload).toMatchObject({
       workspaceId: WS,
+      actorId: "admin-1",
       factId: FACT,
       verb: "retract",
       correctionEpisodeId: EPISODE,
       requestId: "req-7",
-      err: "internal DB circuit breaker is open",
     });
+    // The Error OBJECT, not `err.message`: pino's `scrubErrSerializer` then
+    // captures the stack and, for a pg rejection, `code`/`detail`/`constraint`.
+    // An `err`-less "audit failed" is not actionable at all — `errOf` throws
+    // rather than letting a missing field pass as a match.
+    expect(errOf(failure).message).toBe("internal DB circuit breaker is open");
     // The message is a recovery instruction: it must name what SURVIVES, or an
     // operator reads it as "the correction was lost".
     expect(failure?.message).toContain("brain_episodes");
     expect(failure?.message).toContain("admin_action");
+    // …and it must NOT claim the row is definitely gone. A deadline does not
+    // cancel an insert, so an operator told "not committed" may hand-insert a
+    // duplicate forensic row.
+    expect(failure?.message).toContain("may not have been committed");
   });
 
   test("a HUNG write is bounded — a degraded internal DB cannot hold the turn open", async () => {
@@ -372,7 +425,88 @@ describe("the write is awaited, bounded, and never swallowed", () => {
     expect(committed).toHaveLength(0);
     const errors = logCalls.filter((c) => c.level === "error");
     expect(errors).toHaveLength(1);
-    expect((errors[0]?.payload as { err?: string } | undefined)?.err).toContain("timed out");
+    expect(errOf(errors[0]).message).toContain("timed out");
+  });
+
+  test("a write that FAILS after the deadline still surfaces its real cause", async () => {
+    // `Promise.race` discards the losing branch's outcome, so without a
+    // continuation the pg error explaining a slow write is dropped and the only
+    // line an operator ever sees is "timed out" — which names the symptom and
+    // never the cause.
+    auditBehaviour = () =>
+      new Promise<void>((_, reject) => {
+        setTimeout(() => reject(new Error('relation "admin_action_log" does not exist')), 40);
+      });
+
+    await correctFact(
+      { ctx: admin, factId: FACT, verb: "pin", requestId: "req-late" },
+      { ...fakeTransaction(), auditWriteTimeoutMs: 10 },
+    );
+    // The deadline line fires first; the cause arrives after.
+    expect(logCalls.filter((c) => c.level === "error")).toHaveLength(1);
+    await new Promise((resolve) => setTimeout(resolve, 80));
+
+    const errors = logCalls.filter((c) => c.level === "error");
+    expect(errors).toHaveLength(2);
+    const late = errors[1];
+    expect(late?.message).toContain("after its deadline");
+    expect(errOf(late).message).toContain("admin_action_log");
+  });
+
+  test("a throw while BUILDING the entry cannot escape onto a committed correction", async () => {
+    // The never-throws contract has to be structural, not a comment, because a
+    // leak lands on an ALREADY-COMMITTED correction and reaches a caller whose
+    // error copy says "nothing was changed — retry"
+    // (`lib/tools/correct-fact.ts`), which mints a second correction episode
+    // for one human decision. The realistic trigger is not the audit write at
+    // all: it is a partial `mock.module` elsewhere leaving `ADMIN_ACTIONS`
+    // undefined, i.e. a throw BEFORE the write is even attempted — so the entry
+    // literal has to be inside the try, not just the `await`.
+    breakAdminActions = true;
+
+    const outcome = await correctFact(
+      { ctx: admin, factId: FACT, verb: "retract", requestId: "req-break" },
+      fakeTransaction(),
+    );
+
+    expect(outcome.kind).toBe("corrected");
+    expect(attempted).toHaveLength(0);
+    expect(errOf(logCalls.filter((c) => c.level === "error")[0]).message).toContain(
+      "ADMIN_ACTIONS",
+    );
+  });
+
+  test("a non-positive deadline falls back to the real bound instead of timing out instantly", async () => {
+    // `??` only catches nullish, so a `0` (or negative, or NaN) seam value would
+    // mean "every audit write times out immediately" — a deadline that drops
+    // every row while looking like a configured one. The invariant the type
+    // cannot express is "a positive number of milliseconds".
+    auditBehaviour = () =>
+      new Promise<void>((resolve) => {
+        setTimeout(resolve, 5);
+      });
+
+    await correctFact(
+      { ctx: admin, factId: FACT, verb: "pin", requestId: "req-zero" },
+      { ...fakeTransaction(), auditWriteTimeoutMs: 0 },
+    );
+
+    expect(committed).toHaveLength(1);
+    expect(logCalls.filter((c) => c.level === "error")).toHaveLength(0);
+  });
+
+  test("a write with no request context WARNS — an unattributed row is worse than none", async () => {
+    // `resolveEntry` falls back to the literal `"unknown"` actor with no
+    // complaint, so the module header's "a third entry point inherits the audit
+    // trail" is true of the ROW and not of its attribution. This file's logger
+    // mock returns no context, which is exactly the future-scheduler case.
+    await correctFact(
+      { ctx: admin, factId: FACT, verb: "pin", requestId: "req-noctx" },
+      fakeTransaction(),
+    );
+    const warns = logCalls.filter((c) => c.level === "warn" && c.message.includes("actor 'unknown'"));
+    expect(warns).toHaveLength(1);
+    expect(warns[0]?.message).toContain("withRequestContext");
   });
 
   test("a prompt write CLEARS its deadline timer instead of leaving it armed", async () => {
@@ -442,14 +576,12 @@ const ROOTS = [
 const REPO_ROOT = join(import.meta.dir, "../../../../../..");
 
 function walk(dir: string, out: string[]): void {
-  let entries: string[];
-  try {
-    entries = readdirSync(dir);
-  } catch {
-    // A root that vanished is a shrunken guard, not a pass — the ROOTS
-    // assertion below turns this into a failure rather than silence.
-    return;
-  }
+  // Deliberately UNGUARDED. A swallowed `readdirSync` — EACCES, ELOOP, a
+  // directory removed mid-walk — silently shrinks the swept surface while the
+  // suite stays green, which is the same failure shape as the bug being
+  // guarded. The ROOTS assertion only covers the five top-level roots, so it is
+  // no substitute; letting a subdirectory failure throw is.
+  const entries: string[] = readdirSync(dir);
   for (const entry of entries) {
     if (entry === "node_modules" || entry === "dist" || entry === ".next") continue;
     const full = join(dir, entry);
@@ -467,10 +599,21 @@ function walk(dir: string, out: string[]): void {
 }
 
 /**
- * Comments and string literals stripped, strings FIRST so a `//` inside a URL
- * cannot eat the rest of its line. Both matter here: this file's own prose
- * names `logAdminAction` repeatedly, and a log message naming its own helper is
- * an ordinary thing to write.
+ * Comments and string literals stripped.
+ *
+ * Both halves are load-bearing, and each has a real in-tree case:
+ * `packages/api/src/lib/brain/candidates.ts` names `correctFact({ verb: … })`
+ * inside a doc comment, so without comment-stripping the sweep enrols a phantom
+ * caller; and a log message naming its own helper is an ordinary thing to write,
+ * so without string-stripping a `"...logAdminAction..."` literal reads as a call.
+ *
+ * Strings go first so a `//` inside a URL cannot eat the rest of its line. That
+ * ordering has a cost the {@link STRIP_ALLOWLIST} canary exists to pay: a lone
+ * backtick makes the template-literal regex pair with the NEXT backtick in the
+ * file and blank everything between, across lines. Over-stripping is the
+ * dangerous direction — it produces a silent false NEGATIVE, exactly the bug
+ * being guarded — so the canary compares raw discovery against stripped
+ * discovery and fails on any delta it does not expect.
  */
 function strip(source: string): string {
   return source
@@ -480,6 +623,16 @@ function strip(source: string): string {
     .replace(/\/\*[\s\S]*?\*\//g, " ")
     .replace(/\/\/[^\n]*/g, " ");
 }
+
+const CALLS_CORRECT_FACT = /\bcorrectFact\s*\(/;
+
+/**
+ * Files whose RAW source names `correctFact(` but whose stripped source does
+ * not — i.e. the mentions `strip` is supposed to remove. Every entry is a
+ * documented non-caller; anything else appearing in the delta means `strip`
+ * has started eating code, and the sweep has quietly stopped guarding.
+ */
+const STRIP_ALLOWLIST = new Set(["packages/api/src/lib/brain/candidates.ts"]);
 
 describe("source guard: the machinery is the ONLY audit-writing layer for corrections", () => {
   const MACHINERY = join(REPO_ROOT, "packages/api/src/lib/brain/correction.ts");
@@ -491,13 +644,40 @@ describe("source guard: the machinery is the ONLY audit-writing layer for correc
     }
   });
 
-  test("no caller of correctFact writes an audit row of its own", () => {
+  test("`strip` removes prose, not code — the discovery delta is the allowlist", () => {
+    // The defeat this catches, reproduced before it was written: one unbalanced
+    // backtick anywhere in a file makes the `/gs` template regex pair with the
+    // next backtick in the FILE and blank everything between. 13 of the ~1000
+    // walked files already have an odd backtick count. A third entry point
+    // landing inside such a region would call `correctFact` AND
+    // `logAdminAction` and be invisible to the sweep below — a silent false
+    // negative, which is the failure mode the sweep exists to prevent.
+    const files: string[] = [];
+    for (const root of ROOTS) walk(join(REPO_ROOT, root), files);
+
+    const delta = files
+      .filter((file) => {
+        const source = readFileSync(file, "utf8");
+        return CALLS_CORRECT_FACT.test(source) && !CALLS_CORRECT_FACT.test(strip(source));
+      })
+      .map((f) => f.slice(REPO_ROOT.length + 1))
+      .filter((f) => !STRIP_ALLOWLIST.has(f));
+
+    expect(
+      delta,
+      "`strip` removed a real `correctFact(` call site. Either the file has an unbalanced backtick and " +
+        "the template-literal regex ate code, or the mention is a new documented non-caller that belongs " +
+        "in STRIP_ALLOWLIST. Do NOT widen the allowlist without reading the file",
+    ).toEqual([]);
+  });
+
+  test("no caller of correctFact writes a CORRECTION audit row of its own", () => {
     const files: string[] = [];
     for (const root of ROOTS) walk(join(REPO_ROOT, root), files);
 
     const callers = files.filter((file) => {
       if (file === MACHINERY) return false;
-      return /\bcorrectFact\s*\(/.test(strip(readFileSync(file, "utf8")));
+      return CALLS_CORRECT_FACT.test(strip(readFileSync(file, "utf8")));
     });
 
     // Discovery must actually find the known entry points, or the sweep is
@@ -506,13 +686,23 @@ describe("source guard: the machinery is the ONLY audit-writing layer for correc
     expect(relative).toContain("packages/api/src/api/routes/admin-brain-facts.ts");
     expect(relative).toContain("packages/api/src/lib/tools/correct-fact.ts");
 
+    // Scoped to the brainFact vocabulary rather than any `logAdminAction(`:
+    // `admin-brain-facts.ts` may legitimately grow an unrelated admin action
+    // one day, and a guard that fails on it — with a message about
+    // double-logging — teaches the next author to weaken the test.
+    //
+    // The CATALOG reference, not the string value, and that is not a weaker
+    // check: `AdminActionType` is the union of `ADMIN_ACTIONS`' values, so a
+    // hand-written `"brain_fact.correct"` does not type-check. Matching the
+    // identifier also survives `strip`, which removes string literals.
     const offenders = callers.filter((file) =>
-      /\blogAdminAction(Await)?\s*\(/.test(strip(readFileSync(file, "utf8"))),
+      /\bADMIN_ACTIONS\.brainFact\b/.test(strip(readFileSync(file, "utf8"))),
     );
     expect(
       offenders.map((f) => f.slice(REPO_ROOT.length + 1)),
-      "an entry point onto correctFact writes its own admin_action_log row — that is either the #4934 " +
-        "double-log or a second metadata shape for one decision. The row belongs to lib/brain/correction.ts",
+      "an entry point onto correctFact reaches for the correction audit vocabulary — that is either the " +
+        "#4934 double-log or a second metadata shape for one decision. The row belongs to " +
+        "lib/brain/correction.ts",
     ).toEqual([]);
   });
 

--- a/packages/api/src/lib/brain/correction.ts
+++ b/packages/api/src/lib/brain/correction.ts
@@ -724,7 +724,16 @@ const MAX_TIMER_MS = 2_147_483_647;
  * {@link MAX_TIMER_MS} would all pass through and mean "time out immediately".
  */
 function resolveAuditDeadline(ms: number | undefined): number {
-  if (ms === undefined || !Number.isFinite(ms) || ms <= 0 || ms > MAX_TIMER_MS) {
+  if (ms === undefined) return AUDIT_WRITE_TIMEOUT_MS;
+  if (!Number.isFinite(ms) || ms <= 0 || ms > MAX_TIMER_MS) {
+    // Named, not silently substituted. A mis-specified seam that quietly became
+    // 5s is exactly the kind of silent fallback that turns a wrong test into a
+    // five-second mystery.
+    log.warn(
+      { requested: ms, using: AUDIT_WRITE_TIMEOUT_MS, max: MAX_TIMER_MS },
+      "brain correction: auditWriteTimeoutMs is out of range (must be finite, positive, and within the " +
+        "32-bit timer ceiling) — falling back to the default audit deadline",
+    );
     return AUDIT_WRITE_TIMEOUT_MS;
   }
   return ms;
@@ -758,12 +767,14 @@ function resolveAuditDeadline(ms: number | undefined): number {
  * pino line exists either and the correction episode in `brain_episodes` is the
  * sole surviving record.
  *
- * NEVER THROWS, and the whole body is inside the `try` rather than just the
- * `await`, so a synchronous throw anywhere in the entry construction is
- * contained instead of landing on an already-committed correction and reaching
- * a caller whose error copy says "nothing was changed — retry". (The residual:
- * the `catch`'s own `log.error` is outside that guarantee. A logger broken
- * badly enough to throw is not a failure mode this module can absorb.)
+ * NEVER THROWS: the entry construction is inside the `try` rather than just the
+ * `await`, so a synchronous throw there is contained instead of landing on an
+ * already-committed correction and reaching a caller whose error copy says
+ * "nothing was changed — retry". Two residuals, both deliberate: the `lost`
+ * payload is assembled before the `try` because the `catch` reads it (it only
+ * copies fields that are non-optional on `BrainFactCorrectionResponse`), and the
+ * `catch`'s own `log.error` is outside the guarantee — a logger broken badly
+ * enough to throw is not a failure mode this module can absorb.
  */
 async function emitCorrectionAudit(args: {
   readonly ctx: BrainPrincipalContext;
@@ -836,7 +847,12 @@ async function emitCorrectionAudit(args: {
     // as a missing context does. Both entry points today supply a user, so this
     // never fires; a future one that does not would produce a row that exists
     // and lies, which is a worse artifact than the missing row #4934 fixed.
-    if (getRequestContext()?.user?.id === undefined) {
+    // The `unauthenticated-local` arm is exempt: that deployment has DECLARED
+    // it has no ids to record (see the authority gate at the top of
+    // `correctFact`), so `actor 'unknown'` is the correct row there, not a
+    // finding. Warning on it would fire on every correction in a
+    // correctly-configured deployment, which is how a guard gets deleted.
+    if (ctx.origin !== "unauthenticated-local" && getRequestContext()?.user?.id === undefined) {
       log.warn(
         { ...lost },
         "brain correction: no actor in the request context at audit time — the admin_action_log row will " +

--- a/packages/api/src/lib/brain/correction.ts
+++ b/packages/api/src/lib/brain/correction.ts
@@ -114,11 +114,11 @@
  * THIRD entry point inherits the audit trail instead of having to remember it,
  * and two entry points cannot drift into two metadata shapes (they already had:
  * `/retract` logged `flaggedForReReview` unconditionally, `/correct` only when
- * non-empty). `lib/brain/extract.ts`, `scheduler/byot-catalog-refresh.ts` and
- * `scheduler/openapi-install-rediscover.ts` are the only other places in this
- * subsystem that emit from BELOW the route layer, so `lib/` writing this table
- * is established — though they are unattended loops labelling themselves with
- * `systemActor`, which is a different argument from this one.
+ * non-empty). `lib/` writing this table is thoroughly established —
+ * `auth/middleware.ts`, `auth/invitations.ts`, `rate-limit/middleware.ts`,
+ * `lib/brain/extract.ts` and two schedulers all do it — though the schedulers'
+ * case is unattended loops labelling themselves with `systemActor`, which is a
+ * different argument from this one.
  * `resolveEntry` reads actor, org and requestId off the AsyncLocalStorage
  * request context, which both entry points run inside, so attribution needs no
  * plumbing from either — and {@link emitCorrectionAudit} warns loudly if a
@@ -248,7 +248,12 @@ export interface CorrectionDeps {
    * Test seam for {@link AUDIT_WRITE_TIMEOUT_MS}. Exists so the deadline on the
    * post-commit audit write is provable in milliseconds instead of seconds —
    * without it the only way to pin "a hung internal DB cannot hold a chat turn
-   * open" is a 5-second test, which is longer than the default test timeout.
+   * open" is a 5-second test, which sits exactly on bun's default per-test
+   * timeout.
+   *
+   * A positive, finite number of milliseconds no greater than 2_147_483_647.
+   * Anything else falls back to the real bound — see `resolveAuditDeadline`,
+   * which is where that is enforced, because the type cannot say it.
    */
   readonly auditWriteTimeoutMs?: number;
 }
@@ -679,13 +684,7 @@ export async function correctFact(
     ctx,
     result,
     requestId,
-    // `??` only catches nullish, so a `0` or negative seam value would mean
-    // "every audit write times out immediately". The invariant is a positive
-    // number of milliseconds, and this is where it is enforced.
-    timeoutMs:
-      deps.auditWriteTimeoutMs !== undefined && deps.auditWriteTimeoutMs > 0
-        ? deps.auditWriteTimeoutMs
-        : AUDIT_WRITE_TIMEOUT_MS,
+    timeoutMs: resolveAuditDeadline(deps.auditWriteTimeoutMs),
   });
   return { kind: "corrected", result };
 }
@@ -702,12 +701,34 @@ export async function correctFact(
  * Not yet shared with those two hand-rolled copies on purpose: consolidating
  * would mean editing `auth/middleware.ts`'s fail-closed 500 path, which is a
  * security-surface change that does not belong in a brain-audit fix. One thing
- * for whoever does consolidate: this copy CLEARS its deadline in a `finally`
- * and neither precedent does (`grep -n clearTimeout` finds nothing in either),
- * so they leave a timer armed for the full bound on every fast path. This is
- * the side to keep.
+ * for whoever does consolidate: as of #4934 this copy CLEARS its deadline in a
+ * `finally` and neither precedent does, so they leave a timer armed for the full
+ * bound on every fast path. This is the side to keep.
  */
 const AUDIT_WRITE_TIMEOUT_MS = 5_000;
+
+/**
+ * `setTimeout`'s 32-bit ceiling. Above it the delay is CLAMPED TO 1ms, with
+ * nothing but a `TimeoutOverflowWarning` on stderr — so `Infinity`, the natural
+ * spelling of "no deadline for this test", would silently make every audit
+ * write time out instantly. That is the same failure the lower bound guards,
+ * entered from the other end.
+ */
+const MAX_TIMER_MS = 2_147_483_647;
+
+/**
+ * The deadline actually used, normalized here rather than at the read site so
+ * the invariant lives beside the constant that expresses it: a POSITIVE, FINITE
+ * number of milliseconds that a timer can represent. `??` alone would not do —
+ * it only catches nullish, so `0`, a negative, `NaN` and anything past
+ * {@link MAX_TIMER_MS} would all pass through and mean "time out immediately".
+ */
+function resolveAuditDeadline(ms: number | undefined): number {
+  if (ms === undefined || !Number.isFinite(ms) || ms <= 0 || ms > MAX_TIMER_MS) {
+    return AUDIT_WRITE_TIMEOUT_MS;
+  }
+  return ms;
+}
 
 /**
  * The forensic `admin_action_log` row for a correction that already committed.
@@ -729,17 +750,20 @@ const AUDIT_WRITE_TIMEOUT_MS = 5_000;
  * mints a SECOND correction episode for one human decision.
  *
  * The message names what actually survives, so the line is a usable recovery
- * instruction rather than an alarm: the correction episode in `brain_episodes`
- * (immutable, actor-attributed, in the same transaction as the effect) and the
- * `admin_action` pino line, which `logAdminActionAwait` emits BEFORE the insert
- * and therefore emits even on this path. What is lost is only the queryable
- * row.
+ * instruction rather than an alarm — and it names DIFFERENT things depending on
+ * how far the emitter got, which is what `writeAttempted` is for. Once
+ * `logAdminActionAwait` has been called the actor-attributed `admin_action`
+ * pino line exists (it emits BEFORE the insert), so only the queryable row is
+ * at risk; a throw while BUILDING the entry never reached the writer, so no
+ * pino line exists either and the correction episode in `brain_episodes` is the
+ * sole surviving record.
  *
- * NEVER THROWS, and the whole body is inside the `try` so that is structural
- * rather than a promise — a partial `mock.module("@atlas/api/lib/audit")` that
- * leaves `ADMIN_ACTIONS` undefined would otherwise throw while BUILDING the
- * entry, land on an already-committed correction, and reach a caller whose
- * error copy says "nothing was changed — retry".
+ * NEVER THROWS, and the whole body is inside the `try` rather than just the
+ * `await`, so a synchronous throw anywhere in the entry construction is
+ * contained instead of landing on an already-committed correction and reaching
+ * a caller whose error copy says "nothing was changed — retry". (The residual:
+ * the `catch`'s own `log.error` is outside that guarantee. A logger broken
+ * badly enough to throw is not a failure mode this module can absorb.)
  */
 async function emitCorrectionAudit(args: {
   readonly ctx: BrainPrincipalContext;
@@ -751,6 +775,25 @@ async function emitCorrectionAudit(args: {
   let deadline: ReturnType<typeof setTimeout> | undefined;
   /** Distinguishes the write's own rejection from a post-deadline one. */
   let timedOut = false;
+  /**
+   * Whether `logAdminActionAwait` was ever CALLED. It emits the actor-attributed
+   * `admin_action` pino line before its insert, so this is exactly the predicate
+   * for "does that line exist" — and the recovery instruction below is a
+   * different instruction depending on the answer.
+   */
+  let writeAttempted = false;
+  // Everything an operator needs to reconstruct the row BY HAND, shared by all
+  // three lines that can report it lost. The row IS the actor-attributed
+  // record, so a line saying it is gone without the actor is not a recovery
+  // instruction.
+  const lost = {
+    workspaceId: ctx.workspaceId,
+    actorId: ctx.userId,
+    factId: result.factId,
+    verb: result.verb,
+    correctionEpisodeId: result.correctionEpisodeId,
+    requestId,
+  } as const;
   try {
     // Retract keeps its dedicated action type so existing audit consumers see
     // one vocabulary for one semantics; the other three verbs share `correct`
@@ -786,50 +829,57 @@ async function emitCorrectionAudit(args: {
 
     // The module header claims a future entry point INHERITS the audit trail.
     // It inherits the row; it does not inherit the attribution — `resolveEntry`
-    // reads actor, org and requestId off the AsyncLocalStorage context and
-    // falls back to the literal `"unknown"` with no complaint. Both entry
-    // points today establish one, so this never fires; a scheduler fiber or a
-    // background session resume calling `correctFact` would produce a row that
-    // exists and lies, which is a worse artifact than the missing row #4934
-    // fixed. Loud, so it is a finding rather than a mystery.
-    if (getRequestContext() === undefined) {
+    // reads the actor off the AsyncLocalStorage context and falls back to the
+    // literal `"unknown"` with no complaint. The test is the ACTOR, not the
+    // context: `withRequestContext({ requestId })` with no `user` is the
+    // canonical scheduler/background shape, and it resolves to `"unknown"` just
+    // as a missing context does. Both entry points today supply a user, so this
+    // never fires; a future one that does not would produce a row that exists
+    // and lies, which is a worse artifact than the missing row #4934 fixed.
+    if (getRequestContext()?.user?.id === undefined) {
       log.warn(
-        { workspaceId: ctx.workspaceId, factId: result.factId, verb: result.verb, requestId },
-        "brain correction: no request context at audit time — the admin_action_log row will record " +
-          "actor 'unknown'. A correction entry point must run inside withRequestContext",
+        { ...lost },
+        "brain correction: no actor in the request context at audit time — the admin_action_log row will " +
+          "record actor 'unknown'. A correction entry point must run inside withRequestContext with a user",
       );
     }
 
+    writeAttempted = true;
     const write = logAdminActionAwait(entry);
     // A deadline does not CANCEL the insert, and `Promise.race` discards the
     // losing branch's outcome. Without this continuation the pg error that
     // explains a slow write — `relation ... does not exist`, pool exhaustion —
     // is dropped and the only line an operator ever sees is "timed out".
-    void write.then(
-      () => {
-        if (timedOut) {
-          log.warn(
-            { workspaceId: ctx.workspaceId, factId: result.factId, requestId },
-            "brain correction: admin_action_log row COMMITTED after its deadline — the earlier timeout " +
-              "line for this requestId reports the same event; the row is present, not lost",
-          );
-        }
-      },
-      (err: unknown) => {
-        if (timedOut) {
-          log.error(
-            {
-              workspaceId: ctx.workspaceId,
-              factId: result.factId,
-              requestId,
-              err: err instanceof Error ? err : new Error(String(err)),
-            },
-            "brain correction: admin_action_log write FAILED after its deadline — this is the underlying " +
-              "cause behind the earlier timeout line for this requestId",
-          );
-        }
-      },
-    );
+    void write
+      .then(
+        () => {
+          if (timedOut) {
+            log.warn(
+              { ...lost },
+              "brain correction: admin_action_log write COMPLETED after its deadline — the earlier timeout " +
+                "line for this requestId reports the same event; a row is present unless this deployment " +
+                "has no internal DB",
+            );
+          }
+        },
+        (err: unknown) => {
+          if (timedOut) {
+            log.error(
+              { ...lost, ...pgErrorFields(err), err: err instanceof Error ? err : new Error(String(err)) },
+              "brain correction: admin_action_log write FAILED after its deadline — this is the underlying " +
+                "cause behind the earlier timeout line for this requestId",
+            );
+          }
+        },
+      )
+      // This chain is DETACHED — it settles after the response has gone out, so
+      // no `try` on the correction path can reach it, and an unhandled rejection
+      // is process-fatal by default. A committed correction's bookkeeping must
+      // not be able to take down the worker.
+      .catch(() => {
+        // intentionally ignored: best-effort observability on a detached
+        // promise; the only way here is the logger itself throwing.
+      });
 
     await Promise.race([
       write,
@@ -846,31 +896,55 @@ async function emitCorrectionAudit(args: {
   } catch (err: unknown) {
     log.error(
       {
-        workspaceId: ctx.workspaceId,
-        // The row that was lost is the ACTOR-attributed one, so the line saying
-        // it is gone has to carry enough to reconstruct it by hand.
-        actorId: ctx.userId,
-        factId: result.factId,
-        verb: result.verb,
-        correctionEpisodeId: result.correctionEpisodeId,
-        requestId,
-        // The Error OBJECT, matching `auth/middleware.ts`: pino's
-        // `scrubErrSerializer` then captures the stack and, for a pg rejection,
-        // `code` / `detail` / `constraint` — which is the difference between
-        // "which failure mode was this" being an answer and a guess.
+        ...lost,
+        writeAttempted,
+        ...pgErrorFields(err),
+        // The Error OBJECT, matching `auth/middleware.ts`, so pino's
+        // `scrubErrSerializer` captures the stack. It rebuilds the error into
+        // `{ type, message, stack }` and DROPS everything else, which is why the
+        // pg fields are lifted out separately above rather than left to ride on
+        // the error.
         err: err instanceof Error ? err : new Error(String(err)),
       },
-      // Deliberately "may not have committed": a deadline does not cancel the
-      // insert, so a timed-out write can still land at t+6s. Telling an
-      // operator the row is gone invites a hand-inserted duplicate.
-      "brain correction: admin_action_log row may not have been committed — the correction itself IS " +
-        "committed. Check admin_action_log for this requestId before re-creating anything; the surviving " +
-        "records are the correction episode in brain_episodes and the actor-attributed `admin_action` " +
-        "pino line for this requestId",
+      // Two structurally different failures share this catch, and they need
+      // different instructions. A WRITE failure is a database problem and the
+      // `admin_action` pino line already exists (`logAdminActionAwait` emits it
+      // BEFORE its insert); it also may still commit, because a deadline does
+      // not cancel an insert — so "may not have been committed", since telling
+      // an operator the row is gone invites a hand-inserted duplicate. A
+      // BUILD failure never called the writer at all, so no pino line exists
+      // and no amount of checking the database will help.
+      writeAttempted
+        ? "brain correction: admin_action_log row may not have been committed — the correction itself IS " +
+            "committed. Check admin_action_log for this requestId before re-creating anything; the " +
+            "surviving records are the correction episode in brain_episodes and the actor-attributed " +
+            "`admin_action` pino line for this requestId"
+        : "brain correction: the admin_action_log entry could not even be BUILT — neither a row nor an " +
+            "`admin_action` pino line exists for this correction. This is a code or wiring defect, not a " +
+            "database one; the only surviving record is the correction episode in brain_episodes",
     );
   } finally {
     if (deadline !== undefined) clearTimeout(deadline);
   }
+}
+
+/**
+ * A pg rejection's diagnostic triple, lifted onto the log payload as its own
+ * fields.
+ *
+ * Necessary because `scrubErrSerializer` reduces the `err` object to
+ * `{ type, message, stack }`, so `code` / `constraint` — the difference between
+ * "which failure mode was this" being an answer and a guess (`42P01` a missing
+ * relation, `53300` pool exhaustion) — do not survive on the error itself.
+ * `detail` is deliberately left off: pg echoes row values into it.
+ */
+function pgErrorFields(err: unknown): { pgCode?: string; pgConstraint?: string } {
+  if (typeof err !== "object" || err === null) return {};
+  const { code, constraint } = err as { code?: unknown; constraint?: unknown };
+  return {
+    ...(typeof code === "string" ? { pgCode: code } : {}),
+    ...(typeof constraint === "string" ? { pgConstraint: constraint } : {}),
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/api/src/lib/brain/correction.ts
+++ b/packages/api/src/lib/brain/correction.ts
@@ -100,10 +100,34 @@
  * mid-transaction throws {@link CorrectionRefusedError}, which rolls the
  * episode back — a correction that half-happened must not leave an authored
  * episode asserting it did.
+ *
+ * ## THIS layer owns the admin-actions audit row — not the entry points
+ *
+ * A correction has two entry points onto this one write: the admin HTTP routes
+ * (`api/routes/admin-brain-facts.ts`) and the `correct_fact` agent tool
+ * (`lib/tools/correct-fact.ts`). #4915 built both and wired the
+ * `admin_action_log` vocabulary to only the first, so the same verb through
+ * chat produced the in-brain episode and no forensic row (#4934). The row is
+ * emitted HERE, once, for the `corrected` outcome only — so a THIRD entry point
+ * inherits the audit trail instead of having to remember it. That is the
+ * established pattern in this very subsystem: `lib/brain/extract.ts` emits its
+ * own cycle row from an unattended fiber, as do the BYOT-catalog and
+ * OpenAPI-rediscover schedulers. `resolveEntry` reads actor, org and requestId
+ * off the AsyncLocalStorage request context, which both entry points run
+ * inside, so attribution needs no plumbing from either.
+ *
+ * REFUSALS AND NOT-FOUNDS STAY UNAUDITED, deliberately: `admin_action_log`
+ * consumers today may reasonably read the table as success-only, and widening
+ * that is a separate change with its own blast radius (#4934 non-goal).
+ *
+ * The write is AWAITED with a deadline rather than fire-and-forget — see
+ * {@link emitCorrectionAudit} for why that is not a contradiction of "a failed
+ * audit never affects a committed correction".
  */
 
 import { randomUUID } from "node:crypto";
 import { createLogger } from "@atlas/api/lib/logger";
+import { ADMIN_ACTIONS, logAdminActionAwait } from "@atlas/api/lib/audit";
 import {
   aclVisibilityClause,
   isUnknownArray,
@@ -207,6 +231,13 @@ export interface CorrectionDeps {
   readonly now?: () => Date;
   /** Test seam for the episode's unique `source_id` suffix. */
   readonly newCorrectionId?: () => string;
+  /**
+   * Test seam for {@link AUDIT_WRITE_TIMEOUT_MS}. Exists so the deadline on the
+   * post-commit audit write is provable in milliseconds instead of seconds —
+   * without it the only way to pin "a hung internal DB cannot hold a chat turn
+   * open" is a 5-second test, which is longer than the default test timeout.
+   */
+  readonly auditWriteTimeoutMs?: number;
 }
 
 /** What became of one correction request. */
@@ -613,6 +644,17 @@ export async function correctFact(
       },
       "brain correction: verb applied — human-authoritative, recorded as an immutable correction episode",
     );
+    // Emitted from here, not from either entry point — see the module header.
+    // `emitCorrectionAudit` is contracted never to throw, so it cannot reach
+    // the refusal catch below and cannot turn a committed correction into an
+    // error the caller would retry.
+    await emitCorrectionAudit(
+      ctx.workspaceId,
+      factId,
+      result,
+      requestId,
+      deps.auditWriteTimeoutMs ?? AUDIT_WRITE_TIMEOUT_MS,
+    );
     return { kind: "corrected", result };
   } catch (err) {
     if (err instanceof CorrectionRefusedError) {
@@ -624,6 +666,110 @@ export async function correctFact(
       return { kind: "refused", reason: err.reason, message: err.message };
     }
     throw err;
+  }
+}
+
+/**
+ * How long an awaited audit write may hold a committed correction's response
+ * open. Same bound and same reason as `auth/middleware.ts` and
+ * `admin-knowledge.ts`: `logAdminActionAwait` goes through `internalQuery`,
+ * which deliberately bypasses the internal-DB circuit breaker, and the internal
+ * pool sets no statement timeout — so without a deadline a DEGRADED internal DB
+ * (reachable, not answering) would hang this call indefinitely. An UNREACHABLE
+ * one is already bounded by the pool's `connectionTimeoutMillis`.
+ *
+ * Not yet shared with those two hand-rolled copies on purpose: consolidating
+ * would mean editing `auth/middleware.ts`'s fail-closed 500 path, which is a
+ * security-surface change that does not belong in a brain-audit fix.
+ */
+const AUDIT_WRITE_TIMEOUT_MS = 5_000;
+
+/**
+ * The forensic `admin_action_log` row for a correction that already committed.
+ *
+ * AWAITED, not fire-and-forget, and that is not a contradiction of #4934's
+ * "a failed audit write never affects a committed correction" — the two claims
+ * are about different things. The correction is never rolled back and this
+ * function never throws; what awaiting buys is that a DROPPED row is LOUD.
+ * `logAdminAction` posts the insert into the circuit breaker and returns, so
+ * an open breaker discards the row with nothing but an internal counter — the
+ * exact silent-gap shape #4937 found on the adjacent publish path, and a
+ * silent gap here reproduces the very bug this call site exists to fix.
+ * CLAUDE.md: never silently swallow errors; prefer errors over silent
+ * fallbacks.
+ *
+ * Failure is logged at ERROR and the correction still returns `corrected`,
+ * because it HAS been corrected: the episode, the tombstone/stamp/marker and
+ * the edges are committed, and reporting failure would invite a retry that
+ * mints a SECOND correction episode for one human decision.
+ *
+ * The message names what actually survives, so the line is a usable recovery
+ * instruction rather than an alarm: the correction episode in `brain_episodes`
+ * (immutable, actor-attributed, in the same transaction as the effect) and the
+ * `admin_action` pino line, which `logAdminActionAwait` emits BEFORE the insert
+ * and therefore emits even on this path. What is lost is only the queryable
+ * row.
+ */
+async function emitCorrectionAudit(
+  workspaceId: string,
+  factId: string,
+  result: BrainFactCorrectionResponse,
+  requestId: string | undefined,
+  timeoutMs: number,
+): Promise<void> {
+  // Retract keeps its dedicated action type so existing audit consumers see
+  // one vocabulary for one semantics; the other three verbs share `correct`
+  // with the verb in `metadata.verb`.
+  const entry = {
+    actionType:
+      result.verb === "retract"
+        ? ADMIN_ACTIONS.brainFact.retract
+        : ADMIN_ACTIONS.brainFact.correct,
+    targetType: "brainFact",
+    targetId: factId,
+    metadata: {
+      verb: result.verb,
+      workspaceId,
+      correctionEpisodeId: result.correctionEpisodeId,
+      ...(result.invalidatedAt !== null ? { invalidatedAt: result.invalidatedAt } : {}),
+      ...(result.flaggedForReReview.length > 0
+        ? { flaggedForReReview: result.flaggedForReReview }
+        : {}),
+      ...(result.supersededBy !== null ? { supersededBy: result.supersededBy } : {}),
+      ...(result.validTo !== null ? { validTo: result.validTo } : {}),
+    },
+  } as const;
+
+  let deadline: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      logAdminActionAwait(entry),
+      // Cleared in the `finally` — an uncleared 5s timer would hold the event
+      // loop open on every correction, which on the agent-tool path is a
+      // per-chat-turn cost.
+      new Promise<never>((_, reject) => {
+        deadline = setTimeout(
+          () => reject(new Error(`audit write timed out after ${timeoutMs}ms`)),
+          timeoutMs,
+        );
+      }),
+    ]);
+  } catch (err: unknown) {
+    log.error(
+      {
+        workspaceId,
+        factId,
+        verb: result.verb,
+        correctionEpisodeId: result.correctionEpisodeId,
+        requestId,
+        err: err instanceof Error ? err.message : String(err),
+      },
+      "brain correction: admin_action_log row was not committed — the correction itself IS committed; " +
+        "the surviving records are the correction episode in brain_episodes and the actor-attributed " +
+        "`admin_action` pino line for this requestId. Only the queryable audit row is lost",
+    );
+  } finally {
+    if (deadline !== undefined) clearTimeout(deadline);
   }
 }
 

--- a/packages/api/src/lib/brain/correction.ts
+++ b/packages/api/src/lib/brain/correction.ts
@@ -108,17 +108,30 @@
  * (`lib/tools/correct-fact.ts`). #4915 built both and wired the
  * `admin_action_log` vocabulary to only the first, so the same verb through
  * chat produced the in-brain episode and no forensic row (#4934). The row is
- * emitted HERE, once, for the `corrected` outcome only — so a THIRD entry point
- * inherits the audit trail instead of having to remember it. That is the
- * established pattern in this very subsystem: `lib/brain/extract.ts` emits its
- * own cycle row from an unattended fiber, as do the BYOT-catalog and
- * OpenAPI-rediscover schedulers. `resolveEntry` reads actor, org and requestId
- * off the AsyncLocalStorage request context, which both entry points run
- * inside, so attribution needs no plumbing from either.
+ * emitted HERE, once, for the `corrected` outcome only.
  *
- * REFUSALS AND NOT-FOUNDS STAY UNAUDITED, deliberately: `admin_action_log`
- * consumers today may reasonably read the table as success-only, and widening
- * that is a separate change with its own blast radius (#4934 non-goal).
+ * The principle is one write, one audit row, emitted where the write is — so a
+ * THIRD entry point inherits the audit trail instead of having to remember it,
+ * and two entry points cannot drift into two metadata shapes (they already had:
+ * `/retract` logged `flaggedForReReview` unconditionally, `/correct` only when
+ * non-empty). `lib/brain/extract.ts`, `scheduler/byot-catalog-refresh.ts` and
+ * `scheduler/openapi-install-rediscover.ts` are the only other places in this
+ * subsystem that emit from BELOW the route layer, so `lib/` writing this table
+ * is established — though they are unattended loops labelling themselves with
+ * `systemActor`, which is a different argument from this one.
+ * `resolveEntry` reads actor, org and requestId off the AsyncLocalStorage
+ * request context, which both entry points run inside, so attribution needs no
+ * plumbing from either — and {@link emitCorrectionAudit} warns loudly if a
+ * future caller arrives without one.
+ *
+ * REFUSALS AND NOT-FOUNDS STAY UNAUDITED — a scope call, not a semantic one
+ * (#4934 non-goal). The table is NOT success-only: `AdminActionEntry.status`
+ * takes `"failure"` and dozens of call sites pass it, including a refusal on
+ * the closest precedent to this change (`sso.enforcement_block` in
+ * `auth/middleware.ts`). So auditing refused corrections is legitimate and can
+ * be added later; it just needs its own decision about volume, and about
+ * whether a not-found — which is deliberately indistinguishable from "not
+ * visible to you" — is an event at all.
  *
  * The write is AWAITED with a deadline rather than fire-and-forget — see
  * {@link emitCorrectionAudit} for why that is not a contradiction of "a failed
@@ -126,8 +139,8 @@
  */
 
 import { randomUUID } from "node:crypto";
-import { createLogger } from "@atlas/api/lib/logger";
-import { ADMIN_ACTIONS, logAdminActionAwait } from "@atlas/api/lib/audit";
+import { createLogger, getRequestContext } from "@atlas/api/lib/logger";
+import { ADMIN_ACTIONS, logAdminActionAwait, type AdminActionEntry } from "@atlas/api/lib/audit";
 import {
   aclVisibilityClause,
   isUnknownArray,
@@ -511,8 +524,14 @@ export async function correctFact(
   // that deployment declared it has no ids to record.
   const sourcePrincipal = ctx.userId !== null ? `user:${ctx.userId}` : "human:local-operator";
 
+  // Bound OUTSIDE the try, and the try holds nothing but the transaction. The
+  // audit write below is post-commit work, and a post-commit throw reaching
+  // this catch would be classified as a refusal or rethrown to a caller whose
+  // own error copy says "nothing was changed — retry" (`lib/tools/correct-fact.ts`).
+  // Placement, not a comment, is what keeps that impossible.
+  let result: BrainFactCorrectionResponse | null;
   try {
-    const result = await withTransaction(async (tx) => {
+    result = await withTransaction(async (tx) => {
       // ── The target, ACL-gated and row-locked ──────────────────────────
       const params: unknown[] = [...acl.params, factId];
       const targetResult = await tx.query(correctionTargetSql(acl.sql, params.length), params);
@@ -622,40 +641,6 @@ export async function correctFact(
         }
       }
     });
-
-    if (result === null) {
-      log.info(
-        { workspaceId: ctx.workspaceId, factId, verb, userId: ctx.userId, requestId },
-        "brain correction: verb matched no row — absent, already retracted, or not visible to this actor",
-      );
-      return { kind: "not-found" };
-    }
-
-    log.info(
-      {
-        workspaceId: ctx.workspaceId,
-        factId,
-        verb,
-        userId: ctx.userId,
-        correctionEpisodeId: result.correctionEpisodeId,
-        supersededBy: result.supersededBy,
-        flaggedForReReview: result.flaggedForReReview.length,
-        requestId,
-      },
-      "brain correction: verb applied — human-authoritative, recorded as an immutable correction episode",
-    );
-    // Emitted from here, not from either entry point — see the module header.
-    // `emitCorrectionAudit` is contracted never to throw, so it cannot reach
-    // the refusal catch below and cannot turn a committed correction into an
-    // error the caller would retry.
-    await emitCorrectionAudit(
-      ctx.workspaceId,
-      factId,
-      result,
-      requestId,
-      deps.auditWriteTimeoutMs ?? AUDIT_WRITE_TIMEOUT_MS,
-    );
-    return { kind: "corrected", result };
   } catch (err) {
     if (err instanceof CorrectionRefusedError) {
       // The throw already rolled the transaction (and any episode row) back.
@@ -667,6 +652,42 @@ export async function correctFact(
     }
     throw err;
   }
+
+  if (result === null) {
+    log.info(
+      { workspaceId: ctx.workspaceId, factId, verb, userId: ctx.userId, requestId },
+      "brain correction: verb matched no row — absent, already retracted, or not visible to this actor",
+    );
+    return { kind: "not-found" };
+  }
+
+  log.info(
+    {
+      workspaceId: ctx.workspaceId,
+      factId,
+      verb,
+      userId: ctx.userId,
+      correctionEpisodeId: result.correctionEpisodeId,
+      supersededBy: result.supersededBy,
+      flaggedForReReview: result.flaggedForReReview.length,
+      requestId,
+    },
+    "brain correction: verb applied — human-authoritative, recorded as an immutable correction episode",
+  );
+  // Emitted from here, not from either entry point — see the module header.
+  await emitCorrectionAudit({
+    ctx,
+    result,
+    requestId,
+    // `??` only catches nullish, so a `0` or negative seam value would mean
+    // "every audit write times out immediately". The invariant is a positive
+    // number of milliseconds, and this is where it is enforced.
+    timeoutMs:
+      deps.auditWriteTimeoutMs !== undefined && deps.auditWriteTimeoutMs > 0
+        ? deps.auditWriteTimeoutMs
+        : AUDIT_WRITE_TIMEOUT_MS,
+  });
+  return { kind: "corrected", result };
 }
 
 /**
@@ -680,7 +701,11 @@ export async function correctFact(
  *
  * Not yet shared with those two hand-rolled copies on purpose: consolidating
  * would mean editing `auth/middleware.ts`'s fail-closed 500 path, which is a
- * security-surface change that does not belong in a brain-audit fix.
+ * security-surface change that does not belong in a brain-audit fix. One thing
+ * for whoever does consolidate: this copy CLEARS its deadline in a `finally`
+ * and neither precedent does (`grep -n clearTimeout` finds nothing in either),
+ * so they leave a timer armed for the full bound on every fast path. This is
+ * the side to keep.
  */
 const AUDIT_WRITE_TIMEOUT_MS = 5_000;
 
@@ -693,9 +718,9 @@ const AUDIT_WRITE_TIMEOUT_MS = 5_000;
  * function never throws; what awaiting buys is that a DROPPED row is LOUD.
  * `logAdminAction` posts the insert into the circuit breaker and returns, so
  * an open breaker discards the row with nothing but an internal counter — the
- * exact silent-gap shape #4937 found on the adjacent publish path, and a
- * silent gap here reproduces the very bug this call site exists to fix.
- * CLAUDE.md: never silently swallow errors; prefer errors over silent
+ * shape #4937's fix (#4944) adopted on the adjacent publish path after finding
+ * it there, and a silent gap here reproduces the very bug this call site exists
+ * to fix. CLAUDE.md: never silently swallow errors; prefer errors over silent
  * fallbacks.
  *
  * Failure is logged at ERROR and the correction still returns `corrected`,
@@ -709,64 +734,139 @@ const AUDIT_WRITE_TIMEOUT_MS = 5_000;
  * `admin_action` pino line, which `logAdminActionAwait` emits BEFORE the insert
  * and therefore emits even on this path. What is lost is only the queryable
  * row.
+ *
+ * NEVER THROWS, and the whole body is inside the `try` so that is structural
+ * rather than a promise — a partial `mock.module("@atlas/api/lib/audit")` that
+ * leaves `ADMIN_ACTIONS` undefined would otherwise throw while BUILDING the
+ * entry, land on an already-committed correction, and reach a caller whose
+ * error copy says "nothing was changed — retry".
  */
-async function emitCorrectionAudit(
-  workspaceId: string,
-  factId: string,
-  result: BrainFactCorrectionResponse,
-  requestId: string | undefined,
-  timeoutMs: number,
-): Promise<void> {
-  // Retract keeps its dedicated action type so existing audit consumers see
-  // one vocabulary for one semantics; the other three verbs share `correct`
-  // with the verb in `metadata.verb`.
-  const entry = {
-    actionType:
-      result.verb === "retract"
-        ? ADMIN_ACTIONS.brainFact.retract
-        : ADMIN_ACTIONS.brainFact.correct,
-    targetType: "brainFact",
-    targetId: factId,
-    metadata: {
-      verb: result.verb,
-      workspaceId,
-      correctionEpisodeId: result.correctionEpisodeId,
-      ...(result.invalidatedAt !== null ? { invalidatedAt: result.invalidatedAt } : {}),
-      ...(result.flaggedForReReview.length > 0
-        ? { flaggedForReReview: result.flaggedForReReview }
-        : {}),
-      ...(result.supersededBy !== null ? { supersededBy: result.supersededBy } : {}),
-      ...(result.validTo !== null ? { validTo: result.validTo } : {}),
-    },
-  } as const;
-
+async function emitCorrectionAudit(args: {
+  readonly ctx: BrainPrincipalContext;
+  readonly result: BrainFactCorrectionResponse;
+  readonly requestId: string | undefined;
+  readonly timeoutMs: number;
+}): Promise<void> {
+  const { ctx, result, requestId, timeoutMs } = args;
   let deadline: ReturnType<typeof setTimeout> | undefined;
+  /** Distinguishes the write's own rejection from a post-deadline one. */
+  let timedOut = false;
   try {
+    // Retract keeps its dedicated action type so existing audit consumers see
+    // one vocabulary for one semantics; the other three verbs share `correct`
+    // with the verb in `metadata.verb`. `satisfies` rather than a bare
+    // annotation so the literal types survive; `as const` alone would leave a
+    // misspelled optional key (`staus`, `ipaddress`) compiling to a silent
+    // no-op, because excess-property checking does not apply to a variable.
+    //
+    // `result.factId` rather than the caller's `factId`: the response carries
+    // `f.id::text` as Postgres canonicalized it, while the agent tool accepts
+    // the id as a bare `z.string()`, so an LLM echoing a differently-cased uuid
+    // would otherwise produce a `target_id` that does not string-join to
+    // `brain_facts.id`.
+    const entry = {
+      actionType:
+        result.verb === "retract"
+          ? ADMIN_ACTIONS.brainFact.retract
+          : ADMIN_ACTIONS.brainFact.correct,
+      targetType: "brainFact",
+      targetId: result.factId,
+      metadata: {
+        verb: result.verb,
+        workspaceId: ctx.workspaceId,
+        correctionEpisodeId: result.correctionEpisodeId,
+        ...(result.invalidatedAt !== null ? { invalidatedAt: result.invalidatedAt } : {}),
+        ...(result.flaggedForReReview.length > 0
+          ? { flaggedForReReview: result.flaggedForReReview }
+          : {}),
+        ...(result.supersededBy !== null ? { supersededBy: result.supersededBy } : {}),
+        ...(result.validTo !== null ? { validTo: result.validTo } : {}),
+      },
+    } as const satisfies AdminActionEntry;
+
+    // The module header claims a future entry point INHERITS the audit trail.
+    // It inherits the row; it does not inherit the attribution — `resolveEntry`
+    // reads actor, org and requestId off the AsyncLocalStorage context and
+    // falls back to the literal `"unknown"` with no complaint. Both entry
+    // points today establish one, so this never fires; a scheduler fiber or a
+    // background session resume calling `correctFact` would produce a row that
+    // exists and lies, which is a worse artifact than the missing row #4934
+    // fixed. Loud, so it is a finding rather than a mystery.
+    if (getRequestContext() === undefined) {
+      log.warn(
+        { workspaceId: ctx.workspaceId, factId: result.factId, verb: result.verb, requestId },
+        "brain correction: no request context at audit time — the admin_action_log row will record " +
+          "actor 'unknown'. A correction entry point must run inside withRequestContext",
+      );
+    }
+
+    const write = logAdminActionAwait(entry);
+    // A deadline does not CANCEL the insert, and `Promise.race` discards the
+    // losing branch's outcome. Without this continuation the pg error that
+    // explains a slow write — `relation ... does not exist`, pool exhaustion —
+    // is dropped and the only line an operator ever sees is "timed out".
+    void write.then(
+      () => {
+        if (timedOut) {
+          log.warn(
+            { workspaceId: ctx.workspaceId, factId: result.factId, requestId },
+            "brain correction: admin_action_log row COMMITTED after its deadline — the earlier timeout " +
+              "line for this requestId reports the same event; the row is present, not lost",
+          );
+        }
+      },
+      (err: unknown) => {
+        if (timedOut) {
+          log.error(
+            {
+              workspaceId: ctx.workspaceId,
+              factId: result.factId,
+              requestId,
+              err: err instanceof Error ? err : new Error(String(err)),
+            },
+            "brain correction: admin_action_log write FAILED after its deadline — this is the underlying " +
+              "cause behind the earlier timeout line for this requestId",
+          );
+        }
+      },
+    );
+
     await Promise.race([
-      logAdminActionAwait(entry),
+      write,
       // Cleared in the `finally` — an uncleared 5s timer would hold the event
       // loop open on every correction, which on the agent-tool path is a
       // per-chat-turn cost.
       new Promise<never>((_, reject) => {
-        deadline = setTimeout(
-          () => reject(new Error(`audit write timed out after ${timeoutMs}ms`)),
-          timeoutMs,
-        );
+        deadline = setTimeout(() => {
+          timedOut = true;
+          reject(new Error(`audit write timed out after ${timeoutMs}ms`));
+        }, timeoutMs);
       }),
     ]);
   } catch (err: unknown) {
     log.error(
       {
-        workspaceId,
-        factId,
+        workspaceId: ctx.workspaceId,
+        // The row that was lost is the ACTOR-attributed one, so the line saying
+        // it is gone has to carry enough to reconstruct it by hand.
+        actorId: ctx.userId,
+        factId: result.factId,
         verb: result.verb,
         correctionEpisodeId: result.correctionEpisodeId,
         requestId,
-        err: err instanceof Error ? err.message : String(err),
+        // The Error OBJECT, matching `auth/middleware.ts`: pino's
+        // `scrubErrSerializer` then captures the stack and, for a pg rejection,
+        // `code` / `detail` / `constraint` — which is the difference between
+        // "which failure mode was this" being an answer and a guess.
+        err: err instanceof Error ? err : new Error(String(err)),
       },
-      "brain correction: admin_action_log row was not committed — the correction itself IS committed; " +
-        "the surviving records are the correction episode in brain_episodes and the actor-attributed " +
-        "`admin_action` pino line for this requestId. Only the queryable audit row is lost",
+      // Deliberately "may not have committed": a deadline does not cancel the
+      // insert, so a timed-out write can still land at t+6s. Telling an
+      // operator the row is gone invites a hand-inserted duplicate.
+      "brain correction: admin_action_log row may not have been committed — the correction itself IS " +
+        "committed. Check admin_action_log for this requestId before re-creating anything; the surviving " +
+        "records are the correction episode in brain_episodes and the actor-attributed `admin_action` " +
+        "pino line for this requestId",
     );
   } finally {
     if (deadline !== undefined) clearTimeout(deadline);

--- a/packages/api/src/lib/content-mode/port.ts
+++ b/packages/api/src/lib/content-mode/port.ts
@@ -185,8 +185,10 @@ export interface GrantWidening {
  * This type covers only the PUBLISH path's events — a `PromotionReport` is
  * emitted by a publish phase, so `collectSupersessions` structurally cannot see
  * a correction's supersession, which records itself through the correction
- * response and `admin-brain-facts.ts`'s own audit row (`supersededBy` /
- * `validTo`) instead. Neither record is a superset of the other; a reader
+ * response and the `admin_action_log` row `lib/brain/correction.ts` emits for
+ * EVERY correction entry point — the agent tool included since #4934 —
+ * carrying `supersededBy` / `validTo` in its metadata. Neither record is a
+ * superset of the other; a reader
  * asking "everything that retired this fact" must consult the `supersedes`
  * edges, which both paths write.
  *

--- a/packages/api/src/lib/tools/correct-fact.ts
+++ b/packages/api/src/lib/tools/correct-fact.ts
@@ -144,6 +144,12 @@ export const correctFactTool = tool({
     // construction. Outcome mapping happens OUTSIDE it: a (today unreachable)
     // throw while shaping the success response must never tell the agent to
     // retry a correction that already committed.
+    //
+    // `correctFact` does post-commit work of its own since #4934 — it emits the
+    // `admin_action_log` row — so that "by construction" now rests on
+    // `emitCorrectionAudit` never throwing, which its own body enforces by
+    // holding everything inside the try. If that ever changes, this catch
+    // starts telling users to re-run a correction that already landed.
     let outcome: CorrectionOutcome;
     try {
       const db = getInternalDB();


### PR DESCRIPTION
Closes #4934

`correct_fact` has **two** entry points onto one human-authoritative write, and #4915 wired the `admin_action_log` vocabulary to only one of them. An owner correcting a fact through chat produced the immutable in-brain correction episode and **no row in the forensic trail**; the same verb through the admin console produced both.

## What changed

The row now belongs to `lib/brain/correction.ts` — emitted once, by the machinery, for the `corrected` outcome only — and both route call sites are deleted. A **third** entry point inherits the audit trail instead of having to remember it, which is the class of bug being fixed, not just the instance. This is the established pattern (`lib/brain/extract.ts` emits its own cycle row from an unattended fiber; `auth/middleware.ts`, `auth/invitations.ts` and `rate-limit/middleware.ts` all write this table from `lib/`), and `resolveEntry` already resolves actor/org/requestId off the request context both entry points run inside, so attribution needed no plumbing.

`retract` keeps its dedicated `brain_fact.retract` action type; the other three verbs ride `brain_fact.correct` with the verb in `metadata.verb`. The two deleted call sites had already drifted into **two metadata shapes** for one decision (`/retract` logged `flaggedForReReview` unconditionally, `/correct` only when non-empty) — the conditional shape is the one kept, so a `pin` no longer asserts decisions it did not make.

## The write is awaited and bounded, not fire-and-forget

The issue's AC says "audit stays fire-and-forget; a failed audit write never affects a committed correction". The second half is honoured exactly — the correction is never rolled back and the emitter never throws. The first half is not, deliberately, and the two are not the same claim:

`logAdminAction` posts its insert into the internal-DB circuit breaker and returns, so an **open breaker discards the row with nothing but a counter**. That is the silent-gap shape #4937's fix (#4944) found on the adjacent publish path — and here it would silently reproduce the very bug this call site exists to fix, in the one condition where the forensic trail matters most. Per CLAUDE.md: never silently swallow errors; prefer errors over silent fallbacks.

So: `logAdminActionAwait`, raced against a 5s deadline (`internalQuery` bypasses the breaker and the internal pool sets no statement timeout), failure logged at ERROR with the surviving records named, request still succeeds. The timer is cleared in a `finally`, which neither of the two precedents does.

The failure line branches on whether the write was ever attempted, because the two cases need different instructions: a **write** failure means the actor-attributed `admin_action` pino line already exists (it is emitted before the insert) and the row may still land, so the message says "may not have been committed" — telling an operator it is gone invites a hand-inserted duplicate. A **build** failure never called the writer, so no pino line exists either and no amount of checking the database will help.

## Coverage

- `correction-audit.test.ts` (21 tests) — the row's shape per verb; neither refusal shape audited (the pre-transaction authority return **and** the in-transaction rollback catch, which are different return paths); the write has COMMITTED before `correctFact` resolves; a failed write surfaced at ERROR not swallowed; a hung write bounded; a post-deadline failure surfacing its real cause; a synchronous throw during entry construction contained; the deadline clamped at both ends; the deadline timer disarmed.
- `correction-audit-pg.test.ts` (4 tests, live Postgres) — the **resolved** row: `actor_id`, `actor_email`, `org_id`, `request_id`, which `resolveEntry` derives from the request context a mocked suite structurally cannot see. Plus `supersede`'s `supersededBy` / `validTo`, which needs real reconcile, and an upper-cased uuid proving `target_id` is the Postgres-canonical id rather than the caller's string.
- A **source-level guard** that discovers every direct `correctFact(` call site across seven roots and pins that `lib/brain/correction.ts` is the only file reaching for the correction vocabulary — the half that makes "a third entry point cannot land uncovered" structural rather than a review promise. With a canary that fails if its own comment/string stripping ever starts eating code.
- The route suite flips to asserting the router emits nothing on any path of either route, with a per-iteration expected status so each swept path is one that was actually walked.

## Verification

- **31 mutations** applied to the real files and verified red, each reverted. Three initially passed and exposed genuine test gaps (a refusal audited via the rollback catch; a leaked deadline timer; a silently substituted deadline) — the tests were strengthened and re-verified.
- `/review-panel` ran three rounds. Rounds 1 and 2 returned substantive findings, all addressed; round 3 returned **no merge blockers** from either reviewer.
- `/ci`: **33/33 gates green**, including the full suite (999 api + 320 web + 52 ee + 49 cli + 38 mcp files, 0 failures) with `TEST_DATABASE_URL` set so the `-pg` suites actually ran.

## Non-goals (recorded in #4934)

Refusals and not-founds stay unaudited. Noted in the source: the table is **not** success-only (`AdminActionEntry.status` takes `"failure"`, and `sso.enforcement_block` audits a refusal that way), so this is a scope call, not a semantic one — auditing them later is legitimate and needs its own decision about volume.
