### PR TITLE
refactor(tools,mcp): one searchBrain input schema, and decouple the shared description budget (#4954)

### DIFF
--- a/apps/docs/content/shared/architecture/mcp-tools.mdx
+++ b/apps/docs/content/shared/architecture/mcp-tools.mdx
@@ -19,13 +19,15 @@ The rubric is the cheapest defense — every tool description follows the same s
 
 Every typed MCP tool description must:
 
-- **80–150 words** in the long-form body (excluding the appended `Error contract:` section). Keeps every tool in the same length band so the LLM doesn't bias on volume.
+- **80–150 words** of the tool's own prose in the long-form body — excluding the appended `Error contract:` section, and excluding any shared constant the description interpolates. Keeps every tool in the same length band so the LLM doesn't bias on volume. A shared constant carries its own separate budget (`MAX_SHARED_WORDS`, against the registry in `SHARED_INTERPOLATIONS`, both in the rubric test) so that growing it fails one test naming the constant, rather than the word-count gate of every tool that happens to interpolate it. The *composed* string — your prose plus those constants, still before the `Error contract:` section is appended — has its own separate ceiling.
 - Contain a **`Use this when …`** directive. Positive routing anchor — tells the LLM what the tool is for.
 - Contain a **`Don't use this …`** or **`Avoid …`** directive. Negative routing anchor — pushes the LLM away from the most common wrong choices for this tool.
 - Include at least one **inline JSON example** showing call shape (preferred) or response shape. LLMs trained on tool use produce better-shaped calls when the description shows the call shape verbatim.
 - End with the structured **`Error contract:`** section. Appended at the MCP layer by `withErrorContract(BASE, CODES)` — the LLM reads purpose → recovery in one continuous block. Codes must match what the dispatch path actually returns.
 
-The base description bodies live in [`packages/api/src/lib/tools/descriptions.ts`](https://github.com/AtlasDevHQ/atlas/blob/main/packages/api/src/lib/tools/descriptions.ts) — the single source of truth that both `explore` / `executeSQL` (legacy AI SDK tool wrappers), `listEntities` / `describeEntity` / `searchGlossary` / `runMetric` (typed semantic tools), and `query` (the NL-agent tool) read from.
+The base description bodies live in [`packages/api/src/lib/tools/descriptions.ts`](https://github.com/AtlasDevHQ/atlas/blob/main/packages/api/src/lib/tools/descriptions.ts) — the single source of truth that both `explore` / `executeSQL` (legacy AI SDK tool wrappers), `listEntities` / `describeEntity` / `searchGlossary` / `runMetric` (typed semantic tools), `searchBrain` (the company-brain read), and `query` (the NL-agent tool) read from.
+
+`searchBrain` additionally single-sources its **argument** schema — the per-argument `.describe()` prose the MCP tool advertises — from [`packages/api/src/lib/tools/search-brain-schema.ts`](https://github.com/AtlasDevHQ/atlas/blob/main/packages/api/src/lib/tools/search-brain-schema.ts), rather than the MCP package re-declaring it. The rubric above governs tool descriptions; argument prose has no word budget, but the same drift rule applies — author it once.
 
 ### `query` vs `executeSQL` — two shapes of data access
 

--- a/packages/api/src/lib/tools/__tests__/description-rubric.test.ts
+++ b/packages/api/src/lib/tools/__tests__/description-rubric.test.ts
@@ -6,9 +6,13 @@
  * any new tool opts into the rubric.
  *
  * Per-tool checks:
- *   - Long-form description is 80–150 words (LLMs weight verbose
- *     descriptions heavier than terse ones — keep all six in the same
- *     length band).
+ *   - Long-form description is 80–150 words of the tool's OWN prose, and the
+ *     COMPOSED string (own prose + any shared interpolation, still excluding
+ *     the `Error contract:` appendage) stays under the
+ *     composed ceiling (LLMs weight verbose descriptions heavier than terse
+ *     ones — keep every tool in the same length band). Shared interpolated
+ *     constants are excluded from the per-tool budget and carry their own;
+ *     see the decoupling note on `SHARED_INTERPOLATIONS` below.
  *   - Contains a `Use this when …` directive (positive routing signal).
  *   - Contains a `Don't use this …` or `Avoid …` directive (pushes the
  *     LLM away from common wrong choices).
@@ -27,6 +31,7 @@ import { describe, expect, it } from "bun:test";
 
 import type { AtlasMcpToolErrorCode } from "@useatlas/types/mcp";
 
+import { KNOWLEDGE_TRUST_FRAMING } from "../../knowledge/framing";
 import {
   DESCRIBE_ENTITY_ERROR_CODES,
   DESCRIBE_ENTITY_TOOL_DESCRIPTION,
@@ -49,6 +54,64 @@ import {
 
 const MIN_WORDS = 80;
 const MAX_WORDS = 150;
+
+/**
+ * The shared-constant budget, decoupled from the per-tool one (#4954).
+ *
+ * `KNOWLEDGE_TRUST_FRAMING` is authored ONCE and interpolated into two of the
+ * descriptions measured below. While its words were billed to each
+ * interpolating tool's independent 80–150 budget, the budget was not a
+ * per-tool property at all: `searchBrain` sat at 148/150 and `explore` at
+ * 149/150, so adding three words to the SHARED constant failed the gate for
+ * both tools at once — and the failure named the tools, not the constant, so
+ * an author who had touched neither description was sent to trim prose that
+ * was not the cause.
+ *
+ * Resolution: the per-tool budget measures the tool's OWN prose, and the
+ * shared constant carries its own explicitly-named ceiling here. Growing the
+ * shared constant now fails ONE test that says so, instead of silently
+ * spending headroom in every description that interpolates it.
+ *
+ * The string an LLM actually reads is still bounded, but by a DIFFERENT
+ * number and by its own assertion: `composed word count` below caps the total
+ * at {@link COMPOSED_CEILING}. That arm is not redundant
+ * arithmetic — `authoredWordCount` removes EVERY occurrence and nothing caps
+ * how many there are, so without it a description interpolating the constant
+ * six times clears every authored budget at up to 180 composed words (150 + 6x5).
+ *
+ * `interpolatedInto` is not documentation: `is actually interpolated` asserts
+ * it, because the removal below is a silent no-op if the constant ever
+ * stops appearing verbatim in a description (reworded, wrapped, split). That
+ * no-op would restore the exact coupling this decoupling removes, with nothing
+ * red to say so.
+ *
+ * 8 rather than the 5 the constant measures today: three words of deliberate
+ * slack, so a wording fix to the constant does not need a budget edit in the
+ * same commit, while a rewrite past 8 words does.
+ */
+const MAX_SHARED_WORDS = 8;
+
+const SHARED_INTERPOLATIONS = [
+  {
+    name: "KNOWLEDGE_TRUST_FRAMING",
+    text: KNOWLEDGE_TRUST_FRAMING,
+    interpolatedInto: ["explore", "searchBrain"],
+  },
+] as const;
+
+/**
+ * Derived from the registry rather than written as `MAX_WORDS + 8`, so adding
+ * a second shared constant widens the composed ceiling by exactly its budget
+ * instead of silently squeezing every interpolating tool's own prose.
+ * One occurrence of each constant is the allowance; a description that
+ * interpolates one twice pays for the second out of its own budget.
+ *
+ * The slack is real and worth knowing: for the shorter of the two, searchBrain
+ * at 148 composed, a SECOND and THIRD interpolation of the 5-word constant
+ * still fit (153, 158) and the fourth trips this; `explore` at 149 trips one
+ * earlier. It bounds runaway repetition, not a single duplicate.
+ */
+const COMPOSED_CEILING = MAX_WORDS + SHARED_INTERPOLATIONS.length * MAX_SHARED_WORDS;
 
 // A `{ …"key": value… }` block whose key is one of the recognized tool
 // arg / response keys we ship today. Without the key whitelist, a stub
@@ -99,6 +162,39 @@ function wordCount(text: string): number {
   return text.trim().split(/\s+/).filter(Boolean).length;
 }
 
+/**
+ * Words the tool's author is accountable for: the description with every
+ * occurrence of a shared interpolated constant removed.
+ *
+ * Removal-then-recount, NOT `wordCount(text) - wordCount(constant)`. The
+ * subtraction looks tidier and is wrong wherever the interpolation abuts
+ * punctuation — which is both RUBRIC-MEASURED call sites (`lib/knowledge/mirror.ts`
+ * interpolates it too, into a string this rubric does not measure):
+ * `${…FRAMING}, never queryable`
+ * and `${…FRAMING}.`. There the constant's last word absorbs the author's
+ * comma or period into one token, so the constant contributes five tokens but
+ * the author's own text loses only four when it goes, and subtracting five
+ * hands the author a free word. Silent, and permissive, which is the direction
+ * nobody notices.
+ *
+ * Removal has no such precondition: what is left IS the author's prose, glued
+ * boundaries and stranded punctuation included, so the count is CONSERVATIVE
+ * by construction rather than resting on a spacing rule a future edit could
+ * quietly violate. Conservative, not exact — the stranded `,` or `.` is left
+ * behind as a token of its own, so the author is over-charged by one per
+ * interpolation THAT ABUTS PUNCTUATION — which is both of today's sites
+ * (searchBrain reads 144, where a clean subtraction would say 143). A
+ * space-surrounded interpolation costs nothing extra. Erring toward charging the author is the safe direction; erring the
+ * other way is the free word this replaced.
+ */
+function authoredWordCount(text: string): number {
+  let stripped = text;
+  for (const shared of SHARED_INTERPOLATIONS) {
+    stripped = stripped.split(shared.text).join(" ");
+  }
+  return wordCount(stripped);
+}
+
 describe("MCP tool description rubric", () => {
   it("covers every typed MCP tool", () => {
     expect(TOOLS.map((t) => t.name).sort()).toEqual([
@@ -115,16 +211,30 @@ describe("MCP tool description rubric", () => {
 
   for (const tool of TOOLS) {
     describe(tool.name, () => {
-      it(`base description word count is in [${MIN_WORDS}, ${MAX_WORDS}]`, () => {
+      it(`authored word count is in [${MIN_WORDS}, ${MAX_WORDS}]`, () => {
+        const count = authoredWordCount(tool.base);
+        const detail = `${tool.name} base description has ${count} authored words (shared interpolated constants excluded — they carry their own budget); rubric requires ${MIN_WORDS}–${MAX_WORDS}.`;
+        expect(count, detail).toBeGreaterThanOrEqual(MIN_WORDS);
+        expect(count, detail).toBeLessThanOrEqual(MAX_WORDS);
+      });
+
+      it(`composed word count is within the ceiling of ${COMPOSED_CEILING}`, () => {
+        // The bound on the base string as composed, as opposed to the slice of
+        // it its author is charged for. (Still the BASE — the `Error contract:`
+        // appendage `withErrorContract` adds at registration is outside every
+        // budget in this file, as the header says.)
+        //
+        // NOT implied by the two budgets above: `authoredWordCount` removes
+        // EVERY occurrence and nothing caps occurrences, so a description
+        // interpolating the shared constant six times clears every authored
+        // budget at up to 180 composed words — the rubric's own premise
+        // (comparable weight across tools) quietly abandoned. Decoupling was
+        // meant to change who gets BLAMED, not what is bounded.
         const count = wordCount(tool.base);
         expect(
           count,
-          `${tool.name} base description has ${count} words; rubric requires ${MIN_WORDS}–${MAX_WORDS}.`,
-        ).toBeGreaterThanOrEqual(MIN_WORDS);
-        expect(
-          count,
-          `${tool.name} base description has ${count} words; rubric requires ${MIN_WORDS}–${MAX_WORDS}.`,
-        ).toBeLessThanOrEqual(MAX_WORDS);
+          `${tool.name}'s composed description is ${count} words, over the ceiling of ${COMPOSED_CEILING} (${MAX_WORDS} own prose + ${MAX_SHARED_WORDS} for each of the ${SHARED_INTERPOLATIONS.length} shared interpolation(s)). Trim this tool's own clauses or drop a repeated interpolation — each shared constant has its own named test and is not the thing to cut here.`,
+        ).toBeLessThanOrEqual(COMPOSED_CEILING);
       });
 
       it("contains a 'Use this when' directive", () => {
@@ -156,6 +266,58 @@ describe("MCP tool description rubric", () => {
         // the LLM reads purpose → recovery in order, never recovery first.
         const baseLength = tool.base.length;
         expect(full.indexOf("Error contract:"), `${tool.name}: 'Error contract:' must appear after the base description.`).toBeGreaterThan(baseLength - 1);
+      });
+    });
+  }
+});
+
+/**
+ * The shared-constant half of the budget (#4954).
+ *
+ * These are the tests that make the decoupling above safe rather than a hole:
+ * the per-tool budget no longer charges for a shared constant, so the constant
+ * needs a ceiling of its own, and the exclusion needs to be provably live.
+ */
+describe("MCP tool description rubric — shared interpolated constants", () => {
+  for (const shared of SHARED_INTERPOLATIONS) {
+    describe(shared.name, () => {
+      it(`fits its own budget of ${MAX_SHARED_WORDS} words`, () => {
+        const count = wordCount(shared.text);
+        expect(
+          count,
+          `${shared.name} is ${count} words, over its ${MAX_SHARED_WORDS}-word budget. It is interpolated into ${shared.interpolatedInto.length} rubric-measured tool descriptions (${shared.interpolatedInto.join(", ")}) — plus non-rubric agent surfaces this test cannot see, listed on the constant itself in lib/knowledge/framing.ts — so every word here is spent on every one of them. Raise MAX_SHARED_WORDS deliberately or tighten the constant — do NOT trim an unrelated tool's prose to pay for it.`,
+        ).toBeLessThanOrEqual(MAX_SHARED_WORDS);
+      });
+
+      it("is actually interpolated into every description it is excluded from", () => {
+        // Without this, `authoredWordCount`'s removal is a silent no-op:
+        // reword the constant, or wrap it so it no longer appears verbatim,
+        // and every interpolating tool is quietly back on the coupled budget
+        // with nothing red to say so.
+        for (const name of shared.interpolatedInto) {
+          const tool = TOOLS.find((t) => t.name === name);
+          expect(tool, `${shared.name} claims to be interpolated into an unknown tool '${name}'`).toBeDefined();
+          expect(
+            tool?.base.includes(shared.text),
+            `${name}'s description no longer contains ${shared.name} verbatim, so excluding it from ${name}'s budget silently removes nothing. Re-interpolate it, or drop '${name}' from its interpolatedInto list.`,
+          ).toBe(true);
+        }
+      });
+
+      it("is not interpolated anywhere the exclusion was never declared", () => {
+        // The other direction. `authoredWordCount` matches on TEXT, not on
+        // this list, so a new description that interpolates the constant gets
+        // the discount whether or not it is declared here — and the budget
+        // failure above would then under-report which tools a growing constant
+        // costs, which is the one thing that message exists to get right.
+        const declared = new Set<string>(shared.interpolatedInto);
+        const undeclared = TOOLS.filter(
+          (t) => t.base.includes(shared.text) && !declared.has(t.name),
+        ).map((t) => t.name);
+        expect(
+          undeclared,
+          `these tool descriptions interpolate ${shared.name} but are not listed in its interpolatedInto: ${undeclared.join(", ")}. Add them, so the budget failure can name every tool the constant costs.`,
+        ).toEqual([]);
       });
     });
   }
@@ -199,6 +361,11 @@ describe("MCP tool description rubric — plugin-contributed tools", () => {
   for (const tool of pluginTools) {
     describe(tool.qualifiedName, () => {
       it(`base description word count is in [${MIN_WORDS}, ${MAX_WORDS}]`, () => {
+        // `wordCount`, not `authoredWordCount` (#4954): the shared-constant
+        // exclusion is scoped to native descriptions, which DECLARE which
+        // constants they interpolate. A plugin cannot make that declaration —
+        // it is a third party — so a plugin string that happened to contain
+        // the same phrase would get a discount nobody recorded.
         const count = wordCount(tool.description);
         expect(
           count,

--- a/packages/api/src/lib/tools/__tests__/search-brain-tool.test.ts
+++ b/packages/api/src/lib/tools/__tests__/search-brain-tool.test.ts
@@ -14,6 +14,20 @@
  *
  * Kept in its own file (mock.module is file-global under the isolated runner) so
  * the mock-free query-builder tests stay clean.
+ *
+ * ## As of #4954 this file is also the SOLE owner of the argument-schema rules
+ *
+ * `searchBrain`'s input schema used to be declared twice, and the MCP package
+ * carried a hand-mirrored copy of each rule below. There is now one schema
+ * (`lib/tools/search-brain-schema.ts`), and `packages/mcp`'s suite asserts
+ * only that the schema it SERVES is that module's — it derives its expectation
+ * from the same source, so it cannot see a prose regression at all.
+ *
+ * Concretely: the `asOf` retraction carve-out (#4933) and `include`
+ * precondition (#4939) blocks below are the only thing guarding those rules
+ * for EXTERNAL MCP clients as well as the in-process agent. Weakening one here
+ * leaves that surface unguarded with nothing red in that package to say so.
+ * Trim with that in mind.
  */
 
 import { describe, expect, it, beforeEach, mock } from "bun:test";
@@ -92,6 +106,14 @@ void mock.module("@atlas/api/lib/logger", () => ({
 
 const { searchBrain, SEARCH_BRAIN_DESCRIPTION } = await import("@atlas/api/lib/tools/search-brain");
 const { SEARCH_BRAIN_TOOL_DESCRIPTION } = await import("@atlas/api/lib/tools/descriptions");
+const { searchBrainInputSchema, SEARCH_BRAIN_INPUT_SHAPE } = await import(
+  "@atlas/api/lib/tools/search-brain-schema"
+);
+// The constants the schema's value constraints must keep deriving from — read
+// from their own sources, so a pin against them cannot be satisfied by the
+// schema agreeing with itself.
+const { BRAIN_RESULT_TIERS } = await import("@useatlas/schemas");
+const { MAX_SEARCH_LIMIT } = await import("@atlas/api/lib/brain/search");
 
 function run(input: Record<string, unknown> = {}) {
   // AI SDK tool.execute(args, ToolCallOptions). Cast through unknown: the tool's
@@ -585,22 +607,181 @@ describe.each([
 });
 
 /**
- * The third of the four strings that CARRY THE RETRACTION PROMISE, and the one
- * neither block above reaches: the `asOf` ARGUMENT description on this tool's
- * input schema (#4933). The four are the system prompt
- * (`SEARCH_BRAIN_DESCRIPTION`), the tool prose (`SEARCH_BRAIN_TOOL_DESCRIPTION`,
- * both blocks above), this argument, and its re-declared MCP twin. (searchBrain
- * has a dozen-odd other `.describe()` strings; none of them say anything about
- * retraction, which is why the count here is four and not twenty.) A model
- * deciding whether to PASS `asOf` reads the argument, not the tool prose, and
- * this one shipped promising "retracted facts never" — the same absolute, on a
- * surface with its own reader.
+ * The dedupe itself (#4954) — the wiring that makes every prose pin below
+ * cover BOTH agent surfaces instead of just this one.
  *
- * `packages/mcp/src/tools.ts` re-declares the whole input schema rather than
- * importing it — `asOf` is only the argument where that drift is
- * correctness-bearing, and `query` has already drifted harmlessly — so the
- * fourth string is pinned there (`__tests__/tools.test.ts`, through
- * `listTools()`). Two files because there are genuinely two strings.
+ * `packages/mcp/src/tools.ts` used to re-declare this schema argument for
+ * argument, so a fix authored here structurally could not reach an MCP client:
+ * that is how the MCP `asOf` shipped with #4933's unqualified absolute and
+ * without #4939's `include` precondition, each fixed twice. There is now one
+ * definition in `lib/tools/search-brain-schema.ts`.
+ *
+ * Only the FIRST pin below stops it becoming two again, and only on this side
+ * — nothing in this file observes `packages/mcp/src/tools.ts`. That half is
+ * held by `packages/mcp/src/__tests__/tools.test.ts`, which pins the MCP
+ * registration by identity and its served JSON Schema by value.
+ */
+describe("searchBrain input schema — one definition, two surfaces (#4954)", () => {
+  it("the AI SDK tool serves the shared schema, not a local re-declaration", () => {
+    // Identity, not deep equality: a hand-copied literal here would be
+    // deep-equal on the day it was written and is exactly what this guards.
+    expect(
+      searchBrain.inputSchema,
+      "searchBrain.inputSchema is no longer the object exported by lib/tools/search-brain-schema.ts — the api surface has re-grown its own copy",
+    ).toBe(searchBrainInputSchema);
+  });
+
+  it("the assembled object and the exported raw shape are the same definition", () => {
+    // Both spellings are exported because the two SDKs want different ones —
+    // the MCP SDK's `registerTool` takes a `ZodRawShape`, the AI SDK's `tool`
+    // takes a `ZodObject`. That is only safe while the object is BUILT from
+    // the shape; declared side by side they would drift like the two packages
+    // did. Compared through `toJSONSchema` because that is the artifact both
+    // surfaces actually serve a model.
+    //
+    // Read honestly, this is a CANARY, not coverage of anything shipping: it
+    // can only fail once `searchBrainInputSchema` stops being literally
+    // `z.object(SEARCH_BRAIN_INPUT_SHAPE)`. That is exactly the refactor it
+    // guards, so keep it — but do not read a green here as evidence the two
+    // exports agree about anything a caller can observe.
+    //
+    // The WHOLE schema, not just `.properties`: in zod v4 JSON Schema an
+    // argument's optionality lives in the sibling `required` array, so a copy
+    // that marked `collection` required would be `.properties`-equal to this
+    // one and differ in the half a caller trips over first.
+    expect(z.toJSONSchema(searchBrainInputSchema)).toEqual(
+      z.toJSONSchema(z.object(SEARCH_BRAIN_INPUT_SHAPE)),
+    );
+  });
+
+  it("every argument carries prose, and the argument set is the one both surfaces advertise", () => {
+    // The prose pins below read ONE argument each. This is the arm that
+    // notices a NEW argument arriving undescribed — it reaches a
+    // model as a bare `string` with no guidance, on both surfaces at once, and
+    // no existing assertion would say a word.
+    const properties = z.toJSONSchema(searchBrainInputSchema).properties ?? {};
+    expect(Object.keys(properties).sort()).toEqual([
+      "asOf",
+      "collection",
+      "expand",
+      "include",
+      "limit",
+      "query",
+      "since",
+      "tags",
+      "type",
+    ]);
+    const undescribed = Object.entries(properties)
+      .filter(
+        ([, schema]) =>
+          typeof schema !== "object" ||
+          !("description" in schema) ||
+          typeof schema.description !== "string" ||
+          schema.description.trim() === "",
+      )
+      .map(([name]) => name);
+    expect(
+      undescribed,
+      "these searchBrain arguments have no `.describe()` — a model sees the type and nothing else, on the agent surface and over MCP",
+    ).toEqual([]);
+  });
+
+  it("the two argument VALUE constraints still AGREE with their source constants", () => {
+    // Keys, prose and optionality are all pinned above; the constraints were
+    // not, and they are the ones the SDK enforces before the tool body runs.
+    //
+    // Agreement, not derivation — say what it does: a hardcoded copy that
+    // happens to match today passes. This fires on the day a source constant
+    // moves and the copy does not, which is the drift that matters.
+    //
+    // `include`'s enum is the sharp one. Hardcode it and drop a tier and every
+    // pin in this PR stays green — key set unchanged, prose unchanged,
+    // optionality unchanged, and the MCP value pin derives its expectation
+    // from this same module so both sides move together.
+    //
+    // What breaks is SELECTION, not the store: `searchBrainCore` defaults to
+    // the runtime `BRAIN_RESULT_TIERS`, so an unfiltered search keeps
+    // returning that tier's rows — which is exactly what makes the drift
+    // quiet. But a client that NAMES the tier has its whole call refused
+    // before dispatch, and the tier becomes unselectable, while the same
+    // argument's description (which interpolates the real constant) goes on
+    // advertising it.
+    const properties = z.toJSONSchema(searchBrainInputSchema, { io: "input" }).properties ?? {};
+    const include = properties.include;
+    const items =
+      typeof include === "object" && "items" in include ? include.items : undefined;
+    expect(
+      typeof items === "object" && items !== null && "enum" in items ? items.enum : undefined,
+      "`include`'s enum no longer agrees with BRAIN_RESULT_TIERS — a call naming the dropped tier is refused whole, before dispatch, and the tier becomes unselectable, while the same argument's description still advertises it",
+    ).toEqual([...BRAIN_RESULT_TIERS]);
+
+    // Same class, lower stakes: a hardcoded or drifted cap silently disagrees
+    // with `MAX_SEARCH_LIMIT`, which the description also interpolates.
+    const limit = properties.limit;
+    expect(
+      typeof limit === "object" ? { min: limit.minimum, max: limit.maximum } : undefined,
+      "`limit`'s bounds no longer derive from MAX_SEARCH_LIMIT — the cap the description advertises and the cap the SDK enforces have drifted apart",
+    ).toEqual({ min: 1, max: MAX_SEARCH_LIMIT });
+  });
+
+  it("the shape object is frozen — the 'ONE definition' claim, asserted rather than assumed", () => {
+    // Aliased by reference into two registrars in one process, and mutating a
+    // shape key after `z.object(shape)` does propagate — so a re-pointed key
+    // rewrites both surfaces at once and they stay deep-equal to each other.
+    // The pins above read the shape's post-mutation content, so they would
+    // catch a re-point that dropped prose or narrowed the enum; what none of
+    // them can see is a CONFORMING re-point — same prose, same enum, same
+    // optionality. Shallow by nature (the zod nodes behind the keys are not
+    // sealed), which is why the served-value pin still exists.
+    expect(Object.isFrozen(SEARCH_BRAIN_INPUT_SHAPE)).toBe(true);
+  });
+
+  it("every argument is still OPTIONAL — the one drift the schema/normalizer key pin cannot see", () => {
+    // The key-set pins in `search-brain.ts` compare KEY SETS, so dropping
+    // `.optional()` from `asOf` compiles clean: the key is still there, and
+    // `asOf: string` is assignable to `SearchBrainInput`'s `asOf?: string`.
+    // The MCP suite's served-vs-source comparison cannot see it either — both
+    // sides read this same source, so they move together; only its own
+    // `required` tripwire fires, and this is the pin that names the argument.
+    //
+    // The consequence is not cosmetic. Every argument here is optional by
+    // design (`query` omitted browses recent entries; `include` omitted
+    // searches all three stores), so a stray required flag makes previously
+    // valid calls fail SDK validation before dispatch — returned as a bare
+    // `isError` result carrying the SDK's validation text, with no
+    // `request_id` and no envelope `code`, unlike every runtime refusal.
+    //
+    // `io: "input"` matters here for the same reason it does in the MCP
+    // suite: the default `io: "output"` reports a `.default()` field as
+    // required, which would make this fire on a change that does not affect
+    // what a caller must send.
+    const schema = z.toJSONSchema(searchBrainInputSchema, { io: "input" });
+    expect(
+      schema.required,
+      "a searchBrain argument is no longer optional. Every one of them is optional by design, and a required flag refuses previously valid calls at the SDK boundary — before dispatch, so without a request_id. If this is deliberate, update the argument's `.describe()` to say it is required and change this pin.",
+    ).toBeUndefined();
+  });
+});
+
+/**
+ * The third and LAST of the strings that CARRY THE RETRACTION PROMISE, and the
+ * one neither block above reaches: the `asOf` ARGUMENT description on this
+ * tool's input schema (#4933). The three are the system prompt
+ * (`SEARCH_BRAIN_DESCRIPTION`), the tool prose (`SEARCH_BRAIN_TOOL_DESCRIPTION`,
+ * both blocks above), and this argument. (searchBrain has a dozen-odd other
+ * `.describe()` strings; none of them say anything about retraction, which is
+ * why the count here is three and not twenty.) A model deciding whether to
+ * PASS `asOf` reads the argument, not the tool prose, and this one shipped
+ * promising "retracted facts never" — the same absolute, on a surface with its
+ * own reader.
+ *
+ * It was FOUR strings until #4954: `packages/mcp/src/tools.ts` re-declared the
+ * whole input schema rather than importing it, so its `asOf` twin was pinned
+ * separately in that package with a hand-mirrored copy of the rule below.
+ * There is now ONE schema (`lib/tools/search-brain-schema.ts`), which this
+ * tool's `inputSchema` is built from and which the MCP tool registers
+ * directly, so the rule is asserted once — here — and the MCP suite asserts
+ * only that the schema it SERVES is that module's.
  */
 describe("searchBrain `asOf` argument description — the carve-out travels with the promise (#4933)", () => {
   const asOfDescription = ((): string => {
@@ -666,9 +847,12 @@ describe("searchBrain `asOf` argument description — the carve-out travels with
   // facts (`lib/brain/search.ts`) — it is the caller's input problem and is
   // reported as such rather than degraded. A model deciding whether to combine
   // the two arguments reads THIS string, so the precondition living only in
-  // the refusal makes the refusal reachable by a well-behaved caller. The
-  // MCP twin re-declares this schema and had dropped the sentence; its own
-  // suite carries the same rule.
+  // the refusal makes the refusal reachable by a well-behaved caller. Until
+  // #4954 the MCP surface re-declared this argument and had dropped the
+  // sentence, so the rule needed a second copy in that package; it now serves
+  // this same schema, so this one pin covers both readers — and is the ONLY
+  // thing covering the MCP one. Weaken it and an external client's model is
+  // unguarded with nothing in `packages/mcp` to say so.
   it("states the `include` precondition the read hard-refuses without", () => {
     expect(
       statesIncludePrecondition(asOfDescription),

--- a/packages/api/src/lib/tools/descriptions.ts
+++ b/packages/api/src/lib/tools/descriptions.ts
@@ -82,9 +82,21 @@ Don't use this when no metric id matches; fall back to \`executeSQL\` with a que
 // came out of the opening sentence, the attribution and age clauses, the
 // folded-in `extraction: "pending"` sentence, the JSON example, and both
 // routing paragraphs. The `asOf` clause was restructured, not squeezed — it
-// still costs what it did, so it is not the place to look for slack. The
-// string now sits at 148: two words of headroom, and `KNOWLEDGE_TRUST_FRAMING`
-// is interpolated, so growing that shared constant spends this margin too.
+// still costs what it did, so it is not the place to look for slack.
+//
+// The string is 148 words, of which 5 are the interpolated
+// `KNOWLEDGE_TRUST_FRAMING`. Those are NOT charged here as of #4954: the
+// rubric measures each tool's own prose and the shared constant carries a
+// separate, explicitly-named budget. The reason is that while it was charged
+// twice, this description had two words of headroom and `explore`'s (149/150)
+// had one — so three words added to a constant NEITHER of them owns failed
+// both gates at once, naming the two tools rather than the constant. This
+// description's own prose is 144 of 150, so there is real headroom now, but it
+// is headroom for THIS description's clauses only, and the COMPOSED string
+// (own prose + the framing, still before `withErrorContract` appends the error
+// section) is separately capped by `description-rubric.test.ts`. Growing
+// the shared framing still costs every interpolating tool; it now fails one
+// named test that says so instead of two that blame the wrong prose.
 //
 // The system-prompt twin in `lib/tools/search-brain.ts` is longer and uncapped,
 // not a copy and not a strict superset (it carries the as-of-NOW clarifier and

--- a/packages/api/src/lib/tools/search-brain-schema.ts
+++ b/packages/api/src/lib/tools/search-brain-schema.ts
@@ -1,0 +1,183 @@
+/**
+ * The ONE `searchBrain` input schema (#4954).
+ *
+ * Both agent surfaces read this module: the AI SDK tool in
+ * `lib/tools/search-brain.ts` wraps {@link SEARCH_BRAIN_INPUT_SHAPE} in a
+ * `z.object`, and the MCP tool in `packages/mcp/src/tools.ts` hands the raw
+ * shape straight to `registerTool` (the MCP SDK takes a `ZodRawShape`, the AI
+ * SDK takes a `ZodObject` — the only reason both spellings are exported).
+ *
+ * ## Why this is its own module and not a `search-brain.ts` export
+ *
+ * The load-bearing property is not that this module is small — it is that
+ * **the MCP suite does not `mock.module` it.**
+ * `packages/mcp/src/__tests__/tools.test.ts` mocks
+ * `@atlas/api/lib/tools/search-brain` wholesale, so that it can stub
+ * `execute`. Argument prose exported from there would reach `listTools()` as
+ * the STUB, and that suite's two #4954 pins — the registration-identity one
+ * and the served-value one — would compare a stub against a stub. Both sides
+ * read the same import, so a stub is the one edit that turns them green
+ * without anything being right. That property has to survive someone later
+ * adding an import here, so state it as the invariant rather than as "leaf
+ * module": this file may grow dependencies, but neither it NOR ANYTHING IT
+ * IMPORTS may become one of the modules that suite stubs. That is not
+ * theoretical — the `limit` and `include` prose interpolate constants from
+ * `lib/brain/search` and `@useatlas/schemas`, so a stub of either would blank
+ * those two descriptions on BOTH sides of the value pin and leave it green
+ * while clients are served "max undefined". (CLAUDE.md's mock-all-exports rule makes the
+ * mistake likely rather than exotic — a maintainer adding an export here and
+ * dutifully stubbing it there is all it takes.)
+ *
+ * ## Why the duplication was worth deleting
+ *
+ * Until #4954 the shape was declared twice with independently authored
+ * `.describe()` prose, kept in agreement only by a test on each side plus a
+ * hand-mirrored copy of each rule. Both correctness bugs that arrangement
+ * produced landed on `asOf`: an unqualified "retracted never" (#4933) and a
+ * dropped `include` precondition (#4939), each of which then had to be fixed
+ * TWICE, once per copy. `query` drifted too, harmlessly.
+ *
+ * So by the base commit both copies already carried both clauses — the
+ * duplication that remained was structural, not a live defect. Every argument
+ * below is the api-side spelling, the surface those fixes were authored
+ * against, which leaves that surface byte-identical. The MCP surface changes
+ * mostly in verbosity, with two deltas worth naming. `asOf` GAINS the
+ * `non-ISO forms` rejection case (which `parseBrainAsOf` does enforce) and
+ * the `later-superseded` qualifier, neither of which its copy ever carried.
+ * `query` LOSES the trust-tier adjectives "reviewed" and "raw" — not a
+ * verbosity trim, but nothing becomes unsayable: the tool description MCP is
+ * served labels all three tiers already.
+ *
+ * ## Two exports, and what they are not for
+ *
+ * The raw shape and the assembled object exist because the two SDKs want
+ * different spellings, and the object is BUILT from the shape so they cannot
+ * be edited apart. Neither is a general-purpose building block: a third
+ * consumer re-assembling its own `z.object(SHAPE).strict()` would diverge in
+ * BEHAVIOUR while passing every pin that guards these exports — none of them
+ * observes a third consumer's own assembly. Register one of these two, or add
+ * a pin alongside them.
+ *
+ * ## Why `packages/mcp` imports `zod/v4` and this file imports `zod`
+ *
+ * Not an oversight, and not the peer-differentiated nominal-clash trap: both
+ * packages resolve one `zod@4.4.3`, whose root entry re-exports the v4
+ * classic namespace, and the MCP SDK types `registerTool` against its own
+ * structural `Record<string, AnySchema>` rather than zod's nominal classes.
+ * Unifying the two spellings is a no-op; don't do it as a "cleanup" on the
+ * assumption it is currently broken.
+ *
+ * ## What still lives elsewhere
+ *
+ * The TOOL description (not the arguments) is `SEARCH_BRAIN_TOOL_DESCRIPTION`
+ * in `lib/tools/descriptions.ts`, already single-sourced — MCP derives it from
+ * `searchBrain.description` via `withErrorContract`. The system-prompt
+ * guidance block is `SEARCH_BRAIN_DESCRIPTION` in `lib/tools/search-brain.ts`,
+ * a genuinely different string for a different reader.
+ */
+
+import { z } from "zod";
+import { DEFAULT_SEARCH_LIMIT, MAX_SEARCH_LIMIT } from "@atlas/api/lib/brain/search";
+import { BRAIN_RESULT_TIERS } from "@useatlas/schemas";
+
+/**
+ * The raw shape, for the MCP SDK's `registerTool({ inputSchema })`, which
+ * takes a `ZodRawShape` rather than an assembled object.
+ *
+ * The `asOf` prose is the correctness-bearing entry and carries two clauses
+ * that read as decoration and are not:
+ *
+ *   - **"never as a RESULT, only as a `tensions` counterpart labelled by
+ *     `invalidatedAt`"** (#4933). A retracted fact IS still reachable — #4913
+ *     keeps it in `tensions` on purpose so a settled retraction stays
+ *     distinguishable from a live rival. An unqualified "retracted never"
+ *     here teaches the model to report a settled retraction as a live
+ *     contradiction.
+ *   - **"Requires the fact store in `include`"** (#4939). Not advisory:
+ *     `searchBrainCore` HARD-REFUSES an `asOf` read whose `include` omits
+ *     facts, validated before any store runs. Unstated, it is a refusal a
+ *     well-behaved caller cannot avoid.
+ *
+ * Both rules are asserted against this module in
+ * `__tests__/search-brain-tool.test.ts`; the MCP suite asserts only that the
+ * schema it serves IS this one.
+ *
+ * `limit` and `include` are the two arguments whose VALUES the SDK rejects
+ * before the tool body ever sees them, and that is worth knowing before
+ * anyone copies the pattern onto a sibling. The MCP SDK validates
+ * `inputSchema` first, so `limit: 0` or an unrecognized `include` tier comes
+ * back as a bare `isError` tool result carrying the SDK's own validation
+ * text — NOT the `{ code, message, request_id }` envelope every runtime
+ * refusal here returns, because it never reaches `dispatch()`. (It is a
+ * resolved result, not a transport-level failure; `callTool` does not
+ * reject.) A side effect worth noting: `normalizeSearchInput`'s
+ * drop-unrecognized-`include`-and-log path is therefore unreachable for any
+ * caller that went through zod, and exists for the ones that did not.
+ *
+ * Both bounds are kept anyway, because rejecting is more honest than
+ * `normalizeSearchInput`'s clamp silently turning `limit: 500` into 50, and
+ * the descriptions state the cap and the tier list so a well-behaved model
+ * never trips either. Do NOT "fix" `asOf` the same way by adding a format
+ * constraint: it is deliberately a bare `z.string()` so `parseBrainAsOf` can
+ * refuse it with a logged, id-carrying `validation_failed` naming the
+ * offending value (#4916).
+ *
+ * `satisfies z.ZodRawShape` reports a non-zod entry HERE rather than at
+ * whichever package imports it. `Object.freeze` blocks a RE-POINTED key —
+ * the object is aliased by reference into two registrars in one process, so
+ * a reassignment from either would silently rewrite both surfaces and stay
+ * deep-equal to itself. It is shallow: it cannot stop someone mutating a zod
+ * node in place, which is part of why the served-value pin exists.
+ */
+export const SEARCH_BRAIN_INPUT_SHAPE = Object.freeze({
+  query: z
+    .string()
+    .optional()
+    .describe(
+      "Free-text search across claims, source records, and document bodies. Omit to browse the most recent entries in each store.",
+    ),
+  include: z
+    .array(z.enum(BRAIN_RESULT_TIERS))
+    .optional()
+    .describe(
+      `Restrict to specific result classes (${BRAIN_RESULT_TIERS.join(", ")}). Omit to search all three.`,
+    ),
+  type: z.string().optional().describe("Documents only: filter to one OKF document type, e.g. 'Runbook'."),
+  tags: z
+    .array(z.string())
+    .optional()
+    .describe("Documents only: filter to documents carrying ALL of these OKF tags."),
+  collection: z
+    .string()
+    .optional()
+    .describe("Documents only: restrict to a single knowledge collection (install slug)."),
+  since: z
+    .string()
+    .optional()
+    .describe("Documents only: ISO-8601 date; documents at or after this timestamp."),
+  asOf: z
+    .string()
+    .optional()
+    .describe(
+      "Facts only: historical point read — returns the reviewed facts valid at that moment (later-superseded versions included; a retracted fact never as a RESULT, only as a `tensions` counterpart labelled by `invalidatedAt`). An ISO-8601 date (2026-07-27) or a timestamp with an EXPLICIT zone (2026-07-27T09:00:00Z); zone-less times, non-ISO forms, and future instants are rejected. Requires the fact store in `include`. Omit for current beliefs.",
+    ),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(MAX_SEARCH_LIMIT)
+    .optional()
+    .describe(`Max fused results to return (default ${DEFAULT_SEARCH_LIMIT}, max ${MAX_SEARCH_LIMIT}).`),
+  expand: z
+    .boolean()
+    .optional()
+    .describe("Include 1-hop linked neighbors of the matched documents (default true)."),
+} satisfies z.ZodRawShape);
+
+/**
+ * The assembled object, for the AI SDK's `tool({ inputSchema })`.
+ *
+ * Built FROM {@link SEARCH_BRAIN_INPUT_SHAPE} rather than declared alongside
+ * it, so the two spellings cannot be edited apart.
+ */
+export const searchBrainInputSchema = z.object(SEARCH_BRAIN_INPUT_SHAPE);

--- a/packages/api/src/lib/tools/search-brain.ts
+++ b/packages/api/src/lib/tools/search-brain.ts
@@ -61,7 +61,7 @@
  */
 
 import { tool } from "ai";
-import { z } from "zod";
+import type { z } from "zod";
 import { createLogger, getRequestContext } from "@atlas/api/lib/logger";
 import { getInternalDB, hasInternalDB } from "@atlas/api/lib/db/internal";
 import { detectAuthMode } from "@atlas/api/lib/auth/detect";
@@ -77,7 +77,8 @@ import {
   resolveBrainReaderContext,
 } from "@atlas/api/lib/brain/reader-context";
 import { SEARCH_BRAIN_TOOL_DESCRIPTION } from "@atlas/api/lib/tools/descriptions";
-import { BRAIN_RESULT_TIERS, isBrainResultTier } from "@useatlas/schemas";
+import { searchBrainInputSchema } from "@atlas/api/lib/tools/search-brain-schema";
+import { isBrainResultTier } from "@useatlas/schemas";
 import type { AtlasMode } from "@useatlas/types/auth";
 import type {
   BrainResultTier,
@@ -181,6 +182,14 @@ function withRequestId(message: string, requestId: string | undefined): string {
   return requestId ? `${message} (request ${requestId})` : message;
 }
 
+/**
+ * The normalizer's input contract — deliberately LOOSER than the schema.
+ *
+ * `include?: string[]` rather than `BrainResultTier[]` is the point: the
+ * drop-unrecognized-and-log path below has to stay reachable for a caller that
+ * did not go through zod, because an unrecognized tier silently meaning "search
+ * nothing" is indistinguishable from an empty brain.
+ */
 export interface SearchBrainInput {
   query?: string;
   include?: string[];
@@ -192,6 +201,52 @@ export interface SearchBrainInput {
   limit?: number;
   expand?: boolean;
 }
+
+/**
+ * Compile error if the shared schema and this contract stop naming the same
+ * arguments — in EITHER direction.
+ *
+ * `SearchBrainInput` is an all-optional weak type, and TypeScript's weak-type
+ * check only fires when two types share NO properties. So a partial drift —
+ * the schema renaming `asOf`, say — compiles silently: `execute` still
+ * typechecks, `normalizeSearchInput` reads `undefined`, and every historical
+ * read degrades to an as-of-now read, which is the exact silent fall-through
+ * #4916 exists to forbid. `exactOptionalPropertyTypes` is off repo-wide, so
+ * nothing else catches it.
+ *
+ * It earned its keep at #4954: the schema is no longer in the same file as the
+ * function that consumes it, it is in another module, edited by people fixing
+ * the MCP surface. Both directions matter — a schema key missing here is an
+ * argument the normalizer drops on the floor; a key here missing from the
+ * schema is a field no model can ever send — so they are two consts rather
+ * than one, and each one's failing type is the LEFTOVER KEY. tsc then names
+ * the direction and the argument (`Type 'true' is not assignable to type
+ * '"as_of"'`) instead of an anonymous `never`. Same `_`-const idiom as
+ * {@link _UnavailableIsReason} above.
+ *
+ * The `[X] extends [never]` tupling is deliberate: a bare `X extends never`
+ * distributes over a union and collapses on `never` itself, so both arms would
+ * silently answer the wrong question.
+ *
+ * KEY SETS only. The other two halves live elsewhere on purpose. An argument's
+ * TYPE is checked where `normalizeSearchInput(input)` is called below — a
+ * `z.string()` limit fails there, not here, and only while `execute` keeps
+ * passing `input` straight through. Its OPTIONALITY is pinned in
+ * `__tests__/search-brain-tool.test.ts`, because dropping `.optional()`
+ * changes neither the key set nor assignability to this all-optional weak type.
+ */
+type _SchemaKeys = keyof z.infer<typeof searchBrainInputSchema>;
+type _SchemaKeyNotInInput = Exclude<_SchemaKeys, keyof SearchBrainInput>;
+type _InputKeyNotInSchema = Exclude<keyof SearchBrainInput, _SchemaKeys>;
+
+const _noSchemaKeyMissingFromInput: [_SchemaKeyNotInInput] extends [never]
+  ? true
+  : _SchemaKeyNotInInput = true;
+const _noInputKeyMissingFromSchema: [_InputKeyNotInSchema] extends [never]
+  ? true
+  : _InputKeyNotInSchema = true;
+void _noSchemaKeyMissingFromInput;
+void _noInputKeyMissingFromSchema;
 
 /**
  * Clamp + normalize raw tool input. Exported for tests.
@@ -242,50 +297,11 @@ export function normalizeSearchInput(input: SearchBrainInput): {
 export const searchBrain = tool({
   description: SEARCH_BRAIN_TOOL_DESCRIPTION,
 
-  inputSchema: z.object({
-    query: z
-      .string()
-      .optional()
-      .describe(
-        "Free-text search across claims, source records, and document bodies. Omit to browse the most recent entries in each store.",
-      ),
-    include: z
-      .array(z.enum(BRAIN_RESULT_TIERS))
-      .optional()
-      .describe(
-        `Restrict to specific result classes (${BRAIN_RESULT_TIERS.join(", ")}). Omit to search all three.`,
-      ),
-    type: z.string().optional().describe("Documents only: filter to one OKF document type, e.g. 'Runbook'."),
-    tags: z
-      .array(z.string())
-      .optional()
-      .describe("Documents only: filter to documents carrying ALL of these OKF tags."),
-    collection: z
-      .string()
-      .optional()
-      .describe("Documents only: restrict to a single knowledge collection (install slug)."),
-    since: z
-      .string()
-      .optional()
-      .describe("Documents only: ISO-8601 date; documents at or after this timestamp."),
-    asOf: z
-      .string()
-      .optional()
-      .describe(
-        "Facts only: historical point read — returns the reviewed facts valid at that moment (later-superseded versions included; a retracted fact never as a RESULT, only as a `tensions` counterpart labelled by `invalidatedAt`). An ISO-8601 date (2026-07-27) or a timestamp with an EXPLICIT zone (2026-07-27T09:00:00Z); zone-less times, non-ISO forms, and future instants are rejected. Requires the fact store in `include`. Omit for current beliefs.",
-      ),
-    limit: z
-      .number()
-      .int()
-      .min(1)
-      .max(MAX_SEARCH_LIMIT)
-      .optional()
-      .describe(`Max fused results to return (default ${DEFAULT_SEARCH_LIMIT}, max ${MAX_SEARCH_LIMIT}).`),
-    expand: z
-      .boolean()
-      .optional()
-      .describe("Include 1-hop linked neighbors of the matched documents (default true)."),
-  }),
+  // The ONE definition, shared with the MCP tool (#4954). It lives in its own
+  // module rather than here because the MCP suite `mock.module`s THIS file —
+  // argument prose exported from here would reach `listTools()` as a stub and
+  // every pin that reads the served schema would pass vacuously.
+  inputSchema: searchBrainInputSchema,
 
   execute: async (input) => {
     const reqCtx = getRequestContext();

--- a/packages/mcp/src/__tests__/tools.test.ts
+++ b/packages/mcp/src/__tests__/tools.test.ts
@@ -1,10 +1,18 @@
 import { describe, expect, it, mock, beforeEach } from "bun:test";
+import { z } from "zod/v4";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { createAtlasUser } from "@atlas/api/lib/auth/types";
 import { getRequestContext } from "@atlas/api/lib/logger";
 import { parseAtlasMcpToolError } from "@useatlas/types/mcp";
+// The single input-schema definition (#4954). Deliberately imported from its
+// own module and NOT from `@atlas/api/lib/tools/search-brain`, which this file
+// `mock.module`s wholesale below — a stubbed schema would make the served-vs-
+// source comparison compare two stubs. For the same reason, do NOT add a
+// `mock.module` for `search-brain-schema` itself: both sides of that
+// comparison read this import, so stubbing it turns the pins green on a stub.
+import { SEARCH_BRAIN_INPUT_SHAPE } from "@atlas/api/lib/tools/search-brain-schema";
 import { registerTools } from "../tools.js";
 import { executeSqlOutputSchema } from "../structured-output.js";
 
@@ -182,9 +190,14 @@ describe("MCP tools", () => {
       tools.map((t) => [t.name, t.annotations]),
     );
 
-    // All six native tools are read-only: explore + the semantic-layer
-    // tools read YAML, executeSQL / runMetric are SELECT-only (validated).
-    // A client must NOT prompt for confirmation on any of them.
+    // Every native tool is read-only: explore + the semantic-layer tools read
+    // YAML, executeSQL / runMetric are SELECT-only (validated), searchBrain
+    // reads the internal DB. A client must NOT prompt for confirmation on any
+    // of them.
+    //
+    // `searchBrain` was added to this loop in #4954. It has declared both
+    // annotations since #4773 and neither was asserted — the comment still
+    // said "all six" while the sibling test above listed seven tools.
     for (const name of [
       "explore",
       "executeSQL",
@@ -192,17 +205,20 @@ describe("MCP tools", () => {
       "describeEntity",
       "searchGlossary",
       "runMetric",
+      "searchBrain",
     ]) {
       expect(annotationsByName.get(name)?.readOnlyHint).toBe(true);
     }
 
-    // Semantic-layer tools operate on a closed, local domain (the semantic
-    // directory) → openWorldHint false.
+    // Tools over a closed, local domain → openWorldHint false: the
+    // semantic-layer reads (the semantic directory) and searchBrain (the
+    // internal DB — no reach outside this deployment).
     for (const name of [
       "explore",
       "listEntities",
       "describeEntity",
       "searchGlossary",
+      "searchBrain",
     ]) {
       expect(annotationsByName.get(name)?.openWorldHint).toBe(false);
     }
@@ -1018,8 +1034,8 @@ describe("MCP tools", () => {
       // growing a hand-written literal here. The retraction labels are pinned
       // on the constant in the api package
       // (`lib/tools/__tests__/search-brain-tool.test.ts`); nothing there would
-      // notice this file re-declaring the prose, and every retraction
-      // assertion in this suite would still be green.
+      // notice this file re-declaring the prose, and since #4954 the retraction
+      // rules live ONLY in that file, which cannot see this one.
       //
       // The stub text comes from the module mock at the top of this file, so
       // this asserts the WIRING, not the prose — which is the only half that
@@ -1038,106 +1054,179 @@ describe("MCP tools", () => {
       expect(description).toContain("Error contract:");
     });
 
-    it("the advertised `asOf` argument does not promise retracted facts are unreachable (#4933)", async () => {
-      // Unlike the tool prose above, the whole input schema is re-declared in
-      // `src/tools.ts` rather than imported — `query` has already drifted from
-      // its api-side twin — so `asOf` is the argument where that drift is
-      // correctness-bearing and a fix in `lib/tools/descriptions.ts`
-      // structurally cannot reach it. It shipped saying "retracted never",
-      // full stop. #4913 kept a retracted rival in `tensions` precisely so it
-      // stays distinguishable, so the absolute was false of the response and
-      // true only of `results`; a model reading it reports a settled
-      // retraction as a live contradiction.
+    // Until #4954 `src/tools.ts` re-declared this whole schema with its own
+    // hand-authored `.describe()` prose, and this suite carried a
+    // hand-mirrored copy of each api-side rule to keep the two honest. That
+    // arrangement is exactly how the MCP `asOf` shipped with #4933's
+    // unqualified "retracted never" and without #4939's `include`
+    // precondition: both were fixed on the api string first, and neither fix
+    // could structurally reach this surface.
+    //
+    // So this suite no longer restates the RULES — `search-brain-tool.test.ts`
+    // owns them, once, against the shared module. The consequence is worth
+    // stating plainly, because nothing here will: **this package's suite is
+    // now blind to a prose regression.** Re-add #4933's absolute to the shared
+    // `asOf` string and every test in this file stays green. That is the
+    // intended trade — one owner per rule beats two copies that drift — but it
+    // means the guarantees an external MCP client depends on now rest on a
+    // test in a DIFFERENT package continuing to exist. Weakening
+    // `search-brain-tool.test.ts`'s `asOf` block leaves this surface
+    // unguarded, silently.
+    //
+    // What this file owns instead is the link that makes owning them once
+    // sufficient, and it takes BOTH tests below, because either alone has a
+    // hole:
+    //
+    //   - identity alone would not notice the registration being handed the
+    //     right object and the SDK serving something else;
+    //   - value alone goes GREEN on a verbatim local re-declaration — two
+    //     copies, in agreement today, drifting later, which is the precise
+    //     state #4954 exists to eliminate.
+    it("hands the MCP registration the api package's shape object itself (#4954)", async () => {
+      // Identity at the registration boundary. Captured at the call rather
+      // than read back off the wire, because the wire only ever carries a
+      // converted JSON Schema — by then a `{ ...SHAPE }` spread and the shape
+      // itself are indistinguishable.
       //
-      // Asserted through `listTools()` rather than against the source string
-      // because what an external client's model actually reads is the
-      // REGISTERED schema.
-      const { client } = await createTestClient();
-      const { tools } = await client.listTools();
-      // Narrowed, not asserted: the MCP SDK types `properties` as
-      // `Record<string, object>`, so a cast here would re-introduce on this
-      // side exactly the blind widening the api-side twin was rewritten to
-      // avoid.
-      const asOf = tools.find((t) => t.name === "searchBrain")?.inputSchema.properties?.asOf;
-      const description =
-        asOf && "description" in asOf && typeof asOf.description === "string"
-          ? asOf.description
-          : undefined;
-      expect(
-        description,
-        "searchBrain's registered inputSchema has no `asOf` description — the registration in src/tools.ts changed shape, so the retraction pins below would pass vacuously",
-      ).toBeTruthy();
-      // Both arms, so neither half can be dropped: the carve-out has to be
-      // stated (`tensions`) AND the field that labels it has to be nameable
-      // (`invalidatedAt`), or the guidance is unactionable.
-      expect(description).toContain("tensions");
-      expect(description).toContain("invalidatedAt");
-      // The never-arm the carve-out could plausibly displace: a retracted fact
-      // is still never a RESULT, which is what makes `asOf` safe to trust.
-      expect(description).toMatch(/never as a RESULT/);
-      // And the arm the three pins above survive: a rewrite that keeps every
-      // token and re-adds the absolute in a neighbouring sentence.
+      // A wrapper rather than `spyOn`: `registerTool` is a single generic
+      // method with two type params, so bun types `spy.mock.calls` as `never[]`
+      // and reading an argument off it needs a cast that says MORE than this
+      // wrapper's does. The two casts here are narrow — an arrow cannot be
+      // assignable to a generic method without the outer one, and the bound
+      // original cannot be called with widened args without the inner one —
+      // and neither papers over a type gap.
       //
-      // A deliberate second copy of `unqualifiedRetractionSentences` from the
-      // api suite, not a forced one — `@atlas/api` does export a `./testing/*`
-      // entrypoint these four lines could live behind. The rule is OWNED
-      // there, where it is stated in full; a tightening there has to be
-      // mirrored here by hand, which is the cost of not adding a cross-package
-      // test-utility export to a scoped fix. The `\n(?=[-*] )` bullet arm is
-      // omitted because this string is prose, not markdown.
-      const unqualified = (description ?? "")
-        .split(/(?<=\.)\s+/)
-        .filter((s) => /retract/i.test(s))
-        .filter((s) =>
-          /retract\w*\s+(?:facts?\s+)?(?:is |are )?never|never\s+(?:returned|surfaces?|appears?|as a RESULT)|retract\w*[^.]{0,40}\b(?:excluded|omitted)\b/i.test(
-            s,
-          ),
-        )
-        .filter((s) => !/(only|except|still appears?|the one place)[^.]{0,80}tensions/i.test(s));
+      // Residual risk, contained deliberately: the outer cast decouples the
+      // arrow's parameter list from the real signature, so an SDK that
+      // reordered those three would still compile and fill `seen` with
+      // garbage. That is why the `seen.has` assertion below carries its own
+      // message instead of leaning on the identity check to fail sensibly.
+      const server = new McpServer({ name: "test", version: "0.0.1" });
+      const seen = new Map<string, unknown>();
+      const original = server.registerTool.bind(server);
+      server.registerTool = ((name: string, config: { inputSchema?: unknown }, cb: unknown) => {
+        // The SDK throws on a duplicate tool name anyway; this fires first
+        // and says why the CAPTURE MAP, not just the registry, cares — `set`
+        // would quietly keep the last one and the identity check below would
+        // then be asserting about a registration nobody meant to inspect.
+        expect(seen.has(name), `${name} was registered twice`).toBe(false);
+        seen.set(name, config.inputSchema);
+        return (original as (...a: unknown[]) => unknown)(name, config, cb);
+      }) as typeof server.registerTool;
+
+      registerTools(server, { actor: TEST_ACTOR });
+
       expect(
-        unqualified,
-        "a sentence promising retracted facts never come back must name the `tensions` carve-out in that same sentence",
-      ).toEqual([]);
+        seen.has("searchBrain"),
+        "searchBrain was never registered — the identity check below would pass vacuously",
+      ).toBe(true);
+      expect(
+        seen.get("searchBrain"),
+        "src/tools.ts no longer passes SEARCH_BRAIN_INPUT_SHAPE itself. A spread or a re-declared literal is deep-equal on the day it is written and drifts on the next api-side prose fix — which is the entire failure #4954 removed.",
+      ).toBe(SEARCH_BRAIN_INPUT_SHAPE);
     });
 
-    it("the advertised `asOf` argument states the `include` precondition the read refuses without (#4939)", async () => {
-      // The second sentence this re-declared schema had dropped. It is not
-      // advisory: `searchBrain` throws `BrainAsOfInvalidError` when `asOf` is
-      // passed and `include` excludes facts — validated FIRST, before any
-      // store runs — so an MCP model was the only caller told to combine two
-      // arguments it would be refused for combining. The api-side twin has
-      // always carried it; `search-brain-tool.test.ts` owns the same rule.
-      //
-      // Read off `listTools()` for the same reason the retraction pins above
-      // are: the registered schema is what an external client's model reads.
+    it("serves that shape's JSON Schema to a client, argument prose included (#4954)", async () => {
+      // Value at the wire. Read through `listTools()` on purpose: the
+      // registered JSON Schema is what an external client's model actually
+      // reads, and the identity pin above says nothing about what the SDK
+      // does with the object afterwards.
       const { client } = await createTestClient();
       const { tools } = await client.listTools();
-      const asOf = tools.find((t) => t.name === "searchBrain")?.inputSchema.properties?.asOf;
-      const description =
-        asOf && "description" in asOf && typeof asOf.description === "string"
-          ? asOf.description
-          : undefined;
-      expect(
-        description,
-        "searchBrain's registered inputSchema has no `asOf` description — the precondition pin below would pass vacuously",
-      ).toBeTruthy();
+      const served = tools.find((t) => t.name === "searchBrain");
+      expect(served, "searchBrain is not registered — the comparison below would pass vacuously").toBeDefined();
 
-      // Word-bounded AND required to sit in a sentence that reads as a
-      // requirement. A bare substring check passes vacuously on this exact
-      // string: it already says "superseded versions INCLUDED". A deliberate
-      // second copy of the api suite's `statesIncludePrecondition`, on the
-      // same terms as the `unqualifiedRetractionSentences` copy above — the
-      // rule is OWNED there and a tightening there has to be mirrored here by
-      // hand. Kept byte-identical to it on purpose, bullet arm included: that
-      // arm is inert against this prose string, but a copy that diverged
-      // "harmlessly" is how the two stop being the same rule.
-      const statesPrecondition = (description ?? "")
-        .split(/(?<=\.)\s+|\n(?=[-*] )/)
-        .some((s) => /\binclude\b/.test(s) && /\b(requires?|needs?|must|only with)\b/i.test(s));
+      // `properties` AND `required`, not `properties` alone: in JSON Schema an
+      // argument's optionality lives in the sibling `required` array, so a
+      // served schema that marked `collection` REQUIRED would be
+      // `.properties`-equal to this one while breaking every call.
+      //
+      // `$schema` and `additionalProperties` are deliberately NOT compared —
+      // they are the serializer's envelope, not the api package's definition.
+      // `$schema` genuinely diverges today (the SDK targets draft-07; zod
+      // emits 2020-12). `additionalProperties` currently AGREES — both omit
+      // it — but only because of the `io: "input"` below; it comes back as
+      // `false` in output mode. So it is excluded as envelope, not because it
+      // differs right now: don't "simplify" by folding it back in on the
+      // strength of a green run. Pinning either would fail on an SDK upgrade
+      // while saying "the prose drifted", and the question of WHICH OBJECT was
+      // registered is already settled by the identity pin above.
+      //
+      // Both sides widened to `unknown` rather than either one cast to the
+      // other's shape: the MCP SDK types `properties` as
+      // `Record<string, object>` and zod's `_JSONSchema` admits `boolean`, so
+      // a cast would be an assertion about the payload rather than a
+      // comparison of it — which is the blind widening the api-side twin was
+      // rewritten to avoid. `toEqual` is a runtime deep-equal, so widening
+      // costs no detection power.
+      //
+      // `io: "input"` is load-bearing, not decoration. `z.toJSONSchema`
+      // defaults to `io: "output"`, where a `.default()` makes a field
+      // REQUIRED (the output always has it) while the MCP SDK — correctly
+      // serving an INPUT contract — leaves it optional. Give `limit` the
+      // default that today lives in `normalizeSearchInput` and the two
+      // disagree, and this test fails blaming a "local re-declaration" or an
+      // SDK change, neither of which happened. The served schema is an input
+      // contract; say so.
+      const contractOf = (
+        schema: { properties?: unknown; required?: unknown } | undefined,
+      ): { properties: unknown; required: unknown } => ({
+        properties: schema?.properties,
+        required: schema?.required,
+      });
+      const expectedSchema = z.toJSONSchema(z.object(SEARCH_BRAIN_INPUT_SHAPE), { io: "input" });
+      const expected = contractOf(expectedSchema);
+
+      // Sanity on the fixture itself: an empty or description-free expectation
+      // would make the deep-equal below satisfiable by an equally empty served
+      // schema. `asOf` is named because it is the correctness-bearing argument.
+      expect(Object.keys(expectedSchema.properties ?? {}).length).toBeGreaterThan(0);
+      expect(expectedSchema.properties?.asOf).toHaveProperty("description");
+      // And the `required` half is VACUOUS today — every searchBrain argument
+      // is optional, so both serializers omit the key and that half of the
+      // deep-equal compares `undefined` to `undefined`. Stated as its own
+      // tripwire so the comparison above is not read as actively pinning
+      // something it is only guarding against: the day an argument becomes
+      // required, this line is the one that says so out loud.
       expect(
-        statesPrecondition,
-        "the MCP `asOf` argument states no `include` precondition — the read hard-refuses that combination, so the model cannot avoid a refusal it was never told about",
-      ).toBe(true);
+        expectedSchema.required,
+        "a searchBrain argument became required — intended? The served/expected comparison below now genuinely pins requiredness; update this tripwire deliberately.",
+      ).toBeUndefined();
+
+      expect(
+        contractOf(served?.inputSchema),
+        "the searchBrain schema served over MCP is not the one @atlas/api/lib/tools/search-brain-schema builds. Either src/tools.ts has re-grown a local declaration — in which case every argument-prose fix authored on the api side now stops at the package boundary — or the MCP SDK changed how it converts a shape to JSON Schema, in which case re-point this expectation at whatever it now emits rather than relaxing it.",
+      ).toEqual(expected);
+    });
+
+    it("a schema-rejected argument is refused BEFORE dispatch, without the error envelope (#4954)", async () => {
+      // `search-brain-schema.ts` spends a paragraph on this, and until now it
+      // was prose: the MCP SDK validates `inputSchema` before the handler
+      // runs, so ANY schema violation — `limit` and `include`'s value
+      // constraints, which are the only ones beyond type, or a wrong type on
+      // any of the nine arguments — is the one searchBrain failure class that
+      // reaches a client with no `code` and no `request_id`. Every runtime
+      // refusal (`invalid_as_of`, `reader_unresolved`, `no_internal_db`,
+      // `search_failed`) gets both. (`no_workspace` is absent on purpose: it
+      // rides `unavailable` on a shaped 200, never an error.) A claim about
+      // the wire, on the surface whose model Atlas does not control, should
+      // not rest on a comment. `limit: 0` is the cheapest way in.
+      //
+      // It is a RESOLVED `isError` result, not a transport-level throw —
+      // `callTool` does not reject — which is the part most likely to be
+      // mis-remembered when someone adds a constraint to a sibling argument.
+      const { client } = await createTestClient();
+      const result = await client.callTool({ name: "searchBrain", arguments: { limit: 0 } });
+
+      expect(result.isError).toBe(true);
+      expect(
+        parseAtlasMcpToolError(getContentText(result.content)),
+        "a schema-rejected argument now returns the typed envelope — if the SDK started routing validation through the dispatch path, the schema module's note about `limit`/`include` being the envelope-less failure class is stale and should be deleted, not left to rot",
+      ).toBeNull();
+      expect(
+        mockSearchBrainExecute,
+        "the tool body ran despite schema-invalid input — validation is no longer pre-dispatch",
+      ).not.toHaveBeenCalled();
     });
 
     it("returns the fused payload as JSON on success", async () => {

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -32,15 +32,14 @@ import {
   searchBrain,
   type BrainToolReason,
 } from "@atlas/api/lib/tools/search-brain";
+import { SEARCH_BRAIN_INPUT_SHAPE } from "@atlas/api/lib/tools/search-brain-schema";
 import type { AtlasMcpToolErrorCode } from "@useatlas/types/mcp";
-import { DEFAULT_SEARCH_LIMIT, MAX_SEARCH_LIMIT } from "@atlas/api/lib/brain/search";
 import {
   EXECUTE_SQL_ERROR_CODES,
   EXPLORE_ERROR_CODES,
   SEARCH_BRAIN_ERROR_CODES,
   withErrorContract,
 } from "@atlas/api/lib/tools/descriptions";
-import { BRAIN_RESULT_TIERS } from "@useatlas/schemas";
 import type { AtlasUser } from "@atlas/api/lib/auth/types";
 import { getConfig } from "@atlas/api/lib/config";
 import { writeScopeDenied } from "@atlas/api/lib/mcp/dispatch-gate-contract";
@@ -356,66 +355,19 @@ export function registerTools(server: McpServer, opts: RegisterToolsOptions): vo
     {
       title: "Search the Company Brain",
       description: withErrorContract(searchBrain.description ?? "", SEARCH_BRAIN_ERROR_CODES),
-      inputSchema: {
-        query: z
-          .string()
-          .optional()
-          .describe(
-            "Free-text search across reviewed claims, raw source records, and knowledge documents. Omit to browse the most recent entries.",
-          ),
-        include: z
-          .array(z.enum(BRAIN_RESULT_TIERS))
-          .optional()
-          .describe(
-            `Restrict to specific result classes (${BRAIN_RESULT_TIERS.join(", ")}). Omit to search all three.`,
-          ),
-        type: z.string().optional().describe("Documents only: one OKF document type, e.g. 'Runbook'."),
-        tags: z
-          .array(z.string())
-          .optional()
-          .describe("Documents only: documents carrying ALL of these OKF tags."),
-        collection: z
-          .string()
-          .optional()
-          .describe("Documents only: a single knowledge collection (install slug)."),
-        since: z
-          .string()
-          .optional()
-          .describe("Documents only: ISO-8601 date; documents at or after this timestamp."),
-        // "retracted never" was true of RESULTS and false of the response as a
-        // whole (#4933): #4913 kept a retracted rival in `tensions` precisely
-        // so it stays distinguishable, and an unqualified absolute here taught
-        // the MCP model the opposite. The wording names which field carries
-        // the label, so the guidance is actionable rather than a promise the
-        // wire does not keep.
-        //
-        // "Requires the fact store in `include`" is the second precondition
-        // this schema had dropped (#4939). It is not advisory: `searchBrain`
-        // HARD-REFUSES an `asOf` read whose `include` omits facts
-        // (`lib/brain/search.ts`), and the AI SDK twin has always said so —
-        // so the MCP model was the only caller told to combine two arguments
-        // it would be refused for combining. The rule is pinned in two suites,
-        // one per spelling: `search-brain-tool.test.ts` for the api argument,
-        // and this package's `__tests__/tools.test.ts`, which reads THIS one
-        // back out of the SERVED JSON Schema via `listTools()`.
-        asOf: z
-          .string()
-          .optional()
-          .describe(
-            "Facts only: historical point read — the reviewed facts valid at that moment (superseded versions included; a retracted fact never as a RESULT, only as a `tensions` counterpart labelled by `invalidatedAt`). ISO-8601 date (2026-07-27) or timestamp with an explicit zone (2026-07-27T09:00:00Z); zone-less times and future instants are rejected. Requires the fact store in `include`. Omit for current beliefs.",
-          ),
-        limit: z
-          .number()
-          .int()
-          .min(1)
-          .max(MAX_SEARCH_LIMIT)
-          .optional()
-          .describe(`Max fused results (default ${DEFAULT_SEARCH_LIMIT}, max ${MAX_SEARCH_LIMIT}).`),
-        expand: z
-          .boolean()
-          .optional()
-          .describe("Include 1-hop linked neighbors of matched documents (default true)."),
-      },
+      // #4954 — IMPORTED, not re-declared. Until then this schema was a second
+      // hand-authored copy of the api-side one, kept in agreement only by a
+      // test on each side plus a hand-mirrored copy of each rule. `query` had
+      // drifted harmlessly and `asOf` had drifted twice in correctness-bearing
+      // ways (#4933's unqualified "retracted never", #4939's dropped `include`
+      // precondition) — each then fixed by hand HERE as well as on the api
+      // side, which is the second edit this dedupe removes. The prose and the
+      // reasons behind each clause now live once, in
+      // `lib/tools/search-brain-schema.ts`. This package's
+      // `__tests__/tools.test.ts` pins both halves: that this registration
+      // passes that module's object by identity, and that the JSON Schema
+      // `listTools()` serves is the one it builds.
+      inputSchema: SEARCH_BRAIN_INPUT_SHAPE,
       // Reads the INTERNAL database only — no writes anywhere, and no reach
       // outside this deployment, so the world is closed. Same posture as
       // `explore`, and deliberately narrower than `executeSQL`, which does


### PR DESCRIPTION
Closes #4954

## The duplication

`searchBrain`'s input schema was declared twice — the AI SDK tool in `packages/api`, the MCP tool in `packages/mcp` — with independently authored `.describe()` prose per argument, kept in agreement only by a test on each side plus a hand-mirrored copy of each rule. **Both #4933 and #4939 had to be fixed twice because of it.** Two workers independently reached the same deferral on this seam, which is what made it worth doing deliberately.

One definition now lives in `lib/tools/search-brain-schema.ts`.

It is **its own module**, not an export from `search-brain.ts`, because the MCP suite `mock.module`s `search-brain` wholesale — prose exported from there would reach `listTools()` as a stub, and both new pins would compare a stub against a stub.

## Test ownership

The MCP suite's two hand-mirrored `asOf` prose tests are replaced by an **identity pin at the registration boundary** plus a **value pin at the wire**. Either alone has a hole: value-only goes green on a byte-identical re-declaration. The #4933/#4939 rules are now owned once, in `search-brain-tool.test.ts`, which is the sole guard for **both** surfaces — stated in that file's header and in the MCP suite, since the warning previously lived only in the package that can no longer see the problem.

## The budget question — decoupled, not raised

`KNOWLEDGE_TRUST_FRAMING` is decoupled from the per-tool 150-word budget rather than the cap being raised. `searchBrain` sat at 148 and `explore` at 149, so three words added to a constant **neither tool owns** failed both gates and named the tools instead of the constant — the next author would have failed a gate for a tool they weren't touching.

The rubric now measures each tool's own prose, the shared constant carries its own named ceiling, and a composed ceiling bounds the string a model actually reads. Verified numbers: 148/144, 149/145, framing 5, composed ceiling 158.

## Advertised prose — what changed

Byte-identical on the AI SDK surface. On MCP, two deliberate changes:

- `asOf` **gains** the non-ISO-forms rejection case it never carried.
- `query` **loses** the tier adjectives, which the served tool description already supplies.

Per the issue's scope boundary, the retraction/supersession semantics tuned by #4951 and #4953 are untouched.

## `canonical-mcp-eval`

Expected to drift on any tool-surface change, and it is a **non-required** check. Locally it fails on `auth_unavailable` before reaching any assertion, so red there is not evidence of prose drift — read its output rather than treating the color as a verdict.

## Review

`/review-panel` ran **3 rounds**. Round 3 was comment-accuracy only but caught five overstatements in prose written during round 2, including one inside an **assertion message** — a test whose failure text lied about what it proved:

- Claimed a dropped `include` tier makes a brain store "unreachable". False: `searchBrainCore` defaults to the runtime constant, so unfiltered searches still return that tier. What breaks is *selection* — naming the tier refuses the call pre-dispatch while the argument's own description still advertises it.
- Justified excluding `additionalProperties` by claiming the serializers disagree. Under `io: "input"` they agree; it is excluded as envelope. A maintainer checking that claim would have concluded the exclusion was cargo cult.
- Claimed a double-registration assertion catches something the SDK hides; the SDK already throws on duplicate names.
- Called `limit`/`include` "the one failure class" without a request id — it is any schema violation on any of nine arguments, and the runtime-refusal list omitted `no_internal_db`.
- A test titled "still **derive** from their source constants" only checks agreement — a hardcode matching today passes. Retitled, limitation documented.

## Mutation verification

**28 real-file mutations** — 24 suite + 4 compile-time — each seen failing, then reverted. This is **below the 21/31/55 bar** from the last batch; stating that plainly rather than padding it.

Two are deliberate negatives that must stay *green*: the `+3 words on the shared framing` case, proving the decoupling actually holds, and the `.default()` case, proving the `io: "input"` trap is closed.


### What each guard proved

**Budget decoupling (6)** — `R1` pad `searchBrain` past 150 authored → RED on its authored budget · `R3` grow the framing to 9 words → RED on the constant's *own* named test, not on any tool · **`R4` +3 words on the framing must NOT fail the two per-tool budgets → GREEN**; before this PR the identical mutation failed both, which is the whole proof the coupling is gone · `R5` `explore` stops interpolating → RED `is actually interpolated` (the exclusion can't silently no-op) · `R7` `runMetric` interpolates it undeclared → RED `is not interpolated anywhere the exclusion was never declared` · `R8` six interpolations while every authored budget still clears → RED on the composed ceiling.

**Single-source wiring, api (3)** — `S1` api re-assembles its own object → RED on the identity pin · `S4` an argument loses `.describe()` → RED · `V3` the shape is no longer frozen → RED.

**Drift the key pin structurally cannot see (4)** — `N1` drop `.optional()` from `asOf` → RED on both surfaces · **`N2` a `.default()` on `limit` must NOT read as a served/source mismatch → GREEN** (the `io: "input"` trap; under the default `io: "output"` this test would have failed blaming a re-declaration that never happened) · `V1` `include`'s enum hardcoded, dropping a tier → RED; this one passed *every other pin in the PR* while making the tier unselectable · `V2` `limit`'s max hardcoded away from `MAX_SEARCH_LIMIT` → RED.

**Compile-time (4)** — `T1` rename `asOf` on the schema → `Type 'true' is not assignable to type '"as_of"'` · `T2` add a key `SearchBrainInput` has and the schema lacks → `…to type '"minTier"'`. Both directions fire, and each names the offending key rather than an anonymous `never`.

**The #4933/#4939 rules, now owned once (4)** — `P1` drop the `tensions` carve-out → RED ×3 · `P2` re-add the absolute in a *neighbouring* sentence → RED (the "buy immunity with a token" hole stays closed) · `P3` drop the `include` precondition → RED · `P4` mention `include` in passing rather than as a requirement → RED (the predicate is requirement-shaped, not a substring match).

**Single-source wiring, MCP (5)** — `M5` description stops deriving from the api constant → RED · `M6` `{ ...SHAPE }` spread → RED on the identity pin · **`M7` byte-identical re-declaration of `asOf` → RED on the identity pin.** This went GREEN under this PR's own first draft; it is a concrete instance of false-pass class (a) from the issue, introduced by me and caught by review · `M8` a served copy marks `collection` REQUIRED (`.properties`-equal) → RED on the value pin · `A1` `searchBrain` loses `readOnlyHint` → RED (an annotation declared since #4773 that nothing asserted until now).

**Pre-existing two-surface pins (2)** — `D1` the `SUPERSEDED` label → RED ×2 · `V4` the SDK-enforced bound removed → RED on both the constraint pin and the pre-dispatch behavioural test.

### The three false-pass classes the issue named

- **(a) `toContain` satisfied by a verbatim-copied opening** — found *in this PR's own first draft* (`M7`) and closed with the identity pin. The pre-existing description-wiring pin still exact-matches the pre-contract paragraph.
- **(b) an absolute borrowing the next bullet's carve-out** — the bullet-aware `\n(?=[-*] )` splitter arm survives, and its hand-mirrored MCP copy — which had *deliberately dropped* that arm as "inert against this prose string" — is deleted, so the divergence the comment itself flagged is gone.
- **(c) a substring assertion satisfied by a longer field name** — the `include` predicate stays word-bounded and requirement-shaped (`P4`), and every new assertion is exact equality on a sorted key list rather than a substring.

### Verification

`bash scripts/ci-local.sh` — **33/33 gates PASS** · `bun run type` / `lint` / `lint:type-aware` clean · `packages/api --affected` 523/523 · `packages/mcp` 38/38 · `check-docs-links` PASS (670 pages).
