### PR TITLE
feat(brain): materialize claim identity keys and repoint the three slot consumers (#5020)

### DIFF
--- a/packages/api/src/api/routes/admin-migrate.ts
+++ b/packages/api/src/api/routes/admin-migrate.ts
@@ -1119,6 +1119,26 @@ export async function importBundle(
         // whole org. It cannot be re-derived here — the import writes `status`
         // verbatim, so the fact never re-publishes and the widening UPDATE
         // that is its only writer never runs again.
+        //
+        // ⚠️ The three IDENTITY KEY columns (`subject_key`, `predicate_key`,
+        // `object_key`) are absent from this list, and since #5020 that has a
+        // consequence this INSERT is the sole producer of: an imported fact
+        // lands UNKEYED, and all three slot consumers compare keys with `=` or
+        // `<>`, both of which are UNKNOWN against NULL. So an imported claim
+        // corroborates nothing (a re-observation forks a duplicate draft), earns
+        // no `in-tension-with` edge, and can neither supersede nor be superseded
+        // at the publish gate — where the will-supersede disclosure then reports
+        // "nothing to supersede" without being able to say the check could not
+        // run. Fail-closed, and invisible.
+        //
+        // #5035 is the fix and it is a CARRY, not a re-derive: ADR-0037 §8
+        // settles that a row-copy path carries keys verbatim, because
+        // re-deriving fails to OVER-match (irreversible) where carrying fails to
+        // under-match (recoverable). That needs the v3 bundle to project them,
+        // which `keys-not-on-the-wire.test.ts` forbids until §8's exception is
+        // implemented — so adding the columns here ahead of #5035 is not
+        // available, and migration 0188's backfill cannot cover it either (it
+        // runs at boot; this runs whenever an admin triggers an import).
         `INSERT INTO brain_facts (id, workspace_id, subject, predicate, object, valid_from, valid_to, ingested_at, invalidated_at, extracted_at, source_episode_id, provenance, status, visible_to, pre_widening_visible_to, predicate_cardinality, created_at, updated_at)
          VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18)`,
         [

--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -564,6 +564,9 @@ describe("migrateAuthTables", () => {
             // belongs in this already-applied set for the same reason 0185 and
             // 0186 do.
             { name: "0187_brain_fact_identity_keys.sql" },
+            // 0188 (re-key of unkeyed brain facts, #5020) is a plain UPDATE on
+            // `brain_facts` — same reasoning as 0187 above.
+            { name: "0188_rekey_unkeyed_brain_facts.sql" },
           ],
         };
       }

--- a/packages/api/src/lib/brain/__tests__/candidates-pg.test.ts
+++ b/packages/api/src/lib/brain/__tests__/candidates-pg.test.ts
@@ -55,6 +55,7 @@ import {
   loadFactCandidates,
 } from "@atlas/api/lib/brain/candidates";
 import { CORRECTION_REFUSAL_REASONS, correctFact } from "@atlas/api/lib/brain/correction";
+import { identityAlias, slotKey } from "@atlas/api/lib/brain/identity";
 import type { ReconcileTransactionRunner } from "@atlas/api/lib/brain/reconcile";
 import { LAST_OBSERVED_AT_SELECT } from "@atlas/api/lib/brain/staleness";
 import type { BrainPrincipalContext } from "@atlas/api/lib/brain/acl";
@@ -141,23 +142,34 @@ describeIfPg("brain fact candidates (real Postgres)", () => {
     /** The grant before publish-time widening; omit for a never-widened fact. */
     preWideningVisibleTo?: readonly (string | null)[];
   }): Promise<string> {
+    const predicate = opts.predicate ?? "uses";
+    const object = opts.object ?? "Postgres";
     const { rows } = await pool.query<{ id: string }>(
       `INSERT INTO brain_facts
          (workspace_id, subject, predicate, object, source_episode_id, provenance,
-          status, visible_to, pre_widening_visible_to, predicate_cardinality)
-       VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7, $8::text[], $9::text[], $10)
+          status, visible_to, pre_widening_visible_to, predicate_cardinality,
+          subject_key, predicate_key, object_key)
+       VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7, $8::text[], $9::text[], $10,
+               $11, $12, $13)
        RETURNING id`,
       [
         WS,
         opts.subject,
-        opts.predicate ?? "uses",
-        opts.object ?? "Postgres",
+        predicate,
+        object,
         opts.episodeId,
         JSON.stringify(opts.provenance ?? { source: "slack", actor: "U1" }),
         opts.status ?? "draft",
         opts.visibleTo ?? ["org"],
         opts.preWideningVisibleTo ?? null,
         opts.cardinality ?? "multi",
+        // Keyed like an ingested row (#5020) — `correct_fact`'s replacement path
+        // runs the reconcile lookups, which match on the keys and see nothing on
+        // an unkeyed row. Derived through `slotKey` — the same function
+        // `reconcile.ts` calls when binding `INSERT_FACT_SQL`.
+        slotKey(opts.subject, identityAlias),
+        slotKey(predicate, identityAlias),
+        slotKey(object, identityAlias),
       ],
     );
     return rows[0]!.id;

--- a/packages/api/src/lib/brain/__tests__/correction-audit-pg.test.ts
+++ b/packages/api/src/lib/brain/__tests__/correction-audit-pg.test.ts
@@ -43,6 +43,7 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { Pool } from "pg";
 import { runMigrations } from "@atlas/api/lib/db/migrate";
+import { identityAlias, slotKey } from "@atlas/api/lib/brain/identity";
 import { MANAGED_AUTH_MIGRATIONS, _resetPool } from "@atlas/api/lib/db/internal";
 import { withRequestContext } from "@atlas/api/lib/logger";
 import { CORRECTION_REFUSAL_REASONS, correctFact } from "@atlas/api/lib/brain/correction";
@@ -179,8 +180,10 @@ describeIfPg("correction audit row (real Postgres)", () => {
     const { rows } = await pool.query<{ id: string }>(
       `INSERT INTO brain_facts
          (workspace_id, subject, predicate, object, source_episode_id, provenance,
-          status, visible_to, predicate_cardinality)
-       VALUES ($1, $2, $3, $4, $5, $6::jsonb, 'published', ARRAY['org'], 'single')
+          status, visible_to, predicate_cardinality,
+          subject_key, predicate_key, object_key)
+       VALUES ($1, $2, $3, $4, $5, $6::jsonb, 'published', ARRAY['org'], 'single',
+               $7, $8, $9)
        RETURNING id`,
       [
         WS,
@@ -189,6 +192,15 @@ describeIfPg("correction audit row (real Postgres)", () => {
         opts.object,
         episodeId,
         JSON.stringify({ source: "slack", actor: "U1" }),
+        // Keyed like an ingested row (#5020). These tests assert audit-row
+        // SHAPE, so they pass either way today — but `correct_fact`'s supersede
+        // verb runs the pivoted corroboration and tension lookups, and an
+        // unkeyed seed is a corpus state the ingest path cannot produce. The
+        // next assertion anyone adds here about corroboration or tension edges
+        // would be silently vacuous against it.
+        slotKey(opts.subject, identityAlias),
+        slotKey(opts.predicate, identityAlias),
+        slotKey(opts.object, identityAlias),
       ],
     );
     const factId = rows[0]?.id;

--- a/packages/api/src/lib/brain/__tests__/correction.test.ts
+++ b/packages/api/src/lib/brain/__tests__/correction.test.ts
@@ -58,6 +58,7 @@ import {
   INSERT_SUPERSEDES_EDGES_SQL,
   SUPERSEDE_STAMP_SQL,
 } from "@atlas/api/lib/content-mode/adapters/brain-facts";
+import { identityAlias, slotKey } from "@atlas/api/lib/brain/identity";
 import { BrainReaderUnresolvedError } from "@atlas/api/lib/brain/reader-context";
 import type { BrainPrincipalContext } from "@atlas/api/lib/brain/acl";
 
@@ -93,6 +94,14 @@ interface StoredFact {
   subject: string;
   predicate: string;
   object: string;
+  /**
+   * The materialized identity (#5020) — what reconcile's two lookups match on.
+   * A seeded fact stands for a row already in the corpus, so `seedFact` keys it
+   * the way the ingest path would; the reconcile INSERT arm records the keys it
+   * was actually BOUND, which is what would catch a stage that stopped
+   * supplying them.
+   */
+  slot: { subject: string | null; predicate: string | null; object: string | null };
   /** Set only by the reconcile insert; seeded facts default to null. */
   validFrom?: string | null;
   status: string;
@@ -105,6 +114,22 @@ interface StoredFact {
   /** Simulates the ACL predicate: a hidden fact never comes back. */
   hidden?: boolean;
 }
+
+/** Three consecutive key binds, read positionally — `null` survives as `null`. */
+function slotParams(
+  params: readonly unknown[],
+  from: number,
+): { subject: string | null; predicate: string | null; object: string | null } {
+  const at = (i: number): string | null => {
+    const v = params[from + i];
+    return v === null || v === undefined ? null : String(v);
+  };
+  return { subject: at(0), predicate: at(1), object: at(2) };
+}
+
+/** Postgres `=` / `<>`: both UNKNOWN — never a match — when either side is NULL. */
+const sqlEq = (a: string | null, b: string | null): boolean => a !== null && b !== null && a === b;
+const sqlNe = (a: string | null, b: string | null): boolean => a !== null && b !== null && a !== b;
 
 interface StoredEpisode {
   id: string;
@@ -140,7 +165,7 @@ class FakeCorrectionStore {
   };
 
   seedFact(partial: Partial<StoredFact> & { id: string }): StoredFact {
-    const fact: StoredFact = {
+    const base = {
       subject: "Billing",
       predicate: "is owned by",
       object: "Ana",
@@ -152,6 +177,19 @@ class FakeCorrectionStore {
       invalidatedAt: null,
       sourceEpisodeId: "ep-src",
       ...partial,
+    };
+    const fact: StoredFact = {
+      // Keyed through the SAME function the ingest path calls, so a seeded row
+      // stands for a real corpus row rather than for a hand-written key that
+      // happens to agree with one. An explicit `slot` in `partial` still wins —
+      // that is how a test seeds the unkeyed rows a region import leaves
+      // behind (#5035).
+      slot: {
+        subject: slotKey(base.subject, identityAlias),
+        predicate: slotKey(base.predicate, identityAlias),
+        object: slotKey(base.object, identityAlias),
+      },
+      ...base,
     };
     this.facts.push(fact);
     return fact;
@@ -283,12 +321,12 @@ class FakeCorrectionStore {
     // ── reconcile's statements (the supersede replacement path) ─────────
     if (sql === RECONCILE_LOCK_SQL) return { rows: [] };
     if (sql === CORROBORATION_LOOKUP_SQL) {
-      const [, subject, predicate, object] = params;
+      const slot = slotParams(params, 1);
       const existing = this.facts.find(
         (f) =>
-          f.subject === subject &&
-          f.predicate === predicate &&
-          f.object === object &&
+          sqlEq(f.slot.subject, slot.subject) &&
+          sqlEq(f.slot.predicate, slot.predicate) &&
+          sqlEq(f.slot.object, slot.object) &&
           f.invalidatedAt === null &&
           f.validTo === null,
       );
@@ -301,6 +339,7 @@ class FakeCorrectionStore {
         subject: String(params[1]),
         predicate: String(params[2]),
         object: String(params[3]),
+        slot: slotParams(params, 10),
         validFrom: params[4] === null ? null : String(params[4]),
         status: "draft",
         cardinality: String(params[9]),
@@ -335,12 +374,13 @@ class FakeCorrectionStore {
     // replacement BEFORE stamping the target, the target would show up here
     // and the supersede test's no-tension-edge assertion would fail.
     if (sql === TENSION_CANDIDATES_SQL) {
-      const [, subject, predicate, object, selfId] = params;
+      const slot = slotParams(params, 1);
+      const selfId = params[4];
       const rivals = this.facts.filter(
         (f) =>
-          f.subject === subject &&
-          f.predicate === predicate &&
-          f.object !== object &&
+          sqlEq(f.slot.subject, slot.subject) &&
+          sqlEq(f.slot.predicate, slot.predicate) &&
+          sqlNe(f.slot.object, slot.object) &&
           f.id !== selfId &&
           f.invalidatedAt === null &&
           f.validTo === null,
@@ -1021,6 +1061,72 @@ describe("supersede", () => {
       reason: CORRECTION_REFUSAL_REASONS.replacementIdentical,
     });
     expect(store.episodes).toHaveLength(0);
+  });
+
+  test("refuses a replacement that restates the object in a DIFFERENT SPELLING (#5020)", async () => {
+    // "Restates what the fact already says" has to mean what the rest of the
+    // system means by the same claim, and since #5020 that is the slot key.
+    // Left byte-exact, this guard would pass `Bob` → `bob` through to
+    // `SUPERSEDE_STAMP_SQL`: a published belief closed and replaced by a
+    // successor in the IDENTICAL slot, with a `supersedes` edge recording an
+    // arbitration that settled nothing — the irreversible direction, reached
+    // through a spelling difference.
+    // Case, edge whitespace, and — on a multi-token object — the separator
+    // class. NOT `A_N-A`: interior separators norm to spaces, so that is
+    // `a n a` and a genuinely different slot, which is the line the lexical
+    // layer is drawing.
+    for (const [target, restatement] of [
+      ["Ana", "ana"],
+      ["Ana", "  ANA  "],
+      ["Deploy Box", "deploy_box"],
+      ["Deploy Box", "DEPLOY-BOX"],
+    ] as const) {
+      const store = new FakeCorrectionStore();
+      store.seedFact({ id: "old", object: target });
+      const outcome = await run(store, {
+        factId: "old",
+        verb: "supersede",
+        replacement: { object: restatement },
+      });
+      expect(outcome, `${JSON.stringify(restatement)} was accepted as a new claim`).toMatchObject({
+        kind: "refused",
+        reason: CORRECTION_REFUSAL_REASONS.replacementIdentical,
+      });
+      // Refused BEFORE any write — no correction episode, and no stamp.
+      expect(store.episodes).toHaveLength(0);
+      expect(store.fact("old").validTo).toBeNull();
+    }
+  });
+
+  test("still accepts a replacement that lands in a genuinely different slot", async () => {
+    // The positive control for the arm above: the guard must not have become a
+    // blanket refusal. `Bo` is not a spelling of `Ana`.
+    const store = new FakeCorrectionStore();
+    store.seedFact({ id: "old", object: "Ana" });
+    const outcome = await run(store, {
+      factId: "old",
+      verb: "supersede",
+      replacement: { object: "Bo" },
+    });
+    expect(outcome.kind).toBe("corrected");
+  });
+
+  test("refuses when BOTH objects norm away — there is no belief to retire", async () => {
+    // Two surfaces with no identity are not two claims; `slotKey` returns null
+    // for each, and the conservative arm is the one that does not stamp
+    // `valid_to` on a row that asserts nothing.
+    const store = new FakeCorrectionStore();
+    store.seedFact({ id: "old", object: "-" });
+    const outcome = await run(store, {
+      factId: "old",
+      verb: "supersede",
+      replacement: { object: "___" },
+    });
+    expect(outcome).toMatchObject({
+      kind: "refused",
+      reason: CORRECTION_REFUSAL_REASONS.replacementIdentical,
+    });
+    expect(store.fact("old").validTo).toBeNull();
   });
 
   test("refuses a draft target with a pointer to retract instead", async () => {

--- a/packages/api/src/lib/brain/__tests__/extract-reconcile-pg.test.ts
+++ b/packages/api/src/lib/brain/__tests__/extract-reconcile-pg.test.ts
@@ -332,6 +332,220 @@ describeIfPg("brain extraction + reconcile (real Postgres)", () => {
     );
   });
 
+  // ── claim identity (#5020, ADR-0037 §1) ─────────────────────────────────
+  //
+  // The write side and the two lookups that now read it. Only a live schema
+  // settles these: the unit suite's fake records what the stage BOUND, which
+  // cannot tell a correct bind from one the column list drops on the floor —
+  // an INSERT naming ten columns and passing thirteen params errors, but one
+  // whose keys land in the wrong columns does not.
+
+  /** The stored identity of every fact, in insertion order. */
+  async function slots(): Promise<
+    { subject_key: string | null; predicate_key: string | null; object_key: string | null }[]
+  > {
+    const { rows } = await pool.query(
+      `SELECT subject_key, predicate_key, object_key FROM brain_facts ORDER BY ingested_at, id`,
+    );
+    return rows;
+  }
+
+  it("materializes all three keys on a new fact, off the RESOLVED surfaces", async () => {
+    const episode = await insertEpisode({ sourceId: "C01:key-1" });
+    await reconcileFacts({
+      episode,
+      candidates: [candidate({ subject: "Deploy_Window", predicate: "Ships  On" })],
+      producer: "p",
+      extractedAt: new Date(),
+      // The key must describe the row that was STORED, so it is derived after
+      // resolution — not from the candidate's raw surface.
+      resolveEntity: (surface) =>
+        surface === "Deploy_Window" ? { canonical: "The Deploy Box" } : { canonical: surface },
+    });
+
+    expect(await slots()).toEqual([
+      { subject_key: "the deploy box", predicate_key: "ships on", object_key: "thursdays" },
+    ]);
+    // The retained surface is the resolver's canonical form, untouched by the
+    // fold — identity moved, the record of the claim did not.
+    expect((await facts())[0]).toMatchObject({ subject: "The Deploy Box" });
+  });
+
+  it("⭐ corroborates across a phrasing difference — the slot, not the spelling", async () => {
+    // THE behaviour this slice buys, end to end. Byte-exactness minted a second
+    // draft here and the reviewer got two rows asserting one thing; the keys
+    // make the second observation strengthen the first.
+    const first = await insertEpisode({ sourceId: "C01:key-2" });
+    const second = await insertEpisode({ sourceId: "C01:key-3" });
+
+    // Every one of the three arms varies, so each is load-bearing here —
+    // mutation-checked one at a time.
+    await reconcileFacts({
+      episode: first,
+      candidates: [candidate({ subject: "deploy_window", predicate: "ships_on", object: "Thursdays" })],
+      producer: "p",
+      extractedAt: new Date(),
+    });
+    const report = await reconcileFacts({
+      episode: second,
+      candidates: [candidate({ subject: "Deploy Window", predicate: "Ships On", object: "thursdays" })],
+      producer: "p",
+      extractedAt: new Date(),
+    });
+
+    expect(report.corroborated).toBe(1);
+    const stored = await facts();
+    expect(stored).toHaveLength(1);
+    // The FIRST phrasing is what the corpus keeps; the second episode arrives
+    // as evidence on the row that already exists.
+    expect(stored[0]).toMatchObject({ subject: "deploy_window" });
+    expect((await edges()).filter((e) => e.edge_type === "provenance")).toHaveLength(2);
+  });
+
+  it("does NOT unify what the vocabulary owns — `is priced at` is not `priced at`", async () => {
+    // The refusal the lexical layer is built around. Collapsing these is a
+    // curated entry with a reviewer behind it (ADR-0037 §6 / #5016), because the same rule
+    // applied generally folds `is owned by` into `owns` — and `led_by`/`leads`,
+    // which are INVERSE relations, into one slot whose join arm stamps
+    // `valid_to`.
+    const first = await insertEpisode({ sourceId: "C01:key-4" });
+    const second = await insertEpisode({ sourceId: "C01:key-5" });
+
+    await reconcileFacts({
+      episode: first,
+      candidates: [candidate({ predicate: "is priced at" })],
+      producer: "p",
+      extractedAt: new Date(),
+    });
+    const report = await reconcileFacts({
+      episode: second,
+      candidates: [candidate({ predicate: "priced at" })],
+      producer: "p",
+      extractedAt: new Date(),
+    });
+
+    expect(report.corroborated).toBe(0);
+    expect(await facts()).toHaveLength(2);
+  });
+
+  it("keys a surface that norms away as NULL, and NULL corroborates nothing", async () => {
+    // `-` and `___` survive the MALFORMED_CLAIM guard (`trim` strips whitespace,
+    // not `_` or `-`), so they are storable claims with no slot. They must NOT
+    // share one: a stored `''` — or a NULL-safe join arm — would file every
+    // placeholder in the corpus under one key, and at `single` cardinality
+    // publishing either would stamp `valid_to` on the other.
+    //
+    // What the column read below pins is that `slotKey` returned `null` rather
+    // than `""` — NOT that no `DEFAULT ''` exists, since `INSERT_FACT_SQL` now
+    // binds `object_key` explicitly and an explicit NULL always beats a default.
+    // `identity-pg.test.ts` introspects the column for the default itself.
+    const first = await insertEpisode({ sourceId: "C01:key-6" });
+    const second = await insertEpisode({ sourceId: "C01:key-7" });
+
+    await reconcileFacts({
+      episode: first,
+      candidates: [candidate({ object: "-" })],
+      producer: "p",
+      extractedAt: new Date(),
+    });
+    const report = await reconcileFacts({
+      episode: second,
+      candidates: [candidate({ object: "___" })],
+      producer: "p",
+      extractedAt: new Date(),
+    });
+
+    expect(report.corroborated).toBe(0);
+    const stored = await facts();
+    expect(stored).toHaveLength(2);
+    // The degenerate SURFACES survive to the column verbatim — a reviewer has
+    // to be able to see what the producer emitted in order to repair it.
+    expect(stored.map((f) => f.object)).toEqual(["-", "___"]);
+    for (const slot of await slots()) {
+      expect(slot.object_key).toBeNull();
+      expect(slot.subject_key).toBe("deploy window");
+    }
+  });
+
+  it("flags a tension the phrasing used to hide — the rival scan is the slot too", async () => {
+    // The first row of #5020's consumer table. Two `single`-cardinality claims
+    // about one slot, spelled differently: on the surface columns the rival scan
+    // matched nothing, so the second claim landed with no `in-tension-with` edge
+    // and the reviewer saw two uncontested facts where there was a genuine
+    // contradiction. Mutation-checked — reverting the SUBJECT or PREDICATE arm
+    // of `TENSION_CANDIDATES_SQL` to the surfaces turns this red. The OBJECT arm
+    // needs a degenerate rival to distinguish it, which is the next case: here
+    // `Grace` and `Alan` differ on the surface and on the key alike.
+    const first = await insertEpisode({ sourceId: "C01:key-8" });
+    const second = await insertEpisode({ sourceId: "C01:key-9" });
+
+    await reconcileFacts({
+      episode: first,
+      candidates: [
+        candidate({
+          subject: "Ada",
+          predicate: "Reports_To",
+          object: "Grace",
+          predicateCardinality: "single",
+        }),
+      ],
+      producer: "p",
+      extractedAt: new Date(),
+    });
+    const report = await reconcileFacts({
+      episode: second,
+      candidates: [
+        candidate({
+          subject: "ada",
+          predicate: "reports to",
+          object: "Alan",
+          predicateCardinality: "single",
+        }),
+      ],
+      producer: "p",
+      extractedAt: new Date(),
+    });
+
+    // Two beliefs — the objects genuinely differ — and now they are visibly in
+    // tension. Advisory only: nothing was superseded or invalidated.
+    expect(report.outcomes[0]).toMatchObject({ kind: "created", tensionEdges: 1 });
+    expect(await facts()).toHaveLength(2);
+    expect((await edges()).filter((e) => e.edge_type === "in-tension-with")).toHaveLength(1);
+  });
+
+  it("a rival with NO object identity is not a rival — the object arm's falsifier", async () => {
+    // This is what makes `object_key <> $4` load-bearing rather than
+    // decorative, and it took a review to find: a live row in the same slot
+    // whose object is `-` has `object_key IS NULL`, so the corroboration
+    // lookup does not return it either (`object_key = $4` is unknown) and it
+    // survives to the rival scan. There the two spellings genuinely diverge —
+    // `object <> $4` is TRUE, `object_key <> $4` is unknown.
+    //
+    // Wiring the edge would be the worse outcome: a permanent advisory
+    // `in-tension-with` from a real claim to a placeholder that asserts
+    // nothing, shown to a reviewer as a contradiction to arbitrate.
+    const first = await insertEpisode({ sourceId: "C01:key-10" });
+    const second = await insertEpisode({ sourceId: "C01:key-11" });
+
+    await reconcileFacts({
+      episode: first,
+      candidates: [candidate({ object: "-", predicateCardinality: "single" })],
+      producer: "p",
+      extractedAt: new Date(),
+    });
+    const report = await reconcileFacts({
+      episode: second,
+      candidates: [candidate({ object: "Thursdays", predicateCardinality: "single" })],
+      producer: "p",
+      extractedAt: new Date(),
+    });
+
+    // Two facts — the degenerate one could not corroborate — and NO edge.
+    expect(report.outcomes[0]).toMatchObject({ kind: "created", tensionEdges: 0 });
+    expect(await facts()).toHaveLength(2);
+    expect((await edges()).filter((e) => e.edge_type === "in-tension-with")).toHaveLength(0);
+  });
+
   it("records an advisory in-tension-with edge without invalidating anything", async () => {
     const first = await insertEpisode({ sourceId: "C01:3" });
     const second = await insertEpisode({ sourceId: "C01:4" });

--- a/packages/api/src/lib/brain/__tests__/extract.test.ts
+++ b/packages/api/src/lib/brain/__tests__/extract.test.ts
@@ -221,10 +221,15 @@ describe("llmFactExtractor", () => {
     { subject: "deploy window", predicate: "is", object: "Thursdays", cardinality: "multi" },
   ];
 
-  test("pins temperature to 0 — the dedupe it feeds is byte-exact", async () => {
+  test("pins temperature to 0 — the dedupe it feeds is lexical, not semantic", async () => {
     // Not a quality preference: the reconcile stage collapses a re-extraction
-    // only when the model reproduces its own output verbatim, and re-extraction
-    // after a crash is the whole idempotence story.
+    // only when the model reproduces its own output closely enough to land in
+    // the same SLOT, and re-extraction after a crash is the whole idempotence
+    // story. Since #5020 that slot is `alias(lexicalNorm(surface))`, so a
+    // re-phrasing that differs only in case or separators now collapses too —
+    // the same determinism argument at a coarser grain. It is still nowhere
+    // near enough to cover "is" vs "is on", which is why the temperature is
+    // pinned rather than relied upon to matter less.
     const { model, calls } = modelReturning(oneFact);
     await llmFactExtractor({ episode, body: "hello", model, modelId: "m" });
     expect(calls[0]?.temperature).toBe(0);

--- a/packages/api/src/lib/brain/__tests__/identity.test.ts
+++ b/packages/api/src/lib/brain/__tests__/identity.test.ts
@@ -13,7 +13,12 @@
  */
 
 import { describe, expect, it } from "bun:test";
-import { identityKey, lexicalNorm } from "@atlas/api/lib/brain/identity";
+import {
+  identityAlias,
+  identityKey,
+  lexicalNorm,
+  slotKey,
+} from "@atlas/api/lib/brain/identity";
 import { DEGENERATE_SURFACES, PAIRED_SURFACES } from "./identity-fixtures";
 
 describe("lexicalNorm", () => {
@@ -85,6 +90,99 @@ describe("lexicalNorm", () => {
       // why the arm above is a live rule rather than defence in depth.
       expect("-".trim()).not.toBe("");
       expect("___".trim()).not.toBe("");
+    });
+  });
+
+  describe("slotKey — the whole composition (#5020)", () => {
+    it("is `identityKey` while the vocabulary is empty", () => {
+      // The day-one claim, and the reason #5019's slice changed no behaviour:
+      // `alias` is the identity function, so every key produced today is
+      // exactly what migration 0187's backfill wrote.
+      for (const surface of ["Owned_By", "  Reports   To  ", "led_by", "leads", "$499"]) {
+        expect(slotKey(surface, identityAlias), surface).toBe(identityKey(surface));
+      }
+      for (const degenerate of DEGENERATE_SURFACES) {
+        expect(slotKey(degenerate, identityAlias)).toBeNull();
+      }
+    });
+
+    it("composes the vocabulary OVER the norm, not over the surface", () => {
+      // The seam's shape, which is what this slice pins. An entry maps a
+      // NORMALIZED spelling, so one entry covers every casing and separator
+      // variant of both sides — a lookup keyed on raw surfaces would need
+      // `Is_Priced At`, `IS PRICED AT`, and the rest spelled out.
+      const seen: string[] = [];
+      const vocabulary = (norm: string): string => {
+        seen.push(norm);
+        return norm === "is priced at" ? "priced at" : norm;
+      };
+
+      expect(slotKey("Is_Priced  At", vocabulary)).toBe("priced at");
+      expect(slotKey("priced at", vocabulary)).toBe("priced at");
+      expect(seen).toEqual(["is priced at", "priced at"]);
+    });
+
+    it("never consults the vocabulary for a surface that asserts nothing", () => {
+      // A claim whose subject norms away has no slot to look up, so there is
+      // nothing for an entry to map — and calling out with `""` would invite a
+      // vocabulary that answers it.
+      let consulted = 0;
+      const vocabulary = (norm: string): string => {
+        consulted++;
+        return norm;
+      };
+      for (const degenerate of DEGENERATE_SURFACES) {
+        expect(slotKey(degenerate, vocabulary)).toBeNull();
+      }
+      expect(consulted).toBe(0);
+    });
+
+    it("RE-NORMS the vocabulary's answer instead of trusting it", () => {
+      // The failure this defends against is an authoring mistake, not a bug: an
+      // admin types the canonical DISPLAY form as an entry's target. Trusted
+      // verbatim, `Priced At` is a key that joins nothing to anything,
+      // corpus-wide, with nothing anywhere saying so.
+      //
+      // A vocabulary that does NOT already return norms, on purpose — a
+      // conforming one cannot tell `alias(norm)` from `identityKey(alias(norm))`
+      // and would make this assertion unfalsifiable.
+      expect(slotKey("is_priced  at", () => "Priced   At")).toBe("priced at");
+      // …and the empty-key arm falls out of the same call rather than being a
+      // special case: a target that norms away is the `DEFAULT ''` hazard
+      // reached from the vocabulary side, and `null` joins nothing.
+      expect(slotKey("owned by", () => "")).toBeNull();
+      expect(slotKey("owned by", () => " - _ ")).toBeNull();
+    });
+
+    it("leaves the fixpoint intact — a key re-keys to itself", () => {
+      // `f(f(x)) === f(x)`, which is what lets ADR-0037 §7's drift re-key run
+      // over a corpus without walking rows to a new slot on each pass. Driven
+      // off the shared corpus with the REAL default alias, rather than off a
+      // hand-written vocabulary that satisfies idempotence by construction.
+      for (const surface of [
+        ...PAIRED_SURFACES.inverseRelations,
+        ...PAIRED_SURFACES.copulaPair,
+        ...PAIRED_SURFACES.caseFold,
+        ...PAIRED_SURFACES.nonAsciiSpace,
+        "  __Reports-_ To\t\t",
+        "$499",
+      ]) {
+        const once = slotKey(surface, identityAlias);
+        if (once === null) continue;
+        expect(
+          slotKey(once, identityAlias),
+          `${JSON.stringify(surface)} does not re-key to itself`,
+        ).toBe(once);
+      }
+    });
+
+    it("identityAlias returns its input unchanged, including the empty norm", () => {
+      // Only `identityAlias` itself is pinned here. That the DEFAULT is this
+      // function is not separately assertable — any identity-behaving default
+      // satisfies the same equality — and the day-one equivalence above
+      // (`slotKey === identityKey` across the corpus) is what covers it.
+      expect(identityAlias("owned by")).toBe("owned by");
+      expect(identityAlias("")).toBe("");
     });
   });
 

--- a/packages/api/src/lib/brain/__tests__/multi-source-pg.test.ts
+++ b/packages/api/src/lib/brain/__tests__/multi-source-pg.test.ts
@@ -11,7 +11,8 @@
  * at once, which is the one thing a per-connector suite cannot pose:
  *
  *   1. **Cross-class corroboration.** `CORROBORATION_LOOKUP_SQL` matches on
- *      workspace+subject+predicate+object and is deliberately blind to source,
+ *      the workspace plus the three SLOT KEYS (#5020) and is deliberately blind
+ *      to source,
  *      so a claim said in a meeting and repeated in a mail must strengthen ONE
  *      row rather than mint two. This is the first time that lookup sees two
  *      genuinely different classes, and the failure mode is silent: two rows
@@ -529,10 +530,13 @@ type Candidate = {
  * The claim asserted in BOTH classes — ONE object, referenced twice.
  *
  * Deliberately a shared constant rather than two literals: corroboration matches
- * on subject+predicate+object exactly, so two hand-spelled copies would drift on
- * the first edit and the file's flagship assertion would silently become "two
- * unrelated facts were created", which is also what a BROKEN corroboration looks
- * like. One binding makes the two observations the same claim by construction.
+ * on the three slot keys, so two hand-spelled copies would drift on the first
+ * edit and the file's flagship assertion would silently become "two unrelated
+ * facts were created", which is also what a BROKEN corroboration looks like. One
+ * binding makes the two observations the same claim by construction. (Since
+ * #5020 a drift confined to case or separators would still corroborate, so the
+ * shared constant guards a narrower class than it once did — but a reworded
+ * subject is still the failure it was, and that is the likelier edit.)
  */
 const CORROBORATED_CLAIM: Candidate = {
   subject: "Q3 revenue target",
@@ -1683,8 +1687,9 @@ describeIfPg("brain M3 multi-source loop (real Postgres)", () => {
 
       // ---- 7. the human gate arbitrates ACROSS classes ---------------------
       // Advisory tension is not arbitration; a reviewer publishing IS. The gate
-      // picks by the supersession collision — subject+predicate+`single` — and
-      // is blind to class, which is the property this step pins.
+      // picks by the supersession collision — the (subject, predicate) SLOT
+      // plus `single` on both sides — and is blind to class, which is the
+      // property this step pins.
       const gate = await publish();
       expect(gate.promoted).toBe(1);
       expect(gate.refused).toEqual([]);

--- a/packages/api/src/lib/brain/__tests__/promotion-pg.test.ts
+++ b/packages/api/src/lib/brain/__tests__/promotion-pg.test.ts
@@ -41,6 +41,7 @@ import {
   aclVisibilityClause,
   resolvePrincipalContext,
 } from "@atlas/api/lib/brain/acl";
+import { identityAlias, slotKey } from "@atlas/api/lib/brain/identity";
 import { FACT_REFUSAL_REASONS } from "@atlas/api/lib/brain/promotion";
 import { CORROBORATION_LOOKUP_SQL } from "@atlas/api/lib/brain/reconcile";
 import { loadSupersessionPreview } from "@atlas/api/lib/brain/oversight";
@@ -1237,22 +1238,47 @@ describeIfPg("brain fact review gate (real Postgres)", () => {
       episodeId: string;
       subject: string;
       object: string;
+      /** Defaults to `manager`; override to vary the PREDICATE slot. */
+      predicate?: string;
       cardinality?: "single" | "multi";
       status?: "draft" | "published";
+      /**
+       * Land the row UNKEYED — all three key columns NULL — which is what a
+       * region import produces today (`admin-migrate.ts`'s 18-column INSERT
+       * names none of them, #5035) and what every row written between migration
+       * 0187 and #5020 looked like before 0188's backfill repeat.
+       */
+      unkeyed?: boolean;
     }): Promise<string> {
+      const predicate = opts.predicate ?? "manager";
+      // Keyed like an ingested row (#5020): the collision join and the
+      // corroboration lookup both match on `*_key`, so a seed that omitted them
+      // would be an UNKEYED row — a legitimate corpus state (0187's interval,
+      // and a region import until #5035) but not the one these tests are about,
+      // and one that collides with nothing. Derived through `slotKey`, the same
+      // function `INSERT_FACT_SQL` calls, rather than hand-written beside the
+      // surface where the two could quietly disagree. (`INSERT_FACT_SQL` is a
+      // string constant; the function is what `reconcile.ts` calls when binding
+      // it.)
       const { rows } = await pool.query<{ id: string }>(
         `INSERT INTO brain_facts
            (workspace_id, subject, predicate, object, source_episode_id,
-            provenance, status, visible_to, predicate_cardinality)
-         VALUES ($1, $2, 'manager', $3, $4, '{"actor":"test"}'::jsonb, $5, '{org}', $6)
+            provenance, status, visible_to, predicate_cardinality,
+            subject_key, predicate_key, object_key)
+         VALUES ($1, $2, $3, $4, $5, '{"actor":"test"}'::jsonb, $6, '{org}', $7,
+                 $8, $9, $10)
          RETURNING id`,
         [
           opts.workspaceId,
           opts.subject,
+          predicate,
           opts.object,
           opts.episodeId,
           opts.status ?? "draft",
           opts.cardinality ?? "single",
+          opts.unkeyed === true ? null : slotKey(opts.subject, identityAlias),
+          opts.unkeyed === true ? null : slotKey(predicate, identityAlias),
+          opts.unkeyed === true ? null : slotKey(opts.object, identityAlias),
         ],
       );
       return rows[0]!.id;
@@ -1461,17 +1487,23 @@ describeIfPg("brain fact review gate (real Postgres)", () => {
         await publish(ws);
         expect((await factState(old)).valid_to).not.toBeNull();
 
-        // The exact string `reconcile.ts` runs. "alice manager bob" flips back:
+        // The exact string `reconcile.ts` runs, bound the way it binds it — the
+        // SLOT KEYS, not the surfaces (#5020). "alice manager bob" flips back:
         // the superseded row must NOT absorb the evidence — it is hidden from
         // every as-of-now read, so corroborating it would swallow the flip.
-        const back = await pool.query(CORROBORATION_LOOKUP_SQL, [ws, "alice", "manager", "bob"]);
+        const back = await pool.query(CORROBORATION_LOOKUP_SQL, [
+          ws,
+          slotKey("alice", identityAlias),
+          slotKey("manager", identityAlias),
+          slotKey("bob", identityAlias),
+        ]);
         expect(back.rows).toEqual([]);
         // The CURRENT claim still corroborates normally.
         const current = await pool.query<{ id: string }>(CORROBORATION_LOOKUP_SQL, [
           ws,
-          "alice",
-          "manager",
-          "carol",
+          slotKey("alice", identityAlias),
+          slotKey("manager", identityAlias),
+          slotKey("carol", identityAlias),
         ]);
         expect(current.rows.map((r) => r.id)).toEqual([draft]);
       },
@@ -1527,6 +1559,228 @@ describeIfPg("brain fact review gate (real Postgres)", () => {
     );
 
     it(
+      "⭐ supersedes across a phrasing difference — the collision is the SLOT (#5020)",
+      async () => {
+        // The third consumer's half of #5020, end to end. On the surface
+        // columns this pair did not collide: `p.subject = d.subject` is false
+        // for `alice` vs `Alice`, so publish left TWO current `single` values
+        // standing, the will-supersede disclosure showed nothing, and nothing
+        // anywhere said so. Nothing about the two rows changed — only what
+        // counts as the same slot.
+        const ws = "ws-5020-phrasing";
+        const ep = await seedEpisode(ws, "phrasing");
+        const old = await seedFact({
+          workspaceId: ws,
+          episodeId: ep,
+          subject: "alice",
+          object: "bob",
+          status: "published",
+        });
+        const draft = await seedFact({
+          workspaceId: ws,
+          episodeId: ep,
+          // Same slot, different spelling — case AND separator, on BOTH the
+          // subject and the predicate, so each key arm is load-bearing here.
+          subject: "Alice",
+          predicate: "Manager",
+          object: "carol",
+        });
+
+        // Disclosed before the admin confirms, and disclosed as the SAME pair
+        // the transaction then stamps — the two must not drift.
+        const reader = await resolvePrincipalContext(pool, {
+          workspaceId: ws,
+          mode: "managed",
+          userId: "u1",
+          resolvedRole: { role: "owner", orgId: ws },
+        });
+        const preview = await loadSupersessionPreview(pool, reader);
+        expect(preview.total).toBe(1);
+        expect(preview.pairs.map((p) => [p.draftId, p.supersededId])).toEqual([[draft, old]]);
+        // Both LABELS carry the surfaces the producers actually used — the keys
+        // decide the collision and never reach the reviewer's screen.
+        expect(preview.pairs[0]).toMatchObject({
+          draftLabel: "Alice Manager carol",
+          supersededLabel: "alice manager bob",
+        });
+
+        const report = await publish(ws);
+        expect(report.superseded).toEqual([{ rowId: draft, superseded: [old] }]);
+        expect((await factState(old)).valid_to).not.toBeNull();
+        expect(await supersedesEdges(ws)).toEqual([{ f: draft, t: old }]);
+      },
+      PG_TEST_TIMEOUT_MS,
+    );
+
+    it(
+      "does NOT supersede a rival whose OBJECT is the same slot spelled differently",
+      async () => {
+        // The object arm, and the direction that actually costs something. On
+        // the surfaces `p.object <> d.object` is TRUE for `Bob` vs `bob`, so
+        // publishing the draft stamped `valid_to` on a published fact asserting
+        // THE SAME THING — retiring a belief nobody contradicted, invisibly,
+        // because every as-of-now read then hides the row it touched. On the
+        // keys the pair is one claim and the two coexist.
+        //
+        // Reachable without reconcile ever minting the pair: every row written
+        // before #5020 was stored under byte-exact identity, so `Bob` and `bob`
+        // were two claims and both are live — and migration 0187's backfill then
+        // keyed them into ONE slot. (NOT via a region import, which is the
+        // obvious guess and is wrong: `admin-migrate.ts`'s 18-column INSERT
+        // names no key column, so an imported row lands UNKEYED and drops out of
+        // this join entirely rather than colliding.)
+        const ws = "ws-5020-object";
+        const ep = await seedEpisode(ws, "object-slot");
+        const old = await seedFact({
+          workspaceId: ws,
+          episodeId: ep,
+          subject: "alice",
+          object: "bob",
+          status: "published",
+        });
+        const draft = await seedFact({
+          workspaceId: ws,
+          episodeId: ep,
+          subject: "alice",
+          object: "Bob",
+        });
+
+        const report = await publish(ws);
+        expect(report.promoted).toBe(1);
+        expect(report.superseded).toEqual([]);
+        expect((await factState(old)).valid_to).toBeNull();
+        expect((await factState(draft)).valid_to).toBeNull();
+        expect(await supersedesEdges(ws)).toEqual([]);
+      },
+      PG_TEST_TIMEOUT_MS,
+    );
+
+    it(
+      "an UNKEYED row supersedes nothing and is superseded by nothing — fail-closed, in both directions",
+      async () => {
+        // The state that dominates the corpus this deploys onto, and the one
+        // the new seeder would otherwise have erased from the suite: a row a
+        // region import landed (#5035), or one written in the 0187→#5020 window
+        // that 0188's backfill has not reached. `=` and `<>` are both UNKNOWN
+        // against NULL, so such a row drops out of `supersessionCollisionJoin`
+        // entirely — from BOTH sides, which is the half the docstring claims
+        // and nothing pinned.
+        //
+        // Fail-closed is the right direction (no collision ⇒ no `valid_to`
+        // stamp ⇒ nothing irreversible), but it is not free: the pair below
+        // WOULD collide if either row were keyed, and the reviewer is shown an
+        // affirmative "this publish supersedes nothing".
+        const ws = "ws-5020-unkeyed";
+        const ep = await seedEpisode(ws, "unkeyed");
+
+        // (a) unkeyed PUBLISHED incumbent, keyed draft that would replace it.
+        const oldUnkeyed = await seedFact({
+          workspaceId: ws,
+          episodeId: ep,
+          subject: "alice",
+          object: "bob",
+          status: "published",
+          unkeyed: true,
+        });
+        const draftKeyed = await seedFact({
+          workspaceId: ws,
+          episodeId: ep,
+          subject: "alice",
+          object: "carol",
+        });
+        // (b) the converse — keyed incumbent, unkeyed draft.
+        const oldKeyed = await seedFact({
+          workspaceId: ws,
+          episodeId: ep,
+          subject: "dana",
+          object: "erin",
+          status: "published",
+        });
+        const draftUnkeyed = await seedFact({
+          workspaceId: ws,
+          episodeId: ep,
+          subject: "dana",
+          object: "frank",
+          unkeyed: true,
+        });
+
+        const reader = await resolvePrincipalContext(pool, {
+          workspaceId: ws,
+          mode: "managed",
+          userId: "u1",
+          resolvedRole: { role: "owner", orgId: ws },
+        });
+        // Disclosed as "nothing to supersede", because the check could not run.
+        expect(await loadSupersessionPreview(pool, reader)).toMatchObject({
+          total: 0,
+          pairs: [],
+        });
+
+        const report = await publish(ws);
+        expect(report.promoted).toBe(2);
+        expect(report.superseded).toEqual([]);
+        for (const id of [oldUnkeyed, draftKeyed, oldKeyed, draftUnkeyed]) {
+          expect((await factState(id)).valid_to).toBeNull();
+        }
+        expect(await supersedesEdges(ws)).toEqual([]);
+      },
+      PG_TEST_TIMEOUT_MS,
+    );
+
+    it(
+      "a PARTIALLY keyed row does not collide either — the `<>` arm's own NULL case",
+      async () => {
+        // The unkeyed case above is decided by the `=` arms before the object
+        // arm is ever consulted, so it leaves `object_key <> object_key`
+        // unfalsified. This is that arm: both rows are in the SAME slot
+        // (`alice` / `manager`), and only the OBJECT key is NULL.
+        //
+        // Reachable straight off the ingest path — `reconcile.ts` stores
+        // `alice manager -` with two real keys and `object_key IS NULL`, and
+        // nothing in `classifyFactForPromotion` refuses it, so it is a
+        // promotable draft. Under a NULL-safe arm (`IS DISTINCT FROM`)
+        // publishing it would stamp `valid_to` on the real published belief in
+        // its slot — the irreversible write, spent on a placeholder.
+        const ws = "ws-5020-partial";
+        const ep = await seedEpisode(ws, "partial");
+        const published = await seedFact({
+          workspaceId: ws,
+          episodeId: ep,
+          subject: "alice",
+          object: "bob",
+          status: "published",
+        });
+        // `slotKey("-")` is null, so the seeder keys subject and predicate and
+        // leaves `object_key` NULL — exactly what the ingest path produces.
+        const placeholder = await seedFact({
+          workspaceId: ws,
+          episodeId: ep,
+          subject: "alice",
+          object: "-",
+        });
+
+        const reader = await resolvePrincipalContext(pool, {
+          workspaceId: ws,
+          mode: "managed",
+          userId: "u1",
+          resolvedRole: { role: "owner", orgId: ws },
+        });
+        expect(await loadSupersessionPreview(pool, reader)).toMatchObject({
+          total: 0,
+          pairs: [],
+        });
+
+        const report = await publish(ws);
+        expect(report.promoted).toBe(1);
+        expect(report.superseded).toEqual([]);
+        expect((await factState(published)).valid_to).toBeNull();
+        expect((await factState(placeholder)).valid_to).toBeNull();
+        expect(await supersedesEdges(ws)).toEqual([]);
+      },
+      PG_TEST_TIMEOUT_MS,
+    );
+
+    it(
       "withholds a pair whose PUBLISHED side the reader may not see — counted, never listed",
       async () => {
         const ws = "ws-4912-withheld";
@@ -1535,10 +1789,18 @@ describeIfPg("brain fact review gate (real Postgres)", () => {
         await pool.query(
           `INSERT INTO brain_facts
              (workspace_id, subject, predicate, object, source_episode_id,
-              provenance, status, visible_to, predicate_cardinality)
+              provenance, status, visible_to, predicate_cardinality,
+              subject_key, predicate_key, object_key)
            VALUES ($1, 'alice', 'manager', 'bob', $2, '{"actor":"t"}'::jsonb,
-                   'published', $3::text[], 'single')`,
-          [ws, privateEp, [SUPERSEDE_PRIVATE_GRANT]],
+                   'published', $3::text[], 'single', $4, $5, $6)`,
+          [
+            ws,
+            privateEp,
+            [SUPERSEDE_PRIVATE_GRANT],
+            slotKey("alice", identityAlias),
+            slotKey("manager", identityAlias),
+            slotKey("bob", identityAlias),
+          ],
         );
         await seedFact({
           workspaceId: ws,

--- a/packages/api/src/lib/brain/__tests__/reconcile.test.ts
+++ b/packages/api/src/lib/brain/__tests__/reconcile.test.ts
@@ -46,12 +46,41 @@ interface StoredFact {
   subject: string;
   predicate: string;
   object: string;
+  /**
+   * What the stage bound to the key columns (#5020). Stored SEPARATELY from the
+   * surfaces and matched on by the two lookups below, because that separation
+   * IS the behaviour under test: a fake that re-derived a key from the stored
+   * surface could not tell a stage that keys its rows from one that does not.
+   */
+  slot: { subject: string | null; predicate: string | null; object: string | null };
   provenance: Record<string, unknown>;
   visibleTo: string[];
   cardinality: string;
   validFrom: string | null;
   extractedAt: string | null;
 }
+
+/**
+ * Three consecutive key binds, read positionally — `null` stays `null` rather
+ * than becoming `"null"` through `String()`, which is the whole distinction
+ * these tests are about.
+ */
+function keyParams(
+  params: readonly unknown[],
+  from: number,
+): { subject: string | null; predicate: string | null; object: string | null } {
+  const at = (i: number): string | null => {
+    const v = params[from + i];
+    return v === null || v === undefined ? null : String(v);
+  };
+  return { subject: at(0), predicate: at(1), object: at(2) };
+}
+
+/** Postgres `=`: UNKNOWN (→ not a match) whenever either side is NULL. */
+const sqlEq = (a: string | null, b: string | null): boolean => a !== null && b !== null && a === b;
+
+/** Postgres `<>`: likewise UNKNOWN against a NULL, never "different". */
+const sqlNe = (a: string | null, b: string | null): boolean => a !== null && b !== null && a !== b;
 
 interface StoredEdge {
   workspaceId: string;
@@ -87,13 +116,18 @@ class FakeBrainStore {
         return { rows: [] };
       }
       case CORROBORATION_LOOKUP_SQL: {
-        const [workspaceId, subject, predicate, object] = params.map(String);
+        const [workspaceId] = params.map(String);
+        const slot = keyParams(params, 1);
         const hit = this.facts.find(
           (f) =>
             f.workspaceId === workspaceId &&
-            f.subject === subject &&
-            f.predicate === predicate &&
-            f.object === object,
+            // `=` against a NULL bind is UNKNOWN in Postgres, so a candidate
+            // whose surface norms away matches nothing — deliberately, since a
+            // NULL-safe comparison would make every degenerate claim
+            // corroborate every other one. Modelled, not assumed away.
+            sqlEq(f.slot.subject, slot.subject) &&
+            sqlEq(f.slot.predicate, slot.predicate) &&
+            sqlEq(f.slot.object, slot.object),
         );
         return { rows: hit ? [{ id: hit.id }] : [] };
       }
@@ -110,6 +144,7 @@ class FakeBrainStore {
           provenance: JSON.parse(String(params[7])) as Record<string, unknown>,
           visibleTo: JSON.parse(String(params[8])) as string[],
           cardinality: String(params[9]),
+          slot: keyParams(params, 10),
         });
         return { rows: [{ id }] };
       }
@@ -133,13 +168,17 @@ class FakeBrainStore {
         return { rows: [{ id: `edge-${++this.seq}` }] };
       }
       case TENSION_CANDIDATES_SQL: {
-        const [workspaceId, subject, predicate, object, selfId] = params.map(String);
+        const workspaceId = String(params[0]);
+        const slot = keyParams(params, 1);
+        const selfId = String(params[4]);
         const rivals = this.facts.filter(
           (f) =>
             f.workspaceId === workspaceId &&
-            f.subject === subject &&
-            f.predicate === predicate &&
-            f.object !== object &&
+            sqlEq(f.slot.subject, slot.subject) &&
+            sqlEq(f.slot.predicate, slot.predicate) &&
+            // `<>` is UNKNOWN against NULL on either side too — a NULL object
+            // key abstains OUT of tension rather than into it.
+            sqlNe(f.slot.object, slot.object) &&
             f.id !== selfId,
         );
         return { rows: rivals.map((f) => ({ id: f.id })) };
@@ -612,18 +651,128 @@ describe("the draft candidate", () => {
     ).rejects.toThrow("edge insert failed");
   });
 
-  test("identity is byte-exact — canonicalizing is the resolver's job, not this stage's", async () => {
+  test("identity is the slot key — a phrasing variant corroborates instead of forking (#5020)", async () => {
+    // The behaviour #5020 buys — pinned here at the level this file can reach.
+    // `Ships On` / `ships_on` differ in case AND separator, which is the whole
+    // of `lexicalNorm`, so this fails if the stage stops keying its binds.
+    //
+    // What it CANNOT catch, stated because the assertion looks stronger than it
+    // is: the store dispatches on SQL IDENTITY and reads the binds positionally,
+    // so it cannot see which COLUMNS the statement names. Repointing
+    // `CORROBORATION_LOOKUP_SQL` back at the surface columns leaves this green.
+    // What it DOES hold is the bind half — swapping `item.keys.*` back to the
+    // surface fields turns this file red. The COLUMN half is
+    // `extract-reconcile-pg.test.ts`'s (it runs the real strings against the
+    // real schema), with a cheap lexical backstop in the SQL-shape test below
+    // so a revert does not need `TEST_DATABASE_URL` to be caught.
     const store = new FakeBrainStore();
-    await run(store, { candidates: [candidate({ subject: "Alice" })] });
-    await run(store, {
+    await run(store, { candidates: [candidate({ predicate: "Ships On" })] });
+    const second = await run(store, {
       episode: episode({ id: "ep-2" }),
-      candidates: [candidate({ subject: "alice" })],
+      candidates: [candidate({ predicate: "ships_on" })],
     });
 
-    // Two facts, not one. A `lower()` comparison here would quietly take the
-    // "are these the same entity?" decision away from the seam that exists to
-    // make it — and make it globally, for every workspace, with no reviewer.
+    expect(second.corroborated).toBe(1);
+    expect(store.facts).toHaveLength(1);
+    // The RETAINED surface is untouched — identity moved, the record of what
+    // the producer actually said did not. The fact keeps the FIRST phrasing;
+    // the second episode arrives as evidence.
+    expect(store.facts[0]).toMatchObject({ predicate: "Ships On" });
+    expect(store.facts[0]!.slot).toMatchObject({ predicate: "ships on" });
+  });
+
+  test("the workspace's vocabulary reaches every slot, and a throwing one abstains", async () => {
+    // The `alias` seam, end to end through the stage. Without this the whole
+    // threading is unfalsifiable: the default IS `identityAlias`, so dropping
+    // `request.alias` — or dropping the second argument at the three `slotKey`
+    // calls — changes nothing observable and leaves the suite green.
+    const store = new FakeBrainStore();
+    const vocabulary = (norm: string): string =>
+      norm === "is priced at" ? "priced at" : norm;
+
+    await run(store, {
+      alias: vocabulary,
+      candidates: [candidate({ predicate: "Is_Priced At" })],
+    });
+    const second = await run(store, {
+      alias: vocabulary,
+      episode: episode({ id: "ep-2" }),
+      candidates: [candidate({ predicate: "priced at" })],
+    });
+
+    // #5000's pair, closed by an ENTRY rather than by a normalization rule —
+    // which is the whole reason the seam exists.
+    expect(second.corroborated).toBe(1);
+    expect(store.facts).toHaveLength(1);
+    expect(store.facts[0]?.slot).toMatchObject({ predicate: "priced at" });
+    // …and it is the PREDICATE slot, not only the entity-resolved sides.
+    expect(store.facts[0]?.predicate).toBe("Is_Priced At");
+  });
+
+  test("a throwing vocabulary aborts the episode — it never degrades to the un-aliased norm", async () => {
+    // `identity.ts` documents this as a deliberate asymmetry with `tryResolve`,
+    // which catches a throwing ENTITY resolver and flags the candidate
+    // provisional. There is no safe degraded answer for a failed vocabulary
+    // lookup: falling back to the un-aliased norm keys the row into the slot
+    // the vocabulary exists to move it out of, and nothing surfaces it
+    // afterwards. Pinned because the behaviour is true only by ABSENCE of a
+    // catch, and wrapping it in `tryResolve`'s shape is the obvious refactor.
+    const store = new FakeBrainStore();
+    const boom = (): string => {
+      throw new Error("vocabulary unavailable");
+    };
+
+    await expect(run(store, { alias: boom })).rejects.toThrow("vocabulary unavailable");
+    // Nothing written, and no transaction opened — the keys are computed in the
+    // preparation loop, above the transaction.
+    expect(store.facts).toHaveLength(0);
+    expect(store.transactions).toBe(0);
+  });
+
+  test("the lexical layer takes no decision the entity resolver owns", async () => {
+    // The line the keys must not cross. `deploy-01` and `the deploy box` are
+    // the SAME machine and different strings; unifying them is a per-workspace
+    // decision with a seam built for it, not a normalization rule applied
+    // globally with no reviewer. Same for `is priced at` / `priced at`, which
+    // ADR-0037 §6 settles as a vocabulary ENTRY (#5016) rather than a rule.
+    const store = new FakeBrainStore();
+    await run(store, { candidates: [candidate({ subject: "deploy-01", predicate: "is priced at" })] });
+    await run(store, {
+      episode: episode({ id: "ep-2" }),
+      candidates: [candidate({ subject: "the deploy box", predicate: "is priced at" })],
+    });
+    await run(store, {
+      episode: episode({ id: "ep-3" }),
+      candidates: [candidate({ subject: "deploy-01", predicate: "priced at" })],
+    });
+
+    expect(store.facts).toHaveLength(3);
+  });
+
+  test("a surface that norms away is keyed NULL and corroborates nothing", async () => {
+    // `-` survives the MALFORMED_CLAIM guard (`trim()` strips whitespace, not
+    // `_` or `-`), so it is a storable claim whose key is permanently NULL.
+    // Two such claims must NOT share a slot: a stored `''` — or a NULL-safe
+    // comparison — would make every placeholder corroborate every other one and,
+    // at `single` cardinality, publishing either would stamp `valid_to` on the
+    // other. Under-matching costs a duplicate row instead.
+    const store = new FakeBrainStore();
+    await run(store, { candidates: [candidate({ object: "-" })] });
+    const second = await run(store, {
+      episode: episode({ id: "ep-2" }),
+      candidates: [candidate({ object: "___" })],
+    });
+
+    expect(second.corroborated).toBe(0);
     expect(store.facts).toHaveLength(2);
+    for (const fact of store.facts) {
+      expect(fact.slot.object).toBeNull();
+    }
+    // …and each degenerate surface is still stored VERBATIM, so the reviewer can
+    // see what the producer emitted and repair it. Asserted on `object` — the
+    // column that actually carries one; the subject is the shared default and
+    // would prove nothing.
+    expect(store.facts.map((f) => f.object)).toEqual(["-", "___"]);
   });
 
   test("surrounding whitespace is trimmed, so it never forks a claim", async () => {
@@ -700,5 +849,37 @@ describe("no autonomous supersession (#4912)", () => {
 
   test("tension edges target only CURRENT rivals — settled history is not a contradiction", () => {
     expect(TENSION_CANDIDATES_SQL).toContain("valid_to IS NULL");
+  });
+
+  test("both lookups match on the SLOT KEYS and on no surface column (#5020)", () => {
+    // The lexical backstop for the pivot. The fake store above dispatches on
+    // each statement's string IDENTITY and reads its binds positionally, so
+    // repointing either statement at the surface columns leaves every other test
+    // in this file green — and the real proof lives in
+    // `extract-reconcile-pg.test.ts`, which SKIPS without `TEST_DATABASE_URL`.
+    // Without these assertions the revert is green on a default local run.
+    expect(CORROBORATION_LOOKUP_SQL).toContain("subject_key = $2");
+    expect(CORROBORATION_LOOKUP_SQL).toContain("predicate_key = $3");
+    expect(CORROBORATION_LOOKUP_SQL).toContain("object_key = $4");
+    expect(TENSION_CANDIDATES_SQL).toContain("subject_key = $2");
+    expect(TENSION_CANDIDATES_SQL).toContain("predicate_key = $3");
+    // `<>`, never `=`: a rival asserts a DIFFERENT value in the same slot.
+    expect(TENSION_CANDIDATES_SQL).toContain("object_key <> $4");
+    // …and no surviving surface comparison in either. An AND-ed surface arm
+    // beside a key arm reads as pivoted and is not.
+    for (const [name, sql] of [
+      ["CORROBORATION_LOOKUP_SQL", CORROBORATION_LOOKUP_SQL],
+      ["TENSION_CANDIDATES_SQL", TENSION_CANDIDATES_SQL],
+    ] as const) {
+      for (const column of ["subject", "predicate", "object"]) {
+        expect(
+          new RegExp(`\\b${column}\\b(?!_key)\\s*(=|<>)`).test(sql),
+          `${name} still compares the ${column} SURFACE — identity is the materialized key (ADR-0037 §1)`,
+        ).toBe(false);
+      }
+    }
+    // The write half: the INSERT must name all three, or every row it lands is
+    // unkeyed and inert in the two statements above.
+    expect(INSERT_FACT_SQL).toContain("subject_key, predicate_key, object_key");
   });
 });

--- a/packages/api/src/lib/brain/correction.ts
+++ b/packages/api/src/lib/brain/correction.ts
@@ -154,6 +154,7 @@ import {
   isUnknownArray,
   type BrainPrincipalContext,
 } from "@atlas/api/lib/brain/acl";
+import { identityAlias, slotKey, type AliasLookup } from "@atlas/api/lib/brain/identity";
 import { BrainReaderUnresolvedError } from "@atlas/api/lib/brain/reader-context";
 import {
   INSERT_PROVENANCE_EDGE_SQL,
@@ -328,6 +329,19 @@ export interface CorrectionDeps {
    * which is where that is enforced, because the type cannot say it.
    */
   readonly auditWriteTimeoutMs?: number;
+  /**
+   * The workspace's identity vocabulary (ADR-0037 §6 / #5016), threaded for
+   * `reconcileFacts`' reason and used at BOTH of this module's key sites: the
+   * supersede guard's slot comparison, and the replacement claim it hands to
+   * reconcile. Defaults to `identityAlias`, which is the whole vocabulary
+   * today.
+   *
+   * Both sites have to use the SAME lookup the ingest path used, or the guard
+   * refuses a different set than the corpus considers identical and the
+   * replacement lands keyed under a different identity function than every
+   * other row in the workspace. Neither is visible at rest.
+   */
+  readonly alias?: AliasLookup;
 }
 
 /** What became of one correction request. */
@@ -622,6 +636,7 @@ export async function correctFact(
   const { ctx, factId, verb, requestId } = request;
   const now = deps.now ?? (() => new Date());
   const withTransaction = deps.withTransaction ?? withBrainTransaction;
+  const alias = deps.alias ?? identityAlias;
   const newCorrectionId = deps.newCorrectionId ?? randomUUID;
 
   // ── Authority ─────────────────────────────────────────────────────────
@@ -775,7 +790,43 @@ export async function correctFact(
               "no current belief to supersede. Correct the CURRENT fact for this subject and predicate instead.",
           );
         }
-        if (replacement !== null && replacement.object === target.object) {
+        // Compared on the SLOT KEY, not byte-exactly (#5020, ADR-0037 §1).
+        // "Restates what the fact already says" has to mean what the rest of
+        // the system means by the same claim, and since #5020 that is
+        // `alias(lexicalNorm(surface))`: `Bob` and `bob` are ONE object slot.
+        // Left byte-exact, this guard would pass such a replacement through to
+        // `SUPERSEDE_STAMP_SQL` — closing a published belief and standing up a
+        // successor in the identical slot, with a `supersedes` edge recording
+        // an arbitration that settled nothing. That is the irreversible
+        // direction reached through a spelling difference, which is exactly
+        // what the guard exists to prevent.
+        //
+        // Two NULL keys count as identical, which is the same conservative
+        // arm: neither surface asserts anything, so there is no belief to
+        // retire and refusing costs a `valid_to` stamp nobody could justify.
+        // (Note this is a comparison, never a WRITE — the keys are derived at
+        // ingest and `check-brain-fact-promotion.sh` gates only UPDATEs.)
+        //
+        // ONE case it deliberately does NOT cover: a degenerate replacement
+        // against a REAL target (`-` superseding `bob`) is `null !== "bob"`, so
+        // it passes here and installs a successor with no identity — a row that
+        // can never corroborate, contradict, or be superseded. It needs no
+        // refusal of its own: the `MALFORMED_CLAIM` tightening that 0187's
+        // header item 3 requires for `SET NOT NULL` blocks exactly this
+        // candidate at the ingest seam, and the replacement below goes through
+        // that seam, so the block rolls this verb's stamp back with it. Adding
+        // a second refusal here would be a second spelling of that guard.
+        //
+        // The keys are RE-DERIVED from the surfaces rather than read: the
+        // target read cannot project a key (`keys-not-on-the-wire.test.ts`), so
+        // this is the one place ADR-0037 §8's "carry, never re-derive" cannot
+        // be honoured literally. Equal to the stored key while `alias` is
+        // deterministic and unchanged since the target was ingested; #5016 has
+        // to revisit it when the vocabulary becomes versioned.
+        if (
+          replacement !== null &&
+          slotKey(replacement.object, alias) === slotKey(target.object, alias)
+        ) {
           throw new CorrectionRefusedError(
             CORRECTION_REFUSAL_REASONS.replacementIdentical,
             `The replacement restates what the fact already says ("${target.object}"), so there is nothing ` +
@@ -882,6 +933,7 @@ export async function correctFact(
             actor,
             correctionSourceId,
             grantTokens: target.grantTokens,
+            alias,
           });
         case "re-authority":
           return applyVouch(tx, ctx.workspaceId, target, episodeId, at, base, "reAuthority", actor);
@@ -1324,6 +1376,8 @@ interface SupersedeInputs {
   readonly actor: string;
   readonly correctionSourceId: string;
   readonly grantTokens: readonly string[];
+  /** The workspace's vocabulary, so the replacement keys the way ingest does. */
+  readonly alias: AliasLookup;
 }
 
 async function applySupersede(
@@ -1337,9 +1391,14 @@ async function applySupersede(
 ): Promise<BrainFactCorrectionResponse> {
   // #4912's stamp FIRST, via the publish gate's own statement — before the
   // replacement reconciles. The ordering is load-bearing: reconcile's tension
-  // pass flags every LIVE same-subject/predicate rival of a new single-
-  // cardinality claim, and the target is exactly such a rival until its
-  // window closes. Stamping first means the belief being retired is already
+  // pass flags every LIVE rival in the same SLOT (`subject_key`,
+  // `predicate_key` since #5020) of a new single-cardinality claim, and the
+  // target is exactly such a rival until its window closes — more surely than
+  // before, since the replacement inherits the target's own subject and
+  // predicate SURFACES below and therefore keys into the target's slot — by
+  // construction for a KEYED target, and vacuously for an unkeyed one, whose
+  // slot is `(NULL, NULL)` and joins nothing either way. Stamping first means
+  // the belief being retired is already
   // settled history when the pass runs (`TENSION_CANDIDATES_SQL` filters
   // `valid_to IS NULL`), so this verb cannot mint a permanent
   // `in-tension-with` edge recording a conflict the same transaction
@@ -1380,6 +1439,7 @@ async function applySupersede(
           predicateCardinality: target.cardinality,
         },
       ],
+      alias: inputs.alias,
       producer: "correction",
       // An authored claim is not extracted from anything.
       extractedAt: null,

--- a/packages/api/src/lib/brain/extract.ts
+++ b/packages/api/src/lib/brain/extract.ts
@@ -26,9 +26,13 @@
  * existing fact gains at most an already-present provenance edge. So the cost
  * of a crash is a repeated model call.
  *
- * That "no-op" is conditional and the condition is ours to hold: dedupe is
- * BYTE-EXACT on the SPO, so it collapses a re-extraction only if the model
- * reproduces its own output. `llmFactExtractor` therefore pins `temperature: 0`.
+ * That "no-op" is conditional and the condition is ours to hold: dedupe is on
+ * the claim's SLOT KEY (`alias(lexicalNorm(surface))` since #5020), so it
+ * collapses a re-extraction only if the model reproduces its own output closely
+ * enough to land in the same slot. That is looser than the byte-exactness it
+ * replaced — a re-phrasing differing only in case or separators now collapses —
+ * and nowhere near loose enough to absorb "is" vs "is on".
+ * `llmFactExtractor` therefore still pins `temperature: 0`.
  * A paraphrase would mint a second draft for one claim — not corruption (the
  * reviewer collapses it), but not free either, which is why determinism is
  * load-bearing here rather than a preference.
@@ -447,9 +451,10 @@ export const llmFactExtractor: FactExtractor = async ({ episode, body, model, mo
     model,
     schema: ExtractionSchema,
     system: EXTRACTION_SYSTEM_PROMPT,
-    // Pinned. The reconcile stage's corroboration dedupe is BYTE-EXACT on the
-    // SPO, so a re-extraction that paraphrases its own earlier output mints a
-    // duplicate belief instead of strengthening one — and re-extraction is
+    // Pinned. The reconcile stage's corroboration dedupe is on the SLOT KEY
+    // (#5020) — case and separators are folded, nothing semantic is — so a
+    // re-extraction that PARAPHRASES its own earlier output still mints a
+    // duplicate belief instead of strengthening one, and re-extraction is
     // routine here (it is the whole crash-safety story). Determinism is not a
     // quality preference; it is what makes idempotence real.
     temperature: 0,

--- a/packages/api/src/lib/brain/identity.ts
+++ b/packages/api/src/lib/brain/identity.ts
@@ -5,11 +5,17 @@
  *
  *   key = alias( lexicalNorm( surface ) )
  *
- * This module owns the INNER one. `alias` — the curated, versioned workspace
- * vocabulary — is a later slice, and until it exists it is the identity
- * function, so every key produced today is exactly {@link identityKey} of the
- * surface: `lexicalNorm(surface)`, or `null` where that is empty. That is why
- * this slice is expected to change no observable behaviour at all.
+ * This module owns the INNER one, and since #5020 it also owns the composition
+ * ({@link slotKey}). `alias` — the curated, versioned workspace vocabulary
+ * (ADR-0037 §6 / #5016) — does not exist yet, and until it does it is the
+ * identity function, so every key produced today is exactly {@link identityKey}
+ * of the surface: `lexicalNorm(surface)`, or `null` where that is empty.
+ *
+ * That made #5019 — the columns and the backfill — a slice with no observable
+ * behaviour at all. It does NOT make #5020 one: materializing these keys and
+ * pivoting the three slot consumers onto them is exactly what turns two
+ * spellings of a claim into one, and `reconcile.ts`'s header owns that
+ * consequence.
  *
  * ## What `lexicalNorm` is, and the harder question of what it is NOT
  *
@@ -109,9 +115,13 @@ const foldAscii = (c: string): string => String.fromCharCode(c.charCodeAt(0) + 3
  * The lexical layer of a claim's identity key.
  *
  * TOTAL — every string has a norm, including the empty one. Totality is not a
- * convenience: the vocabulary's forest invariant rests on `f(f(x)) === f(x)`,
- * and a partial function has no fixpoint to reason about. A surface made only
- * of separators norms to `""`.
+ * convenience: the vocabulary composes over this function and relies on
+ * `f(f(x)) === f(x)` (ADR-0037 §6, and {@link slotKey}, which re-norms the
+ * vocabulary's answer on the strength of it), and a partial function has no
+ * fixpoint to reason about. A surface made only of separators norms to `""`.
+ * (An earlier version of this line called that a "forest invariant" — §6
+ * retracts T3's forest framing by name, and the ADR lists it again under
+ * "Corrections to the record".)
  *
  * `""` is a norm. It is NOT a key — see {@link identityKey}.
  */
@@ -156,9 +166,117 @@ export function lexicalNorm(surface: string): string {
  * Kept SEPARATE from `lexicalNorm` rather than folded into it, because the two
  * answer different questions: `lexicalNorm` is the pure normalization the
  * vocabulary composes over (and must stay total to have a fixpoint), while this
- * is the storage decision. #5020 calls this one at the INSERT site.
+ * is the storage decision. {@link slotKey} is what #5020 calls at the INSERT
+ * site; this is its vocabulary-free half.
  */
 export function identityKey(surface: string): string | null {
   const norm = lexicalNorm(surface);
   return norm === "" ? null : norm;
+}
+
+/**
+ * The OUTER layer of `key = alias(lexicalNorm(surface))` — the curated,
+ * versioned workspace vocabulary, as a seam.
+ *
+ * Empty today, and {@link identityAlias} is the whole implementation. The seam
+ * exists now rather than with the vocabulary itself (ADR-0037 §6 / #5016) for
+ * the same reason `reconcile.ts`'s
+ * `EntityResolver` seam predates any entity store: what this slice pins is the
+ * SHAPE — a norm goes in, a norm comes out, and the composition happens in ONE
+ * place — so slice B adds a vocabulary rather than moving the call site under
+ * live data.
+ *
+ * Takes the NORM, not the surface: the vocabulary maps normalized spellings to
+ * a chosen one (`is priced at` → `priced at`), so a lookup keyed on raw surfaces
+ * would need an entry per casing and separator variant of both sides. Composing
+ * over `lexicalNorm` is what makes one entry cover them all.
+ *
+ * TOTAL, like the layer beneath it: a norm with no vocabulary entry maps to
+ * itself. ADR-0037 §6 builds `alias` as a lookup against the TRANSITIVE CLOSURE
+ * of at-most-one-parent approved edges, so an effective target is already its
+ * own target and `f(f(x)) === f(x)` falls out — but only if every input has an
+ * answer. (Do NOT call that a "forest invariant". §6 retracts T3's, by name, as
+ * self-contradictory — depth-1 AND composing — and lists it under the ADR's
+ * "Corrections to the record".)
+ *
+ * ## What the signature cannot say, and what {@link slotKey} does about it
+ *
+ * `(norm: string) => string` expresses totality and NOTHING ELSE. It cannot say
+ * that the input is a norm, and — the half that bites — it cannot say the OUTPUT
+ * must be one. A vocabulary row authored as `is priced at → "Priced At"` (an
+ * admin typing the canonical DISPLAY form, the likeliest authoring mistake once
+ * this is a reviewed data table) would otherwise store a key that joins nothing,
+ * corpus-wide and silently. `slotKey` re-norms the result rather than trusting
+ * it; see there.
+ *
+ * ## A throwing alias is NOT caught, deliberately
+ *
+ * `reconcile.ts` catches a throwing `EntityResolver` and degrades the candidate
+ * to provisional, and the opposite choice here is the point of the asymmetry: an
+ * unresolved ENTITY is a quality failure a reviewer can repair, while a
+ * vocabulary lookup that fails has no safe degraded answer. Falling back to the
+ * un-aliased norm would key the row into the slot the vocabulary exists to move
+ * it OUT of — an under-match today, and an over-match the moment an entry merges
+ * two spellings — and neither is visible afterwards. So it propagates: a
+ * data-backed alias that throws aborts the episode before the transaction opens,
+ * and the episode stays on the queue for the next cycle.
+ */
+export type AliasLookup = (norm: string) => string;
+
+/** The day-one vocabulary: every norm is its own alias. */
+export const identityAlias: AliasLookup = (norm) => norm;
+
+/**
+ * A claim slot's stored key — `alias(lexicalNorm(surface))`, or `null`.
+ *
+ * THE call site for the whole composition. `reconcile.ts` materializes all
+ * three of a candidate's keys through this function before `INSERT_FACT_SQL`
+ * (#5020), and no consumer ever re-derives one: ADR-0037 §8 settles that even a
+ * row-copy path carries keys VERBATIM, because re-deriving fails to OVER-match
+ * — the irreversible direction — where carrying fails to under-match.
+ *
+ * ## The vocabulary's answer is re-normed, not trusted
+ *
+ * `identityKey(alias(norm))`, not `alias(norm)`. `lexicalNorm` is idempotent, so
+ * for a well-behaved vocabulary — one whose targets are already norms — this is
+ * a no-op and the composition is exactly `alias(lexicalNorm(surface))`. For a
+ * MISBEHAVING one it is the difference between a harmless correction and a
+ * silent corpus-wide under-match, because `alias` is going to be a data table
+ * with a reviewer behind it and not a proof: `Priced At` as an entry's target
+ * keys nothing to anything, and nothing anywhere would say so.
+ *
+ * It also subsumes the empty-string arm rather than special-casing it. A
+ * vocabulary that maps a real norm to `""` (or to `" - "`) reaches the same
+ * `null` as a surface that norms away, and that is the right answer for the
+ * `DEFAULT ''` reason migration 0187's header gives: a stored `""` is the ONE
+ * key value that joins every other degenerate row, so two unrelated claims would
+ * occupy one slot and publishing either would stamp `valid_to` on the other.
+ *
+ * ## Two ways to reach `null`
+ *
+ * The surface norms away (`-`, `___`, `  `) — {@link identityKey}'s case, and
+ * the alias is never consulted, because a claim that asserts nothing has no slot
+ * to look up and calling out with `""` would invite a vocabulary that answers
+ * it. Or the vocabulary's own answer norms away, per the paragraph above.
+ *
+ * ## `alias` is REQUIRED, and that is the point
+ *
+ * It would default to {@link identityAlias} perfectly well today, and a default
+ * is precisely what would make the vocabulary slice (#5016) dangerous: a call
+ * site that forgot to pass the workspace's vocabulary would keep compiling and
+ * key its rows under a DIFFERENT identity function than the ingest path — an
+ * under-match spread corpus-wide, invisible at rest, and unfixable afterwards
+ * without a re-key. Spelled explicitly, every such site is `grep identityAlias`
+ * and every new one is a compile error. `reconcile.ts` threads the workspace's
+ * lookup through `ReconcileRequest.alias`; everything else names the day-one
+ * vocabulary out loud, which is the choice being made and should read like one.
+ *
+ * Note what this does NOT do: collapse a null key into a sentinel so the
+ * eventual `SET NOT NULL` can land. See {@link identityKey}'s ⚠️ — the
+ * constraint's prerequisite is a TIGHTER ingest guard, not a wider key.
+ */
+export function slotKey(surface: string, alias: AliasLookup): string | null {
+  const norm = identityKey(surface);
+  if (norm === null) return null;
+  return identityKey(alias(norm));
 }

--- a/packages/api/src/lib/brain/ingest/__tests__/slack-webhook-pg.test.ts
+++ b/packages/api/src/lib/brain/ingest/__tests__/slack-webhook-pg.test.ts
@@ -269,10 +269,15 @@ describeIfPg("Slack brain webhook fast-path (real Postgres)", () => {
   /**
    * Reconcile ONE claim off every stored episode — the shape extraction takes
    * when both copies of a duplicated message reach the extractor. Byte-identical
-   * candidates on purpose: `reconcile.ts` identifies a claim byte-exactly on the
-   * trimmed, resolved SPO, so identical input is what makes the SECOND pass a
-   * corroboration of the first rather than a second fact. That is precisely the
-   * path a duplicate episode would travel.
+   * candidates on purpose: `reconcile.ts` identifies a claim by the SLOT KEY of
+   * the trimmed, resolved SPO (`alias(lexicalNorm(surface))` since #5020), and
+   * identical input is the case that is guaranteed to land in one slot — so the
+   * SECOND pass is a corroboration of the first rather than a second fact. That
+   * is precisely the path a duplicate episode would travel. Byte-identical is
+   * now sufficient rather than necessary for ANY surface that has a key — a
+   * surface that norms away (`-`) keys NULL on both passes and corroborates
+   * with nothing, byte-identical or not — which only makes this fixture a
+   * stricter test of the dedupe than it needs to be.
    */
   async function extractSameClaimFromEveryEpisode(): Promise<void> {
     for (const row of await episodes()) {

--- a/packages/api/src/lib/brain/reconcile.ts
+++ b/packages/api/src/lib/brain/reconcile.ts
@@ -76,39 +76,110 @@
  * (acceptance criterion 5) and what lets `extract.ts` stamp the queue marker
  * AFTER the commit — a crash in that window costs a repeated LLM call and, when
  * the producer reproduces its own output, no duplicated belief. That proviso is
- * load-bearing; see the byte-exactness note below for what a paraphrase costs.
+ * load-bearing; see the third bullet of the slot-key note below for what a
+ * paraphrase still costs.
  *
  * Two writers racing on the same claim would defeat a bare read-then-insert, so
  * the transaction opens by taking a per-workspace transaction-scoped advisory
- * lock. The rejected alternative was a partial UNIQUE index on
- * `(workspace_id, subject, predicate, object) WHERE invalidated_at IS NULL` plus
+ * lock. The rejected alternative was a partial UNIQUE index on the claim tuple
+ * (as written then, `(workspace_id, subject, predicate, object)`; today it would
+ * be the key columns) `WHERE invalidated_at IS NULL` plus
  * `ON CONFLICT DO NOTHING`: structurally stronger, but it needs a migration to
  * a table this milestone is still shaping, and it would make an ordinary
  * bi-temporal case (the same SPO re-asserted over a different validity window,
  * which M2 owns) unrepresentable rather than merely unusual. The lock is
  * reversible; the index would be a decision M2 has to live with. Revisit it
- * when M2 settles supersession.
+ * when M2 settles supersession — and read `identity-pg.test.ts`'s argument
+ * against a UNIQUE slot index first, which is a second and independent reason:
+ * on the keys it would make a tension between two live objects structurally
+ * unrepresentable.
  *
- * Identity is BYTE-EXACT on the trimmed, resolved SPO — deliberately, so that
- * deciding whether `Alice` and `alice` are one entity stays the ENTITY
- * RESOLVER's job. A `lower()` comparison here would silently take that decision
- * away from the seam that exists to make it.
+ * Identity is the materialized SLOT KEY of the trimmed, resolved SPO —
+ * `alias(lexicalNorm(surface))`, computed by `lib/brain/identity.ts`'s
+ * {@link slotKey} once per candidate here and stored on the row (#5020,
+ * ADR-0037 §1). It REPLACED a byte-exact comparison of the surface columns, and
+ * that is an observable change, not a refactor: `Ships On` and `ships_on` were
+ * two slots and are now one, so a claim that used to duplicate silently now
+ * corroborates. The retained surface is still exactly what the producer said —
+ * only what COUNTS AS THE SAME CLAIM moved.
  *
- * ADR-0037 is replacing byte-exactness with a materialized identity key
- * (`alias(lexicalNorm(surface))`, `lib/brain/identity.ts`), which keeps that
- * separation — the lexical layer does nothing semantic, and everything that
- * WOULD take a decision from the resolver is curated vocabulary with a reviewer
- * behind it. Migration 0187 added the columns and repointed
- * `idx_brain_facts_subject` onto them; until #5020 supplies them at
- * `INSERT_FACT_SQL` and pivots the join arm below, this lookup still compares
- * surfaces and no longer has an index behind it.
+ * What did NOT move is the entity resolver's job. The lexical layer folds ASCII
+ * case and separators and does nothing semantic (no stemming — the corpus
+ * carries `led_by` and `leads`, which are INVERSE relations), so deciding that
+ * `the deploy box` and `deploy-01` are one entity is still the resolver's
+ * decision, made per workspace at a seam built for it. Anything beyond the
+ * lexical layer that WOULD take a decision from the resolver arrives as curated
+ * vocabulary with a reviewer behind it, never as a rule here — which is why
+ * `is priced at` and `priced at` still do not unify.
  *
- * The cost of byte-exactness, stated because it is easy to over-read the
- * paragraph above: dedupe is only as good as the producer's determinism. Two
- * passes that phrase one claim differently ("is" vs "is on") are two claims
- * here, and a pass whose entity resolution CHANGES between runs will miss its
- * own earlier row. The reviewer collapses those; nothing in this stage can.
- * `extract.ts` pins its model call to `temperature: 0` for exactly this reason.
+ * The keys are written at `INSERT_FACT_SQL` and READ by the two lookups below.
+ * No PRODUCER outside this stage derives one (ADR-0037 §8 — a region import
+ * carries keys verbatim, #5035); the two writers that legitimately key rows they
+ * did not author are both migrations of the corpus rather than claim producers —
+ * 0187/0188's backfill, and ADR-0037 §7's drift re-key inside the
+ * alias-approval decide transaction.
+ *
+ * ## The fold widens matching, and two downstreams feel it
+ *
+ * Stated because the NULL bullets below are all UNDER-matches and would
+ * otherwise read as the whole risk register. Folding `Ships On` into `ships_on`
+ * makes more things one claim, and one claim is a join arm:
+ *
+ *   - **The grant.** A corroboration writes a `provenance` edge, and publish
+ *     unions the grants of every evidenced episode into the promoted fact
+ *     (`widenGrantFromEvidence`, #4823). So a restatement in a WIDER-audience
+ *     episode now attaches to a claim first seen in a private channel, where
+ *     byte-exactness minted a separate fact that kept its narrow grant. Not a
+ *     hole — the widening happens only at the review gate and is disclosed to
+ *     the admin as a `GrantWidening` — but the ACL surface did move.
+ *   - **`valid_to`.** The same fold reaches `supersessionCollisionJoin`, and a
+ *     collision is what the publish gate stamps. The irreversible write is now
+ *     reachable through a lexical rule rather than a byte comparison. Bounded
+ *     (ASCII case and separators, nothing semantic), human-gated, and
+ *     previewed pair-by-pair by `loadSupersessionPreview` — which is the whole
+ *     mitigation, and it is only as good as the reviewer reading the first
+ *     batch after this deploys.
+ *
+ * It NARROWS the two `<>` arms in the same move, and that direction is worth
+ * naming because it is the one an operator sees first: a live rival whose object
+ * differs only by case or separator stops being a rival, so a workspace's
+ * will-supersede count can DROP at this deploy and some standing advisory
+ * `in-tension-with` edges stop being minted. At ingest that is strictly better
+ * — those pairs corroborate instead. For rows already in the corpus it is a
+ * visible number moving the opposite way from the paragraph above.
+ *
+ * ## What the NULLABLE keys cost
+ *
+ * The acceptance criteria for #5020 also asked for `SET NOT NULL` on all three
+ * columns. It is deliberately NOT in this cut: migration 0187's header
+ * enumerates three prerequisites, and the third — tightening `MALFORMED_CLAIM`
+ * to refuse a candidate whose key is null — is unowned, so the constraint would
+ * turn a claim that is storable TODAY into a transaction-killing violation. Read
+ * that header before flipping it.
+ *
+ *   - A surface that norms away (`-`, `___`) has a NULL key, so it corroborates
+ *     nothing and earns no tension edge — where byte-exactness would have
+ *     matched another `-`. `null = null` is unknown in SQL, and that is the
+ *     point: the alternative, a stored `''`, is the one key value that joins
+ *     every other degenerate row (migration 0187's header). Never write these
+ *     comparisons NULL-safe. This one is PERMANENT and legal; no backfill
+ *     repairs it, which is why it is logged at the prepare loop below.
+ *   - A row written between 0187 deploying and this code deploying is unkeyed,
+ *     and drops out of all three slot consumers. Migration 0188 repeats 0187's
+ *     re-runnable backfill in THIS deploy to close exactly that window — the
+ *     correctness need arrives here, not at the constraint flip, because here is
+ *     where the consumers start depending on the column.
+ *   - Every row a region import lands is likewise unkeyed until #5035 carries
+ *     keys verbatim on the v3 bundle, and 0188 cannot help: it runs at boot and
+ *     an import runs whenever an admin triggers one. Those facts are inert in
+ *     all three consumers in the meantime — fail-closed, and #5035's to fix.
+ *   - Dedupe is still only as good as the producer's determinism, just at a
+ *     coarser grain. Two passes that phrase one claim differently ("is" vs "is
+ *     on") remain two claims — that pair is a vocabulary ENTRY, not a
+ *     normalization rule — and a pass whose entity resolution CHANGES between
+ *     runs still misses its own earlier row. The reviewer collapses those;
+ *     nothing in this stage can. `extract.ts` pins its model call to
+ *     `temperature: 0` for exactly this reason.
  *
  * ## What this slice does NOT do
  *
@@ -137,6 +208,11 @@ import { logGrantAnomalies } from "@atlas/api/lib/brain/acl";
 // happen. It lives under `ingest/` for historical reasons but is a pure
 // grant-vocabulary helper with no ingest state.
 import { isUsableGrant } from "@atlas/api/lib/brain/ingest/grant";
+// The identity composition, imported rather than spelled here: `slotKey` is the
+// ONE place `alias(lexicalNorm(surface))` is assembled, and a second assembly
+// site is how the write side and a future re-key start disagreeing about what a
+// claim's slot IS.
+import { identityAlias, slotKey, type AliasLookup } from "@atlas/api/lib/brain/identity";
 import type {
   BrainFactProvenance,
   EntityRole,
@@ -288,6 +364,20 @@ export interface ReconcileRequest {
   readonly sourcePrincipal?: string | null;
   /** Defaults to {@link passthroughEntityResolver}. */
   readonly resolveEntity?: EntityResolver;
+  /**
+   * The workspace's curated identity vocabulary, as a lookup over lexical norms
+   * (ADR-0037 §6 / #5016). Defaults to `identityAlias`, which is the whole
+   * vocabulary today.
+   *
+   * Threaded through the REQUEST rather than left as `slotKey`'s default
+   * parameter for `resolveEntity`'s reason exactly: a real vocabulary is
+   * per-workspace and DB-backed, so the caller loads it once — above the
+   * per-candidate loop, which is what lets the seam stay synchronous — and
+   * drops it in without this module changing. A default parameter would have
+   * made slice B edit these call sites, which is the work the seam exists to
+   * avoid.
+   */
+  readonly alias?: AliasLookup;
 }
 
 export interface ReconcileDeps {
@@ -401,11 +491,18 @@ export const RECONCILE_LOCK_SQL = `SELECT pg_advisory_xact_lock($1, hashtext($2)
 /**
  * Does a live fact already assert exactly this claim?
  *
- * NOT served by an index as written. `idx_brain_facts_subject` was this
- * statement's access path until 0187 repointed it onto the identity keys
- * (#5019); #5020 pivots the three arms below onto `subject_key` /
- * `predicate_key` / `object_key` and gets it back, with the tighter
- * `valid_to IS NULL` partial predicate this statement already requires.
+ * Matched on the SLOT KEYS, not the surfaces (#5020) — so a re-observation that
+ * says `Ships On` where the stored row says `ships_on` strengthens it instead of
+ * minting a second belief. `idx_brain_facts_subject` serves this again: 0187
+ * repointed it onto `(workspace_id, subject_key, predicate_key)` with the
+ * tighter `invalidated_at IS NULL AND valid_to IS NULL` partial predicate, both
+ * of which this statement requires.
+ *
+ * A NULL bind (the candidate's surface norms away) matches NOTHING here, and
+ * that is deliberate rather than tolerated: `IS NOT DISTINCT FROM` would make
+ * every degenerate claim corroborate every other one, which is the same
+ * corpus-corrupting over-match migration 0187's header rejects `DEFAULT ''` for.
+ * A duplicate row is the price and it is the recoverable direction.
  *
  * Deliberately NOT filtered by review state: a claim re-observed after it was
  * published must corroborate the published fact, not mint a fresh draft
@@ -433,9 +530,9 @@ export const RECONCILE_LOCK_SQL = `SELECT pg_advisory_xact_lock($1, hashtext($2)
 export const CORROBORATION_LOOKUP_SQL = `SELECT id
      FROM brain_facts
     WHERE workspace_id = $1
-      AND subject = $2
-      AND predicate = $3
-      AND object = $4
+      AND subject_key = $2
+      AND predicate_key = $3
+      AND object_key = $4
       AND invalidated_at IS NULL
       AND valid_to IS NULL
     ORDER BY ingested_at
@@ -452,13 +549,27 @@ export const CORROBORATION_LOOKUP_SQL = `SELECT id
  * `unknown[]`, and it is structurally satisfied by both the `pg` client and a
  * test literal. Keeping every parameter a JSON scalar means no driver-specific
  * array marshalling can leak into that seam.
+ *
+ * ## The identity keys are named here, and this is their only deriver (#5020)
+ *
+ * Derived at ingest exactly as the grant is — which is why
+ * `check-brain-fact-promotion.sh` gates the key columns on UPDATE only, and says
+ * in as many words that OMITTING them is not a fix. They travel as three more
+ * JSON scalars, `null` included: a surface that norms away has no key, and a
+ * sentinel would file every such claim under one slot.
+ *
+ * `RETURNING id` and nothing else. A key must never reach a consumer that could
+ * branch on it — that is what makes an alias un-removable — and
+ * `keys-not-on-the-wire.test.ts` scans RETURNING lists naming this exact shape.
  */
 export const INSERT_FACT_SQL = `INSERT INTO brain_facts
          (workspace_id, subject, predicate, object, valid_from, extracted_at,
-          source_episode_id, provenance, visible_to, predicate_cardinality)
+          source_episode_id, provenance, visible_to, predicate_cardinality,
+          subject_key, predicate_key, object_key)
        VALUES ($1, $2, $3, $4, $5::timestamptz, $6::timestamptz,
                $7::uuid, $8::jsonb,
-               ARRAY(SELECT jsonb_array_elements_text($9::jsonb)), $10)
+               ARRAY(SELECT jsonb_array_elements_text($9::jsonb)), $10,
+               $11, $12, $13)
        RETURNING id`;
 
 /**
@@ -491,13 +602,36 @@ export const INSERT_PROVENANCE_EDGE_SQL = `INSERT INTO brain_edges
  * A FUTURE-dated `valid_to` (region import only) is likewise skipped — the
  * same accepted coexistence `supersessionCollisionJoin` documents: its end is
  * already decided, so it is neither a rival to flag nor a belief to supersede.
+ *
+ * Matched on the SLOT KEYS (#5020), which moves the rule in BOTH directions and
+ * each is the intended one: `Alice`/`alice` under the same subject and predicate
+ * are one claim rather than two rivals (they corroborated above and never
+ * reached here), while `Ships On`/`ships_on` as PREDICATES now put their
+ * differing objects in tension instead of sorting into two silent slots.
+ *
+ * A NULL key on either side matches nothing — `object_key <> NULL` is unknown,
+ * so a degenerate or unkeyed row abstains OUT of tension. That is the weaker
+ * direction (#5000's shape, and the reason the acceptance criteria want these
+ * columns `NOT NULL` eventually), and it is still strictly better than the
+ * over-match a NULL-safe comparison would buy: an edge here is advisory and a
+ * missing one costs a reviewer a hint, where a wrong SLOT costs a `valid_to`
+ * stamp at the publish gate.
+ *
+ * The object arm's falsifying case is a DEGENERATE rival, and it is reachable
+ * without a region import, a concurrent writer, or `correct_fact`. A live row
+ * in this slot whose object is `-` has `object_key IS NULL`, so
+ * {@link CORROBORATION_LOOKUP_SQL} does not return it either (`object_key = $4`
+ * is unknown too) and it survives to this scan. There `object_key <> $4` is
+ * unknown — not a rival — while `object <> $4` would be TRUE, wiring a
+ * permanent advisory edge from a real claim to a placeholder that asserts
+ * nothing. Pinned by `extract-reconcile-pg.test.ts`.
  */
 export const TENSION_CANDIDATES_SQL = `SELECT id
      FROM brain_facts
     WHERE workspace_id = $1
-      AND subject = $2
-      AND predicate = $3
-      AND object <> $4
+      AND subject_key = $2
+      AND predicate_key = $3
+      AND object_key <> $4
       AND invalidated_at IS NULL
       AND valid_to IS NULL
       AND id <> $5::uuid
@@ -540,6 +674,7 @@ export async function reconcileFacts(
 ): Promise<ReconcileReport> {
   const { episode, candidates, producer } = request;
   const resolveEntity = request.resolveEntity ?? passthroughEntityResolver;
+  const alias = request.alias ?? identityAlias;
   const now = deps.now ?? (() => new Date());
 
   const blocked: Record<ReconcileBlockReason, number> = { ...NO_BLOCKS };
@@ -644,11 +779,24 @@ export async function reconcileFacts(
     if (resolvedSubject === null) unresolved.push("subject");
     if (resolvedObject === null) unresolved.push("object");
 
+    const storedSubject = resolvedSubject?.canonical ?? subject;
+    const storedObject = resolvedObject?.canonical ?? object;
+
+    // Materialized ONCE, here, off the RESOLVED surfaces — the strings that land
+    // in the SPO columns, so the stored key always describes the stored row.
+    // Computing it later, per statement, is how the corroboration lookup and the
+    // INSERT would start disagreeing about which slot a claim is in.
+    const keys: SlotKeys = {
+      subject: slotKey(storedSubject, alias),
+      predicate: slotKey(predicate, alias),
+      object: slotKey(storedObject, alias),
+    };
     prepared.push({
       kind: "prepared",
-      subject: resolvedSubject?.canonical ?? subject,
+      subject: storedSubject,
       predicate,
-      object: resolvedObject?.canonical ?? object,
+      object: storedObject,
+      keys,
       unresolved,
       entityIds: {
         ...(resolvedSubject?.entityId !== undefined ? { subject: resolvedSubject.entityId } : {}),
@@ -725,11 +873,62 @@ export async function reconcileFacts(
 // Internals
 // ---------------------------------------------------------------------------
 
+/**
+ * A candidate's three materialized slot keys, `null` where the surface norms
+ * away (`lib/brain/identity.ts`).
+ *
+ * Named by ROLE rather than as `subjectKey` / `predicateKey` / `objectKey`:
+ * `keys-not-on-the-wire.test.ts` bans those three identifiers outright in any
+ * source file that speaks about `brain_facts`, because a fact-shaped TYPE that
+ * grows a key field is the leak it exists to catch and it cannot tell one from a
+ * local. This shape is internal to the stage and never reaches a row type.
+ */
+interface SlotKeys {
+  readonly subject: string | null;
+  readonly predicate: string | null;
+  readonly object: string | null;
+}
+
+/**
+ * The three roles, once. Tied to {@link SlotKeys} by `satisfies`, so a renamed
+ * field is a compile error here rather than a filter that silently matches
+ * nothing.
+ */
+const SLOT_ROLES = ["subject", "predicate", "object"] as const satisfies readonly (keyof SlotKeys)[];
+
+/**
+ * The triple, in the order all three statements bind it.
+ *
+ * `ReconcileExecutor.query` takes `unknown[]`, so `[…, item.subject,
+ * item.predicate, item.object]` type-checks perfectly at every one of these call
+ * sites and silently restores byte-exact identity — the regression this cut
+ * exists to undo. (The unit suite DOES catch that one: its fake records the
+ * binds it was given and matches on them, so a surface bind fails the phrasing
+ * test. What it cannot see is the COLUMN half — the statement text — which is
+ * `extract-reconcile-pg.test.ts`'s plus the lexical backstop beside it.) One
+ * spelling, spread three times, is what removes that class along with the
+ * order-drift one.
+ *
+ * A fixed-length TUPLE, not `(string | null)[]`, and the arity is what it buys:
+ * `TENSION_CANDIDATES_SQL` spreads this in the MIDDLE of its bind list, so a
+ * fourth key added here (the `_cmp` columns `check-brain-fact-promotion.sh`
+ * already gates, #5032) would silently push `factId` into `$6` and hand `$5`
+ * — declared `::uuid` — a key string. In `INSERT_FACT_SQL` the spread is last
+ * and pg would at least raise an arity error; here it would not. It does NOT
+ * catch subject/predicate/object ORDER drift, since all three members share a
+ * type; only a brand would, and a brand buys nothing against `unknown[]`.
+ */
+function keyBinds(keys: SlotKeys): readonly [string | null, string | null, string | null] {
+  return [keys.subject, keys.predicate, keys.object];
+}
+
 interface PreparedCandidate {
   readonly kind: "prepared";
   readonly subject: string;
   readonly predicate: string;
   readonly object: string;
+  /** The identity of the claim above — what the two lookups below match on. */
+  readonly keys: SlotKeys;
   /** Empty when both sides resolved. */
   readonly unresolved: readonly EntityRole[];
   readonly entityIds: Partial<Record<EntityRole, string>>;
@@ -865,9 +1064,7 @@ async function writeCandidate(
 
   const existing = await tx.query(CORROBORATION_LOOKUP_SQL, [
     episode.workspaceId,
-    item.subject,
-    item.predicate,
-    item.object,
+    ...keyBinds(item.keys),
   ]);
   const existingId = firstId(existing.rows);
   if (existingId !== null) {
@@ -945,6 +1142,7 @@ async function writeCandidate(
     JSON.stringify(provenance),
     JSON.stringify(ctx.grantTokens),
     cardinality,
+    ...keyBinds(item.keys),
   ]);
   const factId = firstId(inserted.rows);
   if (factId === null) {
@@ -958,13 +1156,47 @@ async function writeCandidate(
 
   await tx.query(INSERT_PROVENANCE_EDGE_SQL, [episode.workspaceId, factId, episode.id]);
 
+  // A null key is legal, permanent, and invisible everywhere else: the row is
+  // stored and then joins nothing — no corroboration, no tension edge, and no
+  // supersession at the publish gate — for as long as it exists. No backfill
+  // repairs it (0187/0188 write the same NULL), so this line is the only signal
+  // such a claim ever produces.
+  //
+  // Emitted HERE rather than in the preparation loop so it describes a row that
+  // exists: everything after this point can still roll the episode back, and on
+  // the extraction path a failing episode is retried every cycle until
+  // quarantine — which would have re-emitted the identical line for a fact that
+  // was never written. `factId` is what makes it actionable.
+  //
+  // Warned rather than blocked because blocking is a GUARD change: 0187's header
+  // item 3 wants `MALFORMED_CLAIM` widened from `trim() === ""` to this
+  // predicate, and that is the `SET NOT NULL` prerequisite nobody owns yet.
+  // Refusing here unilaterally would drop claims a reviewer can currently see
+  // and repair.
+  const unkeyed = SLOT_ROLES.filter((role) => item.keys[role] === null);
+  if (unkeyed.length > 0) {
+    log.warn(
+      {
+        workspaceId: episode.workspaceId,
+        episodeId: episode.id,
+        producer: ctx.producer,
+        factId,
+        unkeyed,
+      },
+      // Two causes, and the message names both because it cannot distinguish
+      // them once the vocabulary is real: the SURFACE norms away (`-`, `___`,
+      // and the only reachable cause today), or an alias entry maps a real slot
+      // to something that does. Naming only the producer would send an operator
+      // after the wrong subsystem the day #5016 lands.
+      "brain reconcile: stored a claim with no identity for one or more slots — it will never corroborate, earn a tension edge, or be superseded at publish. Either the producer emitted a surface that norms away (fix the producer, or tighten the MALFORMED_CLAIM guard — migration 0187's header, item 3) or a vocabulary entry maps that slot to nothing",
+    );
+  }
+
   let tensionEdges = 0;
   if (cardinality === "single") {
     const rivals = await tx.query(TENSION_CANDIDATES_SQL, [
       episode.workspaceId,
-      item.subject,
-      item.predicate,
-      item.object,
+      ...keyBinds(item.keys),
       factId,
       TENSION_EDGE_CAP,
     ]);

--- a/packages/api/src/lib/content-mode/adapters/__tests__/brain-facts.test.ts
+++ b/packages/api/src/lib/content-mode/adapters/__tests__/brain-facts.test.ts
@@ -704,7 +704,34 @@ describe("promoteBrainFacts — supersession (#4912)", () => {
     expect(SUPERSESSION_TARGETS_SQL).toContain("p.status = 'published'");
     expect(SUPERSESSION_TARGETS_SQL).toContain("p.invalidated_at IS NULL");
     expect(SUPERSESSION_TARGETS_SQL).toContain("p.valid_to IS NULL");
-    expect(SUPERSESSION_TARGETS_SQL).toContain("p.object <> d.object");
+    expect(SUPERSESSION_TARGETS_SQL).toContain("p.object_key <> d.object_key");
+  });
+
+  it("collides on the identity keys and on no surface column (#5020)", () => {
+    // The pivot, asserted as a REPLACEMENT rather than an addition. Matching
+    // both would let a surface arm survive beside a key arm, which is the one
+    // shape that reads as fixed and is not: an AND-ed `p.subject = d.subject`
+    // re-imposes byte-exactness on top of the key and the join silently
+    // no-ops on exactly the phrasing mismatch #5020 exists to close.
+    // The WHOLE arm, both sides — `p.subject_key = d.subject` contains
+    // `p.subject_key` and is a mixed arm that silently restores byte-exactness
+    // on one side of the comparison.
+    expect(SUPERSESSION_TARGETS_SQL).toContain("p.subject_key = d.subject_key");
+    expect(SUPERSESSION_TARGETS_SQL).toContain("p.predicate_key = d.predicate_key");
+    expect(SUPERSESSION_TARGETS_SQL).toContain("p.object_key <> d.object_key");
+    // A slot column can only be named `<role>_key` here, so a bare `p.subject`
+    // is a surviving surface arm. `\b` alone is enough — `_` is a word
+    // character, so `\bp\.subject\b` cannot match inside `p.subject_key`; the
+    // `(?!_key)` is belt-and-braces against a future `-`-separated spelling.
+    // BOTH aliases are swept, which is what the mixed arm above needs.
+    for (const alias of ["p", "d"]) {
+      for (const surface of ["subject", "predicate", "object"]) {
+        expect(
+          new RegExp(`\\b${alias}\\.${surface}\\b(?!_key)`).test(SUPERSESSION_TARGETS_SQL),
+          `the collision join still compares ${alias}'s ${surface} SURFACE. Identity is the materialized key (ADR-0037 §1); a surface arm — even on ONE side of a comparison whose other side is a key — restores the byte-exactness the keys replaced, and the join goes back to no-op'ing on a phrasing mismatch.`,
+        ).toBe(false);
+      }
+    }
   });
 
   it("supersession is NOT retraction — the stamp never touches the tombstone or the review verdict", () => {

--- a/packages/api/src/lib/content-mode/adapters/brain-facts.ts
+++ b/packages/api/src/lib/content-mode/adapters/brain-facts.ts
@@ -328,11 +328,38 @@ export const WIDEN_AND_PROMOTE_FACTS_SQL = `
  * The supersession collision (#4912, ADR-0036 §Temporal), spelled ONCE.
  *
  * Joins a draft alias `d` to every already-published fact it would supersede:
- * same (subject, predicate), a DIFFERENT object, and BOTH sides
- * `single`-cardinality. The published side must be live (not tombstoned) and
- * current (`valid_to IS NULL`) — a fact some earlier promotion already
- * superseded is settled history, and stamping it twice would rewrite when the
- * belief ended.
+ * the same SLOT — `(subject_key, predicate_key)` — a DIFFERENT object slot, and
+ * BOTH sides `single`-cardinality. The published side must be live (not
+ * tombstoned) and current (`valid_to IS NULL`) — a fact some earlier promotion
+ * already superseded is settled history, and stamping it twice would rewrite
+ * when the belief ended.
+ *
+ * ## Why the keys and not the surfaces (#5020, ADR-0037 §1)
+ *
+ * This is a column-to-column join, so BOTH sides are the materialized identity
+ * `alias(lexicalNorm(surface))`, written at ingest by `reconcile.ts` and never
+ * re-derived here. On the surfaces it silently no-op'd on a phrasing mismatch: a
+ * draft saying `Ships On` never collided with a published `ships_on`, so publish
+ * left two current `single` values standing and the disclosure showed nothing to
+ * disclose. Same index either way — 0187 repointed `idx_brain_facts_subject`
+ * onto the key columns with a partial predicate this join already satisfies.
+ *
+ * A NULL key on EITHER side excludes the pair, since `=` and `<>` are both
+ * unknown against NULL. That is fail-closed and the direction this join must
+ * fail in — no collision means no `valid_to` stamp, which is the recoverable
+ * outcome — but it is not free, and the cost is symmetric: such a row can
+ * neither BE superseded nor supersede anything, so an unkeyed draft publishes
+ * beside a live rival and an unkeyed published fact survives one. Three
+ * populations reach it, and only two of them are transient:
+ *
+ *   - Rows written between migration 0187 and #5020 — closed by 0188, which
+ *     repeats 0187's re-runnable backfill in #5020's own deploy.
+ *   - Rows a region import lands, until #5035 carries keys verbatim on the v3
+ *     bundle (`admin-migrate.ts`'s 18-column INSERT names no key column). A
+ *     backfill cannot own this one: it runs at boot, the import runs on demand.
+ *   - A surface that norms away (`-`, `___`) — PERMANENT and legal, per
+ *     `identityKey`'s ⚠️. No backfill repairs it; `reconcile.ts` warns at
+ *     ingest, which is the only signal such a claim ever produces.
  *
  * `valid_to IS NULL`, deliberately NOT `brainFactCurrentClause`'s wider
  * `IS NULL OR > now()`: a FUTURE-dated `valid_to` (reachable only via a region
@@ -364,9 +391,9 @@ export const WIDEN_AND_PROMOTE_FACTS_SQL = `
 export function supersessionCollisionJoin(d: string, p: string): string {
   return `JOIN brain_facts ${p}
       ON ${p}.workspace_id = ${d}.workspace_id
-     AND ${p}.subject = ${d}.subject
-     AND ${p}.predicate = ${d}.predicate
-     AND ${p}.object <> ${d}.object
+     AND ${p}.subject_key = ${d}.subject_key
+     AND ${p}.predicate_key = ${d}.predicate_key
+     AND ${p}.object_key <> ${d}.object_key
      AND ${p}.predicate_cardinality = 'single'
      AND ${d}.predicate_cardinality = 'single'
      AND ${p}.status = 'published'

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -266,7 +266,12 @@ describe("runMigrations", () => {
     //   columns, the day-one backfill that fills them from the retained
     //   surface form, and the repoint of `idx_brain_facts_subject` onto them,
     //   #5019 / ADR-0037) = 188.
-    expect(count).toBe(188);
+    //   Plus 0188 (rekey_unkeyed_brain_facts — repeats 0187's backfill, which
+    //   is re-runnable by design, because #5020 is the deploy that pivots the
+    //   three slot consumers onto the keys: rows written in the 0187→#5020
+    //   window are unkeyed and would silently stop corroborating, earning
+    //   tension edges, and being supersedable at publish) = 189.
+    expect(count).toBe(189);
 
     // Advisory lock acquired before anything else
     expect(queries[0]).toContain("pg_advisory_lock");
@@ -483,6 +488,7 @@ describe("runMigrations", () => {
         "0185_backfill_slack_bot_user_id.sql",
         "0186_brain_audience_reverify_attempt.sql",
         "0187_brain_fact_identity_keys.sql",
+        "0188_rekey_unkeyed_brain_facts.sql",
       ],
     });
 
@@ -1386,5 +1392,65 @@ describe("0127_plan_tier_locked.sql", () => {
     expect(internalSrc).toMatch(
       /MANAGED_AUTH_MIGRATIONS\s*=\s*\[[^\]]*"0127_plan_tier_locked\.sql"/,
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: 0188_rekey_unkeyed_brain_facts.sql
+// ---------------------------------------------------------------------------
+
+describe("0188_rekey_unkeyed_brain_facts.sql", () => {
+  /** Comments and blank lines stripped — the executable statement only. */
+  function statementOf(file: string): string {
+    const src = fs.readFileSync(path.join(MIGRATIONS_DIR, file), "utf-8");
+    return src
+      .split("\n")
+      .filter((line) => !line.trimStart().startsWith("--"))
+      .join("\n")
+      .trim();
+  }
+
+  it("re-runs 0187's backfill statement CHARACTER-FOR-CHARACTER", () => {
+    // 0188 is a second copy of a hand-written SQL reimplementation of
+    // `lexicalNorm`, and its own header stakes the file on the two being one
+    // statement. Nothing else checks that: `identity-pg.test.ts` reads 0187 by
+    // name and never touches 0188, and `migrate-pg.test.ts` runs 0188 against
+    // an EMPTY `brain_facts`, so it proves only that the file parses.
+    //
+    // Every failure mode the header names is invisible without this: a
+    // `lower()` creeping back in (which disagrees with `String#toLowerCase()`
+    // above ASCII and moves with the database collation), a dropped `chr(11)`,
+    // a lost `NULLIF` (which reintroduces the `DEFAULT ''` hazard from the
+    // other side), a stray `updated_at = now()` (which reshuffles every
+    // reviewer's draft queue into backfill order), or the scoping mutation the
+    // header calls out by name — `WHERE status = 'published' AND subject_key IS
+    // NULL OR …`, which mutation-testing found passing every assertion in
+    // `identity-pg.test.ts`.
+    //
+    // A TEXT comparison on purpose. A behavioural pairing would pass on two
+    // expressions that agree only over the corpus it happens to seed, and the
+    // property that matters here is narrower and stronger: these are the same
+    // statement, so 0187's row-by-row pairing against the TypeScript covers
+    // both.
+    const declarations = statementOf("0187_brain_fact_identity_keys.sql");
+    const backfill = declarations.slice(declarations.indexOf("UPDATE brain_facts"));
+    const rerun = statementOf("0188_rekey_unkeyed_brain_facts.sql");
+
+    expect(
+      backfill.startsWith(rerun),
+      "0188's statement is no longer 0187's backfill verbatim. Both are hand-written SQL twins of `lexicalNorm`, and two copies that drift are two functions — one keying the corpus at boot and the other having keyed it at 0187. Re-sync them, or delete 0188 if the repeat is no longer wanted.",
+    ).toBe(true);
+  });
+
+  it("is the WHOLE of 0188 — nothing else rides along", () => {
+    // 0187 additionally drops and recreates `idx_brain_facts_subject`; 0188
+    // must not, and must not have acquired any other statement. `;` is the
+    // runner's own segmentation, so counting them is counting statements.
+    const rerun = statementOf("0188_rekey_unkeyed_brain_facts.sql");
+    expect(rerun.split(";").filter((s) => s.trim() !== "")).toHaveLength(1);
+    expect(rerun).not.toMatch(/\b(CREATE|DROP|ALTER)\b/i);
+    // …and it is not scoped. The header's parenthesised WHERE exists for this.
+    expect(rerun).not.toMatch(/\bstatus\b/i);
+    expect(rerun).not.toMatch(/\bupdated_at\b/i);
   });
 });

--- a/packages/api/src/lib/db/migrations/0188_rekey_unkeyed_brain_facts.sql
+++ b/packages/api/src/lib/db/migrations/0188_rekey_unkeyed_brain_facts.sql
@@ -1,0 +1,124 @@
+-- 0188 — Re-run 0187's identity-key backfill, because #5020 is the deploy that
+-- makes an unkeyed row start MATTERING (ADR-0037 §1, §7).
+--
+-- 0187's header says the backfill "is re-runnable by design (`WHERE … IS NULL`);
+-- repeat it", and assigns that repeat to whoever flips `SET NOT NULL`. This file
+-- moves it one step earlier, to the PR that pivots the three slot consumers onto
+-- the key columns, because that is where the need actually arises:
+--
+--   * Between 0187 deploying and #5020 deploying — two separate PRs with no
+--     enforced ordering — `INSERT_FACT_SQL` named none of these columns and
+--     there is no column default, so every fact written in that window is
+--     unkeyed. Nothing repaired them, and nothing would have until the
+--     constraint flip.
+--   * As of #5020 those rows silently drop OUT of all three slot consumers:
+--     `CORROBORATION_LOOKUP_SQL` (a re-observation forks a duplicate draft
+--     instead of strengthening them), `TENSION_CANDIDATES_SQL` (no advisory
+--     edge), and `supersessionCollisionJoin` (they can neither supersede nor be
+--     superseded, so a publish leaves two current `single` values standing and
+--     the will-supersede disclosure shows nothing to disclose).
+--
+-- `=` and `<>` are both UNKNOWN against NULL, so that exclusion is fail-CLOSED
+-- and every one of those outcomes is an under-match — the recoverable direction,
+-- and the one this cut is allowed to be wrong in. It is still a working path
+-- becoming a quietly-degraded one at a deploy boundary, for rows nobody can see
+-- are affected, which is what this file exists to close.
+--
+-- ## Why a migration and not the drift re-key
+--
+-- `check-brain-fact-promotion.sh`'s identity remedy block says of a corpus-wide
+-- re-key: "Still the decide transaction — ADR-0037 §7 makes the drift re-key
+-- TypeScript, at request time, NOT another migration. 0187 was the one-off
+-- day-one backfill and is done." That
+-- rule is about RE-keying — rewriting a key because the VOCABULARY moved, which
+-- needs the reviewer, the vocabulary version, and the preview the decide
+-- transaction has and a migration does not. This statement keys rows that have
+-- no key at all, from the retained surface form, with no vocabulary involved. It
+-- is the same operation 0187 performed, on the rows 0187 could not see because
+-- they did not exist yet.
+--
+-- ## Two properties that make repeating it safe, both from 0187's header
+--
+--   1. **Re-runnable, and a no-op where there is nothing to do.** `WHERE … IS
+--      NULL` matches nothing once every row has all three keys, which is every
+--      fresh install and every CI run. It does NOT match nothing forever: a row
+--      whose SURFACE norms away keys to NULL permanently and legally, so it
+--      re-matches on every run — and note what that means, because it is the
+--      one non-obvious consequence here: such a row has its OTHER two key
+--      columns REWRITTEN each time. Harmless while `alias` is the identity
+--      function; after that it is the same overwrite hazard as item 2, on rows
+--      item 2 would otherwise read as safe.
+--   2. **PRE-VOCABULARY.** 0187's caveat is that re-running it once `alias` is a
+--      real table OVERWRITES aliased keys, because it writes the raw
+--      `identityKey`. `alias` is still the identity function (slice B, ADR-0037
+--      §6 / #5016, has not landed), so there is nothing to overwrite. That
+--      holds until #5016 lands, and it is the reason this repeat is spelled as
+--      a migration rather than left for the constraint flip: once the
+--      vocabulary exists, the drift re-key inside the decide transaction is the
+--      only correct rewriter and a file like this one becomes wrong.
+--
+-- ## What this does NOT fix
+--
+--   * **Region imports.** `admin-migrate.ts`'s 18-column INSERT still names no
+--     key column (ADR-0024), so every fact a v2 bundle lands after this
+--     migration runs is unkeyed again. #5035 carries keys verbatim on the v3
+--     bundle and is the fix; until it merges, imported facts are inert in all
+--     three consumers. A backfill cannot own this — it runs at boot, and the
+--     import runs whenever an admin triggers it.
+--   * **A rolling deploy's own overlap.** This runs at boot on the NEW
+--     instance and is recorded in `__atlas_migrations`, so it never runs again —
+--     while the N-1 instance is still draining and its extraction fiber is
+--     still writing facts through an `INSERT_FACT_SQL` that names no key
+--     column. Those rows are unkeyed permanently, by the same mechanism this
+--     file exists to repair. A migration structurally cannot close a window
+--     that ends after it commits; the `SET NOT NULL` flip's own backfill re-run
+--     is what sweeps the residue.
+--   * **Surfaces that norm away.** `-`, `___`, and `  ` key to NULL
+--     permanently and legally (`identityKey`'s `NULLIF` twin, and the ⚠️ on
+--     `identityKey` itself). They are re-visited by every run of this statement
+--     and stay NULL — a no-op, three expressions over one row. Which is why
+--     "count the unkeyed rows" means comparing against the EXPRESSION, never
+--     testing the column, exactly as 0187's header says.
+--
+-- Scale: one full-table `UPDATE` under the migration runner's advisory lock,
+-- with 0187's estimate and its caveat — a four-figure corpus at the largest
+-- deployment the team could observe as of 2026-08-03, so sub-second, growing
+-- linearly. On a corpus that deployed 0187 and #5020 together it touches zero
+-- rows and only pays the scan.
+
+-- Character-for-character 0187's expression, and it has to stay that way: it is
+-- the SQL twin of `lib/brain/identity.ts`'s `lexicalNorm`, and every reason
+-- 0187's header gives for the shape holds here unchanged — `chr()` instead of a
+-- backslash class (escape processing is a GUC, and `\v` silently degrades to a
+-- literal `v`, shredding every key containing one), `translate()` instead of
+-- `lower()` (`lower()` disagrees with `String#toLowerCase()` on U+0130 and on
+-- word-final sigma, and moves with the database collation), and `NULLIF(…, '')`
+-- instead of a stored empty string (which would make every degenerate row join
+-- every other one). `identity-pg.test.ts` pins 0187's copy against the
+-- TypeScript row by row and does NOT run this file. What pins THIS copy is
+-- `db/__tests__/migrate.test.ts`'s byte-identity assertion against 0187's
+-- statement — deliberately a text comparison rather than a second behavioural
+-- suite, because the property that matters is "these two are the same
+-- statement", and a behavioural test would pass on two expressions that agree
+-- only on the corpus it happens to seed. `migrate-pg.test.ts` additionally
+-- proves the file PARSES and runs, but it runs against an empty `brain_facts`,
+-- so it sees nothing about the expression.
+UPDATE brain_facts
+   SET subject_key   = NULLIF(btrim(regexp_replace(translate(subject,   'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz'), '[ ' || chr(9) || chr(10) || chr(11) || chr(12) || chr(13) || '_-]+', ' ', 'g'), ' '), ''),
+       predicate_key = NULLIF(btrim(regexp_replace(translate(predicate, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz'), '[ ' || chr(9) || chr(10) || chr(11) || chr(12) || chr(13) || '_-]+', ' ', 'g'), ' '), ''),
+       object_key    = NULLIF(btrim(regexp_replace(translate(object,    'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz'), '[ ' || chr(9) || chr(10) || chr(11) || chr(12) || chr(13) || '_-]+', ' ', 'g'), ' '), '')
+-- Parenthesized for 0187's reason, which is worth restating rather than
+-- cross-referencing: the arms are all `OR`, so the group is redundant TODAY and
+-- `AND` binds tighter, so a fourth arm that scopes the statement
+-- (`WHERE status = 'published' AND subject_key IS NULL OR …`) READS as unscoped
+-- and is not. Mutation-testing 0187 found that exact shape passing every
+-- assertion in `identity-pg.test.ts`.
+--
+-- `updated_at` is deliberately NOT stamped, same as 0187: it is the publish
+-- preview's sort key and is projected on the wire by the candidates read, so a
+-- workspace-wide stamp would reshuffle every reviewer's draft queue into
+-- backfill order. A key recomputation moved neither the claim's content nor its
+-- review state.
+ WHERE (subject_key IS NULL
+     OR predicate_key IS NULL
+     OR object_key IS NULL);

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -3280,8 +3280,9 @@ export const brainFacts = pgTable(
     //
     // NULLABLE, and for longer than one slice. `alias` is the identity function
     // until the vocabulary lands, so 0187 fills every existing row with
-    // `identityKey(surface)` — but no INSERT site names these columns yet, so
-    // `NOT NULL` here would refuse every write.
+    // `identityKey(surface)`. `INSERT_FACT_SQL` names all three since #5020;
+    // the region import's 18-column INSERT still names none of them (#5035), so
+    // `NOT NULL` here would still refuse every import.
     //
     // NULL carries TWO meanings, and conflating them is how the constraint
     // plan goes wrong: "no writer has keyed this row yet" (transient, what
@@ -3406,10 +3407,11 @@ export const brainFacts = pgTable(
     // scan of one publish's draft set either way.) The index gets strictly
     // smaller.
     //
-    // The three consumers still compare the SURFACE columns until #5020 pivots
-    // them onto the keys, so until that PR merges they lose their
-    // `(subject, predicate)` access path. Deliberate — carrying two indexes
-    // through the cut is the thing "repoint, not add" exists to avoid.
+    // #5020 pivoted all three consumers onto the key columns, so this index is
+    // their access path again. For the window between the two PRs — separate
+    // merges, no enforced ordering — they compared the SURFACE columns and had
+    // none, which was the accepted cost of "repoint, not add" rather than
+    // carrying two indexes through the cut.
     index("idx_brain_facts_subject")
       .on(t.workspaceId, t.subjectKey, t.predicateKey)
       .where(sql`invalidated_at IS NULL AND valid_to IS NULL`),

--- a/packages/api/src/lib/knowledge/__tests__/knowledge-lifecycle-pg.test.ts
+++ b/packages/api/src/lib/knowledge/__tests__/knowledge-lifecycle-pg.test.ts
@@ -19,6 +19,7 @@ import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { Pool } from "pg";
 import { zipSync, strToU8 } from "fflate";
 import { runMigrations } from "@atlas/api/lib/db/migrate";
+import { identityAlias, slotKey } from "@atlas/api/lib/brain/identity";
 import { MANAGED_AUTH_MIGRATIONS } from "@atlas/api/lib/db/internal";
 import { extractBundle } from "@atlas/api/lib/knowledge/bundle-archive";
 import { parseLenientBundle } from "@atlas/api/lib/knowledge/parse-lenient";
@@ -960,12 +961,29 @@ describeIfPg("knowledge ingest lifecycle against the live schema", () => {
     const episodeId = epRows[0]!.id;
     const seedFact = async (object: string, status: "draft" | "published") => {
       const { rows } = await pool.query<{ id: string }>(
+        // Keyed like an ingested row (#5020): `supersessionCollisionJoin`
+        // matches on `subject_key`/`predicate_key`/`object_key`, and `=` and
+        // `<>` are both UNKNOWN against NULL — so an unkeyed seed collides with
+        // nothing, `collectSupersessions` returns `[]`, and this test's whole
+        // chain reads as an adapter-registration drift. Derived through
+        // `slotKey`, the same function `reconcile.ts` calls when binding
+        // `INSERT_FACT_SQL`.
         `INSERT INTO brain_facts
            (workspace_id, subject, predicate, object, source_episode_id,
-            provenance, status, visible_to, predicate_cardinality)
-         VALUES ($1, 'alice', 'manager', $2, $3, '{"actor":"test"}'::jsonb, $4, '{org}', 'single')
+            provenance, status, visible_to, predicate_cardinality,
+            subject_key, predicate_key, object_key)
+         VALUES ($1, 'alice', 'manager', $2, $3, '{"actor":"test"}'::jsonb, $4, '{org}', 'single',
+                 $5, $6, $7)
          RETURNING id`,
-        [wsPromote, object, episodeId, status],
+        [
+          wsPromote,
+          object,
+          episodeId,
+          status,
+          slotKey("alice", identityAlias),
+          slotKey("manager", identityAlias),
+          slotKey(object, identityAlias),
+        ],
       );
       return rows[0]!.id;
     };


### PR DESCRIPTION
Slice A of [ADR-0037](docs/adr/0037-claim-identity-in-the-brain.md) §1. #5019 added the three key columns and the day-one backfill; nothing wrote them on new rows and nothing joined on them. This closes both halves — writing keys without repointing is dead weight, repointing without writing breaks every new fact.

## ⚠️ Deviation from the acceptance criteria — decided before work started

**AC bullet 3 ("the slot keys are total, `NOT NULL`") is deliberately NOT in this PR.** The three key columns stay nullable. Filed as **#5047**.

`identityKey` returns NULL for a surface whose lexical norm is empty (`-`, `___`, `  `), and `reconcile.ts`'s `MALFORMED_CLAIM` guard tests `surface.trim() === ""` — `trim` strips whitespace but not `_` or `-`. Those are storable claims *today*, so `SET NOT NULL` would turn an ordinary ingest into a not-null violation that fails the whole reconcile transaction. It also needs #5035 first, since the region import's 18-column INSERT names none of the key columns. The ⚠️ block in `0187_brain_fact_identity_keys.sql`'s header is the source of truth and enumerates all three prerequisites; #5047 owns them, including the guard change nobody owned.

## What changed

| | |
|---|---|
| **Write** | `INSERT_FACT_SQL` names all three key columns. They are derived **once per candidate**, off the **resolved** surfaces (the strings that land in the SPO columns), so the stored key always describes the stored row. `RETURNING id` is unchanged — `keys-not-on-the-wire.test.ts` scans RETURNING lists. |
| **Read** | `CORROBORATION_LOOKUP_SQL`, `TENSION_CANDIDATES_SQL` (`lib/brain/reconcile.ts`) and `supersessionCollisionJoin` (`lib/content-mode/adapters/brain-facts.ts`) swap their join arms onto the keys — a swap and nothing more, no consumer re-derives. This also gets back the access path 0187 repointed `idx_brain_facts_subject` onto. |
| **Seam** | `identity.ts` gains `AliasLookup` / `identityAlias` / `slotKey`, and `slotKey` re-norms the vocabulary's answer rather than trusting it. Threaded through `ReconcileRequest.alias` and `CorrectionDeps.alias` so slice B (#5016) adds a table instead of moving call sites; the parameter is **required**, so a site that forgets is a compile error rather than a silent identity-function fallback. |

## This is an observable behaviour change, not a refactor

`Ships On` and `ships_on` were two slots and are now one. Concretely, per the issue's consumer table: a re-observation that rephrases now **corroborates** instead of forking a duplicate draft; two `single` claims about one slot now earn their advisory `in-tension-with` edge; and a draft now **supersedes** a published rival it silently coexisted with. The retained surface columns are untouched — only what counts as the same claim moved. `is priced at` / `priced at` still do **not** collide (that pair is a vocabulary entry, not a normalization rule).

Two directions worth flagging for the first post-deploy publish, both documented in `reconcile.ts`'s header:

- **The fold widens matching**, so it reaches grant widening (a wider-audience restatement now attaches as evidence to a narrower claim — human-gated at publish, disclosed as a `GrantWidening`) and `valid_to` (the irreversible write is now reachable through a lexical rule). `loadSupersessionPreview` discloses every pair before the admin confirms; that is the mitigation.
- **It narrows the two `<>` arms**, so a workspace's will-supersede count can *drop* at this deploy and some standing advisory edges stop being minted. At ingest that is strictly better — those pairs corroborate instead.

## Beyond the stated scope, and why

**Migration 0188 repeats 0187's backfill.** Not the constraint — the backfill. 0187's header assigns the repeat to whoever flips `SET NOT NULL`; this PR is one step earlier and is where the need actually arises. Rows written in the 0187→#5020 window are unkeyed, and *as of this PR* they drop out of all three consumers (`=` and `<>` are both UNKNOWN against NULL). It is idempotent (`WHERE … IS NULL`) and pre-vocabulary, so it is a no-op on any corpus that deployed both PRs together, and it is the last deploy at which repeating it is safe. `migrate.test.ts` pins its statement byte-identical to 0187's, since two hand-written SQL twins of `lexicalNorm` that drift are two functions.

**`correction.ts`'s `replacementIdentical` guard now compares slot keys.** Left byte-exact it would pass `Bob` → `bob` through to `SUPERSEDE_STAMP_SQL` — closing a published belief and standing up a successor in the identical slot, with a `supersedes` edge recording an arbitration that settled nothing. That is the irreversible direction reached through a spelling difference, and the pivot is what created it.

**A `log.warn` when a stored claim has a null key.** Permanent, legal, and otherwise invisible: no backfill repairs it, and the row then joins nothing for as long as it exists.

## Known windows, both owned elsewhere

- **Region imports** land unkeyed until **#5035** carries keys verbatim on the v3 bundle (ADR-0037 §8 — a carry, never a re-derive). Those facts are inert in all three consumers meanwhile: fail-closed, but the publish gate's disclosure reports "nothing to supersede" without being able to say the check could not run. Now documented at `admin-migrate.ts`'s INSERT, which is the site that produces the population.
- **A degenerate replacement against a real target** (`-` superseding `bob`) still passes the correction guard. It needs no refusal of its own — the `MALFORMED_CLAIM` tightening in #5047 blocks that candidate at the ingest seam, and the replacement routes through that seam, so the block rolls the stamp back with it.

## Verification

- `bash scripts/ci-local.sh` with `TEST_DATABASE_URL` set: **33/33 green**, real Postgres, full suite.
- **Every join arm mutation-tested individually** — all six SQL arms plus all three collision-join arms die to a specific `-pg` case. The object arm of `TENSION_CANDIDATES_SQL` initially survived; the review panel found the reachable falsifier (a live rival whose object is `-` has a NULL object key, so it escapes the corroboration lookup and reaches the rival scan), and it now has a test. 0188's three mutations (a `lower()`, a dropped `chr(11)`, a scoping `WHERE`) all die too.
- The `-pg` seeders that participate in slot joins now key their rows through `slotKey` — including `knowledge-lifecycle-pg.test.ts`, which the full suite caught and `--affected` could not reach.

Closes #5020
