### PR TITLE
fix(brain): scope the Outlook stall detector to the mailbox it names

### DIFF
--- a/packages/api/src/lib/brain/ingest/__tests__/outlook-client.test.ts
+++ b/packages/api/src/lib/brain/ingest/__tests__/outlook-client.test.ts
@@ -229,6 +229,137 @@ describe("the block arm — RETRYABLE, freezes the resume point", () => {
     expect(changes.warnings?.join(" ")).toMatch(/made no forward progress/);
   });
 
+  it("⭐ names ONLY the mailbox that actually blocked as stalled (#4994)", async () => {
+    // The detector's own comment says why the gate is a per-mailbox delta; this
+    // is the pass shape that tells the two spellings apart. The direction the
+    // bug erred in was SAFE — it over-reported — which is exactly why it needs a
+    // test: nothing in the output looks wrong, and the cost is paid later, when
+    // an operator who has learned this line names innocent mailboxes stops
+    // reading the one that names a real one.
+    //
+    // ⚠️ The ORDER of `mailboxes` is load-bearing. The pass-scoped counter only
+    // leaks FORWARD, so A — the mailbox that blocks — must be walked first.
+    // Swap the two and this test passes under the bug as well as the fix.
+    //
+    // A blocks: its membership write throws, so `blockedAudience` hits 1 and A
+    // never reaches the `coveredThrough` assignment.
+    // B blocks nothing: its first page arrives with an unreadable entry, which
+    // truncates the walk with `coveredThrough` still null — incomplete, no block.
+    // (Budget exhaustion is the other route to the same gate; one is enough,
+    // they are the same two lines of state.)
+    //
+    // MUTATION THIS CATCHES: the delta gate → `skips.blockedAudience > 0`, i.e.
+    // the pass-scoped gate this replaced.
+    const vendor = createOutlookMailClient({
+      workspaceId: "ws",
+      resolveToken: async () => "tok",
+      mailboxes: ["a@contoso.com", "b@contoso.com"],
+      backfillWindowMs: 30 * 86_400_000,
+      now: () => NOW,
+      api: {
+        fetchMailbox: async (_t, mailbox) => ({
+          ok: true as const,
+          mailbox: {
+            id: mailbox === "a@contoso.com" ? "mb-a" : "mb-b",
+            userPrincipalName: mailbox,
+            mail: mailbox,
+          },
+        }),
+        fetchMailboxMessagesPage: async (_t, request) =>
+          request.mailboxId === "mb-a"
+            ? { ok: true as const, messages: [message()], nextLink: null, dropped: 0 }
+            : { ok: true as const, messages: [], nextLink: null, dropped: 1 },
+        fetchMailboxMessagesNextPage: async () => ({
+          ok: true as const,
+          messages: [],
+          nextLink: null,
+          dropped: 0,
+        }),
+      },
+      audienceDeps: {
+        resolve: async (_ws, principals) => ({
+          resolved: new Map(principals.map((p) => [p.id, `u-${p.id}`])),
+          unresolvedCount: 0,
+        }),
+        reconcile: async () => {
+          throw new Error("membership write failed");
+        },
+      },
+    });
+    const changes = await vendor.fetchEpisodes(PARAMS);
+    const warnings = changes.warnings ?? [];
+    // ⭐ THE NEGATIVE, and the reason this test exists. B made no forward
+    // progress and is reported as incomplete — it just did not BLOCK, so it is
+    // not stalled on anything.
+    expect(warnings.join(" ")).not.toMatch(/Mailbox b@contoso\.com made no forward progress/);
+    // …and the true positive in the same pass still fires, so the negative above
+    // is not passing because the detector went silent altogether.
+    expect(warnings.join(" ")).toMatch(/Mailbox a@contoso\.com made no forward progress/);
+    // "Not stalled" is not "not a problem" — B is still reported. Note which
+    // assertion carries that: `coverageIncomplete` is PASS-scoped, so A alone
+    // sets it and it would hold with B deleted from the test entirely. B's own
+    // evidence is the warning below, and it is also what stops the negative
+    // above from passing vacuously if B were never walked.
+    expect(changes.coverageIncomplete).toBe(true);
+    // `entr\w+` and not `entry`: the source picks singular/plural off the count,
+    // and this pin is about #4994, not about that branch.
+    expect(warnings.join(" ")).toMatch(/unreadable message entr\w+ in mailbox b@contoso\.com/);
+  });
+
+  it("⭐ names EVERY mailbox that blocked and stalled, not just the first", async () => {
+    // The other direction of #4994, and the one the pass-scoped gate got right
+    // by accident. Narrowing the gate to a per-mailbox delta must not narrow it
+    // to "report one stall per pass" — a fleet-wide outage (an expired secret,
+    // say, failing every membership write) is precisely when the detector is
+    // load-bearing, and it is the shape a "report the first stall" refactor
+    // would break while leaving the negative test above green.
+    //
+    // MUTATION THIS CATCHES: any gate that latches after the first stall — e.g.
+    // hoisting a `let stallReported = false` out of the mailboxes loop.
+    const vendor = createOutlookMailClient({
+      workspaceId: "ws",
+      resolveToken: async () => "tok",
+      mailboxes: ["a@contoso.com", "b@contoso.com"],
+      backfillWindowMs: 30 * 86_400_000,
+      now: () => NOW,
+      api: {
+        fetchMailbox: async (_t, mailbox) => ({
+          ok: true as const,
+          mailbox: {
+            id: mailbox === "a@contoso.com" ? "mb-a" : "mb-b",
+            userPrincipalName: mailbox,
+            mail: mailbox,
+          },
+        }),
+        fetchMailboxMessagesPage: async () => ({
+          ok: true as const,
+          messages: [message()],
+          nextLink: null,
+          dropped: 0,
+        }),
+        fetchMailboxMessagesNextPage: async () => ({
+          ok: true as const,
+          messages: [],
+          nextLink: null,
+          dropped: 0,
+        }),
+      },
+      audienceDeps: {
+        resolve: async (_ws, principals) => ({
+          resolved: new Map(principals.map((p) => [p.id, `u-${p.id}`])),
+          unresolvedCount: 0,
+        }),
+        reconcile: async () => {
+          throw new Error("membership write failed");
+        },
+      },
+    });
+    const changes = await vendor.fetchEpisodes(PARAMS);
+    const warnings = (changes.warnings ?? []).join(" ");
+    expect(warnings).toMatch(/Mailbox a@contoso\.com made no forward progress/);
+    expect(warnings).toMatch(/Mailbox b@contoso\.com made no forward progress/);
+  });
+
   it("⭐ BLOCKS a message whose grant cannot be derived — never skips past it", async () => {
     // The arm nothing reached until this test existed. `deriveEmailRecipientGrant`
     // returning null is the ONE in-band block — every other block arrives as a

--- a/packages/api/src/lib/brain/ingest/outlook/client.ts
+++ b/packages/api/src/lib/brain/ingest/outlook/client.ts
@@ -669,12 +669,16 @@ export function createOutlookMailClient(
       //
       // What says so is the stall detector further down, which raises a
       // `log.error` AND an operator-facing warning. Two things about it are
-      // easy to assume and wrong. Its gate is a CONJUNCTION — `blockedAudience
-      // > 0`, which is PASS-scoped across every mailbox, AND this mailbox
-      // making no forward progress. And on timing: unless nothing ahead of the
-      // block advanced `coveredThrough` past the stored mark — the block being
-      // the first timestamped message walked, or everything ahead of it sharing
-      // the resume instant, which bulk mail routinely does — it fires from the
+      // easy to assume and wrong. Its gate is a CONJUNCTION — THIS mailbox
+      // blocking at least one message, AND this mailbox making no forward
+      // progress. The first conjunct is read as a DELTA on `blockedAudience`
+      // rather than off the counter itself, because `skips` is pass-scoped
+      // while the detector is per-mailbox; #4994 was the pass-scoped spelling,
+      // where one mailbox's block armed the detector for every mailbox after
+      // it. And on timing: unless nothing ahead of the block advanced
+      // `coveredThrough` past the stored mark — the block being the first
+      // timestamped message walked, or everything ahead of it sharing the
+      // resume instant, which bulk mail routinely does — it fires from the
       // SECOND consecutive stalled cycle, once the mark has converged on
       // `coveredThrough`.
       //
@@ -850,6 +854,45 @@ export function createOutlookMailClient(
       let newestIngested: string | null = null;
 
       mailboxes: for (const configured of options.mailboxes) {
+        /**
+         * `skips.blockedAudience` as it stood BEFORE this mailbox was walked, so
+         * the stall detector below can ask "did THIS mailbox block?" of a
+         * counter that is pass-scoped. First statement in the loop body, ahead
+         * even of the identity read, so any block a future edit tallies earlier
+         * than the walk still lands inside its own mailbox's delta.
+         *
+         * Read as a delta rather than tracked in a second per-mailbox counter
+         * deliberately: `skips` is the SSOT every block already tallies through,
+         * and a parallel counter would have to be incremented at every
+         * `tallyOutcome` call site (two today) — so the next arm added could
+         * forget it, which is the exact failure `tallyOutcome`'s own "one site
+         * is the point" rationale exists to prevent.
+         *
+         * ⚠️ Two properties make the delta mean what it says, and BOTH are
+         * structural rather than typed:
+         *
+         *   - `tallyOutcome` only ever increments, so nothing can walk the
+         *     counter back under a snapshot.
+         *   - Mailboxes are walked SEQUENTIALLY. Walking them concurrently
+         *     smears one mailbox's blocks into another's delta and silently
+         *     restores #4994, in a nondeterministic form far harder to
+         *     reproduce than the bug it came from. That is not the only reason,
+         *     so refactoring the delta away would not license it: the mailboxes
+         *     share one `remainingEpisodes` budget decremented across them, and
+         *     the throttle bail `break mailboxes` means nothing under
+         *     concurrency. Sequential by REQUIREMENT, as are the page and
+         *     message walks nested inside it —
+         *     those two carry the module header's contiguous-prefix invariant,
+         *     which parallelising would destroy just as thoroughly. CLAUDE.md's
+         *     "no async waterfalls" does not apply to any of the three.
+         *
+         * `skips` itself cannot quietly move: it is also the pass-level SSOT
+         * read after the loop, so an initializer pushed inside would take the
+         * aggregate log and `permanentDrops` out of scope with it — a compile
+         * error, not a silent regression, which is why it is not on the list
+         * above.
+         */
+        const blockedAudienceAtMailboxStart = skips.blockedAudience;
         // Resolve to the object id FIRST. Everything downstream — the cursor
         // key, the audience token — is keyed on it, so a mailbox whose identity
         // cannot be resolved contributes nothing rather than contributing
@@ -1064,12 +1107,39 @@ export function createOutlookMailClient(
           // fails deterministically for one message, say. Loud, distinct, and
           // naming the instant it is stuck at, because the repair is not the
           // same as for a one-off block.
-          if (
-            skips.blockedAudience > 0 &&
-            (coveredThrough === null || coveredThrough === storedMark)
-          ) {
+          //
+          // Gated on THIS MAILBOX's blocks — the DELTA, per the snapshot's own
+          // comment at the top of the `mailboxes` loop. #4994 read the
+          // pass-scoped counter here, so the first mailbox to block armed it
+          // for every mailbox walked after it, and any later one that made no
+          // forward progress (budget exhaustion, a dropped page) was named as
+          // stuck having blocked nothing. Over-reporting is the safe direction,
+          // which is exactly why it survived: this detector's whole value is
+          // precision, and one that cries wolf on innocent mailboxes teaches
+          // operators to skip the line that is supposed to be unignorable.
+          const blockedHere = skips.blockedAudience - blockedAudienceAtMailboxStart;
+          if (blockedHere > 0 && (coveredThrough === null || coveredThrough === storedMark)) {
             log.error(
-              { workspaceId: options.workspaceId, mailbox: configured, stalledAt: since },
+              // `blocked` is THIS mailbox's count, which only became derivable
+              // with the delta above — the pass-level tally at the end of the
+              // walk is a sum and cannot be decomposed per mailbox. Don't
+              // aggregate the two: the same key carries both grains.
+              //
+              // Today it is ALWAYS 1, and that is worth saying rather than
+              // leaving a reader to hunt for a `blocked: 5` that cannot exist:
+              // both block arms `break pages` the moment they tally, so a
+              // mailbox blocks at most once per pass. Emitted anyway so the
+              // line states its own grain without a join to the pass-level
+              // tally — NOT as a tripwire for a future non-halting block arm,
+              // which this line could not catch: such an arm would let later
+              // messages advance `coveredThrough`, and the second conjunct
+              // below would then suppress the whole log.
+              {
+                workspaceId: options.workspaceId,
+                mailbox: configured,
+                stalledAt: since,
+                blocked: blockedHere,
+              },
               "Outlook mailbox made NO forward progress and blocked at least one message — it is stuck at this instant and every later message in it is not being ingested. A block is retried by design, so a repeat of this line across cycles is a block that is not clearing, not a transient failure",
             );
             warnings.push(


### PR DESCRIPTION
Closes #4994.

## The bug

`fetchEpisodes` declares `skips: MessageSkips` once per **pass**, before the `mailboxes:` loop opens. The stall detector runs **inside** that loop and gated on the pass-scoped counter:

```ts
if (skips.blockedAudience > 0 && (coveredThrough === null || coveredThrough === storedMark)) {
```

So once any mailbox blocked a message, `skips.blockedAudience` stayed non-zero for every mailbox processed after it. A later mailbox that blocked nothing but merely made no forward progress this cycle — ordinary budget exhaustion (`maxEpisodes` / `MAX_MESSAGE_PAGES_PER_MAILBOX`) or a dropped page — then satisfied the conjunction, and both the `log.error` and the operator-facing warning named the **wrong mailbox**.

## The fix

Snapshot `skips.blockedAudience` as the first statement of each mailbox iteration and gate on the delta.

Read as a delta rather than tracked in a second per-mailbox counter deliberately: `skips` is the SSOT every block already tallies through, so a future block arm cannot forget to increment a parallel counter — the same argument `tallyOutcome`'s own "one site is the point" rationale makes.

The aggregate `blockedAudience > 0` at the end of the walk keeps pass-scoped semantics. It answers a different question ("did this pass refuse anything on the safety arm") and was already correct.

## Also in this diff

- **A stale comment 400 lines up.** `runMessage`'s block-arm comment asserted the gate was "`blockedAudience > 0`, which is PASS-scoped across every mailbox" — framed as *the* authoritative correction of a common misreading. Post-fix that is false and inverted, so it would have taught the next maintainer the pre-fix behaviour. Three reviewers flagged it independently.
- **`blocked: <count>` on the `log.error`**, which only became derivable with the delta — the pass-level tally is a sum and cannot be decomposed per mailbox. The comment states plainly that it is always `1` today (both block arms `break pages` on tally) rather than leaving an operator to hunt for a value that cannot exist.

## Verification — by mutation, not by green

| Mutation | Result |
|---|---|
| delta gate → `skips.blockedAudience > 0` (the pass-scoped revert) | RED — the new negative test only, with mailbox B named as stalled in the received string |
| pass-scoped `stallReported` latch (report one stall per pass) | RED — the new fan-out test only |

The negative test pairs `.not.toMatch` on mailbox B with a **true positive on mailbox A in the same pass**, so "the detector went silent" cannot pass as "the bug is fixed", plus a B-scoped warning assertion so it cannot pass because B was never walked. The mailbox ORDER is load-bearing and the test says so — the pass-scoped counter only leaks forward.

## Acceptance criteria

- [x] The detector gates on a mailbox-scoped blocked count
- [x] A test pins the negative: A blocks, B makes no forward progress and blocks nothing → no stall error names B
- [x] The existing true-positive case still fires
- [x] The aggregate `blockedAudience` gate keeps pass-scoped semantics
- [x] Verified by mutation

⚠️ **One AC is met in code but not pinned by a test.** The aggregate gate keeping pass-scoped semantics is unenforced: an alternative fix that *resets* `skips.blockedAudience = 0` per mailbox instead of taking a delta passes the entire suite while silently capping the pass-level safety warn at 1 block per pass. `blockedAudience` is log-only — not returned in `changes`, not in `PERMANENT_SKIP_REASONS` — so pinning it needs a logger observable this file does not currently have. Flagging rather than marking green; the new snapshot comment documents the hazard at the site.

## Review

`/review-panel` — 3 rounds. Round 1 CHANGES REQUESTED (the stale comment above). Rounds 2 and 3 found only comment-accuracy issues in my own new prose, all corrected: a tripwire claim the enclosing gates cannot deliver, a false "the one place in the file" superlative about async waterfalls, and a mis-stated load-bearing invariant. Behaviour was confirmed correct on every round, on every reachable `continue` / `break mailboxes` arm.

`/ci` — all 33 gates green.