### PR TITLE
chore(agent): make runAgent's `tools` required so the compiler enforces the surface gate (#4943)

### DIFF
--- a/packages/api/src/lib/__tests__/agent-answer-style-prompt-shape.test.ts
+++ b/packages/api/src/lib/__tests__/agent-answer-style-prompt-shape.test.ts
@@ -111,8 +111,8 @@ function makeSpyingModel(): InstanceType<typeof MockLanguageModelV3> {
 }
 
 const { runAgent } = await import("@atlas/api/lib/agent");
-// #4943 — runAgent's `tools` is required; nonDashboardRegistry is the restricted
-// surface these turns already resolved to when they omitted it.
+// #4943 — runAgent's `tools` is now required; this is its own fail-closed
+// default, so these turns are unchanged. See agent.ts's `@param tools`.
 const { nonDashboardRegistry } = await import("@atlas/api/lib/tools/registry");
 
 function userMessages(text: string): UIMessage[] {

--- a/packages/api/src/lib/__tests__/agent-answer-style-prompt-shape.test.ts
+++ b/packages/api/src/lib/__tests__/agent-answer-style-prompt-shape.test.ts
@@ -111,6 +111,9 @@ function makeSpyingModel(): InstanceType<typeof MockLanguageModelV3> {
 }
 
 const { runAgent } = await import("@atlas/api/lib/agent");
+// #4943 — runAgent's `tools` is required; nonDashboardRegistry is the restricted
+// surface these turns already resolved to when they omitted it.
+const { nonDashboardRegistry } = await import("@atlas/api/lib/tools/registry");
 
 function userMessages(text: string): UIMessage[] {
   return [
@@ -128,6 +131,7 @@ async function runTurn(
 ): Promise<string> {
   lastSystemPrompt = undefined;
   const result = await runAgent({
+    tools: nonDashboardRegistry,
     // The acceptance criterion's simple-question case (#4299).
     messages,
     aiModel: {

--- a/packages/api/src/lib/__tests__/agent-answer-style-workspace-default.test.ts
+++ b/packages/api/src/lib/__tests__/agent-answer-style-workspace-default.test.ts
@@ -88,8 +88,8 @@ void mock.module("@atlas/api/lib/learn/org-knowledge-section", () => ({
 const { runAgent, resolveWorkspaceDefaultAnswerStyle } = await import(
   "@atlas/api/lib/agent"
 );
-// #4943 — runAgent's `tools` is required; nonDashboardRegistry is the restricted
-// surface these turns already resolved to when they omitted it.
+// #4943 — runAgent's `tools` is now required; this is its own fail-closed
+// default, so these turns are unchanged. See agent.ts's `@param tools`.
 const { nonDashboardRegistry } = await import("@atlas/api/lib/tools/registry");
 const { withRequestContext } = await import("@atlas/api/lib/logger");
 const { _resetPool } = await import("@atlas/api/lib/db/internal");

--- a/packages/api/src/lib/__tests__/agent-answer-style-workspace-default.test.ts
+++ b/packages/api/src/lib/__tests__/agent-answer-style-workspace-default.test.ts
@@ -88,6 +88,9 @@ void mock.module("@atlas/api/lib/learn/org-knowledge-section", () => ({
 const { runAgent, resolveWorkspaceDefaultAnswerStyle } = await import(
   "@atlas/api/lib/agent"
 );
+// #4943 — runAgent's `tools` is required; nonDashboardRegistry is the restricted
+// surface these turns already resolved to when they omitted it.
+const { nonDashboardRegistry } = await import("@atlas/api/lib/tools/registry");
 const { withRequestContext } = await import("@atlas/api/lib/logger");
 const { _resetPool } = await import("@atlas/api/lib/db/internal");
 type InternalPool = import("@atlas/api/lib/db/internal").InternalPool;
@@ -271,6 +274,7 @@ async function runTurn(
 ): Promise<string> {
   lastSystemPrompt = undefined;
   const result = await runAgent({
+    tools: nonDashboardRegistry,
     messages: [
       {
         id: "msg-1",

--- a/packages/api/src/lib/__tests__/agent-compaction-integration.test.ts
+++ b/packages/api/src/lib/__tests__/agent-compaction-integration.test.ts
@@ -192,8 +192,8 @@ void mock.module("@atlas/api/lib/cache/index", () => ({
 // ---------------------------------------------------------------------------
 
 const { runAgent } = await import("@atlas/api/lib/agent");
-// #4943 — runAgent's `tools` is required; nonDashboardRegistry is the restricted
-// surface these turns already resolved to when they omitted it.
+// #4943 — runAgent's `tools` is now required; this is its own fail-closed
+// default, so these turns are unchanged. See agent.ts's `@param tools`.
 const { nonDashboardRegistry } = await import("@atlas/api/lib/tools/registry");
 const { invalidateExploreBackend } = await import("@atlas/api/lib/tools/explore");
 const { COMPACTION_SUMMARY_PREFIX, COMPACTION_STREAM_PART_TYPE } = await import("@atlas/api/lib/agent-compaction");

--- a/packages/api/src/lib/__tests__/agent-compaction-integration.test.ts
+++ b/packages/api/src/lib/__tests__/agent-compaction-integration.test.ts
@@ -192,6 +192,9 @@ void mock.module("@atlas/api/lib/cache/index", () => ({
 // ---------------------------------------------------------------------------
 
 const { runAgent } = await import("@atlas/api/lib/agent");
+// #4943 — runAgent's `tools` is required; nonDashboardRegistry is the restricted
+// surface these turns already resolved to when they omitted it.
+const { nonDashboardRegistry } = await import("@atlas/api/lib/tools/registry");
 const { invalidateExploreBackend } = await import("@atlas/api/lib/tools/explore");
 const { COMPACTION_SUMMARY_PREFIX, COMPACTION_STREAM_PART_TYPE } = await import("@atlas/api/lib/agent-compaction");
 const { _resetSettingsCache } = await import("@atlas/api/lib/settings");
@@ -346,7 +349,7 @@ describe("agent compaction — runAgent seam (#3759)", () => {
   it("enabled + past threshold → compaction fires and the turn completes", async () => {
     enableCompaction();
 
-    const result = await runAgent({ messages: userMessages("Analyze companies") });
+    const result = await runAgent({ tools: nonDashboardRegistry, messages: userMessages("Analyze companies") });
     const steps = await result.steps;
 
     // Turn ran to natural completion (4 SQL steps + 1 text step), not an error.
@@ -370,7 +373,7 @@ describe("agent compaction — runAgent seam (#3759)", () => {
   it("pins the system prompt + most-recent N steps and drops older steps verbatim", async () => {
     enableCompaction();
 
-    const result = await runAgent({ messages: userMessages("Analyze companies") });
+    const result = await runAgent({ tools: nonDashboardRegistry, messages: userMessages("Analyze companies") });
     await result.steps;
 
     // The final turn-loop model call is the text step. By then the loop has 4
@@ -393,7 +396,7 @@ describe("agent compaction — runAgent seam (#3759)", () => {
   it("rolls the summary forward incrementally rather than re-reading the whole older slice each step", async () => {
     enableCompaction();
 
-    const result = await runAgent({ messages: userMessages("Analyze companies") });
+    const result = await runAgent({ tools: nonDashboardRegistry, messages: userMessages("Analyze companies") });
     await result.steps;
 
     // The threshold trips on multiple steps, so the summarizer runs more than
@@ -408,7 +411,7 @@ describe("agent compaction — runAgent seam (#3759)", () => {
 
   it("flag off (default) → no compaction regardless of context size", async () => {
     // Default off: do not set ATLAS_COMPACTION_ENABLED.
-    const result = await runAgent({ messages: userMessages("Analyze companies") });
+    const result = await runAgent({ tools: nonDashboardRegistry, messages: userMessages("Analyze companies") });
     const steps = await result.steps;
 
     expect(steps.length).toBe(5); // identical loop behaviour
@@ -477,7 +480,7 @@ describe("agent compaction — per-model context window at the runAgent seam (#3
 
     // Small window — trips the threshold, summarizer runs.
     mockModel = buildModel("gpt-4o");
-    const small = await runAgent({ messages: userMessages(BIG_QUESTION) });
+    const small = await runAgent({ tools: nonDashboardRegistry, messages: userMessages(BIG_QUESTION) });
     await small.steps;
     const smallSummarizerCalls = summarizerCalls;
 
@@ -491,7 +494,7 @@ describe("agent compaction — per-model context window at the runAgent seam (#3
 
     // Large window — same fraction + same context, but 60k threshold not crossed.
     mockModel = buildModel("claude-opus-4-8");
-    const large = await runAgent({ messages: userMessages(BIG_QUESTION) });
+    const large = await runAgent({ tools: nonDashboardRegistry, messages: userMessages(BIG_QUESTION) });
     await large.steps;
     const largeSummarizerCalls = summarizerCalls;
 
@@ -506,7 +509,7 @@ describe("agent compaction — per-model context window at the runAgent seam (#3
 
     // Unknown model id ⇒ catalog miss ⇒ safe 200k default (same as claude here).
     mockModel = buildModel("some-bespoke-local-model");
-    const result = await runAgent({ messages: userMessages(BIG_QUESTION) });
+    const result = await runAgent({ tools: nonDashboardRegistry, messages: userMessages(BIG_QUESTION) });
     const steps = await result.steps;
 
     // Turn completed (did not error) on the default window; 0.3×200k = 60k not
@@ -522,7 +525,7 @@ describe("agent compaction — per-model context window at the runAgent seam (#3
     _resetSettingsCache();
 
     mockModel = buildModel("claude-opus-4-8");
-    const result = await runAgent({ messages: userMessages("Analyze companies") });
+    const result = await runAgent({ tools: nonDashboardRegistry, messages: userMessages("Analyze companies") });
     await result.steps;
 
     // With the catalog's 200k window, 0.3 would NOT trip on a tiny context; the
@@ -561,7 +564,7 @@ describe("agent compaction — per-model context window at the runAgent seam (#3
       enablePerModelCompaction();
       // Gateway-shaped id, so the air-gap gate lets the lookup through.
       mockModel = buildModel("anthropic/claude-opus-4.8");
-      const result = await runAgent({ messages: userMessages(BIG_QUESTION) });
+      const result = await runAgent({ tools: nonDashboardRegistry, messages: userMessages(BIG_QUESTION) });
       const steps = await result.steps;
 
       expect(steps.length).toBe(5);
@@ -625,7 +628,7 @@ describe("agent compaction — cheaper summary model (#3761)", () => {
     _resetSettingsCache();
     summaryMockModel = buildSummaryModel("summary-model-id");
 
-    const result = await runAgent({ messages: userMessages("Analyze companies") });
+    const result = await runAgent({ tools: nonDashboardRegistry, messages: userMessages("Analyze companies") });
     await result.steps;
 
     // The summarization call resolved to the SEPARATE summary model…
@@ -641,7 +644,7 @@ describe("agent compaction — cheaper summary model (#3761)", () => {
   it("summarizes on the turn model when the knob is unset (Compaction 1 default)", async () => {
     enable();
     // No ATLAS_COMPACTION_SUMMARY_MODEL set.
-    const result = await runAgent({ messages: userMessages("Analyze companies") });
+    const result = await runAgent({ tools: nonDashboardRegistry, messages: userMessages("Analyze companies") });
     await result.steps;
 
     // The turn model did the summarizing; the separate model was never invoked.
@@ -657,7 +660,7 @@ describe("agent compaction — cheaper summary model (#3761)", () => {
     // Even with a separate mock available, an equal id must not resolve it.
     summaryMockModel = buildSummaryModel("should-not-be-used");
 
-    const result = await runAgent({ messages: userMessages("Analyze companies") });
+    const result = await runAgent({ tools: nonDashboardRegistry, messages: userMessages("Analyze companies") });
     await result.steps;
 
     expect(summarizerCalls).toBeGreaterThanOrEqual(1);
@@ -680,6 +683,7 @@ describe("agent compaction — cheaper summary model (#3761)", () => {
     summaryMockModel = buildSummaryModel("summary-model-id");
 
     const result = await runAgent({
+      tools: nonDashboardRegistry,
       messages: userMessages(`Analyze companies. ${"x".repeat(200_000)}`),
     });
     await result.steps;
@@ -697,7 +701,7 @@ describe("agent compaction — cheaper summary model (#3761)", () => {
     summaryModelResolutionThrows = true;
     summaryMockModel = buildSummaryModel("never-built");
 
-    const result = await runAgent({ messages: userMessages("Analyze companies") });
+    const result = await runAgent({ tools: nonDashboardRegistry, messages: userMessages("Analyze companies") });
     const steps = await result.steps;
 
     // The turn completed normally (4 SQL steps + 1 text step), not an error.
@@ -765,7 +769,7 @@ describe("agent compaction — client stream marker (#3761)", () => {
     } as unknown as Parameters<typeof setStreamWriter>[1];
     await withRequestContext({ requestId: REQ_ID }, async () => {
       setStreamWriter(REQ_ID, fakeWriter);
-      const result = await runAgent({ messages: userMessages(content) });
+      const result = await runAgent({ tools: nonDashboardRegistry, messages: userMessages(content) });
       await result.steps;
     });
     return parts;
@@ -823,7 +827,7 @@ describe("agent compaction — client stream marker (#3761)", () => {
 
     const steps = await withRequestContext({ requestId: REQ_ID }, async () => {
       setStreamWriter(REQ_ID, throwingWriter);
-      const result = await runAgent({ messages: userMessages("Analyze companies") });
+      const result = await runAgent({ tools: nonDashboardRegistry, messages: userMessages("Analyze companies") });
       return result.steps;
     });
 

--- a/packages/api/src/lib/__tests__/agent-compaction-resume.test.ts
+++ b/packages/api/src/lib/__tests__/agent-compaction-resume.test.ts
@@ -202,8 +202,8 @@ void mock.module("@atlas/api/lib/db/internal", () => ({
 // ---------------------------------------------------------------------------
 
 const { runAgent } = await import("@atlas/api/lib/agent");
-// #4943 — runAgent's `tools` is required; nonDashboardRegistry is the restricted
-// surface these turns already resolved to when they omitted it.
+// #4943 — runAgent's `tools` is now required; this is its own fail-closed
+// default, so these turns are unchanged. See agent.ts's `@param tools`.
 const { nonDashboardRegistry } = await import("@atlas/api/lib/tools/registry");
 const { invalidateExploreBackend } = await import("@atlas/api/lib/tools/explore");
 const { COMPACTION_SUMMARY_PREFIX, COMPACTION_STREAM_PART_TYPE } = await import(

--- a/packages/api/src/lib/__tests__/agent-compaction-resume.test.ts
+++ b/packages/api/src/lib/__tests__/agent-compaction-resume.test.ts
@@ -202,6 +202,9 @@ void mock.module("@atlas/api/lib/db/internal", () => ({
 // ---------------------------------------------------------------------------
 
 const { runAgent } = await import("@atlas/api/lib/agent");
+// #4943 — runAgent's `tools` is required; nonDashboardRegistry is the restricted
+// surface these turns already resolved to when they omitted it.
+const { nonDashboardRegistry } = await import("@atlas/api/lib/tools/registry");
 const { invalidateExploreBackend } = await import("@atlas/api/lib/tools/explore");
 const { COMPACTION_SUMMARY_PREFIX, COMPACTION_STREAM_PART_TYPE } = await import(
   "@atlas/api/lib/agent-compaction"
@@ -425,6 +428,7 @@ describe("agent compaction — compact-on-resume seam (#3762)", () => {
     const transcript = rehydratedTranscript(6);
 
     const result = await runAgent({
+      tools: nonDashboardRegistry,
       messages: userMessages("Analyze companies"),
       conversationId: "conv-resume-1",
       resume: { runId: RESUMED_RUN_ID, transcript, priorStepIndex: 6 },
@@ -459,6 +463,7 @@ describe("agent compaction — compact-on-resume seam (#3762)", () => {
     const transcript = rehydratedTranscript(6);
 
     const result = await runAgent({
+      tools: nonDashboardRegistry,
       messages: userMessages("Analyze companies"),
       conversationId: "conv-resume-roll",
       resume: { runId: RESUMED_RUN_ID, transcript, priorStepIndex: 6 },
@@ -491,6 +496,7 @@ describe("agent compaction — compact-on-resume seam (#3762)", () => {
     const transcript = rehydratedTranscript(6);
 
     const result = await runAgent({
+      tools: nonDashboardRegistry,
       messages: userMessages("Analyze companies"),
       conversationId: "conv-resume-failsoft",
       resume: { runId: RESUMED_RUN_ID, transcript, priorStepIndex: 6 },
@@ -516,6 +522,7 @@ describe("agent compaction — compact-on-resume seam (#3762)", () => {
     const transcript = rehydratedTranscript(6);
 
     const result = await runAgent({
+      tools: nonDashboardRegistry,
       messages: userMessages("Analyze companies"),
       conversationId: "conv-resume-2",
       resume: { runId: RESUMED_RUN_ID, transcript, priorStepIndex: 6 },
@@ -552,6 +559,7 @@ describe("agent compaction — compact-on-resume seam (#3762)", () => {
     const transcript = rehydratedTranscript(3);
 
     const result = await runAgent({
+      tools: nonDashboardRegistry,
       messages: userMessages("Analyze companies"),
       conversationId: "conv-resume-3",
       resume: { runId: RESUMED_RUN_ID, transcript, priorStepIndex: 3 },
@@ -576,6 +584,7 @@ describe("agent compaction — compact-on-resume seam (#3762)", () => {
     const transcript = rehydratedTranscript(6);
 
     const result = await runAgent({
+      tools: nonDashboardRegistry,
       messages: userMessages("Analyze companies"),
       conversationId: "conv-resume-4",
       resume: { runId: RESUMED_RUN_ID, transcript, priorStepIndex: 6 },
@@ -605,6 +614,7 @@ describe("agent compaction — compact-on-resume seam (#3762)", () => {
     const transcript = rehydratedTranscript(6);
 
     const result = await runAgent({
+      tools: nonDashboardRegistry,
       messages: userMessages("Analyze companies"),
       conversationId: "conv-resume-5",
       resume: { runId: RESUMED_RUN_ID, transcript, priorStepIndex: 6 },
@@ -630,6 +640,7 @@ describe("agent compaction — compact-on-resume seam (#3762)", () => {
     const transcript = rehydratedTranscript(6);
 
     const result = await runAgent({
+      tools: nonDashboardRegistry,
       messages: userMessages("Analyze companies"),
       conversationId: "conv-resume-nodb-enabled",
       resume: { runId: RESUMED_RUN_ID, transcript, priorStepIndex: 6 },
@@ -652,6 +663,7 @@ describe("agent compaction — compact-on-resume seam (#3762)", () => {
     const transcript = rehydratedTranscript(6);
 
     const result = await runAgent({
+      tools: nonDashboardRegistry,
       messages: userMessages("Analyze companies"),
       conversationId: "conv-resume-6",
       resume: { runId: RESUMED_RUN_ID, transcript, priorStepIndex: 6 },
@@ -683,6 +695,7 @@ describe("agent compaction — compact-on-resume seam (#3762)", () => {
       await withRequestContext({ requestId: REQ_ID }, async () => {
         setStreamWriter(REQ_ID, fakeWriter);
         const result = await runAgent({
+          tools: nonDashboardRegistry,
           messages: userMessages("Analyze companies"),
           conversationId: "conv-resume-7",
           resume: { runId: RESUMED_RUN_ID, transcript, priorStepIndex: 6 },

--- a/packages/api/src/lib/__tests__/agent-context-warnings.test.ts
+++ b/packages/api/src/lib/__tests__/agent-context-warnings.test.ts
@@ -162,8 +162,8 @@ void mock.module("@atlas/api/lib/cache/index", () => ({
 }));
 
 const { runAgent } = await import("@atlas/api/lib/agent");
-// #4943 — runAgent's `tools` is required; nonDashboardRegistry is the restricted
-// surface these turns already resolved to when they omitted it.
+// #4943 — runAgent's `tools` is now required; this is its own fail-closed
+// default, so these turns are unchanged. See agent.ts's `@param tools`.
 const { nonDashboardRegistry } = await import("@atlas/api/lib/tools/registry");
 
 const MOCK_USAGE = {

--- a/packages/api/src/lib/__tests__/agent-context-warnings.test.ts
+++ b/packages/api/src/lib/__tests__/agent-context-warnings.test.ts
@@ -162,6 +162,9 @@ void mock.module("@atlas/api/lib/cache/index", () => ({
 }));
 
 const { runAgent } = await import("@atlas/api/lib/agent");
+// #4943 — runAgent's `tools` is required; nonDashboardRegistry is the restricted
+// surface these turns already resolved to when they omitted it.
+const { nonDashboardRegistry } = await import("@atlas/api/lib/tools/registry");
 
 const MOCK_USAGE = {
   inputTokens: { total: 5, noCache: 5, cacheRead: undefined, cacheWrite: undefined },
@@ -199,6 +202,7 @@ describe("runAgent contextWarnings out-array (#1988 B5)", () => {
   it("populates structured warnings when both preflight loaders fail", async () => {
     const contextWarnings: ChatContextWarning[] = [];
     const result = await runAgent({
+      tools: nonDashboardRegistry,
       messages: userMessages("how many companies?"),
       contextWarnings,
     });
@@ -226,6 +230,7 @@ describe("runAgent contextWarnings out-array (#1988 B5)", () => {
     semanticState.patternsThrows = false;
     const contextWarnings: ChatContextWarning[] = [];
     const result = await runAgent({
+      tools: nonDashboardRegistry,
       messages: userMessages("how many companies?"),
       contextWarnings,
     });
@@ -240,6 +245,7 @@ describe("runAgent contextWarnings out-array (#1988 B5)", () => {
     semanticState.patternsThrows = true;
     const contextWarnings: ChatContextWarning[] = [];
     const result = await runAgent({
+      tools: nonDashboardRegistry,
       messages: userMessages("how many companies?"),
       contextWarnings,
     });
@@ -254,6 +260,7 @@ describe("runAgent contextWarnings out-array (#1988 B5)", () => {
     semanticState.patternsThrows = false;
     const contextWarnings: ChatContextWarning[] = [];
     const result = await runAgent({
+      tools: nonDashboardRegistry,
       messages: userMessages("how many companies?"),
       contextWarnings,
     });
@@ -266,6 +273,7 @@ describe("runAgent contextWarnings out-array (#1988 B5)", () => {
     // Legacy callers (or tests pre-#1988) that don't pass `contextWarnings`
     // get the existing system-prompt-string behavior with no extra cost.
     const result = await runAgent({
+      tools: nonDashboardRegistry,
       messages: userMessages("how many companies?"),
     });
     await result.steps;
@@ -310,6 +318,7 @@ describe("#4941 — runAgent renders caller `warnings` into the model's system p
 
   it("a caller warning reaches the model under a `## Warnings` heading", async () => {
     const result = await runAgent({
+      tools: nonDashboardRegistry,
       messages: userMessages("email me the Q3 numbers"),
       warnings: ["SENTINEL-4941: the operator action tools did not load."],
     });
@@ -321,7 +330,7 @@ describe("#4941 — runAgent renders caller `warnings` into the model's system p
   });
 
   it("no `## Warnings` section at all when the caller passes none", async () => {
-    const result = await runAgent({ messages: userMessages("how many companies?") });
+    const result = await runAgent({ tools: nonDashboardRegistry, messages: userMessages("how many companies?") });
     await result.steps;
 
     const prompt = JSON.stringify(capturedPrompt);

--- a/packages/api/src/lib/__tests__/agent-cross-env-routing.test.ts
+++ b/packages/api/src/lib/__tests__/agent-cross-env-routing.test.ts
@@ -148,6 +148,9 @@ void mock.module("@atlas/api/lib/cache/index", () => ({
 // ---------------------------------------------------------------------------
 
 const { runAgent } = await import("@atlas/api/lib/agent");
+// #4943 — runAgent's `tools` is required; nonDashboardRegistry is the restricted
+// surface these turns already resolved to when they omitted it.
+const { nonDashboardRegistry } = await import("@atlas/api/lib/tools/registry");
 const { withRequestContext } = await import("@atlas/api/lib/logger");
 
 // ---------------------------------------------------------------------------
@@ -270,7 +273,7 @@ describe("agent cross-env routing — executeSQL `scope`", () => {
       },
     });
 
-    const result = await runAgent({ messages: userMessages("Compare revenue across regions") });
+    const result = await runAgent({ tools: nonDashboardRegistry, messages: userMessages("Compare revenue across regions") });
     const steps = await result.steps;
     const sqlResults = findToolResults(steps, "executeSQL") as SQLOutput[];
 
@@ -335,7 +338,7 @@ describe("agent cross-env routing — executeSQL `scope`", () => {
       },
     });
 
-    const result = await runAgent({ messages: userMessages("EU sales last week") });
+    const result = await runAgent({ tools: nonDashboardRegistry, messages: userMessages("EU sales last week") });
     const steps = await result.steps;
     const sqlResults = findToolResults(steps, "executeSQL") as SQLOutput[];
 
@@ -390,7 +393,7 @@ describe("agent cross-env routing — executeSQL `scope`", () => {
       },
     });
 
-    const result = await runAgent({ messages: userMessages("Compare across regions") });
+    const result = await runAgent({ tools: nonDashboardRegistry, messages: userMessages("Compare across regions") });
     const steps = await result.steps;
     const sqlResults = findToolResults(steps, "executeSQL") as SQLOutput[];
 
@@ -443,7 +446,7 @@ describe("agent cross-env routing — executeSQL `scope`", () => {
       },
     });
 
-    const result = await runAgent({ messages: userMessages("List ids") });
+    const result = await runAgent({ tools: nonDashboardRegistry, messages: userMessages("List ids") });
     const steps = await result.steps;
     const sqlResults = findToolResults(steps, "executeSQL") as SQLOutput[];
 
@@ -502,7 +505,7 @@ describe("agent cross-env routing — executeSQL `scope`", () => {
 
     const result = await withRequestContext(
       { requestId: "test-all-fail", connectionId: "us-int", connectionGroupId: "prod" },
-      () => runAgent({ messages: userMessages("Compare across regions") }),
+      () => runAgent({ tools: nonDashboardRegistry, messages: userMessages("Compare across regions") }),
     );
     const steps = await result.steps;
     const sqlResults = findToolResults(steps, "executeSQL") as SQLOutput[];

--- a/packages/api/src/lib/__tests__/agent-cross-env-routing.test.ts
+++ b/packages/api/src/lib/__tests__/agent-cross-env-routing.test.ts
@@ -148,8 +148,8 @@ void mock.module("@atlas/api/lib/cache/index", () => ({
 // ---------------------------------------------------------------------------
 
 const { runAgent } = await import("@atlas/api/lib/agent");
-// #4943 — runAgent's `tools` is required; nonDashboardRegistry is the restricted
-// surface these turns already resolved to when they omitted it.
+// #4943 — runAgent's `tools` is now required; this is its own fail-closed
+// default, so these turns are unchanged. See agent.ts's `@param tools`.
 const { nonDashboardRegistry } = await import("@atlas/api/lib/tools/registry");
 const { withRequestContext } = await import("@atlas/api/lib/logger");
 

--- a/packages/api/src/lib/__tests__/agent-dialect-specialist-seam.test.ts
+++ b/packages/api/src/lib/__tests__/agent-dialect-specialist-seam.test.ts
@@ -112,6 +112,9 @@ function makeSpyingModel(): InstanceType<typeof MockLanguageModelV3> {
 }
 
 const { runAgent } = await import("@atlas/api/lib/agent");
+// #4943 — runAgent's `tools` is required; nonDashboardRegistry is the restricted
+// surface these turns already resolved to when they omitted it.
+const { nonDashboardRegistry } = await import("@atlas/api/lib/tools/registry");
 
 function userMessages(text: string): UIMessage[] {
   return [{ id: "msg-1", role: "user" as const, parts: [{ type: "text" as const, text }] }];
@@ -120,6 +123,7 @@ function userMessages(text: string): UIMessage[] {
 async function runTurn(): Promise<string> {
   lastSystemPrompt = undefined;
   const result = await runAgent({
+    tools: nonDashboardRegistry,
     messages: userMessages("How many orders last month?"),
     aiModel: {
       model: makeSpyingModel(),

--- a/packages/api/src/lib/__tests__/agent-dialect-specialist-seam.test.ts
+++ b/packages/api/src/lib/__tests__/agent-dialect-specialist-seam.test.ts
@@ -112,8 +112,8 @@ function makeSpyingModel(): InstanceType<typeof MockLanguageModelV3> {
 }
 
 const { runAgent } = await import("@atlas/api/lib/agent");
-// #4943 — runAgent's `tools` is required; nonDashboardRegistry is the restricted
-// surface these turns already resolved to when they omitted it.
+// #4943 — runAgent's `tools` is now required; this is its own fail-closed
+// default, so these turns are unchanged. See agent.ts's `@param tools`.
 const { nonDashboardRegistry } = await import("@atlas/api/lib/tools/registry");
 
 function userMessages(text: string): UIMessage[] {

--- a/packages/api/src/lib/__tests__/agent-durable-session.test.ts
+++ b/packages/api/src/lib/__tests__/agent-durable-session.test.ts
@@ -80,8 +80,8 @@ void mock.module("@atlas/api/lib/db/internal", () => ({
 }));
 
 const { runAgent } = await import("@atlas/api/lib/agent");
-// #4943 — runAgent's `tools` is required; nonDashboardRegistry is the restricted
-// surface these turns already resolved to when they omitted it.
+// #4943 — runAgent's `tools` is now required; this is its own fail-closed
+// default, so these turns are unchanged. See agent.ts's `@param tools`.
 const { nonDashboardRegistry } = await import("@atlas/api/lib/tools/registry");
 
 const STOP_USAGE: LanguageModelV3Usage = {

--- a/packages/api/src/lib/__tests__/agent-durable-session.test.ts
+++ b/packages/api/src/lib/__tests__/agent-durable-session.test.ts
@@ -80,6 +80,9 @@ void mock.module("@atlas/api/lib/db/internal", () => ({
 }));
 
 const { runAgent } = await import("@atlas/api/lib/agent");
+// #4943 — runAgent's `tools` is required; nonDashboardRegistry is the restricted
+// surface these turns already resolved to when they omitted it.
+const { nonDashboardRegistry } = await import("@atlas/api/lib/tools/registry");
 
 const STOP_USAGE: LanguageModelV3Usage = {
   inputTokens: { total: 10, noCache: 10, cacheRead: undefined, cacheWrite: undefined },
@@ -216,7 +219,7 @@ function interruptAfterFirstStepModel(
 /** Drain the data stream so the streamText onFinish/onError callback runs. */
 async function drive(model: InstanceType<typeof MockLanguageModelV3>): Promise<void> {
   mockModel = model;
-  const result = await runAgent({ messages: userMessages("hi"), conversationId: "conv-1" });
+  const result = await runAgent({ tools: nonDashboardRegistry, messages: userMessages("hi"), conversationId: "conv-1" });
   try {
     await result.steps;
     await result.consumeStream?.();
@@ -338,7 +341,7 @@ describe("agent_runs checkpoint write path (#3745 terminal, #3746 per-step)", ()
       release = () => r();
     });
     mockModel = interruptAfterFirstStepModel(gate);
-    const result = await runAgent({ messages: userMessages("hi"), conversationId: "conv-1" });
+    const result = await runAgent({ tools: nonDashboardRegistry, messages: userMessages("hi"), conversationId: "conv-1" });
     // Consume in the background; the model blocks on the second step.
     const consumed = Promise.resolve(result.consumeStream?.()).catch(() => {});
 
@@ -365,6 +368,7 @@ describe("agent_runs checkpoint write path (#3745 terminal, #3746 per-step)", ()
     mockModel = interruptAfterFirstStepModel(gate);
     const ac = new AbortController();
     const result = await runAgent({
+      tools: nonDashboardRegistry,
       messages: userMessages("hi"),
       conversationId: "conv-1",
       runId: "run-4294",

--- a/packages/api/src/lib/__tests__/agent-expert-persona-prompt.test.ts
+++ b/packages/api/src/lib/__tests__/agent-expert-persona-prompt.test.ts
@@ -113,8 +113,8 @@ function makeSpyingModel(): InstanceType<typeof MockLanguageModelV3> {
 }
 
 const { runAgent } = await import("@atlas/api/lib/agent");
-// #4943 — runAgent's `tools` is required; nonDashboardRegistry is the restricted
-// surface these turns already resolved to when they omitted it.
+// #4943 — runAgent's `tools` is now required; this is its own fail-closed
+// default, so these turns are unchanged. See agent.ts's `@param tools`.
 const { nonDashboardRegistry } = await import("@atlas/api/lib/tools/registry");
 
 function userMessages(text: string): UIMessage[] {

--- a/packages/api/src/lib/__tests__/agent-expert-persona-prompt.test.ts
+++ b/packages/api/src/lib/__tests__/agent-expert-persona-prompt.test.ts
@@ -113,6 +113,9 @@ function makeSpyingModel(): InstanceType<typeof MockLanguageModelV3> {
 }
 
 const { runAgent } = await import("@atlas/api/lib/agent");
+// #4943 — runAgent's `tools` is required; nonDashboardRegistry is the restricted
+// surface these turns already resolved to when they omitted it.
+const { nonDashboardRegistry } = await import("@atlas/api/lib/tools/registry");
 
 function userMessages(text: string): UIMessage[] {
   return [
@@ -127,6 +130,7 @@ function userMessages(text: string): UIMessage[] {
 async function runTurn(persona?: string, briefing?: string): Promise<string> {
   lastSystemPrompt = undefined;
   const result = await runAgent({
+    tools: nonDashboardRegistry,
     messages: userMessages("Improve the orders entity."),
     aiModel: {
       model: makeSpyingModel(),

--- a/packages/api/src/lib/__tests__/agent-integration.test.ts
+++ b/packages/api/src/lib/__tests__/agent-integration.test.ts
@@ -133,6 +133,9 @@ void mock.module("@atlas/api/lib/cache/index", () => ({
 // ---------------------------------------------------------------------------
 
 const { runAgent } = await import("@atlas/api/lib/agent");
+// #4943 — runAgent's `tools` is required; nonDashboardRegistry is the restricted
+// surface these turns already resolved to when they omitted it.
+const { nonDashboardRegistry } = await import("@atlas/api/lib/tools/registry");
 const { invalidateExploreBackend } = await import("@atlas/api/lib/tools/explore");
 
 // ---------------------------------------------------------------------------
@@ -251,7 +254,7 @@ describe("agent integration", () => {
       },
     });
 
-    const result = await runAgent({ messages: userMessages("Show me all companies") });
+    const result = await runAgent({ tools: nonDashboardRegistry, messages: userMessages("Show me all companies") });
     const steps = await result.steps;
 
     // Loop terminated naturally after 3 steps (explore + executeSQL + text-only)
@@ -294,7 +297,7 @@ describe("agent integration", () => {
       },
     });
 
-    const result = await runAgent({ messages: userMessages("List companies") });
+    const result = await runAgent({ tools: nonDashboardRegistry, messages: userMessages("List companies") });
     const steps = await result.steps;
 
     const sqlResults = findToolResults(steps, "executeSQL") as SQLOutput[];
@@ -324,6 +327,7 @@ describe("agent integration", () => {
     });
 
     const result = await runAgent({
+      tools: nonDashboardRegistry,
       messages: userMessages("What data do you have?"),
     });
     const steps = await result.steps;
@@ -354,7 +358,7 @@ describe("agent integration", () => {
       },
     });
 
-    const result = await runAgent({ messages: userMessages("Read .env") });
+    const result = await runAgent({ tools: nonDashboardRegistry, messages: userMessages("Read .env") });
     const steps = await result.steps;
 
     // The real boundary is sandbox isolation (writes never touch host files),
@@ -395,7 +399,7 @@ describe("agent integration", () => {
       },
     });
 
-    const result = await runAgent({ messages: userMessages("Show secret data") });
+    const result = await runAgent({ tools: nonDashboardRegistry, messages: userMessages("Show secret data") });
     const steps = await result.steps;
 
     const sqlResults = findToolResults(steps, "executeSQL") as SQLOutput[];
@@ -428,6 +432,7 @@ describe("agent integration", () => {
     });
 
     const result = await runAgent({
+      tools: nonDashboardRegistry,
       messages: userMessages("Do something bad"),
     });
     const steps = await result.steps;
@@ -473,7 +478,7 @@ describe("agent integration", () => {
       },
     });
 
-    const result = await runAgent({ messages: userMessages("Test") });
+    const result = await runAgent({ tools: nonDashboardRegistry, messages: userMessages("Test") });
     const steps = await result.steps;
     const sqlResults = findToolResults(steps, "executeSQL") as SQLOutput[];
     expect(sqlResults.length).toBe(1);
@@ -512,7 +517,7 @@ describe("agent integration", () => {
       },
     });
 
-    const result = await runAgent({ messages: userMessages("Test") });
+    const result = await runAgent({ tools: nonDashboardRegistry, messages: userMessages("Test") });
     const steps = await result.steps;
     const sqlResults = findToolResults(steps, "executeSQL") as SQLOutput[];
     expect(sqlResults.length).toBe(1);
@@ -550,7 +555,7 @@ describe("agent integration", () => {
       },
     });
 
-    const result = await runAgent({ messages: userMessages("Test") });
+    const result = await runAgent({ tools: nonDashboardRegistry, messages: userMessages("Test") });
     await result.steps;
     expect(capturedSQL).toContain("LIMIT 1000");
   });

--- a/packages/api/src/lib/__tests__/agent-integration.test.ts
+++ b/packages/api/src/lib/__tests__/agent-integration.test.ts
@@ -133,8 +133,8 @@ void mock.module("@atlas/api/lib/cache/index", () => ({
 // ---------------------------------------------------------------------------
 
 const { runAgent } = await import("@atlas/api/lib/agent");
-// #4943 — runAgent's `tools` is required; nonDashboardRegistry is the restricted
-// surface these turns already resolved to when they omitted it.
+// #4943 — runAgent's `tools` is now required; this is its own fail-closed
+// default, so these turns are unchanged. See agent.ts's `@param tools`.
 const { nonDashboardRegistry } = await import("@atlas/api/lib/tools/registry");
 const { invalidateExploreBackend } = await import("@atlas/api/lib/tools/explore");
 

--- a/packages/api/src/lib/__tests__/agent-resume.test.ts
+++ b/packages/api/src/lib/__tests__/agent-resume.test.ts
@@ -87,11 +87,14 @@ void mock.module("@atlas/api/lib/db/internal", () => ({
 }));
 
 const { runAgent } = await import("@atlas/api/lib/agent");
-// #4943 — runAgent's `tools` is required; nonDashboardRegistry is the restricted
-// surface these turns already resolved to when they omitted it. Named at each
-// `drive(...)` call rather than defaulted inside the helper: a helper that filled
-// it in would be exactly the pre-built-bag shape that launders the posture out of
-// sight, which is the one escape the compiler cannot see.
+// #4943 — runAgent's `tools` is now required; this is its own fail-closed
+// default, so these turns are unchanged. See agent.ts's `@param tools`.
+//
+// Named at each `drive(...)` call rather than defaulted inside the helper:
+// `drive` forwards a pre-built bag to `runAgent(opts)`, a shape neither guard
+// can read (the scanner treats it as `absent`, and it skips `__tests__` anyway),
+// so keeping the registry in each test body is the only thing that makes the
+// posture visible here.
 const { nonDashboardRegistry } = await import("@atlas/api/lib/tools/registry");
 
 const STOP_USAGE: LanguageModelV3Usage = {

--- a/packages/api/src/lib/__tests__/agent-resume.test.ts
+++ b/packages/api/src/lib/__tests__/agent-resume.test.ts
@@ -87,6 +87,12 @@ void mock.module("@atlas/api/lib/db/internal", () => ({
 }));
 
 const { runAgent } = await import("@atlas/api/lib/agent");
+// #4943 — runAgent's `tools` is required; nonDashboardRegistry is the restricted
+// surface these turns already resolved to when they omitted it. Named at each
+// `drive(...)` call rather than defaulted inside the helper: a helper that filled
+// it in would be exactly the pre-built-bag shape that launders the posture out of
+// sight, which is the one escape the compiler cannot see.
+const { nonDashboardRegistry } = await import("@atlas/api/lib/tools/registry");
 
 const STOP_USAGE: LanguageModelV3Usage = {
   inputTokens: { total: 10, noCache: 10, cacheRead: undefined, cacheWrite: undefined },
@@ -210,6 +216,7 @@ describe("agent crash-resume seam (#3747)", () => {
     ];
 
     await drive(finalTextOnlyModel(), {
+      tools: nonDashboardRegistry,
       messages: userMessages("hi"),
       conversationId: "conv-1",
       resume: { runId: RESUMED_RUN_ID, transcript: storedTranscript, priorStepIndex: 2 },
@@ -235,7 +242,7 @@ describe("agent crash-resume seam (#3747)", () => {
   it("resumed step accounting equals the uninterrupted run (same final index + transcript, one token row)", async () => {
     // Baseline: an uninterrupted 3-step turn. Capture its final step index AND
     // its terminal transcript — the resume must converge on both.
-    await drive(multiStepModel(), { messages: userMessages("hi"), conversationId: "conv-1" });
+    await drive(multiStepModel(), { tools: nonDashboardRegistry, messages: userMessages("hi"), conversationId: "conv-1" });
     const baselineTerminal = terminalWrites();
     expect(baselineTerminal).toHaveLength(1);
     const baselineFinalIndex = stepIndexOf(baselineTerminal[0]!);
@@ -257,6 +264,7 @@ describe("agent crash-resume seam (#3747)", () => {
       { role: "tool", content: [{ type: "tool-result", toolCallId: "c1", toolName: "executeSQL", output: { type: "json", value: { rows: [] } } }] },
     ];
     await drive(finalTextOnlyModel(), {
+      tools: nonDashboardRegistry,
       messages: userMessages("hi"),
       conversationId: "conv-1",
       resume: { runId: RESUMED_RUN_ID, transcript: storedTranscript, priorStepIndex: 2 },
@@ -277,7 +285,7 @@ describe("agent crash-resume seam (#3747)", () => {
   });
 
   it("a fresh turn (no resume) is unchanged — new (minted) run id, lands at the full step count", async () => {
-    await drive(multiStepModel(), { messages: userMessages("hi"), conversationId: "conv-fresh" });
+    await drive(multiStepModel(), { tools: nonDashboardRegistry, messages: userMessages("hi"), conversationId: "conv-fresh" });
     const terminals = terminalWrites();
     expect(terminals).toHaveLength(1);
     // A fresh turn mints a UUID run id (not one we supplied via `resume`).

--- a/packages/api/src/lib/__tests__/agent-routing-mode.test.ts
+++ b/packages/api/src/lib/__tests__/agent-routing-mode.test.ts
@@ -150,6 +150,9 @@ void mock.module("@atlas/api/lib/cache/index", () => ({
 // ---------------------------------------------------------------------------
 
 const { runAgent } = await import("@atlas/api/lib/agent");
+// #4943 — runAgent's `tools` is required; nonDashboardRegistry is the restricted
+// surface these turns already resolved to when they omitted it.
+const { nonDashboardRegistry } = await import("@atlas/api/lib/tools/registry");
 const { withRequestContext } = await import("@atlas/api/lib/logger");
 
 // ---------------------------------------------------------------------------
@@ -290,7 +293,7 @@ describe("agent routing-mode picker — executeSQL `routingMode`", () => {
         connectionId: "eu",
         routingMode: "pin",
       },
-      () => runAgent({ messages: userMessages("EU revenue this month") }),
+      () => runAgent({ tools: nonDashboardRegistry, messages: userMessages("EU revenue this month") }),
     );
     const steps = await result.steps;
     const sqlResults = findToolResults(steps, "executeSQL") as SQLOutput[];
@@ -325,7 +328,7 @@ describe("agent routing-mode picker — executeSQL `routingMode`", () => {
         connectionId: "us-int",
         routingMode: "all",
       },
-      () => runAgent({ messages: userMessages("Compare across regions") }),
+      () => runAgent({ tools: nonDashboardRegistry, messages: userMessages("Compare across regions") }),
     );
     const steps = await result.steps;
     const sqlResults = findToolResults(steps, "executeSQL") as SQLOutput[];
@@ -357,7 +360,7 @@ describe("agent routing-mode picker — executeSQL `routingMode`", () => {
         connectionId: "us-int",
         routingMode: "all",
       },
-      () => runAgent({ messages: userMessages("Compare across regions") }),
+      () => runAgent({ tools: nonDashboardRegistry, messages: userMessages("Compare across regions") }),
     );
     const steps = await result.steps;
     const sqlResults = findToolResults(steps, "executeSQL") as SQLOutput[];
@@ -383,7 +386,7 @@ describe("agent routing-mode picker — executeSQL `routingMode`", () => {
         connectionId: "us-int",
         routingMode: "auto",
       },
-      () => runAgent({ messages: userMessages("Compare across regions") }),
+      () => runAgent({ tools: nonDashboardRegistry, messages: userMessages("Compare across regions") }),
     );
     const steps = await result.steps;
     const sqlResults = findToolResults(steps, "executeSQL") as SQLOutput[];
@@ -405,7 +408,7 @@ describe("agent routing-mode picker — executeSQL `routingMode`", () => {
         connectionId: "eu",
         routingMode: "auto",
       },
-      () => runAgent({ messages: userMessages("EU revenue") }),
+      () => runAgent({ tools: nonDashboardRegistry, messages: userMessages("EU revenue") }),
     );
     const steps = await result.steps;
     const sqlResults = findToolResults(steps, "executeSQL") as SQLOutput[];
@@ -438,7 +441,7 @@ describe("agent routing-mode picker — executeSQL `routingMode`", () => {
         // conversation NULL→'pin' default. Tools / MCP / scheduler /
         // direct unit tests fall through to the agent-decides default.
       },
-      () => runAgent({ messages: userMessages("Compare across regions") }),
+      () => runAgent({ tools: nonDashboardRegistry, messages: userMessages("Compare across regions") }),
     );
     const steps = await result.steps;
     const sqlResults = findToolResults(steps, "executeSQL") as SQLOutput[];

--- a/packages/api/src/lib/__tests__/agent-routing-mode.test.ts
+++ b/packages/api/src/lib/__tests__/agent-routing-mode.test.ts
@@ -150,8 +150,8 @@ void mock.module("@atlas/api/lib/cache/index", () => ({
 // ---------------------------------------------------------------------------
 
 const { runAgent } = await import("@atlas/api/lib/agent");
-// #4943 — runAgent's `tools` is required; nonDashboardRegistry is the restricted
-// surface these turns already resolved to when they omitted it.
+// #4943 — runAgent's `tools` is now required; this is its own fail-closed
+// default, so these turns are unchanged. See agent.ts's `@param tools`.
 const { nonDashboardRegistry } = await import("@atlas/api/lib/tools/registry");
 const { withRequestContext } = await import("@atlas/api/lib/logger");
 

--- a/packages/api/src/lib/__tests__/agent-runagent-call-sites.test.ts
+++ b/packages/api/src/lib/__tests__/agent-runagent-call-sites.test.ts
@@ -1,6 +1,28 @@
 /**
  * #4936 — the `runAgent` tool-surface guardrail.
  *
+ * DIVISION OF LABOUR (changed by #4943). `tools` is now a REQUIRED property of
+ * `runAgent`'s options, so the COMPILER is the primary enforcement: it rejects
+ * all five shapes of this bug class — conditional spread on a ternary, on `&&`,
+ * a spread of a partial options object, plain omission, and a possibly-
+ * `undefined` value — because TypeScript distributes the spread over the union
+ * and the empty branch surfaces `tools` as optional against a required target.
+ *
+ * This file is the BACKSTOP, and it is not redundant. Three things it catches
+ * that a required parameter cannot:
+ *
+ *   - WHICH registry each surface must resolve to (`EXPECTED_REGISTRY`). No
+ *     type expresses "the demo route gets the restricted one"; passing the
+ *     WRONG registry typechecks perfectly.
+ *   - `runAgent(opts)`, where a pre-built bag typed as the options object
+ *     compiles clean while laundering the posture out of sight.
+ *   - Anything outside the type-checked graph — an `any`-typed caller, a
+ *     separately compiled plugin — which is also why `runAgent` keeps its
+ *     fail-closed destructuring default rather than trusting the signature.
+ *
+ * The rest of this comment describes the shape of the original bug, which is
+ * what both layers exist to keep closed.
+ *
  * #4915 keeps `correct_fact` — a brain-mutating WRITE — off the read-safe
  * agent surface by registering it only when a `dashboardUrlResolver` is
  * present (`lib/tools/registry.ts`). That gate decides what each REGISTRY
@@ -58,6 +80,7 @@ import {
 import type { LanguageModelV3StreamPart } from "@ai-sdk/provider";
 import type { UIMessage } from "ai";
 import { createConnectionMock } from "@atlas/api/testing/connection";
+import type { ToolRegistry } from "@atlas/api/lib/tools/registry";
 
 // ---------------------------------------------------------------------------
 // 1. Behavioural — what tool set does the model actually receive?
@@ -127,7 +150,17 @@ void mock.module("@atlas/api/lib/learn/org-knowledge-section", () => ({
 }));
 
 const { runAgent } = await import("@atlas/api/lib/agent");
-const { defaultRegistry } = await import("@atlas/api/lib/tools/registry");
+const { defaultRegistry, nonDashboardRegistry } = await import("@atlas/api/lib/tools/registry");
+
+/**
+ * The omission the runtime backstop exists for. Since #4943 a TYPED caller
+ * cannot omit `tools` at all, so the only way left to reach the destructuring
+ * default is to stand in for a caller the type system never sees — an
+ * `any`-typed options bag, a separately compiled plugin. That is what this cast
+ * models, and it is the whole reason the first behavioural test below is still
+ * a real assertion rather than a tautology about a registry it passed itself.
+ */
+const OMITTED_TOOLS = undefined as unknown as ToolRegistry;
 
 let lastToolNames: string[] | undefined;
 
@@ -184,6 +217,7 @@ async function toolNamesForTurn(
   lastToolNames = undefined;
   const result = await runAgent({
     messages: userMessages("How many orders last month?"),
+    tools: nonDashboardRegistry,
     aiModel: {
       model: makeSpyingModel(),
       providerType: "openai",
@@ -202,7 +236,9 @@ const DASHBOARD_WRITE_TOOL = "createDashboard";
 
 describe("#4936 — runAgent's default tool surface fails closed", () => {
   it("a turn that omits `tools` gets no brain-write and no dashboard-write verb", async () => {
-    const names = await toolNamesForTurn({});
+    // `...extra` is spread LAST, so this genuinely overrides the base call's
+    // registry with nothing and lands on runAgent's own default.
+    const names = await toolNamesForTurn({ tools: OMITTED_TOOLS });
 
     // The whole point of the issue: omitting `tools` used to yield
     // `defaultRegistry`, which carries both of these.

--- a/packages/api/src/lib/__tests__/agent-runagent-call-sites.test.ts
+++ b/packages/api/src/lib/__tests__/agent-runagent-call-sites.test.ts
@@ -5,10 +5,14 @@
  * `runAgent`'s options, so the COMPILER is the primary enforcement: it rejects
  * all five shapes of this bug class — conditional spread on a ternary, on `&&`,
  * a spread of a partial options object, plain omission, and a possibly-
- * `undefined` value — because TypeScript distributes the spread over the union
- * and the empty branch surfaces `tools` as optional against a required target.
+ * `undefined` value. The mechanism is not spread-over-union distribution:
+ * TypeScript MERGES `{ tools: T } | {}` into one object type with `tools`
+ * OPTIONAL, and that fails the required target on property incompatibility
+ * ("Type 'undefined' is not assignable to type 'ToolRegistry'"). Section 1b
+ * below pins each shape with a `@ts-expect-error`, which is also what stops the
+ * property being silently re-widened to `tools?:`.
  *
- * This file is the BACKSTOP, and it is not redundant. Three things it catches
+ * This file is the BACKSTOP, and it is not redundant. Four things it catches
  * that a required parameter cannot:
  *
  *   - WHICH registry each surface must resolve to (`EXPECTED_REGISTRY`). No
@@ -16,12 +20,21 @@
  *     WRONG registry typechecks perfectly.
  *   - `runAgent(opts)`, where a pre-built bag typed as the options object
  *     compiles clean while laundering the posture out of sight.
+ *   - A LATER spread that RE-ASSIGNS `tools` (`{ tools: nonDashboardRegistry,
+ *     ...(isInternal && { tools: defaultRegistry }) }`). Object spread is
+ *     last-write-wins, so this compiles clean under a required property — and
+ *     it is the one escape shape whose failure direction is UPWARD, re-adding
+ *     `correct_fact` rather than landing on the fail-closed default. The most
+ *     dangerous shape here is the one the compiler cannot see at all.
  *   - Anything outside the type-checked graph — an `any`-typed caller, a
- *     separately compiled plugin — which is also why `runAgent` keeps its
- *     fail-closed destructuring default rather than trusting the signature.
+ *     separately compiled plugin, or a tree the root tsconfig excludes
+ *     (`scripts/`, `deploy/`, `examples/*`, `plugins/obsidian`), which the
+ *     repo-wide `git grep` drift check at the bottom of this file covers. That
+ *     is also why `runAgent` keeps its fail-closed fall-back coalesce rather
+ *     than trusting the signature.
  *
- * The rest of this comment describes the shape of the original bug, which is
- * what both layers exist to keep closed.
+ * The rest of this comment is the original bug's shape, plus the two axes this
+ * file still pins.
  *
  * #4915 keeps `correct_fact` — a brain-mutating WRITE — off the read-safe
  * agent surface by registering it only when a `dashboardUrlResolver` is
@@ -37,10 +50,12 @@
  * WHICH REGISTRY EACH CALL SITE RESOLVES TO. This file closes that axis from
  * both ends:
  *
- *   1. BEHAVIOURAL — a real `runAgent` turn with no `tools` hands the model a
- *      tool set with no brain-write and no dashboard-write verb. The same turn
- *      with `defaultRegistry` passed explicitly DOES carry them, so the
- *      assertion is a real gate and not a tautology about an empty tool set.
+ *   1. BEHAVIOURAL — a real `runAgent` turn that reaches the fall-back
+ *      coalesce (since #4943 a typed caller cannot omit `tools`, so the turn
+ *      goes through the `OMIT_TOOLS` stand-in for an untyped one) hands the
+ *      model a tool set with no brain-write and no dashboard-write verb. The
+ *      same turn with `defaultRegistry` passed explicitly DOES carry them, so
+ *      the assertion is a real gate and not a tautology about an empty tool set.
  *   2. STRUCTURAL — every production `runAgent(...)` call site resolves to the
  *      registry its surface is supposed to have. Not merely "passes something
  *      called `tools`": `EXPECTED_REGISTRY` pins the actual expression per
@@ -58,9 +73,9 @@
  *      surface's behavioural test — named per entry, including the one entry
  *      (`admin-semantic-improve.ts`) whose route test mocks its builder.
  *
- * The safe default is the backstop for anything the scan cannot see (an
- * untyped caller, a plugin compiled separately); naming the registry at the
- * surface is the contract.
+ * The safe fall-back is the backstop for anything neither the scan nor the
+ * compiler can see (an untyped caller, a plugin compiled separately); naming
+ * the registry at the surface is the contract.
  *
  * Sibling guardrail: `agent-surface-registry.test.ts` pins the ACTOR-binding
  * axis (F-54/F-55), but over a DIFFERENT set — its roots are
@@ -150,17 +165,7 @@ void mock.module("@atlas/api/lib/learn/org-knowledge-section", () => ({
 }));
 
 const { runAgent } = await import("@atlas/api/lib/agent");
-const { defaultRegistry, nonDashboardRegistry } = await import("@atlas/api/lib/tools/registry");
-
-/**
- * The omission the runtime backstop exists for. Since #4943 a TYPED caller
- * cannot omit `tools` at all, so the only way left to reach the destructuring
- * default is to stand in for a caller the type system never sees — an
- * `any`-typed options bag, a separately compiled plugin. That is what this cast
- * models, and it is the whole reason the first behavioural test below is still
- * a real assertion rather than a tautology about a registry it passed itself.
- */
-const OMITTED_TOOLS = undefined as unknown as ToolRegistry;
+const { defaultRegistry } = await import("@atlas/api/lib/tools/registry");
 
 let lastToolNames: string[] | undefined;
 
@@ -209,7 +214,21 @@ function userMessages(text: string): UIMessage[] {
  * `Partial<…>` rather than a hand-written bag: it is tied to `runAgent`'s real
  * signature, so a misspelled option (`tolls:`) is a compile error instead of a
  * silently ignored key that would turn the negative assertions below into a
- * tautology about a default-tools turn.
+ * tautology about the base call's own registry.
+ *
+ * This is the one place a `Partial` of `runAgent`'s options is legitimate —
+ * erasing the #4943 requirement is the entire point, because there is otherwise
+ * no way to reach the fall-back coalesce from typed code. Everywhere else, a
+ * helper that forwards to `runAgent` takes the FULL parameter type (see
+ * `agent-resume.test.ts`), or it silently exempts every caller behind it.
+ *
+ * The base call deliberately passes `defaultRegistry`, NOT the value the
+ * default resolves to. If it passed `nonDashboardRegistry`, the assertions
+ * below would hold whether or not the `OMIT_TOOLS` override actually landed —
+ * the test would be pinning a registry it supplied itself. Passing the
+ * write-carrying registry makes the override load-bearing: any future edit that
+ * stops `...extra` winning (reordering it above `tools:`, or a defensive
+ * `tools: extra.tools ?? …`) fails both `not.toContain` assertions loudly.
  */
 async function toolNamesForTurn(
   extra: Partial<Parameters<typeof runAgent>[0]>,
@@ -217,7 +236,7 @@ async function toolNamesForTurn(
   lastToolNames = undefined;
   const result = await runAgent({
     messages: userMessages("How many orders last month?"),
-    tools: nonDashboardRegistry,
+    tools: defaultRegistry,
     aiModel: {
       model: makeSpyingModel(),
       providerType: "openai",
@@ -234,11 +253,32 @@ async function toolNamesForTurn(
 const BRAIN_WRITE_TOOL = "correct_fact";
 const DASHBOARD_WRITE_TOOL = "createDashboard";
 
+/**
+ * The omission `runAgent`'s fall-back coalesce exists for. Since #4943 a
+ * TYPED caller cannot omit `tools` at all, so the only way left to reach that
+ * default is to stand in for a caller the type system never sees — an
+ * `any`-typed options bag, a separately compiled plugin.
+ *
+ * Shaped as a `Pick` fragment rather than `undefined as unknown as ToolRegistry`
+ * so nothing is mis-typed as a registry: this value cannot be dereferenced, it
+ * can only be spread. `...extra` is spread LAST in `toolNamesForTurn`, and an
+ * own key whose value is `undefined` still wins over the base literal, so the
+ * property arrives as `undefined` and the default fires.
+ *
+ * Deleting this is not a cleanup: with the 16 test files that used to exercise
+ * the default now naming their registry explicitly, this is the only remaining
+ * BEHAVIOURAL assertion that the default is least-privileged. The source-text
+ * pin in "the fail-closed defaults are pinned in source" below is its only
+ * other net, and that one reads spelling, not behaviour.
+ */
+const OMIT_TOOLS = { tools: undefined } as unknown as Pick<
+  Parameters<typeof runAgent>[0],
+  "tools"
+>;
+
 describe("#4936 — runAgent's default tool surface fails closed", () => {
-  it("a turn that omits `tools` gets no brain-write and no dashboard-write verb", async () => {
-    // `...extra` is spread LAST, so this genuinely overrides the base call's
-    // registry with nothing and lands on runAgent's own default.
-    const names = await toolNamesForTurn({ tools: OMITTED_TOOLS });
+  it("a turn that reaches the fall-back coalesce gets no brain-write and no dashboard-write verb", async () => {
+    const names = await toolNamesForTurn(OMIT_TOOLS);
 
     // The whole point of the issue: omitting `tools` used to yield
     // `defaultRegistry`, which carries both of these.
@@ -262,6 +302,50 @@ describe("#4936 — runAgent's default tool surface fails closed", () => {
     expect(names).toContain(DASHBOARD_WRITE_TOOL);
   });
 });
+
+// ---------------------------------------------------------------------------
+// 1b. Compile-time — the PRIMARY gate pins itself
+// ---------------------------------------------------------------------------
+
+/**
+ * #4943's gate is a TYPE, so its guard has to be a type too.
+ *
+ * Nothing below runs. The assertion IS each `@ts-expect-error`: `tsgo --noEmit`
+ * reports an UNUSED directive as an error, so `bun run type` fails the moment
+ * the shape it marks stops being rejected. Test files are inside the root
+ * program (`packages/api/tsconfig.json` includes `src/**` and the root config
+ * excludes neither), so this is a live CI gate, not decoration.
+ *
+ * Without it, widening `tools: ToolRegistry` back to `tools?: ToolRegistry` is
+ * SILENT: every test in this file still passes, every call site still passes
+ * `tools`, and the two source pins below only read the DEFAULT's spelling —
+ * which is byte-identical either way. Enforcement would quietly drop back to
+ * text-scanning, while the header six hundred lines up kept claiming otherwise.
+ *
+ * `maybeRegistry` is `declare`d rather than assigned because a `const`
+ * initialised from a definite value is narrowed by control flow, and the last
+ * two shapes then compile clean — a false pass that this fixture, of all
+ * things, must not have. (Learned the hard way while verifying #4943.)
+ */
+declare function maybeRegistry(): ToolRegistry | undefined;
+
+// oxlint-disable-next-line no-unused-vars -- compile-time fixture; never invoked
+function _compilerRejectsEveryOmissionShape(): void {
+  const messages: UIMessage[] = [];
+  const maybe = maybeRegistry();
+  const partial: Partial<Parameters<typeof runAgent>[0]> = {};
+
+  // @ts-expect-error #4943 — ternary conditional spread (the pre-fix ee/answer-adapter.ts shape)
+  void runAgent({ messages, ...(maybe ? { tools: maybe } : {}) });
+  // @ts-expect-error #4943 — `&&` conditional spread (the pre-fix routes/chat.ts shape)
+  void runAgent({ messages, ...(maybe && { tools: maybe }) });
+  // @ts-expect-error #4943 — spread of a partial options object
+  void runAgent({ messages, ...partial });
+  // @ts-expect-error #4943 — plain omission (the pre-fix resume-turn.ts / demo.ts shape)
+  void runAgent({ messages });
+  // @ts-expect-error #4943 — a value that may be `undefined`
+  void runAgent({ messages, tools: maybe });
+}
 
 // ---------------------------------------------------------------------------
 // 2. Structural — every production call site names the RIGHT registry
@@ -438,10 +522,21 @@ function inspectToolsProp(args: string): ToolsProp {
  * A call site is an offender if it does not name `tools` UNCONDITIONALLY, with
  * a value that cannot be `undefined`.
  *
- * The last clause matters because `exactOptionalPropertyTypes` is off, so
- * `tools: ToolRegistry | undefined` typechecks against `tools?: ToolRegistry`:
- * `tools: cond ? registry : undefined` reads as explicit and behaves as
- * omission. `SCANNER_FIXTURES` pins every one of these shapes.
+ * Since #4943 a typed caller cannot reach most of these shapes at all — the
+ * required property rejects them. The `undefined` arms are kept because this is
+ * a TEXT guard over trees the compiler may not cover (the root tsconfig
+ * excludes `scripts/`, `deploy/`, `examples/*`, `plugins/obsidian`) and callers
+ * it never sees, and because a second, independently-spelled signal is the
+ * point of a backstop.
+ *
+ * The assertion arm is new pressure created by #4943: a caller holding a
+ * `ToolRegistry | undefined` can no longer pass it, so the path of least
+ * resistance becomes `tools: reg!` or `tools: reg as ToolRegistry`. Both
+ * typecheck, both satisfy `EXPECTED_REGISTRY`'s regexes, and both can still be
+ * `undefined` at runtime — the requirement is declared and not met. It fails
+ * DOWNWARD onto the fail-closed default, so it is not an open door, but it
+ * voids the "declared unconditionally at the surface" contract silently.
+ * `SCANNER_FIXTURES` pins every one of these shapes.
  */
 function offenceFor(args: string): string | undefined {
   const prop = inspectToolsProp(args);
@@ -455,8 +550,16 @@ function offenceFor(args: string): string | undefined {
     case "shorthand":
       return undefined;
     case "value":
-      return /\bundefined\b/.test(prop.text)
-        ? "passes a `tools` value that can be `undefined`, which is the same as omitting it"
+      if (/\bundefined\b/.test(prop.text)) {
+        return "passes a `tools` value that can be `undefined`, which is the same as omitting it";
+      }
+      // A trailing `!` or `as ToolRegistry` on the whole value — `reg!`,
+      // `map.get(id)!`, `maybeReg as ToolRegistry`. Deliberately anchored to the
+      // END of the value so an assertion INSIDE a resolved expression
+      // (`(await buildHeadlessRegistry()).registry`) is untouched.
+      return /(?:!|\bas\s+ToolRegistry)\s*$/.test(prop.text)
+        ? "asserts the `tools` value non-null (`!` / `as ToolRegistry`) rather than resolving one — " +
+            "the assertion hides exactly the `undefined` the required parameter exists to reject"
         : undefined;
   }
 }
@@ -623,10 +726,23 @@ describe("#4936 — the call-site scanner detects the shapes the bug actually ha
       true,
     ],
     ["explicit undefined", `{ messages, tools: undefined }`, true],
-    // `exactOptionalPropertyTypes` is off, so a value that MAY be undefined
-    // typechecks against `tools?: ToolRegistry` and behaves as an omission.
+    // Rejected by the compiler too since #4943; kept because this guard also
+    // covers trees the root tsconfig excludes and callers it never typechecks.
     ["ternary that can yield undefined", `{ messages, tools: cond ? reg : undefined }`, true],
     ["nullish-coalescing to undefined", `{ messages, tools: reg ?? undefined }`, true],
+    // The shape a required `tools` pressures a caller toward: the requirement is
+    // declared, the assertion is what actually satisfies it, and the value can
+    // still be undefined at runtime.
+    ["non-null assertion on a maybe-registry", `{ messages, tools: maybeReg! }`, true],
+    ["non-null assertion on a lookup", `{ messages, tools: registries.get(id)! }`, true],
+    ["cast that erases the undefined", `{ messages, tools: maybeReg as ToolRegistry }`, true],
+    // …but an assertion INSIDE an otherwise-resolved expression is not the
+    // `tools` value being asserted, and must not be flagged.
+    [
+      "an assertion nested inside a resolved value",
+      `{ messages, tools: (await buildRegistry(opts!)).registry }`,
+      false,
+    ],
     // A nested `tools` is not the options-object property.
     ["tools nested under another key", `{ messages, resume: { runId, tools: r } }`, true],
     ["a pre-built options bag hides the posture", `opts`, true],
@@ -747,11 +863,15 @@ describe("#4936 — the fail-closed defaults are pinned in source", () => {
   it("runAgent defaults `tools` to nonDashboardRegistry, never a write-carrying registry", async () => {
     const source = await readFile(resolve(REPO_ROOT, AGENT_MODULE), "utf8");
 
+    // #4943 moved this off the destructuring default: a default on a REQUIRED
+    // property is dead code to the compiler, and the repo's type-aware lint
+    // (`typescript/no-useless-default-assignment`) errors on it. Same invariant,
+    // spelled as a body coalesce — so this pin reads the coalesce.
     expect(
       source,
-      "runAgent's `tools` default must stay the least-privileged registry — reverting it " +
-        "to `defaultRegistry` re-opens #4936 for every caller that omits `tools`.",
-    ).toMatch(/tools:\s*toolRegistry\s*=\s*nonDashboardRegistry/);
+      "runAgent's `tools` backstop must stay the least-privileged registry — reverting it " +
+        "to `defaultRegistry` re-opens #4936 for every caller the type system never sees.",
+    ).toMatch(/declaredToolRegistry\s*\?\?\s*nonDashboardRegistry/);
   });
 
   it("buildSystemParam defaults `registry` to nonDashboardRegistry too", async () => {
@@ -762,6 +882,22 @@ describe("#4936 — the fail-closed defaults are pinned in source", () => {
     const source = await readFile(resolve(REPO_ROOT, AGENT_MODULE), "utf8");
 
     expect(source).toMatch(/registry\s*=\s*nonDashboardRegistry,/);
+  });
+
+  it("#4943 — `tools` is still REQUIRED on the options type", async () => {
+    // Second signal for the compile-time fixtures above, in a different CI job:
+    // `_compilerRejectsEveryOmissionShape` fails the `type` gate, this fails the
+    // `test` gate. A revert to `tools?: ToolRegistry` demotes the compiler back
+    // to a no-op and leaves text scanning as the only enforcement — the posture
+    // #4943 exists to end. Both nets read the signature; neither reads the other.
+    const source = await readFile(resolve(REPO_ROOT, AGENT_MODULE), "utf8");
+
+    expect(
+      source,
+      "runAgent's `tools` must stay REQUIRED. Making it optional again means the compiler " +
+        "stops rejecting the five omission shapes (#4943) and this file's text scan becomes " +
+        "the only gate.",
+    ).not.toMatch(/^\s*tools\?:\s*ToolRegistry/m);
   });
 });
 

--- a/packages/api/src/lib/__tests__/agent-scope-prompt.test.ts
+++ b/packages/api/src/lib/__tests__/agent-scope-prompt.test.ts
@@ -254,8 +254,10 @@ function makeSpyingModel(toolCallArgs: Record<string, unknown>): InstanceType<ty
 const { runAgent } = await import("@atlas/api/lib/agent");
 const { buildSystemParam, buildRestDatasourceScopeNote } = await import("@atlas/api/lib/agent");
 const { withRequestContext } = await import("@atlas/api/lib/logger");
-// #4943 — runAgent's `tools` is required; nonDashboardRegistry is the restricted
-// surface these turns already resolved to when they omitted it.
+// #4943 — runAgent's `tools` is now required. `nonDashboardRegistry` (added
+// here) is its own fail-closed default, so those turns are unchanged; see
+// agent.ts's `@param tools`. `defaultRegistry` is unrelated and pre-existing —
+// the #3067 focus-strip turns below need `createDashboard` present.
 const { defaultRegistry, nonDashboardRegistry } = await import("@atlas/api/lib/tools/registry");
 
 function userMessages(content: string): UIMessage[] {

--- a/packages/api/src/lib/__tests__/agent-scope-prompt.test.ts
+++ b/packages/api/src/lib/__tests__/agent-scope-prompt.test.ts
@@ -254,7 +254,9 @@ function makeSpyingModel(toolCallArgs: Record<string, unknown>): InstanceType<ty
 const { runAgent } = await import("@atlas/api/lib/agent");
 const { buildSystemParam, buildRestDatasourceScopeNote } = await import("@atlas/api/lib/agent");
 const { withRequestContext } = await import("@atlas/api/lib/logger");
-const { defaultRegistry } = await import("@atlas/api/lib/tools/registry");
+// #4943 — runAgent's `tools` is required; nonDashboardRegistry is the restricted
+// surface these turns already resolved to when they omitted it.
+const { defaultRegistry, nonDashboardRegistry } = await import("@atlas/api/lib/tools/registry");
 
 function userMessages(content: string): UIMessage[] {
   return [
@@ -415,7 +417,7 @@ describe("agent integration — scope routing via mocked LLM (slice 2)", () => {
 
     const result = await withRequestContext(
       { requestId: "test-1", connectionId: "us-int", connectionGroupId: "prod" },
-      () => runAgent({ messages: userMessages("compare revenue across regions") }),
+      () => runAgent({ tools: nonDashboardRegistry, messages: userMessages("compare revenue across regions") }),
     );
     const steps = await result.steps;
     const sqlResults = findToolResults(steps, "executeSQL");
@@ -442,7 +444,7 @@ describe("agent integration — scope routing via mocked LLM (slice 2)", () => {
 
     const result = await withRequestContext(
       { requestId: "test-2", connectionId: "us-int", connectionGroupId: "prod" },
-      () => runAgent({ messages: userMessages("EU sales last week") }),
+      () => runAgent({ tools: nonDashboardRegistry, messages: userMessages("EU sales last week") }),
     );
     const steps = await result.steps;
     const sqlResults = findToolResults(steps, "executeSQL");
@@ -461,7 +463,7 @@ describe("agent integration — scope routing via mocked LLM (slice 2)", () => {
 
     const result = await withRequestContext(
       { requestId: "test-3", connectionId: "us-int", connectionGroupId: "prod" },
-      () => runAgent({ messages: userMessages("show me orders") }),
+      () => runAgent({ tools: nonDashboardRegistry, messages: userMessages("show me orders") }),
     );
     const steps = await result.steps;
     const sqlResults = findToolResults(steps, "executeSQL");
@@ -521,7 +523,7 @@ describe("agent loop — REST datasource scope threading (#3044)", () => {
         connectionGroupId: "prod",
         user: { id: "u1", mode: "managed", label: "u@test", role: "member", activeOrganizationId: "org-1" },
       },
-      () => runAgent({ messages: userMessages("hello") }),
+      () => runAgent({ tools: nonDashboardRegistry, messages: userMessages("hello") }),
     );
     expect(capturedRestResolveArgs).toBeDefined();
     expect(capturedRestResolveArgs!.orgId).toBe("org-1");
@@ -538,7 +540,7 @@ describe("agent loop — REST datasource scope threading (#3044)", () => {
         connectionId: "us-int",
         user: { id: "u1", mode: "managed", label: "u@test", role: "member", activeOrganizationId: "org-1" },
       },
-      () => runAgent({ messages: userMessages("hello") }),
+      () => runAgent({ tools: nonDashboardRegistry, messages: userMessages("hello") }),
     );
     expect(capturedRestResolveArgs!.deps).toEqual({ activeGroupId: "prod" });
   });
@@ -550,7 +552,7 @@ describe("agent loop — REST datasource scope threading (#3044)", () => {
         connectionId: "ungrouped-conn",
         user: { id: "u1", mode: "managed", label: "u@test", role: "member", activeOrganizationId: "org-1" },
       },
-      () => runAgent({ messages: userMessages("hello") }),
+      () => runAgent({ tools: nonDashboardRegistry, messages: userMessages("hello") }),
     );
     expect(capturedRestResolveArgs!.deps).toEqual({ activeGroupId: null });
     // `undefined` would disable scoping in the resolver (the confirm-replay path)

--- a/packages/api/src/lib/__tests__/agent-token-usage.test.ts
+++ b/packages/api/src/lib/__tests__/agent-token-usage.test.ts
@@ -87,6 +87,9 @@ void mock.module("@atlas/api/lib/db/internal", () => ({
 }));
 
 const { runAgent } = await import("@atlas/api/lib/agent");
+// #4943 — runAgent's `tools` is required; nonDashboardRegistry is the restricted
+// surface these turns already resolved to when they omitted it.
+const { nonDashboardRegistry } = await import("@atlas/api/lib/tools/registry");
 
 /**
  * Raw V3 finish-chunk usage carrying a cache split. The AI SDK normalizes
@@ -149,7 +152,7 @@ async function drive(model: InstanceType<typeof MockLanguageModelV3>): Promise<v
   mockModel = model;
   // userId/orgId derive from the request context (null here), which is fine —
   // the token_usage INSERT still fires on `hasInternalDB() && totalUsage`.
-  const result = await runAgent({ messages: userMessages("hi"), conversationId: "conv-1" });
+  const result = await runAgent({ tools: nonDashboardRegistry, messages: userMessages("hi"), conversationId: "conv-1" });
   await result.steps;
   await result.consumeStream?.();
 }

--- a/packages/api/src/lib/__tests__/agent-token-usage.test.ts
+++ b/packages/api/src/lib/__tests__/agent-token-usage.test.ts
@@ -87,8 +87,8 @@ void mock.module("@atlas/api/lib/db/internal", () => ({
 }));
 
 const { runAgent } = await import("@atlas/api/lib/agent");
-// #4943 — runAgent's `tools` is required; nonDashboardRegistry is the restricted
-// surface these turns already resolved to when they omitted it.
+// #4943 — runAgent's `tools` is now required; this is its own fail-closed
+// default, so these turns are unchanged. See agent.ts's `@param tools`.
 const { nonDashboardRegistry } = await import("@atlas/api/lib/tools/registry");
 
 /**

--- a/packages/api/src/lib/agent-query.ts
+++ b/packages/api/src/lib/agent-query.ts
@@ -275,8 +275,9 @@ export async function executeAgentQuery(
     // #4936 — that construction moved into `registry.ts` so the chat-plugin
     // approval RESUME of a turn started here rebuilds from the identical POLICY
     // instead of re-deriving it (or, as it did, omitting `tools` and inheriting
-    // the workspace registry). We still pass `tools` explicitly: `runAgent`'s
-    // default now fails closed, but the surface's choice belongs in the surface.
+    // the workspace registry). Passing `tools` is no longer discipline —
+    // #4943 made it a required parameter, so the compiler enforces what this
+    // comment used to ask for.
     //
     // #4941 — the seam also returns the warnings this surface must relay; the
     // narrative for why they exist is `buildHeadlessRegistry`'s docstring.

--- a/packages/api/src/lib/agent.ts
+++ b/packages/api/src/lib/agent.ts
@@ -1,16 +1,18 @@
 /**
  * The Atlas agent.
  *
- * Runs a single-agent loop driven by a ToolRegistry (default: explore,
- * executeSQL). The loop runs until the step limit is reached (configurable
- * via `ATLAS_AGENT_MAX_STEPS`, default 25) or the model stops issuing
- * tool calls.
+ * Runs a single-agent loop driven by a ToolRegistry, which every caller names
+ * explicitly — see the `@param tools` note on {@link runAgent} for what the
+ * fall-back registry actually carries (it is lesser-privileged, not minimal).
+ * The loop runs until the step limit is reached (configurable via
+ * `ATLAS_AGENT_MAX_STEPS`, default 25) or the model stops issuing tool calls.
  *
  * Effect migration (P10c):
- * The agent function optionally reads its dependencies (model, tools,
- * user context) from Effect Context when available, falling back to
- * global singletons otherwise. This makes the agent testable via
- * Layer.provide with mock services.
+ * The agent function optionally reads its dependencies (model, user context)
+ * from Effect Context when available, falling back to global singletons
+ * otherwise. This makes the agent testable via Layer.provide with mock
+ * services. The tool registry is NOT among them — it is a required parameter
+ * (#4943), not a context lookup.
  */
 
 import {
@@ -1085,19 +1087,33 @@ function wrapToolsWithDurableState(toolSet: ToolSet, store: DurableStateStore): 
  *   what enforces that. A required property rejects all five shapes the bug
  *   class used, including the two conditional spreads that were its actual
  *   source (`...(reg ? { tools: reg } : {})`, `...(reg && { tools: reg })`):
- *   TypeScript distributes the spread over the union, so the empty branch
- *   surfaces `tools` as optional and fails the required target.
+ *   TypeScript merges the spread of `{ tools: T } | {}` into ONE object type
+ *   with `tools` OPTIONAL, which then fails the required target with "Type
+ *   'undefined' is not assignable to type 'ToolRegistry'". Each shape is pinned
+ *   by a `@ts-expect-error` fixture in `agent-runagent-call-sites.test.ts`, so
+ *   re-widening this property to `tools?:` fails `bun run type`.
  *
- *   `agent-runagent-call-sites.test.ts` is the BACKSTOP, not the gate. It still
- *   pins WHICH registry each production surface must resolve to — a choice no
- *   type can express — and still catches `runAgent(opts)`, where a pre-built
- *   bag typechecks clean while laundering the posture out of sight. It scans
- *   the roots listed in its `SCAN_ROOTS` (`packages/api|mcp|sdk/src` +
+ *   Corollary for helpers: a wrapper that forwards to `runAgent` types its
+ *   options as the FULL `Parameters<typeof runAgent>[0]`, never `Partial<…>` —
+ *   a `Partial` wrapper fills `tools` in on its callers' behalf and erases the
+ *   requirement for every surface behind it.
+ *
+ *   `agent-runagent-call-sites.test.ts` is the BACKSTOP, not the gate, and it
+ *   is not redundant — it catches four things no type can: WHICH registry each
+ *   production surface must resolve to; `runAgent(opts)`, where a pre-built bag
+ *   typechecks clean while laundering the posture out of sight; a LATER spread
+ *   re-assigning `tools` (last-write-wins, the one escape that fails UPWARD by
+ *   re-adding `correct_fact`) which compiles clean under a required property;
+ *   and trees the root tsconfig excludes (`scripts/`, `deploy/`, `examples/*`,
+ *   `plugins/obsidian`), which its repo-wide `git grep` drift check covers. It
+ *   scans the roots listed in its `SCAN_ROOTS` (`packages/api|mcp|sdk/src` +
  *   `ee/src`) — add a root there when a new package can reach `runAgent`.
  *
- *   The destructuring default below stays as defense in depth: it covers
- *   callers the type system never sees (an `any`-typed bag, a separately
- *   compiled plugin). It is now {@link nonDashboardRegistry}, not the
+ *   The first line of the function body coalesces to a fall-back registry as
+ *   defense in depth for callers the type system never sees (an `any`-typed
+ *   bag, a separately compiled plugin). Note it fires on `undefined` ONLY — a
+ *   `null` from such a caller is not covered and will fail later in the turn.
+ *   That fall-back is now {@link nonDashboardRegistry}, not the
  *   dashboards-owning `defaultRegistry` (#4936). The old default was
  *   write-carrying: any caller that omitted `tools` silently received
  *   `createDashboard` AND `correct_fact` — re-opening, from the outside, the
@@ -1120,7 +1136,7 @@ function wrapToolsWithDurableState(toolSet: ToolSet, store: DurableStateStore): 
  */
 export async function runAgent({
   messages,
-  tools: toolRegistry = nonDashboardRegistry,
+  tools: declaredToolRegistry,
   conversationId,
   warnings,
   persona,
@@ -1274,6 +1290,16 @@ export async function runAgent({
    */
   abortSignal?: AbortSignal;
 }) {
+  // #4943 — the fail-closed backstop, moved off the destructuring default (a
+  // default on a REQUIRED property is dead code to the compiler, and
+  // `typescript/no-useless-default-assignment` says so as an error). It is not
+  // dead to callers the type system never sees: an `any`-typed options bag, a
+  // separately compiled plugin. Forgetting a registry has to land on the
+  // LESSER-privileged one — the pre-#4936 default carried `createDashboard`
+  // AND `correct_fact`, which re-opened the #4915 surface gate from outside.
+  // Coalesces on `undefined` only; a `null` from such a caller is not covered
+  // and fails later in the turn.
+  const toolRegistry = declaredToolRegistry ?? nonDashboardRegistry;
   // #3931 — per-turn latency clock. Captured at runAgent entry so the
   // token_usage INSERT in onFinish can persist the agent-turn wall-clock
   // (entry → finish) on the same row as the turn's tokens + cache split.

--- a/packages/api/src/lib/agent.ts
+++ b/packages/api/src/lib/agent.ts
@@ -1080,17 +1080,24 @@ function wrapToolsWithDurableState(toolSet: ToolSet, store: DurableStateStore): 
  * Run the Atlas agent loop.
  *
  * @param messages - The conversation history from the chat UI.
- * @param tools - The surface's {@link ToolRegistry}. Every production call site
- *   passes it explicitly, and `agent-runagent-call-sites.test.ts` pins WHICH
- *   registry each one must resolve to. That guard scans the roots listed in its
- *   `SCAN_ROOTS` (`packages/api|mcp|sdk/src` + `ee/src`) — add a root there when
- *   a new package can reach `runAgent`.
+ * @param tools - The surface's {@link ToolRegistry}. REQUIRED (#4943): every
+ *   call site — production and test — names its registry, and the COMPILER is
+ *   what enforces that. A required property rejects all five shapes the bug
+ *   class used, including the two conditional spreads that were its actual
+ *   source (`...(reg ? { tools: reg } : {})`, `...(reg && { tools: reg })`):
+ *   TypeScript distributes the spread over the union, so the empty branch
+ *   surfaces `tools` as optional and fails the required target.
  *
- *   The parameter stays optional for TESTS; production callers are required to
- *   name a registry. Making it required outright — so the compiler enforces this
- *   instead of a source scanner — is #4943.
+ *   `agent-runagent-call-sites.test.ts` is the BACKSTOP, not the gate. It still
+ *   pins WHICH registry each production surface must resolve to — a choice no
+ *   type can express — and still catches `runAgent(opts)`, where a pre-built
+ *   bag typechecks clean while laundering the posture out of sight. It scans
+ *   the roots listed in its `SCAN_ROOTS` (`packages/api|mcp|sdk/src` +
+ *   `ee/src`) — add a root there when a new package can reach `runAgent`.
  *
- *   The default is now {@link nonDashboardRegistry}, not the
+ *   The destructuring default below stays as defense in depth: it covers
+ *   callers the type system never sees (an `any`-typed bag, a separately
+ *   compiled plugin). It is now {@link nonDashboardRegistry}, not the
  *   dashboards-owning `defaultRegistry` (#4936). The old default was
  *   write-carrying: any caller that omitted `tools` silently received
  *   `createDashboard` AND `correct_fact` — re-opening, from the outside, the
@@ -1130,7 +1137,8 @@ export async function runAgent({
   abortSignal,
 }: {
   messages: UIMessage[];
-  tools?: ToolRegistry;
+  /** Required — see the `@param tools` note above (#4943). */
+  tools: ToolRegistry;
   conversationId?: string;
   warnings?: string[];
   /**

--- a/packages/api/src/lib/content-mode/__tests__/publish-caller-supersession-wiring.test.ts
+++ b/packages/api/src/lib/content-mode/__tests__/publish-caller-supersession-wiring.test.ts
@@ -249,8 +249,11 @@ describe("every runPublishPhases caller handles the supersession report (#4937)"
         expect(clean.match(/collectSupersessions\(/g) ?? []).toHaveLength(prefixes.length);
         for (const name of bound) {
           // `$` is a regex anchor and a legal identifier character, so it is
-          // escaped rather than interpolated raw.
-          const ident = name.replace(/\$/g, "\\$");
+          // escaped rather than interpolated raw. The class is deliberately
+          // TOTAL (`\` too) even though `bound` only ever yields
+          // `[A-Za-z0-9_$]` — a partial escape trips CodeQL's
+          // js/incomplete-sanitization (#4958). Do not narrow it back.
+          const ident = name.replace(/[\\$]/g, "\\$&");
           expect({
             name,
             reachesSweep: new RegExp(

--- a/packages/api/src/lib/openapi/__tests__/twenty-acceptance.test.ts
+++ b/packages/api/src/lib/openapi/__tests__/twenty-acceptance.test.ts
@@ -116,8 +116,8 @@ void mock.module("@atlas/api/lib/openapi/workspace-datasource", () => ({
 }));
 
 const { runAgent } = await import("@atlas/api/lib/agent");
-// #4943 — runAgent's `tools` is required; nonDashboardRegistry is the restricted
-// surface these turns already resolved to when they omitted it.
+// #4943 — runAgent's `tools` is now required; this is its own fail-closed
+// default, so these turns are unchanged. See agent.ts's `@param tools`.
 const { nonDashboardRegistry } = await import("@atlas/api/lib/tools/registry");
 
 // ── Fixtures ─────────────────────────────────────────────────────────────

--- a/packages/api/src/lib/openapi/__tests__/twenty-acceptance.test.ts
+++ b/packages/api/src/lib/openapi/__tests__/twenty-acceptance.test.ts
@@ -116,6 +116,9 @@ void mock.module("@atlas/api/lib/openapi/workspace-datasource", () => ({
 }));
 
 const { runAgent } = await import("@atlas/api/lib/agent");
+// #4943 — runAgent's `tools` is required; nonDashboardRegistry is the restricted
+// surface these turns already resolved to when they omitted it.
+const { nonDashboardRegistry } = await import("@atlas/api/lib/tools/registry");
 
 // ── Fixtures ─────────────────────────────────────────────────────────────
 const SPEC = JSON.parse(
@@ -214,7 +217,7 @@ async function runScenario(prompt: string, steps: Step[]) {
         // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- minimal AtlasUser for the request context
       } as any,
     },
-    () => runAgent({ messages: userMessages(prompt) }),
+    () => runAgent({ tools: nonDashboardRegistry, messages: userMessages(prompt) }),
   );
   const agentSteps = await result.steps;
   return {


### PR DESCRIPTION
Implements #4943. Makes `tools` a **required** property of `runAgent`'s options, so the compiler — not a source-text scanner — is the primary enforcement of the tool-surface gate. Follows #4936, which made the runtime default fail closed.

Base is `milestone/brain-m2`, so `Closes` would not fire; #4943 will be closed by hand.

## What changed

- **`tools` is required** on `runAgent`'s options (`tools: ToolRegistry`).
- **The fail-closed coalesce stays**, but moved off the destructuring default into the body: `const toolRegistry = declaredToolRegistry ?? nonDashboardRegistry`. A default on a *required* property is dead code to the compiler, and `typescript/no-useless-default-assignment` flags it as an error. It is not dead to callers the type system never sees — an `any`-typed options bag, a separately compiled plugin.
- **Every call site names its registry** — production and test. No production surface changed which registry it resolves to.
- **The scanner test's header records the new division of labour**: the compiler is the gate, the scanner is the backstop.

## Why the scanner is still not redundant

Four things a required property cannot catch, all still pinned by `agent-runagent-call-sites.test.ts`:

- **Which** registry each surface must resolve to — passing the *wrong* registry typechecks perfectly.
- `runAgent(opts)` with a pre-built bag, which compiles clean while laundering the posture out of sight.
- A **later spread that re-assigns `tools`** — object spread is last-write-wins, so this compiles clean under a required property. It is the one escape shape whose failure direction is **upward**, re-adding `correct_fact` rather than landing on the fail-closed default.
- Trees outside the type-checked graph (`scripts/`, `deploy/`, `examples/*`, `plugins/obsidian`), covered by the repo-wide `git grep` drift check.

## Verification

- `bun run type` — clean, exit 0 across all packages.
- `bun run scripts/test-isolated.ts --affected` — **644 files, 644 passed, 0 failed**.
- `bun run lint` — exit 0 (warnings only; the permanent non-targets per ADR-0031).
- **Mutation-verified, all five shapes.** Re-widening the property to `tools?: ToolRegistry` fails `bun run type` with exactly five `TS2578: Unused '@ts-expect-error' directive` errors — one per shape — then reverted. The five are pinned as permanent compile-time fixtures in `_compilerRejectsEveryOmissionShape`, so they keep failing if the property is ever re-widened:
  - ternary conditional spread (the pre-fix `ee/answer-adapter.ts` shape)
  - `&&` conditional spread (the pre-fix `routes/chat.ts` shape)
  - spread of a partial options object
  - plain omission (the pre-fix `resume-turn.ts` / `demo.ts` shape)
  - a possibly-`undefined` value

Note the mechanism is **not** spread-over-union distribution: TypeScript merges `{ tools: T } | {}` into one object type with `tools` optional, which then fails the required target on property incompatibility.

## Notes

- The behavioural test was made **load-bearing**: its base call now passes `defaultRegistry` (the write-carrying registry), not the value the fall-back resolves to. Passing `nonDashboardRegistry` there would have made the assertions hold whether or not the `OMIT_TOOLS` override landed — the test would have been pinning a registry it supplied itself.
- `Partial<Parameters<typeof runAgent>[0]>` is used in exactly one place — the test helper that must reach the fall-back coalesce from typed code. Everywhere else a forwarding helper takes the **full** parameter type; a `Partial` wrapper would fill `tools` in on its callers' behalf and erase the requirement for every surface behind it.

## Out of scope

- **`exactOptionalPropertyTypes`** — deliberately untouched, per the issue. It is what makes a possibly-`undefined` value assignable to an optional property and deserves its own issue. It did not bite during this work.
- Changing which registry any production call site uses.
- Widening the change to other functions taking an optional registry.
