### PR TITLE
fix(api): #4941 — headless surfaces relay a degraded tool set, and pg errors keep their code

### DIFF
--- a/packages/api/src/api/__tests__/chat-resume.test.ts
+++ b/packages/api/src/api/__tests__/chat-resume.test.ts
@@ -282,6 +282,44 @@ describe("POST /api/v1/chat/:conversationId/resume", () => {
     expect(names).toContain("executeSQL");
   });
 
+  // #4941 — the WEB half of the same defect the headless surfaces had: this
+  // route kept `result.registry` and dropped `result.warnings`, so a resumed web
+  // turn whose action tools failed to load reported the capability as ABSENT
+  // rather than temporarily unavailable. The INITIAL web turn (`chat.ts`, pinned
+  // by chat.test.ts) always threaded them; only the resume did not.
+  describe("#4941 — a degraded registry build reaches the resumed model", () => {
+    it("threads the build-failure warning into the resumed runAgent", async () => {
+      process.env.ATLAS_ACTIONS_ENABLED = "true";
+      // The fatal misconfiguration `buildRegistry` throws on, and the same
+      // lever chat.test.ts uses for the initial turn.
+      process.env.ATLAS_PYTHON_ENABLED = "true";
+      delete process.env.ATLAS_SANDBOX_URL;
+      try {
+        const res = await app.fetch(resumeRequest());
+        expect(res.status).toBe(200);
+        expect(mockRunAgent).toHaveBeenCalledTimes(1);
+
+        const arg = (mockRunAgent.mock.calls as unknown as Array<[{ warnings?: string[] }]>)[0]![0];
+        expect(
+          arg.warnings,
+          "the resumed web turn ran on a degraded tool set and told the model nothing",
+        ).toBeDefined();
+        expect(arg.warnings).toHaveLength(1);
+        expect(arg.warnings![0]).toContain("tool registry failed to build");
+      } finally {
+        delete process.env.ATLAS_ACTIONS_ENABLED;
+        delete process.env.ATLAS_PYTHON_ENABLED;
+      }
+    });
+
+    it("passes no warnings when the build is healthy — the signal is not always-on", async () => {
+      const res = await app.fetch(resumeRequest());
+      expect(res.status).toBe(200);
+      const arg = (mockRunAgent.mock.calls as unknown as Array<[{ warnings?: string[] }]>)[0]![0];
+      expect(arg.warnings).toBeUndefined();
+    });
+  });
+
   // #4302 — a resumed turn rebuilds its system prompt live (the checkpoint
   // stores the transcript, not the system param), so the conversation's
   // pinned answer style must be re-threaded from the row loaded for the

--- a/packages/api/src/api/__tests__/chat-resume.test.ts
+++ b/packages/api/src/api/__tests__/chat-resume.test.ts
@@ -163,8 +163,11 @@ void mock.module("@atlas/api/lib/conversations", () => ({
   updateConversationScope: mock(() => Promise.resolve({ ok: true as const })),
 }));
 
+// Hoisted (#4941) so a test can drive the plugin-merge failure branch, which
+// the resume path used to swallow entirely.
+const mockGetPluginTools: Mock<() => unknown> = mock(() => undefined);
 void mock.module("@atlas/api/lib/plugins/tools", () => ({
-  getPluginTools: mock(() => undefined),
+  getPluginTools: mockGetPluginTools,
   setPluginTools: () => {},
   getContextFragments: () => [],
   setContextFragments: () => {},
@@ -232,6 +235,8 @@ describe("POST /api/v1/chat/:conversationId/resume", () => {
       handle: { runId: "run-abc", transcript: [{ role: "user", content: "hi" }], priorStepIndex: 2, leaseOwner: "lease-1" },
     });
     mockFinishResume.mockReset();
+    mockGetPluginTools.mockReset();
+    mockGetPluginTools.mockReturnValue(undefined);
     mockCheckAgentBillingGate.mockReset();
     mockCheckAgentBillingGate.mockResolvedValue({ allowed: true as const });
     mockRunAgent.mockReset();
@@ -338,6 +343,24 @@ describe("POST /api/v1/chat/:conversationId/resume", () => {
       } finally {
         delete process.env.ATLAS_ACTIONS_ENABLED;
       }
+    });
+
+    it("relays a plugin-merge failure, matching the initial turn", async () => {
+      // The initial web turn warns the model when the plugin merge throws
+      // (pinned in chat.test.ts); the resume path logged and said nothing. It
+      // matters MORE here: the parked call the user just approved may itself be
+      // the plugin tool that failed to load.
+      mockGetPluginTools.mockImplementationOnce(() => {
+        throw new Error("plugin tool has empty name");
+      });
+
+      const res = await app.fetch(resumeRequest());
+      expect(res.status).toBe(200);
+
+      const arg = (mockRunAgent.mock.calls as unknown as Array<[{ warnings?: string[] }]>)[0]![0];
+      expect(arg.warnings).toHaveLength(1);
+      expect(arg.warnings![0]).toContain("Plugin tools failed to load");
+      expect(arg.warnings![0]).toContain("plugin tool has empty name");
     });
 
     it("passes no warnings when actions are not requested — the signal is not always-on", async () => {

--- a/packages/api/src/api/__tests__/chat-resume.test.ts
+++ b/packages/api/src/api/__tests__/chat-resume.test.ts
@@ -87,6 +87,16 @@ const mockRunAgent = mock(() =>
 );
 void mock.module("@atlas/api/lib/agent", () => ({ runAgent: mockRunAgent }));
 
+// #4941 — the action barrel does not load. A throwing factory makes the
+// `await import("./actions")` inside `buildRegistry` reject, which is the branch
+// that authors a warning while the BUILD ITSELF SUCCEEDS — the failure mode the
+// issue is actually about, and the one a `buildRegistry`-throws test cannot
+// reach. Inert for every other test in this file: `buildRegistry` only imports
+// the barrel when `ATLAS_ACTIONS_ENABLED === "true"`, which nothing else sets.
+void mock.module("@atlas/api/lib/tools/actions", () => {
+  throw new Error("simulated action-module load failure (#4941)");
+});
+
 void mock.module("@atlas/api/lib/tools/python-stream", () => ({
   setStreamWriter: () => {},
   clearStreamWriter: () => {},
@@ -305,14 +315,32 @@ describe("POST /api/v1/chat/:conversationId/resume", () => {
           "the resumed web turn ran on a degraded tool set and told the model nothing",
         ).toBeDefined();
         expect(arg.warnings).toHaveLength(1);
-        expect(arg.warnings![0]).toContain("tool registry failed to build");
+        expect(arg.warnings![0]).toContain("stopped the tool registry from building");
       } finally {
         delete process.env.ATLAS_ACTIONS_ENABLED;
         delete process.env.ATLAS_PYTHON_ENABLED;
       }
     });
 
-    it("passes no warnings when the build is healthy — the signal is not always-on", async () => {
+    it("threads a failed ACTION-TOOL load — the build succeeds and still carries a warning", async () => {
+      // Distinct branch from the one above, and the one #4941 is really about:
+      // `buildRegistry` RESOLVES, with a warning in its result. The catch-path
+      // test cannot reach `resumeWarnings.push(...result.warnings)` at all.
+      process.env.ATLAS_ACTIONS_ENABLED = "true";
+      try {
+        const res = await app.fetch(resumeRequest());
+        expect(res.status).toBe(200);
+
+        const arg = (mockRunAgent.mock.calls as unknown as Array<[{ warnings?: string[] }]>)[0]![0];
+        expect(arg.warnings).toHaveLength(1);
+        expect(arg.warnings![0]).toContain("createJiraTicket");
+        expect(arg.warnings![0]).toContain("do NOT tell the user");
+      } finally {
+        delete process.env.ATLAS_ACTIONS_ENABLED;
+      }
+    });
+
+    it("passes no warnings when actions are not requested — the signal is not always-on", async () => {
       const res = await app.fetch(resumeRequest());
       expect(res.status).toBe(200);
       const arg = (mockRunAgent.mock.calls as unknown as Array<[{ warnings?: string[] }]>)[0]![0];

--- a/packages/api/src/api/__tests__/chat.test.ts
+++ b/packages/api/src/api/__tests__/chat.test.ts
@@ -122,25 +122,33 @@ void mock.module("@atlas/api/lib/workspace-capability", () => ({
 
 // Mock action tools so buildRegistry({ includeActions: true }) works
 // without needing JIRA/email credentials or external services.
+//
+// Hoisted to module-level MUTABLE objects (#4941) so one test can break an
+// entry and drive `buildRegistry`'s action-tool failure branch — the case where
+// the build SUCCEEDS and returns a warning, which is what the issue is about
+// and which a "buildRegistry throws" test cannot reach. `mock.module`'s factory
+// is file-wide, so a per-test lever has to be data, not a different factory.
+const mockJiraAction = {
+  name: "createJiraTicket",
+  description: "### Create JIRA Ticket\nMock",
+  tool: { type: "function" },
+  actionType: "jira:create",
+  reversible: true,
+  defaultApproval: "manual",
+  requiredCredentials: ["JIRA_BASE_URL", "JIRA_EMAIL", "JIRA_API_TOKEN"],
+};
+const mockEmailAction = {
+  name: "sendEmailReport",
+  description: "### Send Email Report\nMock",
+  tool: { type: "function" },
+  actionType: "email:send",
+  reversible: false,
+  defaultApproval: "admin-only",
+  requiredCredentials: ["RESEND_API_KEY"],
+};
 void mock.module("@atlas/api/lib/tools/actions", () => ({
-  createJiraTicket: {
-    name: "createJiraTicket",
-    description: "### Create JIRA Ticket\nMock",
-    tool: { type: "function" },
-    actionType: "jira:create",
-    reversible: true,
-    defaultApproval: "manual",
-    requiredCredentials: ["JIRA_BASE_URL", "JIRA_EMAIL", "JIRA_API_TOKEN"],
-  },
-  sendEmailReport: {
-    name: "sendEmailReport",
-    description: "### Send Email Report\nMock",
-    tool: { type: "function" },
-    actionType: "email:send",
-    reversible: false,
-    defaultApproval: "admin-only",
-    requiredCredentials: ["RESEND_API_KEY"],
-  },
+  createJiraTicket: mockJiraAction,
+  sendEmailReport: mockEmailAction,
 }));
 
 const mockCreateConversation = mock((): Promise<{ id: string } | null> =>
@@ -1715,9 +1723,35 @@ describe("POST /api/v1/chat", () => {
       const call = calls[0]![0] as { warnings?: string[] };
       expect(call.warnings).toBeDefined();
       expect(call.warnings!.length).toBe(1);
-      expect(call.warnings![0]).toContain("tool registry failed to build");
+      expect(call.warnings![0]).toContain("stopped the tool registry from building");
     } finally {
       delete process.env.ATLAS_PYTHON_ENABLED;
+    }
+  });
+
+  it("#4941 — relays a failed ACTION-TOOL load, where the build SUCCEEDS with a warning", async () => {
+    // The branch the sibling test above cannot reach: `buildRegistry` resolves,
+    // and its `warnings` ride out on `result.warnings`. This is the reference
+    // implementation the headless seam's docstring points at, so it needs its
+    // own pin — deleting `warnings.push(...result.warnings)` left the whole
+    // suite green before this test existed.
+    process.env.ATLAS_ACTIONS_ENABLED = "true";
+    const realDescription = mockJiraAction.description;
+    // An entry the registry refuses ("Tool description must not be empty"),
+    // which is what `buildRegistry`'s action catch is there for.
+    mockJiraAction.description = "";
+    try {
+      const response = await app.fetch(makeRequest());
+      expect(response.status).toBe(200);
+      const calls = mockRunAgent.mock.calls as unknown as unknown[][];
+      const call = calls[0]![0] as { warnings?: string[] };
+      expect(call.warnings).toHaveLength(1);
+      expect(call.warnings![0]).toContain("createJiraTicket");
+      // The core `sendEmail` is still in the registry, so the copy must not
+      // generalize the loss into "email is unavailable".
+      expect(call.warnings![0]).toContain("do NOT tell the user");
+    } finally {
+      mockJiraAction.description = realDescription;
     }
   });
 
@@ -1778,7 +1812,7 @@ describe("POST /api/v1/chat", () => {
       const call = calls[0]![0] as { warnings?: string[] };
       expect(call.warnings).toBeDefined();
       expect(call.warnings!.length).toBe(2);
-      expect(call.warnings![0]).toContain("tool registry failed to build");
+      expect(call.warnings![0]).toContain("stopped the tool registry from building");
       expect(call.warnings![1]).toContain("Plugin tools failed to load");
     } finally {
       delete process.env.ATLAS_PYTHON_ENABLED;

--- a/packages/api/src/api/routes/chat.ts
+++ b/packages/api/src/api/routes/chat.ts
@@ -1522,9 +1522,15 @@ chat.openapi(chatRoute, async (c) => {
                 { err: errObj },
                 "Failed to build tool registry — falling back to default tools",
               );
-              warnings.push(
-                "Actions were requested but the tool registry failed to build. Action tools are unavailable for this session. Inform the user that actions are currently unavailable and suggest they check server logs or retry later.",
+              // #4941 — one shared copy across all three fallback sites. The
+              // string this replaced said "action tools are unavailable" while
+              // the `defaultRegistry` fallback still carried the core
+              // `sendEmail` / `createLinearIssue`, so the model was primed to
+              // disown a tool it could see.
+              const { registryBuildFailedWarning } = await import(
+                "@atlas/api/lib/tools/registry"
               );
+              warnings.push(registryBuildFailedWarning());
             }
           }
   
@@ -2165,12 +2171,14 @@ chat.openapi(chatResumeRoute, async (c) => {
               toolRegistry = result.registry;
               resumeWarnings.push(...result.warnings);
             } catch (err) {
-              log.error({ err: err instanceof Error ? err : new Error(String(err)) }, "Failed to build tool registry on resume — falling back to default tools");
-              resumeWarnings.push(
-                "Actions were requested but the tool registry failed to build. Action tools are unavailable for this session. Inform the user that actions are currently unavailable and suggest they check server logs or retry later.",
+              log.error({ err: err instanceof Error ? err : new Error(String(err)), conversationId, runId: handle.runId }, "Failed to build tool registry on resume — falling back to default tools");
+              const { registryBuildFailedWarning } = await import(
+                "@atlas/api/lib/tools/registry"
               );
+              resumeWarnings.push(registryBuildFailedWarning());
             }
           }
+          const prePluginResumeRegistry = toolRegistry;
           try {
             const { getPluginTools } = await import("@atlas/api/lib/plugins/tools");
             const pluginTools = getPluginTools();
@@ -2181,7 +2189,18 @@ chat.openapi(chatResumeRoute, async (c) => {
               toolRegistry.freeze();
             }
           } catch (err) {
-            log.error({ err: err instanceof Error ? err : new Error(String(err)) }, "Failed to merge plugin tools on resume — continuing without");
+            // #4941 — the initial turn restores the pre-merge registry and warns
+            // the model; this path did neither. A `freeze()` throw left
+            // `toolRegistry` holding the half-merged registry while the log said
+            // "continuing without", and the user heard nothing at all — which
+            // bites harder on RESUME, where the tool call just approved may
+            // itself be the plugin tool that vanished.
+            toolRegistry = prePluginResumeRegistry;
+            const errObj = err instanceof Error ? err : new Error(String(err));
+            log.error({ err: errObj, conversationId, runId: handle.runId }, "Failed to merge plugin tools on resume — continuing without");
+            resumeWarnings.push(
+              `Plugin tools failed to load: ${errObj.message}. This turn will continue without plugin tools. Inform the user that plugin-provided tools are unavailable for this session.`,
+            );
           }
 
           // #4936 — same opt-in as the chat route above: the WEB resume, on the

--- a/packages/api/src/api/routes/chat.ts
+++ b/packages/api/src/api/routes/chat.ts
@@ -2190,11 +2190,12 @@ chat.openapi(chatResumeRoute, async (c) => {
             }
           } catch (err) {
             // #4941 — the initial turn restores the pre-merge registry and warns
-            // the model; this path did neither. A `freeze()` throw left
-            // `toolRegistry` holding the half-merged registry while the log said
-            // "continuing without", and the user heard nothing at all — which
-            // bites harder on RESUME, where the tool call just approved may
-            // itself be the plugin tool that vanished.
+            // the model; this path did neither. The restore is symmetry rather
+            // than a live fix (every statement in the `try` throws BEFORE the
+            // assignment lands, so `toolRegistry` already holds its pre-merge
+            // value) — the real gap is the warning: a resumed turn whose plugin
+            // tools vanished told the user nothing, which bites hardest when the
+            // call the user just APPROVED is itself the plugin tool.
             toolRegistry = prePluginResumeRegistry;
             const errObj = err instanceof Error ? err : new Error(String(err));
             log.error({ err: errObj, conversationId, runId: handle.runId }, "Failed to merge plugin tools on resume — continuing without");

--- a/packages/api/src/api/routes/chat.ts
+++ b/packages/api/src/api/routes/chat.ts
@@ -2151,14 +2151,24 @@ chat.openapi(chatResumeRoute, async (c) => {
           // resolved inside executeSQL at call time) are bound to the live
           // request, never the checkpoint.
           let toolRegistry: import("@atlas/api/lib/tools/registry").ToolRegistry | undefined;
+          // #4941 — same defect as the headless surfaces had, one route over:
+          // this path kept `result.registry` and dropped `result.warnings`, so a
+          // resumed WEB turn whose action tools failed to load was told nothing
+          // and reported the capability as absent. The initial web turn above
+          // (which threads both) is the reference; this mirrors it.
+          const resumeWarnings: string[] = [];
           const includeActions = process.env.ATLAS_ACTIONS_ENABLED === "true";
           if (includeActions) {
             try {
               const { buildRegistry } = await import("@atlas/api/lib/tools/registry");
               const result = await buildRegistry({ includeActions });
               toolRegistry = result.registry;
+              resumeWarnings.push(...result.warnings);
             } catch (err) {
               log.error({ err: err instanceof Error ? err : new Error(String(err)) }, "Failed to build tool registry on resume — falling back to default tools");
+              resumeWarnings.push(
+                "Actions were requested but the tool registry failed to build. Action tools are unavailable for this session. Inform the user that actions are currently unavailable and suggest they check server logs or retry later.",
+              );
             }
           }
           try {
@@ -2204,6 +2214,7 @@ chat.openapi(chatResumeRoute, async (c) => {
           const agentResult = await runAgent({
             messages: [],
             tools: resolvedToolRegistry,
+            ...(resumeWarnings.length > 0 && { warnings: resumeWarnings }),
             conversationId,
             // #4302 — a resumed turn rebuilds its system prompt live (the
             // checkpoint stores the message transcript, not the system

--- a/packages/api/src/lib/__tests__/agent-context-warnings.test.ts
+++ b/packages/api/src/lib/__tests__/agent-context-warnings.test.ts
@@ -274,3 +274,59 @@ describe("runAgent contextWarnings out-array (#1988 B5)", () => {
     expect(true).toBe(true);
   });
 });
+
+/**
+ * #4941 — the LAST hop, and the one every other test in that arc trusts.
+ *
+ * `contextWarnings` above is the SSE/UI channel. `warnings` is the independent
+ * MODEL channel: it exists so the agent can say "temporarily unavailable" rather
+ * than "I can't do that", which is the whole point of routing a degraded tool
+ * load into it. Every #4941 test on the surfaces asserts `runAgent` was CALLED
+ * with `warnings` — delete the `warnings,` forwarding at the `buildSystemParam`
+ * call site and all of them stay green while the model hears nothing again.
+ * This pins the edge those tests stand on: caller option → `## Warnings` in the
+ * prompt the model actually receives.
+ */
+describe("#4941 — runAgent renders caller `warnings` into the model's system prompt", () => {
+  let capturedPrompt: unknown;
+
+  beforeEach(() => {
+    capturedPrompt = undefined;
+    mockModel = new MockLanguageModelV3({
+      doStream: async (options) => {
+        capturedPrompt = options.prompt;
+        const final: LanguageModelV3StreamPart[] = [
+          { type: "text-delta", id: "t0", delta: "ok" },
+          { type: "finish", usage: MOCK_USAGE, finishReason: { unified: "stop", raw: "end_turn" } },
+        ];
+        return { stream: convertArrayToReadableStream(final) };
+      },
+    });
+    // Both preflight loaders succeed, so `warnings` carries only what the
+    // caller passed — otherwise the negative case below could not be written.
+    semanticState.whitelistThrows = false;
+    semanticState.patternsThrows = false;
+  });
+
+  it("a caller warning reaches the model under a `## Warnings` heading", async () => {
+    const result = await runAgent({
+      messages: userMessages("email me the Q3 numbers"),
+      warnings: ["SENTINEL-4941: the operator action tools did not load."],
+    });
+    await result.steps;
+
+    const prompt = JSON.stringify(capturedPrompt);
+    expect(prompt).toContain("## Warnings");
+    expect(prompt).toContain("SENTINEL-4941: the operator action tools did not load.");
+  });
+
+  it("no `## Warnings` section at all when the caller passes none", async () => {
+    const result = await runAgent({ messages: userMessages("how many companies?") });
+    await result.steps;
+
+    const prompt = JSON.stringify(capturedPrompt);
+    // Not vacuous — the prompt really was captured and really is the system one.
+    expect(prompt).toContain("Atlas");
+    expect(prompt).not.toContain("## Warnings");
+  });
+});

--- a/packages/api/src/lib/__tests__/agent-query-degraded-tools.test.ts
+++ b/packages/api/src/lib/__tests__/agent-query-degraded-tools.test.ts
@@ -1,9 +1,10 @@
 /**
  * #4941 — a degraded tool load on a HEADLESS surface reaches the model.
  *
- * `buildRegistry` authors a warning addressed to the agent ("...are unavailable
- * for this session. Inform the user and suggest they check server logs or retry
- * later"), and `api/routes/chat.ts` threads it into `runAgent({ warnings })` so
+ * `buildRegistry` authors a warning addressed to the agent
+ * (`ACTION_TOOLS_UNAVAILABLE_WARNING` — quoted by name, not inlined, because
+ * this copy has already drifted once), and `api/routes/chat.ts` threads it into
+ * `runAgent({ warnings })` so
  * a web user hears "temporarily unavailable, retry". Every headless surface that
  * BUILDS a registry — the SDK query route, Slack, MCP, the scheduler — goes
  * through `executeAgentQuery` (the chat-platform approval resume calls the seam

--- a/packages/api/src/lib/__tests__/agent-query-degraded-tools.test.ts
+++ b/packages/api/src/lib/__tests__/agent-query-degraded-tools.test.ts
@@ -4,12 +4,14 @@
  * `buildRegistry` authors a warning addressed to the agent ("...are unavailable
  * for this session. Inform the user and suggest they check server logs or retry
  * later"), and `api/routes/chat.ts` threads it into `runAgent({ warnings })` so
- * a web user hears "temporarily unavailable, retry". Every headless surface —
- * the SDK query route, Slack, MCP, the scheduler — goes through
- * `executeAgentQuery`, which resolved a seam that returned a bare registry and
- * dropped the warnings at the destructure. The agent then reported the
- * capability as ABSENT rather than degraded: a wrong explanation, not a missing
- * one, which is what makes it a truthfulness bug rather than a papercut.
+ * a web user hears "temporarily unavailable, retry". Every headless surface that
+ * BUILDS a registry — the SDK query route, Slack, MCP, the scheduler — goes
+ * through `executeAgentQuery`, which resolved a seam that returned a bare
+ * registry and dropped the warnings at the destructure. The agent then reported
+ * the capability as ABSENT rather than degraded: a wrong explanation, not a
+ * missing one, which is what makes it a truthfulness bug rather than a papercut.
+ * (`ee/src/proactive/answer-adapter.ts` is headless too, but passes a STATIC
+ * registry — no build to fail, so nothing to relay.)
  *
  * Own file because proving it needs the action-tool module to actually FAIL,
  * and `mock.module` is file-wide: `lib/tools/__tests__/registry.test.ts` mocks
@@ -18,9 +20,15 @@
  *
  * The assertion is on what `runAgent` RECEIVES, not on what the registry
  * builder returns — "the warning was produced" was already true before the fix.
- * `agent.ts` renders `warnings` under a `## Warnings` heading in the system
- * prompt (pinned by `agent-cache.test.ts`), so the option is the seam where
- * this surface's obligation ends.
+ * The remaining hop, `runAgent({ warnings })` → `## Warnings` in the prompt the
+ * model is handed, is pinned by `agent-context-warnings.test.ts`; without that
+ * this file (and its two siblings) would all stay green if the forwarding were
+ * deleted.
+ *
+ * The real logger is deliberately NOT mocked here: the failing action load must
+ * still emit its operator-facing `error` line, and asserting the user-facing
+ * half while silencing the operator half would miss the point of the issue. The
+ * pino line in this file's output is expected.
  */
 
 import { describe, it, expect, mock } from "bun:test";
@@ -44,6 +52,12 @@ void mock.module("@atlas/api/lib/tools/actions", () => {
 /** Every `runAgent` options bag the surface produced, in call order. */
 const runAgentCalls: { tools?: { getAll(): Record<string, unknown> }; warnings?: string[] }[] = [];
 
+// Partial mock of `lib/agent`, deliberately: `runAgent` is the only symbol any
+// module in this file's reachable graph imports from it (`agent-query.ts:9`), so
+// the "Export named 'X' not found" failure mode that bit `resume-turn.test.ts`
+// cannot fire here. Mocking the full ~11-export surface would drag the real
+// agent module graph in for no gain. If a future import from `lib/agent` appears
+// under `agent-query.ts`, this comment is where to widen the mock.
 void mock.module("@atlas/api/lib/agent", () => ({
   runAgent: mock(async (args: { tools?: { getAll(): Record<string, unknown> }; warnings?: string[] }) => {
     runAgentCalls.push(args);

--- a/packages/api/src/lib/__tests__/agent-query-degraded-tools.test.ts
+++ b/packages/api/src/lib/__tests__/agent-query-degraded-tools.test.ts
@@ -1,0 +1,132 @@
+/**
+ * #4941 — a degraded tool load on a HEADLESS surface reaches the model.
+ *
+ * `buildRegistry` authors a warning addressed to the agent ("...are unavailable
+ * for this session. Inform the user and suggest they check server logs or retry
+ * later"), and `api/routes/chat.ts` threads it into `runAgent({ warnings })` so
+ * a web user hears "temporarily unavailable, retry". Every headless surface —
+ * the SDK query route, Slack, MCP, the scheduler — goes through
+ * `executeAgentQuery`, which resolved a seam that returned a bare registry and
+ * dropped the warnings at the destructure. The agent then reported the
+ * capability as ABSENT rather than degraded: a wrong explanation, not a missing
+ * one, which is what makes it a truthfulness bug rather than a papercut.
+ *
+ * Own file because proving it needs the action-tool module to actually FAIL,
+ * and `mock.module` is file-wide: `lib/tools/__tests__/registry.test.ts` mocks
+ * that same specifier to a WORKING pair, which is what makes its
+ * `includeActions` assertions meaningful. The two mocks cannot coexist.
+ *
+ * The assertion is on what `runAgent` RECEIVES, not on what the registry
+ * builder returns — "the warning was produced" was already true before the fix.
+ * `agent.ts` renders `warnings` under a `## Warnings` heading in the system
+ * prompt (pinned by `agent-cache.test.ts`), so the option is the seam where
+ * this surface's obligation ends.
+ */
+
+import { describe, it, expect, mock } from "bun:test";
+
+/**
+ * The failure being modelled: the action barrel does not load. A throwing
+ * factory makes the `await import("./actions")` inside `buildRegistry` reject,
+ * which is the branch that authors the warning — the same shape as a missing
+ * transitive dep or a module-scope throw in `jira.ts` / `email.ts` on a
+ * misconfigured box.
+ *
+ * Deliberately not a partial mock of the barrel's real exports: there is no
+ * export surface to keep faithful when the premise is that the module is
+ * unusable, and a partial mock would fail with a DIFFERENT error ("Export named
+ * 'X' not found") that this file would then be quietly testing instead.
+ */
+void mock.module("@atlas/api/lib/tools/actions", () => {
+  throw new Error("simulated action-module load failure (#4941)");
+});
+
+/** Every `runAgent` options bag the surface produced, in call order. */
+const runAgentCalls: { tools?: { getAll(): Record<string, unknown> }; warnings?: string[] }[] = [];
+
+void mock.module("@atlas/api/lib/agent", () => ({
+  runAgent: mock(async (args: { tools?: { getAll(): Record<string, unknown> }; warnings?: string[] }) => {
+    runAgentCalls.push(args);
+    return {
+      runId: "run-degraded-1",
+      text: Promise.resolve("done"),
+      steps: Promise.resolve([]),
+      totalUsage: Promise.resolve({ inputTokens: 1, outputTokens: 1 }),
+    };
+  }),
+}));
+
+const { executeAgentQuery } = await import("@atlas/api/lib/agent-query");
+const { buildHeadlessRegistry } = await import("@atlas/api/lib/tools/registry");
+
+/** Run `fn` with the given env keys set/cleared, restoring them afterwards. */
+async function withEnv(
+  overrides: Record<string, string | undefined>,
+  fn: () => Promise<void>,
+): Promise<void> {
+  const saved = new Map(Object.keys(overrides).map((k) => [k, process.env[k]]));
+  try {
+    for (const [k, v] of Object.entries(overrides)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+    await fn();
+  } finally {
+    for (const [k, v] of saved) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  }
+}
+
+const ACTION_WARNING = "Action tools (JIRA, email) failed to load";
+
+describe("#4941 — headless surfaces relay a degraded tool load", () => {
+  it("the headless seam surfaces buildRegistry's action-tool warning to its caller", async () => {
+    await withEnv({ ATLAS_ACTIONS_ENABLED: "true" }, async () => {
+      const { registry, warnings } = await buildHeadlessRegistry();
+
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toContain(ACTION_WARNING);
+      // Degraded, not dead. The read surface is intact, which is exactly why
+      // "I can't do that" was the wrong thing for the model to say.
+      const names = Object.keys(registry.getAll());
+      expect(names).toContain("executeSQL");
+      expect(names).not.toContain("sendEmailReport");
+    });
+  });
+
+  it("executeAgentQuery threads the warning into the agent's context", async () => {
+    runAgentCalls.length = 0;
+    await withEnv({ ATLAS_ACTIONS_ENABLED: "true" }, async () => {
+      await executeAgentQuery("email me the Q3 numbers", "req-degraded");
+    });
+
+    expect(runAgentCalls).toHaveLength(1);
+    const warnings = runAgentCalls[0]!.warnings;
+    expect(
+      warnings,
+      "the headless turn ran with a degraded tool set and told the model nothing about it",
+    ).toBeDefined();
+    expect(warnings).toHaveLength(1);
+    expect(warnings![0]).toContain(ACTION_WARNING);
+    // The instruction half is what makes it relayable copy rather than an
+    // operator log line; dropping it leaves the model free to invent a reason.
+    expect(warnings![0]).toContain("Inform the user");
+  });
+
+  it("a healthy turn passes no warnings — the signal is not always-on", async () => {
+    // Without this, "warnings is populated" is satisfiable by a surface that
+    // always warns, which would open every headless answer with an apology.
+    // `ATLAS_ACTIONS_ENABLED` unset means the failing module is never imported.
+    runAgentCalls.length = 0;
+    await withEnv({ ATLAS_ACTIONS_ENABLED: undefined }, async () => {
+      await executeAgentQuery("how many customers?", "req-healthy");
+    });
+
+    expect(runAgentCalls).toHaveLength(1);
+    expect(runAgentCalls[0]!.warnings).toBeUndefined();
+    // Not vacuous: the turn really did run the headless registry.
+    expect(Object.keys(runAgentCalls[0]!.tools!.getAll())).toContain("executeSQL");
+  });
+});

--- a/packages/api/src/lib/__tests__/agent-query-degraded-tools.test.ts
+++ b/packages/api/src/lib/__tests__/agent-query-degraded-tools.test.ts
@@ -6,8 +6,10 @@
  * later"), and `api/routes/chat.ts` threads it into `runAgent({ warnings })` so
  * a web user hears "temporarily unavailable, retry". Every headless surface that
  * BUILDS a registry — the SDK query route, Slack, MCP, the scheduler — goes
- * through `executeAgentQuery`, which resolved a seam that returned a bare
- * registry and dropped the warnings at the destructure. The agent then reported
+ * through `executeAgentQuery` (the chat-platform approval resume calls the seam
+ * directly, and is covered by its own file), which resolved a seam that
+ * returned a bare registry and dropped the warnings at the destructure. The
+ * agent then reported
  * the capability as ABSENT rather than degraded: a wrong explanation, not a
  * missing one, which is what makes it a truthfulness bug rather than a papercut.
  * (`ee/src/proactive/answer-adapter.ts` is headless too, but passes a STATIC
@@ -93,7 +95,7 @@ async function withEnv(
   }
 }
 
-const ACTION_WARNING = "Action tools (JIRA, email) failed to load";
+const ACTION_WARNING = "The operator action tools (createJiraTicket, sendEmailReport) failed to load";
 
 describe("#4941 — headless surfaces relay a degraded tool load", () => {
   it("the headless seam surfaces buildRegistry's action-tool warning to its caller", async () => {
@@ -126,7 +128,11 @@ describe("#4941 — headless surfaces relay a degraded tool load", () => {
     expect(warnings![0]).toContain(ACTION_WARNING);
     // The instruction half is what makes it relayable copy rather than an
     // operator log line; dropping it leaves the model free to invent a reason.
-    expect(warnings![0]).toContain("Inform the user");
+    // Both halves matter: the second stops the model generalizing "the action
+    // tools are gone" into "email is gone", when the core `sendEmail` is right
+    // there in its tool list.
+    expect(warnings![0]).toContain("temporarily unavailable");
+    expect(warnings![0]).toContain("do NOT tell the user that one of them is unavailable");
   });
 
   it("a healthy turn passes no warnings — the signal is not always-on", async () => {

--- a/packages/api/src/lib/__tests__/agent-runagent-call-sites.test.ts
+++ b/packages/api/src/lib/__tests__/agent-runagent-call-sites.test.ts
@@ -596,7 +596,11 @@ describe("#4936 — the call-site scanner detects the shapes the bug actually ha
     ["a pre-built options bag hides the posture", `opts`, true],
     ["unconditional — the fixed shape", `{ messages, tools: resolvedToolRegistry }`, false],
     ["unconditional, first key", `{ tools: nonDashboardRegistry, messages }`, false],
-    ["unconditional await", `{ messages: [], tools: await buildHeadlessRegistry() }`, false],
+    [
+      "unconditional await",
+      `{ messages: [], tools: (await buildHeadlessRegistry()).registry }`,
+      false,
+    ],
     ["shorthand property", `{ messages, tools }`, false],
     // Last-write-wins escalation — the only escape shape that fails UPWARD.
     [
@@ -663,7 +667,8 @@ describe("#4936 — every production runAgent call site names the right registry
         "fail-closed (`nonDashboardRegistry`), so this is not an open door — but the " +
         "surface's tool posture must be declared AT the surface, unconditionally. Pass " +
         "`defaultRegistry` if it owns `/dashboards/[id]` and has a human in the loop; " +
-        "`buildHeadlessRegistry()` if it is an SDK / chat-platform / MCP / scheduler " +
+        "the `registry` half of `await buildHeadlessRegistry()` if it is an SDK / " +
+        "chat-platform / MCP / scheduler " +
         "surface; a purpose-built registry otherwise. See #4936 and the gating comment " +
         "in lib/tools/registry.ts.",
     ).toEqual([]);

--- a/packages/api/src/lib/__tests__/agent-runagent-call-sites.test.ts
+++ b/packages/api/src/lib/__tests__/agent-runagent-call-sites.test.ts
@@ -467,8 +467,11 @@ const EXPECTED_REGISTRY: ReadonlyArray<readonly [file: string, expected: RegExp,
   ],
   [
     "packages/api/src/lib/chat-plugin/resume-turn.ts",
-    /tools:\s*await buildHeadlessRegistry\(\)/,
-    "approval resume must rebuild the SAME headless set the parked turn ran under",
+    /tools:\s*toolRegistry\b/,
+    "approval resume must rebuild the SAME headless set the parked turn ran under — the local " +
+      "binds buildHeadlessRegistry()'s registry half (#4941 split the seam's return into " +
+      "{ registry, warnings }, so the inline `await` spelling is gone). Identity backstopped by " +
+      "chat-plugin/__tests__/resume-turn.test.ts, which asserts the resumed tool NAMES",
   ],
   [
     "ee/src/proactive/answer-adapter.ts",

--- a/packages/api/src/lib/__tests__/logger.test.ts
+++ b/packages/api/src/lib/__tests__/logger.test.ts
@@ -411,6 +411,16 @@ describe("logger", () => {
       expect((scrubErrSerializer(objectish) as Record<string, unknown>).code).toBeUndefined();
     });
 
+    test("a value AT the bound survives — the boundary is inclusive", () => {
+      // 63 is `NAMEDATALEN - 1`, i.e. the longest legal Postgres identifier, so
+      // an off-by-one here would replace a real max-length constraint name with
+      // the oversized sentinel — losing exactly the signal the whitelist exists
+      // for, and only for the longest names.
+      const maxLength = "c".repeat(63);
+      const err = Object.assign(new Error("fk violation"), { constraint: maxLength });
+      expect((scrubErrSerializer(err) as { constraint?: string }).constraint).toBe(maxLength);
+    });
+
     test("an oversized code is replaced by a sentinel, not silently dropped", () => {
       // A SQLSTATE is 5 chars and a pg identifier caps at 63, so a longer value
       // is not the field the disclosure argument reasoned about — it is some

--- a/packages/api/src/lib/__tests__/logger.test.ts
+++ b/packages/api/src/lib/__tests__/logger.test.ts
@@ -337,6 +337,94 @@ describe("logger", () => {
       expect(scrubErrSerializer(null)).toBe("null");
       expect(scrubErrSerializer(undefined)).toBe("undefined");
     });
+
+    // --- #4941: the pg diagnostic whitelist -------------------------------
+    //
+    // The serializer rebuilds an Error from a whitelist, so anything not named
+    // is dropped. `code` and `constraint` are what tell an operator WHICH
+    // invariant rejected a write (`23505` unique vs `23503` foreign key vs
+    // `42P01` missing relation); without them the log says a write failed and
+    // nothing more, which is less actionable than the raw driver error was.
+
+    test("a pg error's code and constraint survive serialization", () => {
+      const pgish = Object.assign(new Error("duplicate key value violates unique constraint"), {
+        code: "23505",
+        constraint: "brain_facts_org_id_subject_key",
+      });
+      const out = scrubErrSerializer(pgish) as { code?: string; constraint?: string; message: string };
+      expect(out.code).toBe("23505");
+      expect(out.constraint).toBe("brain_facts_org_id_subject_key");
+      // The pre-existing guarantees are untouched.
+      expect(out.message).toBe("duplicate key value violates unique constraint");
+    });
+
+    test("a Node system error's code survives too — the whitelist is not pg-only", () => {
+      const enoent = Object.assign(new Error("no such file or directory"), { code: "ENOENT" });
+      expect((scrubErrSerializer(enoent) as { code?: string }).code).toBe("ENOENT");
+    });
+
+    test("an error with no diagnostic fields gains no keys", () => {
+      // Guards the other direction: the spread must not stamp `code: undefined`
+      // onto every serialized error in the fleet.
+      const out = scrubErrSerializer(new Error("plain")) as Record<string, unknown>;
+      expect(Object.keys(out).sort()).toEqual(["message", "stack", "type"]);
+    });
+
+    test("only the whitelisted fields ride along — pg's row-echoing detail does not", () => {
+      // The disclosure line. `detail` is where pg writes the offending VALUES
+      // ("Key (email)=(a@b.com) already exists"), and `where`/`internalQuery`
+      // carry statement text. Diagnostic value does not justify putting
+      // customer rows in the log.
+      const pgish = Object.assign(new Error("duplicate key"), {
+        code: "23505",
+        detail: "Key (email)=(alice@example.com) already exists.",
+        where: "SQL statement \"INSERT INTO users ...\"",
+        internalQuery: "INSERT INTO users (email) VALUES ('alice@example.com')",
+        table: "users",
+      });
+      const out = scrubErrSerializer(pgish) as Record<string, unknown>;
+      expect(Object.keys(out).sort()).toEqual(["code", "message", "stack", "type"]);
+      expect(JSON.stringify(out)).not.toContain("alice@example.com");
+    });
+
+    test("a non-string or oversized code is dropped rather than echoed", () => {
+      // A SQLSTATE is 5 chars and a pg identifier is capped at 63 bytes, so a
+      // longer value is not the field the disclosure argument reasoned about —
+      // it is some other library's `code` carrying a payload. A numeric code is
+      // dropped for the same reason the field's type must not vary by thrower.
+      const numeric = Object.assign(new Error("http failure"), { code: 500 });
+      expect((scrubErrSerializer(numeric) as Record<string, unknown>).code).toBeUndefined();
+
+      const oversized = Object.assign(new Error("odd driver"), {
+        code: `postgres://user:hunter2@db.internal/atlas ${"x".repeat(64)}`,
+      });
+      expect((scrubErrSerializer(oversized) as Record<string, unknown>).code).toBeUndefined();
+    });
+
+    test("a diagnostic field is still scrubbed, not trusted", () => {
+      // Belt and braces: within the length bound the value goes through the
+      // same userinfo scrub as the message, so a driver that ever stuffed a DSN
+      // into `constraint` cannot leak the password through this door.
+      const err = Object.assign(new Error("weird"), { constraint: "postgres://u:pw@h/db" });
+      expect((scrubErrSerializer(err) as { constraint?: string }).constraint).toBe(
+        "postgres://***@h/db",
+      );
+    });
+
+    test("the serialized diagnostic fields reach the emitted log line", () => {
+      // End to end through a real pino instance with the redact paths applied —
+      // the serializer returning a field is not the same as it surviving to the
+      // sink, and `redact.paths` is the thing that could eat it.
+      const { chunks, stream } = captureSink();
+      const log = makeScrubLogger(stream);
+      log.error(
+        { err: Object.assign(new Error("fk violation"), { code: "23503", constraint: "fk_org" }) },
+        "write failed",
+      );
+      const line = JSON.parse(chunks.join("")) as { err: { code?: string; constraint?: string } };
+      expect(line.err.code).toBe("23503");
+      expect(line.err.constraint).toBe("fk_org");
+    });
   });
 
   describe("scrubLogFormatter (F-44)", () => {

--- a/packages/api/src/lib/__tests__/logger.test.ts
+++ b/packages/api/src/lib/__tests__/logger.test.ts
@@ -370,7 +370,7 @@ describe("logger", () => {
       expect(Object.keys(out).sort()).toEqual(["message", "stack", "type"]);
     });
 
-    test("only the whitelisted fields ride along — pg's row-echoing detail does not", () => {
+    test("only the whitelisted fields ride along an ERROR — pg's row-echoing detail does not", () => {
       // The disclosure line. `detail` is where pg writes the offending VALUES
       // ("Key (email)=(a@b.com) already exists"), and `where`/`internalQuery`
       // carry statement text. Diagnostic value does not justify putting
@@ -387,18 +387,95 @@ describe("logger", () => {
       expect(JSON.stringify(out)).not.toContain("alice@example.com");
     });
 
-    test("a non-string or oversized code is dropped rather than echoed", () => {
-      // A SQLSTATE is 5 chars and a pg identifier is capped at 63 bytes, so a
-      // longer value is not the field the disclosure argument reasoned about —
-      // it is some other library's `code` carrying a payload. A numeric code is
-      // dropped for the same reason the field's type must not vary by thrower.
-      const numeric = Object.assign(new Error("http failure"), { code: 500 });
-      expect((scrubErrSerializer(numeric) as Record<string, unknown>).code).toBeUndefined();
+    test("the whitelist guards the Error branch only — a pre-serialized object still passes through", () => {
+      // Pins the LIMIT of the guarantee above, so nobody reads that test as
+      // repo-wide. The object branch spreads the caller's fields verbatim; no
+      // live producer hands a raw pg object to `err` (the audit path normalizes
+      // to an Error first), but a future one would not be covered.
+      const out = scrubErrSerializer({
+        message: "duplicate key",
+        code: "23505",
+        detail: "Key (email)=(alice@example.com) already exists.",
+      }) as Record<string, unknown>;
+      expect(out.detail).toBe("Key (email)=(alice@example.com) already exists.");
+    });
 
+    test("a numeric code is coerced, not dropped", () => {
+      // `mysql2` and Node both use numeric codes; dropping real signal to keep
+      // the field's type stable is a worse trade than coercing, which keeps
+      // both. Non-numeric, non-string values are still skipped.
+      const numeric = Object.assign(new Error("http failure"), { code: 500 });
+      expect((scrubErrSerializer(numeric) as Record<string, unknown>).code).toBe("500");
+
+      const objectish = Object.assign(new Error("odd driver"), { code: { nested: true } });
+      expect((scrubErrSerializer(objectish) as Record<string, unknown>).code).toBeUndefined();
+    });
+
+    test("an oversized code is replaced by a sentinel, not silently dropped", () => {
+      // A SQLSTATE is 5 chars and a pg identifier caps at 63, so a longer value
+      // is not the field the disclosure argument reasoned about — it is some
+      // other library's `code` carrying a payload, and must not be echoed. But
+      // vanishing reads to an operator as "the driver set no code", which is a
+      // different and wrong diagnosis, so the field survives as a sentinel.
       const oversized = Object.assign(new Error("odd driver"), {
         code: `postgres://user:hunter2@db.internal/atlas ${"x".repeat(64)}`,
       });
-      expect((scrubErrSerializer(oversized) as Record<string, unknown>).code).toBeUndefined();
+      const out = scrubErrSerializer(oversized) as Record<string, unknown>;
+      expect(out.code).toBe("[dropped: oversized]");
+      expect(JSON.stringify(out)).not.toContain("hunter2");
+    });
+
+    // Two independent defenses, one per test — together they stop a hostile
+    // thrower from collapsing the whole payload to "[log scrub failed]" (losing
+    // type, message AND stack, a strictly worse line than the one this feature
+    // set out to improve). Split because either alone makes the other's
+    // mutation survive, and a defense nothing can fail is not a defense.
+
+    test("a diagnostic accessor is never INVOKED — own data properties only", () => {
+      let invoked = false;
+      const hostile = new Error("write failed");
+      Object.defineProperty(hostile, "code", {
+        get() {
+          invoked = true;
+          throw new Error("trap");
+        },
+        enumerable: true,
+        configurable: true,
+      });
+
+      const out = scrubErrSerializer(hostile) as Record<string, unknown>;
+      expect(invoked, "the lift read through an accessor instead of its own descriptor").toBe(false);
+      expect(out.type).toBe("Error");
+      expect(out.message).toBe("write failed");
+      expect(out.code).toBeUndefined();
+    });
+
+    test("a trapping descriptor lookup costs only the diagnostics, not the whole error", () => {
+      // Belt to the descriptor read's braces: a Proxy can trap the descriptor
+      // lookup itself, which no amount of careful reading avoids. Without the
+      // lift's own catch this reaches the serializer's outer catch.
+      const hostile = new Proxy(new Error("write failed"), {
+        getOwnPropertyDescriptor() {
+          throw new Error("trap");
+        },
+      });
+
+      const out = scrubErrSerializer(hostile) as Record<string, unknown>;
+      expect(out.type).toBe("Error");
+      expect(out.message).toBe("write failed");
+      expect(out.code).toBeUndefined();
+    });
+
+    test("a whitelisted field can never clobber the scrubbed core fields", () => {
+      // The diagnostics spread runs FIRST, so even an own `message`/`stack` on
+      // the thrower loses to the scrubbed value. (`message` is not on today's
+      // whitelist; this pins the ORDER that keeps a future addition harmless.)
+      const shadowing = Object.assign(new Error("real postgres://u:pw@h/db message"), {
+        code: "23505",
+      });
+      const out = scrubErrSerializer(shadowing) as Record<string, unknown>;
+      expect(out.message).toBe("real postgres://***@h/db message");
+      expect(out.code).toBe("23505");
     });
 
     test("a diagnostic field is still scrubbed, not trusted", () => {

--- a/packages/api/src/lib/__tests__/logger.test.ts
+++ b/packages/api/src/lib/__tests__/logger.test.ts
@@ -401,9 +401,12 @@ describe("logger", () => {
     });
 
     test("a numeric code is coerced, not dropped", () => {
-      // `mysql2` and Node both use numeric codes; dropping real signal to keep
-      // the field's type stable is a worse trade than coercing, which keeps
-      // both. Non-numeric, non-string values are still skipped.
+      // Not pg / mysql2 / Node — all three put a STRING in `code` (`23505`,
+      // `ER_DUP_ENTRY`, `ENOENT`) and the integer in `errno`, which is not a
+      // diagnostic field. The coercion is for some other SDK that puts an
+      // integer in `code`: keeping it costs nothing and keeps the serialized
+      // field's type from varying by thrower, which dropping would not.
+      // Non-numeric, non-string values are still skipped.
       const numeric = Object.assign(new Error("http failure"), { code: 500 });
       expect((scrubErrSerializer(numeric) as Record<string, unknown>).code).toBe("500");
 
@@ -476,10 +479,13 @@ describe("logger", () => {
       expect(out.code).toBeUndefined();
     });
 
-    test("a whitelisted field can never clobber the scrubbed core fields", () => {
-      // The diagnostics spread runs FIRST, so even an own `message`/`stack` on
-      // the thrower loses to the scrubbed value. (`message` is not on today's
-      // whitelist; this pins the ORDER that keeps a future addition harmless.)
+    test("a thrower's own fields never displace the scrubbed core fields", () => {
+      // What this pins is the OUTCOME: `message` is the scrubbed one, and the
+      // diagnostics ride alongside. The ordering that guarantees it (diagnostics
+      // spread first) is belt to the type's braces —
+      // `Partial<Record<ErrorDiagnosticField, string>>` already makes a
+      // colliding key unspellable, so reordering alone is not observable today
+      // and this test does not claim to catch it.
       const shadowing = Object.assign(new Error("real postgres://u:pw@h/db message"), {
         code: "23505",
       });

--- a/packages/api/src/lib/agent-query.ts
+++ b/packages/api/src/lib/agent-query.ts
@@ -277,12 +277,18 @@ export async function executeAgentQuery(
     // instead of re-deriving it (or, as it did, omitting `tools` and inheriting
     // the workspace registry). We still pass `tools` explicitly: `runAgent`'s
     // default now fails closed, but the surface's choice belongs in the surface.
+    //
+    // #4941 — the seam also returns the warnings the MODEL is meant to relay
+    // (action tools failed to load; the whole build failed and we degraded to
+    // the core set). Dropping them is what made a headless agent say "I can't
+    // do that" where the web surface says "temporarily unavailable, retry".
     const { buildHeadlessRegistry } = await import("@atlas/api/lib/tools/registry");
-    const toolRegistry = await buildHeadlessRegistry();
+    const { registry: toolRegistry, warnings: registryWarnings } = await buildHeadlessRegistry();
 
     const result = await runAgent({
       messages,
       tools: toolRegistry,
+      ...(registryWarnings.length > 0 && { warnings: registryWarnings }),
       ...(options?.conversationId && { conversationId: options.conversationId }),
       ...(options?.answerStyle && { answerStyle: options.answerStyle }),
       ...(options?.abortSignal && { abortSignal: options.abortSignal }),

--- a/packages/api/src/lib/agent-query.ts
+++ b/packages/api/src/lib/agent-query.ts
@@ -278,17 +278,27 @@ export async function executeAgentQuery(
     // the workspace registry). We still pass `tools` explicitly: `runAgent`'s
     // default now fails closed, but the surface's choice belongs in the surface.
     //
-    // #4941 — the seam also returns the warnings the MODEL is meant to relay
-    // (action tools failed to load; the whole build failed and we degraded to
-    // the core set). Dropping them is what made a headless agent say "I can't
-    // do that" where the web surface says "temporarily unavailable, retry".
+    // #4941 — the seam also returns the warnings this surface must relay; the
+    // narrative for why they exist is `buildHeadlessRegistry`'s docstring.
+    // Copied on the way in: `runAgent` treats `warnings` as an in/out param and
+    // pushes its own (semantic-layer, focus-datasource) into whatever array it
+    // is handed, so it must never be given the seam's.
     const { buildHeadlessRegistry } = await import("@atlas/api/lib/tools/registry");
     const { registry: toolRegistry, warnings: registryWarnings } = await buildHeadlessRegistry();
+    if (registryWarnings.length > 0) {
+      // The operator half. The model is told below; this is the line that ties
+      // "the Slack bot said X was unavailable" to a requestId (stamped by the
+      // pino mixin from the context bound above).
+      log.warn(
+        { requestId: id, warningCount: registryWarnings.length },
+        "Headless agent turn running on a DEGRADED tool set — see the preceding registry error",
+      );
+    }
 
     const result = await runAgent({
       messages,
       tools: toolRegistry,
-      ...(registryWarnings.length > 0 && { warnings: registryWarnings }),
+      ...(registryWarnings.length > 0 && { warnings: [...registryWarnings] }),
       ...(options?.conversationId && { conversationId: options.conversationId }),
       ...(options?.answerStyle && { answerStyle: options.answerStyle }),
       ...(options?.abortSignal && { abortSignal: options.abortSignal }),

--- a/packages/api/src/lib/agent.ts
+++ b/packages/api/src/lib/agent.ts
@@ -1097,7 +1097,9 @@ function wrapToolsWithDurableState(toolSet: ToolSet, store: DurableStateStore): 
  *   surface gate `registry.ts` applies from the inside (#4915). Defaulting to
  *   the lesser-privileged registry makes forgetting fail CLOSED. A surface that
  *   owns `/dashboards/[id]` opts in by passing `defaultRegistry`; a headless one
- *   passes `buildHeadlessRegistry()`.
+ *   passes the `registry` half of `await buildHeadlessRegistry()` — and, per
+ *   #4941, threads that call's `warnings` into {@link warnings} rather than
+ *   dropping them.
  *
  *   `nonDashboardRegistry` is lesser-privileged, not side-effect-free: `sendEmail`
  *   / `createLinearIssue` / `querySalesforce` are core tools, gated at execute

--- a/packages/api/src/lib/audit/diagnostic-scrub.ts
+++ b/packages/api/src/lib/audit/diagnostic-scrub.ts
@@ -1,0 +1,73 @@
+/**
+ * Driver DIAGNOSTIC fields — `code` and `constraint` — normalized for a log
+ * line (#4941).
+ *
+ * These are what separate "the write failed" from "WHICH invariant rejected the
+ * write": `23505` a unique violation, `23503` a foreign key, `42P01` a missing
+ * relation, `53300` pool exhaustion. Two places lift them onto a log payload —
+ * `scrubErrSerializer`'s whitelist in `lib/logger.ts`, and `pgErrorFields`'s
+ * top-level lift in `lib/brain/correction.ts` — and they are two doors onto the
+ * same log line. The normalization lives here once so they cannot drift into
+ * two different disclosure rules; a duplicated bound is exactly how that
+ * happens.
+ *
+ * ## Why this is not in `error-scrub.ts`
+ *
+ * It belongs there thematically, and `errorMessage` is imported FROM there. But
+ * seven test files partially `mock.module("@atlas/api/lib/audit/error-scrub")`,
+ * supplying only `errorMessage` (+ sometimes `causeToError`), and bun fails the
+ * whole import with "Export named 'X' not found" when a consumer names a symbol
+ * a partial mock omits — a repo-wide landmine that fires in an unrelated file
+ * on an unrelated PR. Adding an export to a widely-partially-mocked module is
+ * the trigger; adding a NEW module nobody mocks is not. Those seven mocks all
+ * supply `errorMessage`, so this module's own import of it is safe under every
+ * one of them.
+ */
+
+import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
+
+/**
+ * Longest value accepted for a diagnostic field.
+ *
+ * A SQLSTATE is 5 characters and a Postgres identifier is capped at 63 bytes
+ * (`NAMEDATALEN - 1`), so anything longer is not the field the disclosure
+ * argument in `lib/logger.ts` reasoned about — it is some other library's
+ * `code` carrying a payload.
+ *
+ * Measured in UTF-16 code units, not bytes, and both directions of that are
+ * deliberate: it never rejects a legitimate 63-byte ASCII identifier, at the
+ * cost of admitting up to ~3x the bytes for a multi-byte one. The bound is a
+ * sanity check on field IDENTITY, not a byte budget — the disclosure guarantee
+ * is carried by the whitelist of field NAMES, not by this number.
+ */
+export const DIAGNOSTIC_FIELD_MAX = 63;
+
+/** Stands in for an over-length diagnostic value. See {@link diagnosticValue}. */
+export const DIAGNOSTIC_OVERSIZED = "[dropped: oversized]";
+
+/**
+ * Normalize one diagnostic value, or `undefined` if it is not one.
+ *
+ *   - A number is coerced. Some SDKs put an integer in `code`; coercing keeps
+ *     the serialized field's type from varying by thrower without throwing real
+ *     signal away. (pg, mysql2 and Node all use a STRING `code` — `23505`,
+ *     `ER_DUP_ENTRY`, `ENOENT` — and keep the integer in `errno`, which is
+ *     deliberately not a diagnostic field.) Anything else is skipped, so the
+ *     field's type never depends on who threw.
+ *   - An over-length value becomes {@link DIAGNOSTIC_OVERSIZED} rather than
+ *     vanishing: dropping it silently reads to an operator as "the driver set
+ *     no code", which is a different — and wrong — diagnosis.
+ *   - Whatever survives goes through `errorMessage`. These fields are already
+ *     argued safe (a SQLSTATE and a schema identifier, never a row value);
+ *     scrubbing anyway means a driver that ever stuffed a DSN into `constraint`
+ *     cannot open a new credential door.
+ *
+ * Reading the value SAFELY off a thrown object — own, non-accessor, guarded —
+ * is the caller's job, and both callers do it the same way. It is not folded in
+ * here because the two differ in what they must do when the read traps.
+ */
+export function diagnosticValue(raw: unknown): string | undefined {
+  const text = typeof raw === "string" || typeof raw === "number" ? String(raw) : undefined;
+  if (text === undefined || text.length === 0) return undefined;
+  return text.length <= DIAGNOSTIC_FIELD_MAX ? errorMessage(text) : DIAGNOSTIC_OVERSIZED;
+}

--- a/packages/api/src/lib/audit/diagnostic-scrub.ts
+++ b/packages/api/src/lib/audit/diagnostic-scrub.ts
@@ -14,14 +14,16 @@
  * ## Why this is not in `error-scrub.ts`
  *
  * It belongs there thematically, and `errorMessage` is imported FROM there. But
- * seven test files partially `mock.module("@atlas/api/lib/audit/error-scrub")`,
- * supplying only `errorMessage` (+ sometimes `causeToError`), and bun fails the
- * whole import with "Export named 'X' not found" when a consumer names a symbol
- * a partial mock omits — a repo-wide landmine that fires in an unrelated file
- * on an unrelated PR. Adding an export to a widely-partially-mocked module is
- * the trigger; adding a NEW module nobody mocks is not. Those seven mocks all
- * supply `errorMessage`, so this module's own import of it is safe under every
- * one of them.
+ * ten test files `mock.module("@atlas/api/lib/audit/error-scrub")` — eight under
+ * `packages/api`, two under `ee/` — and nine of them reproduce its full
+ * two-export surface exactly. That completeness is precisely what makes a THIRD
+ * export a landmine: bun fails the whole import with "Export named 'X' not
+ * found" the moment a consumer names a symbol a mock omits, and the failure
+ * lands in an unrelated file on an unrelated PR. (Adding `diagnosticValue`
+ * there broke `conversations-budget.test.ts`, the one file mocking only
+ * `errorMessage`.) Adding a NEW module nobody mocks has no such blast radius,
+ * and all ten mocks supply `errorMessage`, so this module's own import is safe
+ * under every one of them.
  */
 
 import { errorMessage } from "@atlas/api/lib/audit/error-scrub";

--- a/packages/api/src/lib/brain/__tests__/correction-audit.test.ts
+++ b/packages/api/src/lib/brain/__tests__/correction-audit.test.ts
@@ -472,7 +472,8 @@ describe("the write is awaited, bounded, and never swallowed", () => {
       requestId: "req-7",
     });
     // The Error OBJECT, not `err.message`: pino's `scrubErrSerializer` then
-    // captures the stack and, for a pg rejection, `code`/`detail`/`constraint`.
+    // captures the stack, plus whatever `ERROR_DIAGNOSTIC_FIELDS` the rejection
+    // carries (`code`/`constraint` — never `detail`, which echoes row values).
     // An `err`-less "audit failed" is not actionable at all — `errOf` throws
     // rather than letting a missing field pass as a match.
     expect(errOf(failure).message).toBe("internal DB circuit breaker is open");

--- a/packages/api/src/lib/brain/__tests__/correction-audit.test.ts
+++ b/packages/api/src/lib/brain/__tests__/correction-audit.test.ts
@@ -592,9 +592,10 @@ describe("the write is awaited, bounded, and never swallowed", () => {
     const errors = logCalls.filter((c) => c.level === "error");
     expect(errors).toHaveLength(1);
     expect(errors[0]?.message).toContain("may not have been committed");
-    // `scrubErrSerializer` rebuilds the error into `{ type, message, stack }`
-    // and DROPS everything else, so a pg rejection's diagnostics only reach an
-    // operator if they are lifted onto the payload as their own fields.
+    // The top-level lift, under stable keys this assertion pins. #4941 also put
+    // `code`/`constraint` on `scrubErrSerializer`'s whitelist, so they survive
+    // on the serialized `err` too — but that serializer is opt-in per pino
+    // instance, and this payload must carry the diagnostics either way.
     expect(errors[0]?.payload).toMatchObject({
       writeAttempted: true,
       pgCode: "42P01",

--- a/packages/api/src/lib/brain/__tests__/correction-audit.test.ts
+++ b/packages/api/src/lib/brain/__tests__/correction-audit.test.ts
@@ -595,12 +595,103 @@ describe("the write is awaited, bounded, and never swallowed", () => {
     expect(errors[0]?.message).toContain("may not have been committed");
     // The top-level lift, under stable keys this assertion pins. #4941 also put
     // `code`/`constraint` on `scrubErrSerializer`'s whitelist, so they survive
-    // on the serialized `err` too — but that serializer is opt-in per pino
-    // instance, and this payload must carry the diagnostics either way.
+    // on the serialized `err` too — but the `err:` field is normalized through
+    // `new Error(String(err))`, which discards a non-`Error` thrower's own
+    // properties, so on that path this lift is still the only copy.
     expect(errors[0]?.payload).toMatchObject({
       writeAttempted: true,
       pgCode: "42P01",
       pgConstraint: "pk_admin_action_log",
+    });
+  });
+
+  // #4941 — the lift shares its value policy with `scrubErrSerializer`'s
+  // whitelist (`diagnosticValue`), and the docstring's claim that "two doors
+  // onto one log line must not enforce two different disclosure rules" is only
+  // worth anything if this door has the negative cases too. Before these, every
+  // assertion here used a short, already-clean string.
+  describe("#4941 — the lift enforces the same disclosure policy as the serializer", () => {
+    /** Run a correction whose audit write rejects with `thrown`, return the error payload. */
+    async function payloadForRejection(thrown: unknown): Promise<Record<string, unknown>> {
+      logCalls.length = 0;
+      auditBehaviour = async () => {
+        throw thrown;
+      };
+      await correctFact(
+        { ctx: admin, factId: FACT, verb: "pin", requestId: "req-pg" },
+        fakeTransaction(),
+      );
+      const errors = logCalls.filter((c) => c.level === "error");
+      expect(errors).toHaveLength(1);
+      return (errors[0]?.payload ?? {}) as Record<string, unknown>;
+    }
+
+    test("an over-length code becomes a sentinel rather than being echoed or vanishing", async () => {
+      const payload = await payloadForRejection(
+        Object.assign(new Error("odd driver"), {
+          code: `postgres://user:hunter2@db.internal/atlas ${"x".repeat(64)}`,
+        }),
+      );
+      expect(payload.pgCode).toBe("[dropped: oversized]");
+      // Scoped to the LIFTED field on purpose. This file mocks
+      // `scrubErrSerializer` to the identity function, so the raw `err` object
+      // sits in the payload unscrubbed — a harness artifact, not the shipped
+      // path (the real serializer sentinels the same value, pinned in
+      // logger.test.ts). Asserting over the whole payload would be asserting
+      // about the mock.
+      expect(String(payload.pgCode)).not.toContain("hunter2");
+    });
+
+    test("a value inside the bound is still scrubbed, not trusted", async () => {
+      const payload = await payloadForRejection(
+        Object.assign(new Error("weird"), { constraint: "postgres://u:pw@h/db" }),
+      );
+      expect(payload.pgConstraint).toBe("postgres://***@h/db");
+    });
+
+    test("a numeric code is coerced rather than dropped", async () => {
+      const payload = await payloadForRejection(
+        Object.assign(new Error("http failure"), { code: 500 }),
+      );
+      expect(payload.pgCode).toBe("500");
+    });
+
+    test("a diagnostic accessor is never INVOKED — own data properties only", async () => {
+      // `emitCorrectionAudit` is awaited on an ALREADY-COMMITTED correction and
+      // is contracted NEVER to throw: a throw from this logging helper surfaces
+      // as "nothing was changed — retry", inviting a duplicate brain mutation.
+      // Two defenses hold that line and each has its own test, because the
+      // guarded read alone and the catch alone each make the other's mutation
+      // survive. This one is the read.
+      let invoked = false;
+      const hostile = new Error("write failed");
+      Object.defineProperty(hostile, "code", {
+        get() {
+          invoked = true;
+          throw new Error("trap");
+        },
+        enumerable: true,
+        configurable: true,
+      });
+
+      const payload = await payloadForRejection(hostile);
+      expect(invoked, "the lift read through an accessor instead of its own descriptor").toBe(false);
+      expect(payload.writeAttempted).toBe(true);
+      expect(payload.pgCode).toBeUndefined();
+    });
+
+    test("a trapping descriptor lookup still costs only the fields, never a throw", async () => {
+      // And this one is the catch: a Proxy can trap the descriptor lookup
+      // itself, which no amount of careful reading avoids.
+      const hostile = new Proxy(new Error("write failed"), {
+        getOwnPropertyDescriptor() {
+          throw new Error("trap");
+        },
+      });
+
+      const payload = await payloadForRejection(hostile);
+      expect(payload.writeAttempted).toBe(true);
+      expect(payload.pgCode).toBeUndefined();
     });
   });
 

--- a/packages/api/src/lib/brain/correction.ts
+++ b/packages/api/src/lib/brain/correction.ts
@@ -1061,10 +1061,10 @@ async function emitCorrectionAudit(args: {
         writeAttempted,
         ...pgErrorFields(err),
         // The Error OBJECT, matching `auth/middleware.ts`, so pino's
-        // `scrubErrSerializer` captures the stack. It rebuilds the error into
-        // `{ type, message, stack }` and DROPS everything else, which is why the
-        // pg fields are lifted out separately above rather than left to ride on
-        // the error.
+        // `scrubErrSerializer` captures the stack. It rebuilds the error from a
+        // whitelist and drops every own property outside it; `code` and
+        // `constraint` are on that whitelist as of #4941, so they now ride on
+        // the error too — see `pgErrorFields` for why the lift stays anyway.
         err: err instanceof Error ? err : new Error(String(err)),
       },
       // Two structurally different failures share this catch, and they need
@@ -1093,11 +1093,18 @@ async function emitCorrectionAudit(args: {
  * A pg rejection's diagnostic triple, lifted onto the log payload as its own
  * fields.
  *
- * Necessary because `scrubErrSerializer` reduces the `err` object to
- * `{ type, message, stack }`, so `code` / `constraint` — the difference between
- * "which failure mode was this" being an answer and a guess (`42P01` a missing
- * relation, `53300` pool exhaustion) — do not survive on the error itself.
- * `detail` is deliberately left off: pg echoes row values into it.
+ * `code` / `constraint` are the difference between "which failure mode was
+ * this" being an answer and a guess (`42P01` a missing relation, `53300` pool
+ * exhaustion). #4941 added both to `scrubErrSerializer`'s whitelist, so they
+ * now survive on the serialized `err` as well — this lift is no longer the only
+ * copy, and it stays for two reasons. It names them at the TOP level under
+ * stable keys the operator runbook and this module's test already key on; and
+ * it does not depend on `scrubErrSerializer` being installed, which is per-pino-
+ * instance and opt-in (a caller that builds its own logger without
+ * `serializers.err` still gets these fields from here).
+ *
+ * `detail` is deliberately left off, on both paths: pg echoes row values into
+ * it.
  */
 function pgErrorFields(err: unknown): { pgCode?: string; pgConstraint?: string } {
   if (typeof err !== "object" || err === null) return {};

--- a/packages/api/src/lib/brain/correction.ts
+++ b/packages/api/src/lib/brain/correction.ts
@@ -147,7 +147,7 @@
 
 import { randomUUID } from "node:crypto";
 import { createLogger, getRequestContext } from "@atlas/api/lib/logger";
-import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
+import { diagnosticValue } from "@atlas/api/lib/audit/diagnostic-scrub";
 import { ADMIN_ACTIONS, logAdminActionAwait, type AdminActionEntry } from "@atlas/api/lib/audit";
 import {
   aclVisibilityClause,
@@ -1104,27 +1104,38 @@ async function emitCorrectionAudit(args: {
  * still the only copy. It also names the fields at the top level under the
  * stable keys this module's test pins.
  *
- * Bounded and scrubbed to the same policy as the serializer's whitelist,
- * deliberately: two doors onto one log line must not enforce two different
- * disclosure rules. `detail` is left off on both: pg echoes row values into it.
+ * Value policy is `diagnosticValue` — the SAME function the serializer's
+ * whitelist uses, not a parallel bound: two doors onto one log line must not
+ * enforce two different disclosure rules, and a duplicated constant is how they
+ * would drift. `detail` is left off on both: pg echoes row values into it.
+ *
+ * The read is guarded because `emitCorrectionAudit` is contracted NEVER to
+ * throw and this runs inside it, on an already-committed correction. A plain
+ * destructure would invoke an accessor; if that accessor threw, the throw would
+ * escape into `applyCorrection`'s catch and tell the caller to RETRY a
+ * correction that already landed — a duplicate brain mutation authored by a
+ * logging helper. Own non-accessor reads plus a catch, matching
+ * `errorDiagnostics`. The catch also covers `diagnosticValue` being absent under
+ * a partial `mock.module` in some other test file: the cost is a missing log
+ * field, never a throw.
  */
-const PG_FIELD_MAX = 63;
-
-function pgDiagnostic(value: unknown): string | undefined {
-  const text = typeof value === "string" || typeof value === "number" ? String(value) : undefined;
-  if (text === undefined || text.length === 0) return undefined;
-  return text.length <= PG_FIELD_MAX ? errorMessage(text) : "[dropped: oversized]";
-}
-
 function pgErrorFields(err: unknown): { pgCode?: string; pgConstraint?: string } {
   if (typeof err !== "object" || err === null) return {};
-  const { code, constraint } = err as { code?: unknown; constraint?: unknown };
-  const pgCode = pgDiagnostic(code);
-  const pgConstraint = pgDiagnostic(constraint);
-  return {
-    ...(pgCode !== undefined && { pgCode }),
-    ...(pgConstraint !== undefined && { pgConstraint }),
-  };
+  try {
+    const pgCode = diagnosticValue(Object.getOwnPropertyDescriptor(err, "code")?.value);
+    const pgConstraint = diagnosticValue(
+      Object.getOwnPropertyDescriptor(err, "constraint")?.value,
+    );
+    return {
+      ...(pgCode !== undefined && { pgCode }),
+      ...(pgConstraint !== undefined && { pgConstraint }),
+    };
+  } catch (err_) {
+    // intentionally ignored: a trapping diagnostic property must not turn a
+    // best-effort audit log line into a throw out of a never-throw contract.
+    void err_;
+    return {};
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/api/src/lib/brain/correction.ts
+++ b/packages/api/src/lib/brain/correction.ts
@@ -147,6 +147,7 @@
 
 import { randomUUID } from "node:crypto";
 import { createLogger, getRequestContext } from "@atlas/api/lib/logger";
+import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
 import { ADMIN_ACTIONS, logAdminActionAwait, type AdminActionEntry } from "@atlas/api/lib/audit";
 import {
   aclVisibilityClause,
@@ -1090,28 +1091,39 @@ async function emitCorrectionAudit(args: {
 }
 
 /**
- * A pg rejection's diagnostic triple, lifted onto the log payload as its own
- * fields.
+ * A pg rejection's `code` / `constraint`, lifted onto the log payload as its
+ * own fields — the difference between "which failure mode was this" being an
+ * answer and a guess (`42P01` a missing relation, `53300` pool exhaustion).
  *
- * `code` / `constraint` are the difference between "which failure mode was
- * this" being an answer and a guess (`42P01` a missing relation, `53300` pool
- * exhaustion). #4941 added both to `scrubErrSerializer`'s whitelist, so they
- * now survive on the serialized `err` as well — this lift is no longer the only
- * copy, and it stays for two reasons. It names them at the TOP level under
- * stable keys the operator runbook and this module's test already key on; and
- * it does not depend on `scrubErrSerializer` being installed, which is per-pino-
- * instance and opt-in (a caller that builds its own logger without
- * `serializers.err` still gets these fields from here).
+ * #4941 added both to `scrubErrSerializer`'s whitelist, so they now survive on
+ * the serialized `err` too. This lift is therefore no longer the only copy, and
+ * it stays for a reason that copy cannot cover: the `err:` field above is
+ * normalized with `err instanceof Error ? err : new Error(String(err))`, which
+ * discards a NON-`Error` thrower's own properties before the serializer ever
+ * sees them. `pgErrorFields` reads the raw rejection, so on that path it is
+ * still the only copy. It also names the fields at the top level under the
+ * stable keys this module's test pins.
  *
- * `detail` is deliberately left off, on both paths: pg echoes row values into
- * it.
+ * Bounded and scrubbed to the same policy as the serializer's whitelist,
+ * deliberately: two doors onto one log line must not enforce two different
+ * disclosure rules. `detail` is left off on both: pg echoes row values into it.
  */
+const PG_FIELD_MAX = 63;
+
+function pgDiagnostic(value: unknown): string | undefined {
+  const text = typeof value === "string" || typeof value === "number" ? String(value) : undefined;
+  if (text === undefined || text.length === 0) return undefined;
+  return text.length <= PG_FIELD_MAX ? errorMessage(text) : "[dropped: oversized]";
+}
+
 function pgErrorFields(err: unknown): { pgCode?: string; pgConstraint?: string } {
   if (typeof err !== "object" || err === null) return {};
   const { code, constraint } = err as { code?: unknown; constraint?: unknown };
+  const pgCode = pgDiagnostic(code);
+  const pgConstraint = pgDiagnostic(constraint);
   return {
-    ...(typeof code === "string" ? { pgCode: code } : {}),
-    ...(typeof constraint === "string" ? { pgConstraint: constraint } : {}),
+    ...(pgCode !== undefined && { pgCode }),
+    ...(pgConstraint !== undefined && { pgConstraint }),
   };
 }
 

--- a/packages/api/src/lib/brain/correction.ts
+++ b/packages/api/src/lib/brain/correction.ts
@@ -1112,12 +1112,12 @@ async function emitCorrectionAudit(args: {
  * The read is guarded because `emitCorrectionAudit` is contracted NEVER to
  * throw and this runs inside it, on an already-committed correction. A plain
  * destructure would invoke an accessor; if that accessor threw, the throw would
- * escape into `applyCorrection`'s catch and tell the caller to RETRY a
- * correction that already landed — a duplicate brain mutation authored by a
- * logging helper. Own non-accessor reads plus a catch, matching
- * `errorDiagnostics`. The catch also covers `diagnosticValue` being absent under
- * a partial `mock.module` in some other test file: the cost is a missing log
- * field, never a throw.
+ * escape `correctFact` — the audit call sits after its try/catch — and reach a
+ * caller whose error copy says "nothing was changed, retry", inviting a
+ * duplicate brain mutation authored by a logging helper. Hence own non-accessor
+ * reads (an accessor descriptor has no `value`, so the getter is never called)
+ * plus a `catch` for a Proxy that traps the descriptor lookup itself — the two
+ * defenses `errorDiagnostics` uses, for the same reasons.
  */
 function pgErrorFields(err: unknown): { pgCode?: string; pgConstraint?: string } {
   if (typeof err !== "object" || err === null) return {};

--- a/packages/api/src/lib/chat-plugin/__tests__/resume-turn.test.ts
+++ b/packages/api/src/lib/chat-plugin/__tests__/resume-turn.test.ts
@@ -166,7 +166,9 @@ describe("resumeChatTurn (#3750)", () => {
   });
 
   it("#4941 — a healthy build passes no warnings (the resumed model is not told to apologise)", async () => {
-    await resumeChatTurn({ ...BASE, externalUserId: "U999" });
+    const result = await resumeChatTurn({ ...BASE, externalUserId: "U999" });
+    // Non-vacuous: the resume really ran and really answered.
+    expect(result).toEqual({ status: "answered", answer: "continued answer" });
     const runArgs = mockRunAgent.mock.calls[0]![0] as { warnings?: string[] };
     expect(runArgs.warnings).toBeUndefined();
   });

--- a/packages/api/src/lib/chat-plugin/__tests__/resume-turn.test.ts
+++ b/packages/api/src/lib/chat-plugin/__tests__/resume-turn.test.ts
@@ -123,6 +123,54 @@ describe("resumeChatTurn (#3750)", () => {
     expect(names).toContain("explore");
   });
 
+  it("#4941 — a degraded registry build tells the resumed model, instead of degrading silently", async () => {
+    // The resume is as headless as the turn it continues, so it owes the user
+    // the same explanation. `ATLAS_PYTHON_ENABLED` without `ATLAS_SANDBOX_URL`
+    // is `buildRegistry`'s fatal misconfiguration; `buildHeadlessRegistry`
+    // catches it and degrades to the non-dashboard core set — deliberately, and
+    // pinned elsewhere — but the user used to be told nothing, so the model
+    // reported the lost capability as one it never had.
+    //
+    // Driven through the FALLBACK branch rather than a failed action-module
+    // import because that needs a file-wide `mock.module`; the action-load half
+    // is pinned in `lib/__tests__/agent-query-degraded-tools.test.ts` on the
+    // other headless caller. Both callers read the same field of the same seam.
+    const savedPython = process.env.ATLAS_PYTHON_ENABLED;
+    const savedSandbox = process.env.ATLAS_SANDBOX_URL;
+    process.env.ATLAS_PYTHON_ENABLED = "true";
+    delete process.env.ATLAS_SANDBOX_URL;
+    try {
+      const result = await resumeChatTurn({ ...BASE, externalUserId: "U999" });
+      expect(result).toEqual({ status: "answered", answer: "continued answer" });
+
+      const runArgs = mockRunAgent.mock.calls[0]![0] as {
+        tools?: { getAll(): Record<string, unknown> };
+        warnings?: string[];
+      };
+      expect(
+        runArgs.warnings,
+        "the resumed turn ran on a degraded tool set and told the model nothing about it",
+      ).toBeDefined();
+      expect(runArgs.warnings).toHaveLength(1);
+      expect(runArgs.warnings![0]).toContain("temporarily unavailable");
+      // Degraded, not dead — and still the headless set, not the workspace one.
+      const degradedNames = Object.keys(runArgs.tools!.getAll());
+      expect(degradedNames).toContain("executeSQL");
+      expect(degradedNames).not.toContain("correct_fact");
+    } finally {
+      if (savedPython === undefined) delete process.env.ATLAS_PYTHON_ENABLED;
+      else process.env.ATLAS_PYTHON_ENABLED = savedPython;
+      if (savedSandbox === undefined) delete process.env.ATLAS_SANDBOX_URL;
+      else process.env.ATLAS_SANDBOX_URL = savedSandbox;
+    }
+  });
+
+  it("#4941 — a healthy build passes no warnings (the resumed model is not told to apologise)", async () => {
+    await resumeChatTurn({ ...BASE, externalUserId: "U999" });
+    const runArgs = mockRunAgent.mock.calls[0]![0] as { warnings?: string[] };
+    expect(runArgs.warnings).toBeUndefined();
+  });
+
   it("blocks (does not resume) when billing re-resolution refuses", async () => {
     mockBillingGate.mockResolvedValueOnce({
       allowed: false,

--- a/packages/api/src/lib/chat-plugin/resume-turn.ts
+++ b/packages/api/src/lib/chat-plugin/resume-turn.ts
@@ -178,9 +178,11 @@ export async function resumeChatTurn(input: ResumeChatTurnInput): Promise<Resume
         const { registry: toolRegistry, warnings: registryWarnings } =
           await buildHeadlessRegistry();
         if (registryWarnings.length > 0) {
-          // The operator half: the registry's own error line carries only
-          // `component: "registry"`, and these are the identifiers whoever
-          // fields "why did Slack say X was unavailable" actually has.
+          // The operator half. The registry's own error line already carries a
+          // requestId (the pino mixin reads the context bound above) but
+          // nothing domain-level; conversationId / orgId / runId are the
+          // identifiers whoever fields "why did Slack say X was unavailable"
+          // actually has.
           log.warn(
             { conversationId, orgId, runId: handle.runId, warningCount: registryWarnings.length },
             "Chat resume running on a DEGRADED tool set — the approved turn may lack the tool it parked on",

--- a/packages/api/src/lib/chat-plugin/resume-turn.ts
+++ b/packages/api/src/lib/chat-plugin/resume-turn.ts
@@ -170,10 +170,17 @@ export async function resumeChatTurn(input: ResumeChatTurnInput): Promise<Resume
         // resume could actually have mutated the brain. Even where the gate did
         // hold, the posture is that a brain-mutating tool must not be on this
         // surface at all.
+        //
+        // #4941 — the seam also hands back the warnings the model must relay
+        // (degraded action tools, or a fallback to the core set). A resumed
+        // turn is as headless as the parked one, so it needs the same telling.
         const { buildHeadlessRegistry } = await import("@atlas/api/lib/tools/registry");
+        const { registry: toolRegistry, warnings: registryWarnings } =
+          await buildHeadlessRegistry();
         const agentResult = await runAgent({
           messages: [],
-          tools: await buildHeadlessRegistry(),
+          tools: toolRegistry,
+          ...(registryWarnings.length > 0 && { warnings: registryWarnings }),
           conversationId,
           resume: {
             runId: handle.runId,

--- a/packages/api/src/lib/chat-plugin/resume-turn.ts
+++ b/packages/api/src/lib/chat-plugin/resume-turn.ts
@@ -177,10 +177,21 @@ export async function resumeChatTurn(input: ResumeChatTurnInput): Promise<Resume
         const { buildHeadlessRegistry } = await import("@atlas/api/lib/tools/registry");
         const { registry: toolRegistry, warnings: registryWarnings } =
           await buildHeadlessRegistry();
+        if (registryWarnings.length > 0) {
+          // The operator half: the registry's own error line carries only
+          // `component: "registry"`, and these are the identifiers whoever
+          // fields "why did Slack say X was unavailable" actually has.
+          log.warn(
+            { conversationId, orgId, runId: handle.runId, warningCount: registryWarnings.length },
+            "Chat resume running on a DEGRADED tool set — the approved turn may lack the tool it parked on",
+          );
+        }
         const agentResult = await runAgent({
           messages: [],
           tools: toolRegistry,
-          ...(registryWarnings.length > 0 && { warnings: registryWarnings }),
+          // Copied: `runAgent` pushes its own warnings into the array it is
+          // handed, and that array belongs to the registry seam.
+          ...(registryWarnings.length > 0 && { warnings: [...registryWarnings] }),
           conversationId,
           resume: {
             runId: handle.runId,

--- a/packages/api/src/lib/db/connection.ts
+++ b/packages/api/src/lib/db/connection.ts
@@ -1599,8 +1599,10 @@ export class ConnectionRegistry {
       // so the `HealthCheckResult.message` surfaced to admin UI / API
       // consumers can't leak credentials. The log line passes the original
       // `err` through so the pino err serializer preserves
-      // `{type, message, stack}` — the stack is useful for triage; scrubbing
-      // there is handled centrally by `scrubErrSerializer` in `lib/logger.ts`.
+      // `{type, message, stack}` — plus the driver's `code`/`constraint`, which
+      // is exactly the case `ERROR_DIAGNOSTIC_FIELDS` (#4941) was added for.
+      // The stack is useful for triage; scrubbing there is handled centrally by
+      // `scrubErrSerializer` in `lib/logger.ts`.
       const scrubbedMessage = errorMessage(err);
       log.warn({ err, connectionId: id, latencyMs }, "Health check failed");
       entry.consecutiveFailures++;

--- a/packages/api/src/lib/logger.ts
+++ b/packages/api/src/lib/logger.ts
@@ -228,12 +228,63 @@ export const redactPaths = [
 const CREDENTIAL_URI_PATTERN = /\b[a-z][a-z0-9+.-]*:\/\/[^\s@/]*@/i;
 
 /**
+ * Driver diagnostic fields carried through the `Error` branch of
+ * {@link scrubErrSerializer} (#4941).
+ *
+ * The serializer rebuilds an `Error` from a whitelist, so every own property
+ * that is not named here is dropped. `code` and `constraint` are what separate
+ * "the write failed" from "WHICH invariant rejected the write" — `23505` a
+ * unique violation, `23503` a foreign key, `42P01` a missing relation, `53300`
+ * pool exhaustion — and without them a pg error in the log is materially less
+ * actionable than the raw driver error was. `code` is also carried by Node
+ * system errors (`ENOENT`) and most SDKs, so this is not pg-only.
+ *
+ * NOT extended to pg's other diagnostic fields, and that is the disclosure
+ * line: `detail` echoes ROW VALUES (`Key (email)=(a@b.com) already exists`),
+ * and `where`/`internalQuery` echo statement text. Those are user data. `code`
+ * is a fixed SQLSTATE and `constraint` is a schema identifier authored in this
+ * repo's migrations — neither is derived from a request, a credential, or a
+ * customer row.
+ */
+const ERROR_DIAGNOSTIC_FIELDS = ["code", "constraint"] as const;
+
+/**
+ * Longest value accepted for an {@link ERROR_DIAGNOSTIC_FIELDS} field.
+ *
+ * A SQLSTATE is 5 characters and a Postgres identifier is capped at 63 bytes
+ * (`NAMEDATALEN - 1`), so anything longer is not the field this whitelist
+ * reasoned about — it is some other library's `code` carrying a payload. Drop
+ * it rather than echo an unbounded value the disclosure argument above never
+ * covered.
+ */
+const ERROR_DIAGNOSTIC_MAX = 64;
+
+/**
+ * Lift the whitelisted diagnostic fields off an error, scrubbed and bounded.
+ * Non-string values are skipped so the serialized shape stays stable (some
+ * SDKs use a numeric `code`; a number is not what an operator greps for and
+ * carrying it would make the field's type depend on the thrower).
+ */
+function errorDiagnostics(err: Error): Record<string, string> {
+  const source = err as unknown as Record<string, unknown>;
+  const out: Record<string, string> = {};
+  for (const field of ERROR_DIAGNOSTIC_FIELDS) {
+    const raw = source[field];
+    if (typeof raw === "string" && raw.length > 0 && raw.length <= ERROR_DIAGNOSTIC_MAX) {
+      out[field] = errorMessage(raw);
+    }
+  }
+  return out;
+}
+
+/**
  * Pino `serializers.err` handler. Funnels every error-shaped value through
  * `errorMessage()` so a driver-echoed connection string (`postgres://u:p@h/db`)
  * gets its userinfo stripped before the line reaches Loki / Railway / Datadog.
  *
  * Accepts:
- *   - Error instance → `{ type, message, stack }` with scrubbed message + stack
+ *   - Error instance → `{ type, message, stack }` with scrubbed message +
+ *     stack, plus any {@link ERROR_DIAGNOSTIC_FIELDS} the error carries
  *   - pre-serialized error-shape object (`{ message, ... }`) → same object
  *     with scrubbed `message`
  *   - string → scrubbed string (this is the hot path — most call sites
@@ -252,6 +303,7 @@ export function scrubErrSerializer(value: unknown): unknown {
         type: value.name,
         message: errorMessage(value),
         ...(scrubbedStack !== undefined && { stack: scrubbedStack }),
+        ...errorDiagnostics(value),
       };
     }
     if (typeof value === "string") return errorMessage(value);

--- a/packages/api/src/lib/logger.ts
+++ b/packages/api/src/lib/logger.ts
@@ -12,6 +12,7 @@ import { AsyncLocalStorage } from "async_hooks";
 import { createHash } from "node:crypto";
 import type { AtlasUser } from "@atlas/api/lib/auth/types";
 import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
+import { diagnosticValue } from "@atlas/api/lib/audit/diagnostic-scrub";
 
 // --- Request context ---
 
@@ -231,9 +232,11 @@ const CREDENTIAL_URI_PATTERN = /\b[a-z][a-z0-9+.-]*:\/\/[^\s@/]*@/i;
  * Driver diagnostic fields carried through the `Error` branch of
  * {@link scrubErrSerializer} (#4941).
  *
- * The serializer rebuilds an `Error`, keeping an own property only if it is
- * `message` / `stack` or is named here. Everything else — `cause`, and every
- * driver field below — is dropped. `code` and `constraint` are what separate
+ * The serializer rebuilds an `Error` as `{ type, message, stack }` from `name`
+ * / `message` / `stack`, then adds only the fields named here, read as own
+ * non-accessor values. `cause` and every other driver field — `detail`,
+ * `where`, `internalQuery`, `table` — are dropped. `code` and `constraint`
+ * are what separate
  * "the write failed" from "WHICH invariant rejected the write" — `23505` a
  * unique violation, `23503` a foreign key, `42P01` a missing relation, `53300`
  * pool exhaustion — and without them a pg error in the log is materially less
@@ -254,46 +257,38 @@ const CREDENTIAL_URI_PATTERN = /\b[a-z][a-z0-9+.-]*:\/\/[^\s@/]*@/i;
  */
 const ERROR_DIAGNOSTIC_FIELDS = ["code", "constraint"] as const;
 
-/**
- * Longest value accepted for an {@link ERROR_DIAGNOSTIC_FIELDS} field.
- *
- * A SQLSTATE is 5 characters and a Postgres identifier is capped at 63 bytes
- * (`NAMEDATALEN - 1`), so anything longer is not the field this whitelist
- * reasoned about — it is some other library's `code` carrying a payload, which
- * the disclosure argument above never covered. Measured in UTF-16 code units
- * rather than bytes: conservative for a multi-byte identifier, which is the
- * direction to err in.
- */
-const ERROR_DIAGNOSTIC_MAX = 63;
-
-/** Stands in for an over-length diagnostic value. See {@link errorDiagnostics}. */
-const ERROR_DIAGNOSTIC_OVERSIZED = "[dropped: oversized]";
+type ErrorDiagnosticField = (typeof ERROR_DIAGNOSTIC_FIELDS)[number];
 
 /**
- * Lift the whitelisted diagnostic fields off an error, scrubbed and bounded.
+ * Lift the whitelisted diagnostic fields off an error.
  *
- * Three deliberate behaviours:
- *   - A number is coerced (`mysql2`'s and Node's numeric codes are real
- *     signal); anything else is skipped, so the serialized field's type never
- *     depends on the thrower.
- *   - An over-length value becomes {@link ERROR_DIAGNOSTIC_OVERSIZED} rather
- *     than vanishing. Dropping it silently reads to an operator as "the driver
- *     set no code", which is a different — and wrong — diagnosis.
- *   - Values are read as OWN, non-accessor properties and the whole lift has
- *     its own `catch`. Without both, a hostile or half-initialized getter on
- *     `code` would throw past the caller's `try` and collapse the entire
- *     serialized error to `"[log scrub failed]"`, costing the operator the
- *     type, message and stack it used to get for free.
+ * Value normalization — number coercion, the length bound, the oversized
+ * sentinel, the scrub — is `diagnosticValue` in `lib/audit/diagnostic-scrub.ts`,
+ * shared with `brain/correction.ts`'s parallel top-level lift so one policy
+ * governs both doors onto the same log line. What is local to here is the READ:
+ *
+ * Values are read as OWN, non-accessor properties (`getOwnPropertyDescriptor`,
+ * never a plain index) and the whole loop has its own `catch`. Without both, a
+ * hostile or half-initialized getter on `code` — or a Proxy trapping the
+ * descriptor lookup — would land in `scrubErrSerializer`'s outer catch and
+ * collapse the entire serialized error to `"[log scrub failed]"`, costing the
+ * operator the type, message and stack it used to get for free. Each defense
+ * has its own test because either alone leaves the other's mutation alive.
+ *
+ * On that trap path the fields are simply ABSENT — no sentinel, unlike the
+ * over-length case. Deliberate: a sentinel would have to be a key outside
+ * {@link ERROR_DIAGNOSTIC_FIELDS}, and the exact-key assertion in
+ * `logger.test.ts` ("only these ever appear on a serialized error") is a
+ * stronger property to keep than a marker for a case no real driver produces.
+ * The prototype-accessor `code` some SDK classes expose is dropped the same
+ * way, and for the same reason.
  */
-function errorDiagnostics(err: Error): Record<string, string> {
-  const out: Record<string, string> = {};
+function errorDiagnostics(err: Error): Partial<Record<ErrorDiagnosticField, string>> {
+  const out: Partial<Record<ErrorDiagnosticField, string>> = {};
   try {
     for (const field of ERROR_DIAGNOSTIC_FIELDS) {
-      const raw = Object.getOwnPropertyDescriptor(err, field)?.value as unknown;
-      const text = typeof raw === "string" || typeof raw === "number" ? String(raw) : undefined;
-      if (text === undefined || text.length === 0) continue;
-      out[field] =
-        text.length <= ERROR_DIAGNOSTIC_MAX ? errorMessage(text) : ERROR_DIAGNOSTIC_OVERSIZED;
+      const value = diagnosticValue(Object.getOwnPropertyDescriptor(err, field)?.value as unknown);
+      if (value !== undefined) out[field] = value;
     }
   } catch (err_) {
     // intentionally ignored: a thrower whose diagnostic property is a trap must
@@ -312,9 +307,12 @@ function errorDiagnostics(err: Error): Record<string, string> {
  * Accepts:
  *   - Error instance → `{ type, message, stack }` with scrubbed message +
  *     stack, plus any {@link ERROR_DIAGNOSTIC_FIELDS} the error carries as a
- *     non-empty own value. Note the whitelist guards this branch only: a
- *     PRE-SERIALIZED error-shape object (below) is passed through field-for-
- *     field, so a raw pg object logged as `err` would still carry `detail`
+ *     non-empty own value (coerced from a number; replaced by a sentinel when
+ *     over-length — see {@link errorDiagnostics}). Note the whitelist guards
+ *     this branch only: a PRE-SERIALIZED error-shape object (below) is passed
+ *     through field-for-field. No live producer does that — pg's
+ *     `DatabaseError` extends `Error`, so a real pg rejection always takes THIS
+ *     branch — but a future one that logged a raw pg object would carry `detail`
  *   - pre-serialized error-shape object (`{ message, ... }`) → same object
  *     with scrubbed `message`
  *   - string → scrubbed string (this is the hot path — most call sites

--- a/packages/api/src/lib/logger.ts
+++ b/packages/api/src/lib/logger.ts
@@ -231,8 +231,9 @@ const CREDENTIAL_URI_PATTERN = /\b[a-z][a-z0-9+.-]*:\/\/[^\s@/]*@/i;
  * Driver diagnostic fields carried through the `Error` branch of
  * {@link scrubErrSerializer} (#4941).
  *
- * The serializer rebuilds an `Error` from a whitelist, so every own property
- * that is not named here is dropped. `code` and `constraint` are what separate
+ * The serializer rebuilds an `Error`, keeping an own property only if it is
+ * `message` / `stack` or is named here. Everything else — `cause`, and every
+ * driver field below — is dropped. `code` and `constraint` are what separate
  * "the write failed" from "WHICH invariant rejected the write" — `23505` a
  * unique violation, `23503` a foreign key, `42P01` a missing relation, `53300`
  * pool exhaustion — and without them a pg error in the log is materially less
@@ -242,9 +243,14 @@ const CREDENTIAL_URI_PATTERN = /\b[a-z][a-z0-9+.-]*:\/\/[^\s@/]*@/i;
  * NOT extended to pg's other diagnostic fields, and that is the disclosure
  * line: `detail` echoes ROW VALUES (`Key (email)=(a@b.com) already exists`),
  * and `where`/`internalQuery` echo statement text. Those are user data. `code`
- * is a fixed SQLSTATE and `constraint` is a schema identifier authored in this
- * repo's migrations — neither is derived from a request, a credential, or a
- * customer row.
+ * is a fixed SQLSTATE; `constraint` is a schema identifier — from this repo's
+ * migrations, a plugin's, or the customer's own analytics schema, since this is
+ * the GLOBAL `err` serializer and datasource errors pass through it too. None
+ * of those is derived from a request, a credential, or a row value.
+ *
+ * Spread BEFORE `type` / `message` / `stack` at the call site, so a future
+ * addition here can never clobber a scrubbed core field — and could only do so
+ * for short values, which is the kind of intermittent corruption nobody spots.
  */
 const ERROR_DIAGNOSTIC_FIELDS = ["code", "constraint"] as const;
 
@@ -253,26 +259,47 @@ const ERROR_DIAGNOSTIC_FIELDS = ["code", "constraint"] as const;
  *
  * A SQLSTATE is 5 characters and a Postgres identifier is capped at 63 bytes
  * (`NAMEDATALEN - 1`), so anything longer is not the field this whitelist
- * reasoned about — it is some other library's `code` carrying a payload. Drop
- * it rather than echo an unbounded value the disclosure argument above never
- * covered.
+ * reasoned about — it is some other library's `code` carrying a payload, which
+ * the disclosure argument above never covered. Measured in UTF-16 code units
+ * rather than bytes: conservative for a multi-byte identifier, which is the
+ * direction to err in.
  */
-const ERROR_DIAGNOSTIC_MAX = 64;
+const ERROR_DIAGNOSTIC_MAX = 63;
+
+/** Stands in for an over-length diagnostic value. See {@link errorDiagnostics}. */
+const ERROR_DIAGNOSTIC_OVERSIZED = "[dropped: oversized]";
 
 /**
  * Lift the whitelisted diagnostic fields off an error, scrubbed and bounded.
- * Non-string values are skipped so the serialized shape stays stable (some
- * SDKs use a numeric `code`; a number is not what an operator greps for and
- * carrying it would make the field's type depend on the thrower).
+ *
+ * Three deliberate behaviours:
+ *   - A number is coerced (`mysql2`'s and Node's numeric codes are real
+ *     signal); anything else is skipped, so the serialized field's type never
+ *     depends on the thrower.
+ *   - An over-length value becomes {@link ERROR_DIAGNOSTIC_OVERSIZED} rather
+ *     than vanishing. Dropping it silently reads to an operator as "the driver
+ *     set no code", which is a different — and wrong — diagnosis.
+ *   - Values are read as OWN, non-accessor properties and the whole lift has
+ *     its own `catch`. Without both, a hostile or half-initialized getter on
+ *     `code` would throw past the caller's `try` and collapse the entire
+ *     serialized error to `"[log scrub failed]"`, costing the operator the
+ *     type, message and stack it used to get for free.
  */
 function errorDiagnostics(err: Error): Record<string, string> {
-  const source = err as unknown as Record<string, unknown>;
   const out: Record<string, string> = {};
-  for (const field of ERROR_DIAGNOSTIC_FIELDS) {
-    const raw = source[field];
-    if (typeof raw === "string" && raw.length > 0 && raw.length <= ERROR_DIAGNOSTIC_MAX) {
-      out[field] = errorMessage(raw);
+  try {
+    for (const field of ERROR_DIAGNOSTIC_FIELDS) {
+      const raw = Object.getOwnPropertyDescriptor(err, field)?.value as unknown;
+      const text = typeof raw === "string" || typeof raw === "number" ? String(raw) : undefined;
+      if (text === undefined || text.length === 0) continue;
+      out[field] =
+        text.length <= ERROR_DIAGNOSTIC_MAX ? errorMessage(text) : ERROR_DIAGNOSTIC_OVERSIZED;
     }
+  } catch (err_) {
+    // intentionally ignored: a thrower whose diagnostic property is a trap must
+    // not cost the caller the error's type/message/stack. `err_` is unusable
+    // here — logging it would re-enter this serializer.
+    void err_;
   }
   return out;
 }
@@ -284,7 +311,10 @@ function errorDiagnostics(err: Error): Record<string, string> {
  *
  * Accepts:
  *   - Error instance → `{ type, message, stack }` with scrubbed message +
- *     stack, plus any {@link ERROR_DIAGNOSTIC_FIELDS} the error carries
+ *     stack, plus any {@link ERROR_DIAGNOSTIC_FIELDS} the error carries as a
+ *     non-empty own value. Note the whitelist guards this branch only: a
+ *     PRE-SERIALIZED error-shape object (below) is passed through field-for-
+ *     field, so a raw pg object logged as `err` would still carry `detail`
  *   - pre-serialized error-shape object (`{ message, ... }`) → same object
  *     with scrubbed `message`
  *   - string → scrubbed string (this is the hot path — most call sites
@@ -300,10 +330,13 @@ export function scrubErrSerializer(value: unknown): unknown {
     if (value instanceof Error) {
       const scrubbedStack = value.stack ? errorMessage(value.stack) : undefined;
       return {
+        // Diagnostics FIRST — see ERROR_DIAGNOSTIC_FIELDS. A future whitelist
+        // entry named `message`/`stack`/`type` must lose to the scrubbed core
+        // fields, not overwrite them.
+        ...errorDiagnostics(value),
         type: value.name,
         message: errorMessage(value),
         ...(scrubbedStack !== undefined && { stack: scrubbedStack }),
-        ...errorDiagnostics(value),
       };
     }
     if (typeof value === "string") return errorMessage(value);

--- a/packages/api/src/lib/logger.ts
+++ b/packages/api/src/lib/logger.ts
@@ -312,7 +312,9 @@ function errorDiagnostics(err: Error): Partial<Record<ErrorDiagnosticField, stri
  *     this branch only: a PRE-SERIALIZED error-shape object (below) is passed
  *     through field-for-field. No live producer does that — pg's
  *     `DatabaseError` extends `Error`, so a real pg rejection always takes THIS
- *     branch — but a future one that logged a raw pg object would carry `detail`
+ *     branch — but a future one logging a raw pg object would carry `detail`
+ *     straight through, which is the limit `logger.test.ts`'s
+ *     pre-serialized-object test pins
  *   - pre-serialized error-shape object (`{ message, ... }`) → same object
  *     with scrubbed `message`
  *   - string → scrubbed string (this is the hot path — most call sites

--- a/packages/api/src/lib/tools/__tests__/registry.test.ts
+++ b/packages/api/src/lib/tools/__tests__/registry.test.ts
@@ -42,6 +42,7 @@ const {
   nonDashboardRegistry,
   buildRegistry,
   buildHeadlessRegistry,
+  HEADLESS_REGISTRY_FALLBACK_WARNING,
   WORKSPACE_DASHBOARD_URL_RESOLVER,
   INTENTIONAL_TOOL_SHADOWS,
   TOOL_SHADOW_REMEDIATIONS,
@@ -479,7 +480,7 @@ describe("buildHeadlessRegistry (#4936)", () => {
   // the parked turn ran under instead of re-deriving it, which is how the
   // surface silently widened across the approval boundary before this fix.
   it("omits both write verbs but keeps the core query tools", async () => {
-    const names = Object.keys((await buildHeadlessRegistry()).getAll());
+    const names = Object.keys((await buildHeadlessRegistry()).registry.getAll());
 
     expect(names).not.toContain("createDashboard");
     expect(names).not.toContain("correct_fact");
@@ -491,10 +492,19 @@ describe("buildHeadlessRegistry (#4936)", () => {
 
   it("keeps operator action tools opt-in behind ATLAS_ACTIONS_ENABLED", async () => {
     await withEnv({ ATLAS_ACTIONS_ENABLED: undefined }, async () => {
-      expect(Object.keys((await buildHeadlessRegistry()).getAll())).not.toContain("sendEmailReport");
+      expect(Object.keys((await buildHeadlessRegistry()).registry.getAll())).not.toContain("sendEmailReport");
     });
     await withEnv({ ATLAS_ACTIONS_ENABLED: "true" }, async () => {
-      expect(Object.keys((await buildHeadlessRegistry()).getAll())).toContain("sendEmailReport");
+      expect(Object.keys((await buildHeadlessRegistry()).registry.getAll())).toContain("sendEmailReport");
+    });
+  });
+
+  it("#4941 — a clean build carries no warnings (the degraded signal is not always-on)", async () => {
+    // The negative half of the pair below. Without it "warnings is non-empty on
+    // failure" is satisfiable by a seam that always warns, which would train
+    // every headless agent to open with an apology.
+    await withEnv({ ATLAS_ACTIONS_ENABLED: "true" }, async () => {
+      expect((await buildHeadlessRegistry()).warnings).toEqual([]);
     });
   });
 
@@ -509,7 +519,7 @@ describe("buildHeadlessRegistry (#4936)", () => {
       async () => {
         await expect(buildRegistry()).rejects.toThrow("ATLAS_SANDBOX_URL");
 
-        const registry = await buildHeadlessRegistry();
+        const { registry } = await buildHeadlessRegistry();
         expect(registry).toBe(nonDashboardRegistry);
         const names = Object.keys(registry.getAll());
         expect(names).not.toContain("createDashboard");
@@ -518,4 +528,29 @@ describe("buildHeadlessRegistry (#4936)", () => {
       },
     );
   });
+
+  it("#4941 — the fallback path authors its own warning instead of degrading silently", async () => {
+    // The degrade above is deliberate and stays; what was missing is that the
+    // user was never told. `nonDashboardRegistry` carries no action tools and no
+    // executePython no matter how the env is set, so a turn that lands here has
+    // lost capability the operator believes is configured.
+    await withEnv(
+      { ATLAS_PYTHON_ENABLED: "true", ATLAS_SANDBOX_URL: undefined, ATLAS_ACTIONS_ENABLED: "true" },
+      async () => {
+        const { registry, warnings } = await buildHeadlessRegistry();
+        expect(registry).toBe(nonDashboardRegistry);
+        expect(warnings).toEqual([HEADLESS_REGISTRY_FALLBACK_WARNING]);
+        // Copy addressed to the MODEL, not to an operator reading logs — it has
+        // to be relayable as-is, which is the whole point of #4941.
+        expect(HEADLESS_REGISTRY_FALLBACK_WARNING).toContain("temporarily unavailable");
+      },
+    );
+  });
+
+  // The OTHER warning source — `buildRegistry`'s action-tool load failure, seen
+  // through this seam — needs the action module itself to fail, which is a
+  // file-wide `mock.module` this file cannot take (its top-level actions mock is
+  // what makes every `includeActions` test above work). It lives in
+  // `lib/__tests__/agent-query-degraded-tools.test.ts` alongside the call-site
+  // assertion that the warning reaches the model.
 });

--- a/packages/api/src/lib/tools/__tests__/registry.test.ts
+++ b/packages/api/src/lib/tools/__tests__/registry.test.ts
@@ -42,7 +42,7 @@ const {
   nonDashboardRegistry,
   buildRegistry,
   buildHeadlessRegistry,
-  HEADLESS_REGISTRY_FALLBACK_WARNING,
+  headlessRegistryFallbackWarning,
   WORKSPACE_DASHBOARD_URL_RESOLVER,
   INTENTIONAL_TOOL_SHADOWS,
   TOOL_SHADOW_REMEDIATIONS,
@@ -531,20 +531,61 @@ describe("buildHeadlessRegistry (#4936)", () => {
 
   it("#4941 — the fallback path authors its own warning instead of degrading silently", async () => {
     // The degrade above is deliberate and stays; what was missing is that the
-    // user was never told. `nonDashboardRegistry` carries no action tools and no
-    // executePython no matter how the env is set, so a turn that lands here has
-    // lost capability the operator believes is configured.
+    // user was never told, so a turn that lands here lost capability the
+    // operator believes is configured and the model called it absent.
     await withEnv(
       { ATLAS_PYTHON_ENABLED: "true", ATLAS_SANDBOX_URL: undefined, ATLAS_ACTIONS_ENABLED: "true" },
       async () => {
         const { registry, warnings } = await buildHeadlessRegistry();
         expect(registry).toBe(nonDashboardRegistry);
-        expect(warnings).toEqual([HEADLESS_REGISTRY_FALLBACK_WARNING]);
+        expect(warnings).toEqual([headlessRegistryFallbackWarning()]);
         // Copy addressed to the MODEL, not to an operator reading logs — it has
         // to be relayable as-is, which is the whole point of #4941.
-        expect(HEADLESS_REGISTRY_FALLBACK_WARNING).toContain("temporarily unavailable");
+        expect(warnings[0]).toContain("temporarily unavailable");
       },
     );
+  });
+
+  // The copy is DERIVED from the env, not fixed, and these two pin why. The
+  // fallback registry is lesser-privileged, not stripped: `sendEmail` and
+  // `createLinearIssue` are core tools and survive it. A fixed string claiming
+  // "action tools (JIRA, email) are unavailable" would hand the model a live
+  // `sendEmail` while telling it email is down — the same wrong-explanation bug
+  // #4941 fixes, one capability over.
+  describe("#4941 — the fallback warning never over-claims", () => {
+    it("names only what the env asked for and the fallback could not carry", async () => {
+      await withEnv({ ATLAS_ACTIONS_ENABLED: "true", ATLAS_PYTHON_ENABLED: "true" }, async () => {
+        const warning = headlessRegistryFallbackWarning();
+        expect(warning).toContain("createJiraTicket");
+        expect(warning).toContain("executePython");
+      });
+    });
+
+    it("claims nothing lost when nothing was configured, and never disowns a surviving tool", async () => {
+      await withEnv({ ATLAS_ACTIONS_ENABLED: undefined, ATLAS_PYTHON_ENABLED: undefined }, async () => {
+        const warning = headlessRegistryFallbackWarning();
+        expect(warning).not.toContain("createJiraTicket");
+        expect(warning).not.toContain("executePython");
+      });
+
+      // Whatever the env, the copy must never name a tool the fallback still
+      // carries — `sendEmail` is the one that made the first draft wrong.
+      for (const env of [{ ATLAS_ACTIONS_ENABLED: "true" }, { ATLAS_ACTIONS_ENABLED: undefined }]) {
+        await withEnv({ ...env, ATLAS_PYTHON_ENABLED: undefined }, async () => {
+          const warning = headlessRegistryFallbackWarning();
+          const survivors = Object.keys(nonDashboardRegistry.getAll());
+          expect(survivors).toContain("sendEmail");
+          for (const survivor of survivors) {
+            // Word-bounded on purpose: the action tool `sendEmailReport` may
+            // legitimately be named, and it CONTAINS the surviving `sendEmail`.
+            expect(
+              new RegExp(`\\b${survivor}\\b`).test(warning),
+              `the warning disowns ${survivor}, which the fallback still carries`,
+            ).toBe(false);
+          }
+        });
+      }
+    });
   });
 
   // The OTHER warning source — `buildRegistry`'s action-tool load failure, seen

--- a/packages/api/src/lib/tools/__tests__/registry.test.ts
+++ b/packages/api/src/lib/tools/__tests__/registry.test.ts
@@ -42,7 +42,8 @@ const {
   nonDashboardRegistry,
   buildRegistry,
   buildHeadlessRegistry,
-  headlessRegistryFallbackWarning,
+  registryBuildFailedWarning,
+  ACTION_TOOLS_UNAVAILABLE_WARNING,
   WORKSPACE_DASHBOARD_URL_RESOLVER,
   INTENTIONAL_TOOL_SHADOWS,
   TOOL_SHADOW_REMEDIATIONS,
@@ -538,7 +539,7 @@ describe("buildHeadlessRegistry (#4936)", () => {
       async () => {
         const { registry, warnings } = await buildHeadlessRegistry();
         expect(registry).toBe(nonDashboardRegistry);
-        expect(warnings).toEqual([headlessRegistryFallbackWarning()]);
+        expect(warnings).toEqual([registryBuildFailedWarning()]);
         // Copy addressed to the MODEL, not to an operator reading logs — it has
         // to be relayable as-is, which is the whole point of #4941.
         expect(warnings[0]).toContain("temporarily unavailable");
@@ -546,42 +547,69 @@ describe("buildHeadlessRegistry (#4936)", () => {
     );
   });
 
-  // The copy is DERIVED from the env, not fixed, and these two pin why. The
-  // fallback registry is lesser-privileged, not stripped: `sendEmail` and
-  // `createLinearIssue` are core tools and survive it. A fixed string claiming
-  // "action tools (JIRA, email) are unavailable" would hand the model a live
-  // `sendEmail` while telling it email is down — the same wrong-explanation bug
-  // #4941 fixes, one capability over.
-  describe("#4941 — the fallback warning never over-claims", () => {
+  // The copy is DERIVED from the env, not fixed, and this block pins why. A
+  // degraded registry is lesser-privileged, not stripped: `sendEmail` and
+  // `createLinearIssue` are CORE tools and survive both the action-load failure
+  // and the whole-build failure. A fixed string claiming "action tools (JIRA,
+  // email) are unavailable" hands the model a live `sendEmail` while telling it
+  // email is down — the same wrong-explanation bug #4941 fixes, one capability
+  // over. Both strings are swept, against both registries a surface can fall
+  // back to, because the over-claim was found in the second one after the first
+  // was fixed.
+  describe("#4941 — no degraded-tools warning ever over-claims", () => {
     it("names only what the env asked for and the fallback could not carry", async () => {
       await withEnv({ ATLAS_ACTIONS_ENABLED: "true", ATLAS_PYTHON_ENABLED: "true" }, async () => {
-        const warning = headlessRegistryFallbackWarning();
+        const warning = registryBuildFailedWarning();
         expect(warning).toContain("createJiraTicket");
         expect(warning).toContain("executePython");
       });
     });
 
-    it("claims nothing lost when nothing was configured, and never disowns a surviving tool", async () => {
+    it("claims nothing lost when nothing was configured", async () => {
       await withEnv({ ATLAS_ACTIONS_ENABLED: undefined, ATLAS_PYTHON_ENABLED: undefined }, async () => {
-        const warning = headlessRegistryFallbackWarning();
+        const warning = registryBuildFailedWarning();
         expect(warning).not.toContain("createJiraTicket");
         expect(warning).not.toContain("executePython");
       });
+    });
 
-      // Whatever the env, the copy must never name a tool the fallback still
-      // carries — `sendEmail` is the one that made the first draft wrong.
+    it("every warning ends with the never-disown-a-visible-tool instruction", async () => {
+      // Naming only what was lost is necessary but not sufficient: the model
+      // generalizes from "the action tools are gone" to "email is gone".
+      await withEnv({ ATLAS_ACTIONS_ENABLED: "true", ATLAS_PYTHON_ENABLED: undefined }, async () => {
+        for (const warning of [ACTION_TOOLS_UNAVAILABLE_WARNING, registryBuildFailedWarning()]) {
+          expect(warning).toContain("do NOT tell the user that one of them is unavailable");
+          expect(warning).toContain("temporarily unavailable");
+          // Addressed to the reader of the answer, who on Slack / SDK / MCP has
+          // no server logs. The operator half is the pino line.
+          expect(warning).not.toContain("server logs");
+        }
+      });
+    });
+
+    it("no warning ever disowns a tool the surface still carries", async () => {
+      // Swept against BOTH fallback registries: `nonDashboardRegistry` (the
+      // headless seam) and `defaultRegistry` (both web chat paths).
       for (const env of [{ ATLAS_ACTIONS_ENABLED: "true" }, { ATLAS_ACTIONS_ENABLED: undefined }]) {
         await withEnv({ ...env, ATLAS_PYTHON_ENABLED: undefined }, async () => {
-          const warning = headlessRegistryFallbackWarning();
-          const survivors = Object.keys(nonDashboardRegistry.getAll());
+          const warnings = [ACTION_TOOLS_UNAVAILABLE_WARNING, registryBuildFailedWarning()];
+          const survivors = [
+            ...Object.keys(nonDashboardRegistry.getAll()),
+            ...Object.keys(defaultRegistry.getAll()),
+          ];
+          // Non-vacuous, and these two are the ones that made the drafts wrong.
           expect(survivors).toContain("sendEmail");
-          for (const survivor of survivors) {
-            // Word-bounded on purpose: the action tool `sendEmailReport` may
-            // legitimately be named, and it CONTAINS the surviving `sendEmail`.
-            expect(
-              new RegExp(`\\b${survivor}\\b`).test(warning),
-              `the warning disowns ${survivor}, which the fallback still carries`,
-            ).toBe(false);
+          expect(survivors).toContain("createLinearIssue");
+
+          for (const warning of warnings) {
+            for (const survivor of survivors) {
+              // Word-bounded on purpose: the action tool `sendEmailReport` is
+              // legitimately named, and it CONTAINS the surviving `sendEmail`.
+              expect(
+                new RegExp(`\\b${survivor}\\b`).test(warning),
+                `"${warning.slice(0, 60)}…" disowns ${survivor}, which the surface still carries`,
+              ).toBe(false);
+            }
           }
         });
       }

--- a/packages/api/src/lib/tools/registry.ts
+++ b/packages/api/src/lib/tools/registry.ts
@@ -454,33 +454,69 @@ export const TOOL_SHADOW_REMEDIATIONS: Readonly<Record<string, string>> = {
  * `buildHeadlessRegistry` returns the same shape, so both builders share one
  * type rather than growing a parallel headless-only one that can drift.
  * Exported because it is the return type of two exported functions — a consumer
- * that wants to hold the result in a named local cannot spell it otherwise.
+ * that wants to name the result can otherwise only spell it as an
+ * `Awaited<ReturnType<…>>` incantation that breaks on any signature change.
+ *
+ * `warnings` is `readonly` for a reason that is not stylistic: `runAgent`
+ * treats its own `warnings` option as an in/out param and PUSHES into whatever
+ * array it is handed (`agent.ts` adds semantic-layer and focus-datasource
+ * warnings). A call site that wrote `warnings: registryWarnings` would hand it
+ * this array; if a builder ever memoized its result, those pushes would
+ * accumulate across turns and poison every later system prompt. `readonly`
+ * makes the spread-copy at each call site the only thing that compiles, which
+ * turns a comment into a compiler error.
  */
 export interface BuildRegistryResult {
-  registry: ToolRegistry;
-  warnings: string[];
+  readonly registry: ToolRegistry;
+  readonly warnings: readonly string[];
 }
 
 /**
- * The warning `buildHeadlessRegistry` authors when it falls back.
+ * The one rule every degraded-tools warning has to end with, and the reason
+ * these strings live here instead of at each surface.
  *
- * Distinct from `buildRegistry`'s action-tool warning, which says "the operator
- * action tools are gone". This one says "the build failed outright, so the
- * session is on the known-good core set" — and it has to be careful, because
- * the fallback (`nonDashboardRegistry`) is lesser-privileged, NOT stripped: it
- * still carries `sendEmail`, `createLinearIssue` and (when the OAuth env is
- * wired) `querySalesforce`, exactly as a successful build would. What the
- * fallback actually loses, relative to a build that succeeded, is only what the
- * env asked for on top: the `tools/actions` operator pair under
- * `ATLAS_ACTIONS_ENABLED`, and `executePython` under `ATLAS_PYTHON_ENABLED`.
- *
- * So the copy is DERIVED from that env rather than fixed. A fixed string
- * claiming "action tools (JIRA, email) are unavailable" would hand the model a
- * live `sendEmail` tool while instructing it to tell the user email is down —
- * re-creating, one capability over, the exact wrong-explanation bug #4941
- * exists to fix. The closing instruction pins the same rule for the model.
+ * A registry that failed to build is still LESSER-PRIVILEGED, not stripped:
+ * `registerCoreTools` gives `nonDashboardRegistry` and `defaultRegistry` alike
+ * `sendEmail`, `createLinearIssue` and (when the OAuth env is wired)
+ * `querySalesforce`, whatever else went wrong. So copy naming a whole category
+ * — "action tools (JIRA, email) are unavailable" — hands the model a live
+ * `sendEmail` while instructing it to tell the user email is down: the exact
+ * wrong-explanation bug #4941 exists to fix, one capability over. Naming only
+ * what was actually lost is necessary but not sufficient, because the model
+ * generalizes; this says the quiet part outright.
  */
-export function headlessRegistryFallbackWarning(): string {
+const NEVER_DISOWN_A_VISIBLE_TOOL =
+  "Every tool you can see in your tool list works — do NOT tell the user that one of them is " +
+  "unavailable. If the user asks for a capability you do not have, say it is temporarily " +
+  "unavailable and suggest they retry or contact their Atlas administrator.";
+
+/**
+ * The warning for "the operator action tools did not load", authored by
+ * {@link buildRegistry} and relayed by every surface that requested them.
+ *
+ * Names the two tools by their registry names rather than "JIRA and email":
+ * `sendEmailReport` is gone, the core `sendEmail` is not, and the model has to
+ * be able to tell them apart.
+ */
+export const ACTION_TOOLS_UNAVAILABLE_WARNING =
+  "The operator action tools (createJiraTicket, sendEmailReport) failed to load and are " +
+  "unavailable for this session. " +
+  NEVER_DISOWN_A_VISIBLE_TOOL;
+
+/**
+ * The warning for "the registry build failed outright and the surface fell back
+ * to a known-good set" — `nonDashboardRegistry` for the headless seam,
+ * `defaultRegistry` for the two web chat paths. One function for all three so
+ * three hand-maintained strings cannot drift into three policies, which is how
+ * the first draft of this fix re-created the bug it was fixing.
+ *
+ * Relative to a build that SUCCEEDED, a fallback loses only what the env asked
+ * for on top of the core set: the `tools/actions` operator pair under
+ * `ATLAS_ACTIONS_ENABLED`, and `executePython` under `ATLAS_PYTHON_ENABLED`.
+ * The copy is derived from exactly that, so a deployment that never enabled
+ * either is never told it lost them.
+ */
+export function registryBuildFailedWarning(): string {
   const lost: string[] = [];
   if (process.env.ATLAS_ACTIONS_ENABLED === "true") {
     lost.push("the operator action tools (createJiraTicket, sendEmailReport)");
@@ -490,11 +526,10 @@ export function headlessRegistryFallbackWarning(): string {
   }
   return (
     "A server configuration problem stopped the tool registry from building, so this session fell " +
-    "back to a known-good core tool set" +
+    "back to a known-good tool set" +
     (lost.length > 0 ? `; ${lost.join(" and ")} did not load.` : ".") +
-    " Every tool you can see in your tool list works — do NOT tell the user that one of them is " +
-    "unavailable. If the user asks for a capability you do not have, say it is temporarily " +
-    "unavailable and suggest they retry or contact their Atlas administrator."
+    " " +
+    NEVER_DISOWN_A_VISIBLE_TOOL
   );
 }
 
@@ -579,9 +614,7 @@ export async function buildRegistry(options?: {
         { err: err instanceof Error ? err : new Error(String(err)) },
         "Failed to load action tools — JIRA and email actions will be unavailable",
       );
-      warnings.push(
-        "Action tools (JIRA, email) failed to load and are unavailable for this session. Inform the user and suggest they check server logs or retry later.",
-      );
+      warnings.push(ACTION_TOOLS_UNAVAILABLE_WARNING);
     }
   }
 
@@ -640,7 +673,7 @@ export async function buildHeadlessRegistry(): Promise<BuildRegistryResult> {
       { err: err instanceof Error ? err : new Error(String(err)) },
       "Failed to build headless tool registry — falling back to the non-dashboard core registry",
     );
-    return { registry: nonDashboardRegistry, warnings: [headlessRegistryFallbackWarning()] };
+    return { registry: nonDashboardRegistry, warnings: [registryBuildFailedWarning()] };
   }
 }
 

--- a/packages/api/src/lib/tools/registry.ts
+++ b/packages/api/src/lib/tools/registry.ts
@@ -444,10 +444,36 @@ export const TOOL_SHADOW_REMEDIATIONS: Readonly<Record<string, string>> = {
     "Unset SALESFORCE_CLIENT_ID/SALESFORCE_CLIENT_SECRET to use the static-url Salesforce tool, or remove the static salesforce:// datasource to use the OAuth per-workspace tool.",
 };
 
-interface BuildRegistryResult {
+/**
+ * What every registry builder resolves to: the registry, plus the warnings the
+ * MODEL is meant to relay. A warning here is user-facing copy, not an operator
+ * log line — it is threaded into `runAgent({ warnings })`, which renders it
+ * under `## Warnings` in the system prompt so the agent says "temporarily
+ * unavailable, retry" instead of "I can't do that" (#4941).
+ *
+ * Exported because `buildHeadlessRegistry` returns the same shape and its
+ * callers destructure it; a parallel headless-only type would be one more place
+ * for the two to drift.
+ */
+export interface BuildRegistryResult {
   registry: ToolRegistry;
   warnings: string[];
 }
+
+/**
+ * The warning `buildHeadlessRegistry` authors when it falls back.
+ *
+ * Distinct from `buildRegistry`'s action-tool warning: that one says "the
+ * action tools are gone", this one says "the whole build failed, so everything
+ * beyond the core read tools is gone" — the fallback registry carries no action
+ * tools and no `executePython` regardless of how the env is configured.
+ * Exported so a test can pin the wording it asserts on rather than re-typing a
+ * substring that silently stops matching.
+ */
+export const HEADLESS_REGISTRY_FALLBACK_WARNING =
+  "The tool registry failed to build, so this session is running on the core query tools only — " +
+  "action tools (JIRA, email) and Python execution are unavailable. Inform the user that those " +
+  "capabilities are temporarily unavailable and suggest they check server logs or retry later.";
 
 /**
  * Build a dynamic ToolRegistry with optional action and Python support.
@@ -565,27 +591,33 @@ export async function buildRegistry(options?: {
  * A build failure falls back to `nonDashboardRegistry`, NOT the dashboards-
  * owning `defaultRegistry`, so both omissions hold on the error path too.
  *
- * Two known limits, deliberately out of #4936's scope and tracked separately:
+ * Returns {@link BuildRegistryResult}, not a bare registry (#4941). The bare
+ * shape had nowhere for `warnings` to go, so a degraded action-tool load was
+ * silently dropped on every headless surface and the model reported the
+ * capability as ABSENT rather than temporarily unavailable — a wrong
+ * explanation, not a missing one. Both callers thread the warnings into
+ * `runAgent({ warnings })`, matching what `api/routes/chat.ts` already does for
+ * the web surface. The fallback path below authors its own warning for the same
+ * reason.
+ *
+ * One known limit remains, deliberately out of scope and tracked separately:
  * this catch also swallows `buildRegistry`'s DELIBERATE fatal throws (#4940 —
  * every caller in the repo already does, and the fallback preserves the
- * isolation invariant by not carrying `executePython`), and the return type has
- * nowhere for `BuildRegistryResult.warnings` to go, so a degraded action-tool
- * load is invisible to the user on every headless surface (#4941).
+ * isolation invariant by not carrying `executePython`).
  */
-export async function buildHeadlessRegistry(): Promise<ToolRegistry> {
+export async function buildHeadlessRegistry(): Promise<BuildRegistryResult> {
   try {
-    const { registry } = await buildRegistry({
+    return await buildRegistry({
       includeActions: process.env.ATLAS_ACTIONS_ENABLED === "true",
       dashboardUrlResolver: null,
     });
-    return registry;
   } catch (err) {
     const { createLogger } = await import("@atlas/api/lib/logger");
     createLogger("registry").error(
       { err: err instanceof Error ? err : new Error(String(err)) },
       "Failed to build headless tool registry — falling back to the non-dashboard core registry",
     );
-    return nonDashboardRegistry;
+    return { registry: nonDashboardRegistry, warnings: [HEADLESS_REGISTRY_FALLBACK_WARNING] };
   }
 }
 

--- a/packages/api/src/lib/tools/registry.ts
+++ b/packages/api/src/lib/tools/registry.ts
@@ -451,9 +451,10 @@ export const TOOL_SHADOW_REMEDIATIONS: Readonly<Record<string, string>> = {
  * under `## Warnings` in the system prompt so the agent says "temporarily
  * unavailable, retry" instead of "I can't do that" (#4941).
  *
- * Exported because `buildHeadlessRegistry` returns the same shape and its
- * callers destructure it; a parallel headless-only type would be one more place
- * for the two to drift.
+ * `buildHeadlessRegistry` returns the same shape, so both builders share one
+ * type rather than growing a parallel headless-only one that can drift.
+ * Exported because it is the return type of two exported functions — a consumer
+ * that wants to hold the result in a named local cannot spell it otherwise.
  */
 export interface BuildRegistryResult {
   registry: ToolRegistry;
@@ -463,17 +464,39 @@ export interface BuildRegistryResult {
 /**
  * The warning `buildHeadlessRegistry` authors when it falls back.
  *
- * Distinct from `buildRegistry`'s action-tool warning: that one says "the
- * action tools are gone", this one says "the whole build failed, so everything
- * beyond the core read tools is gone" — the fallback registry carries no action
- * tools and no `executePython` regardless of how the env is configured.
- * Exported so a test can pin the wording it asserts on rather than re-typing a
- * substring that silently stops matching.
+ * Distinct from `buildRegistry`'s action-tool warning, which says "the operator
+ * action tools are gone". This one says "the build failed outright, so the
+ * session is on the known-good core set" — and it has to be careful, because
+ * the fallback (`nonDashboardRegistry`) is lesser-privileged, NOT stripped: it
+ * still carries `sendEmail`, `createLinearIssue` and (when the OAuth env is
+ * wired) `querySalesforce`, exactly as a successful build would. What the
+ * fallback actually loses, relative to a build that succeeded, is only what the
+ * env asked for on top: the `tools/actions` operator pair under
+ * `ATLAS_ACTIONS_ENABLED`, and `executePython` under `ATLAS_PYTHON_ENABLED`.
+ *
+ * So the copy is DERIVED from that env rather than fixed. A fixed string
+ * claiming "action tools (JIRA, email) are unavailable" would hand the model a
+ * live `sendEmail` tool while instructing it to tell the user email is down —
+ * re-creating, one capability over, the exact wrong-explanation bug #4941
+ * exists to fix. The closing instruction pins the same rule for the model.
  */
-export const HEADLESS_REGISTRY_FALLBACK_WARNING =
-  "The tool registry failed to build, so this session is running on the core query tools only — " +
-  "action tools (JIRA, email) and Python execution are unavailable. Inform the user that those " +
-  "capabilities are temporarily unavailable and suggest they check server logs or retry later.";
+export function headlessRegistryFallbackWarning(): string {
+  const lost: string[] = [];
+  if (process.env.ATLAS_ACTIONS_ENABLED === "true") {
+    lost.push("the operator action tools (createJiraTicket, sendEmailReport)");
+  }
+  if (process.env.ATLAS_PYTHON_ENABLED === "true") {
+    lost.push("Python execution (executePython)");
+  }
+  return (
+    "A server configuration problem stopped the tool registry from building, so this session fell " +
+    "back to a known-good core tool set" +
+    (lost.length > 0 ? `; ${lost.join(" and ")} did not load.` : ".") +
+    " Every tool you can see in your tool list works — do NOT tell the user that one of them is " +
+    "unavailable. If the user asks for a capability you do not have, say it is temporarily " +
+    "unavailable and suggest they retry or contact their Atlas administrator."
+  );
+}
 
 /**
  * Build a dynamic ToolRegistry with optional action and Python support.
@@ -617,7 +640,7 @@ export async function buildHeadlessRegistry(): Promise<BuildRegistryResult> {
       { err: err instanceof Error ? err : new Error(String(err)) },
       "Failed to build headless tool registry — falling back to the non-dashboard core registry",
     );
-    return { registry: nonDashboardRegistry, warnings: [HEADLESS_REGISTRY_FALLBACK_WARNING] };
+    return { registry: nonDashboardRegistry, warnings: [headlessRegistryFallbackWarning()] };
   }
 }
 


### PR DESCRIPTION
Closes #4941

## What was wrong

`buildRegistry` returns `{ registry, warnings }`, and one of those warnings is authored **for the model to relay** — "…are unavailable for this session. Inform the user and suggest they retry later." `api/routes/chat.ts` threads it into `runAgent({ warnings })`, so a web user hears "temporarily unavailable, retry."

`buildHeadlessRegistry` resolved to a bare `ToolRegistry` — a shape with nowhere for warnings to go. So on every headless surface (SDK query, Slack, MCP, scheduler, and the approval-resume added by #4936), a failed action-tool load produced an agent that said **"I can't do that"** instead of "that's temporarily unavailable." A wrong explanation, not a missing one, which is what makes it a bug rather than a papercut.

## The fix

- `buildHeadlessRegistry` returns `BuildRegistryResult`, and authors its own warning on the fallback path where it degrades to the non-dashboard core set.
- Both headless callers (`lib/agent-query.ts`, `lib/chat-plugin/resume-turn.ts`) thread the warnings into `runAgent`, conditionally — a healthy turn still warns about nothing — and each emits an operator `log.warn` carrying its own correlation ids.
- **The web resume path had the identical drop.** `chat.ts`'s resume kept `result.registry` and discarded `result.warnings`; its plugin-merge catch warned nobody either. Same defect class, fixed inline rather than deferred. The initial web turn's behaviour is unchanged.

### The copy is the interesting part

The first two drafts of this fix **re-created the bug they were fixing.** A degraded registry is *lesser-privileged, not stripped*: `registerCoreTools` gives every fallback registry `sendEmail`, `createLinearIssue` and (env-gated) `querySalesforce`. So a fixed string saying "action tools (JIRA, email) are unavailable" hands the model a live `sendEmail` while instructing it to tell the user email is down.

Both strings are now derived and centralised — `ACTION_TOOLS_UNAVAILABLE_WARNING` names the two tools that actually failed (`createJiraTicket`, `sendEmailReport`, distinct from the surviving core `sendEmail`), `registryBuildFailedWarning()` derives its lost-capability list from the same env the builder read, and both end in one shared instruction: *every tool you can see works — do not disown one.* A test sweeps every warning against every tool surviving in **both** fallback registries.

## Second half — the operator side (folded in from #4934's review panel)

Same defect class, other audience: something failed, the system knew why, and the explanation was discarded before reaching whoever needed it.

`scrubErrSerializer` rebuilds an `Error` from a whitelist, so a pg error's `code` and `constraint` — which invariant rejected the write — never reached the log.

**Judgment call, as the brief asked.** The removal was **incidental**, not a deliberate scrub: the serializer keeps `{ type, message, stack }` and drops *everything* else, `cause` included. There was no leakage argument specific to these two fields, so both are kept:

- `code` is a fixed SQLSTATE. `constraint` is a schema identifier — from this repo's migrations, a plugin's, or the customer's own analytics schema, since this is the global `err` serializer. Neither derives from a request, a credential, or a row value.
- **`constraint` is NOT withheld.** The disclosure line is drawn one field over: `detail` echoes row values (`Key (email)=(a@b.com) already exists`), and `where` / `internalQuery` echo statement text. Those stay out, pinned by a test asserting the exact key set and that a sample address never appears in the serialized JSON.
- Values are read as **own, non-accessor** properties inside their own `catch`, length-bounded to 63 (`NAMEDATALEN - 1`), and still passed through `errorMessage`. Nothing newly reachable: an over-length value becomes `[dropped: oversized]` rather than being echoed, and a DSN stuffed into `constraint` is scrubbed like any message.

`correction.ts`'s `pgErrorFields` — added by #4934 as a workaround for this very gap — stays (its keys are top-level, and it is the only copy when a non-`Error` is thrown), now sharing one policy via `lib/audit/diagnostic-scrub.ts`. Its read is also guarded: it runs inside `emitCorrectionAudit`, which is contracted **never to throw**, on an already-committed correction — a throwing accessor would have surfaced as "nothing was changed, retry" and invited a duplicate brain mutation.

> `diagnostic-scrub.ts` is its own module rather than living in `error-scrub.ts` because ten test files mock that specifier, nine of them reproducing its full two-export surface — adding a third export broke one of them immediately.

## Review

`/review-panel` ran **3 rounds**, and earned its keep each time:

- **Round 1** — the fallback warning disowned a live `sendEmail`; `errorDiagnostics` could collapse a whole serialized error to `[log scrub failed]`; and `runAgent({ warnings }) → "## Warnings"` was unpinned end to end, so deleting the forwarding left every surface test green.
- **Round 2** — the same over-claim in `buildRegistry`'s own warning (which this PR is what newly routes to headless surfaces); `pgErrorFields` able to throw out of a never-throws contract; and the action-load **success** branch unpinned on both web paths.
- **Round 3** — two axes clean; six prose claims that no longer matched the code, three of them self-contradictions where a round-2 correction landed in one file and the same falsehood survived in another.

**Mutation-verified 39/39** — every guard applied against a real-file mutation, seen failing, then reverted. Including a typecheck-driven one: `readonly warnings` is what makes the spread-copy at each call site the only thing that compiles, so "remember to copy the array `runAgent` pushes into" is a compile error rather than a comment.
