### PR TITLE
refactor(brain): model Outlook's block-vs-skip as a discriminated union

### DIFF
--- a/packages/api/src/lib/brain/ingest/__tests__/outlook-client.test.ts
+++ b/packages/api/src/lib/brain/ingest/__tests__/outlook-client.test.ts
@@ -213,8 +213,8 @@ describe("the block arm — RETRYABLE, freezes the resume point", () => {
     // …and the range stays uncovered, so the next cycle retries it.
     expect(changes.coverageIncomplete).toBe(true);
     expect(changes.highWaterMark).toBeNull();
-    // ⭐ THE CURSOR, which this test did not assert until round 2. It is the only
-    // observable that separates a block from a skip: `coverageIncomplete` is set
+    // ⭐ THE CURSOR. It is the observable that most directly separates a block
+    // from a skip, and the one this test was missing: `coverageIncomplete` is set
     // by a SEPARATE write (`walkIncomplete`), so it survives a mutation that
     // drops `mailboxIncomplete` in the per-message catch — and with that dropped,
     // the resume point advances past a message whose audience was never written.
@@ -427,15 +427,10 @@ describe("the cursor", () => {
     // A mailbox removed from the config would otherwise keep its watermark
     // forever.
     //
-    // ⚠️ This comment used to justify that by saying a stale mark would
-    // "silently skip everything in between". That is wrong on the merits and is
-    // corrected here rather than deleted, because `serialiseOutlookCursor`'s
-    // docstring carries the same correction and says why two contradictory
-    // accounts of one risk is how the next fix goes the wrong way: resuming from
-    // an OLDER mark OVER-reads and cannot skip, and a mark below the backfill
-    // floor hits the `historyTruncated` branch, which warns and restarts at the
-    // floor. Pruning is about not carrying dead keys, not about lost history —
-    // dropping a LIVE entry is the direction that costs history.
+    // Pruning is about not carrying dead keys, NOT about lost history: resuming
+    // from an older mark over-reads and cannot skip. `serialiseOutlookCursor`'s
+    // docstring is the account of record; this comment previously contradicted
+    // it, which is the drift that docstring warns about.
     const stale = serialiseOutlookCursor({
       [MAILBOX_ID]: "2026-07-01T00:00:00.000Z",
       removed: "2026-01-01T00:00:00.000Z",
@@ -768,7 +763,11 @@ describe("tallyOutcome — the one place an outcome becomes a number", () => {
   // `log.info` these tests do not capture, and the exhaustiveness arm is not
   // reachable from the walk at all. Every mutation named below leaves all 25
   // end-to-end tests above green.
-  const emptySkips = () => ({
+  // Return-type-annotated rather than inferred, so the literal is contextually
+  // typed and excess-property checking fires: without it, REMOVING a reason from
+  // `PERMANENT_SKIP_REASONS` leaves a stale key here that `total()` keeps
+  // counting, quietly weakening every "and nowhere else" assertion below.
+  const emptySkips = (): Parameters<typeof tallyOutcome>[0] => ({
     blockedAudience: 0,
     unattributable: 0,
     unidentifiable: 0,
@@ -777,7 +776,7 @@ describe("tallyOutcome — the one place an outcome becomes a number", () => {
     bodyUnreadable: 0,
     emptyBody: 0,
   });
-  const total = (skips: Record<string, number>) =>
+  const total = (skips: Parameters<typeof tallyOutcome>[0]) =>
     Object.values(skips).reduce((a, b) => a + b, 0);
 
   it("⭐ increments exactly the named counter, and never the safety one", () => {

--- a/packages/api/src/lib/brain/ingest/__tests__/outlook-client.test.ts
+++ b/packages/api/src/lib/brain/ingest/__tests__/outlook-client.test.ts
@@ -55,9 +55,18 @@ interface Harness {
 /** Build a client over canned pages, recording every membership write. */
 function client(
   pages: { messages: OutlookMessage[]; nextLink?: string | null; dropped?: number }[],
-  options: Partial<OutlookMailClientOptions> & { readonly harness?: Harness } = {},
+  options: Partial<OutlookMailClientOptions> & {
+    readonly harness?: Harness;
+    /**
+     * The Graph OBJECT ID `fetchMailbox` resolves to. Overridable because it is
+     * the only input left that can make `deriveEmailRecipientGrant` refuse — see
+     * the grant-null block test.
+     */
+    readonly mailboxId?: string;
+  } = {},
 ) {
   const harness: Harness = options.harness ?? { reconciled: [] };
+  const mailboxId = options.mailboxId ?? MAILBOX_ID;
   let pageIndex = 0;
   const readPage = async () => {
     const page = pages[Math.min(pageIndex++, pages.length - 1)];
@@ -79,7 +88,7 @@ function client(
       api: {
         fetchMailbox: async () => ({
           ok: true as const,
-          mailbox: { id: MAILBOX_ID, userPrincipalName: "a@contoso.com", mail: "a@contoso.com" },
+          mailbox: { id: mailboxId, userPrincipalName: "a@contoso.com", mail: "a@contoso.com" },
         }),
         fetchMailboxMessagesPage: readPage,
         fetchMailboxMessagesNextPage: readPage,
@@ -210,9 +219,44 @@ describe("the block arm — RETRYABLE, freezes the resume point", () => {
     // the resume point advances past a message whose audience was never written.
     // A permanent silent skip on the safety arm, with the pass reporting green.
     expect(parseOutlookCursor(changes.cursor ?? null)[MAILBOX_ID]).not.toBe(NOW.toISOString());
+    // The operator-facing half. Both of these survived every mutation until they
+    // were asserted: deleting the catch's tally-and-warn, and deleting the stall
+    // detector outright, each left the suite green. A block that nothing reports
+    // is the "blocked on the same message for 400 cycles" shape the client's own
+    // comment says an operator has no way to see.
+    expect(changes.warnings?.join(" ")).toMatch(/membership write failed/);
+    expect(changes.warnings?.join(" ")).toMatch(/made no forward progress/);
   });
 
-
+  it("⭐ BLOCKS a message whose grant cannot be derived — never skips past it", async () => {
+    // The arm nothing reached until this test existed. `deriveEmailRecipientGrant`
+    // returning null is the ONE in-band block — every other block arrives as a
+    // throw through the caller's catch — and both it and the caller's
+    // `outcome.kind === "blocked"` handler were dead code as far as this suite
+    // was concerned. That is the safety arm, so it is the worst one to leave
+    // unpinned.
+    //
+    // Reached through the only input the guards above it do not settle: a
+    // mailbox OBJECT ID containing a `:`, which `emailMessageAudienceId` refuses
+    // outright (it would otherwise make the audience token's segments ambiguous).
+    //
+    // MUTATION THIS CATCHES: `kind: "blocked"` → `kind: "skipped"` on the
+    // grant-null arm, and neutering the caller's blocked handler. Both leave the
+    // rest of the suite green, and both advance the resume point past a message
+    // whose audience Atlas could not derive — #4965's silent direction.
+    const { vendor, harness } = client([{ messages: [message()] }], { mailboxId: "mb:a" });
+    const changes = await vendor.fetchEpisodes(PARAMS);
+    expect(changes.episodes).toHaveLength(0);
+    // The block happens BEFORE the membership write, so nothing was granted.
+    expect(harness.reconciled).toHaveLength(0);
+    // RETRYABLE: the pass says so, and the resume point does NOT reach pass-start.
+    expect(changes.coverageIncomplete).toBe(true);
+    expect(changes.highWaterMark).toBeNull();
+    expect(parseOutlookCursor(changes.cursor ?? null)["mb:a"]).not.toBe(NOW.toISOString());
+    expect(changes.warnings?.join(" ")).toMatch(/access grant could not be built/);
+    // No wider-grant fallback on this arm either.
+    expect(JSON.stringify(changes.episodes)).not.toContain("org");
+  });
 
   it("never falls back to a wider grant on the block arm", async () => {
     // There is no `[org]` answer available anywhere in this path — it would

--- a/packages/api/src/lib/brain/ingest/__tests__/outlook-client.test.ts
+++ b/packages/api/src/lib/brain/ingest/__tests__/outlook-client.test.ts
@@ -19,6 +19,7 @@ import {
   composeEmailBody,
   createOutlookMailClient,
   parseOutlookCursor,
+  tallyOutcome,
   serialiseOutlookCursor,
   type OutlookMailClientOptions,
 } from "@atlas/api/lib/brain/ingest/outlook/client";
@@ -254,8 +255,10 @@ describe("the block arm — RETRYABLE, freezes the resume point", () => {
     expect(changes.highWaterMark).toBeNull();
     expect(parseOutlookCursor(changes.cursor ?? null)["mb:a"]).not.toBe(NOW.toISOString());
     expect(changes.warnings?.join(" ")).toMatch(/access grant could not be built/);
-    // No wider-grant fallback on this arm either.
-    expect(JSON.stringify(changes.episodes)).not.toContain("org");
+    // Deliberately NOT asserting `not.toContain("org")` on the episodes here:
+    // they are already asserted empty, so that check cannot fail and would read
+    // as coverage it does not provide. The honest no-wider-grant claim on this
+    // arm is `harness.reconciled` above — nothing was minted at all.
   });
 
   it("never falls back to a wider grant on the block arm", async () => {
@@ -422,9 +425,17 @@ describe("the skip arm — PERMANENT, advances past", () => {
 describe("the cursor", () => {
   it("round-trips, and drops entries a pass was not configured for", async () => {
     // A mailbox removed from the config would otherwise keep its watermark
-    // forever, and re-adding it months later would resume from a stale mark and
-    // silently skip everything in between — invisible, because an append-only
-    // store cannot tell an absence from a not-yet-fetched.
+    // forever.
+    //
+    // ⚠️ This comment used to justify that by saying a stale mark would
+    // "silently skip everything in between". That is wrong on the merits and is
+    // corrected here rather than deleted, because `serialiseOutlookCursor`'s
+    // docstring carries the same correction and says why two contradictory
+    // accounts of one risk is how the next fix goes the wrong way: resuming from
+    // an OLDER mark OVER-reads and cannot skip, and a mark below the backfill
+    // floor hits the `historyTruncated` branch, which warns and restarts at the
+    // floor. Pruning is about not carrying dead keys, not about lost history —
+    // dropping a LIVE entry is the direction that costs history.
     const stale = serialiseOutlookCursor({
       [MAILBOX_ID]: "2026-07-01T00:00:00.000Z",
       removed: "2026-01-01T00:00:00.000Z",
@@ -749,5 +760,90 @@ describe("budgets and throttling", () => {
     expect(changes.episodes).toHaveLength(0);
     expect(changes.coverageIncomplete).toBe(true);
     expect(changes.warnings?.join(" ")).toMatch(/no longer recognises/);
+  });
+});
+
+describe("tallyOutcome — the one place an outcome becomes a number", () => {
+  // Tested directly because the counters reach the outside world only through a
+  // `log.info` these tests do not capture, and the exhaustiveness arm is not
+  // reachable from the walk at all. Every mutation named below leaves all 25
+  // end-to-end tests above green.
+  const emptySkips = () => ({
+    blockedAudience: 0,
+    unattributable: 0,
+    unidentifiable: 0,
+    oversizeAudience: 0,
+    oversizeBody: 0,
+    bodyUnreadable: 0,
+    emptyBody: 0,
+  });
+  const total = (skips: Record<string, number>) =>
+    Object.values(skips).reduce((a, b) => a + b, 0);
+
+  it("⭐ increments exactly the named counter, and never the safety one", () => {
+    // MUTATION THIS CATCHES: `skips[outcome.reason]++` indexing a fixed counter.
+    // The block-vs-skip split is only worth something if a permanent drop cannot
+    // land in `blockedAudience` — that number is what an operator alerts on, and
+    // inflating it with quality losses is what makes it unreadable.
+    const skips = emptySkips();
+    const warnings: string[] = [];
+    tallyOutcome(skips, warnings, { kind: "skipped", reason: "oversizeBody", warning: "w" });
+    expect(skips.oversizeBody).toBe(1);
+    expect(skips.blockedAudience).toBe(0);
+    expect(total(skips)).toBe(1);
+  });
+
+  it("counts a block on the safety counter and nowhere else", () => {
+    const skips = emptySkips();
+    tallyOutcome(skips, [], { kind: "blocked", warning: "w" });
+    expect(skips.blockedAudience).toBe(1);
+    expect(total(skips)).toBe(1);
+  });
+
+  it("counts an ingested message nowhere — `kept` is the episode count", () => {
+    const skips = emptySkips();
+    const warnings: string[] = [];
+    tallyOutcome(skips, warnings, {
+      kind: "ingested",
+      episode: { sourceId: "s", sourceActor: null, body: "b", occurredAt: null, visibleTo: ["x"] },
+    });
+    expect(total(skips)).toBe(0);
+    expect(warnings).toHaveLength(0);
+  });
+
+  it("raises a skip's warning, and stays silent when the arm says `null`", () => {
+    // The `emptyBody` arm is counted but deliberately NOT warned — it is the
+    // high-volume one. MUTATION THIS CATCHES: pushing unconditionally, which
+    // buries the arms an operator needs under per-message noise.
+    const warnings: string[] = [];
+    const skips = emptySkips();
+    tallyOutcome(skips, warnings, { kind: "skipped", reason: "emptyBody", warning: null });
+    expect(warnings).toHaveLength(0);
+    expect(skips.emptyBody).toBe(1);
+    tallyOutcome(skips, warnings, { kind: "skipped", reason: "unidentifiable", warning: "said so" });
+    expect(warnings).toEqual(["said so"]);
+  });
+
+  it("⭐ never puts an outcome's PAYLOAD in the thrown message", () => {
+    // The exhaustiveness arm is unreachable by construction, so nothing but this
+    // test stops it being "improved" back to `JSON.stringify(unexpected)` —
+    // which is what it was until review caught it. That throw is caught by the
+    // walk, interpolated into an operator-facing warning and persisted to
+    // `knowledge_sync_state`, and one arm of this union carries `episode.body`:
+    // the full plaintext of somebody's mail.
+    //
+    // MUTATION THIS CATCHES: stringifying the outcome rather than its discriminant.
+    const rogue = {
+      kind: "someFutureArm",
+      episode: { body: "SECRET PLAINTEXT" },
+    } as unknown as Parameters<typeof tallyOutcome>[2];
+    expect(() => tallyOutcome(emptySkips(), [], rogue)).toThrow(/someFutureArm/);
+    let thrown = "";
+    try {
+      tallyOutcome(emptySkips(), [], rogue);
+    } catch (err) {
+      thrown = err instanceof Error ? err.message : String(err);
+    }
+    expect(thrown).not.toContain("SECRET PLAINTEXT");
   });
 });

--- a/packages/api/src/lib/brain/ingest/outlook/client.ts
+++ b/packages/api/src/lib/brain/ingest/outlook/client.ts
@@ -327,6 +327,10 @@ export function toOutlookClientError(context: string, failure: OutlookReadError)
  * exactly the #4965 direction this file is organised against. Here neither
  * classification is the default: a permanent reason is an entry in this array, a
  * retryable one is a field on the interface below, and both are a visible edit.
+ *
+ * A VALUE rather than a bare union type because the aggregate drop total at the
+ * end of the pass sums over it, which is what keeps that total from drifting
+ * from this list the way its hand-written predecessor did.
  */
 const PERMANENT_SKIP_REASONS = [
   /**
@@ -351,6 +355,21 @@ const PERMANENT_SKIP_REASONS = [
 
 type PermanentSkipReason = (typeof PERMANENT_SKIP_REASONS)[number];
 
+/**
+ * The disjointness the whole split rests on, asserted at compile time.
+ *
+ * `interface … extends Record<…>` permits a member that COLLIDES with an
+ * inherited one as long as the declared type is identical — and `number` vs
+ * `number` is identical. So adding `"blockedAudience"` to the array above
+ * compiles cleanly, and the safety counter silently becomes a legal `skipped`
+ * reason for `skips[outcome.reason]++` to land in. That is the one hole the move
+ * off `Exclude<keyof MessageSkips, …>` opened, and it costs two lines to close.
+ */
+type AssertTrue<T extends true> = T;
+type _BlockStaysRetryable = AssertTrue<
+  "blockedAudience" extends PermanentSkipReason ? false : true
+>;
+
 /** Per-pass drop tally — every message seen but not stored, by reason. */
 interface MessageSkips extends Record<PermanentSkipReason, number> {
   /**
@@ -358,10 +377,7 @@ interface MessageSkips extends Record<PermanentSkipReason, number> {
    * The safety counter an operator alerts on.
    *
    * Deliberately NOT a {@link PermanentSkipReason}, which is what stops a
-   * `skipped` outcome naming it: a permanent condition cannot be tallied as
-   * retryable. Choosing which arm a new CONDITION belongs on is still a human
-   * decision — no type can make it — but it is now spelled once, at `kind`,
-   * instead of inferred from a `blocked: boolean` a new arm can forget.
+   * `skipped` outcome naming it.
    */
   blockedAudience: number;
 }
@@ -388,18 +404,29 @@ type MessageOutcome =
 
 /**
  * The only writer of {@link MessageSkips} — the one place a message that was NOT
- * stored becomes a number, and the one place its warning is raised.
+ * stored becomes a number, and the one place an OUTCOME's warning is raised.
+ * (The caller's throttle branch pushes a warning of its own, but a throttle is
+ * not an outcome of the message; it says so there.)
  *
- * (An INGESTED message becomes numbers at the call site instead, as
- * `episodes.length` and the budget decrement. Nothing to tally: `kept` is the
- * episode count, not a drop counter.)
+ * An INGESTED message becomes numbers at the call site instead, as
+ * `episodes.length` and the budget decrement — `kept` is the episode count, not
+ * a drop counter.
  *
- * One site rather than nine is the point. A tally spread across the arms that
- * produce it is a tally whose next arm can forget to increment, or increment the
- * wrong counter, and neither shows up as anything but a number quietly missing
- * from an operator's log line.
+ * One site is the point. A tally spread across the arms that produce it is a
+ * tally whose next arm can forget to increment, or increment the wrong counter,
+ * and neither shows up as anything but a number quietly missing from an
+ * operator's log line.
+ *
+ * Exported for its own unit tests, like this module's other pure helpers. The
+ * counters reach the outside world only through a `log.info`, so a mutation that
+ * indexes the WRONG counter is invisible to the walk's end-to-end tests — and
+ * the `default` arm's no-payload rule is unreachable from them entirely.
  */
-function tallyOutcome(skips: MessageSkips, warnings: string[], outcome: MessageOutcome): void {
+export function tallyOutcome(
+  skips: MessageSkips,
+  warnings: string[],
+  outcome: MessageOutcome,
+): void {
   switch (outcome.kind) {
     case "ingested":
       return;
@@ -417,9 +444,11 @@ function tallyOutcome(skips: MessageSkips, warnings: string[], outcome: MessageO
     default: {
       const unexpected: never = outcome;
       // The DISCRIMINANT only, never the payload. This message reaches an
-      // operator-visible warning through the caller's `catch`, and the
-      // `ingested` arm carries `episode.body` — the full plaintext of somebody's
-      // mail. Same reason the audience digest is redacted further down.
+      // operator-visible warning through the caller's `catch`, and this union
+      // already has an arm carrying `episode.body` — the full plaintext of
+      // somebody's mail — so any FUTURE arm that lands here must be assumed to
+      // as well. (Today's ingested arm returns above and cannot reach this.)
+      // Same reason the audience digest is redacted further down.
       throw new Error(
         `Unhandled Outlook message outcome: ${String((unexpected as { readonly kind?: unknown }).kind)}`,
       );
@@ -611,7 +640,8 @@ export function createOutlookMailClient(
       // input `deriveEmailRecipientGrant` could reject has already been settled
       // by the guards above. `headersComplete` is the literal `true`,
       // `participants` is non-empty, `source` is a module constant, the digest
-      // is 16 hex bytes by construction, and `messageId` came back non-empty and
+      // is 16 hex characters (64 bits) by construction, and `messageId` came
+      // back non-empty and
       // whitespace-free from `normalizeInternetMessageId`, so the id builder's
       // own trim-and-empty guard cannot fire on it.
       //
@@ -626,10 +656,14 @@ export function createOutlookMailClient(
       // and the mailbox freezes at this message.
       //
       // What says so is the stall detector further down, which raises a
-      // `log.error` AND an operator-facing warning. Note the timing: it is gated
-      // on the mailbox making no forward progress, so unless the block is the
-      // mailbox's first timestamped message it fires from the SECOND consecutive
-      // stalled cycle, once the resume mark has converged on `coveredThrough`.
+      // `log.error` AND an operator-facing warning. Two things about it are
+      // easy to assume and wrong. Its gate is a CONJUNCTION — `blockedAudience
+      // > 0`, which is PASS-scoped across every mailbox, AND this mailbox
+      // making no forward progress. And on timing: unless nothing ahead of the
+      // block in this pass's walk carried a timestamp (the block being the
+      // first message walked, which is the ordinary case after a clean prior
+      // pass), it fires from the SECOND consecutive stalled cycle, once the
+      // resume mark has converged on `coveredThrough`.
       //
       // It stays a block anyway, and that is the deliberate choice rather than
       // the leftover one. Skipping would advance the resume point past a message
@@ -1087,13 +1121,25 @@ export function createOutlookMailClient(
           "Outlook pass blocked messages whose audience could not be established — nothing was ingested from them, and nothing was granted more widely",
         );
       }
-      // Every counter EXCEPT the block one, by construction rather than by a
-      // hand-written sum of six field names. The sum this replaces would have
-      // silently omitted any reason added after it was written, so a whole
-      // permanent-drop class could have gone unreported while its counter sat
-      // right there in the object.
-      const { blockedAudience: _blocked, ...permanentSkips } = skips;
-      if (Object.values(permanentSkips).reduce((total, count) => total + count, 0) > 0) {
+      // Summed over the SSOT itself. Two things that matters for, both of which
+      // the obvious spellings get wrong:
+      //
+      // A hand-written sum of six field names — what this replaces — silently
+      // omits any reason added after it was written, so a whole permanent-drop
+      // class goes unreported while its counter sits right there in the object.
+      //
+      // Subtracting the block counter out of the object instead (`const {
+      // blockedAudience, ...rest } = skips`) fixes that but re-creates, in value
+      // space, the DEFAULT-to-permanent classification that
+      // `PERMANENT_SKIP_REASONS` exists to remove from the type: a second
+      // RETRYABLE counter would land in the rest and be announced on the
+      // permanent-drop line. Reading the array means `blockedAudience` is
+      // excluded because it is not in it, not because it was subtracted out.
+      const permanentDrops = PERMANENT_SKIP_REASONS.reduce(
+        (total, reason) => total + skips[reason],
+        0,
+      );
+      if (permanentDrops > 0) {
         log.info(
           { workspaceId: options.workspaceId, kept: episodes.length, ...skips },
           "Outlook mail pass complete — messages read but not stored, by reason",

--- a/packages/api/src/lib/brain/ingest/outlook/client.ts
+++ b/packages/api/src/lib/brain/ingest/outlook/client.ts
@@ -55,19 +55,41 @@
  * how #4965 shipped an outage. Among the things that stop a message being
  * ingested, some are RETRYABLE and some are PERMANENT:
  *
- *   - **BLOCK** — retryable. An access grant that could not be built from the
- *     mailbox/message ids; a membership write that failed. Nothing is ingested,
+ *   - **BLOCK** — retryable. A membership write that failed; an access grant
+ *     that could not be built from the mailbox/message ids. Nothing is ingested,
  *     the resume point does NOT advance past the message, and the pass reports
- *     `coverageIncomplete`. The next cycle tries again.
+ *     `coverageIncomplete`. The next cycle tries again. (The two are not equally
+ *     transient — the grant arm's own comment says why it is here anyway, and
+ *     what an operator sees if it ever fires.)
  *   - **SKIP** — permanent. Unreadable participant headers; headers that came
  *     back complete and named NOBODY; no RFC 5322 Message-ID; more participants
  *     than the cap; a body over the byte cap; a body Graph returned as HTML
  *     rather than the plain text asked for; a message that composed to nothing
  *     at all. Nothing is ingested, it is COUNTED, and the resume point DOES
- *     advance. All but one also warn — the empty-composed-body skip increments
- *     `skips.emptyBody` and surfaces only in the aggregate `log.info` at the end
- *     of the pass, which is deliberate (it is the high-volume one) but means
- *     "counted and warned" is not true of every arm.
+ *     advance. All but one also WARN — the empty-composed-body skip is counted
+ *     and surfaces only in the aggregate `log.info` at the end of the pass,
+ *     which is deliberate (it is the high-volume one). That exception is in the
+ *     type, not just in this paragraph: the skip arm carries `warning: string |
+ *     null`, so an arm that pushes nothing has to say so rather than simply
+ *     omit a `warnings.push` a reader has to notice is missing.
+ *
+ * ⚠️ **The split is a TYPE, and that is the point.** `runMessage` returns a
+ * `MessageOutcome` — `ingested` / `skipped` / `blocked` — and mutates nothing;
+ * `tallyOutcome` is the single place any outcome becomes a number. The skip
+ * arm's reason is `Exclude<keyof MessageSkips, "blockedAudience">`, so a new
+ * permanent reason is ONE edit (a counter on that interface), lands in its own
+ * counter by index rather than by a hand-written branch, and cannot be spelled
+ * as a block — while a new retryable condition has nowhere to go but `blocked`.
+ *
+ * It was not always so, and the previous shape is why this warning is here.
+ * `runMessage` used to return `{ episode, blocked: boolean }` and hand-increment
+ * a mutable tally at eight sites, one of them outside the function entirely, in
+ * the caller's `catch`. Nothing checked exhaustiveness and one of the four
+ * inhabitants was meaningless. The failure it invited is directional: forgetting
+ * `blocked: true` on a new retryable condition yields a PERMANENT skip that also
+ * advances the resume point, so the message is never revisited and the pass
+ * reports itself fully covered. That is the #4965 outage class in its silent
+ * direction, in the file whose header is about not doing exactly this.
  *
  * ⚠️ **Unreadable participant headers are PERMANENT and belong on the SKIP arm**
  * — the classification `runMessage` implements and the one this list got wrong
@@ -292,6 +314,12 @@ interface MessageSkips {
   /**
    * Messages BLOCKED — retryable, the resume point does not advance past them.
    * The safety counter an operator alerts on.
+   *
+   * The one key {@link PermanentSkipReason} excludes, and that exclusion is what
+   * turns the block-vs-skip split from a convention into a type: no `skipped`
+   * outcome can name this counter, so a permanent condition cannot be tallied as
+   * retryable, and a retryable one has nowhere to go but {@link MessageOutcome}'s
+   * `blocked` arm.
    */
   blockedAudience: number;
   /**
@@ -312,6 +340,68 @@ interface MessageSkips {
   bodyUnreadable: number;
   /** Messages that composed to nothing at all — no headers and no body. */
   emptyBody: number;
+}
+
+/**
+ * Every PERMANENT drop reason — DERIVED from {@link MessageSkips} rather than
+ * listed a second time, so the counters and the reasons cannot drift apart.
+ *
+ * Adding a permanent reason is therefore one edit: a counter on that interface.
+ * It becomes an inhabitant here, a required key on the tally's initializer (so
+ * omitting it does not compile), and a term `tallyOutcome` indexes rather than
+ * branches on.
+ */
+type PermanentSkipReason = Exclude<keyof MessageSkips, "blockedAudience">;
+
+/**
+ * What one message became. The module header's block-vs-skip split, in three
+ * arms — and it is three rather than the previous `{ episode, blocked }`'s four
+ * because that shape's `episode !== null && blocked` never meant anything.
+ *
+ * `warning` sits on the arms rather than being left to the caller for the same
+ * reason `reason` does: it was per-site and therefore forgettable. Exactly one
+ * skip arm deliberately pushes nothing, and `string | null` makes that a
+ * decision an arm states rather than an absence a reader has to notice.
+ */
+type MessageOutcome =
+  | { readonly kind: "ingested"; readonly episode: BrainEpisodeRecord }
+  | {
+      readonly kind: "skipped";
+      readonly reason: PermanentSkipReason;
+      /** `null` on the one arm that is counted but deliberately not warned. */
+      readonly warning: string | null;
+    }
+  | { readonly kind: "blocked"; readonly warning: string };
+
+/**
+ * The ONE place a message outcome becomes a number, and the only writer of
+ * {@link MessageSkips}.
+ *
+ * One site rather than eight is the point: a tally spread across the arms that
+ * produce it is a tally whose next arm can forget to increment, or increment the
+ * wrong counter, and neither shows up as anything but a number quietly missing
+ * from an operator's log line.
+ */
+function tallyOutcome(skips: MessageSkips, warnings: string[], outcome: MessageOutcome): void {
+  switch (outcome.kind) {
+    case "ingested":
+      return;
+    case "blocked":
+      skips.blockedAudience++;
+      warnings.push(outcome.warning);
+      return;
+    case "skipped":
+      // Indexed, not branched: a reason added to `MessageSkips` cannot silently
+      // land in the wrong counter, and — because `PermanentSkipReason` excludes
+      // it — cannot land in `blockedAudience` at all.
+      skips[outcome.reason]++;
+      if (outcome.warning !== null) warnings.push(outcome.warning);
+      return;
+    default: {
+      const unexpected: never = outcome;
+      throw new Error(`Unhandled Outlook message outcome: ${JSON.stringify(unexpected)}`);
+    }
+  }
 }
 
 export interface OutlookMailClientOptions {
@@ -389,34 +479,33 @@ export function createOutlookMailClient(
   /**
    * One message → its episode, or nothing, plus WHY nothing.
    *
-   * `blocked` is returned rather than left to the caller to infer from an absent
-   * episode, because the empty cases mean opposite things and only some of them
-   * may let the resume point advance — see the module header's block-vs-skip
-   * split. Conflating them is how a blocked message gets skipped permanently:
-   * the pass reports itself fully covered, the mark advances past the message,
-   * and no later cycle ever looks at it again.
+   * Returns a {@link MessageOutcome} and mutates NOTHING. The empty cases mean
+   * opposite things and only some of them may let the resume point advance — see
+   * the module header's block-vs-skip split — so which one this is has to be
+   * stated, not inferred from an absent episode. Conflating them is how a
+   * blocked message gets skipped permanently: the pass reports itself fully
+   * covered, the mark advances past the message, and no later cycle ever looks
+   * at it again.
+   *
+   * The counting and the warning both belong to {@link tallyOutcome}, one level
+   * up. This function decides, and the decision is the return value.
    *
    * The AUDIENCE is established and WRITTEN first, before an episode exists.
    * That ordering is the block arm, and `audience.ts` carries why the two
    * failure orders are not symmetric.
    */
-  async function runMessage(
-    mailboxId: string,
-    message: OutlookMessage,
-    skips: MessageSkips,
-    warnings: string[],
-  ): Promise<{ readonly episode: BrainEpisodeRecord | null; readonly blocked: boolean }> {
+  async function runMessage(mailboxId: string, message: OutlookMessage): Promise<MessageOutcome> {
     const messageId = normalizeInternetMessageId(message.internetMessageId);
     if (messageId === null) {
       // PERMANENT: a message without a Message-ID header never grows one. A
       // fallback to Graph's own `message.id` is deliberately NOT taken — it is
       // per-mailbox, so it would re-introduce the one-episode-per-recipient
       // duplication for exactly the messages whose identity is already doubtful.
-      skips.unidentifiable++;
-      warnings.push(
-        `A message in mailbox ${mailboxId} carries no RFC 5322 Message-ID and was skipped — it cannot be deduped against the copy in any other mailbox, so ingesting it would duplicate.`,
-      );
-      return { episode: null, blocked: false };
+      return {
+        kind: "skipped",
+        reason: "unidentifiable",
+        warning: `A message in mailbox ${mailboxId} carries no RFC 5322 Message-ID and was skipped — it cannot be deduped against the copy in any other mailbox, so ingesting it would duplicate.`,
+      };
     }
 
     if (!message.headersComplete) {
@@ -439,15 +528,15 @@ export function createOutlookMailClient(
       // (A genuinely malformed OBJECT is a different path: `parseOutlookMessage`
       // returns null, the page reports it as `dropped`, and THAT truncates the
       // walk retryably.)
-      skips.unattributable++;
-      warnings.push(
-        `Message ${messageId} was NOT ingested — Microsoft Graph did not return its full participant headers, so its audience could not be established. It is not retried; the headers of a stored message do not change.`,
-      );
       log.warn(
         { workspaceId: options.workspaceId, mailboxId },
         "Outlook message refused — incomplete participant headers, so no access grant could be derived. Permanent: the walk advances past it",
       );
-      return { episode: null, blocked: false };
+      return {
+        kind: "skipped",
+        reason: "unattributable",
+        warning: `Message ${messageId} was NOT ingested — Microsoft Graph did not return its full participant headers, so its audience could not be established. It is not retried; the headers of a stored message do not change.`,
+      };
     }
 
     const participants = messageParticipants(message);
@@ -456,23 +545,23 @@ export function createOutlookMailClient(
       // no sender and no To/Cc has no audience to mint, and it will not acquire
       // one — the headers are immutable. So it is REFUSED, not blocked: nothing
       // is ingested and nothing is granted, but the walk does not wait for it.
-      skips.unattributable++;
-      warnings.push(
-        `Message ${messageId} was NOT ingested — its headers name no sender and no recipients, so there is no audience to grant it to. It is not retried; the headers cannot change.`,
-      );
       log.warn(
         { workspaceId: options.workspaceId, mailboxId },
         "Outlook message refused — headers complete but empty, so no access grant could be derived. Permanent: the walk advances past it",
       );
-      return { episode: null, blocked: false };
+      return {
+        kind: "skipped",
+        reason: "unattributable",
+        warning: `Message ${messageId} was NOT ingested — its headers name no sender and no recipients, so there is no audience to grant it to. It is not retried; the headers cannot change.`,
+      };
     }
     if (participants.length > MAX_MESSAGE_PARTICIPANTS) {
       // PERMANENT: the recipient count of a stored message never changes.
-      skips.oversizeAudience++;
-      warnings.push(
-        `Message ${messageId} is addressed to ${participants.length} people, over the ${MAX_MESSAGE_PARTICIPANTS}-participant limit — it was skipped. Raising the limit re-admits it on the next backfill.`,
-      );
-      return { episode: null, blocked: false };
+      return {
+        kind: "skipped",
+        reason: "oversizeAudience",
+        warning: `Message ${messageId} is addressed to ${participants.length} people, over the ${MAX_MESSAGE_PARTICIPANTS}-participant limit — it was skipped. Raising the limit re-admits it on the next backfill.`,
+      };
     }
 
     // ── The BLOCK arm ─────────────────────────────────────────────────────
@@ -492,17 +581,35 @@ export function createOutlookMailClient(
     if (grant === null) {
       // ADR-0036 §T6: grant-derivation failure BLOCKS and LOGS. There is no
       // wider-grant fallback — `[org]` would publish somebody's mail to the
-      // whole company. Retryable: the only ways to reach here past the guards
-      // above are a malformed mailbox id or message id, which a re-read may fix.
-      skips.blockedAudience++;
-      warnings.push(
-        `Message ${messageId} was NOT ingested — an access grant could not be built from its mailbox and message ids. Nothing from it is stored; it is retried next cycle.`,
-      );
+      // whole company.
+      //
+      // ⚠️ This is the BLOCK arm, but do NOT read that as "a re-read may fix
+      // it". An earlier wording said exactly that and it does not hold: every
+      // input `deriveEmailRecipientGrant` could reject has already been settled
+      // by the guards above. `headersComplete` is the literal `true`,
+      // `participants` is non-empty, `source` is a module constant, the digest
+      // is 16 hex bytes by construction, and `messageId` came back non-empty and
+      // byte-checked from `normalizeInternetMessageId`. What is left is a
+      // mailbox object id that is empty or carries a `:` — and that id is
+      // resolved ONCE per pass from Graph and is the same on every retry. So if
+      // this ever fires it does not clear: the mailbox freezes at this message,
+      // and the only thing that says so is the stall detector's `log.error`
+      // further down.
+      //
+      // It stays a block anyway, and that is the deliberate choice rather than
+      // the leftover one. Skipping would advance the resume point past a message
+      // whose audience Atlas could not derive — a silent permanent loss on the
+      // SAFETY arm, which is the worst place to put one. A loud repeating stall
+      // is the better failure of the two. Moving it to the skip arm would be a
+      // BEHAVIOUR change and belongs in its own issue.
       log.warn(
         { workspaceId: options.workspaceId, mailboxId },
         "Outlook message blocked — no access grant could be derived, so nothing was ingested from it",
       );
-      return { episode: null, blocked: true };
+      return {
+        kind: "blocked",
+        warning: `Message ${messageId} was NOT ingested — an access grant could not be built from its mailbox and message ids. Nothing from it is stored; it is retried next cycle.`,
+      };
     }
 
     // Membership BEFORE the episode — see `audience.ts` for why the two failure
@@ -550,11 +657,11 @@ export function createOutlookMailClient(
       //
       // A SKIP rather than a block: `contentType` is a property of the stored
       // message, so retrying reads the same answer forever.
-      skips.bodyUnreadable++;
-      warnings.push(
-        `Message ${messageId} was skipped — Microsoft Graph returned its body as HTML rather than the plain text Atlas asked for, and storing the headers alone would look like a complete message.`,
-      );
-      return { episode: null, blocked: false };
+      return {
+        kind: "skipped",
+        reason: "bodyUnreadable",
+        warning: `Message ${messageId} was skipped — Microsoft Graph returned its body as HTML rather than the plain text Atlas asked for, and storing the headers alone would look like a complete message.`,
+      };
     }
 
     const body = composeEmailBody(message);
@@ -565,8 +672,13 @@ export function createOutlookMailClient(
       // genuinely has no body but DOES have headers is complete evidence (a
       // subject-only "approved — EOM" is a real mail) and is stored as its
       // header block. PERMANENT either way.
-      skips.emptyBody++;
-      return { episode: null, blocked: false };
+      //
+      // The ONE arm with `warning: null`. It is counted like every other skip
+      // and surfaces only in the aggregate `log.info` at the end of the pass,
+      // because it is the high-volume one and a per-message warning would bury
+      // the arms an operator actually needs to read. Stated in the type rather
+      // than left as an absent `warnings.push` — an omission reads as a bug.
+      return { kind: "skipped", reason: "emptyBody", warning: null };
     }
     if (Buffer.byteLength(body, "utf8") > MAX_EMAIL_BODY_BYTES) {
       // `Buffer.byteLength`, not `String.length`: the latter counts UTF-16 code
@@ -574,14 +686,15 @@ export function createOutlookMailClient(
       // PERMANENT, so a SKIP and not a block — routing a permanent size
       // condition through the retry arm is precisely how #4965's size guard
       // became an outage.
-      skips.oversizeBody++;
-      warnings.push(
-        `Message ${messageId} has a body over the ${MAX_EMAIL_BODY_BYTES / 1_048_576}MB limit — it was skipped rather than truncated, so no partial message is stored as if it were whole.`,
-      );
-      return { episode: null, blocked: false };
+      return {
+        kind: "skipped",
+        reason: "oversizeBody",
+        warning: `Message ${messageId} has a body over the ${MAX_EMAIL_BODY_BYTES / 1_048_576}MB limit — it was skipped rather than truncated, so no partial message is stored as if it were whole.`,
+      };
     }
 
     return {
+      kind: "ingested",
       episode: {
         sourceId: outlookEpisodeSourceId(messageId),
         // The SENDER's address. Recipients stay in the body for the extraction
@@ -593,7 +706,6 @@ export function createOutlookMailClient(
         occurredAt: message.receivedDateTime === null ? null : parseDate(message.receivedDateTime),
         visibleTo: grant,
       },
-      blocked: false,
     };
   }
 
@@ -785,8 +897,9 @@ export function createOutlookMailClient(
               break pages;
             }
             try {
-              const produced = await runMessage(mailboxId, message, skips, warnings);
-              if (produced.blocked) {
+              const outcome = await runMessage(mailboxId, message);
+              tallyOutcome(skips, warnings, outcome);
+              if (outcome.kind === "blocked") {
                 // A blocked message leaves its range UNCOVERED. Without this the
                 // pass reports itself fully covered, the resume point advances
                 // past the message, and no later cycle ever looks at it again —
@@ -795,8 +908,8 @@ export function createOutlookMailClient(
                 mailboxIncomplete = true;
                 break pages;
               }
-              if (produced.episode !== null) {
-                episodes.push(produced.episode);
+              if (outcome.kind === "ingested") {
+                episodes.push(outcome.episode);
                 remainingEpisodes--;
                 const at = message.receivedDateTime;
                 if (at !== null && (newestIngested === null || at > newestIngested)) {
@@ -814,7 +927,18 @@ export function createOutlookMailClient(
               if (throttled && episodes.length === 0) throw err;
               mailboxIncomplete = true;
               const messageText = err instanceof Error ? err.message : String(err);
-              if (!throttled) {
+              if (throttled) {
+                // Not an outcome of the message — Graph stopped answering, and
+                // the message itself was never classified. Nothing is tallied.
+                warnings.push(
+                  `Mailbox ${configured} stopped mid-page — Microsoft Graph is rate limiting this tenant. It resumes next cycle.`,
+                );
+              } else {
+                // A throw IS an outcome, so it goes through the same tally as
+                // every other one rather than reaching into the counters by hand
+                // — this used to be the eighth increment site and the only one
+                // outside `runMessage`.
+                //
                 // The dominant throw on this path is a failed membership WRITE —
                 // the most safety-relevant failure in the file, since an audience
                 // that could not be written is an audience nobody is in. It is
@@ -822,13 +946,11 @@ export function createOutlookMailClient(
                 // and it is worded "NOT ingested … retried" rather than "skipped":
                 // "skipped" is this module's word for the permanent arm, and this
                 // one comes back.
-                skips.blockedAudience++;
+                tallyOutcome(skips, warnings, {
+                  kind: "blocked",
+                  warning: `A message in mailbox ${configured} was NOT ingested — ${messageText}. Nothing from it is stored; it is retried next cycle.`,
+                });
               }
-              warnings.push(
-                throttled
-                  ? `Mailbox ${configured} stopped mid-page — Microsoft Graph is rate limiting this tenant. It resumes next cycle.`
-                  : `A message in mailbox ${configured} was NOT ingested — ${messageText}. Nothing from it is stored; it is retried next cycle.`,
-              );
               log.warn(
                 { workspaceId: options.workspaceId, mailbox: configured, err: messageText, throttled },
                 throttled
@@ -931,15 +1053,13 @@ export function createOutlookMailClient(
           "Outlook pass blocked messages whose audience could not be established — nothing was ingested from them, and nothing was granted more widely",
         );
       }
-      if (
-        skips.unidentifiable +
-          skips.unattributable +
-          skips.oversizeAudience +
-          skips.oversizeBody +
-          skips.bodyUnreadable +
-          skips.emptyBody >
-        0
-      ) {
+      // Every counter EXCEPT the block one, by construction rather than by a
+      // hand-written sum of six field names. The sum this replaces would have
+      // silently omitted any reason added after it was written, so a whole
+      // permanent-drop class could have gone unreported while its counter sat
+      // right there in the object.
+      const { blockedAudience: _blocked, ...permanentSkips } = skips;
+      if (Object.values(permanentSkips).reduce((total, count) => total + count, 0) > 0) {
         log.info(
           { workspaceId: options.workspaceId, kept: episodes.length, ...skips },
           "Outlook mail pass complete — messages read but not stored, by reason",

--- a/packages/api/src/lib/brain/ingest/outlook/client.ts
+++ b/packages/api/src/lib/brain/ingest/outlook/client.ts
@@ -315,8 +315,8 @@ export function toOutlookClientError(context: string, failure: OutlookReadError)
 }
 
 /**
- * Every PERMANENT drop reason, and the SSOT for that set — `extract.ts`'s
- * `EXTRACTION_SKIP_REASONS` shape, one directory over.
+ * Every PERMANENT drop reason, and the SSOT for that set — the shape
+ * `lib/brain/extract.ts` uses for `EXTRACTION_SKIP_REASONS`.
  *
  * The list runs this way round rather than being subtracted out of
  * {@link MessageSkips} (`Exclude<keyof MessageSkips, "blockedAudience">`) on
@@ -360,14 +360,20 @@ type PermanentSkipReason = (typeof PERMANENT_SKIP_REASONS)[number];
  *
  * `interface … extends Record<…>` permits a member that COLLIDES with an
  * inherited one as long as the declared type is identical — and `number` vs
- * `number` is identical. So adding `"blockedAudience"` to the array above
- * compiles cleanly, and the safety counter silently becomes a legal `skipped`
- * reason for `skips[outcome.reason]++` to land in. That is the one hole the move
- * off `Exclude<keyof MessageSkips, …>` opened, and it costs two lines to close.
+ * `number` is identical. So without this, adding `"blockedAudience"` to the
+ * array above compiles cleanly and the safety counter silently becomes a legal
+ * `skipped` reason for `skips[outcome.reason]++` to land in. That is the one
+ * hole the move off `Exclude<keyof MessageSkips, …>` opened.
+ *
+ * The false branch is a SENTENCE rather than `false` so the compiler error is
+ * the explanation. `_Expect` is the repo's spelling — see `admin-knowledge.ts`
+ * and `dashboards.ts`.
  */
-type AssertTrue<T extends true> = T;
-type _BlockStaysRetryable = AssertTrue<
-  "blockedAudience" extends PermanentSkipReason ? false : true
+type _Expect<T extends true> = T;
+type _BlockStaysRetryable = _Expect<
+  "blockedAudience" extends PermanentSkipReason
+    ? "blockedAudience is RETRYABLE — it must not be in PERMANENT_SKIP_REASONS"
+    : true
 >;
 
 /** Per-pass drop tally — every message seen but not stored, by reason. */
@@ -418,9 +424,11 @@ type MessageOutcome =
  * operator's log line.
  *
  * Exported for its own unit tests, like this module's other pure helpers. The
- * counters reach the outside world only through a `log.info`, so a mutation that
- * indexes the WRONG counter is invisible to the walk's end-to-end tests — and
- * the `default` arm's no-payload rule is unreachable from them entirely.
+ * PERMANENT counters reach the outside world only through the aggregate
+ * `log.info`, so a mutation that indexes the wrong one of them is invisible to
+ * the walk's end-to-end tests; the `default` arm's no-payload rule is
+ * unreachable from them entirely. (`blockedAudience` is the exception — it also
+ * gates the stall detector, which those tests do assert.)
  */
 export function tallyOutcome(
   skips: MessageSkips,
@@ -531,16 +539,20 @@ export function createOutlookMailClient(
   /**
    * One message → its episode, or nothing, plus WHY nothing.
    *
-   * Returns a {@link MessageOutcome} and mutates NOTHING. The empty cases mean
-   * opposite things and only some of them may let the resume point advance — see
-   * the module header's block-vs-skip split — so which one this is has to be
-   * stated, not inferred from an absent episode. Conflating them is how a
-   * blocked message gets skipped permanently: the pass reports itself fully
-   * covered, the mark advances past the message, and no later cycle ever looks
-   * at it again.
+   * Returns a {@link MessageOutcome} and mutates none of the CALLER's state — no
+   * counter, no warning list. (It is not side-effect-free: it writes audience
+   * membership and it logs. The scope of the claim is the caller's bookkeeping,
+   * which is what used to arrive here as two out-params.)
    *
-   * The counting and the warning both belong to {@link tallyOutcome}, one level
-   * up. This function decides, and the decision is the return value.
+   * The empty cases mean opposite things and only some of them may let the
+   * resume point advance — see the module header's block-vs-skip split — so
+   * which one this is has to be stated, not inferred from an absent episode.
+   * Conflating them is how a blocked message gets skipped permanently: the pass
+   * reports itself fully covered, the mark advances past the message, and no
+   * later cycle ever looks at it again.
+   *
+   * The counting and the outcome's warning both belong to {@link tallyOutcome},
+   * one level up. This function decides, and the decision is the return value.
    *
    * The AUDIENCE is established and WRITTEN first, before an episode exists.
    * That ordering is the block arm, and `audience.ts` carries why the two
@@ -660,10 +672,11 @@ export function createOutlookMailClient(
       // easy to assume and wrong. Its gate is a CONJUNCTION — `blockedAudience
       // > 0`, which is PASS-scoped across every mailbox, AND this mailbox
       // making no forward progress. And on timing: unless nothing ahead of the
-      // block in this pass's walk carried a timestamp (the block being the
-      // first message walked, which is the ordinary case after a clean prior
-      // pass), it fires from the SECOND consecutive stalled cycle, once the
-      // resume mark has converged on `coveredThrough`.
+      // block advanced `coveredThrough` past the stored mark — the block being
+      // the first timestamped message walked, or everything ahead of it sharing
+      // the resume instant, which bulk mail routinely does — it fires from the
+      // SECOND consecutive stalled cycle, once the mark has converged on
+      // `coveredThrough`.
       //
       // It stays a block anyway, and that is the deliberate choice rather than
       // the leftover one. Skipping would advance the resume point past a message
@@ -1134,7 +1147,11 @@ export function createOutlookMailClient(
       // `PERMANENT_SKIP_REASONS` exists to remove from the type: a second
       // RETRYABLE counter would land in the rest and be announced on the
       // permanent-drop line. Reading the array means `blockedAudience` is
-      // excluded because it is not in it, not because it was subtracted out.
+      // excluded because it is not in it, not because it was subtracted out —
+      // and it reads only the six DECLARED numeric keys, where `Object.values`
+      // reads whatever exists at runtime, so one stray non-numeric key would
+      // make the total `NaN` and suppress this line entirely rather than merely
+      // undercount it.
       const permanentDrops = PERMANENT_SKIP_REASONS.reduce(
         (total, reason) => total + skips[reason],
         0,

--- a/packages/api/src/lib/brain/ingest/outlook/client.ts
+++ b/packages/api/src/lib/brain/ingest/outlook/client.ts
@@ -73,23 +73,28 @@
  *     null`, so an arm that pushes nothing has to say so rather than simply
  *     omit a `warnings.push` a reader has to notice is missing.
  *
- * ⚠️ **The split is a TYPE, and that is the point.** `runMessage` returns a
- * `MessageOutcome` — `ingested` / `skipped` / `blocked` — and mutates nothing;
- * `tallyOutcome` is the single place any outcome becomes a number. The skip
- * arm's reason is `Exclude<keyof MessageSkips, "blockedAudience">`, so a new
- * permanent reason is ONE edit (a counter on that interface), lands in its own
- * counter by index rather than by a hand-written branch, and cannot be spelled
- * as a block — while a new retryable condition has nowhere to go but `blocked`.
+ * ⚠️ **Where the split is a TYPE, and where it is still a judgement.**
+ * `runMessage` returns a `MessageOutcome` — `ingested` / `skipped` / `blocked` —
+ * and mutates nothing; `tallyOutcome` is the only writer of the tally. The skip
+ * arm's reason is drawn from `PERMANENT_SKIP_REASONS`, which does not contain
+ * `blockedAudience`, so a `skipped` outcome cannot be tallied as retryable and a
+ * new reason lands in its own counter by index rather than by a hand-written
+ * branch.
  *
- * It was not always so, and the previous shape is why this warning is here.
- * `runMessage` used to return `{ episode, blocked: boolean }` and hand-increment
- * a mutable tally at eight sites, one of them outside the function entirely, in
- * the caller's `catch`. Nothing checked exhaustiveness and one of the four
- * inhabitants was meaningless. The failure it invited is directional: forgetting
- * `blocked: true` on a new retryable condition yields a PERMANENT skip that also
- * advances the resume point, so the message is never revisited and the pass
- * reports itself fully covered. That is the #4965 outage class in its silent
- * direction, in the file whose header is about not doing exactly this.
+ * What the type does NOT do is choose the arm for you. Deciding whether a new
+ * CONDITION is permanent or retryable is a human call, and nothing can make it
+ * otherwise; what changed is that the call is now spelled once, at `kind`, and
+ * that adding a reason to either class is a visible edit rather than a default.
+ *
+ * The previous shape is why the warning is here at all. `runMessage` used to
+ * return `{ episode, blocked: boolean }` and hand-increment a mutable tally at
+ * nine sites, one of them outside the function entirely, in the caller's
+ * `catch`. Nothing checked exhaustiveness and one of the four inhabitants was
+ * meaningless. The failure it invited is directional: forgetting `blocked: true`
+ * on a new retryable condition yields a PERMANENT skip that also advances the
+ * resume point, so the message is never revisited and the pass reports itself
+ * fully covered. That is the #4965 outage class in its silent direction, in the
+ * file whose header is about not doing exactly this.
  *
  * ⚠️ **Unreadable participant headers are PERMANENT and belong on the SKIP arm**
  * — the classification `runMessage` implements and the one this list got wrong
@@ -309,19 +314,21 @@ export function toOutlookClientError(context: string, failure: OutlookReadError)
   }
 }
 
-/** Per-pass drop tally — every message seen but not stored, by reason. */
-interface MessageSkips {
-  /**
-   * Messages BLOCKED — retryable, the resume point does not advance past them.
-   * The safety counter an operator alerts on.
-   *
-   * The one key {@link PermanentSkipReason} excludes, and that exclusion is what
-   * turns the block-vs-skip split from a convention into a type: no `skipped`
-   * outcome can name this counter, so a permanent condition cannot be tallied as
-   * retryable, and a retryable one has nowhere to go but {@link MessageOutcome}'s
-   * `blocked` arm.
-   */
-  blockedAudience: number;
+/**
+ * Every PERMANENT drop reason, and the SSOT for that set — `extract.ts`'s
+ * `EXTRACTION_SKIP_REASONS` shape, one directory over.
+ *
+ * The list runs this way round rather than being subtracted out of
+ * {@link MessageSkips} (`Exclude<keyof MessageSkips, "blockedAudience">`) on
+ * purpose, and the difference is not cosmetic. Subtraction gives a NEW counter a
+ * default classification of "permanent" — so a future retryable counter would
+ * become a legal `skipped` reason with no diagnostic, and a permanent skip that
+ * advances the resume point past a message that should have been retried is
+ * exactly the #4965 direction this file is organised against. Here neither
+ * classification is the default: a permanent reason is an entry in this array, a
+ * retryable one is a field on the interface below, and both are a visible edit.
+ */
+const PERMANENT_SKIP_REASONS = [
   /**
    * Messages whose headers arrived complete and named NOBODY — permanent, so the
    * resume point advances. Counted apart from `blockedAudience` deliberately:
@@ -329,29 +336,35 @@ interface MessageSkips {
    * coming back", and the block-vs-skip distinction is the whole organising idea
    * of this file.
    */
-  unattributable: number;
+  "unattributable",
   /** Messages with no usable RFC 5322 Message-ID. */
-  unidentifiable: number;
+  "unidentifiable",
   /** Messages whose participant set exceeded the cap. */
-  oversizeAudience: number;
+  "oversizeAudience",
   /** Bodies skipped as oversize. */
-  oversizeBody: number;
+  "oversizeBody",
   /** Messages whose body was PRESENT but not plain text, so it was refused. */
-  bodyUnreadable: number;
+  "bodyUnreadable",
   /** Messages that composed to nothing at all — no headers and no body. */
-  emptyBody: number;
-}
+  "emptyBody",
+] as const;
 
-/**
- * Every PERMANENT drop reason — DERIVED from {@link MessageSkips} rather than
- * listed a second time, so the counters and the reasons cannot drift apart.
- *
- * Adding a permanent reason is therefore one edit: a counter on that interface.
- * It becomes an inhabitant here, a required key on the tally's initializer (so
- * omitting it does not compile), and a term `tallyOutcome` indexes rather than
- * branches on.
- */
-type PermanentSkipReason = Exclude<keyof MessageSkips, "blockedAudience">;
+type PermanentSkipReason = (typeof PERMANENT_SKIP_REASONS)[number];
+
+/** Per-pass drop tally — every message seen but not stored, by reason. */
+interface MessageSkips extends Record<PermanentSkipReason, number> {
+  /**
+   * Messages BLOCKED — retryable, the resume point does not advance past them.
+   * The safety counter an operator alerts on.
+   *
+   * Deliberately NOT a {@link PermanentSkipReason}, which is what stops a
+   * `skipped` outcome naming it: a permanent condition cannot be tallied as
+   * retryable. Choosing which arm a new CONDITION belongs on is still a human
+   * decision — no type can make it — but it is now spelled once, at `kind`,
+   * instead of inferred from a `blocked: boolean` a new arm can forget.
+   */
+  blockedAudience: number;
+}
 
 /**
  * What one message became. The module header's block-vs-skip split, in three
@@ -374,10 +387,14 @@ type MessageOutcome =
   | { readonly kind: "blocked"; readonly warning: string };
 
 /**
- * The ONE place a message outcome becomes a number, and the only writer of
- * {@link MessageSkips}.
+ * The only writer of {@link MessageSkips} — the one place a message that was NOT
+ * stored becomes a number, and the one place its warning is raised.
  *
- * One site rather than eight is the point: a tally spread across the arms that
+ * (An INGESTED message becomes numbers at the call site instead, as
+ * `episodes.length` and the budget decrement. Nothing to tally: `kept` is the
+ * episode count, not a drop counter.)
+ *
+ * One site rather than nine is the point. A tally spread across the arms that
  * produce it is a tally whose next arm can forget to increment, or increment the
  * wrong counter, and neither shows up as anything but a number quietly missing
  * from an operator's log line.
@@ -391,15 +408,21 @@ function tallyOutcome(skips: MessageSkips, warnings: string[], outcome: MessageO
       warnings.push(outcome.warning);
       return;
     case "skipped":
-      // Indexed, not branched: a reason added to `MessageSkips` cannot silently
-      // land in the wrong counter, and — because `PermanentSkipReason` excludes
-      // it — cannot land in `blockedAudience` at all.
+      // Indexed, not branched: a reason in `PERMANENT_SKIP_REASONS` cannot
+      // silently land in the wrong counter, and — because `blockedAudience` is
+      // not one of them — cannot land in the safety counter at all.
       skips[outcome.reason]++;
       if (outcome.warning !== null) warnings.push(outcome.warning);
       return;
     default: {
       const unexpected: never = outcome;
-      throw new Error(`Unhandled Outlook message outcome: ${JSON.stringify(unexpected)}`);
+      // The DISCRIMINANT only, never the payload. This message reaches an
+      // operator-visible warning through the caller's `catch`, and the
+      // `ingested` arm carries `episode.body` — the full plaintext of somebody's
+      // mail. Same reason the audience digest is redacted further down.
+      throw new Error(
+        `Unhandled Outlook message outcome: ${String((unexpected as { readonly kind?: unknown }).kind)}`,
+      );
     }
   }
 }
@@ -589,12 +612,24 @@ export function createOutlookMailClient(
       // by the guards above. `headersComplete` is the literal `true`,
       // `participants` is non-empty, `source` is a module constant, the digest
       // is 16 hex bytes by construction, and `messageId` came back non-empty and
-      // byte-checked from `normalizeInternetMessageId`. What is left is a
-      // mailbox object id that is empty or carries a `:` — and that id is
-      // resolved ONCE per pass from Graph and is the same on every retry. So if
-      // this ever fires it does not clear: the mailbox freezes at this message,
-      // and the only thing that says so is the stall detector's `log.error`
-      // further down.
+      // whitespace-free from `normalizeInternetMessageId`, so the id builder's
+      // own trim-and-empty guard cannot fire on it.
+      //
+      // What is left is a mailbox object id that TRIMS to empty or carries a
+      // `:`. A literally empty one never reaches here — `fetchMailbox` refuses
+      // it as a transport error and the mailbox is skipped before any message is
+      // run — so the residual set is a whitespace-only id and a colon-bearing
+      // one, neither of which a Graph object id (a GUID) can be. The id IS
+      // re-read from Graph every pass rather than cached, but an object id is an
+      // immutable directory property, so the re-read returns the same value: a
+      // malformed one is not a transient. If this ever fires it does not clear,
+      // and the mailbox freezes at this message.
+      //
+      // What says so is the stall detector further down, which raises a
+      // `log.error` AND an operator-facing warning. Note the timing: it is gated
+      // on the mailbox making no forward progress, so unless the block is the
+      // mailbox's first timestamped message it fires from the SECOND consecutive
+      // stalled cycle, once the resume mark has converged on `coveredThrough`.
       //
       // It stays a block anyway, and that is the deliberate choice rather than
       // the leftover one. Skipping would advance the resume point past a message
@@ -936,8 +971,7 @@ export function createOutlookMailClient(
               } else {
                 // A throw IS an outcome, so it goes through the same tally as
                 // every other one rather than reaching into the counters by hand
-                // — this used to be the eighth increment site and the only one
-                // outside `runMessage`.
+                // — this is the only classification site outside `runMessage`.
                 //
                 // The dominant throw on this path is a failed membership WRITE —
                 // the most safety-relevant failure in the file, since an audience


### PR DESCRIPTION
`runMessage` returned `{ episode: BrainEpisodeRecord | null; blocked: boolean }` and hand-incremented a mutable `MessageSkips` out-param at **nine** sites — one of them outside the function entirely, in the caller's `catch`. Nothing checked exhaustiveness, and one of the four inhabitants (`episode !== null && blocked`) was meaningless because the caller checks `blocked` first and drops the episode.

The failure that shape invited is directional: forgetting `blocked: true` on a new retryable condition yields a **permanent** skip that *also* advances the resume point, so the message is never revisited while the pass reports itself fully covered. That is #4965's outage class in its silent direction, in the file whose header is about not doing exactly this.

`runMessage` now returns a `MessageOutcome` — `ingested` / `skipped` / `blocked` — and mutates none of the caller's bookkeeping. `tallyOutcome` is the only writer of the tally.

## How the classification is enforced

Following `brain/extract.ts`'s "indexed, not branched" pattern:

```ts
const PERMANENT_SKIP_REASONS = ["unattributable", …] as const;   // SSOT
type PermanentSkipReason = (typeof PERMANENT_SKIP_REASONS)[number];
interface MessageSkips extends Record<PermanentSkipReason, number> {
  blockedAudience: number;   // deliberately NOT a PermanentSkipReason
}
```

The list runs this way round rather than `Exclude<keyof MessageSkips, "blockedAudience">` deliberately. Subtraction gives a **new** counter a default classification of "permanent", so a future retryable counter would become a legal `skipped` reason with no diagnostic — the #4965 direction again. Here neither class is the default: a permanent reason is an array entry, a retryable one is a field on the interface, and both are a visible edit.

**Verified by probe, not by assertion.** Each of these is a compile error today:

- adding a reason to the array without initialising its counter (`TS2741`)
- naming a reason that is not in the array (`TS2322`)
- adding an outcome arm without a tally case (`TS2322` on the `never`)
- adding a **retryable** counter to the interface and using it as a skip reason — this one *compiled silently* under the original `Exclude` derivation
- smuggling `"blockedAudience"` into the array, which `interface … extends Record<…>` otherwise permits because the member types are identical — now caught by a compile-time assertion whose error message *is* the explanation

## Folded-in items from the issue

**The BLOCK arm's "a re-read may fix" comment.** It does not hold. Every input `deriveEmailRecipientGrant` could reject is settled by the guards above it: `headersComplete` is the literal `true`, `participants` is non-empty, `source` is a module constant, the digest is 16 hex characters by construction, and `messageId` came back non-empty and whitespace-free from `normalizeInternetMessageId`. What is left is a mailbox object id that trims to empty or carries a `:` — and a literally empty one never gets here, because `fetchMailbox` refuses it as a transport error first. The id is re-read from Graph every pass, but an object id is an immutable directory property, so a malformed one is not a transient: if this fires it does **not** clear.

It stays a block anyway, and the comment now says why: skipping would advance the resume point past a message whose audience Atlas could not derive — a silent permanent loss on the safety arm, where a loud repeating stall is the better failure. Reclassifying it would be a behaviour change and belongs in its own issue.

**The header's SKIP-arm description.** Now matches every arm, and the un-warned one is structural rather than prose: the skip arm carries `warning: string | null`, so an arm that pushes nothing has to *say so* rather than omit a `warnings.push` a reader has to notice is missing. `emptyBody` is the only `null`.

## Behaviour

Neutral. **The 24 pre-existing Outlook client tests pass unedited** — that was the acceptance criterion, and it is meaningful rather than vacuous here, because those tests assert on the return contract that changed shape underneath them.

## Tests added (beyond the AC, found by the review panel)

The panel found the **grant-null BLOCK arm was unreachable by the suite**: reclassifying it as a permanent skip left 24/24 green, and the caller's `outcome.kind === "blocked"` handler was dead code as far as the tests were concerned. That is the safety arm. Added a test reaching it through the one input the guards do not settle (a mailbox object id containing `:`), plus direct unit tests for `tallyOutcome`, whose counters otherwise reach the world only through a `log.info` no test captures.

Every added assertion is mutation-verified — each mutation fails its intended test and left the suite green before:

| Mutation | Killed by |
|---|---|
| grant-null block → permanent skip | new grant-null block test |
| caller's `blocked` handler neutered | new grant-null block test |
| catch-path tally + warn deleted | membership-write test (new assertions) |
| stall detector deleted | membership-write test (new assertions) |
| `skips[outcome.reason]++` → fixed counter | `tallyOutcome` unit test |
| unconditional `warnings.push` | `tallyOutcome` unit test |
| `default` arm → `JSON.stringify(outcome)` | `tallyOutcome` unit test |

That last one is a real leak the panel caught: the exhaustiveness arm stringified the whole outcome, and one arm of the union carries `episode.body` — the full plaintext of a mail — which the caller's `catch` turns into an operator-visible warning persisted to `knowledge_sync_state`. It now prints the discriminant only, matching the audience-digest redaction this file already does.

## Review panel

Three rounds. Round 1 caught the `Exclude`-derivation defaulting a new counter to permanent, the unpinned safety arm, and the payload leak. Round 2 caught the aggregate drop total re-creating that same subtractive default one layer down, in value space, and the inverse smuggling hole the fix had opened. Round 3's type axis came back **clean and mergeable**; its comment axis caught a claim this branch had introduced (`runMessage` "mutates NOTHING" — it writes audience membership and logs) and several imprecisions, all corrected.

## Out of scope — flagged for a follow-up

Two reviewers independently found a **pre-existing defect in the stall detector** (untouched by this PR): its gate is `skips.blockedAudience > 0 && (coveredThrough === null || coveredThrough === storedMark)`, but `skips` is **pass-scoped** while the check runs **per mailbox**. A block in mailbox A satisfies the first conjunct for mailbox B, and B then only needs to make no forward progress — which happens on an ordinary budget exhaustion or a `dropped > 0` page. B gets a `log.error` and an operator warning claiming it "made NO forward progress and blocked at least one message" when it blocked nothing.

Direction is safe (over-report, never under-report), but this is the one detector standing between a real block and the "stuck for 400 cycles" shape the file says an operator otherwise cannot see, so alert fatigue on it costs exactly the signal it exists to provide. The fix is a mailbox-scoped counter — a **behaviour change**, hence not in this PR. This PR's new tests now assert the stall warning's text, which makes its precision a live contract.

Closes #4986
