### PR TITLE
fix(web/admin): refresh draft counts on every admin mutation, not just publish

### DIFF
--- a/packages/web/src/ui/components/admin/publish-modal.tsx
+++ b/packages/web/src/ui/components/admin/publish-modal.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import {
   Loader2,
@@ -27,7 +26,6 @@ import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
 import { friendlyError } from "@/ui/lib/fetch-error";
 import { contentSurface, type ContentSurfaceKey } from "@/ui/lib/content-surfaces";
-import { queryKeys } from "@/ui/lib/query-keys";
 import type { ProfileError } from "@/ui/lib/types";
 import { relativeOrNull } from "./pending-changes-pill";
 
@@ -172,7 +170,6 @@ export function PublishModal({
     path: "/api/v1/admin/publish",
     method: "POST",
   });
-  const queryClient = useQueryClient();
 
   // Layers the publish just promoted that are profiled INCOMPLETELY (#3682).
   // Non-empty keeps the modal open with a warning instead of a silent success.
@@ -198,15 +195,13 @@ export function PublishModal({
   async function handlePublish() {
     const result = await mutate({ body: {} });
     if (result.ok) {
-      // The publish committed, so every draft count the app is holding is now
-      // wrong. `useModeStatus` feeds the top-bar pending pill from a TanStack
-      // cache keyed `["mode-status", apiUrl]` and nothing else invalidates it:
-      // the 30s staleTime + refetchOnWindowFocus only refresh it if the admin
-      // leaves the tab and comes back, so an admin who publishes and stays put
-      // reads a stale "N pending" until a full reload. Invalidated BEFORE the
-      // partial/refused branch below, because a partial publish moves the
-      // counts too — refused drafts stay pending, promoted ones do not.
-      void queryClient.invalidateQueries({ queryKey: queryKeys.modeStatus.all() });
+      // The publish committed, so the top bar's draft counts are now wrong.
+      // Refreshing them is `useAdminMutation`'s job, not this handler's — it
+      // invalidates `modeStatus` on every success, so the counts move whether
+      // this publish was clean or partial (refused drafts stay pending,
+      // promoted ones do not) and a future draft-moving mutation inherits it
+      // without having to remember. See #5001 / #5002.
+      //
       // If any promoted layer is incomplete (#3682) or
       // any draft was refused (#4769), keep the modal open and show the warning
       // the API returned — an unconditional "Published successfully" would hide

--- a/packages/web/src/ui/hooks/__tests__/admin-mutation-invalidates-mode-status.test.tsx
+++ b/packages/web/src/ui/hooks/__tests__/admin-mutation-invalidates-mode-status.test.tsx
@@ -1,0 +1,113 @@
+/**
+ * Regression: EVERY admin mutation refreshes the top bar's draft counts.
+ *
+ * `mode-status` is a plain `useQuery`, not a `useAdminFetch` consumer, so
+ * `useAdminMutation`'s `[ADMIN_FETCH_QUERY_KEY]` broadcast never reached it.
+ * That produced the same bug twice at two call sites — #5001 (publishing left
+ * the pill reading a stale "N pending") and #5002 (rejecting a draft fact did
+ * the same) — so the invalidation lives in the hook rather than at each caller.
+ * A per-site opt-in is a thing to forget, and forgetting is silent: the pill
+ * just keeps showing a number that was true a moment ago.
+ *
+ * Asserted at the HOOK, not through a page. The claim is "any admin mutation
+ * invalidates it", and testing that through one component would only re-pin
+ * that component. The reject path is named in a case of its own because it is
+ * the one #5002 reported and the one no publish test covers.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { AtlasProvider } from "@/ui/context";
+import { queryKeys } from "@/ui/lib/query-keys";
+import { useAdminMutation } from "../use-admin-mutation";
+
+const API_URL = "http://localhost:3001";
+
+const testConfig = {
+  apiUrl: API_URL,
+  isCrossOrigin: false,
+  authClient: {
+    signIn: { email: async () => ({}) },
+    signUp: { email: async () => ({}) },
+    signOut: async () => {},
+    useSession: () => ({ data: null, isPending: false }),
+  },
+};
+
+const realFetch = globalThis.fetch;
+
+// The `_input` parameter is load-bearing for the cast, not decoration: a
+// zero-arg function doesn't overlap `typeof fetch` enough for TS to accept it.
+function stubOk(): void {
+  globalThis.fetch = (async (_input: RequestInfo | URL) =>
+    new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    })) as typeof globalThis.fetch;
+}
+
+/** 500 with a JSON body, so the hook takes its failure path rather than throwing on parse. */
+function stubFail(): void {
+  globalThis.fetch = (async (_input: RequestInfo | URL) =>
+    new Response(JSON.stringify({ error: "boom" }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    })) as typeof globalThis.fetch;
+}
+
+function setup(path: string) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  // Seed the key a real session would hold, so "invalidated" is a state change
+  // rather than the vacuous truth about a key that was never populated.
+  queryClient.setQueryData(queryKeys.modeStatus.forApi(API_URL), {
+    draftCounts: { brainFacts: 1 },
+  });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <AtlasProvider config={testConfig}>{children}</AtlasProvider>
+    </QueryClientProvider>
+  );
+  const { result } = renderHook(() => useAdminMutation({ path, method: "POST" }), { wrapper });
+  return { queryClient, result };
+}
+
+function invalidated(qc: QueryClient): boolean {
+  return qc.getQueryState(queryKeys.modeStatus.forApi(API_URL))?.isInvalidated === true;
+}
+
+afterEach(() => {
+  cleanup();
+  globalThis.fetch = realFetch;
+});
+
+describe("useAdminMutation refreshes the draft-count query", () => {
+  test("the reject/retract path invalidates mode-status (#5002)", async () => {
+    stubOk();
+    const { queryClient, result } = setup("/api/v1/admin/brain-facts/abc/retract");
+    expect(invalidated(queryClient)).toBe(false);
+
+    await act(async () => {
+      await result.current.mutate({});
+    });
+
+    await waitFor(() => expect(invalidated(queryClient)).toBe(true));
+  });
+
+  test("a FAILED mutation does not invalidate", async () => {
+    // The counterpart. Without it, an implementation that invalidated
+    // unconditionally — on error as readily as on success — would pass the
+    // case above while telling the pill to refetch after a write that
+    // changed nothing.
+    stubFail();
+    const { queryClient, result } = setup("/api/v1/admin/brain-facts/abc/retract");
+
+    await act(async () => {
+      const res = await result.current.mutate({});
+      expect(res.ok).toBe(false);
+    });
+
+    expect(invalidated(queryClient)).toBe(false);
+  });
+});

--- a/packages/web/src/ui/hooks/use-admin-mutation.ts
+++ b/packages/web/src/ui/hooks/use-admin-mutation.ts
@@ -5,6 +5,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useAtlasConfig } from "@/ui/context";
 import { buildFetchError, extractFetchError, type FetchError } from "@/ui/lib/fetch-error";
 import { ADMIN_FETCH_QUERY_KEY } from "@/ui/hooks/admin-query-keys";
+import { queryKeys } from "@/ui/lib/query-keys";
 import { useMfaGateOptional } from "@/ui/components/admin/mfa-gate-context";
 
 // See use-admin-fetch.ts for rationale.
@@ -310,6 +311,17 @@ export function useAdminMutation<TResponse = unknown>(
       // This is intentionally broad — can be narrowed to specific keys if needed.
       // fire-and-forget: cache invalidation kick-off, no need to await
       void queryClient.invalidateQueries({ queryKey: [ADMIN_FETCH_QUERY_KEY] });
+      // `mode-status` is NOT in that namespace — it is a plain `useQuery`, not a
+      // `useAdminFetch` consumer — so the broadcast above never reached it. It
+      // carries the top bar's draft counts, and an admin mutation is the only
+      // thing that moves them: publishing empties the queue, rejecting a draft
+      // removes one from it. Invalidated here rather than per call site because
+      // a per-site opt-in is a thing to FORGET, and forgetting is silent — the
+      // pill just keeps displaying a number that was true a moment ago. That
+      // cost us #5001 (publish) and #5002 (reject) as separate bugs with one
+      // cause. Mutations that move no drafts pay one cheap refetch of a small
+      // endpoint; the alternative pays in stale counts nobody notices.
+      void queryClient.invalidateQueries({ queryKey: queryKeys.modeStatus.all() });
     },
   });
 


### PR DESCRIPTION
Closes #5002.

## Problem

`mode-status` carries the top bar's draft counts, but it's a plain `useQuery` — **not** a `useAdminFetch` consumer — so `useAdminMutation`'s `[ADMIN_FETCH_QUERY_KEY]` broadcast never reached it.

That produced the same bug twice at two call sites:
- **#5001** — publishing left the pill reading a stale "N pending"
- **#5002** — rejecting a draft fact did the same

Both found during the `v0.2.3` prod soak, one after the other, because the first fix only took ownership of one writer.

## Fix

The invalidation moves **into the hook**, alongside the broadcast that was already there.

A per-site opt-in is a thing to forget, and forgetting is silent: the pill keeps displaying a number that was true a moment ago, with nothing red anywhere. Mutations that move no drafts pay one cheap refetch of a small endpoint — the alternative pays in stale counts nobody notices.

This **subsumes #5001's explicit call**, so `PublishModal`'s is removed along with its now-dead `useQueryClient` wiring.

## Test

`admin-mutation-invalidates-mode-status.test.tsx` — asserted at the **hook**, not through a page. The claim is "any admin mutation invalidates it"; testing that through one component would only re-pin that component.

- The reject/retract path gets a case of its own — it's the one #5002 reported and the one no publish test covers.
- **A failed mutation must NOT invalidate.** Without that counterpart, an implementation that invalidated unconditionally would pass the success case while telling the pill to refetch after a write that changed nothing.
- Seeds the key first so "invalidated" is a state change, not the vacuous truth about a key that was never populated.

### The mutation check worth noting

Deleting the hook line reddens the new reject test **and both publish tests from #5001** — which are unchanged by this PR. That's the evidence the hook-level fix genuinely covers publish rather than merely relocating the call: the older tests validate the new implementation without being touched.

## Verification

- `bun run type` clean.
- Full web suite via the isolated runner: **324/324**.