### PR TITLE
refactor(brain): make a brain source and its audience re-verifier one registration unit

### DIFF
--- a/packages/api/src/lib/brain/__tests__/multi-source-pg.test.ts
+++ b/packages/api/src/lib/brain/__tests__/multi-source-pg.test.ts
@@ -873,9 +873,12 @@ describeIfPg("brain M3 multi-source loop (real Postgres)", () => {
     catalogId: "zoom-transcripts-multisource-test",
     source: ZOOM_TRANSCRIPT_SOURCE,
     // A transcript audience is derived per meeting, so the type admits no arm
-    // but this one. Never driven here — this suite exercises the re-verify pass
-    // through `reverifyZoomMeetingAudiences` directly — but stating the real
-    // strategy keeps the fixture honest about what production registers.
+    // but this one. NEVER DRIVEN here: this connector goes to `syncSource` and
+    // never to `registerBrainSourceConnector`, and the suite asserts
+    // `brain_audience_reverify_attempt` stays EMPTY (see the module header —
+    // #4971's scan is out of scope for this file). `zoomAudienceDeps` carries no
+    // `resolveToken` for the same reason. The arm is stated so the fixture is
+    // honest about what production registers, not because it runs.
     audience: { kind: "reverified", reverifier: createZoomAudienceReverifier(zoomAudienceDeps) },
     createClient: () =>
       createZoomTranscriptClient({
@@ -915,7 +918,7 @@ describeIfPg("brain M3 multi-source loop (real Postgres)", () => {
     catalogId: "outlook-mail-multisource-test",
     source: OUTLOOK_MAIL_SOURCE,
     // Same as Zoom above: a mail audience is derived per message, so the type
-    // admits no other arm.
+    // admits no other arm — and this one is equally never driven.
     audience: {
       kind: "reverified",
       reverifier: createOutlookAudienceReverifier(outlookAudienceDeps),

--- a/packages/api/src/lib/brain/__tests__/multi-source-pg.test.ts
+++ b/packages/api/src/lib/brain/__tests__/multi-source-pg.test.ts
@@ -218,7 +218,10 @@ import {
   ZOOM_TRANSCRIPT_SOURCE,
   zoomEpisodeSourceId,
 } from "@atlas/api/lib/brain/ingest/zoom/config";
-import type { ZoomAudienceDeps } from "@atlas/api/lib/brain/ingest/zoom/audience";
+import {
+  createZoomAudienceReverifier,
+  type ZoomAudienceDeps,
+} from "@atlas/api/lib/brain/ingest/zoom/audience";
 import type { ZoomParticipant, ZoomRecordingMeeting } from "@atlas/api/lib/brain/ingest/zoom/api";
 import { createOutlookMailClient } from "@atlas/api/lib/brain/ingest/outlook/client";
 import {
@@ -226,6 +229,7 @@ import {
   outlookEpisodeSourceId,
 } from "@atlas/api/lib/brain/ingest/outlook/config";
 import {
+  createOutlookAudienceReverifier,
   messageParticipants,
   type OutlookAudienceDeps,
 } from "@atlas/api/lib/brain/ingest/outlook/audience";
@@ -827,9 +831,12 @@ describeIfPg("brain M3 multi-source loop (real Postgres)", () => {
     },
   };
 
-  const slackConnector: BrainSourceConnector = {
+  const slackConnector: BrainSourceConnector<typeof SLACK_HISTORY_SOURCE> = {
     catalogId: "slack-history-multisource-test",
     source: SLACK_HISTORY_SOURCE,
+    // Channel-scoped grants, reconciled by the Slack-scoped walk in
+    // `audience/sync.ts` rather than by a registered re-verifier.
+    audience: { kind: "externally-synced" },
     createClient: () =>
       createSlackHistoryClient({
         token: "xoxb-test",
@@ -862,9 +869,14 @@ describeIfPg("brain M3 multi-source loop (real Postgres)", () => {
     },
   };
 
-  const zoomConnector: BrainSourceConnector = {
+  const zoomConnector: BrainSourceConnector<typeof ZOOM_TRANSCRIPT_SOURCE> = {
     catalogId: "zoom-transcripts-multisource-test",
     source: ZOOM_TRANSCRIPT_SOURCE,
+    // A transcript audience is derived per meeting, so the type admits no arm
+    // but this one. Never driven here — this suite exercises the re-verify pass
+    // through `reverifyZoomMeetingAudiences` directly — but stating the real
+    // strategy keeps the fixture honest about what production registers.
+    audience: { kind: "reverified", reverifier: createZoomAudienceReverifier(zoomAudienceDeps) },
     createClient: () =>
       createZoomTranscriptClient({
         workspaceId: WORKSPACE,
@@ -899,9 +911,15 @@ describeIfPg("brain M3 multi-source loop (real Postgres)", () => {
 
   const outlookAudienceDeps: OutlookAudienceDeps = { ...audienceDbDeps };
 
-  const outlookConnector: BrainSourceConnector = {
+  const outlookConnector: BrainSourceConnector<typeof OUTLOOK_MAIL_SOURCE> = {
     catalogId: "outlook-mail-multisource-test",
     source: OUTLOOK_MAIL_SOURCE,
+    // Same as Zoom above: a mail audience is derived per message, so the type
+    // admits no other arm.
+    audience: {
+      kind: "reverified",
+      reverifier: createOutlookAudienceReverifier(outlookAudienceDeps),
+    },
     createClient: () =>
       createOutlookMailClient({
         workspaceId: WORKSPACE,

--- a/packages/api/src/lib/brain/__tests__/temporal-loop-pg.test.ts
+++ b/packages/api/src/lib/brain/__tests__/temporal-loop-pg.test.ts
@@ -518,9 +518,12 @@ describeIfPg("brain M2 temporal loop (real Postgres)", () => {
     },
   };
 
-  const connector: BrainSourceConnector = {
+  const connector: BrainSourceConnector<typeof SLACK_HISTORY_SOURCE> = {
     catalogId: CATALOG_ID,
     source: SLACK_HISTORY_SOURCE,
+    // Channel-scoped grants: `audience/sync.ts` reconciles them off the install,
+    // so this source registers no re-verifier.
+    audience: { kind: "externally-synced" },
     createClient: () =>
       createSlackHistoryClient({
         token: "xoxb-test",

--- a/packages/api/src/lib/brain/__tests__/wedge-loop-pg.test.ts
+++ b/packages/api/src/lib/brain/__tests__/wedge-loop-pg.test.ts
@@ -499,9 +499,12 @@ describeIfPg("brain M1 wedge loop (real Postgres)", () => {
    * The shim exists only because `createSlackHistoryConnector` builds its
    * client without the `api` injection point (see the module header).
    */
-  const connector: BrainSourceConnector = {
+  const connector: BrainSourceConnector<typeof SLACK_HISTORY_SOURCE> = {
     catalogId: CATALOG_ID,
     source: SLACK_HISTORY_SOURCE,
+    // Channel-scoped grants: `audience/sync.ts` reconciles them off the install,
+    // so this source registers no re-verifier.
+    audience: { kind: "externally-synced" },
     createClient: () =>
       createSlackHistoryClient({
         token: "xoxb-test",

--- a/packages/api/src/lib/brain/audience/reverify.ts
+++ b/packages/api/src/lib/brain/audience/reverify.ts
@@ -125,16 +125,23 @@ const registry = new Map<EpisodeSource, AudienceReverifier>();
  * asked the caller to consult it first. That works and it is what #4983 shipped,
  * but the check and the write it protects were two separate statements a future
  * source could put back in the wrong order — or drop. Here they are ONE
- * expression: the duplicate check is the thing that mints the commit, so there is
- * no way to reach the write without having passed the check. Deleting the check
- * deletes the write with it.
+ * expression: the duplicate check is the thing that mints the commit, so a CALLER
+ * cannot reach the write without having passed the check, and deleting the call
+ * deletes both halves together.
+ *
+ * Be precise about the limit of that. It is a property of the call site, not of
+ * this function's body — deleting the `if` below leaves the `registry.set` thunk
+ * intact and turns a duplicate into a silent overwrite. What it buys is that the
+ * ORDERING bug is gone: there is no arrangement of statements a caller can write
+ * that commits one half and then throws on the other.
  *
  * Keyed by the stored source kind, so a duplicate is a loud error rather than a
  * silent overwrite — two re-verifiers for one source would each reconcile against
  * their own roster, and the loser's members would be revoked on every cycle.
  *
  * @returns a commit thunk that CANNOT throw. Call it only once the caller's own
- *   writes are past their last failure point.
+ *   writes are past their last failure point. Dropping it on the floor registers
+ *   nothing — the check has no side effect of its own.
  */
 export function prepareAudienceReverifier(
   source: EpisodeSource,
@@ -155,10 +162,15 @@ export function prepareAudienceReverifier(
  *
  * Production wiring does NOT come through here — a source declares its audience
  * strategy on its connector and `registerBrainSourceConnector` commits both
- * halves in one call (#4985). This is the un-paired entry point that the
- * re-verifier registry's OWN unit suites need (a fixture re-verifier with no
- * connector behind it), and the provocation `register.test.ts` uses to take the
- * name before the real registration reaches it.
+ * halves in one call (#4985). Two test shapes still need the un-paired write, and
+ * they are described rather than enumerated because a hard-coded caller list rots
+ * on the next PR:
+ *
+ *   - a bare fixture re-verifier with no connector behind it, for suites whose
+ *     subject is this registry or the cycle that drains it;
+ *   - the PROVOCATION — taking a source's name before a paired registration
+ *     reaches it, so the pair cannot complete and the all-or-nothing claim has
+ *     something to fail against.
  */
 export function registerAudienceReverifier(
   source: EpisodeSource,
@@ -205,13 +217,18 @@ export async function runRegisteredAudienceReverifiers(): Promise<AudienceReveri
 /**
  * Test-only: clear the re-verifier registry ALONE.
  *
- * ⚠️ Only for a suite whose subject IS this registry — the drain, the duplicate
- * refusal, the summing. A suite that registers a brain source must reset through
- * `_resetBrainSourceConnectors` (`ingest/types.ts`) instead, which clears this
- * registry as well: since #4985 the two are written by one call, so tearing down
- * one and not the other de-syncs them, and the connector registry is the one every
- * `register*Connector` idempotence gate reads. Clearing THIS one alone leaves the
- * gate saying "already registered" about a source whose re-verifier is gone.
+ * ⚠️ The rule is about what the suite REGISTERS, not what it is named after: only
+ * a suite that registers no brain-source connector may call this. A suite that
+ * registers one must reset through `_resetBrainSourceConnectors`
+ * (`ingest/types.ts`), which clears this registry as well — since #4985 the two
+ * are written by one call, so tearing down one and not the other de-syncs them,
+ * and the connector registry is the one every `register*Connector` idempotence
+ * gate reads. Clearing THIS one alone leaves the gate saying "already registered"
+ * about a source whose re-verifier is gone.
+ *
+ * The compliant callers today are the suites for this registry and for the cycle
+ * that drains it (`audience/__tests__/sync.test.ts`), both of which register
+ * fixture re-verifiers only.
  */
 export function _resetAudienceReverifiers(): void {
   registry.clear();

--- a/packages/api/src/lib/brain/audience/reverify.ts
+++ b/packages/api/src/lib/brain/audience/reverify.ts
@@ -107,37 +107,64 @@ export type AudienceReverifier = () => Promise<AudienceReverifyResult>;
 const registry = new Map<EpisodeSource, AudienceReverifier>();
 
 /**
- * Register a source's audience re-verifier. Called once per source at wiring
- * time, keyed by the stored source kind so a duplicate registration is a loud
- * error rather than a silent overwrite — two re-verifiers for one source would
- * each reconcile against their own roster, and the loser's members would be
- * revoked on every cycle.
+ * Check that `source` has no re-verifier yet, and hand back the ONLY thing that
+ * can install one.
+ *
+ * ## Why a prepare/commit pair and not a `hasAudienceReverifier` peek (#4985)
+ *
+ * A brain source and its re-verifier are two writes to two registries, and both
+ * registries throw on a duplicate. `registerBrainSourceConnector`
+ * (`ingest/types.ts`) therefore has to do ALL of its throwing before ANY of its
+ * writing: a connector committed and a re-verifier then rejected leaves a source
+ * that ingests normally for `ATLAS_BRAIN_AUDIENCE_MAX_STALENESS_HOURS` (168h by
+ * default) and then goes silently invisible when `acl.ts` suppresses the
+ * audiences nothing refreshed — a week later, in a different subsystem, with
+ * nothing pointing back at boot.
+ *
+ * The first shape of that fix exported a `hasAudienceReverifier` predicate and
+ * asked the caller to consult it first. That works and it is what #4983 shipped,
+ * but the check and the write it protects were two separate statements a future
+ * source could put back in the wrong order — or drop. Here they are ONE
+ * expression: the duplicate check is the thing that mints the commit, so there is
+ * no way to reach the write without having passed the check. Deleting the check
+ * deletes the write with it.
+ *
+ * Keyed by the stored source kind, so a duplicate is a loud error rather than a
+ * silent overwrite — two re-verifiers for one source would each reconcile against
+ * their own roster, and the loser's members would be revoked on every cycle.
+ *
+ * @returns a commit thunk that CANNOT throw. Call it only once the caller's own
+ *   writes are past their last failure point.
+ */
+export function prepareAudienceReverifier(
+  source: EpisodeSource,
+  reverifier: AudienceReverifier,
+): () => void {
+  if (registry.has(source)) {
+    throw new Error(
+      `Audience re-verifier for source "${source}" is already registered — refusing to register its brain source connector too, because committing one without the other leaves the source ingesting content whose grants are never re-verified`,
+    );
+  }
+  return () => {
+    registry.set(source, reverifier);
+  };
+}
+
+/**
+ * Register a source's audience re-verifier on its own.
+ *
+ * Production wiring does NOT come through here — a source declares its audience
+ * strategy on its connector and `registerBrainSourceConnector` commits both
+ * halves in one call (#4985). This is the un-paired entry point that the
+ * re-verifier registry's OWN unit suites need (a fixture re-verifier with no
+ * connector behind it), and the provocation `register.test.ts` uses to take the
+ * name before the real registration reaches it.
  */
 export function registerAudienceReverifier(
   source: EpisodeSource,
   reverifier: AudienceReverifier,
 ): void {
-  if (registry.has(source)) {
-    throw new Error(`Audience re-verifier for source "${source}" is already registered`);
-  }
-  registry.set(source, reverifier);
-}
-
-/**
- * Is a re-verifier already registered for this source?
- *
- * Exists so a paired registration can ASK before it commits anything. A source
- * and its re-verifier are written to two different registries, and
- * {@link registerAudienceReverifier} throws on a duplicate — so a caller that
- * registers the connector first and discovers the collision second leaves the
- * connector registered and the re-verifier absent. That half-state ingests
- * content whose grants stop being re-verified, which is silent for a week and
- * then indistinguishable from the content not existing. See
- * `registerBrainSourceWithAudienceReverifier` in `ingest/types.ts`, which is the
- * only thing that should need this.
- */
-export function hasAudienceReverifier(source: EpisodeSource): boolean {
-  return registry.has(source);
+  prepareAudienceReverifier(source, reverifier)();
 }
 
 export function listAudienceReverifierSources(): EpisodeSource[] {
@@ -175,7 +202,17 @@ export async function runRegisteredAudienceReverifiers(): Promise<AudienceReveri
   return total;
 }
 
-/** Test-only: clear the registry (tests register fixtures per-suite). */
+/**
+ * Test-only: clear the re-verifier registry ALONE.
+ *
+ * ⚠️ Only for a suite whose subject IS this registry — the drain, the duplicate
+ * refusal, the summing. A suite that registers a brain source must reset through
+ * `_resetBrainSourceConnectors` (`ingest/types.ts`) instead, which clears this
+ * registry as well: since #4985 the two are written by one call, so tearing down
+ * one and not the other de-syncs them, and the connector registry is the one every
+ * `register*Connector` idempotence gate reads. Clearing THIS one alone leaves the
+ * gate saying "already registered" about a source whose re-verifier is gone.
+ */
 export function _resetAudienceReverifiers(): void {
   registry.clear();
 }

--- a/packages/api/src/lib/brain/audience/reverify.ts
+++ b/packages/api/src/lib/brain/audience/reverify.ts
@@ -129,11 +129,18 @@ const registry = new Map<EpisodeSource, AudienceReverifier>();
  * cannot reach the write without having passed the check, and deleting the call
  * deletes both halves together.
  *
- * Be precise about the limit of that. It is a property of the call site, not of
- * this function's body — deleting the `if` below leaves the `registry.set` thunk
- * intact and turns a duplicate into a silent overwrite. What it buys is that the
- * ORDERING bug is gone: there is no arrangement of statements a caller can write
- * that commits one half and then throws on the other.
+ * Be precise about the limits of that, in both directions:
+ *
+ *   - it is a property of the CALL SITE, not of this function's body. Deleting
+ *     the `if` below leaves the `registry.set` thunk intact and turns a duplicate
+ *     into a silent overwrite;
+ *   - it removes the ordering bug in ONE direction — no arrangement of statements
+ *     can commit the CONNECTOR and then throw on its re-verifier. The inverse is
+ *     still reachable and is exactly the PROVOCATION the suites use:
+ *     {@link registerAudienceReverifier} first, connector second, connector
+ *     refused. That leaves a re-verifier with no connector, which is loud (the
+ *     source ingests nothing and `registerStep` logs the throw) rather than the
+ *     silent week-long decay the committed-connector direction produces.
  *
  * Keyed by the stored source kind, so a duplicate is a loud error rather than a
  * silent overwrite — two re-verifiers for one source would each reconcile against
@@ -148,8 +155,13 @@ export function prepareAudienceReverifier(
   reverifier: AudienceReverifier,
 ): () => void {
   if (registry.has(source)) {
+    // Says nothing about a connector: `registerAudienceReverifier` shares this
+    // throw and registers no connector at all, so a message asserting one would
+    // be wrong at half its call sites. "re-verifier for source" is the token that
+    // discriminates it from the duplicate-CATALOG-ID error, which also ends in
+    // "is already registered" — `episode-sync-archive.test.ts` matches on it.
     throw new Error(
-      `Audience re-verifier for source "${source}" is already registered — refusing to register its brain source connector too, because committing one without the other leaves the source ingesting content whose grants are never re-verified`,
+      `Audience re-verifier for source "${source}" is already registered — refusing, because a source and its re-verifier must be committed together, and two re-verifiers for one source would each reconcile against their own roster with the loser's members revoked every cycle`,
     );
   }
   return () => {
@@ -171,6 +183,14 @@ export function prepareAudienceReverifier(
  *   - the PROVOCATION — taking a source's name before a paired registration
  *     reaches it, so the pair cannot complete and the all-or-nothing claim has
  *     something to fail against.
+ *
+ * Deliberately NOT `_`-prefixed, though it is test-only. In this seam the `_`
+ * prefix means test-only TEARDOWN (`_resetAudienceReverifiers`,
+ * `_resetBrainSourceConnectors`, `_resetCatalogIngestClaims`); this is a
+ * constructor, and overloading the convention would make it read as one more
+ * reset. What keeps a production caller out is that there is no reason to write
+ * one — a grant-deriving source that tried would have its connector refused
+ * outright by `registerBrainSourceConnector`.
  */
 export function registerAudienceReverifier(
   source: EpisodeSource,

--- a/packages/api/src/lib/brain/audience/reverify.ts
+++ b/packages/api/src/lib/brain/audience/reverify.ts
@@ -190,7 +190,10 @@ export function prepareAudienceReverifier(
  * constructor, and overloading the convention would make it read as one more
  * reset. What keeps a production caller out is that there is no reason to write
  * one — a grant-deriving source that tried would have its connector refused
- * outright by `registerBrainSourceConnector`.
+ * outright by `registerBrainSourceConnector`. For any OTHER class nothing
+ * refuses it: both halves register and a stray re-verifier just runs every
+ * cycle. See `BrainSourceAudience`'s second outcome in `ingest/types.ts`, which
+ * states why that residual is acceptable rather than closed.
  */
 export function registerAudienceReverifier(
   source: EpisodeSource,

--- a/packages/api/src/lib/brain/ingest/__tests__/episode-sync-archive.test.ts
+++ b/packages/api/src/lib/brain/ingest/__tests__/episode-sync-archive.test.ts
@@ -32,6 +32,11 @@ import {
   type BrainSourceConnector,
 } from "@atlas/api/lib/brain/ingest/types";
 import {
+  ZERO_REVERIFY,
+  listAudienceReverifierSources,
+  registerAudienceReverifier,
+} from "@atlas/api/lib/brain/audience/reverify";
+import {
   CHAT_CLASS,
   HUMAN_SOURCE,
   SLACK_SOURCE,
@@ -150,6 +155,10 @@ describe("the brain source registry", () => {
     return {
       catalogId: "catalog:fixture",
       source: SLACK_SOURCE,
+      // Chat grants are reconciled by the install-driven Slack walk, so the
+      // default fixture registers no re-verifier. The tests below that DO care
+      // override it.
+      audience: { kind: "externally-synced" },
       createClient: () => ({ fetchEpisodes: async () => ({ episodes: [], highWaterMark: null }) }),
       ...overrides,
     };
@@ -219,6 +228,70 @@ describe("the brain source registry", () => {
     expect(() => registerBrainSourceConnector(connector({ source: WAREHOUSE_SOURCE }))).not.toThrow();
     _resetBrainSourceConnectors();
   });
+
+  // ── The audience half, registered as ONE unit with the connector (#4985) ──
+
+  const reverified = (): BrainSourceConnector =>
+    connector({
+      audience: { kind: "reverified", reverifier: () => Promise.resolve(ZERO_REVERIFY) },
+    });
+
+  it("commits the connector AND its re-verifier from one call", () => {
+    // The `reverified` arm is not decoration: a source that declares it must end
+    // up in BOTH registries off a single `registerBrainSourceConnector`, because
+    // the whole point of folding the audience strategy into the connector value
+    // is that there is no second statement anyone can forget.
+    //
+    // MUTATION THIS CATCHES: dropping the `commitReverifier?.()` call.
+    registerBrainSourceConnector(reverified());
+    expect(getBrainSourceConnector("catalog:fixture")).toBeDefined();
+    expect(listAudienceReverifierSources()).toEqual([SLACK_SOURCE]);
+  });
+
+  it("registers NO re-verifier for an externally-synced source", () => {
+    // The other arm has to be a real branch, not a shrug. Slack's grants are
+    // reconciled by the install-driven walk, and a connector that quietly
+    // registered a re-verifier anyway would put a second writer on audiences the
+    // walk already owns.
+    registerBrainSourceConnector(connector());
+    expect(getBrainSourceConnector("catalog:fixture")).toBeDefined();
+    expect(listAudienceReverifierSources()).toEqual([]);
+  });
+
+  it("⭐ registers NEITHER half when the re-verifier registry is already taken", () => {
+    // The half-state this seam exists to prevent, asserted at the registry rather
+    // than per-vendor. A connector committed with its re-verifier rejected ingests
+    // normally for ATLAS_BRAIN_AUDIENCE_MAX_STALENESS_HOURS (168h) and only then
+    // goes wrong, at which point `acl.ts` suppresses every audience nothing
+    // refreshed and the facts behind them read as ABSENT rather than denied.
+    //
+    // MUTATION THIS CATCHES: moving `claimCatalogIngestTarget` / `registry.set`
+    // above the `prepareAudienceReverifier` call, i.e. writing before validating.
+    registerAudienceReverifier(SLACK_SOURCE, () => Promise.resolve(ZERO_REVERIFY));
+
+    expect(() => registerBrainSourceConnector(reverified())).toThrow(/already registered/);
+
+    expect(getBrainSourceConnector("catalog:fixture")).toBeUndefined();
+    expect(listBrainSourceCatalogIds()).toEqual([]);
+  });
+
+  it("⭐ _resetBrainSourceConnectors tears down the re-verifier registry too", () => {
+    // The teardown mirrors the registration one-for-one. If it stopped doing so,
+    // every suite that registers a brain source and re-registers it would fail on
+    // a duplicate re-verifier — a failure with nothing to do with what it was
+    // testing — because the `register*Connector` idempotence gates read only the
+    // CONNECTOR registry and would wave the second attempt through.
+    //
+    // MUTATION THIS CATCHES: dropping `_resetAudienceReverifiers()` from
+    // `_resetBrainSourceConnectors`.
+    registerBrainSourceConnector(reverified());
+    expect(listAudienceReverifierSources()).toEqual([SLACK_SOURCE]);
+
+    _resetBrainSourceConnectors();
+
+    expect(listAudienceReverifierSources()).toEqual([]);
+    expect(() => registerBrainSourceConnector(reverified())).not.toThrow();
+  });
 });
 
 describe("resolving connectors by class + vendor (#4963)", () => {
@@ -238,6 +311,7 @@ describe("resolving connectors by class + vendor (#4963)", () => {
     const make = (catalogId: string, source: EpisodeSource): BrainSourceConnector => ({
       catalogId,
       source,
+      audience: { kind: "externally-synced" },
       createClient: () => ({ fetchEpisodes: async () => ({ episodes: [], highWaterMark: null }) }),
     });
     registerBrainSourceConnector(make("catalog:chat-a", SLACK_SOURCE));
@@ -337,6 +411,7 @@ describe("resolving connectors by class + vendor (#4963)", () => {
     registerBrainSourceConnector({
       catalogId: "catalog:only",
       source: WAREHOUSE_SOURCE,
+      audience: { kind: "externally-synced" },
       createClient: () => ({ fetchEpisodes: async () => ({ episodes: [], highWaterMark: null }) }),
     });
     expect(findBrainSourceConnectors({ sourceClass: CHAT_CLASS })).toEqual([]);

--- a/packages/api/src/lib/brain/ingest/__tests__/episode-sync-archive.test.ts
+++ b/packages/api/src/lib/brain/ingest/__tests__/episode-sync-archive.test.ts
@@ -41,6 +41,7 @@ import {
   ZERO_REVERIFY,
   listAudienceReverifierSources,
   registerAudienceReverifier,
+  runRegisteredAudienceReverifiers,
 } from "@atlas/api/lib/brain/audience/reverify";
 import {
   CHAT_CLASS,
@@ -152,7 +153,18 @@ describe("the episode path cannot reach the engine's archive/upsert half", () =>
 describe("the brain source registry", () => {
   // Same reason as the sibling describe below: these mutate the registry module
   // singleton, and a throwing assertion would otherwise leave it dirty.
-  afterEach(_resetBrainSourceConnectors);
+  //
+  // The knowledge-documents release is NOT covered by the first call —
+  // `_resetBrainSourceConnectors` releases only the `brain-episodes` claims, by
+  // design. One test below claims `catalog:fixture` for the OTHER target to
+  // provoke a collision, and as a trailing statement that release would be
+  // skipped by a throwing assertion, leaving every later registration in this
+  // file failing with `already registered as knowledge-documents` — one real
+  // failure manufacturing several unrelated ones. Harmless when nothing claimed.
+  afterEach(() => {
+    _resetBrainSourceConnectors();
+    _resetCatalogIngestClaims("knowledge-documents");
+  });
 
   // The fixture's SOURCE KIND is a real vocabulary member
   // (`lib/brain/sources.ts`) while its CATALOG ID stays fixture-shaped — the
@@ -251,20 +263,31 @@ describe("the brain source registry", () => {
    * in its fixture. `warehouse` is not a grant-deriving class, so it may declare
    * either arm and the runtime backstop is not what is under test here.
    */
+  /**
+   * A DISTINCTIVE counter, so the re-verifier can be identified by its output.
+   * `ZERO_REVERIFY` would make the declared re-verifier indistinguishable from
+   * any other — see the value assertion in the first test.
+   */
+  const REVERIFIER_FINGERPRINT = Object.freeze({ ...ZERO_REVERIFY, membersAdded: 7 });
+
   const reverified = (): BrainSourceConnector =>
     connector({
       source: WAREHOUSE_SOURCE,
-      audience: { kind: "reverified", reverifier: () => Promise.resolve(ZERO_REVERIFY) },
+      audience: { kind: "reverified", reverifier: () => Promise.resolve(REVERIFIER_FINGERPRINT) },
     });
 
-  it("commits the connector AND its re-verifier from one call", () => {
+  it("commits the connector AND the DECLARED re-verifier from one call", async () => {
     // The `reverified` arm is not decoration: a source that declares it must end
     // up in BOTH registries off a single `registerBrainSourceConnector`, because
     // the whole point of folding the audience strategy into the connector value
     // is that there is no second statement anyone can forget.
     //
-    // MUTATION THIS CATCHES: dropping the `commitReverifier()` call, or keying it
-    // on a literal instead of `connector.source`.
+    // MUTATION THIS CATCHES: dropping the `commitReverifier()` call; keying it on
+    // a literal instead of `connector.source`; and — only because of the VALUE
+    // assertion below — committing some other function under the right key.
+    // Asserting the key alone let that last one survive, and it is the worst of
+    // the three: a source registered, keyed correctly, and re-verified by
+    // something that does nothing is the exact 168h decay this seam prevents.
     //
     // The precondition is load-bearing, not ceremony: without it a re-verifier
     // leaked by an earlier test makes this pass for the wrong reason.
@@ -274,6 +297,9 @@ describe("the brain source registry", () => {
 
     expect(getBrainSourceConnector("catalog:fixture")).toBeDefined();
     expect(listAudienceReverifierSources()).toEqual([WAREHOUSE_SOURCE]);
+    // Drain the registry and read the fingerprint back: this is what proves the
+    // committed function is the one the connector declared.
+    expect(await runRegisteredAudienceReverifiers()).toEqual(REVERIFIER_FINGERPRINT);
   });
 
   it("registers NO re-verifier for an externally-synced source", () => {
@@ -303,12 +329,12 @@ describe("the brain source registry", () => {
     // the claim in particular has no other assertion anywhere in this file.
     registerAudienceReverifier(WAREHOUSE_SOURCE, () => Promise.resolve(ZERO_REVERIFY));
 
-    // The ACTIONABLE half of the message, not the shared prefix: the duplicate
-    // CATALOG ID error also ends in "is already registered", so `/already
-    // registered/` alone cannot tell which registry refused — and this test is
-    // meaningless unless it was the re-verifier one.
+    // Which REGISTRY refused, not the shared prefix: the duplicate CATALOG ID
+    // error also ends in "is already registered", so `/already registered/` alone
+    // cannot discriminate — and this test is meaningless unless it was the
+    // re-verifier one.
     expect(() => registerBrainSourceConnector(reverified())).toThrow(
-      /refusing to register its brain source connector too/,
+      /re-verifier for source .* is already registered/,
     );
 
     expect(getBrainSourceConnector("catalog:fixture")).toBeUndefined();
@@ -322,8 +348,9 @@ describe("the brain source registry", () => {
     // If `prepareAudienceReverifier` wrote eagerly and returned a no-op — a
     // tempting "simplification" — this collision would leave a re-verifier for a
     // source with no connector. That inverted half-state is loud rather than
-    // silent (the vendor's idempotence gate sees no connector, retries, and then
-    // throws `already registered` forever), but it is still a partial commit.
+    // silent — any later registration attempt sees no connector, walks past the
+    // idempotence gate, and throws `already registered` — but it is still a
+    // partial commit.
     //
     // MUTATION THIS CATCHES: making `prepareAudienceReverifier` commit eagerly, or
     // hoisting `commitReverifier()` above `claimCatalogIngestTarget`.
@@ -335,22 +362,25 @@ describe("the brain source registry", () => {
 
     expect(listAudienceReverifierSources()).toEqual([]);
     expect(getBrainSourceConnector("catalog:fixture")).toBeUndefined();
-    _resetCatalogIngestClaims("knowledge-documents");
+    // The knowledge-documents claim is released in `afterEach`, not here — see
+    // its comment for why a trailing release would cascade.
   });
 
   it("⭐ refuses a grant-deriving class that declares externally-synced", () => {
     // The RUNTIME backstop for the lane the type cannot see. `BrainSourceAudienceFor`
     // makes this a TS2322 at a literal-typed connector, but a plugin arrives as
-    // data, and a cast or a widened return type compiles — the cast below is
-    // standing in for all three. Without this check a transcript source would
-    // register cleanly and mint grants nothing ever refreshes.
+    // data, and a cast or a widened return type compiles. No cast is needed to
+    // express it HERE — `connector()` takes `Partial<BrainSourceConnector>` at the
+    // default `S`, where the conditional is false and both arms are legal, so the
+    // fixture's own parameter type is the widener. That is the same widening a
+    // factory reintroduces by declaring the unparameterised return type.
     //
     // MUTATION THIS CATCHES: deleting the `requiresAudienceReverifier` branch from
     // `registerBrainSourceConnector`.
     const widened = connector({
       source: ZOOM_SOURCE,
       audience: { kind: "externally-synced" },
-    } as Partial<BrainSourceConnector>);
+    });
 
     expect(() => registerBrainSourceConnector(widened)).toThrow(/MUST declare audience/);
     // …and the actionable half — what a plugin author actually reads.
@@ -379,8 +409,18 @@ describe("the brain source registry", () => {
     //
     // A `reverified` arm with no function is the subtler half: it would register
     // `undefined` and make `runRegisteredAudienceReverifiers` count that source
-    // failed on every cycle, forever.
-    for (const bad of [undefined, null, {}, { kind: "nonsense" }, { kind: "reverified" }]) {
+    // failed on every cycle, forever. The last case is the CONTRADICTION —
+    // declaring that something else owns the refresh while supplying a
+    // re-verifier — which excess-property checking blocks in-repo but a plugin's
+    // data can express; dropping the function silently would age its audiences out.
+    for (const bad of [
+      undefined,
+      null,
+      {},
+      { kind: "nonsense" },
+      { kind: "reverified" },
+      { kind: "externally-synced", reverifier: () => Promise.resolve(ZERO_REVERIFY) },
+    ]) {
       expect(() =>
         registerBrainSourceConnector(connector({ audience: bad } as Partial<BrainSourceConnector>)),
       ).toThrow(/declared no usable audience strategy/);
@@ -391,15 +431,29 @@ describe("the brain source registry", () => {
   it("⭐ a grant-deriving class cannot declare externally-synced (COMPILE time)", () => {
     // AC-5 of #4985, pinned. Everything else in this describe is a runtime
     // assertion, and the compile-time narrowing degrades SILENTLY and in the
-    // permissive direction: drop an `as const` from an `EPISODE_SOURCE_SPECS`
-    // entry, annotate that map `Record<EpisodeSource, EpisodeSourceSpec>`, revert
-    // `BrainSourceAudienceFor` to a bare `BrainSourceAudience`, or drop the
-    // `const` modifier on `registerBrainSourceConnector`'s type parameter, and the
-    // conditional goes false for EVERY source with not one test going red.
+    // permissive direction.
+    //
+    // MUTATIONS THIS CATCHES, all three verified by applying them:
+    //   - annotating `EPISODE_SOURCE_SPECS` `Record<EpisodeSource, EpisodeSourceSpec>`,
+    //     which widens `class` off the literal;
+    //   - reverting `BrainSourceAudienceFor` to a bare `BrainSourceAudience`;
+    //   - flipping `AUDIENCE_GRAIN.transcript` to `not-required`.
+    //
+    // ⚠️ Two nearby edits are NOT caught, and naming them is the point: dropping
+    // an `as const` from an `EPISODE_SOURCE_SPECS` entry does not weaken anything
+    // (its `satisfies EpisodeSourceSpec` supplies the literal contextually), and
+    // neither does dropping the `const` modifier on `registerBrainSourceConnector`'s
+    // type parameter (the constraint is already a literal union). Both were
+    // checked; neither degrades the type, so there is nothing here to catch.
     //
     // `@ts-expect-error` is the instrument — the same one `sources.test.ts` uses
     // for the sibling claim — because it inverts: when the narrowing evaporates
     // the annotation stops erroring and the unused directive becomes the failure.
+    //
+    // ⚠️ So this test has NO teeth under `bun test` — bun strips types and the
+    // `toHaveLength(3)` below is trivially true. The gate is `bun run type`
+    // (tsgo, /ci stage 0), which compiles `src/**/*.ts` including this file. Do
+    // not "verify" it with the isolated runner and conclude it is dead weight.
     //
     // @ts-expect-error zoom is transcript-class — the reverified arm is the only one
     const zoom: BrainSourceAudienceFor<typeof ZOOM_SOURCE> = { kind: "externally-synced" };

--- a/packages/api/src/lib/brain/ingest/__tests__/episode-sync-archive.test.ts
+++ b/packages/api/src/lib/brain/ingest/__tests__/episode-sync-archive.test.ts
@@ -29,8 +29,14 @@ import {
   getBrainSourceConnector,
   listBrainSourceCatalogIds,
   registerBrainSourceConnector,
+  type BrainSourceAudienceFor,
   type BrainSourceConnector,
 } from "@atlas/api/lib/brain/ingest/types";
+import {
+  _resetCatalogIngestClaims,
+  claimCatalogIngestTarget,
+  getCatalogIngestTarget,
+} from "@atlas/api/lib/knowledge/catalog-claims";
 import {
   ZERO_REVERIFY,
   listAudienceReverifierSources,
@@ -39,9 +45,11 @@ import {
 import {
   CHAT_CLASS,
   HUMAN_SOURCE,
+  OUTLOOK_SOURCE,
   SLACK_SOURCE,
   WAREHOUSE_CLASS,
   WAREHOUSE_SOURCE,
+  ZOOM_SOURCE,
   type EpisodeSource,
   type EpisodeSourceVendor,
 } from "@atlas/api/lib/brain/sources";
@@ -231,8 +239,21 @@ describe("the brain source registry", () => {
 
   // ── The audience half, registered as ONE unit with the connector (#4985) ──
 
+  /**
+   * A `reverified` fixture on WAREHOUSE_SOURCE, not on the fixture default.
+   *
+   * The key the re-verifier lands under has to be DERIVED from
+   * `connector.source`, and the assertions below are the only thing pinning that.
+   * On `SLACK_SOURCE` — which is both the fixture default and the value a
+   * hardcoding mutation would most plausibly reach for — a
+   * `prepareAudienceReverifier(SLACK_SOURCE, …)` mutation would pass every one of
+   * them. Same argument `episode-sync.test.ts` records for using `HUMAN_SOURCE`
+   * in its fixture. `warehouse` is not a grant-deriving class, so it may declare
+   * either arm and the runtime backstop is not what is under test here.
+   */
   const reverified = (): BrainSourceConnector =>
     connector({
+      source: WAREHOUSE_SOURCE,
       audience: { kind: "reverified", reverifier: () => Promise.resolve(ZERO_REVERIFY) },
     });
 
@@ -242,10 +263,17 @@ describe("the brain source registry", () => {
     // the whole point of folding the audience strategy into the connector value
     // is that there is no second statement anyone can forget.
     //
-    // MUTATION THIS CATCHES: dropping the `commitReverifier?.()` call.
+    // MUTATION THIS CATCHES: dropping the `commitReverifier()` call, or keying it
+    // on a literal instead of `connector.source`.
+    //
+    // The precondition is load-bearing, not ceremony: without it a re-verifier
+    // leaked by an earlier test makes this pass for the wrong reason.
+    expect(listAudienceReverifierSources()).toEqual([]);
+
     registerBrainSourceConnector(reverified());
+
     expect(getBrainSourceConnector("catalog:fixture")).toBeDefined();
-    expect(listAudienceReverifierSources()).toEqual([SLACK_SOURCE]);
+    expect(listAudienceReverifierSources()).toEqual([WAREHOUSE_SOURCE]);
   });
 
   it("registers NO re-verifier for an externally-synced source", () => {
@@ -253,6 +281,10 @@ describe("the brain source registry", () => {
     // reconciled by the install-driven walk, and a connector that quietly
     // registered a re-verifier anyway would put a second writer on audiences the
     // walk already owns.
+    //
+    // No mutation is named because none is expressible: the branch reads
+    // `audience.kind`, and the other arm has no `.reverifier` to pass. It earns
+    // its place as the leak detector for the test above.
     registerBrainSourceConnector(connector());
     expect(getBrainSourceConnector("catalog:fixture")).toBeDefined();
     expect(listAudienceReverifierSources()).toEqual([]);
@@ -267,25 +299,132 @@ describe("the brain source registry", () => {
     //
     // MUTATION THIS CATCHES: moving `claimCatalogIngestTarget` / `registry.set`
     // above the `prepareAudienceReverifier` call, i.e. writing before validating.
-    registerAudienceReverifier(SLACK_SOURCE, () => Promise.resolve(ZERO_REVERIFY));
+    // All THREE structures are asserted, so no half of the mutation slips past —
+    // the claim in particular has no other assertion anywhere in this file.
+    registerAudienceReverifier(WAREHOUSE_SOURCE, () => Promise.resolve(ZERO_REVERIFY));
 
-    expect(() => registerBrainSourceConnector(reverified())).toThrow(/already registered/);
+    // The ACTIONABLE half of the message, not the shared prefix: the duplicate
+    // CATALOG ID error also ends in "is already registered", so `/already
+    // registered/` alone cannot tell which registry refused — and this test is
+    // meaningless unless it was the re-verifier one.
+    expect(() => registerBrainSourceConnector(reverified())).toThrow(
+      /refusing to register its brain source connector too/,
+    );
 
     expect(getBrainSourceConnector("catalog:fixture")).toBeUndefined();
+    expect(getCatalogIngestTarget("catalog:fixture")).toBeUndefined();
     expect(listBrainSourceCatalogIds()).toEqual([]);
   });
 
+  it("⭐ leaves the re-verifier registry EMPTY when the catalog claim collides", () => {
+    // The other throw site above the writes, and the one with no coverage before
+    // #4985: `claimCatalogIngestTarget` sits BETWEEN the prepare and the commit.
+    // If `prepareAudienceReverifier` wrote eagerly and returned a no-op — a
+    // tempting "simplification" — this collision would leave a re-verifier for a
+    // source with no connector. That inverted half-state is loud rather than
+    // silent (the vendor's idempotence gate sees no connector, retries, and then
+    // throws `already registered` forever), but it is still a partial commit.
+    //
+    // MUTATION THIS CATCHES: making `prepareAudienceReverifier` commit eagerly, or
+    // hoisting `commitReverifier()` above `claimCatalogIngestTarget`.
+    claimCatalogIngestTarget("catalog:fixture", "knowledge-documents");
+
+    expect(() => registerBrainSourceConnector(reverified())).toThrow(
+      /already registered as knowledge-documents/,
+    );
+
+    expect(listAudienceReverifierSources()).toEqual([]);
+    expect(getBrainSourceConnector("catalog:fixture")).toBeUndefined();
+    _resetCatalogIngestClaims("knowledge-documents");
+  });
+
+  it("⭐ refuses a grant-deriving class that declares externally-synced", () => {
+    // The RUNTIME backstop for the lane the type cannot see. `BrainSourceAudienceFor`
+    // makes this a TS2322 at a literal-typed connector, but a plugin arrives as
+    // data, and a cast or a widened return type compiles — the cast below is
+    // standing in for all three. Without this check a transcript source would
+    // register cleanly and mint grants nothing ever refreshes.
+    //
+    // MUTATION THIS CATCHES: deleting the `requiresAudienceReverifier` branch from
+    // `registerBrainSourceConnector`.
+    const widened = connector({
+      source: ZOOM_SOURCE,
+      audience: { kind: "externally-synced" },
+    } as Partial<BrainSourceConnector>);
+
+    expect(() => registerBrainSourceConnector(widened)).toThrow(/MUST declare audience/);
+    // …and the actionable half — what a plugin author actually reads.
+    expect(() => registerBrainSourceConnector(widened)).toThrow(/reads as ABSENT rather than denied/);
+
+    expect(listBrainSourceCatalogIds()).toEqual([]);
+    expect(listAudienceReverifierSources()).toEqual([]);
+
+    // The same class WITH a re-verifier still registers, so this is a pairing rule
+    // and not a blanket refusal of the transcript class.
+    expect(() =>
+      registerBrainSourceConnector(
+        connector({
+          source: ZOOM_SOURCE,
+          audience: { kind: "reverified", reverifier: () => Promise.resolve(ZERO_REVERIFY) },
+        }),
+      ),
+    ).not.toThrow();
+  });
+
+  it("refuses a malformed audience declaration rather than throwing a TypeError", () => {
+    // Same data lane. An absent field used to surface as `undefined is not an
+    // object (evaluating 'connector.audience.kind')` — fail-closed, but the one
+    // input whose absence is the entire subject of #4985 deserves the same
+    // actionable message every other invalid input here gets.
+    //
+    // A `reverified` arm with no function is the subtler half: it would register
+    // `undefined` and make `runRegisteredAudienceReverifiers` count that source
+    // failed on every cycle, forever.
+    for (const bad of [undefined, null, {}, { kind: "nonsense" }, { kind: "reverified" }]) {
+      expect(() =>
+        registerBrainSourceConnector(connector({ audience: bad } as Partial<BrainSourceConnector>)),
+      ).toThrow(/declared no usable audience strategy/);
+    }
+    expect(listBrainSourceCatalogIds()).toEqual([]);
+  });
+
+  it("⭐ a grant-deriving class cannot declare externally-synced (COMPILE time)", () => {
+    // AC-5 of #4985, pinned. Everything else in this describe is a runtime
+    // assertion, and the compile-time narrowing degrades SILENTLY and in the
+    // permissive direction: drop an `as const` from an `EPISODE_SOURCE_SPECS`
+    // entry, annotate that map `Record<EpisodeSource, EpisodeSourceSpec>`, revert
+    // `BrainSourceAudienceFor` to a bare `BrainSourceAudience`, or drop the
+    // `const` modifier on `registerBrainSourceConnector`'s type parameter, and the
+    // conditional goes false for EVERY source with not one test going red.
+    //
+    // `@ts-expect-error` is the instrument — the same one `sources.test.ts` uses
+    // for the sibling claim — because it inverts: when the narrowing evaporates
+    // the annotation stops erroring and the unused directive becomes the failure.
+    //
+    // @ts-expect-error zoom is transcript-class — the reverified arm is the only one
+    const zoom: BrainSourceAudienceFor<typeof ZOOM_SOURCE> = { kind: "externally-synced" };
+    // @ts-expect-error outlook is email-class — same
+    const outlook: BrainSourceAudienceFor<typeof OUTLOOK_SOURCE> = { kind: "externally-synced" };
+    // Chat is NOT grant-deriving, so both arms are legal — no directive here, and
+    // that asymmetry is what proves the conditional discriminates rather than
+    // refusing everything.
+    const slack: BrainSourceAudienceFor<typeof SLACK_SOURCE> = { kind: "externally-synced" };
+
+    expect([zoom, outlook, slack]).toHaveLength(3);
+  });
+
   it("⭐ _resetBrainSourceConnectors tears down the re-verifier registry too", () => {
-    // The teardown mirrors the registration one-for-one. If it stopped doing so,
-    // every suite that registers a brain source and re-registers it would fail on
-    // a duplicate re-verifier — a failure with nothing to do with what it was
-    // testing — because the `register*Connector` idempotence gates read only the
-    // CONNECTOR registry and would wave the second attempt through.
+    // The teardown mirrors the registration. If it stopped doing so, every suite
+    // that registers a brain source and re-registers it would fail on a duplicate
+    // re-verifier — a failure with nothing to do with what it was testing —
+    // because the `register*Connector` idempotence gates read only the CONNECTOR
+    // registry and would wave the second attempt through.
     //
     // MUTATION THIS CATCHES: dropping `_resetAudienceReverifiers()` from
     // `_resetBrainSourceConnectors`.
+    expect(listAudienceReverifierSources()).toEqual([]);
     registerBrainSourceConnector(reverified());
-    expect(listAudienceReverifierSources()).toEqual([SLACK_SOURCE]);
+    expect(listAudienceReverifierSources()).toEqual([WAREHOUSE_SOURCE]);
 
     _resetBrainSourceConnectors();
 

--- a/packages/api/src/lib/brain/ingest/__tests__/episode-sync-archive.test.ts
+++ b/packages/api/src/lib/brain/ingest/__tests__/episode-sync-archive.test.ts
@@ -158,8 +158,9 @@ describe("the brain source registry", () => {
   // `_resetBrainSourceConnectors` releases only the `brain-episodes` claims, by
   // design. One test below claims `catalog:fixture` for the OTHER target to
   // provoke a collision, and as a trailing statement that release would be
-  // skipped by a throwing assertion, leaving every later registration in this
-  // file failing with `already registered as knowledge-documents` — one real
+  // skipped by a throwing assertion, leaving every later registration of
+  // `catalog:fixture` — the rest of THIS describe; the sibling one uses other
+  // ids — failing with `already registered as knowledge-documents`, one real
   // failure manufacturing several unrelated ones. Harmless when nothing claimed.
   afterEach(() => {
     _resetBrainSourceConnectors();
@@ -252,6 +253,14 @@ describe("the brain source registry", () => {
   // ── The audience half, registered as ONE unit with the connector (#4985) ──
 
   /**
+   * A DISTINCTIVE counter, so the re-verifier can be identified by its OUTPUT and
+   * not merely by the key it landed under. `ZERO_REVERIFY` would make the
+   * declared re-verifier indistinguishable from any other — see the drain in
+   * "commits the connector AND the DECLARED re-verifier from one call".
+   */
+  const REVERIFIER_FINGERPRINT = Object.freeze({ ...ZERO_REVERIFY, membersAdded: 7 });
+
+  /**
    * A `reverified` fixture on WAREHOUSE_SOURCE, not on the fixture default.
    *
    * The key the re-verifier lands under has to be DERIVED from
@@ -263,13 +272,6 @@ describe("the brain source registry", () => {
    * in its fixture. `warehouse` is not a grant-deriving class, so it may declare
    * either arm and the runtime backstop is not what is under test here.
    */
-  /**
-   * A DISTINCTIVE counter, so the re-verifier can be identified by its output.
-   * `ZERO_REVERIFY` would make the declared re-verifier indistinguishable from
-   * any other — see the value assertion in the first test.
-   */
-  const REVERIFIER_FINGERPRINT = Object.freeze({ ...ZERO_REVERIFY, membersAdded: 7 });
-
   const reverified = (): BrainSourceConnector =>
     connector({
       source: WAREHOUSE_SOURCE,
@@ -452,8 +454,8 @@ describe("the brain source registry", () => {
     //
     // ⚠️ So this test has NO teeth under `bun test` — bun strips types and the
     // `toHaveLength(3)` below is trivially true. The gate is `bun run type`
-    // (tsgo, /ci stage 0), which compiles `src/**/*.ts` including this file. Do
-    // not "verify" it with the isolated runner and conclude it is dead weight.
+    // (tsgo, /ci stage 0), which type-checks the whole repo, this file included.
+    // Do not "verify" it with the isolated runner and conclude it is dead weight.
     //
     // @ts-expect-error zoom is transcript-class — the reverified arm is the only one
     const zoom: BrainSourceAudienceFor<typeof ZOOM_SOURCE> = { kind: "externally-synced" };
@@ -465,6 +467,29 @@ describe("the brain source registry", () => {
     const slack: BrainSourceAudienceFor<typeof SLACK_SOURCE> = { kind: "externally-synced" };
 
     expect([zoom, outlook, slack]).toHaveLength(3);
+  });
+
+  it("⭐ …and the check reaches an INLINE connector literal, not just the alias", () => {
+    // The annotations above pin the type; this pins that it still ARRIVES at the
+    // shape production writes. `registerBrainSourceConnector` infers `S` from its
+    // argument, and retyping that parameter to a bare `BrainSourceConnector` — or
+    // widening the `source` field — would leave every assertion above green while
+    // the compile-time check silently stopped applying at every real call site.
+    //
+    // Never invoked: it is compiled, which is the whole point, and calling it
+    // would just exercise the runtime backstop the sibling test already covers.
+    const unreachable = (): void => {
+      registerBrainSourceConnector({
+        catalogId: "catalog:never-registered",
+        source: ZOOM_SOURCE,
+        // @ts-expect-error zoom is transcript-class — the inline literal is checked at the CALL
+        audience: { kind: "externally-synced" },
+        createClient: () => ({ fetchEpisodes: async () => ({ episodes: [], highWaterMark: null }) }),
+      });
+    };
+
+    expect(typeof unreachable).toBe("function");
+    expect(listBrainSourceCatalogIds()).toEqual([]);
   });
 
   it("⭐ _resetBrainSourceConnectors tears down the re-verifier registry too", () => {

--- a/packages/api/src/lib/brain/ingest/__tests__/episode-sync.test.ts
+++ b/packages/api/src/lib/brain/ingest/__tests__/episode-sync.test.ts
@@ -155,7 +155,14 @@ function connectorReturning(
   // that stopped threading `connector.source` and hardcoded `"slack"` pass the
   // pass-through assertion below. A member this path would never produce keeps
   // that property.
-  return { catalogId: "catalog:fixture", source: HUMAN_SOURCE, createClient: () => ({ fetchEpisodes }) };
+  return {
+    catalogId: "catalog:fixture",
+    source: HUMAN_SOURCE,
+    // `human` is not a grant-deriving class, so either arm type-checks; this
+    // suite drives the ingest engine and never the audience seam.
+    audience: { kind: "externally-synced" },
+    createClient: () => ({ fetchEpisodes }),
+  };
 }
 
 function run(connector: BrainSourceConnector) {
@@ -367,6 +374,7 @@ describe("bookkeeping", () => {
       connector: {
         catalogId: "catalog:fixture",
         source: HUMAN_SOURCE,
+        audience: { kind: "externally-synced" },
         createClient: () => {
           throw new Error("unreachable");
         },

--- a/packages/api/src/lib/brain/ingest/__tests__/outlook-connector.test.ts
+++ b/packages/api/src/lib/brain/ingest/__tests__/outlook-connector.test.ts
@@ -120,7 +120,8 @@ const DAY_MS = 86_400_000;
 afterEach(() => {
   SETTING = undefined;
   LOG_CALLS.length = 0;
-  // ONE reset. It clears BOTH registries, which matters because
+  // ONE reset. It clears all three structures a registration writes — connector,
+  // catalog claim, and the re-verifier — which matters because
   // `registerOutlookMailConnector`'s idempotence gate reads only the connector
   // one: clearing that alone would let the gate pass on a second call while the
   // re-verifier commit throws on the duplicate. The totality is pinned in

--- a/packages/api/src/lib/brain/ingest/__tests__/outlook-connector.test.ts
+++ b/packages/api/src/lib/brain/ingest/__tests__/outlook-connector.test.ts
@@ -124,7 +124,8 @@ afterEach(() => {
   // catalog claim, and the re-verifier — which matters because
   // `registerOutlookMailConnector`'s idempotence gate reads only the connector
   // one: clearing that alone would let the gate pass on a second call while the
-  // re-verifier commit throws on the duplicate. The totality is pinned in
+  // re-verifier's duplicate CHECK throws (the commit itself cannot — see
+  // `prepareAudienceReverifier`). The totality is pinned in
   // `episode-sync-archive.test.ts` rather than hedged against here.
   _resetBrainSourceConnectors();
 });

--- a/packages/api/src/lib/brain/ingest/__tests__/outlook-connector.test.ts
+++ b/packages/api/src/lib/brain/ingest/__tests__/outlook-connector.test.ts
@@ -110,7 +110,7 @@ const { OUTLOOK_MAIL_CATALOG_ID, OUTLOOK_MAIL_SOURCE } = await import(
 const { _resetBrainSourceConnectors, getBrainSourceConnector } = await import(
   "@atlas/api/lib/brain/ingest/types"
 );
-const { _resetAudienceReverifiers, listAudienceReverifierSources } = await import(
+const { listAudienceReverifierSources } = await import(
   "@atlas/api/lib/brain/audience/reverify"
 );
 type OutlookCredentialReader = import("@atlas/api/lib/brain/ingest/outlook/connector").OutlookCredentialReader;
@@ -120,12 +120,12 @@ const DAY_MS = 86_400_000;
 afterEach(() => {
   SETTING = undefined;
   LOG_CALLS.length = 0;
+  // ONE reset. It clears BOTH registries, which matters because
+  // `registerOutlookMailConnector`'s idempotence gate reads only the connector
+  // one: clearing that alone would let the gate pass on a second call while the
+  // re-verifier commit throws on the duplicate. The totality is pinned in
+  // `episode-sync-archive.test.ts` rather than hedged against here.
   _resetBrainSourceConnectors();
-  // ⚠️ BOTH registries. `registerOutlookMailConnector`'s idempotence gate reads
-  // only the connector registry, so resetting that alone lets the gate pass on a
-  // second call while `registerAudienceReverifier` throws on the duplicate —
-  // aborting mid-registration with the connector already registered.
-  _resetAudienceReverifiers();
 });
 
 describe("getEmailBackfillWindowMs", () => {
@@ -353,8 +353,10 @@ describe("registerOutlookMailConnector", () => {
     // re-verifier mints `audience:` grants that stop granting at the staleness
     // bound a week later, silently, with every sync green.
     //
-    // MUTATION THIS CATCHES: dropping the `registerOutlookAudienceReverifier`
-    // call. Nothing else in the suite would notice.
+    // MUTATION THIS CATCHES: swapping the connector's `audience` for the
+    // `externally-synced` arm. That is a TS2322 since #4985 — the email class
+    // admits no other arm — but the assertion stays because a cast, or a widened
+    // annotation, still compiles. Nothing else in the suite would notice.
     expect(getBrainSourceConnector(OUTLOOK_MAIL_CATALOG_ID)).toBeUndefined();
     expect(listAudienceReverifierSources()).not.toContain(OUTLOOK_MAIL_SOURCE);
 

--- a/packages/api/src/lib/brain/ingest/__tests__/slack-webhook.test.ts
+++ b/packages/api/src/lib/brain/ingest/__tests__/slack-webhook.test.ts
@@ -43,9 +43,10 @@ const PRIVATE_CHANNEL = "G01PRIVATE";
 const TS = "1750000000.000100";
 
 /** The registered Slack brain source, as the writer sees it in the registry. */
-const CONNECTOR: BrainSourceConnector = {
+const CONNECTOR: BrainSourceConnector<typeof SLACK_SOURCE> = {
   catalogId: SLACK_HISTORY_CATALOG_ID,
   source: SLACK_SOURCE,
+  audience: { kind: "externally-synced" },
   createClient() {
     throw new Error("the webhook path never builds a vendor client");
   },

--- a/packages/api/src/lib/brain/ingest/__tests__/zoom-audience.test.ts
+++ b/packages/api/src/lib/brain/ingest/__tests__/zoom-audience.test.ts
@@ -16,7 +16,7 @@
  *      green.
  */
 
-import { describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import {
   MAX_PARTICIPANT_PAGES,
   readMeetingRoster,
@@ -668,8 +668,25 @@ describe("rotation — this source inherits the shared attempt stamp (#4971)", (
 });
 
 describe("the re-verifier registry", () => {
+  // `_resetAudienceReverifiers` and not `_resetBrainSourceConnectors`, which is
+  // the reset every suite that registers a BRAIN SOURCE must use since #4985.
+  // The distinction is the point rather than an oversight: these tests register
+  // bare fixture re-verifiers and never touch the connector registry, so this is
+  // the un-paired primitive's one legitimate caller — a suite whose subject IS
+  // this registry. A suite that registered a connector and then reset only this
+  // half would leave the idempotence gate (`getBrainSourceConnector(id) !==
+  // undefined`) saying "already registered" about a source whose re-verifier had
+  // just been deleted.
+  //
+  // In `beforeEach`/`afterEach`, not inline at the top and bottom of each test.
+  // The inline form is what `audience/__tests__/sync.test.ts` was burned by: a
+  // reset written after the awaits with no `finally` never runs when the body
+  // throws, so ONE real failure leaks a "zoom" re-verifier into every later test
+  // in the file and manufactures several unrelated ones.
+  beforeEach(_resetAudienceReverifiers);
+  afterEach(_resetAudienceReverifiers);
+
   it("refuses a duplicate registration for one source", () => {
-    _resetAudienceReverifiers();
     registerAudienceReverifier("zoom", async () => ZERO_REVERIFY);
     // Two re-verifiers for one source would each reconcile against their own
     // roster, and the loser's members would be revoked every cycle.
@@ -677,23 +694,19 @@ describe("the re-verifier registry", () => {
       /already registered/,
     );
     expect(listAudienceReverifierSources()).toEqual(["zoom"]);
-    _resetAudienceReverifiers();
   });
 
   it("counts a re-verifier that throws as a FAILURE, so the cycle reports degraded", async () => {
     // Swallowing it would leave the cycle looking clean while a source's
     // audiences quietly age out.
-    _resetAudienceReverifiers();
     registerAudienceReverifier("zoom", async () => {
       throw new Error("kaboom");
     });
     const out = await runRegisteredAudienceReverifiers();
     expect(out.failed).toBe(1);
-    _resetAudienceReverifiers();
   });
 
   it("sums across sources and isolates each", async () => {
-    _resetAudienceReverifiers();
     // Real source kinds, not placeholders: the registry is keyed by
     // `EpisodeSource` so a made-up slug no longer compiles — which is the point,
     // since a drifted key writes membership under a source the re-verifier's
@@ -708,7 +721,6 @@ describe("the re-verifier registry", () => {
       membersRevoked: 3,
       principalsUnresolved: 0,
     });
-    _resetAudienceReverifiers();
   });
 });
 

--- a/packages/api/src/lib/brain/ingest/__tests__/zoom-audience.test.ts
+++ b/packages/api/src/lib/brain/ingest/__tests__/zoom-audience.test.ts
@@ -670,13 +670,13 @@ describe("rotation — this source inherits the shared attempt stamp (#4971)", (
 describe("the re-verifier registry", () => {
   // `_resetAudienceReverifiers` and not `_resetBrainSourceConnectors`, which is
   // the reset every suite that registers a BRAIN SOURCE must use since #4985.
-  // The distinction is the point rather than an oversight: these tests register
-  // bare fixture re-verifiers and never touch the connector registry, so this is
-  // the un-paired primitive's one legitimate caller — a suite whose subject IS
-  // this registry. A suite that registered a connector and then reset only this
-  // half would leave the idempotence gate (`getBrainSourceConnector(id) !==
-  // undefined`) saying "already registered" about a source whose re-verifier had
-  // just been deleted.
+  // The distinction is the point rather than an oversight, and the criterion is
+  // what the suite REGISTERS: these tests register bare fixture re-verifiers and
+  // never a connector, so the un-paired primitive is the right tool (the other
+  // compliant caller is `audience/__tests__/sync.test.ts`, same reason). A suite
+  // that registered a connector and then reset only this half would leave the
+  // idempotence gate (`getBrainSourceConnector(id) !== undefined`) saying
+  // "already registered" about a source whose re-verifier had just been deleted.
   //
   // In `beforeEach`/`afterEach`, not inline at the top and bottom of each test.
   // The inline form is what `audience/__tests__/sync.test.ts` was burned by: a

--- a/packages/api/src/lib/brain/ingest/__tests__/zoom-connector.test.ts
+++ b/packages/api/src/lib/brain/ingest/__tests__/zoom-connector.test.ts
@@ -110,12 +110,9 @@ const { ZOOM_TRANSCRIPTS_CATALOG_ID, ZOOM_TRANSCRIPT_SOURCE } = await import(
 const { _resetBrainSourceConnectors, getBrainSourceConnector } = await import(
   "@atlas/api/lib/brain/ingest/types"
 );
-const {
-  ZERO_REVERIFY,
-  _resetAudienceReverifiers,
-  listAudienceReverifierSources,
-  registerAudienceReverifier,
-} = await import("@atlas/api/lib/brain/audience/reverify");
+const { ZERO_REVERIFY, listAudienceReverifierSources, registerAudienceReverifier } = await import(
+  "@atlas/api/lib/brain/audience/reverify"
+);
 type ZoomCredentialReader =
   import("@atlas/api/lib/brain/ingest/zoom/connector").ZoomCredentialReader;
 
@@ -124,12 +121,14 @@ const DAY_MS = 86_400_000;
 afterEach(() => {
   SETTING = undefined;
   LOG_CALLS.length = 0;
-  // `_resetBrainSourceConnectors` now clears the re-verifier registry too, so
-  // one call is enough. `_resetAudienceReverifiers` stays for the same reason
-  // the Outlook suite keeps it: this file must not depend on that coupling
-  // holding, since the coupling is itself something under test elsewhere.
+  // ONE reset, deliberately. `_resetBrainSourceConnectors` tears down everything
+  // `registerBrainSourceConnector` writes — connector, catalog claim, and the
+  // re-verifier — and that totality is pinned in `episode-sync-archive.test.ts`.
+  // A belt-and-braces `_resetAudienceReverifiers()` beside it used to hedge
+  // against the coupling breaking; it also meant this suite would have stayed
+  // green if it did, which is the wrong way round for the invariant #4985 is
+  // about.
   _resetBrainSourceConnectors();
-  _resetAudienceReverifiers();
 });
 
 describe("getTranscriptBackfillWindowMs", () => {
@@ -405,8 +404,10 @@ describe("registerZoomTranscriptConnector", () => {
     // sync green. `register.ts`'s own comment states this failure mode; nothing
     // proved it held.
     //
-    // MUTATION THIS CATCHES: dropping the `registerZoomAudienceReverifier` call.
-    // Nothing else in the suite would notice.
+    // MUTATION THIS CATCHES: swapping the connector's `audience` for the
+    // `externally-synced` arm. That is a TS2322 since #4985 — the transcript
+    // class admits no other arm — but the assertion stays because a cast, or a
+    // widened annotation, still compiles. Nothing else in the suite would notice.
     expect(getBrainSourceConnector(ZOOM_TRANSCRIPTS_CATALOG_ID)).toBeUndefined();
     expect(listAudienceReverifierSources()).not.toContain(ZOOM_TRANSCRIPT_SOURCE);
 
@@ -441,8 +442,9 @@ describe("registerZoomTranscriptConnector", () => {
     // A clean absence is fail-closed and loud (installs 500 at sync time); the
     // half state is quiet for 168h and then reads as the content not existing.
     //
-    // MUTATION THIS CATCHES: reverting to `registerBrainSourceConnector(...)`
-    // followed by `registerZoomAudienceReverifier(...)`.
+    // MUTATION THIS CATCHES: moving `registerBrainSourceConnector`'s writes above
+    // its `prepareAudienceReverifier` call — i.e. committing the connector before
+    // the re-verifier's duplicate check has run.
     registerAudienceReverifier(ZOOM_TRANSCRIPT_SOURCE, () => Promise.resolve(ZERO_REVERIFY));
 
     expect(() => registerZoomTranscriptConnector()).toThrow(/already registered/);

--- a/packages/api/src/lib/brain/ingest/outlook/audience.ts
+++ b/packages/api/src/lib/brain/ingest/outlook/audience.ts
@@ -419,7 +419,10 @@ export async function reverifyOutlookMessageAudiences(
   const isEnabled = deps.isEnabled ?? isAudienceSyncEnabled;
   const resolveToken = deps.resolveToken;
   if (resolveToken === undefined) {
-    // Unreachable in production — `registerOutlookMailConnector` binds one.
+    // Unreachable in production — the connector literal in
+    // `createOutlookMailConnector` binds one. NOT
+    // `createOutlookAudienceReverifier`, which forwards whatever deps it is
+    // handed (`resolveToken` is optional on `OutlookAudienceDeps`).
     // Loud rather than a silent no-op: a re-verifier that quietly does nothing
     // lets every message audience age past the staleness bound while the cycle
     // reports success, which is the exact failure this module exists to prevent.

--- a/packages/api/src/lib/brain/ingest/outlook/audience.ts
+++ b/packages/api/src/lib/brain/ingest/outlook/audience.ts
@@ -133,9 +133,9 @@ import {
   isAudienceSyncEnabled,
 } from "@atlas/api/lib/brain/audience/sync";
 import {
-  registerAudienceReverifier,
   selectReverifyCandidates,
   ZERO_REVERIFY,
+  type AudienceReverifier,
   type AudienceReverifyResult,
 } from "@atlas/api/lib/brain/audience/reverify";
 import { fetchMessageByInternetMessageId, type OutlookMessage } from "./api";
@@ -685,11 +685,16 @@ async function reverifyWorkspace(
 }
 
 /**
- * Register the Outlook re-verifier. Called from the same wiring seam that
- * registers the connector, so a deployment can never have one without the other
- * — an ingest path that mints audiences with no re-verifier is the silent-expiry
- * bug this module exists to prevent.
+ * Build the Outlook re-verifier. It is the `audience` half of the Outlook
+ * connector value (`connector.ts`), so a deployment can never have one without
+ * the other — an ingest path that mints audiences with no re-verifier is the
+ * silent-expiry bug this module exists to prevent.
+ *
+ * Returns rather than registers (#4985): the registration is
+ * `registerBrainSourceConnector`'s single all-or-nothing write, and a second
+ * function that also wrote to the re-verifier registry would be exactly the loose
+ * half a caller can commit on its own.
  */
-export function registerOutlookAudienceReverifier(deps: OutlookAudienceDeps): void {
-  registerAudienceReverifier(OUTLOOK_MAIL_SOURCE, () => reverifyOutlookMessageAudiences(deps));
+export function createOutlookAudienceReverifier(deps: OutlookAudienceDeps): AudienceReverifier {
+  return () => reverifyOutlookMessageAudiences(deps);
 }

--- a/packages/api/src/lib/brain/ingest/outlook/connector.ts
+++ b/packages/api/src/lib/brain/ingest/outlook/connector.ts
@@ -34,7 +34,7 @@ import { getSettingAuto } from "@atlas/api/lib/settings";
 import { readSyncCredential } from "@atlas/api/lib/knowledge/sync-credentials";
 import { createOutlookMailClient } from "./client";
 import { fetchGraphAccessToken } from "./api";
-import { registerOutlookAudienceReverifier } from "./audience";
+import { createOutlookAudienceReverifier } from "./audience";
 import {
   OUTLOOK_MAIL_CATALOG_ID,
   OUTLOOK_MAIL_SOURCE,
@@ -42,7 +42,7 @@ import {
 } from "./config";
 import {
   getBrainSourceConnector,
-  registerBrainSourceWithAudienceReverifier,
+  registerBrainSourceConnector,
   type BrainSourceConnector,
   type BrainSourceInstallContext,
   type BrainSourceVendorClient,
@@ -197,7 +197,7 @@ export interface OutlookMailConnectorDeps {
 /** Build the Outlook mail brain source. `deps` is test-only injection. */
 export function createOutlookMailConnector(
   deps: OutlookMailConnectorDeps = {},
-): BrainSourceConnector {
+): BrainSourceConnector<typeof OUTLOOK_MAIL_SOURCE> {
   const reader: OutlookCredentialReader = deps.reader ?? {
     readSyncCredential,
     fetchGraphAccessToken,
@@ -205,6 +205,23 @@ export function createOutlookMailConnector(
   return {
     catalogId: OUTLOOK_MAIL_CATALOG_ID,
     source: OUTLOOK_MAIL_SOURCE,
+    // Mail is a grant-DERIVING class: a message's audience comes from its own
+    // headers, so nothing but this re-verifier can refresh it and
+    // `BrainSourceAudienceFor<"outlook">` admits no other arm. Built here, beside
+    // the client, so the connector and its re-verifier share one `reader` and
+    // reach the registry as one value.
+    audience: {
+      kind: "reverified",
+      reverifier: createOutlookAudienceReverifier({
+        // The install id doubles as the credential's `collection_id`, the same
+        // convention every knowledge connector uses.
+        resolveToken: async (workspaceId, installId, config) => {
+          const parsed = parseOutlookMailConfig(config);
+          if (!parsed.ok) throw new Error(parsed.error);
+          return resolveOutlookToken(reader, workspaceId, installId, parsed.tenantId);
+        },
+      }),
+    },
     createClient(ctx: BrainSourceInstallContext): BrainSourceVendorClient {
       const parsed = parseOutlookMailConfig(ctx.config);
       if (!parsed.ok) throw new Error(parsed.error);
@@ -227,30 +244,17 @@ export function createOutlookMailConnector(
  * called from the boot seam that also registers install handlers, and from
  * tests.
  *
- * The pair goes through `registerBrainSourceWithAudienceReverifier` rather than
- * as two statements. Both registries throw on a duplicate, and the gate below
- * reads only the connector registry — so registering the connector first and
- * colliding on the re-verifier second would leave this source ingesting mail
- * whose grants nothing refreshes, permanently and silently. That helper checks
- * the re-verifier registry before it commits anything.
+ * The pair is ONE value and ONE call (#4985). Both registries throw on a
+ * duplicate, and the gate below reads only the connector registry — so a
+ * registration that committed the connector first and collided on the re-verifier
+ * second would leave this source ingesting mail whose grants nothing refreshes,
+ * permanently and silently, because the retry short-circuits on the connector the
+ * failed attempt left behind. `registerBrainSourceConnector` does all of its
+ * throwing before any of its writing, so that half-state has no path.
  */
 export function registerOutlookMailConnector(deps: OutlookMailConnectorDeps = {}): void {
   if (getBrainSourceConnector(OUTLOOK_MAIL_CATALOG_ID) !== undefined) return;
-  const reader: OutlookCredentialReader = deps.reader ?? {
-    readSyncCredential,
-    fetchGraphAccessToken,
-  };
-  registerBrainSourceWithAudienceReverifier(createOutlookMailConnector({ reader }), () =>
-    registerOutlookAudienceReverifier({
-      // The install id doubles as the credential's `collection_id`, the same
-      // convention every knowledge connector uses.
-      resolveToken: async (workspaceId, installId, config) => {
-        const parsed = parseOutlookMailConfig(config);
-        if (!parsed.ok) throw new Error(parsed.error);
-        return resolveOutlookToken(reader, workspaceId, installId, parsed.tenantId);
-      },
-    }),
-  );
+  registerBrainSourceConnector(createOutlookMailConnector(deps));
   log.info(
     { catalogId: OUTLOOK_MAIL_CATALOG_ID },
     "Registered Outlook mail brain source and its audience re-verifier",

--- a/packages/api/src/lib/brain/ingest/slack/connector.ts
+++ b/packages/api/src/lib/brain/ingest/slack/connector.ts
@@ -130,11 +130,17 @@ export interface SlackHistoryConnectorDeps {
 /** Build the Slack chat-history brain source. `deps` is test-only injection. */
 export function createSlackHistoryConnector(
   deps: SlackHistoryConnectorDeps = {},
-): BrainSourceConnector {
+): BrainSourceConnector<typeof SLACK_HISTORY_SOURCE> {
   const store: SlackInstallationReader = deps.store ?? { getInstallationByOrg, getBotToken };
   return {
     catalogId: SLACK_HISTORY_CATALOG_ID,
     source: SLACK_HISTORY_SOURCE,
+    // Slack's grants are CHANNEL-scoped, and `audience/sync.ts` reconciles them
+    // by walking channel rosters off the install — a pass parameterised by
+    // `SLACK_HISTORY_CATALOG_ID` rather than driven from the re-verifier
+    // registry. So this source deliberately registers no re-verifier, and says
+    // so rather than leaving the question open.
+    audience: { kind: "externally-synced" },
     async createClient(ctx: BrainSourceInstallContext): Promise<BrainSourceVendorClient> {
       const parsed = parseSlackHistoryConfig(ctx.config);
       if (!parsed.ok) throw new Error(parsed.error);

--- a/packages/api/src/lib/brain/ingest/types.ts
+++ b/packages/api/src/lib/brain/ingest/types.ts
@@ -52,10 +52,12 @@ import {
 import type { BrainGrant } from "@atlas/api/lib/brain/types";
 import {
   _resetAudienceReverifiers,
-  hasAudienceReverifier,
+  prepareAudienceReverifier,
+  type AudienceReverifier,
 } from "@atlas/api/lib/brain/audience/reverify";
 import {
   EPISODE_SOURCES,
+  EPISODE_SOURCE_SPECS,
   episodeSourceClass,
   episodeSourceVendor,
   isEpisodeSource,
@@ -199,13 +201,108 @@ export interface BrainSourceInstallContext {
 }
 
 /**
- * A registered brain ingest source: one catalog row → one client factory.
+ * How a source's `audience:` grants are kept inside the staleness bound (#4985).
+ *
+ * ## Why this is a FIELD and not a second registration call
+ *
+ * A source that mints per-object grants needs two things registered: the
+ * connector, so it ingests, and an audience re-verifier, so the grants it minted
+ * keep resolving. They live in two registries and both throw on a duplicate, so
+ * written as two statements the first can commit and the second throw — leaving a
+ * source that ingests normally for `ATLAS_BRAIN_AUDIENCE_MAX_STALENESS_HOURS`
+ * (168h by default) and then goes silently invisible when `acl.ts` suppresses the
+ * audiences nothing refreshed. That half-state is worse than either clean
+ * outcome: fully absent is fail-closed and loud (installs 500 at sync time,
+ * someone notices the same day), while half-wired is quiet for a week and then
+ * reads as the content NOT EXISTING rather than as denied, in a different
+ * subsystem, with nothing pointing back at boot.
+ *
+ * #4983 closed that at runtime by checking the re-verifier registry before
+ * committing the connector. This closes it in the SHAPE: a connector carries its
+ * audience strategy as one value, {@link registerBrainSourceConnector} is the
+ * only registration call, and there is no pair of statements a fourth source
+ * could write in the wrong order. "Forgot the re-verifier" stops being a class of
+ * mistake — the field is required, so the only remaining question is which arm,
+ * and {@link BrainSourceAudienceFor} answers that at compile time for the classes
+ * where getting it wrong is the silent failure above.
+ */
+export type BrainSourceAudience =
+  /**
+   * This source mints its own `audience:` grants and brings the re-verifier that
+   * refreshes them. Registered under the connector's `source` kind, so the two
+   * halves cannot be wired to different sources.
+   */
+  | { readonly kind: "reverified"; readonly reverifier: AudienceReverifier }
+  /**
+   * This source's audiences are reconciled by something OTHER than a registered
+   * re-verifier, and it registers none.
+   *
+   * `slack-history` is the shipped case: its grants are channel-scoped and
+   * `audience/sync.ts` walks Slack channel rosters directly, parameterised by
+   * `SLACK_HISTORY_CATALOG_ID`. Naming that here is the point — the arm is a
+   * DECLARATION that somebody else owns the refresh, not an opt-out, so a source
+   * that picks it is making a claim a reviewer can check rather than leaving a
+   * field off.
+   */
+  | { readonly kind: "externally-synced" };
+
+/**
+ * The episode classes whose grants are per-object and therefore CANNOT be
+ * externally synced — a transcript's participants and a mail's recipients are
+ * derived from the record itself, so nothing but a re-verifier for this source
+ * can refresh them.
+ *
+ * ADR-0036's other classes are deliberately absent, each for its own reason:
+ * `chat` grants are channel-scoped and reconciled by the install-driven Slack
+ * walk; `warehouse` and `human` episodes do not come from a connector at all.
+ * Those may legitimately pick either arm, so the type leaves the choice open and
+ * the arm's own docstring is what a reviewer reads.
+ */
+export const REVERIFIER_REQUIRED_CLASSES = ["transcript", "email"] as const satisfies
+  readonly EpisodeSourceClass[];
+
+type ReverifierRequiredClass = (typeof REVERIFIER_REQUIRED_CLASSES)[number];
+
+/**
+ * The audience strategies a source of kind `S` may declare.
+ *
+ * This is AC-5 of #4985 answered YES: for a grant-deriving class, "mints
+ * audience grants with no re-verifier" is a TS2322 at the connector literal
+ * rather than a runbook item. `BrainSourceAudienceFor<"zoom">` is the
+ * `"reverified"` arm alone; `BrainSourceAudienceFor<"slack">` is the whole union.
+ *
+ * The narrowing bites wherever the source is LITERAL-typed, which is every
+ * hand-written connector: each `create*Connector` declares
+ * `BrainSourceConnector<typeof X_SOURCE>`, and {@link registerBrainSourceConnector}
+ * infers `S` from the value it is handed, so an inline literal is checked too.
+ *
+ * At the default `S = EpisodeSource` the class set spans both grant-deriving and
+ * not, the conditional is false, and the field widens to the union. That is what
+ * the registry stores, and it is the honest answer for a connector that arrives
+ * as DATA rather than as a checked type — a plugin-supplied one, compiled
+ * separately. Those get the runtime all-or-nothing guarantee in
+ * {@link registerBrainSourceConnector} and nothing more, which is the same split
+ * `lib/brain/sources.ts` already draws for the source vocabulary itself.
+ */
+export type BrainSourceAudienceFor<S extends EpisodeSource> =
+  (typeof EPISODE_SOURCE_SPECS)[S]["class"] extends ReverifierRequiredClass
+    ? Extract<BrainSourceAudience, { kind: "reverified" }>
+    : BrainSourceAudience;
+
+/**
+ * A registered brain ingest source: one catalog row → one client factory, plus
+ * the audience strategy that keeps its grants alive.
  *
  * `createClient` may throw (bad config, a disconnected upstream OAuth install)
  * — the engine turns that into the source's error outcome with the message
  * surfaced to the admin, so make it actionable.
+ *
+ * The type parameter exists ONLY to carry the compile-time audience narrowing
+ * described on {@link BrainSourceAudienceFor}; every consumer that merely holds
+ * connectors (the registry, the cycle walk, the webhook fast-path) uses the
+ * unparameterised form and sees the widest shape.
  */
-export interface BrainSourceConnector {
+export interface BrainSourceConnector<S extends EpisodeSource = EpisodeSource> {
   /** The catalog row this connector serves — the cycle-walk dispatch key. */
   readonly catalogId: string;
   /**
@@ -230,7 +327,12 @@ export interface BrainSourceConnector {
    * stored column and the registry lookup would answer different questions
    * about the same connector.
    */
-  readonly source: EpisodeSource;
+  readonly source: S;
+  /**
+   * How this source's `audience:` grants stay inside the staleness bound.
+   * Required, and required for a REASON — see {@link BrainSourceAudience}.
+   */
+  readonly audience: BrainSourceAudienceFor<S>;
   createClient(
     ctx: BrainSourceInstallContext,
   ): Promise<BrainSourceVendorClient> | BrainSourceVendorClient;
@@ -245,14 +347,49 @@ const SOURCE_SLUG = /^[a-z0-9][a-z0-9-]*$/;
 const registry = new Map<string, BrainSourceConnector>();
 
 /**
- * Register a brain source for its catalog row. Called once per source at
- * wiring time. Duplicate catalog ids, malformed source slugs, and kinds
- * outside the vocabulary all fail loudly — a silent overwrite would let one
- * source shadow another's installs, a malformed slug would land unqueryable
- * garbage in `brain_episodes.source`, and an unknown kind would land a value
- * that every downstream discriminator silently declines to recognise.
+ * Register a brain source — the connector AND the audience half it declares —
+ * for its catalog row. Called once per source at wiring time.
+ *
+ * Duplicate catalog ids, malformed source slugs, kinds outside the vocabulary,
+ * and a re-verifier already held for this source all fail loudly. A silent
+ * overwrite would let one source shadow another's installs, a malformed slug
+ * would land unqueryable garbage in `brain_episodes.source`, an unknown kind
+ * would land a value that every downstream discriminator silently declines to
+ * recognise, and a duplicate re-verifier would have two of them reconciling
+ * against their own rosters with the loser's members revoked every cycle.
+ *
+ * ## ALL-OR-NOTHING, and how the body is arranged to guarantee it
+ *
+ * This function writes THREE process-global structures — the catalog-ingest
+ * claim, this registry, and the audience re-verifier registry — and a partial
+ * commit is the failure #4983/#4985 exist to prevent (see
+ * {@link BrainSourceAudience} for what a half-wired source costs). `registerStep`
+ * in `integrations/install/register.ts` bounds the blast radius ACROSS vendors and
+ * can do nothing about a vendor that committed to one registry and then threw on
+ * a second, because no catch can undo a write from the outside.
+ *
+ * So every throw site sits ABOVE the first write, and the body is split to make
+ * that readable:
+ *
+ *   - the validation half throws and writes nothing. {@link prepareAudienceReverifier}
+ *     belongs to it: it performs the duplicate check and returns the commit,
+ *     which is why the check cannot be separated from the write it protects;
+ *   - `claimCatalogIngestTarget` is the boundary — it checks before it writes, so
+ *     a cross-target collision still throws with nothing committed anywhere;
+ *   - the two writes after it are `Map.set` calls that cannot fail.
+ *
+ * Registration is single-threaded boot wiring, so there is no window between the
+ * checks and the writes for anything else to claim the source.
+ *
+ * `const S` so an inline connector literal keeps its literal source kind and gets
+ * {@link BrainSourceAudienceFor}'s compile-time check rather than the widened
+ * union. A caller holding an already-widened `BrainSourceConnector` still passes
+ * — that arm is for connectors that arrive as data, and it is the runtime
+ * validation above, not the type, that covers them.
  */
-export function registerBrainSourceConnector(connector: BrainSourceConnector): void {
+export function registerBrainSourceConnector<const S extends EpisodeSource>(
+  connector: BrainSourceConnector<S>,
+): void {
   if (!SOURCE_SLUG.test(connector.source)) {
     throw new Error(
       `Brain source slug "${connector.source}" is invalid — expected a lowercase alphanumeric slug matching ${SOURCE_SLUG.source} (it is stored verbatim in brain_episodes.source)`,
@@ -282,64 +419,23 @@ export function registerBrainSourceConnector(connector: BrainSourceConnector): v
       `Brain source connector for catalog id "${connector.catalogId}" is already registered`,
     );
   }
+  // The re-verifier's duplicate check, fused to the only thing that installs it.
+  // Keyed on `connector.source`, so the connector and its re-verifier cannot be
+  // wired to different sources.
+  const commitReverifier =
+    connector.audience.kind === "reverified"
+      ? prepareAudienceReverifier(connector.source, connector.audience.reverifier)
+      : undefined;
+
+  // ── Past this line nothing may throw with a write already committed. ──
   // One catalog id, one ingest target. Both registries claim through the same
   // module so the check is ORDER-INDEPENDENT — an earlier one-sided peek at the
   // knowledge registry only covered the direction that cannot happen (brain
-  // sources register last today) and missed the one that can.
+  // sources register last today) and missed the one that can. It checks before
+  // it writes, so a collision here still leaves nothing committed.
   claimCatalogIngestTarget(connector.catalogId, "brain-episodes");
   registry.set(connector.catalogId, connector);
-}
-
-/**
- * Register a brain source AND its audience re-verifier as one unit.
- *
- * ## Why this exists rather than two calls in a row
- *
- * A source that derives per-object grants needs BOTH: the connector to ingest,
- * and the re-verifier to keep the grants it minted from going stale. They live
- * in two registries, and both throw on a duplicate. Written as two bare
- * statements — which is how Zoom and Outlook were first wired — a throw from the
- * SECOND leaves the first committed, and the caller's idempotence gate
- * (`getBrainSourceConnector(id) !== undefined`) reads only that first registry.
- * So the retry short-circuits and the half-state is permanent for the process.
- *
- * That half-state is the worst of the three outcomes, and it is worth being
- * precise about why. Fully registered is correct. Fully absent is fail-closed
- * and loud — installs 500 at sync time and someone notices the same day. HALF
- * registered ingests normally for `ATLAS_BRAIN_AUDIENCE_MAX_STALENESS_HOURS`
- * (168h by default) and only then goes wrong, at which point `acl.ts` suppresses
- * every audience the missing re-verifier was supposed to refresh and every fact
- * behind them reads as ABSENT rather than as denied. A week later, in a
- * different subsystem, with nothing pointing back here.
- *
- * So the re-verifier registry is checked BEFORE the connector is committed. That
- * ordering is the whole point: after this check the only remaining throw sites
- * are inside {@link registerBrainSourceConnector}, which validates before it
- * writes and whose own two writes (`claimCatalogIngestTarget` then
- * `registry.set`) already fail with nothing committed. Registration is
- * single-threaded boot wiring, so there is no window between the check and the
- * write for anything else to claim the source.
- *
- * A source with no per-object grants (slack-history — its grants are channel
- * scoped and reconciled by the install-driven sweep) has no re-verifier to pair
- * and calls {@link registerBrainSourceConnector} directly.
- *
- * @param connector the source to register
- * @param registerReverifier commits the re-verifier; called only once the
- *   connector is registered and the duplicate check above has passed. Keyed on
- *   `connector.source`, so the two halves cannot be wired to different sources.
- */
-export function registerBrainSourceWithAudienceReverifier(
-  connector: BrainSourceConnector,
-  registerReverifier: () => void,
-): void {
-  if (hasAudienceReverifier(connector.source)) {
-    throw new Error(
-      `Audience re-verifier for source "${connector.source}" is already registered — refusing to register its brain source connector, because committing one without the other leaves the source ingesting content whose grants are never re-verified`,
-    );
-  }
-  registerBrainSourceConnector(connector);
-  registerReverifier();
+  commitReverifier?.();
 }
 
 export function getBrainSourceConnector(catalogId: string): BrainSourceConnector | undefined {
@@ -439,17 +535,26 @@ export function listBrainSourceCatalogIds(): string[] {
 }
 
 /**
- * Test-only: clear the registry (tests register fixtures per-suite).
+ * Test-only: tear down EVERYTHING {@link registerBrainSourceConnector} writes —
+ * the connector registry, this target's catalog-ingest claims, and the audience
+ * re-verifier registry.
  *
- * Clears the audience-re-verifier registry too, because #4965/#4966 made source
- * registration a TWO-registry write while the idempotence gate inside
- * `registerZoomTranscriptConnector` / `registerOutlookMailConnector` still reads only this one
- * (`if (getBrainSourceConnector(id) !== undefined) return;`). Clearing one and
- * not the other lets them de-sync: a suite that resets connectors and then
- * re-registers passes the gate, reaches `registerXxxAudienceReverifier`, and
- * throws `Audience re-verifier for source "…" is already registered` — a failure
- * with nothing to do with what the suite was testing. Resetting both keeps the
- * pair that boot writes together torn down together.
+ * The three clears mirror the three writes one-for-one, and that is deliberately
+ * the invariant to maintain rather than "remember the re-verifiers too": since
+ * #4985 registration has ONE entry point, so teardown has one, and a future
+ * fourth structure is added to both halves of the same pair of functions.
+ *
+ * Why totality matters here and not just tidiness: `registerZoomTranscriptConnector`
+ * / `registerOutlookMailConnector` gate on the CONNECTOR registry alone
+ * (`if (getBrainSourceConnector(id) !== undefined) return;`). Clearing one and not
+ * the other lets them de-sync — a suite that resets connectors and then
+ * re-registers passes the gate, reaches the re-verifier commit, and throws
+ * `Audience re-verifier for source "…" is already registered`, a failure with
+ * nothing to do with what the suite was testing.
+ *
+ * So this is the reset a suite that registers a brain source calls.
+ * `_resetAudienceReverifiers` is for suites whose subject is the re-verifier
+ * registry itself and which register no connector at all.
  */
 export function _resetBrainSourceConnectors(): void {
   registry.clear();

--- a/packages/api/src/lib/brain/ingest/types.ts
+++ b/packages/api/src/lib/brain/ingest/types.ts
@@ -230,10 +230,21 @@ export interface BrainSourceInstallContext {
  * What this does NOT claim is that the re-verifier registry became unreachable.
  * `registerAudienceReverifier` still exists for the suites that test that
  * registry, and a source could in principle call it and then register a
- * connector declaring `externally-synced`. For a grant-deriving class the
- * runtime check above refuses that outright; for any other class it is a
- * re-verifier with no connector, which is loud rather than silent — the vendor's
- * own registration then throws on the duplicate and `registerStep` logs it.
+ * connector declaring `externally-synced`. Both outcomes are worth stating
+ * exactly, because they differ:
+ *
+ *   - grant-deriving class → {@link requiresAudienceReverifier} (below) refuses
+ *     the connector outright, so what is left is a re-verifier with NO connector.
+ *     Loud: the vendor's registration threw, `registerStep` logged it at `error`,
+ *     and the source ingests nothing at all;
+ *   - any other class → both register cleanly and nothing throws. A stray
+ *     re-verifier then runs every cycle for a source that declared somebody else
+ *     owns the refresh. Nothing detects that, and nothing is meant to — what the
+ *     `externally-synced` arm buys there is a DECLARATION a reviewer can check,
+ *     not a runtime guarantee.
+ *
+ * Neither is the half-state this seam exists to prevent, which is specifically a
+ * COMMITTED connector whose re-verifier was refused.
  */
 export type BrainSourceAudience =
   /**
@@ -260,12 +271,18 @@ export type BrainSourceAudience =
  *
  * `per-object` means the grant is derived from the record itself — a
  * transcript's participants, a mail's recipients — so nothing but a re-verifier
- * registered for THAT source can refresh it. `externally-synced` means something
- * else owns the refresh: chat grants are channel-scoped and reconciled by the
- * install-driven Slack walk, and warehouse/human episodes do not come from a
- * connector at all.
+ * registered for THAT source can refresh it.
+ *
+ * ⚠️ The other value is `not-required` and NOT `"externally-synced"`, even though
+ * that is the {@link BrainSourceAudience} arm it licenses, because the two would
+ * be read as the same fact and they are not. This axis constrains ONE direction:
+ * a `per-object` class MUST declare the `reverified` arm. It says nothing about
+ * what a `not-required` class may declare — `warehouse` is `not-required` and may
+ * legitimately bring a re-verifier anyway. Naming the value after the arm would
+ * assert a biconditional nothing enforces, which is the same phrase-collision
+ * hazard `lib/brain/sources.ts` records for its own two axes.
  */
-type AudienceGrain = "per-object" | "externally-synced";
+type AudienceGrain = "per-object" | "not-required";
 
 /**
  * Every episode class's audience grain — the single place the decision is made.
@@ -281,11 +298,13 @@ type AudienceGrain = "per-object" | "externally-synced";
  * is: it has a runtime reader ({@link requiresAudienceReverifier}).
  */
 const AUDIENCE_GRAIN = Object.freeze({
-  chat: "externally-synced",
+  // Channel-scoped, reconciled by the install-driven Slack walk in `audience/sync.ts`.
+  chat: "not-required",
   transcript: "per-object",
   email: "per-object",
-  warehouse: "externally-synced",
-  human: "externally-synced",
+  // Neither comes from a connector at all, so there is nothing to re-verify.
+  warehouse: "not-required",
+  human: "not-required",
 } as const) satisfies Record<EpisodeSourceClass, AudienceGrain>;
 
 /** The classes {@link AUDIENCE_GRAIN} marks `per-object`, as a type. */
@@ -304,8 +323,13 @@ type ReverifierRequiredClass = {
  * `externally-synced`, register cleanly, and mint `audience:` grants that nothing
  * refreshes — the 168h-then-invisible failure the whole seam exists to prevent,
  * entering through the one lane the type provably cannot see.
+ *
+ * Not exported: the only caller is {@link registerBrainSourceConnector}, and the
+ * check is worth more as an unavoidable step in the one write path than as a
+ * predicate a caller could consult and then not act on — which is precisely the
+ * `hasAudienceReverifier` shape #4985 replaced.
  */
-export function requiresAudienceReverifier(source: EpisodeSource): boolean {
+function requiresAudienceReverifier(source: EpisodeSource): boolean {
   return AUDIENCE_GRAIN[episodeSourceClass(source)] === "per-object";
 }
 
@@ -326,8 +350,15 @@ export function requiresAudienceReverifier(source: EpisodeSource): boolean {
 function isBrainSourceAudience(value: unknown): value is BrainSourceAudience {
   if (typeof value !== "object" || value === null) return false;
   const kind: unknown = Reflect.get(value, "kind");
-  if (kind === "externally-synced") return true;
-  return kind === "reverified" && typeof Reflect.get(value, "reverifier") === "function";
+  const reverifier: unknown = Reflect.get(value, "reverifier");
+  // A reverifier on the `externally-synced` arm is a CONTRADICTION, not an extra
+  // field to ignore — the arm declares that something else owns the refresh.
+  // In-repo it cannot happen (excess-property checking on the literal), but a
+  // plugin arrives as data where excess properties are legal, and silently
+  // dropping the function would leave that author's audiences ageing out at 168h
+  // with the declaration they wrote looking correct.
+  if (kind === "externally-synced") return reverifier === undefined;
+  return kind === "reverified" && typeof reverifier === "function";
 }
 
 /**
@@ -349,12 +380,15 @@ const NO_REVERIFIER_TO_COMMIT = (): void => {};
  * `BrainSourceConnector<typeof X_SOURCE>`, and {@link registerBrainSourceConnector}
  * infers `S` from the value it is handed, so an inline literal is checked too.
  *
- * At the default `S = EpisodeSource` the class set spans both grant-deriving and
- * not, the conditional is false, and the field widens to the union. That is what
- * the registry stores, and it is the honest answer for a connector that arrives
- * as DATA rather than as a checked type — a plugin-supplied one, compiled
- * separately, or an in-repo factory that widened its own return type back to the
- * unparameterised form.
+ * The conditional is deliberately NON-distributive — the checked type is
+ * `(typeof EPISODE_SOURCE_SPECS)[S]["class"]`, not a naked `S` — so a UNION `S`
+ * resolves its whole class set at once and only narrows when every member is
+ * grant-deriving. `<"zoom" | "outlook">` is still the `reverified` arm alone;
+ * `<"zoom" | "slack">` widens. At the default `S = EpisodeSource` the set spans
+ * both and the field is the whole union. That is what the registry stores, and it
+ * is the honest answer for a connector that arrives as DATA rather than as a
+ * checked type — a plugin-supplied one, compiled separately, or an in-repo
+ * factory that widened its own return type back to the unparameterised form.
  *
  * ⚠️ So this type is NOT the enforcement on its own, and it would be a mistake to
  * read it as one: every one of those widenings compiles, and the last is
@@ -465,9 +499,13 @@ const registry = new Map<string, BrainSourceConnector>();
  * Registration is single-threaded boot wiring, so there is no window between the
  * checks and the writes for anything else to claim the source.
  *
- * `const S` so an inline connector literal keeps its literal source kind and gets
- * {@link BrainSourceAudienceFor}'s compile-time check rather than the widened
- * union. A caller holding an already-widened `BrainSourceConnector` still passes,
+ * `S` is inferred from the value so an inline connector literal keeps its literal
+ * source kind and gets {@link BrainSourceAudienceFor}'s compile-time check rather
+ * than the widened union. The `const` modifier is belt-and-braces rather than
+ * load-bearing — the constraint is already a union of string literals, so `S`
+ * infers narrowly without it — and it is kept only so a future widening of
+ * `EpisodeSource` toward `string` cannot silently take the inference with it.
+ * A caller holding an already-widened `BrainSourceConnector` still passes,
  * and that is the lane {@link requiresAudienceReverifier} below exists for: the
  * type cannot see a plugin, a cast, or a factory that widened its own return
  * type, and all three would otherwise re-open exactly the hole this refactor
@@ -667,9 +705,9 @@ export function listBrainSourceCatalogIds(): string[] {
  * / `registerOutlookMailConnector` gate on the CONNECTOR registry alone
  * (`if (getBrainSourceConnector(id) !== undefined) return;`). Clearing one and not
  * the other lets them de-sync — a suite that resets connectors and then
- * re-registers passes the gate, reaches the re-verifier commit, and throws
- * `Audience re-verifier for source "…" is already registered`, a failure with
- * nothing to do with what the suite was testing.
+ * re-registers passes the gate, reaches the re-verifier's duplicate check, and
+ * throws `Audience re-verifier for source "…" is already registered`, a failure
+ * with nothing to do with what the suite was testing.
  *
  * So this is the reset a suite that registers a brain source calls.
  * `_resetAudienceReverifiers` is for suites whose subject is the re-verifier

--- a/packages/api/src/lib/brain/ingest/types.ts
+++ b/packages/api/src/lib/brain/ingest/types.ts
@@ -277,10 +277,12 @@ export type BrainSourceAudience =
  * that is the {@link BrainSourceAudience} arm it licenses, because the two would
  * be read as the same fact and they are not. This axis constrains ONE direction:
  * a `per-object` class MUST declare the `reverified` arm. It says nothing about
- * what a `not-required` class may declare — `warehouse` is `not-required` and may
- * legitimately bring a re-verifier anyway. Naming the value after the arm would
- * assert a biconditional nothing enforces, which is the same phrase-collision
- * hazard `lib/brain/sources.ts` records for its own two axes.
+ * what a `not-required` class may declare, and nothing enforces the converse —
+ * the only instance in-repo is a test fixture. Naming the value after the arm
+ * would assert a biconditional that does not hold, an analogous spelling
+ * collision to the one `lib/brain/sources.ts` records for its own two axes
+ * (theirs is worse: literal-typed constants there are cross-axis assignable, so
+ * it is a compile-time trap and not only a reader-level one).
  */
 type AudienceGrain = "per-object" | "not-required";
 
@@ -298,7 +300,11 @@ type AudienceGrain = "per-object" | "not-required";
  * is: it has a runtime reader ({@link requiresAudienceReverifier}).
  */
 const AUDIENCE_GRAIN = Object.freeze({
-  // Channel-scoped, reconciled by the install-driven Slack walk in `audience/sync.ts`.
+  // Channel-scoped, reconciled by the install-driven Slack walk in
+  // `audience/sync.ts`. ⚠️ This map is keyed by CLASS, so a second chat VENDOR
+  // (Teams, Discord) inherits `not-required` with no walk of its own — the
+  // membership-vs-completeness hazard below, one axis over. Check it when one
+  // arrives; nothing here will.
   chat: "not-required",
   transcript: "per-object",
   email: "per-object",

--- a/packages/api/src/lib/brain/ingest/types.ts
+++ b/packages/api/src/lib/brain/ingest/types.ts
@@ -219,12 +219,21 @@ export interface BrainSourceInstallContext {
  *
  * #4983 closed that at runtime by checking the re-verifier registry before
  * committing the connector. This closes it in the SHAPE: a connector carries its
- * audience strategy as one value, {@link registerBrainSourceConnector} is the
- * only registration call, and there is no pair of statements a fourth source
- * could write in the wrong order. "Forgot the re-verifier" stops being a class of
- * mistake — the field is required, so the only remaining question is which arm,
- * and {@link BrainSourceAudienceFor} answers that at compile time for the classes
- * where getting it wrong is the silent failure above.
+ * audience strategy as one value and {@link registerBrainSourceConnector} is the
+ * only call that writes both registries, so the paired registration has no
+ * statement ORDER left to get wrong. "Forgot the re-verifier" stops being a class
+ * of mistake — the field is required, so the only remaining question is which
+ * arm, and that is answered twice: by {@link BrainSourceAudienceFor} at compile
+ * time, and by {@link requiresAudienceReverifier} at registration for the lane
+ * the type cannot see.
+ *
+ * What this does NOT claim is that the re-verifier registry became unreachable.
+ * `registerAudienceReverifier` still exists for the suites that test that
+ * registry, and a source could in principle call it and then register a
+ * connector declaring `externally-synced`. For a grant-deriving class the
+ * runtime check above refuses that outright; for any other class it is a
+ * re-verifier with no connector, which is loud rather than silent — the vendor's
+ * own registration then throws on the duplicate and `registerStep` logs it.
  */
 export type BrainSourceAudience =
   /**
@@ -247,21 +256,85 @@ export type BrainSourceAudience =
   | { readonly kind: "externally-synced" };
 
 /**
- * The episode classes whose grants are per-object and therefore CANNOT be
- * externally synced — a transcript's participants and a mail's recipients are
- * derived from the record itself, so nothing but a re-verifier for this source
- * can refresh them.
+ * At what GRAIN a class's audiences are refreshed.
  *
- * ADR-0036's other classes are deliberately absent, each for its own reason:
- * `chat` grants are channel-scoped and reconciled by the install-driven Slack
- * walk; `warehouse` and `human` episodes do not come from a connector at all.
- * Those may legitimately pick either arm, so the type leaves the choice open and
- * the arm's own docstring is what a reviewer reads.
+ * `per-object` means the grant is derived from the record itself — a
+ * transcript's participants, a mail's recipients — so nothing but a re-verifier
+ * registered for THAT source can refresh it. `externally-synced` means something
+ * else owns the refresh: chat grants are channel-scoped and reconciled by the
+ * install-driven Slack walk, and warehouse/human episodes do not come from a
+ * connector at all.
  */
-export const REVERIFIER_REQUIRED_CLASSES = ["transcript", "email"] as const satisfies
-  readonly EpisodeSourceClass[];
+type AudienceGrain = "per-object" | "externally-synced";
 
-type ReverifierRequiredClass = (typeof REVERIFIER_REQUIRED_CLASSES)[number];
+/**
+ * Every episode class's audience grain — the single place the decision is made.
+ *
+ * A `Record<EpisodeSourceClass, …>` rather than the list of grant-deriving
+ * classes this started as, because the list form checks MEMBERSHIP and not
+ * COMPLETENESS: adding a sixth class to `lib/brain/sources.ts` (`docs`, `wiki`)
+ * would have silently inherited the permissive arm, which is the same prose-rule
+ * residual `sources.ts` confesses to for `class:` recreated one layer up. Keyed
+ * exhaustively, a new class fails to compile here until its author decides — and
+ * "decides" is the operative word, since the wrong answer for a grant-deriving
+ * class is invisible for 168h. Frozen for the same reason `EPISODE_SOURCE_SPECS`
+ * is: it has a runtime reader ({@link requiresAudienceReverifier}).
+ */
+const AUDIENCE_GRAIN = Object.freeze({
+  chat: "externally-synced",
+  transcript: "per-object",
+  email: "per-object",
+  warehouse: "externally-synced",
+  human: "externally-synced",
+} as const) satisfies Record<EpisodeSourceClass, AudienceGrain>;
+
+/** The classes {@link AUDIENCE_GRAIN} marks `per-object`, as a type. */
+type ReverifierRequiredClass = {
+  [K in EpisodeSourceClass]: (typeof AUDIENCE_GRAIN)[K] extends "per-object" ? K : never;
+}[EpisodeSourceClass];
+
+/**
+ * Must a source of this kind bring its own re-verifier?
+ *
+ * The RUNTIME half of {@link BrainSourceAudienceFor}, and it exists for exactly
+ * the reason `isEpisodeSource` does: the type covers every in-repo connector, but
+ * ADR-0036 M3 makes connectors plugin-shaped and a plugin is compiled separately,
+ * so it reaches this registry as DATA with no literal type to narrow on. Without
+ * this check a plugin-supplied transcript connector could declare
+ * `externally-synced`, register cleanly, and mint `audience:` grants that nothing
+ * refreshes — the 168h-then-invisible failure the whole seam exists to prevent,
+ * entering through the one lane the type provably cannot see.
+ */
+export function requiresAudienceReverifier(source: EpisodeSource): boolean {
+  return AUDIENCE_GRAIN[episodeSourceClass(source)] === "per-object";
+}
+
+/**
+ * Is this a usable {@link BrainSourceAudience}?
+ *
+ * Checks the `reverified` arm's `reverifier` is actually callable, not just that
+ * the discriminant reads right. A `{ kind: "reverified" }` with the function
+ * missing would register `undefined` into the re-verifier registry and
+ * `runRegisteredAudienceReverifiers` would then count that source failed on every
+ * cycle forever — degraded rather than silent, but still a state registration can
+ * refuse for free.
+ *
+ * `Reflect.get` rather than a cast: the input is genuinely `unknown` here (the
+ * plugin lane), and narrowing it with `as` would be asserting the very shape this
+ * function exists to establish.
+ */
+function isBrainSourceAudience(value: unknown): value is BrainSourceAudience {
+  if (typeof value !== "object" || value === null) return false;
+  const kind: unknown = Reflect.get(value, "kind");
+  if (kind === "externally-synced") return true;
+  return kind === "reverified" && typeof Reflect.get(value, "reverifier") === "function";
+}
+
+/**
+ * The `externally-synced` arm's commit — a real no-op, so
+ * {@link registerBrainSourceConnector}'s final write is unconditional.
+ */
+const NO_REVERIFIER_TO_COMMIT = (): void => {};
 
 /**
  * The audience strategies a source of kind `S` may declare.
@@ -280,9 +353,18 @@ type ReverifierRequiredClass = (typeof REVERIFIER_REQUIRED_CLASSES)[number];
  * not, the conditional is false, and the field widens to the union. That is what
  * the registry stores, and it is the honest answer for a connector that arrives
  * as DATA rather than as a checked type — a plugin-supplied one, compiled
- * separately. Those get the runtime all-or-nothing guarantee in
- * {@link registerBrainSourceConnector} and nothing more, which is the same split
- * `lib/brain/sources.ts` already draws for the source vocabulary itself.
+ * separately, or an in-repo factory that widened its own return type back to the
+ * unparameterised form.
+ *
+ * ⚠️ So this type is NOT the enforcement on its own, and it would be a mistake to
+ * read it as one: every one of those widenings compiles, and the last is
+ * literally the signature this refactor deleted from three connectors. What
+ * closes the gap is {@link requiresAudienceReverifier}, re-checked inside
+ * {@link registerBrainSourceConnector} — the SAME type-plus-runtime split
+ * `lib/brain/sources.ts` draws for the source vocabulary, where `EpisodeSource`
+ * stops an in-repo connector inventing a kind and `isEpisodeSource` re-checks the
+ * data lane. The type is the fast, local error at the literal; the runtime check
+ * is what actually holds the invariant.
  */
 export type BrainSourceAudienceFor<S extends EpisodeSource> =
   (typeof EPISODE_SOURCE_SPECS)[S]["class"] extends ReverifierRequiredClass
@@ -350,13 +432,15 @@ const registry = new Map<string, BrainSourceConnector>();
  * Register a brain source — the connector AND the audience half it declares —
  * for its catalog row. Called once per source at wiring time.
  *
- * Duplicate catalog ids, malformed source slugs, kinds outside the vocabulary,
- * and a re-verifier already held for this source all fail loudly. A silent
- * overwrite would let one source shadow another's installs, a malformed slug
- * would land unqueryable garbage in `brain_episodes.source`, an unknown kind
+ * Duplicate catalog ids, malformed source slugs, kinds outside the vocabulary, a
+ * malformed audience declaration, a grant-deriving class that declared no
+ * re-verifier, and a re-verifier already held for this source all fail loudly. A
+ * silent overwrite would let one source shadow another's installs, a malformed
+ * slug would land unqueryable garbage in `brain_episodes.source`, an unknown kind
  * would land a value that every downstream discriminator silently declines to
- * recognise, and a duplicate re-verifier would have two of them reconciling
- * against their own rosters with the loser's members revoked every cycle.
+ * recognise, a grant-deriving source with no re-verifier would go invisible after
+ * 168h, and a duplicate re-verifier would have two of them reconciling against
+ * their own rosters with the loser's members revoked every cycle.
  *
  * ## ALL-OR-NOTHING, and how the body is arranged to guarantee it
  *
@@ -383,9 +467,11 @@ const registry = new Map<string, BrainSourceConnector>();
  *
  * `const S` so an inline connector literal keeps its literal source kind and gets
  * {@link BrainSourceAudienceFor}'s compile-time check rather than the widened
- * union. A caller holding an already-widened `BrainSourceConnector` still passes
- * — that arm is for connectors that arrive as data, and it is the runtime
- * validation above, not the type, that covers them.
+ * union. A caller holding an already-widened `BrainSourceConnector` still passes,
+ * and that is the lane {@link requiresAudienceReverifier} below exists for: the
+ * type cannot see a plugin, a cast, or a factory that widened its own return
+ * type, and all three would otherwise re-open exactly the hole this refactor
+ * closed.
  */
 export function registerBrainSourceConnector<const S extends EpisodeSource>(
   connector: BrainSourceConnector<S>,
@@ -419,13 +505,37 @@ export function registerBrainSourceConnector<const S extends EpisodeSource>(
       `Brain source connector for catalog id "${connector.catalogId}" is already registered`,
     );
   }
+  // `audience` is typed, so this reads as dead code for every in-repo connector —
+  // and it is exactly as dead as `isEpisodeSource` above, for the same reason. A
+  // plugin arrives as data; `undefined.kind` would otherwise be an engine
+  // `TypeError` where every other invalid input here names its own fix, and a
+  // `{ kind: "reverified" }` with no function would register `undefined` and make
+  // the drain throw on every cycle forever.
+  const audience: unknown = connector.audience;
+  if (!isBrainSourceAudience(audience)) {
+    throw new Error(
+      `Brain source connector for catalog id "${connector.catalogId}" declared no usable audience strategy — it must be { kind: "reverified", reverifier } for a source whose grants are derived per object, or { kind: "externally-synced" } when something else reconciles them (see BrainSourceAudience in lib/brain/ingest/types.ts)`,
+    );
+  }
+  // The backstop the type cannot provide on the data lane. See
+  // {@link requiresAudienceReverifier} — declaring `externally-synced` for a
+  // transcript or mail source is the silent 168h decay, so it is refused here
+  // rather than merely discouraged by a conditional type a cast can widen past.
+  if (audience.kind !== "reverified" && requiresAudienceReverifier(connector.source)) {
+    throw new Error(
+      `Brain source "${connector.source}" is ${episodeSourceClass(connector.source)}-class, whose audiences are derived per object — it MUST declare audience: { kind: "reverified", reverifier }. Declaring "externally-synced" would ingest content whose audience: grants nothing refreshes; they stop granting at ATLAS_BRAIN_AUDIENCE_MAX_STALENESS_HOURS and every fact behind them then reads as ABSENT rather than denied`,
+    );
+  }
   // The re-verifier's duplicate check, fused to the only thing that installs it.
   // Keyed on `connector.source`, so the connector and its re-verifier cannot be
-  // wired to different sources.
+  // wired to different sources. The `externally-synced` arm gets a real no-op
+  // rather than `undefined` + `?.()`, so the commit below is UNCONDITIONAL —
+  // "deliberately nothing to commit" and "the thunk went missing" should not be
+  // the same silent skip in an all-or-nothing sequence.
   const commitReverifier =
-    connector.audience.kind === "reverified"
-      ? prepareAudienceReverifier(connector.source, connector.audience.reverifier)
-      : undefined;
+    audience.kind === "reverified"
+      ? prepareAudienceReverifier(connector.source, audience.reverifier)
+      : NO_REVERIFIER_TO_COMMIT;
 
   // ── Past this line nothing may throw with a write already committed. ──
   // One catalog id, one ingest target. Both registries claim through the same
@@ -435,7 +545,7 @@ export function registerBrainSourceConnector<const S extends EpisodeSource>(
   // it writes, so a collision here still leaves nothing committed.
   claimCatalogIngestTarget(connector.catalogId, "brain-episodes");
   registry.set(connector.catalogId, connector);
-  commitReverifier?.();
+  commitReverifier();
 }
 
 export function getBrainSourceConnector(catalogId: string): BrainSourceConnector | undefined {
@@ -539,10 +649,19 @@ export function listBrainSourceCatalogIds(): string[] {
  * the connector registry, this target's catalog-ingest claims, and the audience
  * re-verifier registry.
  *
- * The three clears mirror the three writes one-for-one, and that is deliberately
- * the invariant to maintain rather than "remember the re-verifiers too": since
- * #4985 registration has ONE entry point, so teardown has one, and a future
- * fourth structure is added to both halves of the same pair of functions.
+ * One clear per write, and that is deliberately the invariant to maintain rather
+ * than "remember the re-verifiers too": since #4985 registration has ONE entry
+ * point, so teardown has one, and a future fourth structure is added to both
+ * halves of the same pair of functions.
+ *
+ * ⚠️ The three are not symmetric, and the asymmetry is forced rather than
+ * sloppy. `_resetCatalogIngestClaims("brain-episodes")` is TARGET-SCOPED — a
+ * blanket clear would release the knowledge registry's claims while its own map
+ * still held them (`knowledge/catalog-claims.ts` argues that at length).
+ * `_resetAudienceReverifiers` is a blanket `clear()`, because that registry has
+ * no per-target key to scope by, so it also drops fixture re-verifiers this
+ * function never wrote. That is the behaviour the suites want — a total teardown
+ * — but do not read it as "clears exactly what we registered".
  *
  * Why totality matters here and not just tidiness: `registerZoomTranscriptConnector`
  * / `registerOutlookMailConnector` gate on the CONNECTOR registry alone

--- a/packages/api/src/lib/brain/ingest/zoom/audience.ts
+++ b/packages/api/src/lib/brain/ingest/zoom/audience.ts
@@ -299,7 +299,11 @@ export async function reverifyZoomMeetingAudiences(
   const isEnabled = deps.isEnabled ?? isAudienceSyncEnabled;
   const resolveToken = deps.resolveToken;
   if (resolveToken === undefined) {
-    // Unreachable in production — `createZoomAudienceReverifier` binds one.
+    // Unreachable in production — the connector literal in
+    // `createZoomTranscriptConnector` binds one. NOT
+    // `createZoomAudienceReverifier`, which forwards whatever deps it is handed
+    // (`resolveToken` is optional on `ZoomAudienceDeps`, and test fixtures do
+    // build it without one).
     // Loud rather than a silent no-op: a re-verifier that quietly does nothing
     // lets every meeting audience age past the staleness bound while the cycle
     // reports success, which is the exact failure this module exists to prevent.

--- a/packages/api/src/lib/brain/ingest/zoom/audience.ts
+++ b/packages/api/src/lib/brain/ingest/zoom/audience.ts
@@ -64,9 +64,9 @@ import {
   isAudienceSyncEnabled,
 } from "@atlas/api/lib/brain/audience/sync";
 import {
-  registerAudienceReverifier,
   selectReverifyCandidates,
   ZERO_REVERIFY,
+  type AudienceReverifier,
   type AudienceReverifyResult,
 } from "@atlas/api/lib/brain/audience/reverify";
 import { fetchMeetingParticipantsPage, type ZoomParticipant } from "./api";
@@ -299,7 +299,7 @@ export async function reverifyZoomMeetingAudiences(
   const isEnabled = deps.isEnabled ?? isAudienceSyncEnabled;
   const resolveToken = deps.resolveToken;
   if (resolveToken === undefined) {
-    // Unreachable in production — `registerZoomAudienceReverifier` binds one.
+    // Unreachable in production — `createZoomAudienceReverifier` binds one.
     // Loud rather than a silent no-op: a re-verifier that quietly does nothing
     // lets every meeting audience age past the staleness bound while the cycle
     // reports success, which is the exact failure this module exists to prevent.
@@ -514,11 +514,16 @@ async function reverifyWorkspace(
 }
 
 /**
- * Register the Zoom re-verifier. Called from the same wiring seam that registers
- * the connector, so a deployment can never have one without the other — an
- * ingest path that mints audiences with no re-verifier is the silent-expiry bug
- * this module exists to prevent.
+ * Build the Zoom re-verifier. It is the `audience` half of the Zoom connector
+ * value (`connector.ts`), so a deployment can never have one without the other —
+ * an ingest path that mints audiences with no re-verifier is the silent-expiry
+ * bug this module exists to prevent.
+ *
+ * Returns rather than registers (#4985): the registration is
+ * `registerBrainSourceConnector`'s single all-or-nothing write, and a second
+ * function that also wrote to the re-verifier registry would be exactly the loose
+ * half a caller can commit on its own.
  */
-export function registerZoomAudienceReverifier(deps: ZoomAudienceDeps): void {
-  registerAudienceReverifier(ZOOM_TRANSCRIPT_SOURCE, () => reverifyZoomMeetingAudiences(deps));
+export function createZoomAudienceReverifier(deps: ZoomAudienceDeps): AudienceReverifier {
+  return () => reverifyZoomMeetingAudiences(deps);
 }

--- a/packages/api/src/lib/brain/ingest/zoom/connector.ts
+++ b/packages/api/src/lib/brain/ingest/zoom/connector.ts
@@ -34,7 +34,7 @@ import { getSettingAuto } from "@atlas/api/lib/settings";
 import { readSyncCredential } from "@atlas/api/lib/knowledge/sync-credentials";
 import { createZoomTranscriptClient } from "./client";
 import { fetchZoomAccessToken } from "./api";
-import { registerZoomAudienceReverifier } from "./audience";
+import { createZoomAudienceReverifier } from "./audience";
 import {
   ZOOM_TRANSCRIPTS_CATALOG_ID,
   ZOOM_TRANSCRIPT_SOURCE,
@@ -42,7 +42,7 @@ import {
 } from "./config";
 import {
   getBrainSourceConnector,
-  registerBrainSourceWithAudienceReverifier,
+  registerBrainSourceConnector,
   type BrainSourceConnector,
   type BrainSourceInstallContext,
   type BrainSourceVendorClient,
@@ -238,11 +238,28 @@ export interface ZoomTranscriptConnectorDeps {
 /** Build the Zoom transcript brain source. `deps` is test-only injection. */
 export function createZoomTranscriptConnector(
   deps: ZoomTranscriptConnectorDeps = {},
-): BrainSourceConnector {
+): BrainSourceConnector<typeof ZOOM_TRANSCRIPT_SOURCE> {
   const reader: ZoomCredentialReader = deps.reader ?? { readSyncCredential, fetchZoomAccessToken };
   return {
     catalogId: ZOOM_TRANSCRIPTS_CATALOG_ID,
     source: ZOOM_TRANSCRIPT_SOURCE,
+    // Transcripts are a grant-DERIVING class: a meeting's audience comes from its
+    // own participant list, so nothing but this re-verifier can refresh it and
+    // `BrainSourceAudienceFor<"zoom">` admits no other arm. Built here, beside the
+    // client, so the connector and its re-verifier share one `reader` and reach
+    // the registry as one value.
+    audience: {
+      kind: "reverified",
+      reverifier: createZoomAudienceReverifier({
+        // The install id doubles as the credential's `collection_id`, the same
+        // convention every knowledge connector uses.
+        resolveToken: async (workspaceId, installId, config) => {
+          const parsed = parseZoomTranscriptsConfig(config);
+          if (!parsed.ok) throw new Error(parsed.error);
+          return resolveZoomToken(reader, workspaceId, installId, parsed.accountId);
+        },
+      }),
+    },
     createClient(ctx: BrainSourceInstallContext): BrainSourceVendorClient {
       const parsed = parseZoomTranscriptsConfig(ctx.config);
       if (!parsed.ok) throw new Error(parsed.error);
@@ -266,27 +283,17 @@ export function createZoomTranscriptConnector(
  * — called from the boot seam that also registers install handlers, and from
  * tests.
  *
- * The pair goes through `registerBrainSourceWithAudienceReverifier` rather than
- * as two statements. Both registries throw on a duplicate, and the gate below
- * reads only the connector registry — so registering the connector first and
- * colliding on the re-verifier second would leave this source ingesting
- * transcripts whose grants nothing refreshes, permanently and silently. That
- * helper checks the re-verifier registry before it commits anything.
+ * The pair is ONE value and ONE call (#4985). Both registries throw on a
+ * duplicate, and the gate below reads only the connector registry — so a
+ * registration that committed the connector first and collided on the re-verifier
+ * second would leave this source ingesting transcripts whose grants nothing
+ * refreshes, permanently and silently, because the retry short-circuits on the
+ * connector the failed attempt left behind. `registerBrainSourceConnector` does
+ * all of its throwing before any of its writing, so that half-state has no path.
  */
 export function registerZoomTranscriptConnector(deps: ZoomTranscriptConnectorDeps = {}): void {
   if (getBrainSourceConnector(ZOOM_TRANSCRIPTS_CATALOG_ID) !== undefined) return;
-  const reader: ZoomCredentialReader = deps.reader ?? { readSyncCredential, fetchZoomAccessToken };
-  registerBrainSourceWithAudienceReverifier(createZoomTranscriptConnector({ reader }), () =>
-    registerZoomAudienceReverifier({
-      // The install id doubles as the credential's `collection_id`, the same
-      // convention every knowledge connector uses.
-      resolveToken: async (workspaceId, installId, config) => {
-        const parsed = parseZoomTranscriptsConfig(config);
-        if (!parsed.ok) throw new Error(parsed.error);
-        return resolveZoomToken(reader, workspaceId, installId, parsed.accountId);
-      },
-    }),
-  );
+  registerBrainSourceConnector(createZoomTranscriptConnector(deps));
   log.info(
     { catalogId: ZOOM_TRANSCRIPTS_CATALOG_ID },
     "Registered Zoom transcript brain source and its audience re-verifier",

--- a/packages/api/src/lib/integrations/install/__tests__/register.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/register.test.ts
@@ -600,10 +600,12 @@ describe("registerBuiltinInstallHandlers — BRAIN source connector pairing (#49
     // Same provocation as above: Zoom's re-verifier is taken, so the pair cannot
     // complete. The connector registry must come out of it EMPTY for Zoom.
     //
-    // MUTATION THIS CATCHES: reverting `registerBrainSourceWithAudienceReverifier`
-    // to a bare `registerBrainSourceConnector(...)` + `registerXReverifier(...)`
-    // pair — the ordering this asserts is the only thing standing between a
-    // duplicate re-verifier and a silently decaying source.
+    // MUTATION THIS CATCHES: moving `registerBrainSourceConnector`'s writes above
+    // its `prepareAudienceReverifier` call — the validate-then-commit ordering
+    // this asserts is the only thing standing between a duplicate re-verifier and
+    // a silently decaying source. (#4985 folded the audience half into the
+    // connector value, so the older "two bare statements" mutation this line used
+    // to name is no longer expressible; the ordering claim is unchanged.)
     registerAudienceReverifier(ZOOM_TRANSCRIPT_SOURCE, () => Promise.resolve(ZERO_REVERIFY));
 
     registerBuiltinInstallHandlers();

--- a/packages/api/src/lib/integrations/install/register.ts
+++ b/packages/api/src/lib/integrations/install/register.ts
@@ -217,9 +217,10 @@ let alreadyRegistered = false;
  * no catch can undo it from the outside. `registerBrainSourceConnector`
  * (`brain/ingest/types.ts`) is what makes the brain pair all-or-nothing — it takes
  * the connector and its audience half as ONE value and does all of its throwing
- * above its first write; this message deliberately says "may be partially wired"
- * rather than asserting an absence it cannot verify, because the knowledge
- * connectors and OAuth handlers it also wraps make no such promise.
+ * above its first write. The message below still hedges — "unavailable, OR
+ * PARTIALLY WIRED" — rather than asserting an absence it cannot verify, because
+ * the knowledge connectors and OAuth handlers this also wraps make no such
+ * promise.
  */
 function registerStep(label: string, register: () => void): void {
   try {
@@ -227,7 +228,7 @@ function registerStep(label: string, register: () => void): void {
   } catch (err) {
     log.error(
       { err: err instanceof Error ? err.message : String(err), step: label },
-      `Install handler registration FAILED for ${label} — this integration is unavailable, or partially wired, for the lifetime of this process. Registration continues with the remaining handlers. This is a code defect (duplicate catalog id, unknown source kind, or a re-verifier registered twice), not a config problem`,
+      `Install handler registration FAILED for ${label} — this integration is unavailable, or partially wired, for the lifetime of this process. Registration continues with the remaining handlers. This is a code defect (a duplicate catalog id, an unknown source kind, a malformed connector declaration, a re-verifier registered twice, … — the err field says which), not a config problem`,
     );
   }
 }

--- a/packages/api/src/lib/integrations/install/register.ts
+++ b/packages/api/src/lib/integrations/install/register.ts
@@ -214,10 +214,12 @@ let alreadyRegistered = false;
  * What it does NOT promise is that the failed vendor is cleanly absent. That is
  * the registration's own job, not this wrapper's — a step that commits to one
  * registry and then throws on a second would leave a half-wired vendor here, and
- * no catch can undo it from the outside. `registerBrainSourceWithAudienceReverifier`
- * (`brain/ingest/types.ts`) is what makes the brain pair all-or-nothing; this
- * message deliberately says "may be partially wired" rather than asserting an
- * absence it cannot verify.
+ * no catch can undo it from the outside. `registerBrainSourceConnector`
+ * (`brain/ingest/types.ts`) is what makes the brain pair all-or-nothing — it takes
+ * the connector and its audience half as ONE value and does all of its throwing
+ * above its first write; this message deliberately says "may be partially wired"
+ * rather than asserting an absence it cannot verify, because the knowledge
+ * connectors and OAuth handlers it also wraps make no such promise.
  */
 function registerStep(label: string, register: () => void): void {
   try {

--- a/packages/api/src/lib/integrations/install/register.ts
+++ b/packages/api/src/lib/integrations/install/register.ts
@@ -219,8 +219,9 @@ let alreadyRegistered = false;
  * the connector and its audience half as ONE value and does all of its throwing
  * above its first write. The message below still hedges — "unavailable, OR
  * PARTIALLY WIRED" — rather than asserting an absence it cannot verify, because
- * the knowledge connectors and OAuth handlers this also wraps make no such
- * promise.
+ * the ten knowledge connectors this also wraps make no such promise. (The OAuth
+ * and static-bot handlers are registered by direct unwrapped calls below and are
+ * not this function's concern at all; they are the BLAST RADIUS, not the steps.)
  */
 function registerStep(label: string, register: () => void): void {
   try {

--- a/packages/api/src/lib/knowledge/__tests__/catalog-claims.test.ts
+++ b/packages/api/src/lib/knowledge/__tests__/catalog-claims.test.ts
@@ -46,6 +46,7 @@ function brainConnector(catalogId = CATALOG): BrainSourceConnector {
   return {
     catalogId,
     source: SLACK_SOURCE,
+    audience: { kind: "externally-synced" },
     createClient: () => ({ fetchEpisodes: async () => ({ episodes: [], highWaterMark: null }) }),
   };
 }

--- a/packages/api/src/lib/knowledge/__tests__/sync.test.ts
+++ b/packages/api/src/lib/knowledge/__tests__/sync.test.ts
@@ -881,6 +881,7 @@ describe("runKnowledgeSyncCycle", () => {
     registerBrainSourceConnector({
       catalogId: "catalog:fixture-brain",
       source: HUMAN_SOURCE,
+      audience: { kind: "externally-synced" },
       createClient: () => ({ fetchEpisodes: async () => ({ episodes: [], highWaterMark: null }) }),
     });
     brainSyncCalls.length = 0;
@@ -904,6 +905,7 @@ describe("runKnowledgeSyncCycle", () => {
     registerBrainSourceConnector({
       catalogId: "catalog:fixture-brain",
       source: HUMAN_SOURCE,
+      audience: { kind: "externally-synced" },
       createClient: () => ({ fetchEpisodes: async () => ({ episodes: [], highWaterMark: null }) }),
     });
     INSTALL_ROWS = [];
@@ -921,6 +923,7 @@ describe("runKnowledgeSyncCycle", () => {
     registerBrainSourceConnector({
       catalogId: "catalog:fixture-brain",
       source: HUMAN_SOURCE,
+      audience: { kind: "externally-synced" },
       createClient: () => ({ fetchEpisodes: async () => ({ episodes: [], highWaterMark: null }) }),
     });
     BRAIN_SYNC_STATUS = "error";


### PR DESCRIPTION
Closes #4985.

A brain source that derives per-object grants needs two things registered: the connector (so it ingests) and the audience re-verifier (so the grants it mints keep resolving). They live in two registries that both throw on a duplicate, so as two statements the first can commit and the second throw — leaving a source that ingests normally for `ATLAS_BRAIN_AUDIENCE_MAX_STALENESS_HOURS` (168h) and then goes silently invisible when `acl.ts` suppresses the audiences nothing refreshed.

#4983 closed that at runtime. This closes it in the shape.

## What changed

- **`BrainSourceConnector.audience`** is a required `BrainSourceAudience` — `{ kind: "reverified", reverifier }` or `{ kind: "externally-synced" }`. The second arm is a *declaration* that something else owns the refresh (slack-history's channel-scoped grants, walked by `audience/sync.ts`), not an opt-out.
- **`registerBrainSourceConnector` is the single registration call.** `registerBrainSourceWithAudienceReverifier` and `hasAudienceReverifier` are gone; `register{Zoom,Outlook}AudienceReverifier` became `create*` and return the re-verifier instead of registering it, so it can be the connector's `audience` value.
- **Every throw site sits above every write.** `prepareAudienceReverifier` fuses the re-verifier's duplicate check to the only thing that installs one — you cannot reach the write without passing the check. `claimCatalogIngestTarget` is the boundary (it checks before it writes); the two writes after it are `Map.set` calls, and the `externally-synced` arm commits a real no-op so the last write is unconditional rather than an optional-chain skip.
- **`_resetBrainSourceConnectors`** is the single teardown, mirroring the three writes.

## AC-5 — narrow so grant-deriving classes require a re-verifier? **Yes, and backed at runtime**

`BrainSourceAudienceFor<S>` makes `{ kind: "externally-synced" }` a TS2322 on a transcript- or email-class source, inferred at every literal call site. The decision lives in `AUDIENCE_GRAIN`, a `Record<EpisodeSourceClass, AudienceGrain>` — keyed exhaustively, so a sixth class fails to compile until its author decides rather than silently inheriting the permissive arm.

The type is *not* the enforcement on its own, and the review panel was right to push on that: a cast, a plugin-supplied connector, or a factory that widens its own return type all compile — and that last one is literally the signature this PR deleted from three connectors. So `registerBrainSourceConnector` re-checks the class at runtime, the same type-plus-runtime split `sources.ts` already draws for the source vocabulary. `isBrainSourceAudience` additionally refuses a malformed declaration, a `reverified` arm whose reverifier is not callable, and an `externally-synced` arm that supplies one anyway.

## Verifying the AC's real bar

"Unrepresentable, not merely guarded" was checked by **deleting the runtime duplicate check locally**:

- the bad shape is still a TS2322;
- the failure mode becomes a *fully* registered duplicate — never the half-registered state.

Every `MUTATION THIS CATCHES` claim in the new tests was verified by applying the mutation, and two claims that turned out **not** to degrade the type (dropping an `as const` from an `EPISODE_SOURCE_SPECS` entry; dropping the `const` modifier) are recorded as non-mutations rather than left overclaiming.

## Tests

`register.test.ts`'s assertions are **untouched and green (40/40)** — including the "⭐ …leaves the FAILING vendor wholly unregistered" assertion from #4983. One stale comment there naming a now-removed helper was refreshed; no assertion changed.

New coverage in `episode-sync-archive.test.ts` moves the invariant from per-vendor to the registry, so a fourth source inherits it: both halves committed from one call (drained and fingerprinted, so committing a *different* re-verifier under the right key no longer survives); neither half committed when the re-verifier registry is taken; neither when the catalog claim collides — the throw site between prepare and commit that had no coverage; the grant-deriving refusal; the malformed-audience refusal; teardown totality; and two `@ts-expect-error` pins for the compile-time claim (verified to invert).

## Residue from the issue

`_resetAudienceReverifiers` is now documented by the criterion that matters — what a suite *registers*, not what it is named after — and the connector suites' redundant direct calls are gone, so the coupling is proven rather than hedged against. `zoom-audience.test.ts`'s inline resets moved into `beforeEach`/`afterEach`; the trailing form never runs when the body throws, which is the leak `audience/sync.ts`'s suite was already burned by.

## Gates

`scripts/ci-local.sh`: **33/33 PASS**. `/review-panel`: 3 rounds to clean (round 3 returned CLEAN on types and tests, one narrow comment-only item, fixed).

https://claude.ai/code/session_01N18FhaaoVZ56P7GXncHNZq