### PR TITLE
fix(chat): restore the id-based mention backstop in multi-workspace Slack

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -943,6 +943,7 @@
   },
   "patchedDependencies": {
     "bun-types@1.3.14": "patches/bun-types@1.3.14.patch",
+    "@chat-adapter/slack@4.23.0": "patches/@chat-adapter%2Fslack@4.23.0.patch",
   },
   "overrides": {
     "@discordjs/rest": "^2.6.3",

--- a/deploy/api/Dockerfile
+++ b/deploy/api/Dockerfile
@@ -14,8 +14,11 @@ FROM oven/bun:1.3.13@sha256:87416c977a612a204eb54ab9f3927023c2a3c971f4f345a01da0
 FROM base AS manifests
 WORKDIR /app
 COPY package.json bun.lock* ./
-# The bun-types patch (patchedDependencies in package.json/bun.lock) must be
-# present in the build context for `bun ci` to apply it during install.
+# Both patches (patchedDependencies in package.json/bun.lock) must be present in
+# the build context for `bun ci` to apply them during install. A missing patch
+# file is a hard install error, so pruning this COPY fails the build loudly —
+# but don't: unlike `bun-types`, the `@chat-adapter/slack` patch is runtime
+# load-bearing (multi-workspace Slack @-mention detection, #4911).
 COPY patches patches
 COPY packages/api/package.json packages/api/package.json
 COPY packages/web/package.json packages/web/package.json

--- a/deploy/docs/Dockerfile
+++ b/deploy/docs/Dockerfile
@@ -23,8 +23,11 @@ FROM oven/bun:1.3.13@sha256:87416c977a612a204eb54ab9f3927023c2a3c971f4f345a01da0
 FROM base AS deps
 WORKDIR /app
 COPY package.json bun.lock* ./
-# The bun-types patch (patchedDependencies in package.json/bun.lock) must be
-# present in the build context for `bun ci` to apply it during install.
+# Both patches (patchedDependencies in package.json/bun.lock) must be present in
+# the build context for `bun ci` to apply them during install. Neither is runtime
+# relevant to THIS image (it serves the Fumadocs site) — but
+# `@chat-adapter/slack` is still in the resolved graph, and bun hard-errors on a
+# missing patch file, so pruning this COPY fails the build.
 COPY patches patches
 COPY packages/api/package.json packages/api/package.json
 COPY packages/web/package.json packages/web/package.json

--- a/deploy/web/Dockerfile
+++ b/deploy/web/Dockerfile
@@ -10,8 +10,11 @@ FROM oven/bun:1.3.13@sha256:87416c977a612a204eb54ab9f3927023c2a3c971f4f345a01da0
 FROM base AS deps
 WORKDIR /app
 COPY package.json bun.lock* ./
-# The bun-types patch (patchedDependencies in package.json/bun.lock) must be
-# present in the build context for `bun ci` to apply it during install.
+# Both patches (patchedDependencies in package.json/bun.lock) must be present in
+# the build context for `bun ci` to apply them during install. Neither is runtime
+# relevant to THIS image (it serves `@atlas/web`, which never loads the Slack
+# adapter) — but `@chat-adapter/slack` is still in the resolved graph, and bun
+# hard-errors on a missing patch file, so pruning this COPY fails the build.
 COPY patches patches
 COPY packages/api/package.json packages/api/package.json
 COPY packages/web/package.json packages/web/package.json

--- a/docs/architecture/chat-plugin-atlas-contract.md
+++ b/docs/architecture/chat-plugin-atlas-contract.md
@@ -39,10 +39,10 @@ Citations are `path/file.ts:fn()` so refactors that shift line numbers don't sil
 
 | Field | Owner | Legacy write site | New write site | Read sites | Fail-loud at read? | Status |
 |---|---|---|---|---|---|---|
-| `botToken` | chat-adapter | `packages/api/src/api/routes/slack.ts` legacy OAuth callback (route file removed in #2689) | `lib/integrations/install/slack-oauth-handler.ts:SlackOAuthInstallHandler.handleCallback()` (calls `saveInstallation`) — **sole writer**. (Corrected #4907: this row previously said `@chat-adapter/slack:setInstallation` also writes "on every event". At v4.23.0 `setInstallation` has exactly one caller, the adapter's own `handleOAuthCallback`, which Atlas bypasses.) | `lib/slack/store.ts:getInstallation()` (line 200) → `parseStoredInstallation()`; reached transitively from `lib/chat-plugin/executeQuery.ts` (interactive) and `lib/scheduler/delivery.ts` via `getBotToken()` (line 384) | ✓ — `parseStoredInstallation` warns + returns null on missing/undecryptable token; `executeQuery` throws on missing installation | ✓ verified |
-| `botUserId` | chat-adapter | adapter-only (never written by Atlas) | `lib/slack/store.ts:saveInstallation()` from `oauth.v2.access`'s `bot_user_id` (#4907) — **Atlas is the sole writer in practice**; the adapter's only writer is its own `handleOAuthCallback`, which Atlas bypasses by running `SlackOAuthInstallHandler`. Omitted from the JSONB payload when absent so the merge preserves a stored id | `@chat-adapter/slack:resolveTokenForTeam()` → request-context `botUserId` → `isMessageFromSelf()`. Atlas itself does not read it | ⚠ — silent. A missing id makes `isMessageFromSelf` return false for every self-post; `plugins/chat/src/bridge.ts:recordReplyForBreaker()` is the backstop, and install logs a warning | ✓ verified |
+| `botToken` | chat-adapter | `packages/api/src/api/routes/slack.ts` legacy OAuth callback (route file removed in #2689) | `lib/integrations/install/slack-oauth-handler.ts:SlackOAuthInstallHandler.handleCallback()` (calls `saveInstallation`) — **sole writer**. (Corrected #4907: this row previously said `@chat-adapter/slack:setInstallation` also writes "on every event". At v4.23.0 `setInstallation` has exactly one caller, the adapter's own `handleOAuthCallback`, which Atlas bypasses.) | `lib/slack/store.ts:getInstallation()` → `parseStoredInstallation()`; reached transitively from `lib/chat-plugin/executeQuery.ts` (interactive) and `lib/scheduler/delivery.ts` via `getBotToken()` | ✓ — `parseStoredInstallation` warns + returns null on missing/undecryptable token; `executeQuery` throws on missing installation | ✓ verified |
+| `botUserId` | chat-adapter | adapter-only (never written by Atlas) | `lib/slack/store.ts:saveInstallation()` from `oauth.v2.access`'s `bot_user_id` (#4907) — **Atlas is the sole writer in practice**; the adapter's only writer is its own `handleOAuthCallback`, which Atlas bypasses by running `SlackOAuthInstallHandler`. Omitted from the JSONB payload when absent so the merge preserves a stored id | `@chat-adapter/slack:resolveTokenForTeam()` → request-context `botUserId` → **two** consumers: `isMessageFromSelf()` (#4907) and, since #4911, the patched `resolveInlineMentions()` whose self-suppression is what leaves an id for `detectMention` to match. Atlas itself does not read it | ⚠ — silent, and the two failures compound. A missing id makes `isMessageFromSelf` return false for every self-post (`plugins/chat/src/bridge.ts:recordReplyForBreaker()` is the backstop) **and** degrades @-mention detection to display-name-only, so a bot rename silences that workspace (#4909's failure mode). Install logs a warning naming both | ✓ verified |
 | `teamName` | shared | `slack.ts` legacy OAuth callback (removed in #2689) | `lib/slack/store.ts:saveInstallation()` mirrors `workspaceName` into `teamName` — **sole writer**. (Corrected #4907: previously credited `setInstallation` "from `auth.test`"; the adapter sources it from `result.team.name` in `handleOAuthCallback`, which Atlas bypasses, and `auth.test` never writes it.) | `parseStoredInstallation()` (falls back to `workspaceName`) | lenient — both fields fall back to each other; missing both yields `workspace_name: null` (acceptable for display) | ✓ verified |
-| `orgId` | **Atlas extension** | `slack.ts` legacy OAuth callback (removed in #2689) | `lib/slack/store.ts:saveInstallation()` — **sole writer**; preserved across `setInstallation` rewrites by the pg-adapter JSONB merge | `lib/slack/store.ts:getInstallationByOrg()` (line 247); `ee/src/proactive/workspace-id-resolver.ts:createSlackWorkspaceIdResolver()` (resolves `team_id` → `orgId`); `lib/chat-plugin/executeQuery.ts:executeChatPluginQuery()` (refuses on null, line 192); `ee/src/proactive/user-resolver.ts:defaultVerifyWorkspace()` (boolean) | ✓ — `executeQuery` throws (interactive path); `workspace-id-resolver` warns on row-exists-but-missing with per-teamId dedup (post-#2677, proactive path); `getInstallationByOrg` returns null backed by the partial-expression index | ✓ verified |
+| `orgId` | **Atlas extension** | `slack.ts` legacy OAuth callback (removed in #2689) | `lib/slack/store.ts:saveInstallation()` — **sole writer**; preserved across `setInstallation` rewrites by the pg-adapter JSONB merge | `lib/slack/store.ts:getInstallationByOrg()`; `ee/src/proactive/workspace-id-resolver.ts:createSlackWorkspaceIdResolver()` (resolves `team_id` → `orgId`); `lib/chat-plugin/executeQuery.ts:executeChatPluginQuery()` (refuses on null, line 192); `ee/src/proactive/user-resolver.ts:defaultVerifyWorkspace()` (boolean) | ✓ — `executeQuery` throws (interactive path); `workspace-id-resolver` warns on row-exists-but-missing with per-teamId dedup (post-#2677, proactive path); `getInstallationByOrg` returns null backed by the partial-expression index | ✓ verified |
 | `workspaceName` | **Atlas extension** | `slack.ts` legacy OAuth callback (removed in #2689) | `lib/slack/store.ts:saveInstallation()` — sole writer; preserved by pg-adapter JSONB merge | `parseStoredInstallation()` (display only) | n/a (display-only; admin UI tolerates null) | ✓ verified |
 | `installedAt` | **Atlas extension** | `slack.ts` legacy OAuth callback (removed in #2689) | `lib/slack/store.ts:saveInstallation()` — sole writer; preserved by pg-adapter JSONB merge | `parseStoredInstallation()` (falls back to row's `created_at`) | n/a (display-only) | ✓ verified |
 
@@ -97,16 +97,17 @@ stays the self-host fallback unchanged. ⚠ row to watch: any change to the shap
 overlay (e.g. nesting, or a non-string value) breaks the `{ ...process.env, ...overlay }`
 merge contract — the overlay must stay a flat `Record<string, string>`.
 
-### Adapter identity — `SlackAdapterConfig.userName` / `Chat.userName` (#4909)
+### Adapter identity — `SlackAdapterConfig.userName` / `Chat.userName` (#4909, #4911)
 
 The bot's own handle at the `@chat-adapter/slack` construction boundary. Not
-cosmetic: it is the **only** working input to `detectMention`, the fallback the
-SDK uses when `isMention` wasn't set from the event type.
+cosmetic: it is one of only two working inputs to `detectMention`, the fallback
+the SDK uses when `isMention` wasn't set from the event type.
 
 | Boundary field | Owner | Atlas wiring | Adapter behaviour without it | Status |
 |---|---|---|---|---|
 | `SlackAdapterConfig.userName` | chat-adapter | `plugins/chat/src/adapters/slack.ts` passes `DEFAULT_BOT_USER_NAME` (`config.ts`), overridable per deploy | defaults to the literal `"bot"`; replaced from `auth.test` **only** inside `initialize()`, which runs solely on the single-workspace `defaultBotToken` path | ✓ verified |
 | `Chat.userName` | chat SDK | `bridge.ts` `new Chat({ userName: DEFAULT_BOT_USER_NAME })` — same constant | — | ✓ verified |
+| `resolveInlineMentions(text, skipSelfMention)` self-suppression | chat-adapter | **vendored patch** `patches/@chat-adapter%2Fslack@4.23.0.patch` — swaps the instance field `this._botUserId` for the ctx-aware `this.botUserId` getter. Patches `dist/index.js` only; the shipped `dist/index.js.map` still describes the unpatched token, so a stack trace or debugger step through `resolveInlineMentions` reads one identifier off. Runtime-harmless | unpatched, the guard reads an instance field neither of whose writers reaches multi-workspace, so it never fires and the bot's own `<@U…>` is rewritten to its display name | ✓ verified — patched (effective only where `ctx.botUserId` is populated, see below) |
 
 **Boundary contract.** `detectMention` resolves the handle as
 `adapter.userName || chat.userName`. Because the adapter's default `"bot"` is
@@ -114,16 +115,84 @@ SDK uses when `isMention` wasn't set from the event type.
 and silently does nothing. Both must come from one constant, which is why
 `DEFAULT_BOT_USER_NAME` exists rather than two literals.
 
-The id-based patterns in `detectMention` are **not** a backstop here: the async
-parse path runs `resolveInlineMentions`, which rewrites `<@U0BOT…>` to the bot's
-display name, so no user id survives in `message.text`. (That rewrite is meant to be
-suppressed for the bot itself via `skipSelfMention`, but that guard reads the
-adapter's instance `_botUserId`, which is null in multi-workspace — see the
-`botUserId` row above.) Name matching is the only route.
+As of #4911 the id-based patterns in `detectMention` are a **real backstop for
+installs whose `chat_cache` row carries `botUserId`** — but only because of the
+vendored patch, and only for those installs. The async parse path runs
+`resolveInlineMentions`, which rewrites `<@U0BOT…>` to a display name; the
+`skipSelfMention` guard is supposed to exempt the bot itself, and upstream reads
+the instance `_botUserId` rather than the `botUserId` getter that prefers the
+per-request `ctx.botUserId` `resolveTokenForTeam` supplies. `_botUserId` has two
+writers and neither reaches us: the constructor's `config.botUserId`, which
+`plugins/chat/src/adapters/slack.ts` cannot forward because one static id cannot
+serve N workspace installs, and `auth.test` inside `initialize()`, which only runs
+on the single-workspace `defaultBotToken` path. `lib/slack/store.ts`'s header
+carries the same chain.
 
-⚠ row to watch: this is **single-workspace-safe and multi-workspace-broken** by
-default — the class that produced both #4907 and #4909. Anything that relies on
-`initialize()` having populated adapter instance state is dead in SaaS/BYOT.
+Two things make this an upstream oversight rather than a design choice: the same
+class's `isMessageFromSelf` does exactly that ctx-aware fallback, and upstream's
+own JSDoc on the parameter says `skipSelfMention` exists *"so that mention
+detection (which looks for @botUserId in the text) continues to work"* — the
+invariant the patch restores. The patch makes the one-token swap; without it, name
+matching is again the only route and any display-name drift returns us to the total
+silence of #4909.
+
+**The backstop is not universal — it rests on the field this doc already marks ⚠
+silent.** `ctx.botUserId` comes from the `chat_cache` installation row (the
+`botUserId` row in the *Slack installation row* table above), and that row can lack
+it: `lib/slack/store.ts:upsert()` spreads `botUserId` **conditionally** because it
+may be absent, and `lib/integrations/install/slack-oauth-handler.ts` warns (rather
+than refusing the install) when Slack's OAuth response omits `bot_user_id`. Any
+workspace whose row predates #4907 or hit that warn path has `ctx.botUserId`
+undefined **and** `_botUserId` null, so the guard still never fires. There the two
+failures **compound**: `isMessageFromSelf` is false for every self-post (#4907) and
+mention detection is name-only (#4909) at the same time. Those installs need a
+re-install to gain the id — the patch raises the floor, it does not reach every
+tenant.
+
+**It also rests on *whose* request context is live at dispatch time.**
+`detectMention` reads the `adapter.botUserId` getter inside the SDK's
+`dispatchToHandlers`. Under the SDK default `concurrency: "drop"` — `bridge.ts`
+passes no `concurrency`, so it inherits it — that is the originating request's
+context. Under `"queue"` or `"debounce"` the drain loop dispatches a persisted
+message from another request under the **lock holder's** context, equivalent only
+because a thread is single-team. Slack Connect shared channels are the edge to
+watch: the adapter tracks them explicitly (`is_ext_shared_channel` →
+`_externalChannels`), and one channel id can carry events from two `team_id`s with
+different bot user ids. **Adding** a `concurrency` option is therefore a change to
+this contract — and nothing enforces that: this paragraph is the only guard, no
+test fails if someone sets it.
+
+⚠ row to watch: the **patch is a standing obligation on every
+`@chat-adapter/slack` version bump, and `bun install` only half-catches it.**
+Measured on bun 1.3.13 — the repo pins `"bun": ">=1.3.13 <1.3.14"` and CI sets
+`BUN_VERSION: "1.3.13"`, so this is authoritative everywhere today and must be
+re-measured on a bun bump — there are three failure modes and bun catches one:
+
+| Bump failure mode | bun's behaviour |
+|---|---|
+| Patch file missing (e.g. an image-slimming pass drops `COPY patches patches`) | **hard error, `bun install` exits 1** |
+| `patchedDependencies` key names a version no longer installed | **silently ignored** — install succeeds, package ships unpatched |
+| Hunk context no longer matches | **applied fuzzily, no warning** |
+
+The last two are the realistic bump outcomes, and for them the one real gate is
+`plugins/chat/src/adapters/slack.test.ts` — the `multi-workspace self-mention
+suppression` block, which runs in CI via `test-others` (auto-discovered, no `if:`,
+no path filter) and fails if the shipped adapter doesn't preserve the bot's own id.
+Narrowing the hazard: `plugins/chat/package.json` pins `@chat-adapter/slack`
+**exact, no caret**, so only a deliberate bump can invalidate the patch — never
+passive drift.
+
+On any adapter bump: re-key the patch, re-run that block, and re-check whether
+upstream has fixed it (in which case drop the patch, keep the tests). A red there
+has three causes with opposite responses — the patch stopped taking effect, an
+upstream member the block reaches for was renamed, or (webhook case only) the
+installation row/token failed to resolve, which returns 200 having processed
+nothing. The block's own triage note enumerates them. Do **not** silence a red by
+deleting the patch entry or loosening an assertion.
+
+The underlying class is still **single-workspace-safe and multi-workspace-broken**
+by default — the class that produced #4907, #4909 and #4911. Anything that relies
+on `initialize()` having populated adapter instance state is dead in SaaS/BYOT.
 
 ### Durable approval-park resume delivery — `ChatPluginConfig.onBridgeReady` + `chat:resume-pending:<conversationId>` (#3750)
 

--- a/examples/docker/Dockerfile
+++ b/examples/docker/Dockerfile
@@ -3,8 +3,12 @@ FROM oven/bun:1.3.13@sha256:87416c977a612a204eb54ab9f3927023c2a3c971f4f345a01da0
 FROM base AS deps
 WORKDIR /app
 COPY package.json bun.lock* ./
-# The bun-types patch (patchedDependencies in package.json/bun.lock) must be
-# present in the build context for `bun ci` to apply it during install.
+# Both patches (patchedDependencies in package.json/bun.lock) must be present in
+# the build context for `bun ci` to apply them during install. Neither is runtime
+# relevant to THIS image (it ships no `plugins/` dir and no `atlas.config.ts`, so
+# no chat plugin loads) — but `@chat-adapter/slack` is still in the resolved
+# graph, and bun hard-errors on a missing patch file, so pruning this COPY fails
+# the build.
 COPY patches patches
 COPY packages/api/package.json packages/api/package.json
 COPY packages/web/package.json packages/web/package.json

--- a/package.json
+++ b/package.json
@@ -168,6 +168,7 @@
     "uuid": "^11.1.1"
   },
   "patchedDependencies": {
-    "bun-types@1.3.14": "patches/bun-types@1.3.14.patch"
+    "bun-types@1.3.14": "patches/bun-types@1.3.14.patch",
+    "@chat-adapter/slack@4.23.0": "patches/@chat-adapter%2Fslack@4.23.0.patch"
   }
 }

--- a/packages/api/src/lib/integrations/install/slack-oauth-handler.ts
+++ b/packages/api/src/lib/integrations/install/slack-oauth-handler.ts
@@ -270,16 +270,22 @@ export class SlackOAuthInstallHandler implements OAuthPlatformInstallHandler {
     }
 
     // Slack returns `bot_user_id` on every bot install, so absence is
-    // anomalous rather than routine — and it degrades loop safety (see
-    // the `saveInstallation` call below). Warn loudly rather than
-    // refusing the install: the bridge's per-thread reply breaker is the
-    // backstop that keeps a missing id from becoming another #4907, and
-    // failing an otherwise-valid OAuth exchange on a field Slack has
-    // always sent would trade a real outage for a hypothetical one.
+    // anomalous rather than routine — and it degrades TWO things, both of
+    // which the warn has to name or it points the operator at the wrong
+    // subsystem. Loop safety (see the `saveInstallation` call below, #4907),
+    // and — since #4911 — @-mention detection: the vendored
+    // `@chat-adapter/slack` patch suppresses the bot's own `<@id>` using the
+    // request-context `botUserId` sourced from THIS row, so without it the
+    // id survives nowhere and detection is name-only again (#4909's failure
+    // mode, which is total silence). Warn loudly rather than refusing the
+    // install: the bridge's per-thread reply breaker is the backstop that
+    // keeps a missing id from becoming another #4907, and failing an
+    // otherwise-valid OAuth exchange on a field Slack has always sent would
+    // trade a real outage for a hypothetical one.
     if (!botUserId) {
       log.warn(
         { workspaceId, teamId },
-        "Slack OAuth response omitted bot_user_id — self-message detection will fall back to the bridge reply breaker",
+        "Slack OAuth response omitted bot_user_id — self-message detection falls back to the bridge reply breaker, and @-mention detection for this workspace degrades to display-name matching only (a bot rename will silence it)",
       );
     }
 
@@ -337,11 +343,13 @@ export class SlackOAuthInstallHandler implements OAuthPlatformInstallHandler {
     // and can retry — re-running this method will UPSERT the install
     // row (no-op on config) and re-attempt the credential write.
     try {
-      // `botUserId` is not decoration — it is the only working input to
-      // the adapter's self-message check in multi-workspace mode, and
-      // omitting it turns every reply in a subscribed thread into a new
-      // inbound question (#4907). `lib/slack/store.ts`'s header carries
-      // the full chain.
+      // `botUserId` is not decoration — in multi-workspace mode it is the
+      // only working input to the adapter's self-message check, so omitting
+      // it turns every reply in a subscribed thread into a new inbound
+      // question (#4907), AND (since #4911) the only thing that excludes the
+      // bot from `resolveInlineMentions`'s rewrite set, without which
+      // @-mention detection is display-name-only (#4909). One missing field,
+      // both failures. `lib/slack/store.ts`'s header carries the full chain.
       await saveInstallation(teamId, accessToken, {
         orgId: workspaceId,
         ...(teamName ? { workspaceName: teamName } : {}),

--- a/packages/api/src/lib/slack/store.ts
+++ b/packages/api/src/lib/slack/store.ts
@@ -21,19 +21,29 @@
  *     }
  *
  * `botUserId` is written by Atlas from `oauth.v2.access`'s
- * `bot_user_id` and is **load-bearing for loop safety**. In
- * multi-workspace mode (no `SLACK_BOT_TOKEN` → no `defaultBotToken`:
- * SaaS always, and self-hosted BYOT too) the adapter's
+ * `bot_user_id` and is **load-bearing for loop safety AND for @-mention
+ * detection**. In multi-workspace mode (no `SLACK_BOT_TOKEN` → no
+ * `defaultBotToken`: SaaS always, and self-hosted BYOT too) the adapter's
  * `isMessageFromSelf` has three checks and only one can fire.
  * `_botId` is populated solely by `initialize()` under a
  * single-workspace `defaultBotToken`. `_botUserId` is populated there
  * AND from `config.botUserId`, which `plugins/chat/src/adapters/slack.ts`
- * does not forward — so both instance fields are null here. The
+ * does not forward — and *cannot*, because one static id can't serve N
+ * workspace installs. So both instance fields are null here. The
  * surviving check compares the inbound event's `user` against the
  * request-context `botUserId`, which the adapter sources from THIS row
  * via `resolveTokenForTeam`. Leave it unset and every message Atlas
  * posts reads back as a user message: in a subscribed thread or a DM
  * that is an unbounded reply loop, which is exactly what #4907 was.
+ *
+ * Since #4911 this row has a SECOND reader on the same request-context
+ * path. The vendored `@chat-adapter/slack` patch
+ * (`patches/@chat-adapter%2Fslack@4.23.0.patch`) makes
+ * `resolveInlineMentions` suppress the bot's own `<@id>` using that same
+ * `ctx.botUserId`, which is what lets `detectMention`'s id patterns match.
+ * Leave it unset and mention detection falls back to display-name matching
+ * alone — a bot rename then silences the workspace entirely (#4909). The
+ * two failures compound on exactly the same missing field.
  *
  * The adapter only ever *reads* this field — its sole writer is the
  * SDK's own `handleOAuthCallback`, which Atlas bypasses by running

--- a/patches/@chat-adapter%2Fslack@4.23.0.patch
+++ b/patches/@chat-adapter%2Fslack@4.23.0.patch
@@ -1,0 +1,15 @@
+diff --git a/dist/index.js b/dist/index.js
+index 732fac74f5416c224d6d7d4ccf497dff7df09e8e..ab894e4462bccdb2c043527cd39ece861ce0cddc 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -1784,8 +1784,8 @@ var SlackAdapter = class _SlackAdapter {
+     if (userIds.size === 0 && channelIds.size === 0) {
+       return text;
+     }
+-    if (skipSelfMention && this._botUserId) {
+-      userIds.delete(this._botUserId);
++    if (skipSelfMention && this.botUserId) {
++      userIds.delete(this.botUserId);
+     }
+     if (userIds.size === 0 && channelIds.size === 0) {
+       return text;

--- a/plugins/chat/src/adapters/slack.test.ts
+++ b/plugins/chat/src/adapters/slack.test.ts
@@ -100,3 +100,295 @@ describe("Chat dispatch — @-mention arriving as a plain message event", () => 
     expect(hits).not.toContain("mention");
   });
 });
+
+/**
+ * Pinning tests for `patches/@chat-adapter%2Fslack@4.23.0.patch` (#4911).
+ *
+ * Upstream's `resolveInlineMentions` suppresses the bot's own `<@U…>` via the
+ * INSTANCE field `_botUserId`. That field has two writers: the constructor's
+ * `config.botUserId`, and `auth.test` inside `initialize()` — which only runs on
+ * the single-workspace `defaultBotToken` path. Neither reaches multi-workspace:
+ * `plugins/chat/src/adapters/slack.ts` cannot forward `config.botUserId`, because
+ * one static id cannot serve N workspace installs (`packages/api/src/lib/slack/
+ * store.ts` carries the same reasoning). So the field is null,
+ * the guard never fires, the bot's id is rewritten to its Slack display name, and
+ * `detectMention`'s two id patterns have nothing left to match.
+ *
+ * The patch swaps the field for the `botUserId` GETTER, which prefers the
+ * per-request `ctx.botUserId` that `resolveTokenForTeam` supplies. Two things say
+ * this is an upstream oversight rather than a design choice: the same class's
+ * `isMessageFromSelf` does exactly that ctx-aware fallback, and upstream's own
+ * JSDoc on the parameter (`dist/index.d.ts`) states the invariant the patch
+ * restores — `skipSelfMention` exists "so that mention detection (which looks for
+ * @botUserId in the text) continues to work".
+ *
+ * WHY A TEST AND NOT JUST THE PATCH. Carrying a vendored patch is only safe if a
+ * bump that drops or invalidates it fails CI instead of failing prod silently,
+ * and `bun install` only partly provides that. Measured on bun 1.3.13 (the repo
+ * pins `"bun": ">=1.3.13 <1.3.14"` and CI sets `BUN_VERSION: "1.3.13"`, so this
+ * is authoritative everywhere today and must be re-measured on a bun bump):
+ *   - patch file MISSING          → hard error, `bun install` exits 1. Loud.
+ *   - `patchedDependencies` key naming a version no longer installed
+ *                                 → SILENTLY ignored; install succeeds unpatched.
+ *   - hunk context no longer matches
+ *                                 → applied FUZZILY with no warning.
+ * The last two are the realistic bump outcomes, so THIS BLOCK is the gate for
+ * them. A dropped patch is a total-silence failure in Slack, which is why #4909
+ * needed a prod incident and a log dive to find. Mitigating context:
+ * `plugins/chat/package.json` pins `@chat-adapter/slack` EXACT (no caret), so
+ * only a deliberate bump can invalidate the patch — never passive drift.
+ *
+ * TRIAGING A RED HERE. Three causes, three opposite responses:
+ *   1. The patch stopped taking effect → fix the patch.
+ *   2. One of the members this block reaches for was renamed → fix the test.
+ *      `requestContext`, `lookupUser`, `parseSlackMessage` and `_botUserId` are
+ *      `private` in the published `.d.ts`, so their renames are semver-invisible;
+ *      `setInstallation` is public, so its rename would show in a changelog.
+ *   3. Webhook test only, and it presents identically to (1): if
+ *      `resolveTokenForTeam` can't read the installation row, the adapter logs
+ *      `Could not resolve token for team` and returns 200 having processed
+ *      nothing, so the visible failure is the mention assertion while the real
+ *      fault is `setInstallation` / token encryption. Check stdout for that warn.
+ * Decide which before touching anything — do NOT resolve a red by deleting the
+ * patch entry or loosening an assertion.
+ *
+ * WHAT REVERTING THE PATCH ACTUALLY REDDENS: exactly two of the six cases here,
+ * "never looks up the bot's own id" and the webhook case. The other four are
+ * patch-insensitive by construction and each says so at its own site. Expect two
+ * reds, not six.
+ *
+ * The webhook case — the only one that reaches `detectMention` — deliberately
+ * gives the bot a Slack display name that DIFFERS from `userName`: with the name
+ * backstop matching, an id-only mention would be detected either way and it would
+ * pin nothing. That invariant is asserted, not just asserted-in-prose — see the
+ * first `it` below.
+ */
+describe("multi-workspace self-mention suppression (vendored patch #4911)", () => {
+  const BOT_ID = "U0BOTXYZ";
+  const HUMAN_ID = "U0HUMAN";
+  const TEAM_ID = "T1";
+  /** Deliberately != DEFAULT_BOT_USER_NAME so name matching cannot rescue a red. */
+  const BOT_DISPLAY_NAME = "data-copilot";
+
+  type AdapterInternals = {
+    _botUserId: string | null;
+    requestContext: { run: <T>(store: unknown, fn: () => T) => T };
+    lookupUser: (id: string) => Promise<{ displayName: string; realName: string }>;
+    parseSlackMessage: (event: unknown, threadId: string) => Promise<{ text: string }>;
+    setInstallation: (
+      teamId: string,
+      installation: { botToken: string; botUserId?: string },
+    ) => Promise<void>;
+  };
+
+  /**
+   * Build a multi-workspace adapter — OAuth creds and no `botToken`, so
+   * `defaultBotToken` is unset. `BASE` also passes no `botUserId`, so
+   * `_botUserId` is null straight from the constructor, and `initialize()`
+   * cannot fill it either: the `auth.test` writer is guarded on
+   * `defaultBotToken`, so it stays skipped even in the webhook case, which does
+   * call `chat.initialize()`.
+   *
+   * `lookupUser` is stubbed so no Slack API call is made, and every id it is
+   * asked about is RECORDED. Recording is not incidental: the real `lookupUser`
+   * swallows its own errors and returns `{ displayName: userId }`, so if this
+   * stub ever stopped intercepting (upstream rename, cache wrapper, inlining)
+   * an unpatched adapter would produce the SAME rendered text this block
+   * expects — a false green, plus live egress to slack.com from CI. Asserting
+   * on which ids were looked up is unforgeable by a decayed stub.
+   */
+  function multiWorkspaceAdapter() {
+    const adapter = createSlackAdapter(BASE);
+    const looked: string[] = [];
+    (adapter as unknown as AdapterInternals).lookupUser = async (id: string) => {
+      looked.push(id);
+      return {
+        displayName: id === BOT_ID ? BOT_DISPLAY_NAME : `human-${id}`,
+        realName: id,
+      };
+    };
+    return { adapter, internals: adapter as unknown as AdapterInternals, looked };
+  }
+
+  const event = (text: string) => ({
+    ts: "1700000000.0002",
+    text,
+    user: HUMAN_ID,
+    channel: "C1",
+  });
+
+  const ctx = (botUserId?: string) => ({
+    ...(botUserId ? { botUserId } : {}),
+    teamId: TEAM_ID,
+    token: "xoxb-test",
+  });
+
+  it("keeps the bot's display name distinct from the handle it answers to", () => {
+    // Load-bearing for the webhook case below — the only one that reaches
+    // `detectMention`. If these collide, its NAME pattern matches and the test
+    // stops discriminating between a patched and an unpatched adapter without
+    // going red. (The `parseSlackMessage` cases assert exact text, so they keep
+    // discriminating regardless.) A static invariant over two constants —
+    // patch-insensitive, green either way.
+    expect(BOT_DISPLAY_NAME).not.toBe(DEFAULT_BOT_USER_NAME);
+  });
+
+  it("never looks up the bot's own id, so its <@id> survives for id matching", async () => {
+    const { internals, looked } = multiWorkspaceAdapter();
+
+    // Production wraps event handling in `requestContext.run(ctx, …)` after
+    // `resolveTokenForTeam`, so `ctx.botUserId` is the only correct id here.
+    const msg = await internals.requestContext.run(ctx(BOT_ID), () =>
+      internals.parseSlackMessage(event(`<@${BOT_ID}> what is MRR?`), "slack:C1:x"),
+    );
+
+    // `parseSlackMessage` looks up the message author whenever the event carries
+    // no `username` — which `event()` never sets — so this is the stub-liveness
+    // proof: a decayed stub records nothing and fails HERE, before the real
+    // `lookupUser`'s error-fallback could forge the assertions below.
+    expect(looked).toContain(HUMAN_ID);
+    // The patch's actual effect: the bot is deleted from the lookup set.
+    expect(looked).not.toContain(BOT_ID);
+    // …and the rendered result. Unpatched this is "@data-copilot what is MRR?".
+    expect(msg.text).toBe(`@${BOT_ID} what is MRR?`);
+  });
+
+  it("still resolves OTHER users' mentions to display names", async () => {
+    // Rules out the lazy "fix" of disabling resolution wholesale — everyone
+    // except the bot must still render as a name. Patch-insensitive: unpatched,
+    // `_botUserId` is null so the guard is skipped entirely and U0ALICE is
+    // looked up either way. It is a control, not a pin.
+    const { internals, looked } = multiWorkspaceAdapter();
+
+    const msg = await internals.requestContext.run(ctx(BOT_ID), () =>
+      internals.parseSlackMessage(event("<@U0ALICE> owns this"), "slack:C1:x"),
+    );
+
+    expect(looked).toContain("U0ALICE");
+    expect(msg.text).toBe("@human-U0ALICE owns this");
+  });
+
+  it("keeps the single-workspace path working: no ctx, instance field set", async () => {
+    // The getter's fallback is `this._botUserId || void 0`, so a self-hosted
+    // single-workspace deploy (where `initialize()`'s `auth.test` populated the
+    // instance field and no request context exists) must behave exactly as it
+    // did before the patch. If upstream ever drops that fallback, the patch
+    // would trade a multi-workspace bug for a single-workspace one — silently.
+    // Insensitive to the patch itself (it sets exactly the field the UNPATCHED
+    // guard reads, so the delete happens in both worlds); it pins the getter.
+    const { internals, looked } = multiWorkspaceAdapter();
+    internals._botUserId = BOT_ID;
+
+    const msg = await internals.parseSlackMessage(
+      event(`<@${BOT_ID}> what is MRR?`),
+      "slack:C1:x",
+    );
+
+    expect(looked).not.toContain(BOT_ID);
+    expect(msg.text).toBe(`@${BOT_ID} what is MRR?`);
+  });
+
+  it("documents the install class the patch does NOT reach: no ctx botUserId", async () => {
+    // `ctx.botUserId` comes from the `chat_cache` installation row, and that row
+    // can lack it — `lib/slack/store.ts:upsert()` spreads it conditionally, and
+    // `slack-oauth-handler.ts` warns rather than refusing when Slack's OAuth
+    // response omits `bot_user_id`. With neither ctx nor the instance field set,
+    // the getter yields undefined, the guard cannot fire, and name matching is
+    // still the only route for that workspace.
+    //
+    // NOTE — this is an ANTI-pin: it asserts the UNPATCHED output, so it stays
+    // green if the patch is reverted (as do the two controls above, each for its
+    // own reason). It keeps the contract doc's hedge honest, not the patch.
+    // If that install class is ever eliminated (Atlas backfilling `bot_user_id`,
+    // or the adapter refusing installs without it) this test goes red and must
+    // be DELETED, not repaired.
+    const { internals } = multiWorkspaceAdapter();
+
+    const msg = await internals.requestContext.run(ctx(), () =>
+      internals.parseSlackMessage(event(`<@${BOT_ID}> what is MRR?`), "slack:C1:x"),
+    );
+
+    expect(msg.text).toBe(`@${BOT_DISPLAY_NAME} what is MRR?`);
+  });
+
+  it("detects an id-only mention through the real webhook path", async () => {
+    // The end-to-end shape. Everything above hand-injects the ALS store, so none
+    // of it would notice if upstream stopped WRAPPING the event in a request
+    // context (it already has `withToken`/`withBotToken` for per-call token
+    // resolution — a plausible refactor). That would make the patch a prod
+    // no-op with every other test still green. This one drives a signed
+    // `event_callback` through `chat.webhooks.slack`, so the context comes from
+    // the adapter's own `resolveTokenForTeam` reading a real installation row.
+    const { createHmac } = await import("node:crypto");
+    const { Chat } = await import("chat");
+    const { createStateAdapter } = await import("../state");
+    const state = createStateAdapter({ backend: "memory" }, null);
+    await state.connect();
+
+    const { adapter, internals, looked } = multiWorkspaceAdapter();
+    const chat = new Chat({
+      userName: DEFAULT_BOT_USER_NAME,
+      adapters: { slack: adapter },
+      state,
+    });
+    // `setInstallation` needs the adapter bound to a Chat instance.
+    await chat.initialize();
+    await internals.setInstallation(TEAM_ID, {
+      botToken: "xoxb-test",
+      botUserId: BOT_ID,
+    });
+
+    const hits: string[] = [];
+    chat.onNewMention(async () => {
+      hits.push("mention");
+    });
+    chat.onNewMessage(/.+/, async () => {
+      hits.push("pattern");
+    });
+
+    // A plain `message` event (NOT app_mention), so `isMention` is unset and
+    // `detectMention` has to do the work — the #4909 shape.
+    const body = JSON.stringify({
+      type: "event_callback",
+      team_id: TEAM_ID,
+      event: { ...event(`<@${BOT_ID}> what is MRR?`), type: "message" },
+    });
+    const timestamp = Math.floor(Date.now() / 1000).toString();
+    const signature = `v0=${createHmac("sha256", BASE.signingSecret)
+      .update(`v0:${timestamp}:${body}`)
+      .digest("hex")}`;
+
+    // Production returns 200 immediately and relies on AsyncLocalStorage
+    // propagating into the detached chain; `waitUntil` is the same hook the real
+    // route uses (plugins/chat/src/index.ts) and lets the assertion observe the
+    // result without a sleep.
+    // Collect every registered task rather than the last one — the message path
+    // registers exactly one today, but a second would otherwise go unawaited.
+    const tasks: Promise<unknown>[] = [];
+    const res = await chat.webhooks.slack(
+      new Request("https://example.test/webhooks/slack", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-slack-request-timestamp": timestamp,
+          "x-slack-signature": signature,
+        },
+        body,
+      }),
+      { waitUntil: (t: Promise<unknown>) => { tasks.push(t); } },
+    );
+    // Ordered before the await so a 401 fails here rather than as an empty
+    // `hits`. A resolve failure still returns 200, which the assertions catch.
+    expect(res.status).toBe(200);
+    await Promise.all(tasks);
+    await chat.shutdown?.();
+
+    // Stub liveness first (see "never looks up the bot's own id" for why), then
+    // the patch's effect, then the behaviour the whole patch exists for.
+    expect(looked).toContain(HUMAN_ID);
+    expect(looked).not.toContain(BOT_ID);
+    expect(hits).toContain("mention");
+    expect(hits).not.toContain("pattern");
+  });
+});
+


### PR DESCRIPTION
Closes #4911.

## The gap

`@chat-adapter/slack@4.23.0`'s `resolveInlineMentions` rewrites `<@U…>` to a display name, and is supposed to leave the bot's **own** id alone so `detectMention`'s id patterns still match:

```js
if (skipSelfMention && this._botUserId) {
  userIds.delete(this._botUserId);
}
```

`this._botUserId` is the **instance** field. It has two writers and neither reaches multi-workspace:

- the constructor's `config.botUserId` — Atlas cannot forward it, because one static id cannot serve N workspace installs;
- `auth.test` inside `initialize()` — runs only on the single-workspace `defaultBotToken` path.

So it stays `null`, the guard never fires, the bot's own id is resolved away, and mention detection rests **solely** on the display-name match #4909 restored. Anything that changes the bot's display name silently returns us to "Atlas never answers" — the #4909 symptom, which is total silence and took a prod incident plus a log dive to diagnose.

## The fix — a third option the issue didn't list

The issue offered (1) upstream fix or (2) report-upstream-and-pin. There's a third that ships the real fix now: **do both halves.** This repo already carries `patches/bun-types@1.3.14.patch` via `patchedDependencies`, so `bun patch` is proven infrastructure here.

One token, in `resolveInlineMentions` only:

```diff
-    if (skipSelfMention && this._botUserId) {
-      userIds.delete(this._botUserId);
+    if (skipSelfMention && this.botUserId) {
+      userIds.delete(this.botUserId);
```

`botUserId` is the getter that prefers the per-request `ctx.botUserId` from `resolveTokenForTeam`, falling back to `this._botUserId || undefined`. The patched condition is a **strict superset** of the original, so single-workspace behaviour is byte-identical.

Verified against the vendored adapter (4.23.0), same input the issue used:

| | parsed `.text` |
|---|---|
| before | `@Atlas what is MRR?` |
| after | `@U0BOTXYZ what is MRR?` |

**Why this reads as an upstream oversight, not a design choice.** The same class's `isMessageFromSelf` already does the ctx-aware fallback correctly. And upstream's own JSDoc on the parameter states the invariant the patch restores: `skipSelfMention` exists *"so that mention detection (which looks for @botUserId in the text) continues to work"*. Both go in the upstream report.

## The other half: why the patch needs a test to be safe

Carrying a vendored patch is only safe if a bump that drops or invalidates it fails **CI**, not prod. `bun install` only half-provides that. Measured on bun 1.3.13 (repo pins `"bun": ">=1.3.13 <1.3.14"`, CI sets `BUN_VERSION: "1.3.13"`, so this is authoritative everywhere today):

| Bump failure mode | bun's behaviour |
|---|---|
| Patch file missing | **hard error, exits 1** |
| `patchedDependencies` key names a version no longer installed | **silently ignored** — install succeeds, ships unpatched |
| Hunk context no longer matches | **applied fuzzily, no warning** |

The last two are the realistic bump outcomes, so the test block in `plugins/chat/src/adapters/slack.test.ts` is the only gate for them. It runs in CI via `test-others` (auto-discovered from the workspace globs, no `if:`, no path filter). Narrowing the hazard: `plugins/chat/package.json` pins `@chat-adapter/slack` **exact, no caret** — only a deliberate bump can invalidate the patch, never passive drift.

**Verified the test actually fails without the patch.** Reverting the patch in `node_modules` reddens exactly two of the six cases:

- `never looks up the bot's own id, so its <@id> survives for id matching`
- `detects an id-only mention through the real webhook path`

The other four are patch-insensitive by construction and each says so at its own site (one is an explicit anti-pin documenting the install class the patch does *not* reach). The header states the expected count so a future maintainer doesn't chase phantom greens.

Two design points worth calling out, both from review:

- The tests assert on **which ids `lookupUser` was asked about**, not just rendered text. The real `lookupUser` swallows its errors and returns `{ displayName: userId }` — so a stub that stopped intercepting would make an *unpatched* adapter produce exactly the text a naive test expects. A `looked` array is unforgeable by a decayed stub (and proves no egress to slack.com from CI).
- The last case drives a **signed `event_callback` through `chat.webhooks.slack`** with a real `setInstallation`, so the AsyncLocalStorage context comes from the adapter's own `resolveTokenForTeam`. Every hand-injected test would survive upstream dropping the `requestContext.run` wrapper — a plausible refactor, since `withToken`/`withBotToken` already exist — which would make the patch a prod no-op with everything still green.

## ⚠ Standing maintenance obligation

**This adds an obligation on every `@chat-adapter/slack` version bump**, recorded in the contract doc's ⚠ row: re-key the patch, re-run the block, and re-check whether upstream has fixed it (in which case drop the patch, keep the tests). A red there has three causes with opposite responses — patch stopped taking effect, an upstream member the block reaches for was renamed, or (webhook case only) the installation row failed to resolve. Do not silence it by deleting the patch entry.

## Scope

The backstop is **not universal**, and the doc says so. `ctx.botUserId` comes from the `chat_cache` installation row, and that row can lack it — `store.ts:upsert()` spreads it conditionally, and `slack-oauth-handler.ts` warns rather than refusing when Slack's OAuth response omits `bot_user_id`. Those installs need a re-install to gain the id. The patch raises the floor; it doesn't reach every tenant. Where the id is missing, #4907 and #4909 now compound on the same field — so the install warn and both header comments were widened to name **both** consequences instead of just self-message detection.

## Not in scope — flagged for follow-up

The dispatching session flagged `dist/index.js:3361` as possibly another instance of the same class. **I checked: it isn't.** That line is inside `isMessageFromSelf`, which does the ctx-aware check correctly two lines earlier (`ctx?.botUserId && event.user === ctx.botUserId`) — the `_botUserId` comparison is the fallback arm, exactly as intended. No follow-up needed there.

One genuine adjacent risk **is** documented but **not** enforced: `detectMention` reads the getter inside the SDK's `dispatchToHandlers`. Under the default `concurrency: "drop"` that's the originating request's context; under `"queue"` or `"debounce"` the drain loop dispatches another request's persisted message under the lock holder's context. Safe today only because a thread is single-team — Slack Connect shared channels are the edge. `bridge.ts` passes no `concurrency`, so **adding** one is a change to this contract, and nothing fails if someone does. Prose-only guard, called out as such in the doc.

## Verification

- 6 new cases, all green patched; exactly 2 red with the patch reverted (re-verified after every review round).
- Full `plugins/chat` suite: 511 pass. `test:others`: all 38 packages pass. `type`, `lint`, `lint:type-aware` clean.
- `/ci`: **32 of 33 gates PASS.** The `test` gate flaked locally under 2x CPU oversubscription (load avg 61 on 32 cores from parallel agents) — a *different* file failed on each run (`teams.test.ts` + `teams-discord-always-mount.test.ts`, then `correction.test.ts`), all timeout-shaped (`timed out after 5000ms`, `beforeEach hook timed out`), all pass individually and in pairs, none in this change's import graph, and an earlier full run at lower load was 1022/1022 clean. The remote sharded `api-tests (1/4)`–`(4/4)` are the authoritative verdict.

---
https://claude.ai/code/session_01N18FhaaoVZ56P7GXncHNZq
