### PR TITLE
fix(api): stop credential-bundle parse failures echoing decrypted plaintext (#4984)

### DIFF
--- a/packages/api/src/lib/auth/load-test-tokens.ts
+++ b/packages/api/src/lib/auth/load-test-tokens.ts
@@ -304,9 +304,14 @@ async function unwrapPrivateJwk(
     // than the bearer it protects. The route's failure-path catch
     // forwards `.message` into pino + `admin_action_log.metadata.error`,
     // so the message must carry no attacker-recoverable content. The
-    // `cause` option is also intentionally omitted — pino's err
-    // serializer walks the cause chain and would surface the original
-    // JSON.parse message identically. The bare `catch` (no binding) is
+    // `cause` option is also intentionally omitted — but NOT for the
+    // reason this comment used to give. It claimed pino's err serializer
+    // walks the cause chain; the custom `scrubErrSerializer` this repo
+    // installs does not (verified #4984: it emits `{type, message, stack}`
+    // plus the `code`/`constraint` whitelist, and no 500 renderer
+    // serializes a cause either). Omit it anyway — that is a property of
+    // today's serializer, not a contract, and a secret is the wrong thing
+    // to leave depending on one. The bare `catch` (no binding) is
     // the explicit "we deliberately do not propagate the caught error"
     // signal to project conventions.
     throw new Error(

--- a/packages/api/src/lib/integrations/credentials/__tests__/store.test.ts
+++ b/packages/api/src/lib/integrations/credentials/__tests__/store.test.ts
@@ -28,6 +28,48 @@ void mock.module("@atlas/api/lib/db/internal", () => ({
   getInternalDB: mock(() => ({ query: mock(() => Promise.resolve({ rows: [] })) })),
 }));
 
+/**
+ * Capture EVERY argument of every log call (#4984).
+ *
+ * Asserting on a payload field would miss the two ways a secret actually
+ * reaches a sink: as a value under some other key, or interpolated into the
+ * MESSAGE string. A whole-call capture sees both. Mirrors the harness in
+ * `brain/ingest/__tests__/zoom-connector.test.ts`, which pins the same class
+ * on the same kind of blob.
+ *
+ * `scrubErrSerializer` is passed through as identity here deliberately: this
+ * suite is asserting what the STORE hands the logger, not what pino would
+ * then do with it. The real serializer's behaviour is `logger.test.ts`'s.
+ */
+const LOG_CALLS: unknown[][] = [];
+function createCapturingLogger(): Record<string, (...args: unknown[]) => void> {
+  const record =
+    (level: string) =>
+    (...args: unknown[]): void => {
+      LOG_CALLS.push([level, ...args]);
+    };
+  return {
+    trace: record("trace"),
+    debug: record("debug"),
+    info: record("info"),
+    warn: record("warn"),
+    error: record("error"),
+    fatal: record("fatal"),
+  };
+}
+void mock.module("@atlas/api/lib/logger", () => ({
+  ACTOR_KINDS: ["human", "agent", "mcp", "scheduler", "api_key"] as const,
+  withRequestContext: <T,>(_ctx: unknown, fn: () => T) => fn(),
+  getRequestContext: () => undefined,
+  redactPaths: [] as string[],
+  scrubErrSerializer: (value: unknown) => value,
+  scrubLogFormatter: (value: unknown) => value,
+  getLogger: () => createCapturingLogger(),
+  createLogger: () => createCapturingLogger(),
+  hashShareToken: (token: string) => token,
+  setLogLevel: () => true,
+}));
+
 type StoreModule = typeof import("../store");
 let store!: StoreModule;
 
@@ -43,6 +85,7 @@ beforeEach(() => {
   delete process.env.BETTER_AUTH_SECRET;
   _resetEncryptionKeyCache();
   mockInternalQuery.mockClear();
+  LOG_CALLS.length = 0;
 });
 
 afterEach(() => {
@@ -128,6 +171,79 @@ describe("readCredentialBundle", () => {
     );
 
     await expect(store.readCredentialBundle(WSID, CATALOG_ID)).rejects.toThrow();
+  });
+
+  describe("a row that decrypts cleanly but is not JSON (#4984)", () => {
+    /**
+     * Store a plaintext blob that is NOT JSON, encrypted under a live key, so
+     * `decryptSecret` succeeds and `JSON.parse` is the thing that fails. That
+     * is the reachable case: a hand-repaired row, a LEGACY PLAINTEXT secret
+     * that was never JSON, or a partial decrypt. The AES-GCM auth tag rules
+     * out "decrypted to garbage", which is why that was never the danger.
+     *
+     * ⚠️ DELIMITER-FREE on purpose. JSC's parse error echoes only the leading
+     * IDENTIFIER, which stops at the first `-`, so a realistic `xoxb-<secret>`
+     * shaped token leaks just its public prefix and a fragment assertion on it
+     * passes against the bug. An opaque token leaks in FULL — that is the worst
+     * case and the one worth pinning. Verified empirically under bun/JSC; the
+     * sibling operator-credentials suite was vacuous for exactly this reason
+     * before it was caught by mutation.
+     */
+    const LEGACY_PLAINTEXT_SECRET = "s3cr3tPassw0rdNotJson";
+
+    async function readNonJsonRow(): Promise<unknown> {
+      const { encryptSecret } = await import("@atlas/api/lib/db/secret-encryption");
+      mockInternalQuery.mockImplementationOnce(() =>
+        Promise.resolve([
+          {
+            credentials_encrypted: encryptSecret(LEGACY_PLAINTEXT_SECRET),
+            credentials_key_version: 1,
+          },
+        ]),
+      );
+      return store.readCredentialBundle(WSID, CATALOG_ID).catch((err: unknown) => err);
+    }
+
+    it("⭐ logs no derivative of the decrypted plaintext", async () => {
+      await readNonJsonRow();
+
+      expect(LOG_CALLS.length).toBeGreaterThan(0);
+      const written = JSON.stringify(LOG_CALLS);
+      expect(written).not.toContain(LEGACY_PLAINTEXT_SECRET);
+      // Not merely absent as a whole. `JSON.parse`'s message leaks a LEADING
+      // FRAGMENT — under bun/JSC, `JSON Parse error: Unexpected identifier
+      // "s3cr3t"` — so a test asserting only on the full value passes against
+      // the bug it exists to catch.
+      expect(written).not.toContain("s3cr3t");
+      // MUTATION THIS CATCHES: restoring `err: err instanceof Error ?
+      // err.message : String(err)` to the catch's log payload.
+    });
+
+    it("⭐ still names WHICH row failed — over-redaction is the opposite bug", async () => {
+      await readNonJsonRow();
+
+      const written = JSON.stringify(LOG_CALLS);
+      expect(written).toContain(WSID);
+      expect(written).toContain(CATALOG_ID);
+      // …and the identifiers do not buy back the payload.
+      expect(written).not.toContain("s3cr3t");
+      // MUTATION THIS CATCHES: "fixing" the leak by logging `{}` — which
+      // leaves an operator on a fleet with "a credential is unreadable" and no
+      // way to tell whose. #4983's Zoom fix had to state this the same way.
+    });
+
+    it("throws an error carrying no cause chain back to the parse failure", async () => {
+      const err = await readNonJsonRow();
+
+      expect(err).toBeInstanceOf(Error);
+      // The thrown message is composed from identifiers only, so it is safe —
+      // but `cause` would re-attach the parse error whose message holds the
+      // secret. Today no 500 renderer and no log serializer walks a cause
+      // chain (verified in #4984); this asserts we do not DEPEND on that.
+      expect((err as Error).cause).toBeUndefined();
+      expect(JSON.stringify((err as Error).message)).not.toContain("s3cr3t");
+      // MUTATION THIS CATCHES: restoring `{ cause: err }` on the throw.
+    });
   });
 });
 

--- a/packages/api/src/lib/integrations/credentials/store.ts
+++ b/packages/api/src/lib/integrations/credentials/store.ts
@@ -138,20 +138,40 @@ export async function readCredentialBundle(
   const plaintext = decryptSecret(rows[0].credentials_encrypted);
   try {
     return JSON.parse(plaintext) as CredentialBundle;
-  } catch (err) {
-    // AES-GCM auth-tag verification makes "decrypted to garbage" highly
-    // unlikely, but a JSON.parse failure on a row that decrypted
-    // successfully is data corruption (or a key-version drift that
-    // produced wrong-but-plausible bytes). Surface workspace + catalog
-    // so log search can locate the row; let the caller propagate so the
-    // route returns a 500 with `requestId`.
+  } catch {
+    // No `// intentionally ignored:` marker — that marker is for a catch that
+    // emits NO signal, and this one logs and throws below. What is discarded
+    // is the error OBJECT, deliberately:
+    //
+    // the parse error's MESSAGE echoes its input, and the input here is the
+    // DECRYPTED credential bundle. `JSON.parse("s3cr3t-value")` throws
+    // `JSON Parse error: Unexpected identifier "s3cr3t"` (verified empirically
+    // under bun/JSC). Excluding `plaintext` from the log payload is NOT enough
+    // — which is what the previous version of this catch got wrong: it logged
+    // `err.message` while withholding the payload, and shipped a fragment of a
+    // real secret to the log sink. `brain/ingest/zoom/connector.ts` and
+    // `auth/load-test-tokens.ts` reached this conclusion independently; this is
+    // the same class on the same kind of blob (#4984).
+    //
+    // The AES-GCM auth tag makes "decrypted to garbage" unlikely, and that is
+    // not the dangerous case. The dangerous ones are a hand-repaired row, a
+    // LEGACY PLAINTEXT secret that was never JSON, or a partial decrypt — in
+    // all three the parse error echoes a live secret verbatim.
+    //
+    // `cause` is omitted for the same reason. Today's `scrubErrSerializer`
+    // emits only `{type, message, stack}` plus the `code`/`constraint`
+    // whitelist, so a cause chain does not currently reach a log line and no
+    // 500 renderer serializes one — but that is a property of the current
+    // serializer, not a contract, and this is the wrong place to depend on it.
+    //
+    // The identifiers stay: withholding them too would leave an operator with
+    // "a credential is unreadable" across a fleet and no way to tell whose.
     log.error(
-      { workspaceId, catalogId, err: err instanceof Error ? err.message : String(err) },
-      "Decrypted integration_credentials payload did not parse as JSON",
+      { workspaceId, catalogId },
+      "Decrypted integration_credentials payload did not parse as JSON — the row is corrupt or holds a legacy non-JSON secret; re-save this integration's credentials to repair it",
     );
     throw new Error(
       `integration_credentials JSON.parse failed for (workspace=${workspaceId}, catalog=${catalogId})`,
-      { cause: err },
     );
   }
 }

--- a/packages/api/src/lib/integrations/operator-credentials/__tests__/store.test.ts
+++ b/packages/api/src/lib/integrations/operator-credentials/__tests__/store.test.ts
@@ -29,6 +29,41 @@ void mock.module("@atlas/api/lib/db/internal", () => ({
   getInternalDB: mock(() => ({ query: mock(() => Promise.resolve({ rows: [] })) })),
 }));
 
+/**
+ * Capture every argument of every log call (#4984) — a payload-field assertion
+ * would miss a secret interpolated into the message string. Same harness as
+ * `credentials/__tests__/store.test.ts`, pinning the same class on the sibling
+ * store.
+ */
+const LOG_CALLS: unknown[][] = [];
+function createCapturingLogger(): Record<string, (...args: unknown[]) => void> {
+  const record =
+    (level: string) =>
+    (...args: unknown[]): void => {
+      LOG_CALLS.push([level, ...args]);
+    };
+  return {
+    trace: record("trace"),
+    debug: record("debug"),
+    info: record("info"),
+    warn: record("warn"),
+    error: record("error"),
+    fatal: record("fatal"),
+  };
+}
+void mock.module("@atlas/api/lib/logger", () => ({
+  ACTOR_KINDS: ["human", "agent", "mcp", "scheduler", "api_key"] as const,
+  withRequestContext: <T,>(_ctx: unknown, fn: () => T) => fn(),
+  getRequestContext: () => undefined,
+  redactPaths: [] as string[],
+  scrubErrSerializer: (value: unknown) => value,
+  scrubLogFormatter: (value: unknown) => value,
+  getLogger: () => createCapturingLogger(),
+  createLogger: () => createCapturingLogger(),
+  hashShareToken: (token: string) => token,
+  setLogLevel: () => true,
+}));
+
 type StoreModule = typeof import("../store");
 let store!: StoreModule;
 
@@ -44,6 +79,7 @@ beforeEach(() => {
   delete process.env.BETTER_AUTH_SECRET;
   _resetEncryptionKeyCache();
   mockInternalQuery.mockClear();
+  LOG_CALLS.length = 0;
 });
 
 afterEach(() => {
@@ -155,6 +191,86 @@ describe("readOperatorCredentials", () => {
     );
 
     await expect(store.readOperatorCredentials(PLATFORM)).rejects.toThrow(/validation failed/);
+  });
+
+  describe("a row that decrypts cleanly but is not JSON (#4984)", () => {
+    /**
+     * The sibling of `credentials/store.ts`'s leak, found by the same grep.
+     * `parseBundle` wrapped BOTH the JSON parse and the Zod shape check in one
+     * catch that logged `err.message` — and only one of those two errors can
+     * echo a secret. They are split so the shape arm keeps its diagnostic.
+     *
+     * ⚠️ The fixture is DELIMITER-FREE on purpose, and the first draft of this
+     * test was vacuous for want of that. JSC's message echoes only the leading
+     * IDENTIFIER, which ends at the first `-`: a realistic `xoxb-<secret>` token
+     * leaks just `"xoxb"` — a public prefix — and an assertion on any
+     * secret-bearing fragment of it passes against the bug. An opaque
+     * delimiter-free token leaks in FULL, so that is what this pins. (Verified
+     * empirically against bun/JSC rather than assumed.)
+     */
+    const LEGACY_PLAINTEXT_SECRET = "s3cr3tSlackSigningValueNotJson";
+
+    async function readNonJsonRow(): Promise<unknown> {
+      const { encryptSecret } = await import("@atlas/api/lib/db/secret-encryption");
+      mockInternalQuery.mockImplementationOnce(() =>
+        Promise.resolve([
+          {
+            credentials_encrypted: encryptSecret(LEGACY_PLAINTEXT_SECRET),
+            credentials_key_version: 1,
+          },
+        ]),
+      );
+      return store.readOperatorCredentials(PLATFORM).catch((err: unknown) => err);
+    }
+
+    it("⭐ logs no derivative of the decrypted plaintext, but still names the platform", async () => {
+      await readNonJsonRow();
+
+      expect(LOG_CALLS.length).toBeGreaterThan(0);
+      const written = JSON.stringify(LOG_CALLS);
+      expect(written).not.toContain(LEGACY_PLAINTEXT_SECRET);
+      // The leading fragment is what `JSON.parse`'s message actually carries.
+      expect(written).not.toContain("s3cr3t");
+      // Over-redaction is the opposite bug: the platform is not a secret and
+      // is the only thing that locates the row.
+      expect(written).toContain(PLATFORM);
+    });
+
+    it("throws with no cause chain back to the parse failure", async () => {
+      const err = await readNonJsonRow();
+
+      expect(err).toBeInstanceOf(Error);
+      expect((err as Error).cause).toBeUndefined();
+      expect((err as Error).message).not.toContain("s3cr3t");
+    });
+
+    it("⭐ the SHAPE arm keeps a diagnostic — the split is not a blanket redaction", async () => {
+      // The whole point of splitting the two catches. `z.record(z.string(),
+      // z.string())` issues carry the PATH (an env-var name, not a secret) and
+      // an `invalid_type` code naming the received TYPE — never the value. A
+      // fix that dropped diagnostics from BOTH arms would pass every assertion
+      // above and lose this.
+      const { encryptSecret } = await import("@atlas/api/lib/db/secret-encryption");
+      mockInternalQuery.mockImplementationOnce(() =>
+        Promise.resolve([
+          {
+            credentials_encrypted: encryptSecret(
+              JSON.stringify({ SLACK_CLIENT_ID: 1234, SLACK_CLIENT_SECRET: "fine" }),
+            ),
+            credentials_key_version: 1,
+          },
+        ]),
+      );
+
+      await expect(store.readOperatorCredentials(PLATFORM)).rejects.toThrow(/validation failed/);
+
+      const written = JSON.stringify(LOG_CALLS);
+      expect(written).toContain("SLACK_CLIENT_ID");
+      expect(written).toContain("invalid_type");
+      // The offending VALUE is never logged, even though it is the thing that
+      // failed — and neither is the sibling key's value.
+      expect(written).not.toContain("fine");
+    });
   });
 });
 

--- a/packages/api/src/lib/integrations/operator-credentials/store.ts
+++ b/packages/api/src/lib/integrations/operator-credentials/store.ts
@@ -184,23 +184,48 @@ export async function deleteOperatorCredentials(platform: string): Promise<boole
 
 function parseBundle(platform: string, ciphertext: string): OperatorCredentialBundle {
   const plaintext = decryptSecret(ciphertext);
+  // The JSON parse and the SHAPE validation are split into two catches on
+  // purpose, because only one of them can echo a secret (#4984).
+  //
+  // `JSON.parse`'s error message embeds its input — `JSON.parse("s3cr3t")`
+  // throws `JSON Parse error: Unexpected identifier "s3cr3t"` — and the input
+  // here is the DECRYPTED operator bundle. So this arm logs the platform and
+  // nothing derived from the plaintext, and omits `cause` rather than trusting
+  // that no current log serializer or 500 renderer walks a cause chain.
+  let parsed: unknown;
   try {
-    const parsed = JSON.parse(plaintext) as unknown;
+    parsed = JSON.parse(plaintext);
+  } catch {
+    log.error(
+      { platform },
+      "Decrypted operator_integration_credentials payload did not parse as JSON — the row is corrupt or holds a legacy non-JSON secret; re-save this platform's operator credentials to repair it",
+    );
+    throw new Error(
+      `operator_integration_credentials JSON.parse failed for platform=${platform}`,
+    );
+  }
+  try {
     // Validate the shape (string→string map), not just "is an object" — a
     // mistyped value is corruption and must fail loud here, not silently get
     // dropped by a downstream `typeof` guard.
     return OperatorCredentialBundleSchema.parse(parsed);
   } catch (err) {
-    // AES-GCM auth-tag verification makes "decrypted to garbage" highly
-    // unlikely; a parse/shape failure on a row that decrypted cleanly is data
-    // corruption (or key-version drift producing wrong-but-plausible bytes).
+    // This arm CAN keep a diagnostic, because the schema is
+    // `z.record(z.string(), z.string())`: a Zod issue on it carries the PATH
+    // (the env-var name, which is not a secret) and an `invalid_type` code
+    // naming the received TYPE — never the received value. The issue list is
+    // lifted explicitly rather than logging `err.message`, so that stays true
+    // if the schema later grows a refinement whose message would echo a value.
+    const issues =
+      err instanceof z.ZodError
+        ? err.issues.map((i) => ({ path: i.path.join("."), code: i.code }))
+        : undefined;
     log.error(
-      { platform, err: err instanceof Error ? err.message : String(err) },
-      "Decrypted operator_integration_credentials payload did not parse as a string→string map",
+      { platform, issues },
+      "Decrypted operator_integration_credentials payload is not a string→string map",
     );
     throw new Error(
       `operator_integration_credentials payload validation failed for platform=${platform}`,
-      { cause: err },
     );
   }
 }


### PR DESCRIPTION
Closes #4984.

`readCredentialBundle` logged `err.message` from a `JSON.parse` whose input is the **decrypted** credential bundle. Excluding the payload from the log object is not enough — the parse error's message embeds its input — so a row holding a legacy plaintext secret shipped that secret to the log sink verbatim. Same class #4983 fixed for Zoom, one file outside that diff.

## Scope, confirmed rather than assumed

The issue's open AC was *"confirm whether `cause` is serialized on any 500 path."* It is not:

- `app.onError` (`api/index.ts:741`) and `runHandler`'s defect arm (`lib/effect/hono.ts`) both render a fixed message + `requestId`.
- `scrubErrSerializer` emits `{type, message, stack}` plus the `code`/`constraint` whitelist — it **never walks `cause`**. Verified empirically, not by reading.
- The three sites that do walk `.cause` read codes for classification and render nothing.

**So this was a log-sink leak, not customer-facing disclosure** — the severity should be read that way. `cause` is dropped anyway: that's a property of today's serializer, not a contract, and a secret is the wrong thing to leave depending on one.

## What changed

| File | Change |
|---|---|
| `integrations/credentials/store.ts` | The reported instance. Logs `{workspaceId, catalogId}` only; no `cause` on the throw |
| `integrations/operator-credentials/store.ts` | **The third instance** the grep AC asked for — see below |
| `auth/load-test-tokens.ts` | Comment only — it documented a mechanism this repo does not have |

`operator-credentials`'s `parseBundle` wrapped **both** the JSON parse and the Zod shape check in one catch, but only one of them can echo a secret. Splitting them keeps the shape diagnostic: `z.record(z.string(), z.string())` issues carry the PATH (an env-var name, not a secret) and an `invalid_type` code naming the received TYPE, never the value. The issue list is lifted explicitly rather than logging `err.message`, so that stays true if the schema later grows a refinement whose message would echo a value.

`load-test-tokens.ts` already had the right fix but justified it with *"pino's err serializer walks the cause chain."* False for this repo's custom serializer. Left standing, it teaches the next author to rely on something that isn't there.

**`twenty/store.ts` is not an instance** — its catch wraps `decryptSecret`, whose errors are crypto-layer messages, not plaintext echoes.

## ⚠️ The first operator test was vacuous, and the mutation is what caught it

The mutation *survived*, which normally means the mutation was unfaithful. It wasn't — the **fixture** was wrong. I'd used a realistic `xoxb-s3cr3tSlackToken-not-json`, but JSC's parse error echoes only the leading **identifier**, which stops at the first `-`. The leak was `"xoxb"` — a public prefix — so the fragment assertion passed against the live bug.

Both fixtures are now delimiter-free, the worst case, where the secret leaks in **full**:

```
"xoxb-s3cr3tSlackToken-not-json" => Unexpected identifier "xoxb"
"s3cr3tSlackSigningValueNotJson" => Unexpected identifier "s3cr3tSlackSigningValueNotJson"
```

**The severity is shape-dependent** — a delimited token (`xoxb-…`, `sk-…`) leaks its public prefix; an opaque one leaks entirely. The issue's framing didn't distinguish these. Recorded in both test files.

## Verification

Six mutations, each caught by the test written for it — restore `err.message` (both stores), restore `cause` (both stores), over-redact to `{}` (the opposite failure: an operator on a fleet learns a credential is unreadable and not whose), and blanket-redact the shape arm.

`scripts/ci-local.sh` — **33/33 gates PASS** with `TEST_DATABASE_URL` set, so the `-pg` suites genuinely ran rather than skipping. 41/41 affected suites, `bun run type` clean, `bun run lint` zero errors.

https://claude.ai/code/session_01N18FhaaoVZ56P7GXncHNZq