### PR TITLE
fix(web): count only OPEN conflicts in the brain-facts "in tension (N)" badge

### DIFF
--- a/packages/web/src/app/admin/brain-facts/__tests__/review-honesty.test.tsx
+++ b/packages/web/src/app/admin/brain-facts/__tests__/review-honesty.test.tsx
@@ -854,9 +854,12 @@ describe("the list shows the trust signals without a click", () => {
  * A live tension counterpart. Overrides stamp the lifecycle axes on top.
  *
  * Introduced for the block below; the #4935 fixtures further down hand-roll the
- * same object and are left alone deliberately — re-pointing them here would
- * flip `status` from "draft" to this helper's "published" and quietly gut the
- * assertion they exist for ("retraction never writes `status`").
+ * same object and are left alone. One of them has to be: the WITHDRAWN fixture
+ * carries `status: "draft"` as its whole PREMISE — "retraction never writes
+ * `status`, so a retracted rival still reports Draft" — and no assertion pins
+ * it, so this helper's "published" default would erase the premise while every
+ * assertion in that test stayed green. The other three already carry
+ * "published" and are left hand-rolled only for symmetry with it.
  *
  * Distinct `factId`s are hygiene for the sheet, which keys its cards
  * `${edgeDirection}-${factId}` — nothing dedupes the count, which is a plain

--- a/packages/web/src/app/admin/brain-facts/__tests__/review-honesty.test.tsx
+++ b/packages/web/src/app/admin/brain-facts/__tests__/review-honesty.test.tsx
@@ -852,9 +852,15 @@ describe("the list shows the trust signals without a click", () => {
 /**
  * A live tension counterpart. Overrides stamp the lifecycle axes on top.
  *
- * Distinct `factId`s matter: the surfaces key rivals by id, so three fixtures
- * sharing one id would collapse and the count assertions would pass for the
- * wrong reason.
+ * Introduced for the block below; the #4935 fixtures further down hand-roll the
+ * same object and are left alone deliberately — they predate this helper and
+ * pin the SHEET, so re-pointing them would put a count-focused fixture under
+ * label assertions.
+ *
+ * Distinct `factId`s are hygiene for the sheet, which keys its cards
+ * `${edgeDirection}-${factId}` — nothing dedupes the count, which is a plain
+ * array length, so a shared id would not hide a miscount. It would produce
+ * duplicate React keys in any test that opens the sheet.
  */
 function rival(factId: string, overrides: Record<string, unknown> = {}) {
   return {
@@ -878,10 +884,19 @@ function rival(factId: string, overrides: Record<string, unknown> = {}) {
 /**
  * The QUEUE ROW's own text.
  *
- * Scoped to `tbody` on purpose: the page chrome carries an "In tension only"
- * filter button and an "N in tension" stat tile, both of which are edge-existence
- * signals this fix deliberately leaves alone. A container-wide assertion on the
- * badge's own words would therefore pass whatever the row renders.
+ * Scoped to `tbody` because the page chrome carries an "In tension only" filter
+ * button (`page.tsx`), which is an edge-existence signal this fix deliberately
+ * leaves alone. Unscoped, the button breaks the assertions in BOTH directions:
+ * the negative — the one #4961's acceptance criteria actually demand — would
+ * fail no matter what the row renders, and the positives would pass with the
+ * flags cell deleted outright. (The "N in tension" stat tile does not collide:
+ * it renders lowercase against case-sensitive `toContain`.)
+ *
+ * `querySelector` takes the FIRST tbody, which is the queue's only because the
+ * oversight panel above it — whose table has an "In tension" header — is a
+ * `Collapsible` that defaults to closed and does not `forceMount`. Every caller
+ * below renders exactly one candidate, so "the tbody" and "the row" coincide;
+ * a multi-row fixture would need an index.
  */
 function rowText(view: { container: HTMLElement }): string {
   return view.container.querySelector("tbody")?.textContent ?? "";
@@ -902,6 +917,11 @@ describe("the queue counts OPEN conflicts, not settled ones (#4961)", () => {
       }),
     ]);
     const text = rowText(view);
+    // The row rendered at all — every other assertion here is a negative, and
+    // `rowText` answers "" for a missing tbody, so without this anchor the one
+    // test #4961's acceptance criteria demand is the one that could pass
+    // vacuously if the table markup ever changed.
+    expect(text).toContain("Postgres");
     expect(text).not.toContain("In tension");
     expect(text).not.toContain("(2)");
   });
@@ -911,6 +931,10 @@ describe("the queue counts OPEN conflicts, not settled ones (#4961)", () => {
     // is still why the claim was contested; dropping it from the sheet would
     // read as "nothing ever contradicted this", and the reviewer would lose the
     // evidence that the conflict was resolved rather than absent.
+    //
+    // Overlaps "labels a WITHDRAWN rival" below, deliberately: that one pins
+    // #4935's badge, this one pins that #4961 did not reach the sheet's list at
+    // all. Same fixture, different regression — keep both.
     const view = await renderPage([
       candidate({ tensions: [rival("fact-2", { invalidatedAt: ISO })] }),
     ]);
@@ -936,10 +960,43 @@ describe("the queue counts OPEN conflicts, not settled ones (#4961)", () => {
     ]);
     const text = rowText(view);
     expect(text).toContain("In tension");
-    // Singular — one open rival, so the badge carries no number at all.
-    expect(text).not.toContain("(3)");
-    expect(text).not.toContain("(2)");
-    expect(text).not.toContain("(1)");
+    // Singular — one open rival, so the badge carries no parenthetical at all.
+    // Stated as the pattern rather than as "not (3), not (2), not (1)", which
+    // would miss a count of four and any future "(1 of 3)" spelling.
+    expect(text).not.toMatch(/In tension \(/);
+  });
+
+  test("counts a rival retired on BOTH axes exactly once", async () => {
+    // Supersede-then-retract is reachable. The discriminating case for an
+    // implementation that subtracts per axis rather than testing per rival:
+    // `2 - withdrawn(1) - superseded(1)` is 0 and drops the badge, while every
+    // other fixture in this block yields the right number either way.
+    const view = await renderPage([
+      candidate({
+        tensions: [
+          rival("fact-2"),
+          rival("fact-3", { invalidatedAt: ISO, validTo: ISO }),
+        ],
+      }),
+    ]);
+    const text = rowText(view);
+    expect(text).toContain("In tension");
+    expect(text).not.toMatch(/In tension \(/);
+  });
+
+  test("keeps the truncation banner when the surviving rivals are all settled", async () => {
+    // The combination this fix makes newly reachable. The fan-out cap is
+    // applied page-wide in edge-id order, so a row can arrive holding only
+    // SOME of its rivals; if the ones that arrived are settled, the row now
+    // renders completely quiet while open rivals sit beyond the cap. The
+    // page-level banner is the whole of what is left to warn the reviewer, so
+    // it is asserted together with the badge's absence rather than apart.
+    const view = await renderPage(
+      [candidate({ tensions: [rival("fact-2", { invalidatedAt: ISO })] })],
+      { tensionsTruncated: true },
+    );
+    expect(rowText(view)).not.toContain("In tension");
+    expect(view.container.textContent).toContain("more conflicting claims than Atlas can show");
   });
 
   test("counts a rival whose window has not CLOSED yet", async () => {
@@ -972,8 +1029,8 @@ describe("the queue counts OPEN conflicts, not settled ones (#4961)", () => {
     const text = rowText(view);
     expect(text).toContain("In tension");
     // The settled rival beside it is still excluded — the withheld one is the
-    // only thing holding the badge up.
-    expect(text).not.toContain("(2)");
+    // only thing holding the badge up, so the badge is singular.
+    expect(text).not.toMatch(/In tension \(/);
   });
 });
 
@@ -1093,8 +1150,9 @@ describe("truncation is admitted", () => {
     // The axes are distinct verbs and must not share a badge.
     expect(document.body.textContent).not.toContain("Superseded");
     // The strike-through, which predates #4935 but whose condition #4935
-    // widened to `withdrawn || superseded`. Unasserted, the retraction arm can
-    // be dropped while the supersession fixture keeps every test green.
+    // widened to both axes — spelled `!isTensionOpen(tension)` since #4961
+    // moved it into `tension-state.ts`. Unasserted, the retraction arm can be
+    // dropped while the supersession fixture keeps every test green.
     expect(document.querySelector(".line-through")?.textContent).toContain("MySQL");
   });
 

--- a/packages/web/src/app/admin/brain-facts/__tests__/review-honesty.test.tsx
+++ b/packages/web/src/app/admin/brain-facts/__tests__/review-honesty.test.tsx
@@ -849,6 +849,134 @@ describe("the list shows the trust signals without a click", () => {
   });
 });
 
+/**
+ * A live tension counterpart. Overrides stamp the lifecycle axes on top.
+ *
+ * Distinct `factId`s matter: the surfaces key rivals by id, so three fixtures
+ * sharing one id would collapse and the count assertions would pass for the
+ * wrong reason.
+ */
+function rival(factId: string, overrides: Record<string, unknown> = {}) {
+  return {
+    visible: true,
+    factId,
+    edgeDirection: "to",
+    subject: "Acme",
+    predicate: "uses",
+    object: "MySQL",
+    status: "published",
+    validFrom: null,
+    validTo: null,
+    ingestedAt: ISO,
+    invalidatedAt: null,
+    corroborationCount: 1,
+    provenance: PROVENANCE,
+    ...overrides,
+  };
+}
+
+/**
+ * The QUEUE ROW's own text.
+ *
+ * Scoped to `tbody` on purpose: the page chrome carries an "In tension only"
+ * filter button and an "N in tension" stat tile, both of which are edge-existence
+ * signals this fix deliberately leaves alone. A container-wide assertion on the
+ * badge's own words would therefore pass whatever the row renders.
+ */
+function rowText(view: { container: HTMLElement }): string {
+  return view.container.querySelector("tbody")?.textContent ?? "";
+}
+
+describe("the queue counts OPEN conflicts, not settled ones (#4961)", () => {
+  test("renders NO tension count on a row whose rivals are ALL settled", async () => {
+    // THE negative, and the shipped bug: nothing deletes an `in-tension-with`
+    // edge when a human arbitrates, so a fully resolved row kept wearing "In
+    // tension (2)" — an unresolved-looking row with nothing left to resolve.
+    // One rival per axis, because the count must fall to zero on both.
+    const view = await renderPage([
+      candidate({
+        tensions: [
+          rival("fact-2", { invalidatedAt: ISO }),
+          rival("fact-3", { validTo: ISO }),
+        ],
+      }),
+    ]);
+    const text = rowText(view);
+    expect(text).not.toContain("In tension");
+    expect(text).not.toContain("(2)");
+  });
+
+  test("still SHOWS those settled rivals in the sheet — the count changed, not the record", async () => {
+    // The over-correction this fix must not become. A rival that was withdrawn
+    // is still why the claim was contested; dropping it from the sheet would
+    // read as "nothing ever contradicted this", and the reviewer would lose the
+    // evidence that the conflict was resolved rather than absent.
+    const view = await renderPage([
+      candidate({ tensions: [rival("fact-2", { invalidatedAt: ISO })] }),
+    ]);
+    fireEvent.click(view.container.querySelectorAll("tbody tr")[0]!);
+    await waitFor(() => expect(document.body.textContent).toContain("Conflicting claims"));
+    const text = document.body.textContent ?? "";
+    expect(text).toContain("MySQL");
+    expect(text).toContain("Withdrawn");
+  });
+
+  test("counts only the open rival when a row is PARTLY arbitrated", async () => {
+    // Three rivals, one still open. A fix that merely dropped the badge when
+    // every rival was settled would pass the negative above and fail here; so
+    // would one that kept counting the settled two.
+    const view = await renderPage([
+      candidate({
+        tensions: [
+          rival("fact-2"),
+          rival("fact-3", { invalidatedAt: ISO }),
+          rival("fact-4", { validTo: ISO }),
+        ],
+      }),
+    ]);
+    const text = rowText(view);
+    expect(text).toContain("In tension");
+    // Singular — one open rival, so the badge carries no number at all.
+    expect(text).not.toContain("(3)");
+    expect(text).not.toContain("(2)");
+    expect(text).not.toContain("(1)");
+  });
+
+  test("counts a rival whose window has not CLOSED yet", async () => {
+    // `valid_to` non-null is not retirement: `brainFactCurrentClause` is
+    // `valid_to IS NULL OR valid_to > now()`, so a future-dated stamp is a live
+    // rival whose end is merely scheduled. Suppressing the badge for it would
+    // hide an open conflict — worse than the bug being fixed.
+    const future = new Date(Date.now() + 86_400_000).toISOString();
+    const view = await renderPage([
+      candidate({
+        tensions: [rival("fact-2", { validTo: future }), rival("fact-3", { validTo: future })],
+      }),
+    ]);
+    expect(rowText(view)).toContain("In tension (2)");
+  });
+
+  test("counts a rival the reviewer is not allowed to SEE", async () => {
+    // A withheld rival carries no lifecycle stamps — they are exactly what the
+    // ACL refused to hand over. Inferring "settled" from their absence would be
+    // the guess that suppresses the badge, and "there is a rival you cannot
+    // see" is precisely what should stop a reviewer approving.
+    const view = await renderPage([
+      candidate({
+        tensions: [
+          { visible: false, factId: "fact-2", edgeDirection: "to" },
+          rival("fact-3", { invalidatedAt: ISO }),
+        ],
+      }),
+    ]);
+    const text = rowText(view);
+    expect(text).toContain("In tension");
+    // The settled rival beside it is still excluded — the withheld one is the
+    // only thing holding the badge up.
+    expect(text).not.toContain("(2)");
+  });
+});
+
 describe("a broken queue gates the publish-everything button", () => {
   test("disables Review & publish when the list failed to load", async () => {
     // Publishing is workspace-wide and independent of this ACL read, so an

--- a/packages/web/src/app/admin/brain-facts/__tests__/review-honesty.test.tsx
+++ b/packages/web/src/app/admin/brain-facts/__tests__/review-honesty.test.tsx
@@ -4,6 +4,7 @@ import { createElement, type ReactNode } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { NuqsAdapter } from "nuqs/adapters/next/app";
 import { AtlasProvider, type AtlasAuthClient } from "@/ui/context";
+import type { BrainFactTensionVisible } from "@/ui/lib/types";
 
 /**
  * What the review gate must SAY, not just fetch (#4772, ADR-0036).
@@ -853,16 +854,19 @@ describe("the list shows the trust signals without a click", () => {
  * A live tension counterpart. Overrides stamp the lifecycle axes on top.
  *
  * Introduced for the block below; the #4935 fixtures further down hand-roll the
- * same object and are left alone deliberately — they predate this helper and
- * pin the SHEET, so re-pointing them would put a count-focused fixture under
- * label assertions.
+ * same object and are left alone deliberately — re-pointing them here would
+ * flip `status` from "draft" to this helper's "published" and quietly gut the
+ * assertion they exist for ("retraction never writes `status`").
  *
  * Distinct `factId`s are hygiene for the sheet, which keys its cards
  * `${edgeDirection}-${factId}` — nothing dedupes the count, which is a plain
  * array length, so a shared id would not hide a miscount. It would produce
  * duplicate React keys in any test that opens the sheet.
  */
-function rival(factId: string, overrides: Record<string, unknown> = {}) {
+function rival(
+  factId: string,
+  overrides: Partial<BrainFactTensionVisible> = {},
+): BrainFactTensionVisible {
   return {
     visible: true,
     factId,
@@ -923,7 +927,13 @@ describe("the queue counts OPEN conflicts, not settled ones (#4961)", () => {
     // vacuously if the table markup ever changed.
     expect(text).toContain("Postgres");
     expect(text).not.toContain("In tension");
-    expect(text).not.toContain("(2)");
+    // The stats tile above is UNCHANGED — it asks edge existence server-side,
+    // so it still reports this row. Asserted together with the row's silence
+    // because the divergence is deliberate and load-bearing: a later
+    // "consistency fix" deriving the tile from the rows client-side would pass
+    // every other test in this file while undoing the separation of "has ever
+    // been contested" from "has anything left to resolve".
+    expect(view.container.textContent).toContain("1 in tension");
   });
 
   test("still SHOWS those settled rivals in the sheet — the count changed, not the record", async () => {
@@ -938,6 +948,12 @@ describe("the queue counts OPEN conflicts, not settled ones (#4961)", () => {
     const view = await renderPage([
       candidate({ tensions: [rival("fact-2", { invalidatedAt: ISO })] }),
     ]);
+    // Both surfaces off ONE payload — the cross-surface invariant that is the
+    // whole reason `tension-state.ts` exists. Asserted here rather than in a
+    // second fixture, because "the list is quiet AND the sheet still bears the
+    // record" is a single claim, and split across two renders nothing observes
+    // it.
+    expect(rowText(view)).not.toContain("In tension");
     fireEvent.click(view.container.querySelectorAll("tbody tr")[0]!);
     await waitFor(() => expect(document.body.textContent).toContain("Conflicting claims"));
     const text = document.body.textContent ?? "";
@@ -986,16 +1002,19 @@ describe("the queue counts OPEN conflicts, not settled ones (#4961)", () => {
 
   test("keeps the truncation banner when the surviving rivals are all settled", async () => {
     // The combination this fix makes newly reachable. The fan-out cap is
-    // applied page-wide in edge-id order, so a row can arrive holding only
-    // SOME of its rivals; if the ones that arrived are settled, the row now
-    // renders completely quiet while open rivals sit beyond the cap. The
-    // page-level banner is the whole of what is left to warn the reviewer, so
-    // it is asserted together with the badge's absence rather than apart.
+    // applied page-wide, ordered by the edges' ENDPOINT fact ids, so a row can
+    // arrive holding only SOME of its rivals; if the ones that arrived are
+    // settled, the row now renders completely quiet while open rivals sit
+    // beyond the cap. The page-level banner is the whole of what is left to
+    // warn the reviewer, so it is asserted together with the badge's absence
+    // rather than apart.
     const view = await renderPage(
       [candidate({ tensions: [rival("fact-2", { invalidatedAt: ISO })] })],
       { tensionsTruncated: true },
     );
-    expect(rowText(view)).not.toContain("In tension");
+    const text = rowText(view);
+    expect(text).toContain("Postgres");
+    expect(text).not.toContain("In tension");
     expect(view.container.textContent).toContain("more conflicting claims than Atlas can show");
   });
 

--- a/packages/web/src/app/admin/brain-facts/__tests__/tension-state.test.ts
+++ b/packages/web/src/app/admin/brain-facts/__tests__/tension-state.test.ts
@@ -7,9 +7,9 @@ import { isTensionOpen, isTensionSuperseded, isTensionWithdrawn } from "../tensi
  * the sheet's strike-through (#4961).
  *
  * Unit-level on purpose. `review-honesty.test.tsx` proves the two SURFACES
- * render what this decided; these pin the decision itself, including the arms
- * a render fixture reaches only awkwardly — a junk stamp, a stamp missing from
- * the payload, and both axes at once. The first two are documented in
+ * render what this decided; these pin the decision itself, including the two
+ * arms a render fixture cannot reach without the `drifted()` cast — a junk
+ * stamp and a stamp missing from the payload. Both are documented in
  * `tension-state.ts` as safety properties, and a documented safety property
  * that no test pins is one refactor from silently inverting.
  */
@@ -55,10 +55,13 @@ function visible(overrides: Partial<BrainFactTensionVisible> = {}): BrainFactTen
  * could only build well-typed inputs could not reach them at all.
  *
  * The keys are bound to the wire type through `Extract` rather than spelled as
- * free string literals. Renaming a stamp upstream then collapses this to
- * `never` and fails the call sites — where a free literal would leave the
- * spread setting a phantom property, the real field keeping its `null` from
- * `visible()`, and both drift tests passing while testing nothing.
+ * free string literals: renaming one stamp upstream narrows this to the
+ * SURVIVING key, and the call site passing the renamed one fails as an unknown
+ * property. A free literal would instead leave the spread setting a phantom
+ * property, the real field keeping its `null` from `visible()`, and both drift
+ * tests passing while testing nothing. (Renaming BOTH at once narrows to
+ * `never`, which `Partial<Record<…>>` widens back to `{}` — that case is not
+ * caught, and `visible()`'s typed literal is what fails instead.)
  */
 function drifted(
   stamps: Partial<

--- a/packages/web/src/app/admin/brain-facts/__tests__/tension-state.test.ts
+++ b/packages/web/src/app/admin/brain-facts/__tests__/tension-state.test.ts
@@ -9,8 +9,8 @@ import { isTensionOpen, isTensionSuperseded, isTensionWithdrawn } from "../tensi
  * Unit-level on purpose. `review-honesty.test.tsx` proves the two SURFACES
  * render what this decided; these pin the decision itself, including the arms
  * a render fixture reaches only awkwardly — a junk stamp, a stamp missing from
- * the payload, and both axes at once. Each of those is documented in
- * `tension-state.ts` as a safety property, and a documented safety property
+ * the payload, and both axes at once. The first two are documented in
+ * `tension-state.ts` as safety properties, and a documented safety property
  * that no test pins is one refactor from silently inverting.
  */
 
@@ -50,11 +50,21 @@ function visible(overrides: Partial<BrainFactTensionVisible> = {}): BrainFactTen
  * A payload that DRIFTED from the wire schema — a stamp the server stopped
  * sending, or sent as something other than a string.
  *
- * Cast because the whole point is a value the type forbids: these arms exist
- * for the surface with no runtime parse, and a test that could only build
- * well-typed inputs could not reach them at all.
+ * Cast because the whole point is a value the type forbids: the guards exist
+ * for exactly the inputs a well-typed fixture cannot express, so a test that
+ * could only build well-typed inputs could not reach them at all.
+ *
+ * The keys are bound to the wire type through `Extract` rather than spelled as
+ * free string literals. Renaming a stamp upstream then collapses this to
+ * `never` and fails the call sites — where a free literal would leave the
+ * spread setting a phantom property, the real field keeping its `null` from
+ * `visible()`, and both drift tests passing while testing nothing.
  */
-function drifted(stamps: { invalidatedAt?: unknown; validTo?: unknown }): BrainFactTensionVisible {
+function drifted(
+  stamps: Partial<
+    Record<Extract<keyof BrainFactTensionVisible, "invalidatedAt" | "validTo">, unknown>
+  >,
+): BrainFactTensionVisible {
   return { ...visible(), ...stamps } as BrainFactTensionVisible;
 }
 
@@ -70,6 +80,16 @@ describe("isTensionWithdrawn", () => {
     // live conflict. Every other arm in this module errs the other way, and so
     // must this one.
     expect(isTensionWithdrawn(drifted({ invalidatedAt: undefined }))).toBe(false);
+  });
+
+  test("treats an EMPTY or malformed stamp as not-retracted either", () => {
+    // `typeof === "string"` alone only moves the hazard from an absent field to
+    // an empty one — a serializer coalescing `null → ""` reads as a tombstone
+    // and suppresses the badge. Parseability is what makes this axis agree with
+    // the supersession axis, whose `NaN` comparison already falls through to
+    // open, so the module's "errs toward reporting" claim is true of both.
+    expect(isTensionWithdrawn(visible({ invalidatedAt: "" }))).toBe(false);
+    expect(isTensionWithdrawn(visible({ invalidatedAt: "n/a" }))).toBe(false);
   });
 });
 
@@ -90,9 +110,15 @@ describe("isTensionSuperseded", () => {
   test("treats an UNPARSEABLE stamp as still open", () => {
     // `Date.parse` yields NaN and every comparison with NaN is false, so this
     // falls through to live. Pinned because the equivalent-looking rewrite
-    // `!(ms === null || ms > Date.now())` inverts exactly this case and nothing
+    // `!(Date.parse(...) > Date.now())` inverts exactly this case and nothing
     // else — it would pass every render fixture in the suite.
     expect(isTensionSuperseded(visible({ validTo: "infinity" }))).toBe(false);
+  });
+
+  test("treats a MISSING stamp as still open", () => {
+    // A different arm from the one above, reached earlier: this returns at the
+    // `typeof` guard and never sees `Date.parse`. Separated so that removing
+    // either guard fails its own assertion.
     expect(isTensionSuperseded(drifted({ validTo: undefined }))).toBe(false);
   });
 });
@@ -130,6 +156,10 @@ describe("isTensionOpen", () => {
   test("is exactly the complement of the two axes the sheet badges", () => {
     // The invariant that stops the count and the strike-through drifting apart
     // — the whole reason this module exists rather than two inline copies.
+    // Fixture-bound, so it catches a change to EITHER existing axis but not a
+    // third one added to `isTensionOpen` with no matching sheet badge; a new
+    // axis has to join this list, which is the point at which someone notices
+    // the sheet needs a badge for it.
     for (const t of [
       visible(),
       visible({ invalidatedAt: PAST }),

--- a/packages/web/src/app/admin/brain-facts/__tests__/tension-state.test.ts
+++ b/packages/web/src/app/admin/brain-facts/__tests__/tension-state.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, test } from "bun:test";
+import type { BrainFactTensionVisible, BrainFactTensionView } from "@/ui/lib/types";
+import { isTensionOpen, isTensionSuperseded, isTensionWithdrawn } from "../tension-state";
+
+/**
+ * The lifecycle predicate behind the review queue's "In tension (N)" count and
+ * the sheet's strike-through (#4961).
+ *
+ * Unit-level on purpose. `review-honesty.test.tsx` proves the two SURFACES
+ * render what this decided; these pin the decision itself, including the arms
+ * a render fixture reaches only awkwardly — a junk stamp, a stamp missing from
+ * the payload, and both axes at once. Each of those is documented in
+ * `tension-state.ts` as a safety property, and a documented safety property
+ * that no test pins is one refactor from silently inverting.
+ */
+
+const PAST = "2026-07-01T00:00:00.000Z";
+const FUTURE = new Date(Date.now() + 86_400_000).toISOString();
+
+function visible(overrides: Partial<BrainFactTensionVisible> = {}): BrainFactTensionVisible {
+  return {
+    visible: true,
+    factId: "fact-2",
+    edgeDirection: "to",
+    subject: "Acme",
+    predicate: "uses",
+    object: "MySQL",
+    status: "published",
+    validFrom: null,
+    validTo: null,
+    ingestedAt: PAST,
+    invalidatedAt: null,
+    corroborationCount: 1,
+    provenance: {
+      source: "slack",
+      episodeId: "ep-1",
+      producer: "extraction:v1",
+      attribution: { visible: true, sourceId: "C1/17", actor: "U1", occurredAt: PAST },
+      extractedAt: PAST,
+      reconciledAt: PAST,
+      provisional: false,
+      unresolved: [],
+      payloadComplete: true,
+    },
+    ...overrides,
+  };
+}
+
+/**
+ * A payload that DRIFTED from the wire schema — a stamp the server stopped
+ * sending, or sent as something other than a string.
+ *
+ * Cast because the whole point is a value the type forbids: these arms exist
+ * for the surface with no runtime parse, and a test that could only build
+ * well-typed inputs could not reach them at all.
+ */
+function drifted(stamps: { invalidatedAt?: unknown; validTo?: unknown }): BrainFactTensionVisible {
+  return { ...visible(), ...stamps } as BrainFactTensionVisible;
+}
+
+describe("isTensionWithdrawn", () => {
+  test("is true only for a real retraction stamp", () => {
+    expect(isTensionWithdrawn(visible({ invalidatedAt: PAST }))).toBe(true);
+    expect(isTensionWithdrawn(visible({ invalidatedAt: null }))).toBe(false);
+  });
+
+  test("treats a MISSING stamp as not-retracted, not as retracted", () => {
+    // The arm whose naive spelling (`!== null`) fails toward silence: an absent
+    // field is `!== null`, so a drifted payload would suppress the badge on a
+    // live conflict. Every other arm in this module errs the other way, and so
+    // must this one.
+    expect(isTensionWithdrawn(drifted({ invalidatedAt: undefined }))).toBe(false);
+  });
+});
+
+describe("isTensionSuperseded", () => {
+  test("is true for a window that has CLOSED", () => {
+    expect(isTensionSuperseded(visible({ validTo: PAST }))).toBe(true);
+  });
+
+  test("is false for a window still open, stamped or not", () => {
+    // `brainFactCurrentClause` is `valid_to IS NULL OR valid_to > now()`, so a
+    // future-dated stamp — a region import can carry one — is a LIVE rival
+    // whose end is merely scheduled. Calling it settled would hide an open
+    // conflict, which is worse than the bug #4961 fixes.
+    expect(isTensionSuperseded(visible({ validTo: FUTURE }))).toBe(false);
+    expect(isTensionSuperseded(visible({ validTo: null }))).toBe(false);
+  });
+
+  test("treats an UNPARSEABLE stamp as still open", () => {
+    // `Date.parse` yields NaN and every comparison with NaN is false, so this
+    // falls through to live. Pinned because the equivalent-looking rewrite
+    // `!(ms === null || ms > Date.now())` inverts exactly this case and nothing
+    // else — it would pass every render fixture in the suite.
+    expect(isTensionSuperseded(visible({ validTo: "infinity" }))).toBe(false);
+    expect(isTensionSuperseded(drifted({ validTo: undefined }))).toBe(false);
+  });
+});
+
+describe("isTensionOpen", () => {
+  test("counts a rival the reader is not allowed to SEE", () => {
+    // Its stamps are exactly what the ACL refused to hand over. Inferring
+    // "settled" from their absence is the guess that suppresses the badge, and
+    // "there is a rival you cannot see" is precisely what should stop a
+    // reviewer approving.
+    const withheld: BrainFactTensionView = {
+      visible: false,
+      factId: "fact-2",
+      edgeDirection: "to",
+    };
+    expect(isTensionOpen(withheld)).toBe(true);
+  });
+
+  test("closes on EITHER axis, and on both at once", () => {
+    // Supersede-then-retract is reachable (the reverse is not), and the two are
+    // independent — an implementation that counted axes instead of testing them
+    // would double-subtract this rival.
+    expect(isTensionOpen(visible({ invalidatedAt: PAST }))).toBe(false);
+    expect(isTensionOpen(visible({ validTo: PAST }))).toBe(false);
+    expect(isTensionOpen(visible({ invalidatedAt: PAST, validTo: PAST }))).toBe(false);
+  });
+
+  test("leaves a live rival open", () => {
+    // The negative that keeps every assertion above from being satisfied by a
+    // predicate that simply always closes.
+    expect(isTensionOpen(visible())).toBe(true);
+    expect(isTensionOpen(visible({ validTo: FUTURE }))).toBe(true);
+  });
+
+  test("is exactly the complement of the two axes the sheet badges", () => {
+    // The invariant that stops the count and the strike-through drifting apart
+    // — the whole reason this module exists rather than two inline copies.
+    for (const t of [
+      visible(),
+      visible({ invalidatedAt: PAST }),
+      visible({ validTo: PAST }),
+      visible({ validTo: FUTURE }),
+      visible({ invalidatedAt: PAST, validTo: PAST }),
+    ]) {
+      expect(isTensionOpen(t)).toBe(!isTensionWithdrawn(t) && !isTensionSuperseded(t));
+    }
+  });
+});

--- a/packages/web/src/app/admin/brain-facts/candidate-detail.tsx
+++ b/packages/web/src/app/admin/brain-facts/candidate-detail.tsx
@@ -10,7 +10,13 @@ import { Badge } from "@/components/ui/badge";
 import { RelativeTimestamp } from "@/ui/components/admin/queue";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { AlertTriangle, Clock, ShieldAlert, Split } from "lucide-react";
-import { blockedBadge, decayBadge, provisionalBadge, statusBadge } from "./columns";
+import {
+  blockedBadge,
+  decayBadge,
+  provisionalBadge,
+  statusBadge,
+  tensionRetirement,
+} from "./columns";
 
 /**
  * The body of the review sheet — everything behind the trust call for one
@@ -180,21 +186,11 @@ function TensionCard({ tension }: { tension: BrainFactTensionView }) {
   }
 
   const badge = statusBadge[tension.status];
-  const withdrawn = tension.invalidatedAt !== null;
-  // A CLOSED window, not merely a stamped one. `brainFactCurrentClause` reads
-  // `valid_to IS NULL OR valid_to > now()`, so a future-dated `valid_to` — a
-  // region import (`admin-migrate.ts`) can carry one — is a LIVE fact whose
-  // end is merely scheduled. Badging that as settled would suppress a real
-  // conflict from the reviewer, the exact inverse of the bug this fixes, so
-  // the label uses the same boundary the database does.
-  //
-  // Against the CLIENT clock, accepted: within a skewed browser's offset of
-  // the supersession instant this can disagree with the server. The badge is
-  // advisory, never a gate. An unparseable stamp yields NaN, whose comparison
-  // is false, so it falls through to "live" — the recoverable direction, since
-  // over-reporting a conflict costs a second look and under-reporting hides one.
-  const validToMs = tension.validTo === null ? null : Date.parse(tension.validTo);
-  const superseded = validToMs !== null && validToMs <= Date.now();
+  // Shared with the list's "In tension" count, which counts exactly the rivals
+  // this card does NOT strike through — see `tensionRetirement` for why a
+  // closed window is not the same as a stamped one, and why the client clock
+  // is acceptable here (#4935, #4961).
+  const { withdrawn, superseded, settled } = tensionRetirement(tension);
   return (
     <div className="rounded-md border p-3 space-y-2">
       <div className="flex items-start justify-between gap-2">
@@ -203,7 +199,7 @@ function TensionCard({ tension }: { tension: BrainFactTensionView }) {
             distinction between the two verbs; the strike carries only "this is
             no longer the current claim". */}
         <p
-          className={`text-sm ${withdrawn || superseded ? "line-through decoration-muted-foreground" : ""}`}
+          className={`text-sm ${settled ? "line-through decoration-muted-foreground" : ""}`}
         >
           <span className="font-medium">{tension.subject}</span>{" "}
           <span className="text-muted-foreground">{tension.predicate}</span>{" "}

--- a/packages/web/src/app/admin/brain-facts/candidate-detail.tsx
+++ b/packages/web/src/app/admin/brain-facts/candidate-detail.tsx
@@ -10,13 +10,8 @@ import { Badge } from "@/components/ui/badge";
 import { RelativeTimestamp } from "@/ui/components/admin/queue";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { AlertTriangle, Clock, ShieldAlert, Split } from "lucide-react";
-import {
-  blockedBadge,
-  decayBadge,
-  provisionalBadge,
-  statusBadge,
-  tensionRetirement,
-} from "./columns";
+import { blockedBadge, decayBadge, provisionalBadge, statusBadge } from "./columns";
+import { isTensionOpen, isTensionSuperseded, isTensionWithdrawn } from "./tension-state";
 
 /**
  * The body of the review sheet — everything behind the trust call for one
@@ -187,10 +182,12 @@ function TensionCard({ tension }: { tension: BrainFactTensionView }) {
 
   const badge = statusBadge[tension.status];
   // Shared with the list's "In tension" count, which counts exactly the rivals
-  // this card does NOT strike through — see `tensionRetirement` for why a
-  // closed window is not the same as a stamped one, and why the client clock
-  // is acceptable here (#4935, #4961).
-  const { withdrawn, superseded, settled } = tensionRetirement(tension);
+  // this card does NOT strike through — `tension-state.ts` carries why a closed
+  // window is not the same as a stamped one, and why the client clock is
+  // accepted here (#4935, #4961).
+  const withdrawn = isTensionWithdrawn(tension);
+  const superseded = isTensionSuperseded(tension);
+  const settled = !isTensionOpen(tension);
   return (
     <div className="rounded-md border p-3 space-y-2">
       <div className="flex items-start justify-between gap-2">

--- a/packages/web/src/app/admin/brain-facts/columns.tsx
+++ b/packages/web/src/app/admin/brain-facts/columns.tsx
@@ -219,10 +219,12 @@ export function getBrainFactColumns(
         // claim was contested — but it is not work, and counting it made a
         // fully arbitrated row read as unresolved (#4961).
         //
-        // Deliberately NARROWER than the two server-side signals beside it: the
-        // stats tile's "N in tension" and the "In tension only" filter both ask
-        // edge EXISTENCE (`TENSION_EXISTS_SELECT`), i.e. "has this claim ever
-        // been contested", and are unchanged. So the filter can legitimately
+        // Deliberately NARROWER than the server-side signals around it: the
+        // stats tile's "N in tension", the "In tension only" filter, and the
+        // oversight panel's per-audience column all ask edge EXISTENCE
+        // (`TENSION_EXISTS_SELECT`), i.e. "has this claim ever been contested",
+        // and all are unchanged. So the tile can read a number no row's badge
+        // corroborates, and the filter can legitimately
         // return a row wearing no badge, for either of two reasons — every
         // rival is settled, in which case the sheet's "Withdrawn"/"Superseded"
         // labels explain the row; or the page's tension fan-out cap bit, in

--- a/packages/web/src/app/admin/brain-facts/columns.tsx
+++ b/packages/web/src/app/admin/brain-facts/columns.tsx
@@ -5,15 +5,18 @@ import type {
   BrainFactCandidate,
   BrainFactDecayLevel,
   BrainFactReviewStatus,
-  BrainFactTensionView,
 } from "@/ui/lib/types";
 import { Badge } from "@/components/ui/badge";
 import { DataTableColumnHeader } from "@/components/data-table/data-table-column-header";
 import { RelativeTimestamp } from "@/ui/components/admin/queue";
 import { AlertTriangle, Clock, HelpCircle, Link2, ShieldAlert, Split } from "lucide-react";
+import { isTensionOpen } from "./tension-state";
 
 /**
- * Review-queue columns.
+ * Review-queue columns, and the badge vocabulary the sheet shares with them —
+ * `candidate-detail.tsx` imports these tokens so one claim cannot wear two
+ * spellings of the same state on two surfaces. The lifecycle predicate behind
+ * the "In tension" count is the same idea one file over, in `tension-state.ts`.
  *
  * The list is where a reviewer decides whether a claim is worth OPENING, so
  * every signal that could stop them approving is visible without a click:
@@ -46,63 +49,6 @@ export const tensionBadge = {
   className: "border-violet-300 text-violet-700 dark:border-violet-700 dark:text-violet-400",
   label: "In tension",
 };
-
-/**
- * Which lifecycle stamps a tension counterpart carries, and whether either one
- * means it has stopped being a reason to hold the claim.
- *
- * `settled` is `withdrawn || superseded` and nothing else — derived here rather
- * than at each call site so the list's count and the detail sheet's
- * strike-through can never disagree about whether a conflict is still open.
- */
-export interface TensionRetirement {
-  /** Retracted — the `invalidated_at` tombstone. */
-  readonly withdrawn: boolean;
-  /** Superseded — a `valid_to` window that has actually CLOSED. */
-  readonly superseded: boolean;
-  /** Either axis. The one question the list's "In tension" count asks. */
-  readonly settled: boolean;
-}
-
-/**
- * Has this rival already been arbitrated?
- *
- * ONE definition behind BOTH review surfaces — the list's "In tension (N)"
- * count and the detail sheet's per-rival badges and strike-through. They
- * previously disagreed: the sheet labelled a settled rival while the list still
- * counted it, so a fully arbitrated row read as contested with nothing left to
- * resolve (#4961).
- *
- * A LABEL read off the counterpart's own lifecycle stamps — #4935's invariant
- * holds unchanged. Nothing here sorts, scores, or picks a winner, and no
- * ordering key is introduced; it only answers "is there anything left to
- * resolve".
- *
- * Two deliberate asymmetries, both erring toward reporting a conflict:
- *
- *   - A WITHHELD rival is NEVER settled. Its stamps are exactly what the ACL
- *     refused to hand over, so calling it settled would be a guess — and the
- *     guess that suppresses the badge. "There is a rival you cannot see" is
- *     precisely what should stop a reviewer approving.
- *   - Supersession needs a CLOSED window, not merely a stamped one.
- *     `brainFactCurrentClause` reads `valid_to IS NULL OR valid_to > now()`, so
- *     a future-dated stamp — a region import (`admin-migrate.ts`) can carry one
- *     — is a LIVE rival whose end is merely scheduled. An unparseable stamp
- *     yields `NaN`, whose comparison is false, so it falls through to live: the
- *     recoverable direction, since over-reporting a conflict costs a second
- *     look while under-reporting hides one.
- *
- * Against the CLIENT clock, accepted: within a skewed browser's offset of the
- * supersession instant this can disagree with the server. Both surfaces it
- * feeds are advisory, never a gate.
- */
-export function tensionRetirement(tension: BrainFactTensionView): TensionRetirement {
-  if (!tension.visible) return { withdrawn: false, superseded: false, settled: false };
-  const withdrawn = tension.invalidatedAt !== null;
-  const validToMs = tension.validTo === null ? null : Date.parse(tension.validTo);
-  const superseded = validToMs !== null && validToMs <= Date.now();
-  return { withdrawn, superseded, settled: withdrawn || superseded };
-}
 
 /**
  * Read-time staleness decay (#4914). One informational hue for the three aged
@@ -277,9 +223,15 @@ export function getBrainFactColumns(
         // stats tile's "N in tension" and the "In tension only" filter both ask
         // edge EXISTENCE (`TENSION_EXISTS_SELECT`), i.e. "has this claim ever
         // been contested", and are unchanged. So the filter can legitimately
-        // return a row wearing no badge; the sheet's "Withdrawn"/"Superseded"
-        // labels are where that row explains itself.
-        const contested = c.tensions.filter((t) => !tensionRetirement(t).settled);
+        // return a row wearing no badge, for either of two reasons — every
+        // rival is settled, in which case the sheet's "Withdrawn"/"Superseded"
+        // labels explain the row; or the page's tension fan-out cap bit, in
+        // which case the row's rivals never arrived and the `tensionsTruncated`
+        // banner is the only explanation there is. The banner's "before
+        // treating any row as conflict-free" carries more weight now than when
+        // it was written: pre-#4961 a truncated row still wore a badge for
+        // whatever survived the cap, and now it may wear none at all.
+        const contested = c.tensions.filter(isTensionOpen);
         return (
           <div className="flex flex-wrap gap-1">
             {c.provenance.provisional && (

--- a/packages/web/src/app/admin/brain-facts/columns.tsx
+++ b/packages/web/src/app/admin/brain-facts/columns.tsx
@@ -5,6 +5,7 @@ import type {
   BrainFactCandidate,
   BrainFactDecayLevel,
   BrainFactReviewStatus,
+  BrainFactTensionView,
 } from "@/ui/lib/types";
 import { Badge } from "@/components/ui/badge";
 import { DataTableColumnHeader } from "@/components/data-table/data-table-column-header";
@@ -45,6 +46,63 @@ export const tensionBadge = {
   className: "border-violet-300 text-violet-700 dark:border-violet-700 dark:text-violet-400",
   label: "In tension",
 };
+
+/**
+ * Which lifecycle stamps a tension counterpart carries, and whether either one
+ * means it has stopped being a reason to hold the claim.
+ *
+ * `settled` is `withdrawn || superseded` and nothing else — derived here rather
+ * than at each call site so the list's count and the detail sheet's
+ * strike-through can never disagree about whether a conflict is still open.
+ */
+export interface TensionRetirement {
+  /** Retracted — the `invalidated_at` tombstone. */
+  readonly withdrawn: boolean;
+  /** Superseded — a `valid_to` window that has actually CLOSED. */
+  readonly superseded: boolean;
+  /** Either axis. The one question the list's "In tension" count asks. */
+  readonly settled: boolean;
+}
+
+/**
+ * Has this rival already been arbitrated?
+ *
+ * ONE definition behind BOTH review surfaces — the list's "In tension (N)"
+ * count and the detail sheet's per-rival badges and strike-through. They
+ * previously disagreed: the sheet labelled a settled rival while the list still
+ * counted it, so a fully arbitrated row read as contested with nothing left to
+ * resolve (#4961).
+ *
+ * A LABEL read off the counterpart's own lifecycle stamps — #4935's invariant
+ * holds unchanged. Nothing here sorts, scores, or picks a winner, and no
+ * ordering key is introduced; it only answers "is there anything left to
+ * resolve".
+ *
+ * Two deliberate asymmetries, both erring toward reporting a conflict:
+ *
+ *   - A WITHHELD rival is NEVER settled. Its stamps are exactly what the ACL
+ *     refused to hand over, so calling it settled would be a guess — and the
+ *     guess that suppresses the badge. "There is a rival you cannot see" is
+ *     precisely what should stop a reviewer approving.
+ *   - Supersession needs a CLOSED window, not merely a stamped one.
+ *     `brainFactCurrentClause` reads `valid_to IS NULL OR valid_to > now()`, so
+ *     a future-dated stamp — a region import (`admin-migrate.ts`) can carry one
+ *     — is a LIVE rival whose end is merely scheduled. An unparseable stamp
+ *     yields `NaN`, whose comparison is false, so it falls through to live: the
+ *     recoverable direction, since over-reporting a conflict costs a second
+ *     look while under-reporting hides one.
+ *
+ * Against the CLIENT clock, accepted: within a skewed browser's offset of the
+ * supersession instant this can disagree with the server. Both surfaces it
+ * feeds are advisory, never a gate.
+ */
+export function tensionRetirement(tension: BrainFactTensionView): TensionRetirement {
+  if (!tension.visible) return { withdrawn: false, superseded: false, settled: false };
+  const withdrawn = tension.invalidatedAt !== null;
+  const validToMs = tension.validTo === null ? null : Date.parse(tension.validTo);
+  const superseded = validToMs !== null && validToMs <= Date.now();
+  return { withdrawn, superseded, settled: withdrawn || superseded };
+}
 
 /**
  * Read-time staleness decay (#4914). One informational hue for the three aged
@@ -210,6 +268,18 @@ export function getBrainFactColumns(
       header: () => "Flags",
       cell: ({ row }) => {
         const c = row.original;
+        // OPEN rivals only. A counterpart somebody already retracted or
+        // superseded is still listed in the detail sheet — it is still why this
+        // claim was contested — but it is not work, and counting it made a
+        // fully arbitrated row read as unresolved (#4961).
+        //
+        // Deliberately NARROWER than the two server-side signals beside it: the
+        // stats tile's "N in tension" and the "In tension only" filter both ask
+        // edge EXISTENCE (`TENSION_EXISTS_SELECT`), i.e. "has this claim ever
+        // been contested", and are unchanged. So the filter can legitimately
+        // return a row wearing no badge; the sheet's "Withdrawn"/"Superseded"
+        // labels are where that row explains itself.
+        const contested = c.tensions.filter((t) => !tensionRetirement(t).settled);
         return (
           <div className="flex flex-wrap gap-1">
             {c.provenance.provisional && (
@@ -218,12 +288,12 @@ export function getBrainFactColumns(
                 {provisionalBadge.label}
               </Badge>
             )}
-            {c.tensions.length > 0 && (
+            {contested.length > 0 && (
               <Badge variant={tensionBadge.variant} className={tensionBadge.className}>
                 <Split className="mr-1 size-3" aria-hidden />
-                {c.tensions.length === 1
+                {contested.length === 1
                   ? tensionBadge.label
-                  : `${tensionBadge.label} (${c.tensions.length})`}
+                  : `${tensionBadge.label} (${contested.length})`}
               </Badge>
             )}
             {c.promotionBlock && (

--- a/packages/web/src/app/admin/brain-facts/tension-state.ts
+++ b/packages/web/src/app/admin/brain-facts/tension-state.ts
@@ -7,11 +7,11 @@
  * settled rival while the list still counted it, so a fully arbitrated row read
  * as contested with nothing left to resolve (#4961).
  *
- * Extracted from `columns.tsx` for `list-query.ts`'s reason — this is a domain
- * predicate, not badge vocabulary, and pinning its boundary cases should not
- * require mounting the queue page. `__tests__/tension-state.test.ts` covers
- * them directly; `review-honesty.test.tsx` proves the two surfaces then render
- * what the predicate decided.
+ * Its own module for `list-query.ts`'s reason — this is a domain predicate, not
+ * badge vocabulary, and pinning its boundary cases should not require mounting
+ * the queue page. `__tests__/tension-state.test.ts` covers them directly;
+ * `review-honesty.test.tsx` proves the two surfaces then render what the
+ * predicate decided.
  *
  * ## Why the READER decides this, and not the API
  *
@@ -33,15 +33,15 @@
  * ## Every ambiguous input errs toward REPORTING a conflict
  *
  * Over-reporting costs a reviewer a second look; under-reporting hides a live
- * conflict from the one person who would have caught it. So each arm resolves
- * an absent, junk, or unknowable stamp to "still open":
+ * conflict from the one person who would have caught it. So on both axes, a
+ * stamp that is absent, empty, or malformed resolves to "still open" — and a
+ * WITHHELD rival is never settled at all, because its stamps are exactly what
+ * the ACL refused to hand over and inferring "settled" from their absence is
+ * the guess that suppresses the badge.
  *
- *   - a WITHHELD rival is never settled — its stamps are exactly what the ACL
- *     refused to hand over, and inferring "settled" from their absence is the
- *     guess that suppresses the badge;
- *   - a stamp that is not a string (absent, or drifted) is not a retirement;
- *   - an unparseable stamp yields `NaN`, whose comparison is false;
- *   - a `valid_to` in the FUTURE is a live rival whose end is merely scheduled.
+ * Both axes can be stamped on one rival, and each is tested independently:
+ * supersede-then-retract is reachable, so an implementation that SUBTRACTED
+ * per axis rather than testing per rival would discount that rival twice.
  *
  * ## The client clock, accepted
  *
@@ -50,13 +50,17 @@
  * already superseded — a wider exposure than a knife-edge at the supersession
  * instant, and in the suppressing direction.
  *
- * Accepted deliberately rather than overlooked. The principled fix is a
- * server-computed boolean on `BrainFactTensionVisible`, decided by the same
- * `now()` the database already uses for `brainFactCurrentClause` — a wire
- * change, and the right one when this is worth hardening. What is NOT an
- * improvement is a client-side skew margin here: #4935 shipped the sheet's
- * badges on this same comparison, so a margin on the count alone would
- * re-create exactly the count-vs-label drift #4961 exists to remove.
+ * Accepted deliberately rather than overlooked, and NOT for the tempting
+ * reason. A skew margin added here would not desynchronize the two surfaces —
+ * they now share this predicate, which is what the extraction bought. It is
+ * declined because a margin only trades a suppression window for an
+ * over-reporting window of the same width; it removes no case. What removes the
+ * class is deciding the boundary in Postgres, on the same clock the reads use.
+ * `correctionTargetSql` already does exactly that for the correction verbs
+ * (`NOT brainFactCurrentClause("f") AS window_closed`, #4939) and states the
+ * argument in full; the equivalent here is a computed boolean per counterpart
+ * on `BrainFactTensionVisible` — a wire change, and the right one when this is
+ * worth hardening beyond an advisory badge.
  */
 
 import type { BrainFactTensionView, BrainFactTensionVisible } from "@/ui/lib/types";
@@ -64,31 +68,43 @@ import type { BrainFactTensionView, BrainFactTensionVisible } from "@/ui/lib/typ
 /**
  * Retracted — the `invalidated_at` tombstone.
  *
- * `typeof === "string"` rather than `!== null`: retraction is the arm whose
- * naive spelling fails toward SILENCE, because an absent field is `!== null`
- * and would suppress the badge. Unreachable today (the list response is
- * schema-parsed and `useAdminFetch` throws on a mismatch), but this predicate
- * is also shaped for `BrainSearchTensionView`'s payload, which has no runtime
- * parse — so the guard is where the drift would land, not where it is today.
+ * A stamp that DECODES, rather than merely a non-`null` one. The obvious
+ * spelling `invalidatedAt !== null` is the one arm of this module that fails
+ * toward SILENCE — an absent field is `!== null`, so it would report a
+ * retraction and suppress the badge — and `typeof === "string"` only moves that
+ * hazard from an absent field to an empty or malformed one, which a serializer
+ * coalescing `null → ""` produces. Parseability is the boundary that makes the
+ * module's directional property true on BOTH axes rather than one.
+ *
+ * Nothing on the queue's own path can reach it: `invalidatedAt` is a required
+ * `z.string().nullable()` on the parsed list response, and `useAdminFetch`
+ * throws rather than render a payload that failed to parse. The guard is for
+ * the shape, not for a caller — this is the retirement question asked of a
+ * counterpart payload, and the schema is the only thing currently making the
+ * field trustworthy.
  */
 export function isTensionWithdrawn(tension: BrainFactTensionVisible): boolean {
-  return typeof tension.invalidatedAt === "string";
+  if (typeof tension.invalidatedAt !== "string") return false;
+  return Number.isFinite(Date.parse(tension.invalidatedAt));
 }
 
 /**
  * Superseded — a `valid_to` window that has actually CLOSED.
  *
  * `brainFactCurrentClause` reads `valid_to IS NULL OR valid_to > now()`, so
- * this uses the same boundary the database does. A future-dated stamp — a
- * region import (`admin-migrate.ts`) can carry one — is a LIVE rival.
+ * this uses the same boundary the database does, and a future-dated stamp is a
+ * LIVE rival. What either stamp MEANS, and why past-vs-future is the whole
+ * question, is on `BrainFactTensionVisible.validTo` — the canonical statement,
+ * pointed at rather than restated here for the reason `lib/brain/tensions.ts`
+ * points at it too.
  *
  * (The INGEST side asks the same question from the other end:
- * `TENSION_CANDIDATES_SQL` in `reconcile.ts` skips a rival that is already
- * retracted or superseded, "the arbitration already happened at the publish
- * gate". It also skips a FUTURE-dated one, where this predicate keeps it —
- * deliberately, and in the over-reporting direction: ingest is deciding whether
- * to write an edge, this is deciding whether to show a reviewer one that
- * already exists.)
+ * `TENSION_CANDIDATES_SQL` in `packages/api/src/lib/brain/reconcile.ts` skips a
+ * rival that is already retracted or superseded — "the arbitration already
+ * happened at the publish gate". It also skips a FUTURE-dated one, where this
+ * predicate keeps it. Deliberate, and in the over-reporting direction: ingest
+ * is deciding whether to WRITE an edge, this is deciding whether to show a
+ * reviewer one that already exists.)
  */
 export function isTensionSuperseded(tension: BrainFactTensionVisible): boolean {
   if (typeof tension.validTo !== "string") return false;

--- a/packages/web/src/app/admin/brain-facts/tension-state.ts
+++ b/packages/web/src/app/admin/brain-facts/tension-state.ts
@@ -1,0 +1,108 @@
+/**
+ * Has a tension counterpart already been arbitrated?
+ *
+ * ONE definition behind BOTH review surfaces — the list's "In tension (N)"
+ * count (`columns.tsx`) and the sheet's per-rival badges and strike-through
+ * (`candidate-detail.tsx`). They previously disagreed: the sheet labelled a
+ * settled rival while the list still counted it, so a fully arbitrated row read
+ * as contested with nothing left to resolve (#4961).
+ *
+ * Extracted from `columns.tsx` for `list-query.ts`'s reason — this is a domain
+ * predicate, not badge vocabulary, and pinning its boundary cases should not
+ * require mounting the queue page. `__tests__/tension-state.test.ts` covers
+ * them directly; `review-honesty.test.tsx` proves the two surfaces then render
+ * what the predicate decided.
+ *
+ * ## Why the READER decides this, and not the API
+ *
+ * `lib/brain/tensions.ts` deliberately filters NEITHER temporal axis and
+ * carries both stamps raw: a rival that was retracted or superseded is still
+ * why this claim was contested, so dropping it server-side would make a
+ * conflict vanish the moment somebody resolved one side, and the sheet would
+ * lose the record. "Only the reader can decide whether a window has actually
+ * closed" is that module's own statement of this seam — #4961 names
+ * `tensions.ts` as where settled-vs-contested is decided, and it is not. This
+ * is.
+ *
+ * ## Labels, not a ranking
+ *
+ * #4935's invariant holds unchanged. Nothing here sorts, scores, or picks a
+ * winner, and no ordering key is introduced; these answer only "is there
+ * anything left to resolve".
+ *
+ * ## Every ambiguous input errs toward REPORTING a conflict
+ *
+ * Over-reporting costs a reviewer a second look; under-reporting hides a live
+ * conflict from the one person who would have caught it. So each arm resolves
+ * an absent, junk, or unknowable stamp to "still open":
+ *
+ *   - a WITHHELD rival is never settled — its stamps are exactly what the ACL
+ *     refused to hand over, and inferring "settled" from their absence is the
+ *     guess that suppresses the badge;
+ *   - a stamp that is not a string (absent, or drifted) is not a retirement;
+ *   - an unparseable stamp yields `NaN`, whose comparison is false;
+ *   - a `valid_to` in the FUTURE is a live rival whose end is merely scheduled.
+ *
+ * ## The client clock, accepted
+ *
+ * Both predicates compare against the browser's clock, so a machine whose clock
+ * runs fast by N reads every rival whose window closes within the next N as
+ * already superseded — a wider exposure than a knife-edge at the supersession
+ * instant, and in the suppressing direction.
+ *
+ * Accepted deliberately rather than overlooked. The principled fix is a
+ * server-computed boolean on `BrainFactTensionVisible`, decided by the same
+ * `now()` the database already uses for `brainFactCurrentClause` — a wire
+ * change, and the right one when this is worth hardening. What is NOT an
+ * improvement is a client-side skew margin here: #4935 shipped the sheet's
+ * badges on this same comparison, so a margin on the count alone would
+ * re-create exactly the count-vs-label drift #4961 exists to remove.
+ */
+
+import type { BrainFactTensionView, BrainFactTensionVisible } from "@/ui/lib/types";
+
+/**
+ * Retracted — the `invalidated_at` tombstone.
+ *
+ * `typeof === "string"` rather than `!== null`: retraction is the arm whose
+ * naive spelling fails toward SILENCE, because an absent field is `!== null`
+ * and would suppress the badge. Unreachable today (the list response is
+ * schema-parsed and `useAdminFetch` throws on a mismatch), but this predicate
+ * is also shaped for `BrainSearchTensionView`'s payload, which has no runtime
+ * parse — so the guard is where the drift would land, not where it is today.
+ */
+export function isTensionWithdrawn(tension: BrainFactTensionVisible): boolean {
+  return typeof tension.invalidatedAt === "string";
+}
+
+/**
+ * Superseded — a `valid_to` window that has actually CLOSED.
+ *
+ * `brainFactCurrentClause` reads `valid_to IS NULL OR valid_to > now()`, so
+ * this uses the same boundary the database does. A future-dated stamp — a
+ * region import (`admin-migrate.ts`) can carry one — is a LIVE rival.
+ *
+ * (The INGEST side asks the same question from the other end:
+ * `TENSION_CANDIDATES_SQL` in `reconcile.ts` skips a rival that is already
+ * retracted or superseded, "the arbitration already happened at the publish
+ * gate". It also skips a FUTURE-dated one, where this predicate keeps it —
+ * deliberately, and in the over-reporting direction: ingest is deciding whether
+ * to write an edge, this is deciding whether to show a reviewer one that
+ * already exists.)
+ */
+export function isTensionSuperseded(tension: BrainFactTensionVisible): boolean {
+  if (typeof tension.validTo !== "string") return false;
+  return Date.parse(tension.validTo) <= Date.now();
+}
+
+/**
+ * Is this rival still a reason to hold the claim — i.e. does the list count it?
+ *
+ * The one predicate that takes the WHOLE union, because the withheld arm is
+ * part of the answer and belongs here rather than at each call site. Its
+ * complement is exactly the set the sheet strikes through.
+ */
+export function isTensionOpen(tension: BrainFactTensionView): boolean {
+  if (!tension.visible) return true;
+  return !isTensionWithdrawn(tension) && !isTensionSuperseded(tension);
+}

--- a/packages/web/src/app/admin/brain-facts/tension-state.ts
+++ b/packages/web/src/app/admin/brain-facts/tension-state.ts
@@ -59,7 +59,14 @@
  * `correctionTargetSql` already does exactly that for the correction verbs
  * (`NOT brainFactCurrentClause("f") AS window_closed`, #4939) and states the
  * argument in full; the equivalent here is a computed boolean per counterpart
- * on `BrainFactTensionVisible` — a wire change, and the right one when this is
+ * on `BrainFactTensionVisible`.
+ *
+ * A wire change, and it trades rather than only removes — like every fetch-time
+ * verdict it is fixed until refetch, so a window closing while the reviewer
+ * holds the page open keeps the badge up, where the client comparison
+ * re-evaluates each render. That is the same bound `correctionTargetSql` draws
+ * around its own claim: what a server boundary eliminates is the clock-SOURCE
+ * skew, which is the part that can be eliminated. Worth doing when this is
  * worth hardening beyond an advisory badge.
  */
 

--- a/packages/web/src/ui/lib/types.ts
+++ b/packages/web/src/ui/lib/types.ts
@@ -23,6 +23,7 @@ export type {
   BrainFactWillSupersede,
   BrainFactProvenanceView,
   BrainFactTensionView,
+  BrainFactTensionVisible,
   AdminRole,
   AtlasMode,
   AuthMode,


### PR DESCRIPTION
Brain M2 residue, surfaced by the milestone-wide review at closeout. This is the one item in the batch that currently ships broken — it would go out in `v0.2.3` as-is.

## The bug

Nothing deletes an `in-tension-with` edge when a human arbitrates. The publish gate stamps `valid_to` on the claim it retires and leaves that row's `status` alone; `retract` writes `invalidated_at` and likewise leaves `status`. So a settled rival stays in the cluster, and the queue's `c.tensions.length` counted it — a fully arbitrated row kept wearing **"In tension (2)"** with nothing left to resolve.

The detail sheet already made this call per rival (#4935 gave it "Withdrawn"/"Superseded" badges and a strike-through). The list did not. The two surfaces disagreed about whether a conflict was still open.

## The fix

`tension-state.ts` is now the one definition behind both surfaces:

- `isTensionWithdrawn` / `isTensionSuperseded` — the two axes, on the visible arm only
- `isTensionOpen` — the whole union; the list counts `tensions.filter(isTensionOpen)`, the sheet strikes through its complement

Every ambiguous input errs toward **reporting** a conflict, because over-reporting costs a reviewer a second look while under-reporting hides a live conflict:

- a **withheld** rival is never settled — its stamps are exactly what the ACL refused to hand over, and inferring "settled" from their absence is the guess that suppresses the badge
- supersession needs a **closed** window, not merely a stamped one — `brainFactCurrentClause` is `valid_to IS NULL OR valid_to > now()`, so a future-dated stamp (a region import can carry one) is a live rival
- an absent, empty, or malformed stamp is not a retirement on either axis

## Acceptance criteria

- [x] The count excludes settled counterparts; a fully arbitrated row shows no tension count
- [x] A test pins the negative — `renders NO tension count on a row whose rivals are ALL settled`, one rival per axis
- [x] #4935's label-is-state invariant preserved — nothing sorts, scores, or picks a winner; **no ordering key introduced**

## Mutation-verified

Each arm was confirmed to fail when reverted, not merely to pass:

| Mutation | Kills |
|---|---|
| drop the `filter(isTensionOpen)` | 5 tests, incl. the AC negative |
| `!(Date.parse(...) > Date.now())` — the equivalent-looking rewrite | the unparseable-stamp test (it survived **every** render test before the unit file existed) |
| `invalidatedAt !== null` | the missing-stamp test |
| `typeof === "string"` alone | the empty/malformed-stamp test |
| withheld arm returns "settled" | 2 tests |
| sheet drops settled rivals (the over-correction) | 4 tests, incl. #4935's own |

## Deliberately unchanged

**The server-side signals stay edge-existence.** The stats tile's "N in tension", the "In tension only" filter, and the oversight panel's column all ask `TENSION_EXISTS_SELECT` — "has this claim ever been contested". The badge now asks "is anything left to resolve". So the tile can read a number no row's badge corroborates, and the filter can return a badge-less row. That divergence is deliberate, documented at the call site, and now **pinned by a test** so a later "consistency fix" deriving the tile client-side fails rather than silently undoing this.

**The client clock is accepted, not overlooked.** A fast browser reads a rival whose window closes within the skew as superseded. A skew margin would not drift the two surfaces any more (they share the predicate) — it is declined because it only trades a suppression window for an equal over-reporting window. What removes the class is deciding the boundary in Postgres, as `correctionTargetSql` already does for the correction verbs (#4939); that is a wire change.

## Review panel

Three rounds, converging to merge. Round 1 caught a derived field on a freely-constructible record and a fabricated `withdrawn: false` on withheld rivals (both fixed by dropping the record for predicates), plus the wrong home for a domain predicate (extracted, following `list-query.ts`). Round 2 caught the retraction axis still failing toward silence on an empty stamp, and a skew rationale the extraction had itself invalidated. Round 3: **approve / merge** from both reviewers.

Two panel suggestions were **deferred, not silently dropped** — a muted "Conflict resolved" row badge, and conditioning the sheet's "deciding which holds is your call" prose. Both are new UI on a shipped surface beyond this issue's ACs, and the second would break #4935's deliberate assertion that `is not choosing between them` renders on a superseded fixture. Worth their own issue.

Closes #4961
