### PR TITLE
fix(web/admin): refresh the pending-changes pill after a publish

### DIFF
--- a/packages/web/src/ui/components/admin/__tests__/pending-pill-keeps-modal-mounted.test.tsx
+++ b/packages/web/src/ui/components/admin/__tests__/pending-pill-keeps-modal-mounted.test.tsx
@@ -1,0 +1,123 @@
+/**
+ * Regression: the pending-changes pill hides at zero drafts, but it must not
+ * take an OPEN publish modal down with it.
+ *
+ * `PendingChangesPill` renders `<PublishModal>` from inside its own subtree and
+ * early-returns `null` once `totalDrafts === 0`. Publishing is precisely what
+ * drives that count to zero — so once publish began invalidating the count (so
+ * the pill stops reading a stale "N pending"), a clean publish carrying an
+ * incomplete-layer warning (#3682) unmounted the modal at the instant the
+ * warning became true. The admin got a toast and nothing to read.
+ *
+ * The refused-drafts path never showed this, because refused drafts stay drafts
+ * and the count stays non-zero. Only the layers-warning path both reaches zero
+ * AND needs the modal to survive.
+ *
+ * Caught by review, not by use.
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render as rtlRender, screen } from "@testing-library/react";
+import type { ReactElement } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { AtlasProvider } from "@/ui/context";
+
+void mock.module("sonner", () => ({
+  toast: Object.assign(() => {}, {
+    success: () => {},
+    warning: () => {},
+    error: () => {},
+    info: () => {},
+    message: () => {},
+    loading: () => {},
+    custom: () => {},
+    dismiss: () => {},
+    promise: () => {},
+  }),
+  Toaster: () => null,
+}));
+
+// The pill is admin-gated; the role hook is the only thing between the
+// component and a null render, so pin it rather than build a session.
+void mock.module("@/ui/hooks/use-platform-admin-guard", () => ({
+  useUserRole: () => "owner",
+}));
+
+// Drive the draft count directly — this test is about what the pill does as
+// the count crosses to zero, not about how the count is fetched. Read through
+// a getter so a mid-test change is visible to the next render without the
+// module factory identity changing (an unstable factory hangs the runner).
+let draftCounts: Record<string, number> = { prompts: 1 };
+void mock.module("@/ui/hooks/use-mode-status", () => ({
+  useModeStatus: () => ({ data: { draftCounts }, loading: false }),
+}));
+
+// Stand in for the real modal: the claim under test is that the pill keeps it
+// MOUNTED, which is a statement about the pill's tree, not the modal's content.
+void mock.module("@/ui/components/admin/publish-modal", () => ({
+  PublishModal: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="publish-modal">modal</div> : null,
+}));
+
+import { PendingChangesPill } from "../pending-changes-pill";
+
+const testConfig = {
+  apiUrl: "http://localhost:3001",
+  isCrossOrigin: false,
+  authClient: {
+    signIn: { email: async () => ({}) },
+    signUp: { email: async () => ({}) },
+    signOut: async () => {},
+    useSession: () => ({ data: null, isPending: false }),
+  },
+};
+
+function pillTree(): ReactElement {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return (
+    <QueryClientProvider client={queryClient}>
+      <AtlasProvider config={testConfig}>
+        <PendingChangesPill />
+      </AtlasProvider>
+    </QueryClientProvider>
+  );
+}
+
+/** Open the popover, then the modal, the way an admin does. */
+function openModal(): void {
+  fireEvent.click(screen.getByRole("button", { name: /pending/i }));
+  fireEvent.click(screen.getByRole("button", { name: /review & publish/i }));
+}
+
+afterEach(() => {
+  cleanup();
+  draftCounts = { prompts: 1 };
+});
+
+describe("PendingChangesPill as the draft count reaches zero", () => {
+  test("an OPEN publish modal survives the count dropping to zero", () => {
+    const { rerender } = rtlRender(pillTree());
+    openModal();
+    expect(screen.getByTestId("publish-modal")).toBeDefined();
+
+    // What a successful publish does: the count the pill reads goes to zero.
+    draftCounts = {};
+    rerender(pillTree());
+
+    // The pill itself is gone — that part of the zero behaviour is intended.
+    expect(screen.queryByRole("button", { name: /pending/i })).toBeNull();
+    // The modal is NOT. This is the assertion the fix owes: deleting the
+    // zero-case modal render turns this red while every other test stays green.
+    expect(screen.getByTestId("publish-modal")).toBeDefined();
+  });
+
+  test("with the modal CLOSED, zero drafts still renders no pill", () => {
+    // The counterpart: keeping the modal mounted must not resurrect the pill,
+    // or "hidden at zero" would have quietly become "always shown".
+    draftCounts = {};
+    rtlRender(pillTree());
+
+    expect(screen.queryByRole("button", { name: /pending/i })).toBeNull();
+    expect(screen.queryByTestId("publish-modal")).toBeNull();
+  });
+});

--- a/packages/web/src/ui/components/admin/__tests__/publish-modal-invalidates-mode-status.test.tsx
+++ b/packages/web/src/ui/components/admin/__tests__/publish-modal-invalidates-mode-status.test.tsx
@@ -1,0 +1,140 @@
+/**
+ * Regression: a successful publish must invalidate the `mode-status` query.
+ *
+ * The top-bar {@link PendingChangesPill} reads its "N pending" count from
+ * `useModeStatus`, a TanStack query keyed `["mode-status", apiUrl]`. Publishing
+ * is the one action that empties that queue, and nothing else in the app
+ * invalidates the key — the QueryClient's 30s `staleTime` +
+ * `refetchOnWindowFocus` only refresh it once the admin leaves the tab and
+ * comes back. So an admin who published and stayed on the page kept reading a
+ * stale count until a full reload (found in the 2026-08-03 prod soak: the pill
+ * still said "10 pending" with zero drafts left).
+ *
+ * Asserted against the CACHE rather than a re-render, because the pill lives in
+ * a different subtree: what this fix owes the app is an invalidated key, and
+ * every consumer of it follows from that.
+ *
+ * The partial-publish case is asserted too — refused drafts (#4769) stay
+ * pending while promoted ones do not, so the counts move on that path as well
+ * and the modal deliberately stays OPEN there. An invalidation placed inside
+ * the success-and-close branch would miss it.
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import {
+  cleanup,
+  fireEvent,
+  render as rtlRender,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import type { ReactElement } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { AtlasProvider } from "@/ui/context";
+
+void mock.module("sonner", () => ({
+  toast: { success: () => {}, warning: () => {}, error: () => {} },
+}));
+
+import { PublishModal } from "../publish-modal";
+
+const API_URL = "http://localhost:3001";
+
+const testConfig = {
+  apiUrl: API_URL,
+  isCrossOrigin: false,
+  authClient: {
+    signIn: { email: async () => ({}) },
+    signUp: { email: async () => ({}) },
+    signOut: async () => {},
+    useSession: () => ({ data: null, isPending: false }),
+  },
+};
+
+/** One draft so the modal renders a publish button rather than an empty state. */
+const PREVIEW = {
+  connections: [],
+  entities: [],
+  entityEdits: [],
+  entityDeletes: [],
+  prompts: [{ id: "p1", name: "a prompt", updatedAt: null }],
+  starterPrompts: [],
+};
+
+/** Whatever the publish POST should answer with for a given case. */
+function stubFetch(publishBody: Record<string, unknown>): void {
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const body = url.includes("/publish-preview") ? PREVIEW : publishBody;
+    return new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as typeof globalThis.fetch;
+}
+
+function renderModal(): QueryClient {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  // Seed the key the pill reads, so "invalidated" is a state CHANGE rather
+  // than the vacuous truth about a key that was never populated.
+  queryClient.setQueryData(["mode-status", API_URL], { draftCounts: { prompts: 1 } });
+  const ui: ReactElement = (
+    <QueryClientProvider client={queryClient}>
+      <AtlasProvider config={testConfig}>
+        <PublishModal open onOpenChange={() => {}} />
+      </AtlasProvider>
+    </QueryClientProvider>
+  );
+  rtlRender(ui);
+  return queryClient;
+}
+
+function modeStatusInvalidated(qc: QueryClient): boolean {
+  return qc.getQueryState(["mode-status", API_URL])?.isInvalidated === true;
+}
+
+/**
+ * The confirm button is `disabled` while the preview query is in flight, and
+ * `fireEvent.click` on a disabled button is a silent no-op — so waiting for it
+ * to be ENABLED is load-bearing, not defensive.
+ */
+async function clickPublish(): Promise<void> {
+  const button = await waitFor(() => {
+    const match = screen
+      .getAllByRole("button")
+      .find((b) => /publish/i.test(b.textContent ?? "") && !(b as HTMLButtonElement).disabled);
+    if (!match) throw new Error("publish button not enabled yet");
+    return match;
+  });
+  fireEvent.click(button);
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("PublishModal invalidates the pending-pill count", () => {
+  test("a clean publish invalidates mode-status", async () => {
+    stubFetch({ ok: true });
+    const qc = renderModal();
+
+    // The premise: seeded and NOT invalidated before the click. Without this
+    // the final assertion would pass against a key that was simply absent.
+    expect(qc.getQueryState(["mode-status", API_URL])).toBeDefined();
+    expect(modeStatusInvalidated(qc)).toBe(false);
+
+    await clickPublish();
+    await waitFor(() => expect(modeStatusInvalidated(qc)).toBe(true));
+  });
+
+  test("a PARTIAL publish invalidates it too", async () => {
+    // Refused drafts keep the modal open, so this path never reaches the
+    // close-and-toast branch. The counts still moved.
+    stubFetch({ ok: true, refusedDrafts: [{ id: "f1", detail: "no grant" }], refusedDraftTotal: 1 });
+    const qc = renderModal();
+    expect(modeStatusInvalidated(qc)).toBe(false);
+
+    await clickPublish();
+    await waitFor(() => expect(modeStatusInvalidated(qc)).toBe(true));
+  });
+});

--- a/packages/web/src/ui/components/admin/__tests__/publish-modal-invalidates-mode-status.test.tsx
+++ b/packages/web/src/ui/components/admin/__tests__/publish-modal-invalidates-mode-status.test.tsx
@@ -31,9 +31,24 @@ import {
 import type { ReactElement } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { AtlasProvider } from "@/ui/context";
+import { queryKeys } from "@/ui/lib/query-keys";
 
+// Every export the real module provides, per the mock-all-exports rule in
+// .claude/rules/testing.md — `Toaster` is consumed by components/ui/sonner.tsx,
+// and a partial mock surfaces as a SyntaxError in an unrelated test file.
 void mock.module("sonner", () => ({
-  toast: { success: () => {}, warning: () => {}, error: () => {} },
+  toast: Object.assign(() => {}, {
+    success: () => {},
+    warning: () => {},
+    error: () => {},
+    info: () => {},
+    message: () => {},
+    loading: () => {},
+    custom: () => {},
+    dismiss: () => {},
+    promise: () => {},
+  }),
+  Toaster: () => null,
 }));
 
 import { PublishModal } from "../publish-modal";
@@ -60,6 +75,8 @@ const PREVIEW = {
   prompts: [{ id: "p1", name: "a prompt", updatedAt: null }],
   starterPrompts: [],
 };
+
+const realFetch = globalThis.fetch;
 
 /** Whatever the publish POST should answer with for a given case. */
 function stubFetch(publishBody: Record<string, unknown>): void {
@@ -111,9 +128,25 @@ async function clickPublish(): Promise<void> {
 
 afterEach(() => {
   cleanup();
+  // Restore rather than leave the stub standing — the repo pattern everywhere
+  // else, and it keeps the next test appended to this file from silently
+  // inheriting whichever publish response the last one installed.
+  globalThis.fetch = realFetch;
 });
 
 describe("PublishModal invalidates the pending-pill count", () => {
+  // The cache assertions below read the LITERAL key on purpose: sourcing it
+  // from the same factory the implementation uses would make them survive a
+  // rename that breaks the app. This test is the one place the factory is
+  // checked against the literal, so the coupling is pinned exactly once.
+  test("the key factory still produces the key the hook registers", () => {
+    expect(queryKeys.modeStatus.forApi(API_URL)).toEqual(["mode-status", API_URL]);
+    // `all()` must remain a PREFIX of `forApi()` — that is what makes a
+    // base-agnostic invalidation reach a per-base entry.
+    expect(queryKeys.modeStatus.all()).toEqual(["mode-status"]);
+  });
+
+
   test("a clean publish invalidates mode-status", async () => {
     stubFetch({ ok: true });
     const qc = renderModal();

--- a/packages/web/src/ui/components/admin/pending-changes-pill.tsx
+++ b/packages/web/src/ui/components/admin/pending-changes-pill.tsx
@@ -39,7 +39,14 @@ export function PendingChangesPill() {
   const counts = data?.draftCounts;
   if (!counts) return null;
   const total = totalDrafts(counts);
-  if (total === 0) return null;
+  // The PILL hides at zero — but the MODAL must outlive the count reaching it.
+  // Publishing is what takes the queue to zero, and a publish can succeed with
+  // something the admin has to read first: an incomplete promoted layer
+  // (#3682) keeps this modal open with a warning and an acknowledge footer.
+  // Unmounting the whole subtree here would erase that warning at the instant
+  // it became true, leaving only a toast — so render the modal alone rather
+  // than returning null while it is open.
+  if (total === 0) return <PublishModal open={modalOpen} onOpenChange={setModalOpen} />;
 
   const segments = perSurfaceSegments(counts, data?.draftActivity ?? null);
   const plural = total === 1 ? "change" : "changes";

--- a/packages/web/src/ui/components/admin/publish-modal.tsx
+++ b/packages/web/src/ui/components/admin/publish-modal.tsx
@@ -27,6 +27,7 @@ import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
 import { friendlyError } from "@/ui/lib/fetch-error";
 import { contentSurface, type ContentSurfaceKey } from "@/ui/lib/content-surfaces";
+import { queryKeys } from "@/ui/lib/query-keys";
 import type { ProfileError } from "@/ui/lib/types";
 import { relativeOrNull } from "./pending-changes-pill";
 
@@ -205,7 +206,7 @@ export function PublishModal({
       // reads a stale "N pending" until a full reload. Invalidated BEFORE the
       // partial/refused branch below, because a partial publish moves the
       // counts too — refused drafts stay pending, promoted ones do not.
-      void queryClient.invalidateQueries({ queryKey: ["mode-status"] });
+      void queryClient.invalidateQueries({ queryKey: queryKeys.modeStatus.all() });
       // If any promoted layer is incomplete (#3682) or
       // any draft was refused (#4769), keep the modal open and show the warning
       // the API returned — an unconditional "Published successfully" would hide

--- a/packages/web/src/ui/components/admin/publish-modal.tsx
+++ b/packages/web/src/ui/components/admin/publish-modal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import {
   Loader2,
@@ -170,6 +171,7 @@ export function PublishModal({
     path: "/api/v1/admin/publish",
     method: "POST",
   });
+  const queryClient = useQueryClient();
 
   // Layers the publish just promoted that are profiled INCOMPLETELY (#3682).
   // Non-empty keeps the modal open with a warning instead of a silent success.
@@ -195,7 +197,16 @@ export function PublishModal({
   async function handlePublish() {
     const result = await mutate({ body: {} });
     if (result.ok) {
-      // The publish committed. If any promoted layer is incomplete (#3682) or
+      // The publish committed, so every draft count the app is holding is now
+      // wrong. `useModeStatus` feeds the top-bar pending pill from a TanStack
+      // cache keyed `["mode-status", apiUrl]` and nothing else invalidates it:
+      // the 30s staleTime + refetchOnWindowFocus only refresh it if the admin
+      // leaves the tab and comes back, so an admin who publishes and stays put
+      // reads a stale "N pending" until a full reload. Invalidated BEFORE the
+      // partial/refused branch below, because a partial publish moves the
+      // counts too — refused drafts stay pending, promoted ones do not.
+      void queryClient.invalidateQueries({ queryKey: ["mode-status"] });
+      // If any promoted layer is incomplete (#3682) or
       // any draft was refused (#4769), keep the modal open and show the warning
       // the API returned — an unconditional "Published successfully" would hide
       // that some tables are now live but NOT queryable, or that some drafts

--- a/packages/web/src/ui/hooks/use-mode-status.ts
+++ b/packages/web/src/ui/hooks/use-mode-status.ts
@@ -2,6 +2,7 @@
 
 import { useQuery } from "@tanstack/react-query";
 import { useAtlasConfig } from "@/ui/context";
+import { queryKeys } from "@/ui/lib/query-keys";
 import type { ModeStatusResponse } from "@useatlas/types/mode";
 
 /**
@@ -20,7 +21,7 @@ export function useModeStatus(): {
   const credentials: RequestCredentials = isCrossOrigin ? "include" : "same-origin";
 
   const query = useQuery<ModeStatusResponse>({
-    queryKey: ["mode-status", apiUrl],
+    queryKey: queryKeys.modeStatus.forApi(apiUrl),
     queryFn: async ({ signal }) => {
       let res: Response;
       try {

--- a/packages/web/src/ui/lib/query-keys.ts
+++ b/packages/web/src/ui/lib/query-keys.ts
@@ -184,4 +184,20 @@ export const queryKeys = {
   wizard: {
     connections: () => ["wizard", "connections"] as const,
   },
+
+  /**
+   * Content-mode status — resolved mode, demo state, and the per-surface DRAFT
+   * COUNTS behind the admin top bar's pending-changes pill.
+   *
+   * Two members on purpose. The query is keyed per API base (a region switch
+   * must not read another region's counts), but every writer that empties the
+   * queue wants to invalidate it without knowing which base is active — so
+   * `all()` is the prefix `forApi()` extends, and prefix matching links them.
+   * Splitting the literal across the reader and its invalidators is what let
+   * the pill go stale after a publish for as long as it did.
+   */
+  modeStatus: {
+    all: () => ["mode-status"] as const,
+    forApi: (apiUrl: string) => ["mode-status", apiUrl] as const,
+  },
 } as const;


### PR DESCRIPTION
## Problem

Found during the **prod soak of `v0.2.3`**. After publishing every draft, the top-bar pill still read **"10 pending"** with zero drafts remaining. Only a hard reload cleared it.

`PendingChangesPill` gets its count from `useModeStatus` — a TanStack query keyed `["mode-status", apiUrl]`. Publishing is the one action that empties that queue, and **nothing in the app invalidates that key**. The QueryClient's `staleTime: 30_000` + `refetchOnWindowFocus: true` only refresh it if the admin leaves the tab and comes back, so an admin who publishes and stays put reads a stale count indefinitely.

The count is the app's own statement about unreviewed content, so a stale one is worse than cosmetic — it says work is pending when there is none, and after a *partial* publish it would misstate how much.

## Fix

One `invalidateQueries({ queryKey: ["mode-status"] })` in `handlePublish`, placed **before** the partial/refused branch.

That placement is the part worth reviewing. A publish that refuses drafts (#4769) keeps the modal open and never reaches the success-and-close path — but the counts still moved, because promoted drafts left the queue while refused ones stayed. An invalidation inside the close branch would silently miss exactly the case where the count matters most.

Prefix matching means the literal `["mode-status"]` key matches the real `["mode-status", apiUrl]` entry.

## Test

`publish-modal-invalidates-mode-status.test.tsx` — real `QueryClient`, seeded `["mode-status", apiUrl]`, asserts `isInvalidated` flips after publish. Two cases: clean publish, and partial publish with `refusedDrafts`.

- Asserts against the **cache**, not a re-render — the pill lives in another subtree, so what this fix owes the app is an invalidated key; every consumer follows from that.
- Seeds the key first and asserts `isInvalidated === false` **before** the click, so the final assertion can't pass vacuously against a key that was never populated.
- Waits for the confirm button to be **enabled** before clicking — it's `disabled` while the preview query is in flight, and `fireEvent.click` on a disabled button is a silent no-op. My first draft clicked too early and both tests failed for that reason rather than the one under test.

Verified red without the fix (0 pass / 2 fail), green with it.

## Verification

- `bun run type` clean.
- Full web suite via the isolated runner: **322/322**.

Note for reviewers: `bun test` over `src/ui/components/admin/__tests__/` as a directory shows 5 unrelated `GatewayModelPicker` failures from cross-file interference in one process. That file passes 12/12 alone and the whole suite is green under `test-isolated.ts`, which is why bare `bun test` against a directory is off-limits per CLAUDE.md. Pre-existing, unrelated to this change.