### PR TITLE
test(brain): strip FakeBrainStore of identity answers; one -pg corpus, three verdicts (#5021)

### DIFF
--- a/packages/api/src/lib/brain/__tests__/extract-reconcile-pg.test.ts
+++ b/packages/api/src/lib/brain/__tests__/extract-reconcile-pg.test.ts
@@ -371,62 +371,24 @@ describeIfPg("brain extraction + reconcile (real Postgres)", () => {
     expect((await facts())[0]).toMatchObject({ subject: "The Deploy Box" });
   });
 
-  it("⭐ corroborates across a phrasing difference — the slot, not the spelling", async () => {
-    // THE behaviour this slice buys, end to end. Byte-exactness minted a second
-    // draft here and the reviewer got two rows asserting one thing; the keys
-    // make the second observation strengthen the first.
-    const first = await insertEpisode({ sourceId: "C01:key-2" });
-    const second = await insertEpisode({ sourceId: "C01:key-3" });
-
-    // Every one of the three arms varies, so each is load-bearing here —
-    // mutation-checked one at a time.
-    await reconcileFacts({
-      episode: first,
-      candidates: [candidate({ subject: "deploy_window", predicate: "ships_on", object: "Thursdays" })],
-      producer: "p",
-      extractedAt: new Date(),
-    });
-    const report = await reconcileFacts({
-      episode: second,
-      candidates: [candidate({ subject: "Deploy Window", predicate: "Ships On", object: "thursdays" })],
-      producer: "p",
-      extractedAt: new Date(),
-    });
-
-    expect(report.corroborated).toBe(1);
-    const stored = await facts();
-    expect(stored).toHaveLength(1);
-    // The FIRST phrasing is what the corpus keeps; the second episode arrives
-    // as evidence on the row that already exists.
-    expect(stored[0]).toMatchObject({ subject: "deploy_window" });
-    expect((await edges()).filter((e) => e.edge_type === "provenance")).toHaveLength(2);
-  });
-
-  it("does NOT unify what the vocabulary owns — `is priced at` is not `priced at`", async () => {
-    // The refusal the lexical layer is built around. Collapsing these is a
-    // curated entry with a reviewer behind it (ADR-0037 §6 / #5016), because the same rule
-    // applied generally folds `is owned by` into `owns` — and `led_by`/`leads`,
-    // which are INVERSE relations, into one slot whose join arm stamps
-    // `valid_to`.
-    const first = await insertEpisode({ sourceId: "C01:key-4" });
-    const second = await insertEpisode({ sourceId: "C01:key-5" });
-
-    await reconcileFacts({
-      episode: first,
-      candidates: [candidate({ predicate: "is priced at" })],
-      producer: "p",
-      extractedAt: new Date(),
-    });
-    const report = await reconcileFacts({
-      episode: second,
-      candidates: [candidate({ predicate: "priced at" })],
-      producer: "p",
-      extractedAt: new Date(),
-    });
-
-    expect(report.corroborated).toBe(0);
-    expect(await facts()).toHaveLength(2);
-  });
+  // The three collide/don't-collide cases that used to sit here — a phrasing
+  // variant corroborating, `is priced at` NOT unifying with `priced at`, and a
+  // phrasing-hidden rival earning a tension edge — moved to
+  // `identity-consumers-pg.test.ts` (#5021). They are now asserted over ONE
+  // corpus read by all three consumers, alongside the supersession join, which
+  // is what stops the three drifting into disagreeing about what collides. A
+  // second set of pairs making the same claims here is the drift shape itself.
+  //
+  // What stays below is what that corpus cannot express: a row whose key is
+  // NULL, and a rival whose OBJECT key is NULL. Both need a surface that norms
+  // away, which is a property of one claim rather than a relation between two.
+  //
+  // The other two-claim cases elsewhere in this file (`corroborates a
+  // re-observed claim`, `records an advisory in-tension-with edge`, the
+  // published/retracted/cross-tenant ones) are NOT duplicates of the corpus and
+  // were deliberately kept: each varies a STAGE property — status, grant,
+  // tombstone, tenant — over one fixed claim, rather than varying the claim.
+  // Identity is the corpus's axis; those are this file's.
 
   it("keys a surface that norms away as NULL, and NULL corroborates nothing", async () => {
     // `-` and `___` survive the MALFORMED_CLAIM guard (`trim` strips whitespace,
@@ -465,52 +427,6 @@ describeIfPg("brain extraction + reconcile (real Postgres)", () => {
       expect(slot.object_key).toBeNull();
       expect(slot.subject_key).toBe("deploy window");
     }
-  });
-
-  it("flags a tension the phrasing used to hide — the rival scan is the slot too", async () => {
-    // The first row of #5020's consumer table. Two `single`-cardinality claims
-    // about one slot, spelled differently: on the surface columns the rival scan
-    // matched nothing, so the second claim landed with no `in-tension-with` edge
-    // and the reviewer saw two uncontested facts where there was a genuine
-    // contradiction. Mutation-checked — reverting the SUBJECT or PREDICATE arm
-    // of `TENSION_CANDIDATES_SQL` to the surfaces turns this red. The OBJECT arm
-    // needs a degenerate rival to distinguish it, which is the next case: here
-    // `Grace` and `Alan` differ on the surface and on the key alike.
-    const first = await insertEpisode({ sourceId: "C01:key-8" });
-    const second = await insertEpisode({ sourceId: "C01:key-9" });
-
-    await reconcileFacts({
-      episode: first,
-      candidates: [
-        candidate({
-          subject: "Ada",
-          predicate: "Reports_To",
-          object: "Grace",
-          predicateCardinality: "single",
-        }),
-      ],
-      producer: "p",
-      extractedAt: new Date(),
-    });
-    const report = await reconcileFacts({
-      episode: second,
-      candidates: [
-        candidate({
-          subject: "ada",
-          predicate: "reports to",
-          object: "Alan",
-          predicateCardinality: "single",
-        }),
-      ],
-      producer: "p",
-      extractedAt: new Date(),
-    });
-
-    // Two beliefs — the objects genuinely differ — and now they are visibly in
-    // tension. Advisory only: nothing was superseded or invalidated.
-    expect(report.outcomes[0]).toMatchObject({ kind: "created", tensionEdges: 1 });
-    expect(await facts()).toHaveLength(2);
-    expect((await edges()).filter((e) => e.edge_type === "in-tension-with")).toHaveLength(1);
   });
 
   it("a rival with NO object identity is not a rival — the object arm's falsifier", async () => {
@@ -963,8 +879,11 @@ describeIfPg("brain extraction + reconcile (real Postgres)", () => {
     // lookup, and the stamp. Dropping `workspace_id =` from the first turns a
     // dedupe into a cross-tenant read — tenant B's re-observation attaches a
     // provenance edge to tenant A's fact, and A's fact then cites evidence A
-    // cannot see. The unit suite's fake implements the filter in TypeScript, so
-    // it proves the parameter is PASSED and says nothing about the SQL text.
+    // cannot see. The unit suite can only prove the PARAMETER is passed
+    // (`reconcile.test.ts`, "the lookup's first bind is the episode's
+    // workspace") — since #5021 its fake answers the lookup from a scripted
+    // premise and implements no filter at all. That the SQL TEXT still names
+    // the column is this test's.
     const mine = await insertEpisode({ sourceId: "C01:tenant-a" });
     const { rows } = await pool.query<{ id: string }>(
       `INSERT INTO brain_episodes

--- a/packages/api/src/lib/brain/__tests__/identity-consumers-pg.test.ts
+++ b/packages/api/src/lib/brain/__tests__/identity-consumers-pg.test.ts
@@ -1,0 +1,558 @@
+/**
+ * The three claim-identity consumers, over ONE corpus (#5021, ADR-0037 §9).
+ *
+ * `identity-corpus.ts` holds the fixture set; this file is the only place that
+ * consumes it. Corroboration (`CORROBORATION_LOOKUP_SQL`), the advisory rival
+ * scan (`TENSION_CANDIDATES_SQL`), and the publish gate's
+ * `supersessionCollisionJoin` each read the same materialized
+ * `(subject_key, predicate_key, object_key)` triple, and each turns it into a
+ * different verdict — *same*, *different-and-coexisting*, *different-and-stamping*.
+ * Running all three over one fixture set is what stops them drifting into
+ * disagreeing about what collides, which three private fixture sets could not
+ * detect by construction.
+ *
+ * Every expectation below is COMPUTED from `VERDICTS[pair.relation]` rather than
+ * written beside the assertion, so the table is the single definition of what
+ * collides and flipping a cell turns three tests red.
+ *
+ * ## Why this is a `-pg` suite and not a unit one
+ *
+ * Because the question is which COLUMNS the statements name, and no in-memory
+ * executor can see that. `reconcile.test.ts`'s fake dispatches on each SQL
+ * constant's string identity and reads its binds positionally, so repointing
+ * `CORROBORATION_LOOKUP_SQL` back at the surface columns leaves every
+ * BEHAVIOURAL test in that file green — only its lexical backstop, which greps
+ * the statement text, catches it. That fake no longer answers identity questions
+ * at all (#5021); this file is where the answers moved.
+ *
+ * **Accepted cost, recorded in the map's T7 §4:** the most load-bearing
+ * assertions in the identity slice now live in the slower, WSL2-flakier lane,
+ * and a `--affected` run over `lib/brain/` no longer covers them without
+ * `TEST_DATABASE_URL`. The one-corpus design bounds that rather than removing
+ * it — eight pairs, three consumers, not three suites.
+ *
+ * ## Every prohibition has a positive control, in its own `test()`
+ *
+ * Each consumer gets a *does collide* block and *does not collide* blocks over
+ * the same corpus. The prohibitions are the load-bearing half and every one of
+ * them passes green against machinery that does nothing at all — a rival scan
+ * that returns zero rows satisfies consumer 2's, a lookup that never hits
+ * satisfies consumer 1's, and a join that never matches satisfies consumer 3's.
+ * The positive control is what proves each can fire.
+ *
+ * The control and the prohibitions are SEPARATE `test()` blocks sharing the
+ * fixture, never both arms in one body: in a long proof the first failure hides
+ * the rest, and a positive control that breaks would silently mask the
+ * prohibition it licenses.
+ *
+ * ## Nothing here writes a key
+ *
+ * Both sides of every pair land through `reconcileFacts`, so every `*_key`
+ * column is a value the stage produced. The corpus supplies surfaces and a claim
+ * about English; the system supplies the identity and the observed verdict. A
+ * test that hand-wrote the expected key would pin it twice in one commit and
+ * agree with itself forever.
+ *
+ * ## MUTATIONS THIS CATCHES
+ *
+ * Run one at a time against this file; each line is verified, not asserted.
+ *
+ * | Mutation | Dies on |
+ * |---|---|
+ * | `CORROBORATION_LOOKUP_SQL` repointed at the surface columns | 6 — all three consumers, via both `same-claim` pairs |
+ * | `TENSION_CANDIDATES_SQL` repointed at the surface columns | consumer 2's control, via `rival-through-phrasing` |
+ * | `supersessionCollisionJoin` repointed at the surface columns | consumer 3's control, via `rival-through-phrasing` |
+ * | the corroboration call site binds raw surfaces instead of `item.keys.*` | 6 here — **and 3 in `reconcile.test.ts`**, which is the bind half it can still see |
+ * | the tension call site binds raw surfaces | consumer 2's control |
+ * | `subject_key =` neutralized in the rival scan / dropped from the collision join | consumers 2 and 3, via `subject-differs` |
+ * | `predicate_key =` neutralized in the rival scan / dropped from the collision join | consumers 2 and 3, via `predicate-differs` |
+ * | `identityAlias` given a global rule (`/^is /` stripped) | 3 — all three PROHIBITIONS, via `copula-pair` |
+ * | `lexicalNorm` loses its edge trim | 3 — all three consumers, via `separator-edges` |
+ * | `lexicalNorm` loses its ASCII case fold | 8, across all three consumers |
+ * | `INSERT_TENSION_EDGE_SQL`'s endpoints swapped | consumer 2's control — the edge direction is what the review queue renders |
+ *
+ * Three rows widen what collides rather than narrowing it — `identityAlias`,
+ * which widens the KEY FUNCTION, and the two arm mutations, which widen the
+ * JOINS. All three are caught EXCLUSIVELY by prohibitions, because
+ * `copula-pair`, `subject-differs` and `predicate-differs` are all
+ * `different-claim` entries. Every other row is caught by a positive control.
+ * Delete either half and a whole direction of failure stops being visible.
+ *
+ * The two STATEMENT-repoint rows for the rival scan and the collision join
+ * survived until BOTH sides of `rival-through-phrasing` were spelled off normal
+ * form. A pair with one already-normalized side is blind to either the statement
+ * repoint or the call-site bind, depending which side is clean — see that
+ * entry's `why`.
+ *
+ * NOT in the table, and stated because its absence is load-bearing: the
+ * `object_key <>` arm of either join is NOT falsifiable from this corpus. The
+ * shape that would catch it is `subject =, predicate =, object =` presented as
+ * TWO rows, and `reconcileFacts` cannot produce that — corroboration collapses
+ * it first. That arm's real-schema owner is `promotion-pg.test.ts`, which seeds
+ * both rows directly. Do not consolidate that suite into this one.
+ *
+ * Two entries — `inverse-relations` and `entity-alias` — are not falsified by
+ * any mutation above, and that is stated rather than hidden: no rule reachable
+ * from `lexicalNorm` can swap a subject with an object or unify two spellings of
+ * one machine. They prohibit a direction a FUTURE normalization could take
+ * (T3 §3 falsified morphological folding with the first of them), and they are
+ * licensed by the controls beside them rather than by a mutation of their own.
+ *
+ * Opt in locally with the same scratch database as its sibling brain suites —
+ * every one of them creates and drops its OWN schema, so they share it safely:
+ *   bun run db:up && export TEST_DATABASE_URL=postgresql://atlas:atlas@localhost:5433/brain_4771_scratch
+ */
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
+import { Effect } from "effect";
+import { Pool } from "pg";
+import { runMigrations } from "@atlas/api/lib/db/migrate";
+import { MANAGED_AUTH_MIGRATIONS, _resetPool } from "@atlas/api/lib/db/internal";
+import { promoteBrainFacts } from "@atlas/api/lib/content-mode/adapters/brain-facts";
+import { resolvePrincipalContext } from "@atlas/api/lib/brain/acl";
+import { loadSupersessionPreview } from "@atlas/api/lib/brain/oversight";
+import {
+  reconcileFacts,
+  type ReconcileEpisodeRef,
+} from "@atlas/api/lib/brain/reconcile";
+import {
+  IDENTITY_CORPUS,
+  RELATIONS,
+  VERDICTS,
+  pairsWhere,
+  type Claim,
+  type ClaimPair,
+  type SlotRelation,
+} from "./identity-corpus";
+
+const TEST_DB_URL = process.env.TEST_DATABASE_URL;
+const describeIfPg = TEST_DB_URL ? describe : describe.skip;
+const PG_TEST_TIMEOUT_MS = 60_000;
+
+// ---------------------------------------------------------------------------
+// The corpus's own invariants — deliberately OUTSIDE the Postgres gate
+// ---------------------------------------------------------------------------
+//
+// This needs no database, and it is what licenses every prohibition/control
+// pairing below. `for (const pair of pairsWhere("rival-claim"))` over an empty
+// array registers ZERO `it()` blocks and reports success, so deleting the last
+// entry of a relation silently deletes three tests across three consumers. If
+// this guard sat inside `describeIfPg` it would be skipped in exactly the lane
+// where the rest of the identity coverage is also skipped — the default local
+// and `--affected` runs — which is where a silent deletion would land.
+
+describe("the identity corpus itself (#5021)", () => {
+  it("populates every row of the verdict table", () => {
+    for (const relation of RELATIONS) {
+      expect(
+        pairsWhere(relation).length,
+        `no corpus entry has relation \`${relation}\` — a consumer's control or prohibition is empty`,
+      ).toBeGreaterThan(0);
+    }
+  });
+
+  it("holds no entry that compares a claim with itself", () => {
+    for (const pair of IDENTITY_CORPUS) {
+      expect(pair.a, `corpus entry \`${pair.id}\` compares a claim with itself`).not.toEqual(pair.b);
+    }
+  });
+
+  it("holds no duplicate id", () => {
+    // The id names a workspace AND both episode source ids, so a duplicate makes
+    // two entries share a corpus and points every failure at the wrong one.
+    const ids = IDENTITY_CORPUS.map((pair) => pair.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});
+
+describeIfPg("claim identity — three consumers, one corpus (#5021)", () => {
+  let pool: Pool;
+  let priorDatabaseUrl: string | undefined;
+  const schemaName = `brain_5021_${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
+
+  beforeAll(async () => {
+    // `reconcileFacts` writes through the module-level pool when no runner is
+    // injected. The `_resetPool(pool)` at the end of this hook is what points
+    // that pool at this schema, and is the real guard here; `DATABASE_URL` is set because sibling
+    // brain helpers gate on `hasInternalDB()`, which reads the env var rather
+    // than the pool. Set inside the hook, never at module top level.
+    priorDatabaseUrl = process.env.DATABASE_URL;
+    process.env.DATABASE_URL = TEST_DB_URL;
+    pool = new Pool({
+      connectionString: TEST_DB_URL,
+      options: `-c search_path="${schemaName}",public`,
+    });
+    const bootstrap = new Pool({ connectionString: TEST_DB_URL });
+    try {
+      await bootstrap.query(`CREATE SCHEMA IF NOT EXISTS "${schemaName}"`);
+    } finally {
+      await bootstrap.end();
+    }
+    await runMigrations(pool, { skip: MANAGED_AUTH_MIGRATIONS });
+    _resetPool(pool);
+  }, PG_TEST_TIMEOUT_MS);
+
+  afterAll(async () => {
+    _resetPool(null);
+    if (priorDatabaseUrl === undefined) delete process.env.DATABASE_URL;
+    else process.env.DATABASE_URL = priorDatabaseUrl;
+    if (pool) {
+      await pool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+      await pool.end();
+    }
+  }, PG_TEST_TIMEOUT_MS);
+
+  afterEach(async () => {
+    await pool.query("DELETE FROM brain_edges");
+    await pool.query("DELETE FROM brain_facts");
+    await pool.query("DELETE FROM brain_episodes");
+    await pool.query("DELETE FROM admin_action_log");
+  });
+
+  // ── landing the corpus ──────────────────────────────────────────────────
+
+  /** One workspace per pair, so a failure names the entry that produced it. */
+  const workspaceFor = (pair: ClaimPair): string => `ws-identity-${pair.id}`;
+
+  async function seedEpisode(workspaceId: string, sourceId: string): Promise<ReconcileEpisodeRef> {
+    const occurredAt = new Date("2026-06-21T09:00:00.000Z");
+    const { rows } = await pool.query<{ id: string }>(
+      `INSERT INTO brain_episodes
+         (workspace_id, source, source_id, source_actor, body, occurred_at, visible_to)
+       VALUES ($1, 'slack', $2, 'U123', 'evidence', $3::timestamptz, ARRAY['org'])
+       RETURNING id`,
+      [workspaceId, sourceId, occurredAt.toISOString()],
+    );
+    return {
+      id: rows[0]!.id,
+      workspaceId,
+      source: "slack",
+      sourceId,
+      sourceActor: "U123",
+      occurredAt,
+      visibleTo: ["org"],
+    };
+  }
+
+  /**
+   * Reconcile one side of a pair, through the real stage.
+   *
+   * `single` cardinality throughout, because it is the ONE configuration all
+   * three consumers read: the collision join requires it on BOTH sides, the
+   * rival scan is only ISSUED for a `single` incoming candidate (a TypeScript
+   * gate in `reconcile.ts`, not an arm of the statement), and corroboration is
+   * indifferent. Varying it per consumer would be three configurations of one
+   * corpus, which is the drift this file exists to prevent.
+   */
+  async function land(workspaceId: string, sourceId: string, claim: Claim) {
+    const episode = await seedEpisode(workspaceId, sourceId);
+    const report = await reconcileFacts({
+      episode,
+      candidates: [{ ...claim, predicateCardinality: "single" }],
+      producer: "identity-corpus",
+      extractedAt: new Date("2026-06-21T10:00:00.000Z"),
+    });
+    // A PRECONDITION, asserted where all nine test bodies inherit it.
+    // `reconcileFacts` returns every domain refusal as a counted outcome and
+    // never throws, so a candidate that tripped `MALFORMED_CLAIM` would land
+    // zero rows and every prohibition below would pass against an empty table.
+    // Not hypothetical: `reconcile.ts`'s header plans to widen that guard from
+    // `trim() === ""` to refusing a candidate whose key is null, and a corpus
+    // entry is only ever one edit away from tripping it.
+    expect(
+      report.outcomes[0],
+      `\`${sourceId}\` was refused, not landed — every assertion downstream is vacuous`,
+    ).not.toMatchObject({ kind: "blocked" });
+    return report;
+  }
+
+  /** Both sides of a pair, `a` then `b`, into that pair's own workspace. */
+  async function landPair(pair: ClaimPair) {
+    const workspaceId = workspaceFor(pair);
+    await land(workspaceId, `${pair.id}-a`, pair.a);
+    const b = await land(workspaceId, `${pair.id}-b`, pair.b);
+    return { workspaceId, b };
+  }
+
+  async function publish(workspaceId: string) {
+    const client = await pool.connect();
+    // Set only when ROLLBACK itself failed; passing it to `release` DESTROYS the
+    // connection instead of returning a client with an open transaction to the
+    // pool, where the next test's `afterEach` DELETE would block on its locks
+    // rather than failing where the fault actually was.
+    let destroyReason: Error | undefined;
+    try {
+      await client.query("BEGIN");
+      const report = await Effect.runPromise(promoteBrainFacts(client, workspaceId));
+      await client.query("COMMIT");
+      return report;
+    } catch (err) {
+      // The ROLLBACK must not REPLACE the failure the test was about —
+      // `reconcile.ts`'s own runner is the pattern. Its cause is logged rather
+      // than dropped: a broken socket or a server-side FATAL here is the reason
+      // the next test misbehaves, and silence makes that untraceable.
+      await client.query("ROLLBACK").catch((cause: unknown) => {
+        destroyReason = cause instanceof Error ? cause : new Error(String(cause));
+        console.warn(
+          `publish(${workspaceId}): ROLLBACK failed after "${
+            err instanceof Error ? err.message : String(err)
+          }" — destroying the connection so the next test does not inherit an open transaction: ${destroyReason.message}`,
+        );
+      });
+      throw err;
+    } finally {
+      // In the `finally`, so a throw from `release` on the success path cannot
+      // fall into the catch and re-`ROLLBACK` an already-released client.
+      client.release(destroyReason);
+    }
+  }
+
+  async function factIds(workspaceId: string): Promise<string[]> {
+    const { rows } = await pool.query<{ id: string }>(
+      `SELECT id::text AS id FROM brain_facts WHERE workspace_id = $1 ORDER BY ingested_at, id`,
+      [workspaceId],
+    );
+    return rows.map((r) => r.id);
+  }
+
+  /** The retained SURFACES, in insertion order — what a reviewer actually reads. */
+  async function subjectsOf(workspaceId: string): Promise<string[]> {
+    const { rows } = await pool.query<{ subject: string }>(
+      `SELECT subject FROM brain_facts WHERE workspace_id = $1 ORDER BY ingested_at, id`,
+      [workspaceId],
+    );
+    return rows.map((r) => r.subject);
+  }
+
+  /** Every `in-tension-with` edge's endpoints — the DIRECTION is a contract. */
+  async function tensionEdges(workspaceId: string): Promise<{ from: string; to: string }[]> {
+    const { rows } = await pool.query<{ from: string; to: string }>(
+      `SELECT from_fact_id::text AS "from", to_fact_id::text AS "to"
+         FROM brain_edges
+        WHERE workspace_id = $1 AND edge_type = 'in-tension-with'`,
+      [workspaceId],
+    );
+    return rows;
+  }
+
+  async function tensionEdgeCount(workspaceId: string): Promise<number> {
+    const { rows } = await pool.query<{ n: string }>(
+      `SELECT count(*)::text AS n FROM brain_edges
+        WHERE workspace_id = $1 AND edge_type = 'in-tension-with'`,
+      [workspaceId],
+    );
+    return Number(rows[0]!.n);
+  }
+
+  async function provenanceEdgeCount(workspaceId: string): Promise<number> {
+    const { rows } = await pool.query<{ n: string }>(
+      `SELECT count(*)::text AS n FROM brain_edges
+        WHERE workspace_id = $1 AND edge_type = 'provenance'`,
+      [workspaceId],
+    );
+    return Number(rows[0]!.n);
+  }
+
+  /** Facts still answering as-of-now reads — the population supersession shrinks. */
+  async function currentFactCount(workspaceId: string): Promise<number> {
+    const { rows } = await pool.query<{ n: string }>(
+      `SELECT count(*)::text AS n FROM brain_facts
+        WHERE workspace_id = $1 AND valid_to IS NULL AND invalidated_at IS NULL`,
+      [workspaceId],
+    );
+    return Number(rows[0]!.n);
+  }
+
+  /** How many rows a pair leaves behind: one if it collapsed, two if it did not. */
+  const rowsFor = (pair: ClaimPair): number => (VERDICTS[pair.relation].corroborates ? 1 : 2);
+
+  // ══════════════════════════════════════════════════════════════════════
+  // Consumer 1 — corroboration (CORROBORATION_LOOKUP_SQL): *same*
+  // ══════════════════════════════════════════════════════════════════════
+
+  describe("consumer 1 — corroboration says *same*", () => {
+    // `Record<SlotRelation, …>` rather than three hand-written `pairsWhere("…")`
+    // loops: adding a relation to the corpus is then a COMPILE error here, not a
+    // corpus entry that no consumer reads. Same in the two consumers below.
+    const TITLES: Record<SlotRelation, string> = {
+      "same-claim": "⭐ strengthens instead of forking",
+      "rival-claim": "does not absorb a different VALUE in the same slot",
+      "different-claim": "does not collide a different SLOT",
+    };
+
+    for (const relation of RELATIONS) {
+      for (const pair of pairsWhere(relation)) {
+        it(
+          `${TITLES[relation]}: ${pair.id}`,
+          async () => {
+            const { workspaceId, b } = await landPair(pair);
+            const verdict = VERDICTS[pair.relation];
+
+            expect(b.corroborated).toBe(verdict.corroborates ? 1 : 0);
+            expect(b.created).toBe(verdict.corroborates ? 0 : 1);
+            // The row count is the control that keeps the prohibitions honest:
+            // "did not corroborate" is also true of a stage that wrote nothing.
+            expect(await factIds(workspaceId)).toHaveLength(rowsFor(pair));
+            // Either way BOTH episodes are cited — one belief with two pieces of
+            // evidence behind it, or two beliefs with one each.
+            expect(await provenanceEdgeCount(workspaceId)).toBe(2);
+            // Identity moved; the record of what a producer SAID did not. On a
+            // collapse the corpus keeps the FIRST phrasing verbatim and the
+            // second episode arrives as evidence — a corroboration that
+            // overwrote the surface would silently rewrite history, and nothing
+            // else in the repo pins this.
+            expect(await subjectsOf(workspaceId)).toEqual(
+              verdict.corroborates ? [pair.a.subject] : [pair.a.subject, pair.b.subject],
+            );
+          },
+          PG_TEST_TIMEOUT_MS,
+        );
+      }
+    }
+  });
+
+  // ══════════════════════════════════════════════════════════════════════
+  // Consumer 2 — the rival scan (TENSION_CANDIDATES_SQL):
+  // *different-and-coexisting*
+  // ══════════════════════════════════════════════════════════════════════
+
+  describe("consumer 2 — the rival scan says *different-and-coexisting*", () => {
+    const TITLES: Record<SlotRelation, string> = {
+      "rival-claim": "⭐ flags a contradiction the phrasing used to hide",
+      "same-claim": "does not put one claim in tension with itself",
+      "different-claim": "does not flag two claims that share no slot",
+    };
+
+    for (const relation of RELATIONS) {
+      for (const pair of pairsWhere(relation)) {
+        it(
+          `${TITLES[relation]}: ${pair.id}`,
+          async () => {
+            const { workspaceId, b } = await landPair(pair);
+            const verdict = VERDICTS[pair.relation];
+            const edges = verdict.tension ? 1 : 0;
+
+            expect(await tensionEdgeCount(workspaceId)).toBe(edges);
+            // …and it points the right way. `INSERT_TENSION_EDGE_SQL` sets
+            // `from_fact_id` to the row just written, which is what the review
+            // queue renders as "this new claim contradicts that one". Nothing
+            // else in the repo asserts the direction — every other site counts.
+            if (verdict.tension) {
+              const [aId, bId] = await factIds(workspaceId);
+              expect(await tensionEdges(workspaceId)).toEqual([{ from: bId!, to: aId! }]);
+            }
+            // The stage's own count, on whichever outcome shape the verdict
+            // implies — a corroboration carries no `tensionEdges` at all,
+            // because the claim collapsed into the existing row and the scan
+            // is only reached on the create path.
+            expect(b.outcomes[0]).toMatchObject(
+              verdict.corroborates ? { kind: "corroborated" } : { kind: "created", tensionEdges: edges },
+            );
+            // Both rows have to EXIST for a prohibition to mean anything — an
+            // empty table has no tension either. And where an edge was written,
+            // it is ADVISORY: both beliefs are still current, nothing was
+            // superseded, invalidated, or ranked at ingest. A human at the
+            // publish gate arbitrates — that is consumer 3.
+            expect(await currentFactCount(workspaceId)).toBe(rowsFor(pair));
+          },
+          PG_TEST_TIMEOUT_MS,
+        );
+      }
+    }
+  });
+
+  // ══════════════════════════════════════════════════════════════════════
+  // Consumer 3 — the publish gate (supersessionCollisionJoin):
+  // *different-and-stamping*
+  // ══════════════════════════════════════════════════════════════════════
+
+  describe("consumer 3 — the publish gate says *different-and-stamping*", () => {
+    const TITLES: Record<SlotRelation, string> = {
+      "rival-claim": "⭐ stamps the incumbent it genuinely contradicts",
+      "same-claim": "stamps nothing when the draft merely restates the incumbent",
+      "different-claim": "stamps nothing across two slots — the irreversible direction",
+    };
+
+    /**
+     * Land `a`, publish it so it is the incumbent, then land `b` as a draft.
+     *
+     * The publish-between step is what makes this consumer's question different
+     * from the other two: the collision join reads a PUBLISHED left side, so a
+     * corpus landed all-at-once would exercise nothing.
+     */
+    async function landWithIncumbent(pair: ClaimPair) {
+      const workspaceId = workspaceFor(pair);
+      await land(workspaceId, `${pair.id}-a`, pair.a);
+      expect((await publish(workspaceId)).promoted).toBe(1);
+      const [incumbent] = await factIds(workspaceId);
+      await land(workspaceId, `${pair.id}-b`, pair.b);
+      return { workspaceId, incumbent: incumbent! };
+    }
+
+    async function validToOf(workspaceId: string): Promise<(Date | null)[]> {
+      const { rows } = await pool.query<{ valid_to: Date | null }>(
+        `SELECT valid_to FROM brain_facts WHERE workspace_id = $1 ORDER BY ingested_at, id`,
+        [workspaceId],
+      );
+      return rows.map((r) => r.valid_to);
+    }
+
+    /** The disclosure an admin sees BEFORE pressing publish. */
+    async function previewFor(workspaceId: string) {
+      const reader = await resolvePrincipalContext(pool, {
+        workspaceId,
+        mode: "managed",
+        userId: "u1",
+        resolvedRole: { role: "owner", orgId: workspaceId },
+      });
+      return loadSupersessionPreview(pool, reader);
+    }
+
+    for (const relation of RELATIONS) {
+      for (const pair of pairsWhere(relation)) {
+        it(
+          `${TITLES[relation]}: ${pair.id}`,
+          async () => {
+            const { workspaceId, incumbent } = await landWithIncumbent(pair);
+            const verdict = VERDICTS[pair.relation];
+            const stamps = verdict.supersedes ? 1 : 0;
+
+            // The disclosure and the transaction are two call sites of ONE join,
+            // and drift between them is silent supersession (#4912). Asserted
+            // before the transaction, because that is when an admin reads it —
+            // and on the PAIR IDS, not only the count: a disclosure that says
+            // "1" while naming a different row is exactly the drift, and a count
+            // comparison agrees with it.
+            const preview = await previewFor(workspaceId);
+            expect(preview).toMatchObject({ total: stamps, withheld: 0 });
+            expect(preview.pairs.map((p) => p.supersededId)).toEqual(
+              verdict.supersedes ? [incumbent] : [],
+            );
+
+            const report = await publish(workspaceId);
+            // `superseded` is optional on the report — absent is the same claim
+            // as empty, and `toHaveLength(1)` still fails if the field vanishes.
+            const superseded = report.superseded ?? [];
+            expect(superseded).toHaveLength(stamps);
+            // …and the transaction stamped the row the disclosure named.
+            expect(superseded.flatMap((s) => s.superseded)).toEqual(
+              verdict.supersedes ? [incumbent] : [],
+            );
+
+            const validTo = await validToOf(workspaceId);
+            expect(validTo).toHaveLength(rowsFor(pair));
+            expect(validTo.filter((t) => t !== null)).toHaveLength(stamps);
+            // The population still answering as-of-now reads. For a
+            // `different-claim` this is the whole point: both beliefs survive,
+            // and a stamped `valid_to` has no correction path — `supersede`
+            // refuses a target whose end is already decided, and no verb clears
+            // one, so an over-match here irreversibly ends a true belief. `Osprey rollout led_by Ana`
+            // retired because someone also said `Ana leads Osprey rollout`.
+            expect(await currentFactCount(workspaceId)).toBe(rowsFor(pair) - stamps);
+          },
+          PG_TEST_TIMEOUT_MS,
+        );
+      }
+    }
+  });
+});

--- a/packages/api/src/lib/brain/__tests__/identity-corpus.ts
+++ b/packages/api/src/lib/brain/__tests__/identity-corpus.ts
@@ -1,0 +1,299 @@
+/**
+ * The ONE corpus behind all three claim-identity consumers (#5021, ADR-0037 §9).
+ *
+ * `identity-consumers-pg.test.ts` drives corroboration, the tension scan, and
+ * the publish gate's supersession join over these same rows and asserts a
+ * DIFFERENT verdict from each — corroboration says *same*, tension says
+ * *different-and-coexisting*, supersession says *different-and-stamping*. Three
+ * verdicts over one fixture set, not three suites with three sets of fixtures
+ * that agree with themselves.
+ *
+ * ## What this module fixes, and what it does not
+ *
+ * The trap it exists to close (#5000, and the map's T7 §1): three consumers with
+ * three private fixture sets cannot disagree about what collides, because
+ * nothing ever compares them.
+ *
+ *   - `promotion-pg.test.ts` had the predicate as a SQL literal inside its
+ *     seeder, so the two sides *could not* differ even if an author wanted them
+ *     to. Fixed in #5020.
+ *   - `oversight-pg.test.ts` had the predicate AND the object as SQL literals.
+ *     That is the seeder this change parameterizes — though no test there
+ *     compares two rows' identity yet, so the fix is parity, not coverage.
+ *   - `extract-reconcile-pg.test.ts` spreads one default `candidate()` into both
+ *     sides of every pair, so agreement there is not asserted — it is the same
+ *     reference. **Still open.** Its three overlapping identity cases moved here;
+ *     what remains in that file is the cases this corpus cannot express
+ *     (a NULL-keyed row, a degenerate rival, cross-tenant scoping).
+ *
+ * Exactly one file imports this corpus. It is not what the seeders above are
+ * parameterized by — they take literals from their own call sites.
+ *
+ * ## What a human is allowed to write here
+ *
+ * Surfaces and a claim about MEANING. Nothing else.
+ *
+ * An entry says "a person reading these two claims would call them the same
+ * thing" (or would not) — a statement about English, which a human is the right
+ * oracle for. It never says what key either side normalizes to. Deriving
+ * {@link ClaimPair.relation} from `slotKey` would compare the identity layer to
+ * itself and pass against any implementation, including one that returns a
+ * constant; writing the expected keys by hand would pin them twice in the same
+ * commit and drift on the first change. So: the human authors the STIMULUS and
+ * the meaning, and the system supplies every key and every OBSERVED verdict.
+ *
+ * That is the general form of the rule ADR-0037 §9 states —
+ * *one side of every identity assertion is a value the system produced, not a
+ * value the test wrote* — applied to the inputs rather than the assertions.
+ *
+ * ⚠️ **This is the deterministic half only.** The map's T7 §5 asks for the
+ * predicate side to be produced by driving the real extractor in the eval lane,
+ * precisely so nobody hand-authors it — and that half is not built. Until it is,
+ * this corpus proves the identity layer handles the variation someone thought to
+ * write, and nothing about variation nobody imagined. Do not read a green run
+ * here as closing §9's loop.
+ *
+ * ⚠️ `promotion-pg.test.ts` also still holds a parallel consumer-3 fixture set
+ * of its own (`ws-5020-phrasing`). It is NOT redundant with this corpus — it
+ * additionally asserts the pair LABELS, the `supersedes` edges, and the
+ * unkeyed-row direction, none of which this file expresses. Do not apply the
+ * de-duplication argument above to it without checking what would be lost.
+ *
+ * ## Reading the verdict table
+ *
+ * The three consumers do not each get their own expectation column, because that
+ * would let them drift into disagreeing about what collides. They share
+ * {@link ClaimPair.relation}, and {@link VERDICTS} is what every consumer's
+ * assertions are computed FROM — flip a cell and three tests go red.
+ *
+ * Not a `.test.ts`, so the isolated runner does not execute it — same reason as
+ * `identity-fixtures.ts`, which holds the corpus for the OTHER half of the
+ * identity work (the `lexicalNorm` ↔ migration 0187 pairing). That module pins
+ * the key FUNCTION against the SQL; this one pins the three CONSUMERS against
+ * each other. They are deliberately separate: an entry here has to be a whole
+ * claim, and an entry there has to be a bare surface.
+ */
+
+/** One side of a pair — a whole claim, because identity is a triple. */
+export interface Claim {
+  readonly subject: string;
+  readonly predicate: string;
+  readonly object: string;
+}
+
+/**
+ * Every relation, as the SOURCE the union is derived from.
+ *
+ * This array rather than a bare union so that adding a relation is a COMPILE
+ * error in every `Record<SlotRelation, …>` — the verdict table below, and the
+ * per-consumer title maps in `identity-consumers-pg.test.ts`. A hand-written
+ * union plus hand-written `pairsWhere("…")` loops would let a new relation land
+ * a corpus entry that no consumer ever reads, green.
+ */
+export const RELATIONS = ["same-claim", "rival-claim", "different-claim"] as const;
+
+/**
+ * What a human says the two claims mean, relative to each other:
+ *
+ *   - `same-claim` — one claim, two spellings. Same subject slot, same
+ *     predicate slot, same value.
+ *   - `rival-claim` — one slot, two VALUES. The subject and predicate collide
+ *     through a phrasing difference and the objects genuinely disagree. This is
+ *     the contradiction class: byte-exact matching hid these, which is #5000.
+ *   - `different-claim` — different slots. The claims may look near-identical
+ *     to a lexical matcher and are not the same claim, so nothing may collide
+ *     them. This is the direction where an over-match costs a `valid_to` stamp
+ *     on a belief nobody retired.
+ */
+export type SlotRelation = (typeof RELATIONS)[number];
+
+export interface ClaimPair {
+  /**
+   * Stable id, unique across the corpus — it names the workspace each `-pg` case
+   * runs in and both of its episode source ids, so a failure points somewhere.
+   * Uniqueness is asserted by the corpus guard, not by the type.
+   */
+  readonly id: string;
+  readonly relation: SlotRelation;
+  /** Why a human says so. The argument is in English because the claim is about English. */
+  readonly why: string;
+  readonly a: Claim;
+  readonly b: Claim;
+}
+
+/**
+ * The corpus.
+ *
+ * Every entry varies something a consumer's join arm reads. The
+ * `different-claim` entries are each a documented REFUSAL of the identity layer
+ * rather than an accident — collapsing any one of them is a change someone has
+ * to argue for here.
+ *
+ * ## Covering the arms
+ *
+ * Both `TENSION_CANDIDATES_SQL` and `supersessionCollisionJoin` are
+ * `subject_key = … AND predicate_key = … AND object_key <>`, so a prohibition
+ * can only bite on a given `=` arm when the OTHER two arms would have matched.
+ * An entry whose objects are equal is blocked by the `<>` arm alone and proves
+ * nothing about the subject or predicate arm. The six shapes below are what
+ * make each arm individually falsifiable; `subject-differs` and
+ * `predicate-differs` exist for exactly that reason and for no other.
+ *
+ * | entry | subject | predicate | object |
+ * |---|---|---|---|
+ * | `rival-through-phrasing` | = | = | ≠ |
+ * | `subject-differs`        | ≠ | = | ≠ |
+ * | `predicate-differs`      | = | ≠ | ≠ |
+ * | `inverse-relations`      | ≠ | ≠ | ≠ |
+ * | `copula-pair`            | = | ≠ | = |
+ * | `entity-alias`           | ≠ | = | = |
+ */
+export const IDENTITY_CORPUS = [
+  {
+    id: "phrasing-variant",
+    relation: "same-claim",
+    why:
+      "Case and separator, on all three slots at once — the entirety of `lexicalNorm`. " +
+      "Nobody would read these as two different claims, and byte-exact matching filed " +
+      "them as two rows the reviewer then had to reconcile by hand.",
+    a: { subject: "Deploy Window", predicate: "Ships On", object: "Thursdays" },
+    b: { subject: "deploy_window", predicate: "ships-on", object: "thursdays" },
+  },
+  {
+    id: "separator-edges",
+    relation: "same-claim",
+    why:
+      "A producer's stray edge punctuation is not a claim about the world. Separated " +
+      "from the entry above because it is the only one where the EDGE TRIM is " +
+      "load-bearing: `_` and `-` are separators, so they collapse to a space that then " +
+      "has to be trimmed off, and a norm that collapsed interior runs but kept the " +
+      "edges passes `phrasing-variant` and fails here. " +
+      "Deliberately NOT spelled with leading/trailing spaces — `reconcile.ts` trims the " +
+      "candidate surfaces before it keys them, so a space-edged pair is normalized by " +
+      "the stage no matter what `lexicalNorm` does, and proves nothing about this layer. " +
+      "(Mutation-checked: the space-edged version survives deleting the edge trim.) " +
+      "Both sides off normal form, for the reason spelled out under `rival-through-phrasing`.",
+    a: { subject: "Release-Train", predicate: "Runs", object: "Weekly" },
+    b: { subject: "__release train", predicate: "runs-", object: "-weekly_" },
+  },
+  {
+    id: "rival-through-phrasing",
+    relation: "rival-claim",
+    why:
+      "`Ada` reports to exactly one person and these name two. The subject and predicate " +
+      "are one slot spelled two ways, so on the surface columns the rival scan matched " +
+      "nothing and the reviewer saw two uncontested facts where there was a contradiction. " +
+      "BOTH sides are spelled off normal form, and differently — that is not decoration, " +
+      "it is what makes two separate mutations die. The scan is issued for `b` and compares " +
+      "against `a`'s stored row, so: if `b` were already normalized, binding the raw " +
+      "surfaces at the call site would still find the rival; if `a` were, repointing the " +
+      "STATEMENT at the surface columns would still match `b`'s key binds. " +
+      "(Mutation-checked, and the second case was a live survivor until `a` grew its noise.)",
+    a: { subject: "Ada", predicate: "Reports_To", object: "Grace" },
+    b: { subject: "ADA", predicate: "reports-to", object: "Alan" },
+  },
+  {
+    id: "subject-differs",
+    relation: "different-claim",
+    why:
+      "Two people, each reporting to someone different — no contradiction, nothing to " +
+      "arbitrate. Exists to make the SUBJECT arm falsifiable: the predicates match and " +
+      "the objects differ, so `subject_key =` is the only thing holding these apart, and " +
+      "dropping it from the rival scan or the collision join turns this red. Every other " +
+      "`different-claim` entry is also blocked by some other arm.",
+    a: { subject: "ada", predicate: "reports to", object: "Grace" },
+    b: { subject: "bea", predicate: "reports to", object: "Alan" },
+  },
+  {
+    id: "predicate-differs",
+    relation: "different-claim",
+    why:
+      "Who `Ada` reports to and who she sits with are different questions, and both " +
+      "answers are true at once. The PREDICATE arm's falsifier, by the same argument as " +
+      "the entry above — and the one the repo most needed: the whole supersession section " +
+      "of `promotion-pg.test.ts` runs on a single predicate, so deleting " +
+      "`p.predicate_key = d.predicate_key` from the collision join broke no test anywhere.",
+    a: { subject: "ada", predicate: "reports to", object: "Grace" },
+    b: { subject: "ada", predicate: "sits with", object: "Alan" },
+  },
+  {
+    id: "inverse-relations",
+    relation: "different-claim",
+    why:
+      "`led_by` and `leads` are INVERSE relations: they swap subject and object, so the " +
+      "pair asserts one fact from two directions and neither side is a rival to the other. " +
+      "Morphological normalization folds them together (T3 §3 falsified it with this pair), " +
+      "and at `single` cardinality that hands the publish gate a `valid_to` stamp on a true " +
+      "belief. Live in the corpus that started this map.",
+    a: { subject: "Osprey rollout", predicate: "led_by", object: "Ana" },
+    b: { subject: "Ana", predicate: "leads", object: "Osprey rollout" },
+  },
+  {
+    id: "copula-pair",
+    relation: "different-claim",
+    why:
+      "#5000's PREDICATE pair, with the objects held equal so the predicate slot is the " +
+      "only variable. ADR-0037 §6 settles it as a vocabulary ENTRY with a reviewer behind " +
+      "it (#5016) rather than a normalization rule — because the rule that closes this also " +
+      "folds `is owned by` into `owns`, and `led_by` into `leads` (above). Until an entry " +
+      "exists, the honest answer is two claims. " +
+      "NOT the live #5000 rows: those are `499 a month` vs `599 a month`, whose objects " +
+      "DISAGREE (ADR-0037 §4's correction to the record) — that instance is a contradiction, " +
+      "and would be a `rival-claim` here once an alias entry unified the predicates.",
+    a: { subject: "Business tier", predicate: "is priced at", object: "$499" },
+    b: { subject: "Business tier", predicate: "priced at", object: "$499" },
+  },
+  {
+    id: "entity-alias",
+    relation: "different-claim",
+    why:
+      "The same machine, two names — and unifying them is the ENTITY RESOLVER's decision, " +
+      "per workspace, with a seam built for it. The lexical layer takes no decision it " +
+      "owns: a rule that collapsed these would collapse every abbreviation in the corpus " +
+      "globally, with no reviewer anywhere.",
+    a: { subject: "deploy-01", predicate: "hosts", object: "the release job" },
+    b: { subject: "the deploy box", predicate: "hosts", object: "the release job" },
+  },
+] as const satisfies readonly ClaimPair[];
+
+/** One consumer's contract, per relation. */
+export interface Verdict {
+  /** The second observation strengthens the first instead of minting a row. */
+  readonly corroborates: boolean;
+  /** The pair earns an advisory `in-tension-with` edge at `single` cardinality. */
+  readonly tension: boolean;
+  /** Publishing the second stamps `valid_to` on the first. */
+  readonly supersedes: boolean;
+}
+
+/**
+ * What each consumer must say about each relation. ONE table, and every
+ * assertion in `identity-consumers-pg.test.ts` is COMPUTED from it — flipping a
+ * cell turns three tests red rather than being quietly contradicted by a
+ * hardcoded literal beside it. That is what stops the three consumers drifting
+ * into disagreeing about what collides.
+ *
+ * Read down a column and it is one consumer's contract; read across a row and it
+ * is the three verdicts one relation earns. Every cell is exercised — the
+ * `false` cells are the prohibitions, each paired with the `true` cell from its
+ * own column as the positive control that proves the machinery ran.
+ *
+ * Flipping a cell reddens the tests in THAT COLUMN's consumer — the columns are
+ * not cross-checked against each other, and should not be: they are three
+ * different questions about one relation.
+ */
+export const VERDICTS = {
+  // One claim: it corroborates, so there is no second row to contend with —
+  // both the other two verdicts follow from there being nothing to compare.
+  "same-claim": { corroborates: true, tension: false, supersedes: false },
+  // One slot, two values: the two beliefs coexist and are visibly in tension
+  // while both are drafts, and the publish gate is where a human settles it.
+  "rival-claim": { corroborates: false, tension: true, supersedes: true },
+  // Two slots: every consumer must leave the pair entirely alone.
+  "different-claim": { corroborates: false, tension: false, supersedes: false },
+} as const satisfies Record<SlotRelation, Verdict>;
+
+/** The corpus, split by relation — the two halves of each prohibition/control pairing. */
+export function pairsWhere(relation: SlotRelation): readonly ClaimPair[] {
+  return IDENTITY_CORPUS.filter((pair) => pair.relation === relation);
+}

--- a/packages/api/src/lib/brain/__tests__/oversight-pg.test.ts
+++ b/packages/api/src/lib/brain/__tests__/oversight-pg.test.ts
@@ -37,6 +37,7 @@ import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { Pool } from "pg";
 import { runMigrations } from "@atlas/api/lib/db/migrate";
 import { MANAGED_AUTH_MIGRATIONS } from "@atlas/api/lib/db/internal";
+import { identityAlias, slotKey } from "@atlas/api/lib/brain/identity";
 import {
   OVERSIGHT_BUCKETS_SQL,
   OVERSIGHT_DISTINCT_TOKENS_SQL,
@@ -108,21 +109,41 @@ describeIfPg("brain fact oversight aggregate (real Postgres)", () => {
     return rows[0]!.id;
   }
 
+  /**
+   * All three surfaces are PARAMETERS, and the row is keyed the way an ingested
+   * one is (#5021).
+   *
+   * The predicate and object used to be SQL literals here — `'uses'` and
+   * `'Snowflake'` inside the statement — so two rows this seeder produced could
+   * not differ in those slots even if an author wanted them to.
+   *
+   * ⚠️ **Parity, not coverage.** No test in this file compares two rows'
+   * identity today, and `oversight.ts`'s bucket aggregate reads no `*_key`
+   * column — so nothing here exercises either the new parameters or the keys.
+   * They exist so that a future case CAN vary a slot, and so this seeder cannot
+   * re-introduce the trap the map's T7 §1 names it for. `slotKey` derives the
+   * keys through the same function `reconcile.ts` binds, rather than
+   * hand-written beside the surface where the two could quietly disagree.
+   */
   async function seedFact(opts: {
     workspaceId: string;
     episodeId: string;
     subject: string;
+    predicate?: string;
+    object?: string;
     visibleTo?: readonly (string | null)[];
     status?: "draft" | "published";
     provenance?: string;
     retracted?: boolean;
   }): Promise<string> {
+    const predicate = opts.predicate ?? "uses";
+    const object = opts.object ?? "Snowflake";
     const { rows } = await pool.query<{ id: string }>(
       `INSERT INTO brain_facts
          (workspace_id, subject, predicate, object, source_episode_id, provenance, status, visible_to,
-          invalidated_at)
-       VALUES ($1, $2, 'uses', 'Snowflake', $3, $4::jsonb, $5, $6::text[],
-               CASE WHEN $7 THEN now() ELSE NULL END)
+          invalidated_at, subject_key, predicate_key, object_key)
+       VALUES ($1, $2, $8, $9, $3, $4::jsonb, $5, $6::text[],
+               CASE WHEN $7 THEN now() ELSE NULL END, $10, $11, $12)
        RETURNING id`,
       [
         opts.workspaceId,
@@ -132,6 +153,11 @@ describeIfPg("brain fact oversight aggregate (real Postgres)", () => {
         opts.status ?? "draft",
         opts.visibleTo ?? ["org"],
         opts.retracted ?? false,
+        predicate,
+        object,
+        slotKey(opts.subject, identityAlias),
+        slotKey(predicate, identityAlias),
+        slotKey(object, identityAlias),
       ],
     );
     return rows[0]!.id;

--- a/packages/api/src/lib/brain/__tests__/promotion-pg.test.ts
+++ b/packages/api/src/lib/brain/__tests__/promotion-pg.test.ts
@@ -123,16 +123,29 @@ describeIfPg("brain fact review gate (real Postgres)", () => {
    */
   async function publish(workspaceId: string) {
     const client = await pool.connect();
+    /** Set only when ROLLBACK itself failed — passing it to `release` destroys the client. */
+    let destroyReason: Error | undefined;
     try {
       await client.query("BEGIN");
       const report = await Effect.runPromise(promoteBrainFacts(client, workspaceId));
       await client.query("COMMIT");
       return report;
     } catch (err) {
-      await client.query("ROLLBACK");
+      // The ROLLBACK must not REPLACE the failure the test was about, and a
+      // client with an open transaction must not return to the pool for the
+      // next test to inherit — passing a reason to `release` destroys it
+      // instead. Same shape as `identity-consumers-pg.test.ts`'s helper (#5021).
+      await client.query("ROLLBACK").catch((cause: unknown) => {
+        destroyReason = cause instanceof Error ? cause : new Error(String(cause));
+        console.warn(
+          `publish(${workspaceId}): ROLLBACK failed after "${
+            err instanceof Error ? err.message : String(err)
+          }" — destroying the connection: ${destroyReason.message}`,
+        );
+      });
       throw err;
     } finally {
-      client.release();
+      client.release(destroyReason);
     }
   }
 
@@ -1242,6 +1255,8 @@ describeIfPg("brain fact review gate (real Postgres)", () => {
       predicate?: string;
       cardinality?: "single" | "multi";
       status?: "draft" | "published";
+      /** Defaults to org-wide; override for the ACL-withholding cases. */
+      visibleTo?: readonly string[];
       /**
        * Land the row UNKEYED — all three key columns NULL — which is what a
        * region import produces today (`admin-migrate.ts`'s 18-column INSERT
@@ -1265,7 +1280,7 @@ describeIfPg("brain fact review gate (real Postgres)", () => {
            (workspace_id, subject, predicate, object, source_episode_id,
             provenance, status, visible_to, predicate_cardinality,
             subject_key, predicate_key, object_key)
-         VALUES ($1, $2, $3, $4, $5, '{"actor":"test"}'::jsonb, $6, '{org}', $7,
+         VALUES ($1, $2, $3, $4, $5, '{"actor":"test"}'::jsonb, $6, $11::text[], $7,
                  $8, $9, $10)
          RETURNING id`,
         [
@@ -1279,6 +1294,7 @@ describeIfPg("brain fact review gate (real Postgres)", () => {
           opts.unkeyed === true ? null : slotKey(opts.subject, identityAlias),
           opts.unkeyed === true ? null : slotKey(predicate, identityAlias),
           opts.unkeyed === true ? null : slotKey(opts.object, identityAlias),
+          opts.visibleTo ?? ["org"],
         ],
       );
       return rows[0]!.id;
@@ -1786,22 +1802,18 @@ describeIfPg("brain fact review gate (real Postgres)", () => {
         const ws = "ws-4912-withheld";
         const privateEp = await seedEpisode(ws, "withheld-private", [SUPERSEDE_PRIVATE_GRANT]);
         // The incumbent lives in a private channel; the draft is org-wide.
-        await pool.query(
-          `INSERT INTO brain_facts
-             (workspace_id, subject, predicate, object, source_episode_id,
-              provenance, status, visible_to, predicate_cardinality,
-              subject_key, predicate_key, object_key)
-           VALUES ($1, 'alice', 'manager', 'bob', $2, '{"actor":"t"}'::jsonb,
-                   'published', $3::text[], 'single', $4, $5, $6)`,
-          [
-            ws,
-            privateEp,
-            [SUPERSEDE_PRIVATE_GRANT],
-            slotKey("alice", identityAlias),
-            slotKey("manager", identityAlias),
-            slotKey("bob", identityAlias),
-          ],
-        );
+        // Through `seedFact` like every other row here (#5021): a second inline
+        // INSERT spelling the SPO as SQL literals is a second definition of what
+        // this corpus contains, and the pair below only collides if the two
+        // agree — which nothing would have checked.
+        await seedFact({
+          workspaceId: ws,
+          episodeId: privateEp,
+          subject: "alice",
+          object: "bob",
+          status: "published",
+          visibleTo: [SUPERSEDE_PRIVATE_GRANT],
+        });
         await seedFact({
           workspaceId: ws,
           episodeId: privateEp,

--- a/packages/api/src/lib/brain/__tests__/reconcile.test.ts
+++ b/packages/api/src/lib/brain/__tests__/reconcile.test.ts
@@ -7,7 +7,8 @@
  * cannot make legible: which failure BLOCKS, which failure FLAGS, and exactly
  * what a reviewer ends up holding. The storage-level claims (the CHECKs, the
  * real transaction rollback, two overlapping reconciles racing for one claim,
- * cross-tenant scoping) live in the `-pg` sibling.
+ * cross-tenant scoping) live in the `-pg` siblings — `extract-reconcile-pg` for
+ * the stage, and `identity-consumers-pg` for claim identity (see below).
  *
  * The block-vs-flag asymmetry is the reason this file exists at all. Both
  * directions are failure modes with names:
@@ -15,6 +16,28 @@
  *     nobody can attribute, reaching the review queue as if it were fine);
  *   - a QUALITY failure that blocks is a silent fact-dropper.
  * So every failure class gets a test on the arm it is supposed to take.
+ *
+ * ## ⚠️ What a green run here does NOT mean (#5021, ADR-0037 §9)
+ *
+ * It does not mean claim identity works. This file cannot see identity and no
+ * longer pretends to: the store below dispatches on each SQL constant's string
+ * IDENTITY and reads its binds POSITIONALLY, so it cannot tell which COLUMNS a
+ * statement names, and it stopped deciding which stored fact shares a slot with
+ * an incoming candidate. What survives here is the half that is genuinely
+ * unit-visible — **which values the stage BINDS to the key positions**, and what
+ * it does with a lookup result once it has one.
+ *
+ * *Does this pair of claims collide?* is answered in
+ * `identity-consumers-pg.test.ts`, where eight claim pairs are read by all three
+ * consumers — corroboration, the rival scan, and the publish gate's collision
+ * join — against a real schema. The lexical backstop at the bottom of this file
+ * is the cheap tripwire for a repoint, not the proof.
+ *
+ * That narrowing is the intended outcome and not a regression. Before it, every
+ * BEHAVIOURAL test here stayed green against a `reconcile.ts` whose lookups had
+ * been repointed at the surface columns — only the backstop, which greps the
+ * statement text, caught it. That is the exact defect the identity slice exists
+ * to fix.
  */
 
 import { describe, expect, test } from "bun:test";
@@ -37,8 +60,34 @@ import { WAREHOUSE_SOURCE } from "@atlas/api/lib/brain/sources";
 import { isWarehouseDerived } from "@atlas/api/lib/brain/correction";
 
 // ---------------------------------------------------------------------------
-// A store that answers exactly the six statements the stage issues
+// A store that RECORDS the six statements the stage issues — and answers no
+// identity question it cannot prove (#5021, the map's T7 §4)
 // ---------------------------------------------------------------------------
+//
+// This fake used to decide, in TypeScript, which stored fact was in the same
+// slot as an incoming candidate. That made the file a green light for a property
+// it could not see: it dispatches on each SQL constant's string IDENTITY and
+// reads the binds POSITIONALLY, so it cannot tell which COLUMNS a statement
+// names. Repointing `CORROBORATION_LOOKUP_SQL` back at the surface columns left
+// every BEHAVIOURAL test here passing — verified by mutation, and the defect
+// #5021 exists to retire. (The lexical backstop at the bottom of the file greps
+// the statement text and does catch that one; it is a tripwire, not a proof.)
+//
+// So the two lookups no longer answer. What the store keeps is what it can
+// honestly prove: the statement was issued, in this order, with these binds.
+// A test that needs a lookup to HIT declares that — `corroborateWith`,
+// `scriptRivals` — as a premise about the world, and then asserts what the
+// STAGE does about it. Which claims actually share a slot is a question about
+// SQL against a real schema, and it lives in `identity-consumers-pg.test.ts`,
+// where eight claim pairs are read by all three consumers.
+//
+// The two edge inserts still model their `NOT EXISTS` guards. That is a
+// deliberate line, not an oversight: those guards compare opaque uuids for
+// exact equality, with no normalization and no identity layer anywhere in them,
+// so a JS reimplementation cannot masquerade as identity coverage the way the
+// slot lookups did. The PROVENANCE edge's guard is pinned against a real schema
+// in `extract-reconcile-pg.test.ts` ("re-running over an already-extracted
+// window is a no-op"); the tension edge's dedupe arm is not pinned anywhere.
 
 interface StoredFact {
   id: string;
@@ -47,12 +96,12 @@ interface StoredFact {
   predicate: string;
   object: string;
   /**
-   * What the stage bound to the key columns (#5020). Stored SEPARATELY from the
-   * surfaces and matched on by the two lookups below, because that separation
-   * IS the behaviour under test: a fake that re-derived a key from the stored
-   * surface could not tell a stage that keys its rows from one that does not.
+   * What the stage bound to the key columns (#5020) — a RECORDING, read back by
+   * the tests below, never matched on. Kept separate from the surfaces because
+   * a fake that re-derived a key from the stored surface could not tell a stage
+   * that keys its rows from one that does not.
    */
-  slot: { subject: string | null; predicate: string | null; object: string | null };
+  slot: SlotBinds;
   provenance: Record<string, unknown>;
   visibleTo: string[];
   cardinality: string;
@@ -60,15 +109,18 @@ interface StoredFact {
   extractedAt: string | null;
 }
 
+interface SlotBinds {
+  readonly subject: string | null;
+  readonly predicate: string | null;
+  readonly object: string | null;
+}
+
 /**
  * Three consecutive key binds, read positionally — `null` stays `null` rather
  * than becoming `"null"` through `String()`, which is the whole distinction
  * these tests are about.
  */
-function keyParams(
-  params: readonly unknown[],
-  from: number,
-): { subject: string | null; predicate: string | null; object: string | null } {
+function keyParams(params: readonly unknown[], from: number): SlotBinds {
   const at = (i: number): string | null => {
     const v = params[from + i];
     return v === null || v === undefined ? null : String(v);
@@ -76,11 +128,38 @@ function keyParams(
   return { subject: at(0), predicate: at(1), object: at(2) };
 }
 
-/** Postgres `=`: UNKNOWN (→ not a match) whenever either side is NULL. */
-const sqlEq = (a: string | null, b: string | null): boolean => a !== null && b !== null && a === b;
+/**
+ * The six statements the stage issues, as a CLOSED domain.
+ *
+ * The accessors below take a name from this record rather than a raw SQL string.
+ * That is not ceremony: the tension block asserts that a statement was NOT
+ * issued (`bindsFor("tensionScan")` against a captured baseline), and with a
+ * `string` parameter, passing `INSERT_TENSION_EDGE_SQL` where
+ * `TENSION_CANDIDATES_SQL` was meant —
+ * one word apart, both imported here — type-checks and passes vacuously. That is
+ * the same "green against a property it cannot see" failure this whole file was
+ * rewritten to retire, and it would have been reintroduced at the accessor.
+ *
+ * `keyOffset` lives here too, because the position at which a statement's three
+ * key binds start is a property OF the statement, not of each call site. Restated
+ * at each call site it is one more chance, per site, to read the adjacent
+ * binds instead — and the store itself reads it for the INSERT recording below.
+ */
+const STATEMENTS = {
+  lock: { sql: RECONCILE_LOCK_SQL },
+  corroboration: { sql: CORROBORATION_LOOKUP_SQL, keyOffset: 1 },
+  insertFact: { sql: INSERT_FACT_SQL, keyOffset: 10 },
+  provenanceEdge: { sql: INSERT_PROVENANCE_EDGE_SQL },
+  tensionScan: { sql: TENSION_CANDIDATES_SQL, keyOffset: 1 },
+  tensionEdge: { sql: INSERT_TENSION_EDGE_SQL },
+} as const;
 
-/** Postgres `<>`: likewise UNKNOWN against a NULL, never "different". */
-const sqlNe = (a: string | null, b: string | null): boolean => a !== null && b !== null && a !== b;
+type StatementName = keyof typeof STATEMENTS;
+
+/** The three statements that carry slot keys — the only ones `keyBindsFor` accepts. */
+type KeyedStatementName = {
+  [K in StatementName]: (typeof STATEMENTS)[K] extends { keyOffset: number } ? K : never;
+}[StatementName];
 
 interface StoredEdge {
   workspaceId: string;
@@ -90,13 +169,67 @@ interface StoredEdge {
   toEpisodeId: string | null;
 }
 
+interface RecordedCall {
+  readonly sql: string;
+  readonly params: readonly unknown[];
+}
+
 class FakeBrainStore {
+  /** Every statement the stage issued, in order, with its binds. THE recording. */
+  readonly calls: RecordedCall[] = [];
   readonly facts: StoredFact[] = [];
   readonly edges: StoredEdge[] = [];
   /** Full `pg_advisory_xact_lock` params — the namespace matters as much as the key. */
   readonly locks: unknown[][] = [];
   transactions = 0;
+  /**
+   * The id `CORROBORATION_LOOKUP_SQL` returns, or `null` for no hit.
+   *
+   * A PREMISE the test states, not a conclusion the fake reaches: "suppose the
+   * lookup finds this row". Whether it would is `identity-consumers-pg`'s
+   * question.
+   *
+   * ⚠️ STICKY for the store's lifetime — every later reconcile against the same
+   * store corroborates too. Set it through {@link corroborateWith}, which is
+   * also what stops a phantom id naming a fact that was never written.
+   */
+  private corroborationHit: string | null = null;
+  /** Likewise for `TENSION_CANDIDATES_SQL`; set through {@link scriptRivals}. */
+  private rivalIds: readonly string[] = [];
   private seq = 0;
+
+  /**
+   * "Suppose the corroboration lookup comes back with this row."
+   *
+   * Takes the RECORDED fact rather than a bare id, so a premise can only name a
+   * row the stage actually wrote — a phantom id would have the stage attach a
+   * provenance edge to a fact that does not exist, and the fake would happily
+   * record it.
+   */
+  corroborateWith(fact: StoredFact | undefined): void {
+    if (fact === undefined) throw new Error("corroborateWith: no such fact was recorded");
+    this.corroborationHit = fact.id;
+  }
+
+  /** "Suppose the rival scan comes back with these rows." */
+  scriptRivals(first: StoredFact | undefined, ...rest: (StoredFact | undefined)[]): void {
+    this.rivalIds = [first, ...rest].map((fact) => {
+      if (fact === undefined) throw new Error("scriptRivals: no such fact was recorded");
+      return fact.id;
+    });
+  }
+
+  /** The binds of every call to one statement, in order. */
+  bindsFor(name: StatementName): readonly (readonly unknown[])[] {
+    const { sql } = STATEMENTS[name];
+    return this.calls.filter((c) => c.sql === sql).map((c) => c.params);
+  }
+
+  /** The slot keys the stage bound to one statement's key positions. */
+  keyBindsFor(name: KeyedStatementName): readonly SlotBinds[] {
+    const statement = STATEMENTS[name];
+    return this.bindsFor(name).map((params) => keyParams(params, statement.keyOffset));
+  }
 
   /** A runner shaped like the real one, so "did anything open a tx?" is testable. */
   readonly runner: ReconcileTransactionRunner = async <T>(
@@ -110,28 +243,16 @@ class FakeBrainStore {
     sql: string,
     params: unknown[],
   ): Promise<{ rows: readonly unknown[] }> {
+    this.calls.push({ sql, params });
     switch (sql) {
-      case RECONCILE_LOCK_SQL: {
+      case STATEMENTS.lock.sql: {
         this.locks.push(params);
         return { rows: [] };
       }
-      case CORROBORATION_LOOKUP_SQL: {
-        const [workspaceId] = params.map(String);
-        const slot = keyParams(params, 1);
-        const hit = this.facts.find(
-          (f) =>
-            f.workspaceId === workspaceId &&
-            // `=` against a NULL bind is UNKNOWN in Postgres, so a candidate
-            // whose surface norms away matches nothing — deliberately, since a
-            // NULL-safe comparison would make every degenerate claim
-            // corroborate every other one. Modelled, not assumed away.
-            sqlEq(f.slot.subject, slot.subject) &&
-            sqlEq(f.slot.predicate, slot.predicate) &&
-            sqlEq(f.slot.object, slot.object),
-        );
-        return { rows: hit ? [{ id: hit.id }] : [] };
+      case STATEMENTS.corroboration.sql: {
+        return { rows: this.corroborationHit === null ? [] : [{ id: this.corroborationHit }] };
       }
-      case INSERT_FACT_SQL: {
+      case STATEMENTS.insertFact.sql: {
         const id = `fact-${++this.seq}`;
         this.facts.push({
           id,
@@ -144,11 +265,11 @@ class FakeBrainStore {
           provenance: JSON.parse(String(params[7])) as Record<string, unknown>,
           visibleTo: JSON.parse(String(params[8])) as string[],
           cardinality: String(params[9]),
-          slot: keyParams(params, 10),
+          slot: keyParams(params, STATEMENTS.insertFact.keyOffset),
         });
         return { rows: [{ id }] };
       }
-      case INSERT_PROVENANCE_EDGE_SQL: {
+      case STATEMENTS.provenanceEdge.sql: {
         const [workspaceId, fromFactId, toEpisodeId] = params.map(String);
         const exists = this.edges.some(
           (e) =>
@@ -167,23 +288,15 @@ class FakeBrainStore {
         });
         return { rows: [{ id: `edge-${++this.seq}` }] };
       }
-      case TENSION_CANDIDATES_SQL: {
-        const workspaceId = String(params[0]);
-        const slot = keyParams(params, 1);
+      case STATEMENTS.tensionScan.sql: {
+        // `id <> $5` is the ONE arm still applied here, and it is not identity:
+        // it is the statement refusing to return the row the stage just wrote,
+        // compared by uuid. Modelling it keeps a scripted rival list from
+        // producing a self-edge the real query cannot produce.
         const selfId = String(params[4]);
-        const rivals = this.facts.filter(
-          (f) =>
-            f.workspaceId === workspaceId &&
-            sqlEq(f.slot.subject, slot.subject) &&
-            sqlEq(f.slot.predicate, slot.predicate) &&
-            // `<>` is UNKNOWN against NULL on either side too — a NULL object
-            // key abstains OUT of tension rather than into it.
-            sqlNe(f.slot.object, slot.object) &&
-            f.id !== selfId,
-        );
-        return { rows: rivals.map((f) => ({ id: f.id })) };
+        return { rows: this.rivalIds.filter((id) => id !== selfId).map((id) => ({ id })) };
       }
-      case INSERT_TENSION_EDGE_SQL: {
+      case STATEMENTS.tensionEdge.sql: {
         const [workspaceId, fromFactId, toFactId] = params.map(String);
         const exists = this.edges.some(
           (e) =>
@@ -430,6 +543,9 @@ describe("flag: entity resolution", () => {
     const store = new FakeBrainStore();
     const report = await run(store);
     expect(report.provisional).toBe(0);
+    // The row has to EXIST for its missing flag to mean anything — a stage that
+    // wrote nothing also has no provisional fact.
+    expect(store.facts).toHaveLength(1);
     expect(store.facts[0]?.provenance.provisional).toBeUndefined();
   });
 
@@ -450,9 +566,17 @@ describe("flag: entity resolution", () => {
 // ---------------------------------------------------------------------------
 
 describe("corroboration", () => {
-  test("re-observing a claim strengthens it instead of duplicating it", async () => {
+  // Every test here states the lookup's answer as a PREMISE — "suppose the
+  // corroboration lookup comes back with this row" — and asserts what the stage
+  // then does. Whether a given pair of claims SHOULD produce that hit is a
+  // question about SQL columns against a real schema, and it is asked over one
+  // eight-pair corpus in `identity-consumers-pg.test.ts`.
+
+  test("a lookup hit strengthens the existing belief instead of duplicating it", async () => {
     const store = new FakeBrainStore();
     await run(store);
+    store.corroborateWith(store.facts[0]);
+
     const second = await run(store, {
       episode: episode({ id: "ep-2", sourceId: "C01:1719000900.000200" }),
     });
@@ -466,12 +590,29 @@ describe("corroboration", () => {
     expect(store.edges.filter((e) => e.edgeType === "provenance")).toHaveLength(2);
   });
 
+  test("a lookup MISS mints a fresh draft rather than silently dropping the claim", async () => {
+    // The other arm, and the one that makes the test above mean something: with
+    // no hit the stage must still write. A `corroborated` that fell through to
+    // nothing would lose the claim entirely.
+    const store = new FakeBrainStore();
+    await run(store);
+
+    const second = await run(store, { episode: episode({ id: "ep-2" }) });
+
+    expect(second.created).toBe(1);
+    expect(second.corroborated).toBe(0);
+    expect(store.facts).toHaveLength(2);
+  });
+
   test("re-running the SAME episode adds no second evidence edge", async () => {
     // This is what makes `extract.ts`'s work-then-stamp ordering safe: a crash
     // between the reconcile commit and the queue stamp costs a repeated model
-    // call and nothing else.
+    // call and nothing else. The guard is `INSERT … NOT EXISTS` on
+    // `(workspace, fact, episode)` — uuid equality, no identity layer in it.
     const store = new FakeBrainStore();
     await run(store);
+    store.corroborateWith(store.facts[0]);
+
     const again = await run(store);
 
     expect(again.corroborated).toBe(1);
@@ -485,10 +626,24 @@ describe("corroboration", () => {
     // evidence, not a promotion to a wider audience.
     const store = new FakeBrainStore();
     await run(store, { episode: episode({ visibleTo: ["audience:chat-channel:slack:C1"] }) });
+    store.corroborateWith(store.facts[0]);
+
     await run(store, { episode: episode({ id: "ep-2", visibleTo: ["org"] }) });
 
     expect(store.facts).toHaveLength(1);
     expect(store.facts[0]?.visibleTo).toEqual(["audience:chat-channel:slack:C1"]);
+  });
+
+  test("the lookup's first bind is the episode's workspace", async () => {
+    // `workspace_id = $1`. Dropping it from the statement turns a dedupe into a
+    // cross-tenant read — tenant B's re-observation attaching a provenance edge
+    // to tenant A's fact — and this file can only prove the PARAMETER is passed.
+    // That the SQL text still names the column is
+    // `extract-reconcile-pg.test.ts`'s ("keeps corroboration inside the tenant").
+    const store = new FakeBrainStore();
+    await run(store, { episode: episode({ workspaceId: "ws-other" }) });
+
+    expect(store.bindsFor("corroboration").map((p) => p[0])).toEqual(["ws-other"]);
   });
 });
 
@@ -497,18 +652,18 @@ describe("corroboration", () => {
 // ---------------------------------------------------------------------------
 
 describe("advisory contradiction edges", () => {
-  test("a single-cardinality predicate with a rival object earns an in-tension-with edge", async () => {
+  const single = { subject: "Ada", predicate: "reports to", predicateCardinality: "single" } as const;
+
+  test("a rival the scan returns earns an in-tension-with edge", async () => {
+    // Premise: the scan comes back with a rival. WHICH rows it would come back
+    // with is `identity-consumers-pg`'s `rival-through-phrasing` case.
     const store = new FakeBrainStore();
-    await run(store, {
-      candidates: [
-        candidate({ subject: "Ada", predicate: "reports to", object: "Grace", predicateCardinality: "single" }),
-      ],
-    });
+    await run(store, { candidates: [candidate({ ...single, object: "Grace" })] });
+    store.scriptRivals(store.facts[0]);
+
     const second = await run(store, {
       episode: episode({ id: "ep-2" }),
-      candidates: [
-        candidate({ subject: "Ada", predicate: "reports to", object: "Alan", predicateCardinality: "single" }),
-      ],
+      candidates: [candidate({ ...single, object: "Alan" })],
     });
 
     expect(second.outcomes[0]).toMatchObject({ kind: "created", tensionEdges: 1 });
@@ -518,15 +673,49 @@ describe("advisory contradiction edges", () => {
     expect(store.edges.filter((e) => e.edgeType === "in-tension-with")).toHaveLength(1);
   });
 
-  test("multi-cardinality values coexist with no tension edge", async () => {
+  test("a non-single predicate never even ISSUES the rival scan", async () => {
+    // Stronger than "no edge appeared", and it is the arm a scripted store can
+    // still prove outright: the stage does not reach the statement at all, so no
+    // rival list could produce an edge however the scan behaved. Scripted with a
+    // REAL rival standing by, so the refusal is the cardinality gate rather than
+    // an empty world.
     const store = new FakeBrainStore();
-    await run(store, { candidates: [candidate({ subject: "Ada", predicate: "knows", object: "Ada-lang" })] });
+    await run(store, { candidates: [candidate({ ...single, object: "Grace" })] });
+    store.scriptRivals(store.facts[0]);
+    const scansAfterSetup = store.bindsFor("tensionScan").length;
+
     await run(store, {
       episode: episode({ id: "ep-2" }),
-      candidates: [candidate({ subject: "Ada", predicate: "knows", object: "Fortran" })],
+      candidates: [
+        candidate({ subject: "Ada", predicate: "reports to", object: "Alan", predicateCardinality: "multi" }),
+      ],
     });
 
+    expect(store.bindsFor("tensionScan")).toHaveLength(scansAfterSetup);
     expect(store.edges.filter((e) => e.edgeType === "in-tension-with")).toHaveLength(0);
+  });
+
+  test("an empty rival scan writes no edge", async () => {
+    // The prohibition's positive control is the first test in this block: with
+    // the scan issued and coming back empty, the stage must write nothing.
+    const store = new FakeBrainStore();
+    await run(store, { candidates: [candidate({ ...single, object: "Grace" })] });
+
+    expect(store.bindsFor("tensionScan")).toHaveLength(1);
+    expect(store.edges.filter((e) => e.edgeType === "in-tension-with")).toHaveLength(0);
+  });
+
+  test("the scan binds the row just written as its own self-exclusion", async () => {
+    // `id <> $5`. Without it every `single` fact earns a self-edge the moment it
+    // lands, and the review queue fills with claims contradicting themselves.
+    // The BIND is what this file can prove; that the statement still spells the
+    // arm is the lexical backstop at the bottom.
+    const store = new FakeBrainStore();
+    await run(store, { candidates: [candidate({ ...single, object: "Grace" })] });
+
+    const binds = store.bindsFor("tensionScan");
+    expect(binds, "the rival scan was never issued").toHaveLength(1);
+    expect(binds[0]![4]).toBe(store.facts[0]!.id);
   });
 
   test("cardinality defaults to the conservative arm", async () => {
@@ -651,41 +840,66 @@ describe("the draft candidate", () => {
     ).rejects.toThrow("edge insert failed");
   });
 
-  test("identity is the slot key — a phrasing variant corroborates instead of forking (#5020)", async () => {
-    // The behaviour #5020 buys — pinned here at the level this file can reach.
-    // `Ships On` / `ships_on` differ in case AND separator, which is the whole
-    // of `lexicalNorm`, so this fails if the stage stops keying its binds.
+  test("the stage keys its binds off the surfaces — every slot, every statement (#5020)", async () => {
+    // The bind half of claim identity, which IS unit-visible: swapping
+    // `item.keys.*` back to the surface fields turns this red. `Deploy_Window` /
+    // `Ships  On` differ from their norms in case AND separator, which is the
+    // whole of `lexicalNorm`.
     //
-    // What it CANNOT catch, stated because the assertion looks stronger than it
-    // is: the store dispatches on SQL IDENTITY and reads the binds positionally,
-    // so it cannot see which COLUMNS the statement names. Repointing
-    // `CORROBORATION_LOOKUP_SQL` back at the surface columns leaves this green.
-    // What it DOES hold is the bind half — swapping `item.keys.*` back to the
-    // surface fields turns this file red. The COLUMN half is
-    // `extract-reconcile-pg.test.ts`'s (it runs the real strings against the
-    // real schema), with a cheap lexical backstop in the SQL-shape test below
-    // so a revert does not need `TEST_DATABASE_URL` to be caught.
+    // The COLUMN half — that the two lookups still NAME the key columns — this
+    // file structurally cannot see (see the header). It is proven in
+    // `identity-consumers-pg.test.ts` against a real schema, with the lexical
+    // tripwire at the bottom of this file as the cheap local backstop.
     const store = new FakeBrainStore();
-    await run(store, { candidates: [candidate({ predicate: "Ships On" })] });
-    const second = await run(store, {
-      episode: episode({ id: "ep-2" }),
-      candidates: [candidate({ predicate: "ships_on" })],
+    await run(store, {
+      candidates: [
+        // `single`, so the rival scan is REACHED — at `multi` the stage skips it
+        // and this test would silently assert two of the three statements.
+        candidate({
+          subject: "Deploy_Window",
+          predicate: "Ships  On",
+          object: "Thursdays",
+          predicateCardinality: "single",
+        }),
+      ],
     });
 
-    expect(second.corroborated).toBe(1);
-    expect(store.facts).toHaveLength(1);
+    const keyed = { subject: "deploy window", predicate: "ships on", object: "thursdays" };
+    // All three statements that carry keys agree, and each is asserted: an
+    // INSERT keyed correctly beside a lookup keyed off the raw surface would
+    // write rows nothing can ever find.
+    expect(store.keyBindsFor("insertFact")[0]).toEqual(keyed);
+    expect(store.keyBindsFor("corroboration")[0]).toEqual(keyed);
+    expect(store.keyBindsFor("tensionScan")[0]).toEqual(keyed);
     // The RETAINED surface is untouched — identity moved, the record of what
-    // the producer actually said did not. The fact keeps the FIRST phrasing;
-    // the second episode arrives as evidence.
-    expect(store.facts[0]).toMatchObject({ predicate: "Ships On" });
-    expect(store.facts[0]!.slot).toMatchObject({ predicate: "ships on" });
+    // the producer actually said did not.
+    expect(store.facts[0]).toMatchObject({ subject: "Deploy_Window", predicate: "Ships  On" });
   });
 
-  test("the workspace's vocabulary reaches every slot, and a throwing one abstains", async () => {
-    // The `alias` seam, end to end through the stage. Without this the whole
-    // threading is unfalsifiable: the default IS `identityAlias`, so dropping
-    // `request.alias` — or dropping the second argument at the three `slotKey`
-    // calls — changes nothing observable and leaves the suite green.
+  test("keys are derived AFTER entity resolution, off the surface actually stored", async () => {
+    // A key must describe the row that was written. Deriving it from the raw
+    // candidate would key a fact under a name that appears nowhere in it — and
+    // every resolved fact would then be unreachable by its own identity.
+    const store = new FakeBrainStore();
+    await run(store, {
+      candidates: [candidate({ subject: "deploy-01" })],
+      resolveEntity: (surface, { role }) =>
+        role === "subject" ? { canonical: "The Deploy Box" } : { canonical: surface },
+    });
+
+    expect(store.facts[0]?.subject).toBe("The Deploy Box");
+    expect(store.keyBindsFor("insertFact")[0]).toMatchObject({ subject: "the deploy box" });
+  });
+
+  test("the workspace's vocabulary reaches every slot", async () => {
+    // The `alias` seam, through the stage. Without this the whole threading is
+    // unfalsifiable: the default IS `identityAlias`, so dropping `request.alias`
+    // — or dropping the second argument at the three `slotKey` calls — changes
+    // nothing observable and leaves the suite green.
+    //
+    // #5000's pair, closed by an ENTRY rather than by a normalization rule,
+    // which is the whole reason the seam exists (ADR-0037 §6 / #5016). That the
+    // pair does NOT collide without one is the corpus's `copula-pair` entry.
     const store = new FakeBrainStore();
     const vocabulary = (norm: string): string =>
       norm === "is priced at" ? "priced at" : norm;
@@ -694,18 +908,13 @@ describe("the draft candidate", () => {
       alias: vocabulary,
       candidates: [candidate({ predicate: "Is_Priced At" })],
     });
-    const second = await run(store, {
-      alias: vocabulary,
-      episode: episode({ id: "ep-2" }),
-      candidates: [candidate({ predicate: "priced at" })],
-    });
 
-    // #5000's pair, closed by an ENTRY rather than by a normalization rule —
-    // which is the whole reason the seam exists.
-    expect(second.corroborated).toBe(1);
-    expect(store.facts).toHaveLength(1);
+    // The aliased slot is what both the INSERT and the lookup carry…
+    expect(store.keyBindsFor("insertFact")[0]).toMatchObject({ predicate: "priced at" });
+    expect(store.keyBindsFor("corroboration")[0]).toMatchObject({ predicate: "priced at" });
+    // …the PREDICATE slot, not only the entity-resolved sides…
     expect(store.facts[0]?.slot).toMatchObject({ predicate: "priced at" });
-    // …and it is the PREDICATE slot, not only the entity-resolved sides.
+    // …and the surface the producer emitted is still what the row records.
     expect(store.facts[0]?.predicate).toBe("Is_Priced At");
   });
 
@@ -729,75 +938,41 @@ describe("the draft candidate", () => {
     expect(store.transactions).toBe(0);
   });
 
-  test("the lexical layer takes no decision the entity resolver owns", async () => {
-    // The line the keys must not cross. `deploy-01` and `the deploy box` are
-    // the SAME machine and different strings; unifying them is a per-workspace
-    // decision with a seam built for it, not a normalization rule applied
-    // globally with no reviewer. Same for `is priced at` / `priced at`, which
-    // ADR-0037 §6 settles as a vocabulary ENTRY (#5016) rather than a rule.
+  test("the STORED surface is trimmed, so padding never reaches the corpus", async () => {
+    // `reconcile.ts` trims the candidate surfaces before it resolves or keys
+    // them, and the trimmed form is what lands in the row. Pinned here because
+    // the identity corpus deliberately CANNOT cover it: a space-padded pair is
+    // normalized by this trim no matter what `lexicalNorm` does, which is why
+    // `separator-edges` uses `_`/`-` instead. Deleting `.trim()` outright is
+    // caught by the MALFORMED_CLAIM test above; storing the untrimmed surface
+    // beside a trimmed key is caught only here.
     const store = new FakeBrainStore();
-    await run(store, { candidates: [candidate({ subject: "deploy-01", predicate: "is priced at" })] });
-    await run(store, {
-      episode: episode({ id: "ep-2" }),
-      candidates: [candidate({ subject: "the deploy box", predicate: "is priced at" })],
-    });
-    await run(store, {
-      episode: episode({ id: "ep-3" }),
-      candidates: [candidate({ subject: "deploy-01", predicate: "priced at" })],
-    });
+    await run(store, { candidates: [candidate({ subject: "  deploy window  ", object: " Thursdays " })] });
 
-    expect(store.facts).toHaveLength(3);
+    expect(store.facts).toHaveLength(1);
+    expect(store.facts[0]).toMatchObject({ subject: "deploy window", object: "Thursdays" });
   });
 
-  test("a surface that norms away is keyed NULL and corroborates nothing", async () => {
+  test("a surface that norms away is bound as NULL, never as an empty string", async () => {
     // `-` survives the MALFORMED_CLAIM guard (`trim()` strips whitespace, not
     // `_` or `-`), so it is a storable claim whose key is permanently NULL.
-    // Two such claims must NOT share a slot: a stored `''` — or a NULL-safe
-    // comparison — would make every placeholder corroborate every other one and,
-    // at `single` cardinality, publishing either would stamp `valid_to` on the
-    // other. Under-matching costs a duplicate row instead.
+    // A bound `""` would file every placeholder in the corpus under ONE slot:
+    // two unrelated claims corroborate as one and, at `single` cardinality,
+    // publishing either stamps `valid_to` on the other. `null` joins nothing,
+    // which is the honest answer for a surface that asserts nothing.
+    //
+    // The bind is what this file can see. That two such rows then fail to
+    // corroborate each other is `extract-reconcile-pg.test.ts`'s.
     const store = new FakeBrainStore();
     await run(store, { candidates: [candidate({ object: "-" })] });
-    const second = await run(store, {
-      episode: episode({ id: "ep-2" }),
-      candidates: [candidate({ object: "___" })],
-    });
 
-    expect(second.corroborated).toBe(0);
-    expect(store.facts).toHaveLength(2);
-    for (const fact of store.facts) {
-      expect(fact.slot.object).toBeNull();
-    }
-    // …and each degenerate surface is still stored VERBATIM, so the reviewer can
+    expect(store.keyBindsFor("insertFact")[0]?.object).toBeNull();
+    expect(store.keyBindsFor("corroboration")[0]?.object).toBeNull();
+    // …and the degenerate surface is still stored VERBATIM, so the reviewer can
     // see what the producer emitted and repair it. Asserted on `object` — the
     // column that actually carries one; the subject is the shared default and
     // would prove nothing.
-    expect(store.facts.map((f) => f.object)).toEqual(["-", "___"]);
-  });
-
-  test("surrounding whitespace is trimmed, so it never forks a claim", async () => {
-    const store = new FakeBrainStore();
-    await run(store);
-    const second = await run(store, {
-      episode: episode({ id: "ep-2" }),
-      candidates: [candidate({ subject: "  deploy window  ", object: " Thursdays " })],
-    });
-
-    expect(second.corroborated).toBe(1);
-    expect(store.facts).toHaveLength(1);
-  });
-
-  test("corroboration is scoped to the workspace", async () => {
-    const store = new FakeBrainStore();
-    await run(store);
-    const other = await run(store, {
-      episode: episode({ id: "ep-2", workspaceId: "ws-other" }),
-    });
-
-    // Same claim, different tenant — a corroboration across that line would be
-    // a cross-tenant read dressed as a dedupe.
-    expect(other.created).toBe(1);
-    expect(store.facts).toHaveLength(2);
+    expect(store.facts[0]?.object).toBe("-");
   });
 
   test("no candidates is a no-op, not an empty transaction", async () => {
@@ -852,12 +1027,15 @@ describe("no autonomous supersession (#4912)", () => {
   });
 
   test("both lookups match on the SLOT KEYS and on no surface column (#5020)", () => {
-    // The lexical backstop for the pivot. The fake store above dispatches on
+    // The lexical backstop for the pivot, and after #5021 it is the ONLY thing
+    // in this file that looks at a column name. The store above dispatches on
     // each statement's string IDENTITY and reads its binds positionally, so
     // repointing either statement at the surface columns leaves every other test
     // in this file green — and the real proof lives in
-    // `extract-reconcile-pg.test.ts`, which SKIPS without `TEST_DATABASE_URL`.
-    // Without these assertions the revert is green on a default local run.
+    // `identity-consumers-pg.test.ts` (three consumers over one corpus) and
+    // `extract-reconcile-pg.test.ts`, both of which SKIP without
+    // `TEST_DATABASE_URL`. Without these assertions the revert is green on a
+    // default local run.
     expect(CORROBORATION_LOOKUP_SQL).toContain("subject_key = $2");
     expect(CORROBORATION_LOOKUP_SQL).toContain("predicate_key = $3");
     expect(CORROBORATION_LOOKUP_SQL).toContain("object_key = $4");
@@ -865,6 +1043,10 @@ describe("no autonomous supersession (#4912)", () => {
     expect(TENSION_CANDIDATES_SQL).toContain("predicate_key = $3");
     // `<>`, never `=`: a rival asserts a DIFFERENT value in the same slot.
     expect(TENSION_CANDIDATES_SQL).toContain("object_key <> $4");
+    // …and the self-exclusion, whose BIND is asserted above but whose presence
+    // in the statement nothing else here can see. Without it every `single` fact
+    // is its own rival the moment it lands.
+    expect(TENSION_CANDIDATES_SQL).toContain("id <> $5");
     // …and no surviving surface comparison in either. An AND-ed surface arm
     // beside a key arm reads as pivoted and is not.
     for (const [name, sql] of [


### PR DESCRIPTION
Closes #5021.

## The defect

The unit suite could not see claim identity and said it could. `FakeBrainStore` decided **in TypeScript** which stored fact shared a slot with an incoming candidate, so `reconcile.test.ts` stayed green against a `reconcile.ts` whose lookups had been repointed from the materialized `*_key` columns back to the raw surfaces. Confirmed by mutation before starting — reverting `CORROBORATION_LOOKUP_SQL` to the surface columns left the behavioural tests fully green, because the fake dispatches on each statement's string *identity* and reads binds *positionally*, so it cannot see which columns a statement names.

This issue was specced to land **before** #5020 and did not, so the repoint shipped behind a suite that could not falsify it.

## What changed

**The fake retires from identity.** It is stripped to recording the statement and its binds. The two lookups now answer from a premise the *test* states (`corroborateWith(fact)` / `scriptRivals(...facts)`, which reject a phantom id) rather than a conclusion the fake reaches. A closed `STATEMENTS` registry replaces raw-SQL-string accessors, so asserting against the wrong statement is a compile error instead of a vacuous pass. The header states plainly what a green run no longer means.

**One corpus, three verdicts.** `identity-corpus.ts` holds eight claim pairs; `identity-consumers-pg.test.ts` is the only consumer. Corroboration, the rival scan, and the publish gate's collision join each assert a *different* verdict on the same rows — *same*, *different-and-coexisting*, *different-and-stamping*. Every expectation is computed from one `VERDICTS` table, so the three cannot drift into disagreeing about what collides, and adding a relation is a compile error in each consumer.

**Nothing writes a key.** Both sides of every pair land through `reconcileFacts`. The corpus supplies surfaces and a claim about English; the system supplies every key and every observed verdict.

**Prohibitions are paired with positive controls** in separate `test()` blocks, and the corpus's own guard sits *outside* the Postgres gate — a relation with no entries registers zero tests and reports success, which would be invisible in the lane where the rest of this suite skips.

**Seeders.** `oversight-pg`'s `seedFact` takes `predicate`/`object` instead of SQL literals (parity, not coverage — documented as such, since no test there compares two rows' identity); `promotion-pg`'s inline literal INSERT routes through `seedFact`. The three overlapping identity cases in `extract-reconcile-pg` moved to the corpus; what it cannot express (NULL keys, a degenerate rival, cross-tenant scoping) stays.

## Mutations verified to die

Each run one at a time, against a real schema. **None of the middle six was caught by any test in the repo before this PR.**

| Mutation | Dies on |
|---|---|
| `CORROBORATION_LOOKUP_SQL` → surface columns | 6, all three consumers |
| `TENSION_CANDIDATES_SQL` → surface columns | consumer 2's control |
| `supersessionCollisionJoin` → surface columns | consumer 3's control |
| corroboration call site binds surfaces | 6 here **+ 3 in the unit lane** (the bind half it can still see) |
| tension call site binds surfaces | consumer 2's control |
| `subject_key =` neutralized / dropped | consumers 2 and 3, via `subject-differs` |
| `predicate_key =` neutralized / dropped | consumers 2 and 3, via `predicate-differs` |
| `identityAlias` given a global rule | 3 — **prohibitions only** |
| `lexicalNorm` loses its edge trim | 3 |
| `lexicalNorm` loses its ASCII case fold | 8 |
| tension edge endpoints swapped | consumer 2's control |

Two findings came out of running these rather than assuming them, and both are recorded in the code: a pair with one already-normalized side is blind to either the statement repoint or the call-site bind, and the `object_key <>` arm is **not** falsifiable from this corpus at all (corroboration collapses the shape that would catch it) — `promotion-pg` is named as that arm's owner so nobody consolidates it away.

`inverse-relations` and `entity-alias` are documented as falsified by no mutation; they prohibit a direction a future normalization could take, licensed by the controls beside them.

## Accepted cost

Recorded in the map's T7 §4: the most load-bearing assertions now live in the slower, WSL2-flakier `-pg` lane, and `--affected` over `lib/brain/` no longer covers them without `TEST_DATABASE_URL`. The one-corpus design bounds that. A green unit run no longer implying identity coverage **is the intended outcome**.

## Verification

- `bash scripts/ci-local.sh` with `TEST_DATABASE_URL` set: **33/33 gates PASS** (so the `-pg` lane actually ran, not silently skipped).
- Internal review panel run twice; round-2 findings on assertion strength, error handling in the `publish` helper, and comment accuracy all addressed.

Test-only change — no source file is modified.