### PR TITLE
chore(test): delete counts-in-prose, and move the comment sweep to the final round

### DIFF
--- a/.claude/commands/review-panel.md
+++ b/.claude/commands/review-panel.md
@@ -21,7 +21,23 @@ If there is nothing to review, say so and stop.
 
 **Step 2: Fan out the panel — IN PARALLEL, fresh context**
 
-Launch all four in a single message (multiple `Agent` tool calls, one response) so they run concurrently. Each gets the diff scope and is told to review only the changed lines:
+**The three code reviewers run EVERY round. `comment-analyzer` runs only on the round that turns out to be final.**
+
+The reason is that comment findings are mostly *consequences* of the code findings. A comment sweep in round 1 describes code that round 1's own fixes are about to change, so its output is invalidated by the work it triggered — the round is spent and re-spent. The three code reviewers have no such dependency on each other.
+
+This is safe precisely because it is also useful: comment-only fixes are non-structural. They do not add a code path, so they almost never generate the follow-on round that a fix adding real machinery does. `comment-analyzer` is therefore the one reviewer whose findings can be gathered late without costing a round. **Do not "restore" it to every round** — that is the change this rule exists to prevent.
+
+Which round is final is not a prediction. It is determined structurally:
+
+1. Run the three code reviewers — `silent-failure-hunter`, `type-design-analyzer`, `pr-test-analyzer` — in parallel.
+2. **Any must-fix → report `CHANGES REQUESTED` now.** Do not run `comment-analyzer`; this round is not final and its output would be discarded.
+3. **No must-fix → this round IS the final one.** Run `comment-analyzer` before reporting, merge its findings in, and only then issue a verdict.
+
+So a `CLEAN` verdict is unreachable without a comment sweep on the same diff, and "at least once before merge" is a property of the command rather than something the author has to remember. If `comment-analyzer` then raises a must-fix, the verdict is `CHANGES REQUESTED` like any other — fix and re-run.
+
+Pass `--final` to force all four in one round (useful for a docs- or comment-heavy diff, where deferring the sweep just delays the only review that matters).
+
+Launch each round's reviewers in a single message (multiple `Agent` tool calls, one response) so they run concurrently. Each gets the diff scope and is told to review only the changed lines:
 
 > ⚠️ **Call `Agent` with `run_in_background: false` and NO `name:`.** Both matter, and getting either wrong loses the whole panel *silently* — the agents run, write complete reports, and you never see them.
 >
@@ -31,9 +47,12 @@ Launch all four in a single message (multiple `Agent` tool calls, one response) 
 >
 > **If a panel run ever does come back empty:** the reports are not lost. They are the last assistant message in each `~/.claude/projects/<project>/<session>/subagents/agent-*.jsonl`. Recover them before re-running — a re-run costs four fresh contexts and loses the reasoning.
 
+Every round:
 - `Agent(silent-failure-hunter)` — error handling & silent failures
 - `Agent(type-design-analyzer)` — type invariants & safety
 - `Agent(pr-test-analyzer)` — test coverage & discipline
+
+Final round only (or with `--final`):
 - `Agent(comment-analyzer)` — comment accuracy & idiom
 
 Each is read-only/advisory. Give every agent the same context: the base ref, the changed files, and "review only this diff against Atlas's CLAUDE.md standards; report findings with file:line + severity."
@@ -56,9 +75,25 @@ Merge the four reports. Drop duplicates (e.g. an untested error path flagged by 
 
 ### Clean axes
 - <agents that found nothing>
+
+### Comment sweep
+- <`run` with its findings folded in above · or `deferred — not the final round`>
 ```
 
-End with a one-line verdict: **CLEAN** (nothing must-fix) or **CHANGES REQUESTED** (≥1 must-fix). Callers gate on this verdict.
+End with a one-line verdict: **CLEAN** (nothing must-fix) or **CHANGES REQUESTED** (≥1 must-fix). Callers gate on this verdict. A **CLEAN** verdict asserts the comment sweep ran on this diff — if it didn't, the verdict is not CLEAN yet.
+
+**Step 5: Triage each must-fix BEFORE fixing it**
+
+For every must-fix, say which of two things it is:
+
+- **(a) Local defect** — the fix corrects existing behaviour: a missing null check, an unhandled rejection, a wrong type, a test that cannot fail. **Fix it inline. This is the overwhelming majority and it is not a decision** — it is the repo's standing rule (*fix inline, don't farm follow-ups*), and this step does not soften it.
+- **(b) New machinery** — the fix cannot be made without introducing something that did not exist: a new primitive, a new statement, a new field threaded through a report and its audit trail. Then make the in-PR-vs-follow-up call **explicitly** and **record it in the PR body** with one line of reasoning, whichever way it goes.
+
+The test for (b) is *"does the smallest correct fix add a new thing?"* — not *"is this fix big?"* and never *"am I tired of this PR?"*. A large mechanical edit is still (a). If you cannot name the new primitive, it is (a).
+
+⚠️ **This step does not exist to shrink diffs, and choosing "follow-up" is not the default answer for (b).** In #5033 a round-1 finding — the tier guard refused irreversibly with no operator trace — was fixed inline, which took the diff from ~400 to ~1,900 lines and produced rounds 2 and 3. **That was the right outcome.** The fix added a savepoint primitive; round 2 found it could roll back an entire publish, and round 3 found round 2's `SAVEPOINT` itself unguarded. Capping the rounds would have shipped a diagnostic capable of rolling back a customer's publish.
+
+So the point is not fewer rounds. It is that a fix which triples the diff should be a **visible decision with a recorded reason**, made when the growth is proposed rather than discovered three rounds later — and a PR that grew that way should say so, because the reviewer's read of it changes.
 
 **Rules:**
 - Read-only. The panel reports; it never edits code.

--- a/.claude/commands/ship-issue.md
+++ b/.claude/commands/ship-issue.md
@@ -56,8 +56,9 @@ Use `cd packages/api && bun run scripts/test-isolated.ts --affected` for the fas
 ```
 /review-panel
 ```
-- Verdict **CHANGES REQUESTED** → address the must-fix findings, then re-run `/review-panel` on the new diff.
+- Verdict **CHANGES REQUESTED** → **triage the must-fix findings first** (`/review-panel` Step 5: local defect → fix inline; new machinery → decide in-PR vs follow-up explicitly and record the reason in the PR body), then fix, then re-run `/review-panel` on the new diff.
 - Repeat until **CLEAN**, capped at **3 rounds**. If it can't converge in 3 (usually a spec ambiguity), STOP and ask the human.
+- The cap is on ROUNDS, not on scope. A round-2 fix that adds real machinery *should* earn a round 3 — don't skip the re-review to stay under the cap. If the work genuinely needs a fourth round, that is the STOP-and-ask case, not a reason to merge unreviewed.
 
 **Step 4 — CI gate**
 

--- a/packages/api/src/lib/brain/__tests__/grant-sweep-pg.test.ts
+++ b/packages/api/src/lib/brain/__tests__/grant-sweep-pg.test.ts
@@ -81,7 +81,7 @@ const GRANTS: ReadonlyArray<{
   // NULL` excludes the row. Both are legal at rest (0180's CHECK counts
   // non-NULL non-empty elements; one survivor is enough), both parse to zero
   // principals, and `grantProblem` admits `["everyone", null]` from an import
-  // bundle today. Without these two fixtures the cross-check below passes
+  // bundle today. Without these NULL-bearing fixtures the cross-check below passes
   // vacuously — the only other NULL fixture, `padded-org`, carries `org` and is
   // shed for the right reason.
   { label: "malformed-with-null", visibleTo: ["everyone", null], malformed: true },

--- a/packages/api/src/lib/brain/__tests__/identity-consumers-pg.test.ts
+++ b/packages/api/src/lib/brain/__tests__/identity-consumers-pg.test.ts
@@ -29,7 +29,7 @@
  *
  * ## ⚠️ And since #5033 a fifth relation varies something that is NOT identity
  *
- * `tier-guarded-rival` holds five pairs whose subject, predicate and object are
+ * `tier-guarded-rival` holds pairs whose subject, predicate and object are
  * byte-identical to `priced-rival`'s. Only the episode's stored `source` differs
  * — the value `reconcile.ts` copies into `provenance.source`, which no arm of
  * any consumer's MATCHING reads. Consumers 1 and 2 must therefore answer exactly
@@ -124,7 +124,7 @@
  * re-measured — and the first cut of THIS slice reproduced that exact defect,
  * updating this paragraph while leaving four cells above it stale.
  *
- * The five tier rows are what #5033 buys, and three of them are worth reading
+ * The tier rows are what #5033 buys, and they are worth reading
  * as a set. Two aliases carry the same guard, so "it is present" is not the
  * assertion — *which side* it is present on is, and the one-sided mutations die
  * on DISJOINT fixtures (the two `*-draft` entries versus the two `*-incumbent`
@@ -338,7 +338,7 @@ describe("the identity corpus itself (#5021)", () => {
       ).toEqual([identityOf(control!.a), identityOf(control!.b)]);
     }
 
-    // …and the five entries present five DISTINCT tier shapes. Without this,
+    // …and the entries present pairwise DISTINCT tier shapes. Without this,
     // dropping `source: "warehouse"` from `warehouse-both`'s `b` side leaves
     // every other invariant and all three consumers green — while deleting the
     // only `-pg` test that kills the weakening `warehouse-both` exists to pin

--- a/packages/api/src/lib/brain/__tests__/object-cmp-pg.test.ts
+++ b/packages/api/src/lib/brain/__tests__/object-cmp-pg.test.ts
@@ -351,7 +351,7 @@ describeIfPg("object_cmp against a real schema (#5030)", () => {
     "a pre-store row is `unknown`, so it neither supersedes nor is superseded",
     async () => {
       // What the NULL actually MEANS, asserted rather than left implied by the
-      // two tests above. This is the permanent two-tier corpus the issue records
+      // tests above. This is the permanent two-tier corpus the issue records
       // as an accepted cost, and it is the reason the no-backfill rule is safe
       // to keep: the legacy row is not broken, it abstains.
       const ws = "ws-5030-two-tier";
@@ -513,7 +513,7 @@ describeIfPg("object_cmp against a real schema (#5030)", () => {
         // `split_part('money', ':', 1)` returns the whole string `'money'`,
         // which IS in the known-tag list — so before the `strpos` arm these
         // read as *provably different* from every real value of their own type,
-        // measured on PG 16. The three fixtures above all carry a separator and
+        // measured on PG 16. The fixtures above all carry a separator and
         // so dodge the one shape the membership arm cannot handle alone; that
         // is the fixtures-agree-by-construction trap, inside the test written
         // to close it.

--- a/packages/api/src/lib/brain/__tests__/promotion-pg.test.ts
+++ b/packages/api/src/lib/brain/__tests__/promotion-pg.test.ts
@@ -2062,9 +2062,9 @@ describeIfPg("brain fact review gate (real Postgres)", () => {
     // at all, and that shape is precisely the one the guard's first disjunct
     // exists for. It needs a direct INSERT, which is what this file has.
     //
-    // The four tests below are three prohibitions and the control they share,
-    // differing in ONE field (the fourth prohibition additionally proves the
-    // count is per-PAIR rather than per-workspace). Separate `test()` bodies rather than arms of one,
+    // The tests below are the prohibitions and the control they share,
+    // differing in ONE field; the last additionally proves the count is
+    // per-PAIR rather than per-workspace. Separate `test()` bodies rather than arms of one,
     // for the reason `identity-consumers-pg.test.ts` states: in a long proof the
     // first failure hides the rest, and a broken control would silently mask the
     // prohibitions it licenses.
@@ -2248,7 +2248,7 @@ describeIfPg("brain fact review gate (real Postgres)", () => {
     it(
       "counts PAIRS, not workspaces — two held-back collisions report 2",
       async () => {
-        // The two tests above only ever prove 0 or 1, so a count that collapsed
+        // The prohibitions above only ever prove 0 or 1, so a count that collapsed
         // pairs — `COUNT(DISTINCT d.id)`, or anything `LIMIT 1`-shaped — is
         // green in both. An operator reading "1 held back" when three
         // authoritative beliefs were defended is a quieter version of the

--- a/packages/api/src/lib/brain/__tests__/reconcile.test.ts
+++ b/packages/api/src/lib/brain/__tests__/reconcile.test.ts
@@ -988,7 +988,7 @@ describe("the draft candidate", () => {
     // The vocabulary seam, through the stage. `ReconcileRequest.vocabulary` is
     // REQUIRED since #5022, so it can no longer be dropped silently — but the
     // three `slotKey` calls can still be handed the wrong lookup, or the same
-    // one three times, and that is what this and the two tests below catch.
+    // one three times, and that is what this and the tests below catch.
     //
     // #5000's pair, closed by an ENTRY rather than by a normalization rule,
     // which is the whole reason the seam exists (ADR-0037 §6 / #5016). That the

--- a/packages/api/src/lib/brain/__tests__/search-pg.test.ts
+++ b/packages/api/src/lib/brain/__tests__/search-pg.test.ts
@@ -210,7 +210,8 @@ describeIfPg("searchBrain against the live schema", () => {
   it(
     "matches a snake_case predicate by its spaced spelling, and ranks a subject hit above a predicate-only hit",
     async () => {
-      // Two properties of 0181's expression, both easy to break silently.
+      // The properties of 0181's expression that this pins, each easy to break
+      // silently.
       //
       // 1. Snake_case predicates are matchable as words. This works because the
       //    default parser emits `_` as a blank — NOT because of any special

--- a/packages/api/src/lib/brain/__tests__/sources.test.ts
+++ b/packages/api/src/lib/brain/__tests__/sources.test.ts
@@ -87,10 +87,10 @@ describe("the episode-source vocabulary", () => {
 
   test("narrows an arbitrary stored value, and refuses the vendor names a warehouse connector would reach for", () => {
     // `isEpisodeSource` is the runtime gate `registerBrainSourceConnector`
-    // applies to a connector arriving as data. Three of these four are legal
+    // applies to a connector arriving as data. All but the last are legal
     // `SOURCE_SLUG` values, so the pattern check waves them through and only
-    // the vocabulary stops them — that is the concrete regression. The fourth,
-    // `warehouse:prod`, is caught one gate EARLIER by the slug pattern (the
+    // the vocabulary stops them — that is the concrete regression.
+    // `warehouse:prod` is caught one gate EARLIER by the slug pattern (the
     // colon); it is here because a narrowing predicate should refuse it too,
     // not because the slug check would miss it.
     for (const vendor of ["snowflake", "bigquery", "warehouse-prod", "warehouse:prod"]) {


### PR DESCRIPTION
The mechanical half of the review-panel churn problem. Companion to #5062 (the mutation runner); these two are independent and can land in either order.

## 1. Counts in prose

Swept the brain test files for numbers that mirror a collection which can grow *without the editor ever seeing the number*. Each is deleted or reworded to name the thing rather than count it, following #5033's precedent (`reconcile.test.ts`'s "thirteen claim pairs" → "one corpus of claim pairs").

| File | Was | Now |
|---|---|---|
| `promotion-pg.test.ts` | "The **four tests** below are **three prohibitions**… (the **fourth prohibition** additionally proves…)" | "The tests below are the prohibitions and the control they share… the last additionally proves…" |
| `promotion-pg.test.ts` | "The **two tests** above only ever prove 0 or 1" | "The prohibitions above…" |
| `identity-consumers-pg.test.ts` | "holds **five pairs**" / "The **five** tier rows… **three of them**" / "the **five** entries present **five** DISTINCT tier shapes" | named, not counted |
| `object-cmp-pg.test.ts` | "the **two tests** above" / "The **three fixtures** above" | "the tests above" / "The fixtures above" |
| `reconcile.test.ts` | "this and the **two tests** below" | "this and the tests below" |
| `grant-sweep-pg.test.ts` | "Without these **two** fixtures" | "Without these NULL-bearing fixtures" |
| `sources.test.ts` | "**Three of these four** are legal… The **fourth**" | "All but the last are legal… `warehouse:prod` is caught…" |
| `search-pg.test.ts` | "**Two** properties of 0181's expression" | "The properties… each easy to break silently" |

**One was already wrong.** `promotion-pg.test.ts` described its block as "four tests … three prohibitions and the control they share", then referred to "the fourth prohibition". The block has four tests and three prohibitions — the fourth prohibition does not exist; it meant the last test.

**Deliberately kept:** `vocabulary-pg.test.ts`'s "presented as FIVE failures … three of them naming innocent code". That records an *observed event*, not a count of anything in the tree. Deleting it would destroy the evidence.

**Deliberately untouched:** counts inside mutation-table narratives (`vocabulary-decide-pg.test.ts`'s "six `identityVocabulary` rows", `identity-consumers-pg.test.ts`'s "5→10, because #5033 added five corpus entries"). Those tables are generated by #5060 and converted by #5061 — editing the same paragraphs here would only conflict.

**No load-bearing count needed an assertion added.** The one that looked like it might — `identity-consumers-pg.test.ts`'s "the five entries present five DISTINCT tier shapes" — already asserts the property that matters (pairwise distinctness, plus the both-sides-warehouse shape specifically), and the non-vacuity guard `pairsWhere(relation).length > 0` already exists for every relation. Pinning the cardinality on top would be churn: adding a sixth fixture is legal, collapsing two shapes is not, and only the latter is asserted.

## 2. `comment-analyzer` moves to the final round

It ran every round alongside the three code reviewers, but comment findings are mostly *consequences* of the code findings — round 1's sweep describes code that round 1's own fixes then change, so the round is spent and re-spent.

**Final is determined structurally, not predicted:**

1. Three code reviewers run.
2. Any must-fix → `CHANGES REQUESTED`, sweep skipped (this round isn't final).
3. No must-fix → this round *is* final → sweep runs, findings merge in, *then* the verdict.

So `CLEAN` is unreachable without a comment sweep on that diff, and "at least once before merge" is a property of the command rather than something the author has to remember. `--final` forces all four for a comment-heavy diff.

The rationale is written into the file so a future reader doesn't "restore" it: this is safe *because* it's useful — comment-only fixes are non-structural, so they almost never generate the follow-on round that a fix adding machinery does. That makes `comment-analyzer` the one reviewer whose findings can be gathered late for free.

## 3. Triage step (new Step 5)

Between the panel and the fix. Classify each must-fix as **(a) local defect** → fix inline, or **(b) new machinery** → make the in-PR-vs-follow-up call explicitly and record it in the PR body *either way*. Test: *"does the smallest correct fix add a new thing?"* — not *"is this fix big?"*.

⚠️ **This does not reduce review, and it is not license to defer ordinary defects.** (a) is the overwhelming majority and is explicitly not a decision — the standing *fix inline, don't farm follow-ups* rule is restated, not softened. #5033's round-1 fix tripled the diff and earned rounds 2 and 3, which found a savepoint that could roll back an entire publish and then an unguarded `SAVEPOINT` inside the fix for it. The file says plainly that this was the **right outcome**. The point is that diff growth becomes a visible decision when proposed, rather than a discovery three rounds later.

`ship-issue.md` gains a matching line: the cap is on **rounds, not scope** — don't skip a re-review to stay under it.

## Verification
- `/ci` — **33/33 gates PASS**
- Comment-only changes to test files; no assertions added or removed.