### PR TITLE
fix(web/admin): the feature gate speaks the server's words, and carries the request id (#5068)

### DIFF
--- a/packages/web/src/app/admin/audit/__tests__/analytics-panel-gate.test.tsx
+++ b/packages/web/src/app/admin/audit/__tests__/analytics-panel-gate.test.tsx
@@ -146,13 +146,25 @@ describe("AnalyticsPanel — the gate carries the server's words and the id (#50
     ).toBeNull();
   });
 
-  test("a 503 reaches the gate at all — this file used to omit it from the set", async () => {
-    // The panel wrote its own `[401, 403, 404]` list twice and left 503 out,
-    // so an authz-service outage fell through to five per-chart error banners
-    // rendering the raw message with no correlation id. Now it shares
-    // `isGateStatus`. The `[role="alert"]` assertion is what distinguishes
-    // "routed to the gate" from "routed to the banners" — the copy alone
-    // would appear either way, since the banners render the same message.
+  test("a 404 without a body message still shows the id when one is present", async () => {
+    failAll(404, { error: "not_available", requestId: REQUEST_ID });
+    const view = renderPanel();
+
+    await waitFor(() =>
+      expect(view.container.textContent ?? "").toContain("Query Analytics not enabled"),
+    );
+    const line = view.container.querySelector('[data-testid="feature-gate-request-id"]');
+    if (!line) throw new Error("gate rendered no request-id line");
+    expect(line.textContent).toContain(REQUEST_ID);
+  });
+
+  test("a 503 is NOT promoted to a page-level gate — it stays per-chart", async () => {
+    // 503 is deliberately excluded from this page's gate set. 401/403/404 are
+    // shared verdicts (whatever denies one of the five requests denies all
+    // five), but a 503 can fail one — a restarting replica, an unhealthy
+    // proxy — and gating on the first would discard four charts that rendered
+    // fine. An earlier pass added 503 here and this is the arm that says why
+    // it came back out.
     failAll(503, {
       error: "permissions_unavailable",
       message: "Authorization service is temporarily unavailable.",
@@ -161,12 +173,32 @@ describe("AnalyticsPanel — the gate carries the server's words and the id (#50
     const view = renderPanel();
 
     await waitFor(() =>
-      expect(view.container.textContent ?? "").toContain("Query Analytics is unavailable"),
+      expect(view.container.querySelectorAll('[role="alert"]').length).toBeGreaterThan(0),
     );
-    expect(view.container.querySelector('[role="alert"]')).toBeNull();
-    expect(view.container.textContent ?? "").toContain(
-      "Authorization service is temporarily unavailable.",
-    );
+    // The gate's own headline is the discriminator — the banners render the
+    // server sentence either way, so asserting on the copy proves nothing.
+    expect(view.container.textContent ?? "").not.toContain("Query Analytics is unavailable");
+    // The banners go through `friendlyError`, so they carry the correlation id
+    // that raw `.message` was dropping.
     expect(view.container.textContent ?? "").toContain(REQUEST_ID);
+  });
+
+  test("a 500 is a fault, not a gate — the whitelist still means something", async () => {
+    // The negative the gate arms need: without it, widening `findGateError` to
+    // return ANY errored request passes every positive above. 500 is the
+    // canonical "known status that must NOT gate".
+    failAll(500, {
+      error: "internal_error",
+      message: "Failed to load analytics.",
+      requestId: REQUEST_ID,
+    });
+    const view = renderPanel();
+
+    await waitFor(() =>
+      expect(view.container.querySelectorAll('[role="alert"]').length).toBeGreaterThan(0),
+    );
+    expect(view.container.textContent ?? "").not.toContain("Query Analytics not enabled");
+    expect(view.container.textContent ?? "").not.toContain("Query Analytics is unavailable");
+    expect(view.container.textContent ?? "").not.toContain("Access denied");
   });
 });

--- a/packages/web/src/app/admin/audit/__tests__/analytics-panel-gate.test.tsx
+++ b/packages/web/src/app/admin/audit/__tests__/analytics-panel-gate.test.tsx
@@ -1,0 +1,172 @@
+import { describe, expect, test, mock, beforeEach, afterEach } from "bun:test";
+import { render, cleanup, waitFor } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { NuqsAdapter } from "nuqs/adapters/next/app";
+import { AtlasProvider, type AtlasAuthClient } from "@/ui/context";
+
+/**
+ * The third `FeatureGate` call site (#5068), which had no test of any kind.
+ *
+ * `AdminContentWrapper` and `MutationErrorSurface` are the other two, and both
+ * are covered — so deleting `message` / `requestId` from *this* file was the
+ * one revert of the fix that left the whole web suite green. That is the gap
+ * this file closes: the exact regression #5068 fixes could be reintroduced on
+ * the audit-analytics page silently.
+ *
+ * The panel fires five parallel requests and gates on the first failure among
+ * them, so each arm answers every request with the same envelope.
+ */
+
+void mock.module("next/navigation", () => ({
+  usePathname: () => "/admin/audit",
+  useRouter: () => ({ push: () => {}, replace: () => {}, back: () => {} }),
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+// Recharts is `dynamic(..., { ssr: false })` here and irrelevant to the gate —
+// every arm below returns before a chart renders. Stubbing keeps the failure
+// mode legible if one ever does.
+void mock.module("../volume-chart", () => ({ default: () => null }));
+void mock.module("../error-chart", () => ({ default: () => null }));
+
+const stubAuthClient: AtlasAuthClient = {
+  signIn: { email: async () => ({}) },
+  signUp: { email: async () => ({}) },
+  signOut: async () => {},
+  useSession: () => ({ data: null, isPending: false }),
+};
+
+const { AnalyticsPanel } = await import("../analytics-panel");
+
+let testQueryClient: QueryClient;
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return createElement(
+    NuqsAdapter,
+    null,
+    createElement(
+      QueryClientProvider,
+      { client: testQueryClient },
+      createElement(AtlasProvider, {
+        config: {
+          apiUrl: "http://localhost:3001",
+          isCrossOrigin: false as const,
+          authClient: stubAuthClient,
+        },
+        children,
+      }),
+    ),
+  );
+}
+
+const REQUEST_ID = "8f0c1e2a-4b6d-4f1a-9c3e-77d2b5a10e94";
+
+const originalFetch = globalThis.fetch;
+
+/** Answer every one of the panel's five requests with the same failure. */
+function failAll(status: number, body: Record<string, unknown>) {
+  globalThis.fetch = (async () =>
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    })) as unknown as typeof fetch;
+}
+
+function renderPanel() {
+  return render(createElement(AnalyticsPanel, { from: "", to: "" }), { wrapper: Wrapper });
+}
+
+beforeEach(() => {
+  testQueryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0, staleTime: 0 } },
+  });
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  testQueryClient.clear();
+  cleanup();
+});
+
+describe("AnalyticsPanel — the gate carries the server's words and the id (#5068)", () => {
+  test("a 403 surfaces the server's role message, not the canned admin-role line", async () => {
+    failAll(403, {
+      error: "forbidden_role",
+      message: "Platform admin role required.",
+      requestId: REQUEST_ID,
+    });
+    const view = renderPanel();
+
+    await waitFor(() =>
+      expect(view.container.textContent ?? "").toContain("Access denied"),
+    );
+    expect(view.container.textContent ?? "").toContain("Platform admin role required.");
+    // The role the server did NOT ask for — the canned line this displaces.
+    expect(view.container.textContent ?? "").not.toContain(
+      "You need the admin role to access this page.",
+    );
+    const line = view.container.querySelector('[data-testid="feature-gate-request-id"]');
+    if (!line) throw new Error("gate rendered no request-id line");
+    expect(line.textContent).toContain(REQUEST_ID);
+  });
+
+  test("a 404 surfaces the server's message", async () => {
+    failAll(404, {
+      error: "not_available",
+      message: "No internal database configured.",
+      requestId: REQUEST_ID,
+    });
+    const view = renderPanel();
+
+    await waitFor(() =>
+      expect(view.container.textContent ?? "").toContain("Query Analytics not enabled"),
+    );
+    expect(view.container.textContent ?? "").toContain("No internal database configured.");
+    expect(view.container.textContent ?? "").not.toContain(
+      "Enable this feature in your server configuration",
+    );
+  });
+
+  test("an EMPTY gated body keeps the canned copy — the arm that pins serverMessage()", async () => {
+    // Without this, forwarding `error.message` instead of `serverMessage(error)`
+    // passes both arms above, and puts "HTTP 404" where the guidance belongs.
+    failAll(404, {});
+    const view = renderPanel();
+
+    await waitFor(() =>
+      expect(view.container.textContent ?? "").toContain("Query Analytics not enabled"),
+    );
+    expect(view.container.textContent ?? "").toContain(
+      "Enable this feature in your server configuration to use this page.",
+    );
+    expect(view.container.textContent ?? "").not.toContain("HTTP 404");
+    expect(
+      view.container.querySelector('[data-testid="feature-gate-request-id"]'),
+    ).toBeNull();
+  });
+
+  test("a 503 reaches the gate at all — this file used to omit it from the set", async () => {
+    // The panel wrote its own `[401, 403, 404]` list twice and left 503 out,
+    // so an authz-service outage fell through to five per-chart error banners
+    // rendering the raw message with no correlation id. Now it shares
+    // `isGateStatus`. The `[role="alert"]` assertion is what distinguishes
+    // "routed to the gate" from "routed to the banners" — the copy alone
+    // would appear either way, since the banners render the same message.
+    failAll(503, {
+      error: "permissions_unavailable",
+      message: "Authorization service is temporarily unavailable.",
+      requestId: REQUEST_ID,
+    });
+    const view = renderPanel();
+
+    await waitFor(() =>
+      expect(view.container.textContent ?? "").toContain("Query Analytics is unavailable"),
+    );
+    expect(view.container.querySelector('[role="alert"]')).toBeNull();
+    expect(view.container.textContent ?? "").toContain(
+      "Authorization service is temporarily unavailable.",
+    );
+    expect(view.container.textContent ?? "").toContain(REQUEST_ID);
+  });
+});

--- a/packages/web/src/app/admin/audit/__tests__/analytics-panel-gate.test.tsx
+++ b/packages/web/src/app/admin/audit/__tests__/analytics-panel-gate.test.tsx
@@ -179,8 +179,15 @@ describe("AnalyticsPanel — the gate carries the server's words and the id (#50
     // server sentence either way, so asserting on the copy proves nothing.
     expect(view.container.textContent ?? "").not.toContain("Query Analytics is unavailable");
     // The banners go through `friendlyError`, so they carry the correlation id
-    // that raw `.message` was dropping.
-    expect(view.container.textContent ?? "").toContain(REQUEST_ID);
+    // that raw `.message` was dropping. Asserted PER BANNER, not on the
+    // container: this page has five independent `friendlyError` call sites and
+    // a container-scoped `toContain` is satisfied by any one of them, so
+    // reverting four would have stayed green.
+    const alerts = Array.from(view.container.querySelectorAll('[role="alert"]'));
+    expect(alerts.length).toBe(5);
+    for (const alert of alerts) {
+      expect(alert.textContent ?? "").toContain(REQUEST_ID);
+    }
   });
 
   test("a 500 is a fault, not a gate — the whitelist still means something", async () => {

--- a/packages/web/src/app/admin/audit/analytics-panel.tsx
+++ b/packages/web/src/app/admin/audit/analytics-panel.tsx
@@ -2,6 +2,7 @@
 
 import dynamic from "next/dynamic";
 import { useAdminFetch, type FetchError } from "@/ui/hooks/use-admin-fetch";
+import { serverMessage } from "@/ui/lib/fetch-error";
 import {
   AuditVolumeResponseSchema,
   AuditSlowResponseSchema,
@@ -123,7 +124,14 @@ export function AnalyticsPanel({ from, to }: { from: string; to: string }) {
   // Gate: auth/availability errors surface as FeatureGate
   const gateError = findGateError(volumeError, slowError, frequentError, errorsError, userError);
   if (gateError?.status && [401, 403, 404].includes(gateError.status)) {
-    return <FeatureGate status={gateError.status as 401 | 403 | 404} feature="Query Analytics" />;
+    return (
+      <FeatureGate
+        status={gateError.status as 401 | 403 | 404}
+        feature="Query Analytics"
+        message={serverMessage(gateError)}
+        requestId={gateError.requestId}
+      />
+    );
   }
 
   return (

--- a/packages/web/src/app/admin/audit/analytics-panel.tsx
+++ b/packages/web/src/app/admin/audit/analytics-panel.tsx
@@ -15,7 +15,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { LoadingState } from "@/ui/components/admin/loading-state";
 import { EmptyState } from "@/ui/components/admin/empty-state";
 import { ErrorBanner } from "@/ui/components/admin/error-banner";
-import { FeatureGate } from "@/ui/components/admin/feature-disabled";
+import { FeatureGate, isGateStatus } from "@/ui/components/admin/feature-disabled";
 import { DataTable } from "@/components/data-table/data-table";
 import { useDataTable } from "@/hooks/use-data-table";
 import {
@@ -51,10 +51,20 @@ function buildQS(from: string, to: string): string {
   return parts.length > 0 ? `?${parts.join("&")}` : "";
 }
 
-/** Check if any fetch error is an auth/availability gate error. */
+/**
+ * The first of the five panel fetches whose failure is a gate rather than a
+ * fault.
+ *
+ * Uses the shared `isGateStatus`, which includes **503**; this file used to
+ * write its own `[401, 403, 404]` list twice and silently omit it, so an
+ * authz-service outage fell through to five per-chart error banners rendering
+ * the raw message with no correlation id. Nothing marked that as a decision,
+ * and #5068's premise — a 503 is a refusal to explain, not a fault to retry
+ * per-chart — is the same one that puts it in the set.
+ */
 function findGateError(...errors: (FetchError | null)[]): FetchError | null {
   for (const err of errors) {
-    if (err?.status && [401, 403, 404].includes(err.status)) return err;
+    if (isGateStatus(err?.status)) return err;
   }
   return null;
 }
@@ -123,10 +133,10 @@ export function AnalyticsPanel({ from, to }: { from: string; to: string }) {
 
   // Gate: auth/availability errors surface as FeatureGate
   const gateError = findGateError(volumeError, slowError, frequentError, errorsError, userError);
-  if (gateError?.status && [401, 403, 404].includes(gateError.status)) {
+  if (gateError && isGateStatus(gateError.status)) {
     return (
       <FeatureGate
-        status={gateError.status as 401 | 403 | 404}
+        status={gateError.status}
         feature="Query Analytics"
         message={serverMessage(gateError)}
         requestId={gateError.requestId}

--- a/packages/web/src/app/admin/audit/analytics-panel.tsx
+++ b/packages/web/src/app/admin/audit/analytics-panel.tsx
@@ -2,7 +2,7 @@
 
 import dynamic from "next/dynamic";
 import { useAdminFetch, type FetchError } from "@/ui/hooks/use-admin-fetch";
-import { serverMessage } from "@/ui/lib/fetch-error";
+import { friendlyError, gateProps } from "@/ui/lib/fetch-error";
 import {
   AuditVolumeResponseSchema,
   AuditSlowResponseSchema,
@@ -15,7 +15,11 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { LoadingState } from "@/ui/components/admin/loading-state";
 import { EmptyState } from "@/ui/components/admin/empty-state";
 import { ErrorBanner } from "@/ui/components/admin/error-banner";
-import { FeatureGate, isGateStatus } from "@/ui/components/admin/feature-disabled";
+import {
+  FeatureGate,
+  isGateStatus,
+  type GateStatus,
+} from "@/ui/components/admin/feature-disabled";
 import { DataTable } from "@/components/data-table/data-table";
 import { useDataTable } from "@/hooks/use-data-table";
 import {
@@ -53,18 +57,31 @@ function buildQS(from: string, to: string): string {
 
 /**
  * The first of the five panel fetches whose failure is a gate rather than a
- * fault.
+ * fault — and a gate here replaces the *whole* panel, not one chart.
  *
- * Uses the shared `isGateStatus`, which includes **503**; this file used to
- * write its own `[401, 403, 404]` list twice and silently omit it, so an
- * authz-service outage fell through to five per-chart error banners rendering
- * the raw message with no correlation id. Nothing marked that as a decision,
- * and #5068's premise — a 503 is a refusal to explain, not a fault to retry
- * per-chart — is the same one that puts it in the set.
+ * Deliberately narrower than the shared `GATE_STATUSES`: **503 is excluded**.
+ * 401/403/404 are shared verdicts — whatever denies one of the five requests
+ * denies all five — so promoting the first one to a page-level gate loses
+ * nothing. A 503 is not: a restarting replica or an unhealthy proxy can fail
+ * one request of five, and gating on it would discard four charts that
+ * rendered fine. Those get the per-chart banner instead.
+ *
+ * (This file previously wrote `[401, 403, 404]` inline, twice, with nothing
+ * saying whether the omission was reasoned or accidental. It is reasoned —
+ * but it is derived from the shared set so the two cannot drift apart, and
+ * the narrowing survives as a type.)
  */
-function findGateError(...errors: (FetchError | null)[]): FetchError | null {
+type PanelGateStatus = Exclude<GateStatus, 503>;
+
+function isPanelGateStatus(status: number | undefined): status is PanelGateStatus {
+  return isGateStatus(status) && status !== 503;
+}
+
+function findGateError(
+  ...errors: (FetchError | null)[]
+): (FetchError & { status: PanelGateStatus }) | null {
   for (const err of errors) {
-    if (isGateStatus(err?.status)) return err;
+    if (err && isPanelGateStatus(err.status)) return { ...err, status: err.status };
   }
   return null;
 }
@@ -133,13 +150,12 @@ export function AnalyticsPanel({ from, to }: { from: string; to: string }) {
 
   // Gate: auth/availability errors surface as FeatureGate
   const gateError = findGateError(volumeError, slowError, frequentError, errorsError, userError);
-  if (gateError && isGateStatus(gateError.status)) {
+  if (gateError) {
     return (
       <FeatureGate
         status={gateError.status}
         feature="Query Analytics"
-        message={serverMessage(gateError)}
-        requestId={gateError.requestId}
+        {...gateProps(gateError)}
       />
     );
   }
@@ -156,7 +172,7 @@ export function AnalyticsPanel({ from, to }: { from: string; to: string }) {
         </CardHeader>
         <CardContent>
           {volumeError ? (
-            <ErrorBanner message={volumeError.message} />
+            <ErrorBanner message={friendlyError(volumeError)} />
           ) : volumeLoading ? (
             <div className="flex h-64 items-center justify-center">
               <LoadingState message="Loading volume data..." />
@@ -180,7 +196,7 @@ export function AnalyticsPanel({ from, to }: { from: string; to: string }) {
           </CardHeader>
           <CardContent>
             {slowError ? (
-              <ErrorBanner message={slowError.message} />
+              <ErrorBanner message={friendlyError(slowError)} />
             ) : slowLoading ? (
               <div className="flex h-40 items-center justify-center">
                 <LoadingState message="Loading..." />
@@ -203,7 +219,7 @@ export function AnalyticsPanel({ from, to }: { from: string; to: string }) {
           </CardHeader>
           <CardContent>
             {frequentError ? (
-              <ErrorBanner message={frequentError.message} />
+              <ErrorBanner message={friendlyError(frequentError)} />
             ) : frequentLoading ? (
               <div className="flex h-40 items-center justify-center">
                 <LoadingState message="Loading..." />
@@ -227,7 +243,7 @@ export function AnalyticsPanel({ from, to }: { from: string; to: string }) {
         </CardHeader>
         <CardContent>
           {errorsError ? (
-            <ErrorBanner message={errorsError.message} />
+            <ErrorBanner message={friendlyError(errorsError)} />
           ) : errorLoading ? (
             <div className="flex h-40 items-center justify-center">
               <LoadingState message="Loading..." />
@@ -250,7 +266,7 @@ export function AnalyticsPanel({ from, to }: { from: string; to: string }) {
         </CardHeader>
         <CardContent>
           {userError ? (
-            <ErrorBanner message={userError.message} />
+            <ErrorBanner message={friendlyError(userError)} />
           ) : userLoading ? (
             <div className="flex h-40 items-center justify-center">
               <LoadingState message="Loading..." />

--- a/packages/web/src/app/admin/brain/__tests__/read-only-vitals.test.tsx
+++ b/packages/web/src/app/admin/brain/__tests__/read-only-vitals.test.tsx
@@ -254,6 +254,11 @@ describe("Company Brain overview — counts are never fabricated (#5066)", () =>
     // legitimate, then no digit may remain — which is what catches an
     // UNLABELLED bare count that `expectNoCounts` cannot see. Throws rather
     // than `?.remove()` so a silent no-op strip can't leave this green.
+    //
+    // ⚠️ This couples to `NO_INTERNAL_DB.message` being digit-free, since the
+    // gate now renders it. Give that message a port or a version number and
+    // the failure reads "fabricated count" — which is the wrong place to
+    // start debugging.
     const outsideId = view.container.cloneNode(true) as HTMLElement;
     const idLine = outsideId.querySelector('[data-testid="feature-gate-request-id"]');
     if (!idLine) throw new Error("no request-id line to strip — the 404 gate surface changed");

--- a/packages/web/src/app/admin/brain/__tests__/read-only-vitals.test.tsx
+++ b/packages/web/src/app/admin/brain/__tests__/read-only-vitals.test.tsx
@@ -242,12 +242,23 @@ describe("Company Brain overview — counts are never fabricated (#5066)", () =>
     // The generic banner and its dead Retry button are what must NOT appear.
     expect(view.container.querySelector('[role="alert"]')).toBeNull();
     expect((view.container.textContent ?? "").toLowerCase()).not.toContain("retry");
-    // `expectNoCounts` only, no raw digit sweep: `FeatureGate` currently drops
-    // the server `message`/`requestId`, and a whole-container digit assertion
-    // would silently depend on that — then fail as a "fabricated count" the day
-    // the gate starts rendering the correlation id. The unlabelled-count hazard
-    // is covered on the 500 arm, which is the one that renders alongside the page.
+    // Routing to the gate is not enough on its own: the gate used to render
+    // only its canned "enable this feature in your server configuration"
+    // line, which names nothing an operator can go set. Since #5068 the
+    // server's own sentence and the correlation id both reach the screen.
+    expect(view.container.textContent ?? "").toContain(NO_INTERNAL_DB.message);
+    expect(view.container.textContent ?? "").toContain(REQUEST_ID);
     expectNoCounts(view.container);
+    // The digit sweep this arm had to drop while the gate rendered no id.
+    // Same shape as the 500 arm: strip the one element whose digits are
+    // legitimate, then no digit may remain — which is what catches an
+    // UNLABELLED bare count that `expectNoCounts` cannot see. Throws rather
+    // than `?.remove()` so a silent no-op strip can't leave this green.
+    const outsideId = view.container.cloneNode(true) as HTMLElement;
+    const idLine = outsideId.querySelector('[data-testid="feature-gate-request-id"]');
+    if (!idLine) throw new Error("no request-id line to strip — the 404 gate surface changed");
+    idLine.remove();
+    expect(outsideId.textContent ?? "").not.toMatch(/\d/);
   });
 
   test("a PENDING summary renders no number either", async () => {

--- a/packages/web/src/app/admin/token-usage/__tests__/tab-gate.test.tsx
+++ b/packages/web/src/app/admin/token-usage/__tests__/tab-gate.test.tsx
@@ -1,0 +1,160 @@
+import { describe, expect, test, mock, beforeEach, afterEach } from "bun:test";
+import { render, cleanup, waitFor } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { NuqsAdapter } from "nuqs/adapters/next/app";
+import { AtlasProvider, type AtlasAuthClient } from "@/ui/context";
+
+/**
+ * `token-usage/tab.tsx` had no test of any kind, and #5068's review found that
+ * every mutation to it survives the whole web suite: re-admitting 503 to its
+ * gate set, deleting the gate outright, and reverting all three
+ * `friendlyError` banners were each silently green.
+ *
+ * That matters because this file is one of the gate-set owners. It held the
+ * last of five hand-written copies of the gated-status list, and the *reason*
+ * for its narrowing — 503 stays per-section because it can fail one of three
+ * parallel requests — is a decision nothing was pinning.
+ *
+ * The tab fires three requests and promotes the first gate error to
+ * `AdminContentWrapper`, so each arm answers all three identically.
+ */
+
+void mock.module("next/navigation", () => ({
+  usePathname: () => "/admin/usage",
+  useRouter: () => ({ push: () => {}, replace: () => {}, back: () => {} }),
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+// Recharts is `dynamic(..., { ssr: false })` and irrelevant to every arm here.
+void mock.module("../token-chart", () => ({ default: () => null }));
+
+const stubAuthClient: AtlasAuthClient = {
+  signIn: { email: async () => ({}) },
+  signUp: { email: async () => ({}) },
+  signOut: async () => {},
+  useSession: () => ({ data: null, isPending: false }),
+};
+
+const { TokenUsageTab } = await import("../tab");
+
+let testQueryClient: QueryClient;
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return createElement(
+    NuqsAdapter,
+    null,
+    createElement(
+      QueryClientProvider,
+      { client: testQueryClient },
+      createElement(AtlasProvider, {
+        config: {
+          apiUrl: "http://localhost:3001",
+          isCrossOrigin: false as const,
+          authClient: stubAuthClient,
+        },
+        children,
+      }),
+    ),
+  );
+}
+
+const REQUEST_ID = "8f0c1e2a-4b6d-4f1a-9c3e-77d2b5a10e94";
+
+const originalFetch = globalThis.fetch;
+
+function failAll(status: number, body: Record<string, unknown>) {
+  globalThis.fetch = (async () =>
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    })) as unknown as typeof fetch;
+}
+
+const renderTab = () => render(createElement(TokenUsageTab), { wrapper: Wrapper });
+
+beforeEach(() => {
+  testQueryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0, staleTime: 0 } },
+  });
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  testQueryClient.clear();
+  cleanup();
+});
+
+describe("TokenUsageTab — the gate carries the server's words and the id (#5068)", () => {
+  test("a 403 surfaces the server's role message, not the canned admin-role line", async () => {
+    failAll(403, {
+      error: "forbidden_role",
+      message: "Platform admin role required.",
+      requestId: REQUEST_ID,
+    });
+    const view = renderTab();
+
+    await waitFor(() => expect(view.container.textContent ?? "").toContain("Access denied"));
+    expect(view.container.textContent ?? "").toContain("Platform admin role required.");
+    expect(view.container.textContent ?? "").not.toContain(
+      "You need the admin role to access this page.",
+    );
+    const line = view.container.querySelector('[data-testid="feature-gate-request-id"]');
+    if (!line) throw new Error("gate rendered no request-id line");
+    expect(line.textContent).toContain(REQUEST_ID);
+  });
+
+  test("an EMPTY gated body keeps the canned copy — the arm that pins gateProps()", async () => {
+    // Without this, forwarding `error.message` instead of `gateProps(error)`
+    // passes the arm above and puts "HTTP 404" where the guidance belongs.
+    failAll(404, {});
+    const view = renderTab();
+
+    await waitFor(() =>
+      expect(view.container.textContent ?? "").toContain("Token Usage not enabled"),
+    );
+    expect(view.container.textContent ?? "").toContain(
+      "Enable this feature in your server configuration to use this page.",
+    );
+    expect(view.container.textContent ?? "").not.toContain("HTTP 404");
+  });
+
+  test("a 503 is NOT promoted to a page-level gate — it stays per-section", async () => {
+    // The deliberate narrowing, and the only thing pinning it. A gate here
+    // replaces the whole tab; a 503 can fail one of three parallel requests
+    // (restarting replica, unhealthy proxy) and blanking the tab for that
+    // would discard two sections that loaded fine.
+    failAll(503, {
+      error: "permissions_unavailable",
+      message: "Authorization service is temporarily unavailable.",
+      requestId: REQUEST_ID,
+    });
+    const view = renderTab();
+
+    await waitFor(() =>
+      expect(view.container.querySelectorAll('[role="alert"]').length).toBeGreaterThan(0),
+    );
+    // The gate's headline is the discriminator — the banner renders the server
+    // sentence either way, so asserting on the copy proves nothing.
+    expect(view.container.textContent ?? "").not.toContain("Token Usage is unavailable");
+    expect(view.container.textContent ?? "").not.toContain("Access denied");
+    // Through `friendlyError`, so the banner carries the id raw `.message` dropped.
+    expect(view.container.textContent ?? "").toContain(REQUEST_ID);
+  });
+
+  test("an empty-bodied 500 banner shows actionable copy, never the status echo", async () => {
+    // 500 is not a gate, so this is the negative that keeps the whitelist
+    // meaningful — and the one that pins the `friendlyError` swap on the
+    // summary banner, which previously rendered the literal "HTTP 500".
+    failAll(500, {});
+    const view = renderTab();
+
+    await waitFor(() =>
+      expect(view.container.querySelectorAll('[role="alert"]').length).toBeGreaterThan(0),
+    );
+    expect(view.container.textContent ?? "").not.toContain("HTTP 500");
+    expect(view.container.textContent ?? "").toContain("Retry in a moment");
+    expect(view.container.textContent ?? "").not.toContain("Access denied");
+    expect(view.container.textContent ?? "").not.toContain("Token Usage not enabled");
+  });
+});

--- a/packages/web/src/app/admin/token-usage/__tests__/tab-gate.test.tsx
+++ b/packages/web/src/app/admin/token-usage/__tests__/tab-gate.test.tsx
@@ -138,8 +138,15 @@ describe("TokenUsageTab — the gate carries the server's words and the id (#506
     // sentence either way, so asserting on the copy proves nothing.
     expect(view.container.textContent ?? "").not.toContain("Token Usage is unavailable");
     expect(view.container.textContent ?? "").not.toContain("Access denied");
-    // Through `friendlyError`, so the banner carries the id raw `.message` dropped.
-    expect(view.container.textContent ?? "").toContain(REQUEST_ID);
+    // Per banner, not container-scoped: this tab has three independent
+    // `friendlyError` call sites and a whole-container `toContain` is
+    // satisfied by any one, so reverting two would stay green — the exact
+    // weakness the sibling analytics-panel arm was rewritten to close.
+    const alerts = Array.from(view.container.querySelectorAll('[role="alert"]'));
+    expect(alerts.length).toBe(3);
+    for (const alert of alerts) {
+      expect(alert.textContent ?? "").toContain(REQUEST_ID);
+    }
   });
 
   test("an empty-bodied 500 banner shows actionable copy, never the status echo", async () => {

--- a/packages/web/src/app/admin/token-usage/tab.tsx
+++ b/packages/web/src/app/admin/token-usage/tab.tsx
@@ -63,8 +63,9 @@ function buildQS(from: string, to: string): string {
  * being a verdict on all of them. Those keep their per-section banner.
  *
  * Derived from the shared `GATE_STATUSES` rather than the inline
- * `[401, 403, 404]` this used to hold — which was the sixth copy of that list
- * in the codebase, and indistinguishable from an accidental omission (#5068).
+ * `[401, 403, 404]` this used to hold — the last of five hand-written copies,
+ * and one of the three that spelled it without 503 while two spelled it with,
+ * so an accidental omission and a reasoned one looked identical (#5068).
  */
 function isTabGateStatus(status: number | undefined): status is Exclude<GateStatus, 503> {
   return isGateStatus(status) && status !== 503;

--- a/packages/web/src/app/admin/token-usage/tab.tsx
+++ b/packages/web/src/app/admin/token-usage/tab.tsx
@@ -15,6 +15,8 @@ import dynamic from "next/dynamic";
 import { useQueryStates } from "nuqs";
 import { tokenUsageSearchParams } from "./search-params";
 import { useAdminFetch, type FetchError } from "@/ui/hooks/use-admin-fetch";
+import { friendlyError } from "@/ui/lib/fetch-error";
+import { isGateStatus, type GateStatus } from "@/ui/components/admin/feature-disabled";
 import { TokenSummarySchema, TrendsResponseSchema, TokenUserResponseSchema } from "@/ui/lib/admin-schemas";
 import { useDarkMode } from "@/ui/hooks/use-dark-mode";
 import { formatISODate, formatNumber, parseISODate } from "@/lib/format";
@@ -51,9 +53,26 @@ function buildQS(from: string, to: string): string {
   return parts.length > 0 ? `?${parts.join("&")}` : "";
 }
 
+/**
+ * The first of the three tab fetches whose failure is a gate rather than a
+ * fault. Promoted to `AdminContentWrapper`, so it replaces the whole tab.
+ *
+ * Same narrowing, and the same reason, as `audit/analytics-panel.tsx`: 503 is
+ * excluded because it is the one gated status that can fail *one* of several
+ * parallel requests (a restarting replica, an unhealthy proxy) rather than
+ * being a verdict on all of them. Those keep their per-section banner.
+ *
+ * Derived from the shared `GATE_STATUSES` rather than the inline
+ * `[401, 403, 404]` this used to hold — which was the sixth copy of that list
+ * in the codebase, and indistinguishable from an accidental omission (#5068).
+ */
+function isTabGateStatus(status: number | undefined): status is Exclude<GateStatus, 503> {
+  return isGateStatus(status) && status !== 503;
+}
+
 function findGateError(...errors: (FetchError | null)[]): FetchError | null {
   for (const err of errors) {
-    if (err?.status && [401, 403, 404].includes(err.status)) return err;
+    if (err && isTabGateStatus(err.status)) return err;
   }
   return null;
 }
@@ -139,7 +158,7 @@ export function TokenUsageTab() {
         </Card>
 
         {summaryError ? (
-          <ErrorBanner message={summaryError.message} />
+          <ErrorBanner message={friendlyError(summaryError)} />
         ) : summaryLoading ? (
           <LoadingState message="Loading summary..." />
         ) : summary ? (
@@ -283,7 +302,7 @@ export function TokenUsageTab() {
           </CardHeader>
           <CardContent>
             {trendsError ? (
-              <ErrorBanner message={trendsError.message} />
+              <ErrorBanner message={friendlyError(trendsError)} />
             ) : trendsLoading ? (
               <div className="flex h-64 items-center justify-center">
                 <LoadingState message="Loading trends..." />
@@ -305,7 +324,7 @@ export function TokenUsageTab() {
           </CardHeader>
           <CardContent>
             {usersError ? (
-              <ErrorBanner message={usersError.message} />
+              <ErrorBanner message={friendlyError(usersError)} />
             ) : usersLoading ? (
               <div className="flex h-40 items-center justify-center">
                 <LoadingState message="Loading..." />

--- a/packages/web/src/ui/__tests__/admin-mutation-error-passthrough.test.tsx
+++ b/packages/web/src/ui/__tests__/admin-mutation-error-passthrough.test.tsx
@@ -16,6 +16,13 @@ import type { FetchError } from "../lib/fetch-error";
  *   (requires `error.code` to survive the hook's catch).
  * - Render the `friendlyError`-translated copy on 401/403/404/503 (requires
  *   `error.status` to survive), not the raw `HTTP 4xx` string.
+ *
+ * Since #5068 the gated statuses carry two more fields the wrapper must
+ * forward: the server's own `message` and the `requestId`. The bodies below
+ * are the envelopes the API actually emits (`middleware.ts`,
+ * `admin-router.ts`) rather than invented one-word strings — a fixture whose
+ * message reads "Forbidden" cannot distinguish "the server's words reached
+ * the screen" from "the canned copy did", because neither contains it.
  */
 
 const stubAuthClient: AtlasAuthClient = {
@@ -145,28 +152,42 @@ describe("admin mutation error passthrough", () => {
     expect(utils.container.textContent).not.toContain("HTTP 403");
   });
 
-  test("403 (no enterprise code) renders friendlyError admin-role copy, not 'HTTP 403'", async () => {
-    mockFailure(403, { message: "Forbidden" });
+  test("403 (no enterprise code) renders the server's role message, not 'HTTP 403'", async () => {
+    // `middleware.ts` sends "Platform admin role required." for the platform
+    // routers — the exact case the canned copy ("You need the admin role")
+    // gets WRONG, by naming a role that would not have unlocked the page.
+    mockFailure(403, {
+      error: "forbidden_role",
+      message: "Platform admin role required.",
+      requestId: "req-403-abc",
+    });
 
     let utils!: ReturnType<typeof render>;
     await act(async () => {
       utils = render(<MutationHarness feature="Users" />, { wrapper: Wrapper });
     });
 
-    // Either the FeatureGate access-denied copy or the friendlyError fallback
-    // is acceptable — both prove `error.status` reached the component, which
-    // is the property that would have been lost under a flattened error.
+    // The status-derived headline proves `error.status` survived the hook's
+    // catch; the description proves the server's own sentence did.
     await waitFor(() => {
-      const text = utils.container.textContent ?? "";
-      expect(
-        text.includes("Access denied") || text.includes("admin role"),
-      ).toBe(true);
+      expect(utils.container.textContent).toContain("Access denied");
     });
+    expect(utils.container.textContent).toContain("Platform admin role required.");
+    // The role the server did NOT ask for. Before #5068 this line was the
+    // whole description, on a refusal only a platform admin could clear.
+    expect(utils.container.textContent).not.toContain(
+      "You need the admin role to access this page.",
+    );
+    expect(utils.container.textContent).toContain("req-403-abc");
     expect(utils.container.textContent).not.toContain("HTTP 403");
   });
 
-  test("401 surfaces friendlyError 'sign in' copy, not 'HTTP 401'", async () => {
-    mockFailure(401, { message: "Unauthorized" });
+  test("401 surfaces the server's message, not 'HTTP 401'", async () => {
+    mockFailure(401, {
+      error: "auth_error",
+      message: "Your session expired. Sign in again to continue.",
+      requestId: "req-401-abc",
+    });
 
     let utils!: ReturnType<typeof render>;
     await act(async () => {
@@ -174,16 +195,24 @@ describe("admin mutation error passthrough", () => {
     });
 
     await waitFor(() => {
-      const text = utils.container.textContent ?? "";
-      expect(
-        text.includes("Authentication required") || text.includes("sign in"),
-      ).toBe(true);
+      expect(utils.container.textContent).toContain("Authentication required");
     });
+    expect(utils.container.textContent).toContain(
+      "Your session expired. Sign in again to continue.",
+    );
+    expect(utils.container.textContent).toContain("req-401-abc");
     expect(utils.container.textContent).not.toContain("HTTP 401");
   });
 
-  test("404 surfaces friendlyError feature-not-enabled copy, not 'HTTP 404'", async () => {
-    mockFailure(404, { message: "Not found" });
+  test("404 surfaces the server's message, not 'HTTP 404'", async () => {
+    // `requireOrgContext()`'s NO_INTERNAL_DB_MESSAGE — the motivating case in
+    // #5068. The self-hosted operator on /admin/brain used to be told only to
+    // "enable this feature in your server configuration", which names nothing.
+    mockFailure(404, {
+      error: "not_available",
+      message: "No internal database configured.",
+      requestId: "req-404-abc",
+    });
 
     let utils!: ReturnType<typeof render>;
     await act(async () => {
@@ -191,14 +220,24 @@ describe("admin mutation error passthrough", () => {
     });
 
     await waitFor(() => {
-      const text = utils.container.textContent ?? "";
-      expect(text).toContain("Scheduled Tasks not enabled");
+      expect(utils.container.textContent).toContain("Scheduled Tasks not enabled");
     });
+    expect(utils.container.textContent).toContain("No internal database configured.");
+    expect(utils.container.textContent).toContain("req-404-abc");
     expect(utils.container.textContent).not.toContain("HTTP 404");
   });
 
-  test("503 surfaces friendlyError service-unavailable copy, not 'HTTP 503'", async () => {
-    mockFailure(503, { message: "Unavailable" });
+  test("503 surfaces the server's message and drops the database guess with it", async () => {
+    // `permissions_unavailable` (admin-router.ts) is a 503 that has nothing to
+    // do with DATABASE_URL. Rendering it under "Internal database not
+    // configured" sent an operator to check a variable that was already set,
+    // so the headline gives way alongside the description.
+    mockFailure(503, {
+      error: "permissions_unavailable",
+      message:
+        "Authorization service is temporarily unavailable. Retry in a moment; if this persists, contact an operator.",
+      requestId: "req-503-abc",
+    });
 
     let utils!: ReturnType<typeof render>;
     await act(async () => {
@@ -206,9 +245,54 @@ describe("admin mutation error passthrough", () => {
     });
 
     await waitFor(() => {
-      const text = utils.container.textContent ?? "";
-      expect(text).toContain("Internal database not configured");
+      expect(utils.container.textContent).toContain("Authorization service is temporarily unavailable");
     });
+    expect(utils.container.textContent).toContain("Custom Domains is unavailable");
+    expect(utils.container.textContent).not.toContain("Internal database not configured");
+    expect(utils.container.textContent).not.toContain("DATABASE_URL");
+    expect(utils.container.textContent).toContain("req-503-abc");
     expect(utils.container.textContent).not.toContain("HTTP 503");
+  });
+
+  test("an EMPTY gated body keeps the canned copy and never renders the placeholder", async () => {
+    // The complement of every arm above, and the one that makes them mean
+    // something: `extractFetchError` substitutes `HTTP {status}` when the body
+    // carries no message, so a wrapper that forwarded `error.message` instead
+    // of `serverMessage(error)` would pass all four — and replace the gate's
+    // only guidance with a status echo exactly here.
+    mockFailure(404, {});
+
+    let utils!: ReturnType<typeof render>;
+    await act(async () => {
+      utils = render(<MutationHarness feature="Scheduled Tasks" />, { wrapper: Wrapper });
+    });
+
+    await waitFor(() => {
+      expect(utils.container.textContent).toContain("Scheduled Tasks not enabled");
+    });
+    expect(utils.container.textContent).toContain(
+      "Enable this feature in your server configuration to use this page.",
+    );
+    expect(utils.container.textContent).not.toContain("HTTP 404");
+    // No id in the body, so no id line — an empty "Request ID:" label would
+    // be worse than none.
+    expect(utils.container.textContent).not.toContain("Request ID");
+  });
+
+  test("an EMPTY enterprise_required body keeps the upsell's own copy", async () => {
+    // Same placeholder hazard on the sibling surface: `EnterpriseUpsell` also
+    // renders its `message` prop verbatim as the description.
+    mockFailure(403, { error: "enterprise_required" });
+
+    let utils!: ReturnType<typeof render>;
+    await act(async () => {
+      utils = render(<MutationHarness feature="SSO" />, { wrapper: Wrapper });
+    });
+
+    await waitFor(() => {
+      expect(utils.container.textContent).toContain("SSO requires an enterprise plan");
+    });
+    expect(utils.container.textContent).toContain("contact sales");
+    expect(utils.container.textContent).not.toContain("HTTP 403");
   });
 });

--- a/packages/web/src/ui/__tests__/admin-mutation-error-passthrough.test.tsx
+++ b/packages/web/src/ui/__tests__/admin-mutation-error-passthrough.test.tsx
@@ -125,6 +125,14 @@ describe("admin mutation error passthrough", () => {
     // Must not fall through to the generic banner copy.
     expect(utils.container.textContent).not.toContain("Request failed");
     expect(utils.container.textContent).not.toContain("HTTP 403");
+    // The server's own sentence, and the id, through the WRAPPER path — the
+    // most-travelled `enterprise_required` route and the one whose two new
+    // props had no falsifier: deleting either from the call site left the
+    // whole suite green.
+    expect(utils.container.textContent).toContain("Enterprise features required");
+    const line = utils.container.querySelector('[data-testid="feature-gate-request-id"]');
+    if (!line) throw new Error("wrapper's enterprise upsell rendered no request-id line");
+    expect(line.textContent).toContain("req-ee-123");
   });
 
   test("403 + mfa_enrollment_required renders MfaRequiredPlaceholder, not 'admin role' copy (#2486)", async () => {
@@ -209,10 +217,7 @@ describe("admin mutation error passthrough", () => {
     expect(utils.container.textContent).toContain(
       "Your session expired. Sign in again to continue.",
     );
-    // 401 alone appends rather than displaces — the sign-in affordance is
-    // true whatever the server said, so losing it would leave an accurate
-    // diagnosis with no next step.
-    expect(utils.container.textContent).toContain(
+    expect(utils.container.textContent).not.toContain(
       "Please sign in to access the admin console.",
     );
     expect(utils.container.textContent).toContain("req-401-abc");

--- a/packages/web/src/ui/__tests__/admin-mutation-error-passthrough.test.tsx
+++ b/packages/web/src/ui/__tests__/admin-mutation-error-passthrough.test.tsx
@@ -150,6 +150,15 @@ describe("admin mutation error passthrough", () => {
     expect(utils.container.textContent).not.toContain("admin role");
     expect(utils.container.textContent).not.toContain("Access denied");
     expect(utils.container.textContent).not.toContain("HTTP 403");
+    // The copy stays fixed here on purpose — the enrollment CTA is the value,
+    // not the server's generic two-factor sentence — so #5068's "prefer the
+    // server's words" deliberately does not apply. The correlation id is not
+    // copy though: an admin who HAS enrolled and still lands here needs
+    // something to hand an operator.
+    expect(utils.container.textContent).not.toContain(
+      "Two-factor authentication is required for admin accounts.",
+    );
+    expect(utils.container.textContent).toContain("req-mfa-123");
   });
 
   test("403 (no enterprise code) renders the server's role message, not 'HTTP 403'", async () => {
@@ -200,6 +209,12 @@ describe("admin mutation error passthrough", () => {
     expect(utils.container.textContent).toContain(
       "Your session expired. Sign in again to continue.",
     );
+    // 401 alone appends rather than displaces — the sign-in affordance is
+    // true whatever the server said, so losing it would leave an accurate
+    // diagnosis with no next step.
+    expect(utils.container.textContent).toContain(
+      "Please sign in to access the admin console.",
+    );
     expect(utils.container.textContent).toContain("req-401-abc");
     expect(utils.container.textContent).not.toContain("HTTP 401");
   });
@@ -223,6 +238,9 @@ describe("admin mutation error passthrough", () => {
       expect(utils.container.textContent).toContain("Scheduled Tasks not enabled");
     });
     expect(utils.container.textContent).toContain("No internal database configured.");
+    expect(utils.container.textContent).not.toContain(
+      "Enable this feature in your server configuration",
+    );
     expect(utils.container.textContent).toContain("req-404-abc");
     expect(utils.container.textContent).not.toContain("HTTP 404");
   });

--- a/packages/web/src/ui/__tests__/feature-disabled.test.tsx
+++ b/packages/web/src/ui/__tests__/feature-disabled.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
-import { render } from "@testing-library/react";
+import { cleanup, render } from "@testing-library/react";
 
 // Toggleable deploy mode — the EnterpriseUpsell hosted-only branch reads it.
 // The factory returns a function that reads `mockDeployMode` at call time, so
@@ -41,11 +41,19 @@ describe("FeatureGate — canned copy (no server message)", () => {
     expect(container.textContent).toContain("sign in");
   });
 
-  test("renders 503 — internal database not configured", () => {
+  test("renders 503 — an unexplained outage, NOT a database diagnosis", () => {
+    // The arm used to assert "Internal database not configured / Set
+    // DATABASE_URL". No route emits that: a missing internal DB answers 404
+    // `not_available`, and every real 503 (`permissions_unavailable`, billing
+    // check, browser unavailable) carries a message, so it takes the branch
+    // above. What reaches HERE is an infra 503 with an HTML body — a
+    // restarting service or an unhealthy proxy — where sending the operator
+    // to set an already-set variable is the misdirection.
     const { container } = render(<FeatureGate status={503} feature="Custom Domains" />);
-    expect(container.textContent).toContain("Internal database not configured");
-    expect(container.textContent).toContain("DATABASE_URL");
-    expect(container.textContent).toContain("Custom Domains");
+    expect(container.textContent).toContain("Custom Domains is unavailable");
+    expect(container.textContent).toContain("Retry in a moment");
+    expect(container.textContent).not.toContain("DATABASE_URL");
+    expect(container.textContent).not.toContain("Internal database not configured");
   });
 
   test("renders no request-id line when the response carried no id", () => {
@@ -85,27 +93,26 @@ describe("FeatureGate — the server's message displaces the guess (#5068)", () 
     );
   });
 
-  test("401 prefers the server message over the sign-in line", () => {
+  test("401 ADDS the server message and keeps the sign-in line", () => {
+    // 401 is the one status whose canned line is not a guess at the cause but
+    // the affordance — it is true whatever the server said. Displacing it
+    // leaves an accurate diagnosis with no next step, which is why this arm
+    // appends where the other three replace.
     const { container } = render(
       <FeatureGate
         status={401}
         feature="Audit Log"
-        message="Your session expired. Sign in again to continue."
+        message="Your session expired."
       />,
     );
     expect(container.textContent).toContain("Authentication required");
     expect(container.textContent).toContain("Your session expired.");
-    expect(container.textContent).not.toContain(
+    expect(container.textContent).toContain(
       "Please sign in to access the admin console.",
     );
   });
 
-  test("503 drops the DATABASE_URL guess from the HEADLINE too, not just the body", () => {
-    // A `permissions_unavailable` 503 has nothing to do with the database. If
-    // only the description gave way, the headline would still send an operator
-    // to check a variable that is already set — which is the whole failure this
-    // arm exists to prevent, and it is invisible to a description-only
-    // assertion.
+  test("503 replaces the whole unexplained-outage line, headline included", () => {
     const { container } = render(
       <FeatureGate
         status={503}
@@ -117,8 +124,21 @@ describe("FeatureGate — the server's message displaces the guess (#5068)", () 
     expect(container.textContent).toContain(
       "Authorization service is temporarily unavailable.",
     );
-    expect(container.textContent).not.toContain("Internal database not configured");
-    expect(container.textContent).not.toContain("DATABASE_URL");
+    // The no-message guidance must not tag along behind a real explanation.
+    expect(container.textContent).not.toContain("Retry in a moment");
+  });
+
+  test("a blank server message does not render an empty description", () => {
+    // `serverMessage` normalizes blanks away, but `FeatureGate` takes a bare
+    // `string | undefined` and any caller can hand it one. Icon + headline
+    // over an empty <p> is the blank-chrome failure `buildFetchError` exists
+    // to prevent, and the `??` guard is nullish-only.
+    const { container } = render(
+      <FeatureGate status={404} feature="Users" message="" />,
+    );
+    expect(container.textContent).toContain(
+      "Enable this feature in your server configuration to use this page.",
+    );
   });
 });
 
@@ -134,11 +154,13 @@ describe("FeatureGate — request id (#5068)", () => {
         <FeatureGate status={status} feature="Users" requestId={REQUEST_ID} />,
       );
       const line = container.querySelector('[data-testid="feature-gate-request-id"]');
-      expect(line).not.toBeNull();
+      // `throw` rather than `expect(...).not.toBeNull()` + `line!`: bun's
+      // expect does not narrow, and this names the failure.
+      if (!line) throw new Error(`no request-id line on the ${status} gate`);
       // Read the id off ITS OWN element, not the container: `toContain` on the
       // whole page passes for an id rendered anywhere, including inside a
       // description that happened to quote it.
-      expect(line!.textContent).toContain(REQUEST_ID);
+      expect(line.textContent).toContain(REQUEST_ID);
     });
   }
 
@@ -172,6 +194,18 @@ describe("MfaRequiredPlaceholder", () => {
     const { container } = render(<MfaRequiredPlaceholder feature="AI Provider" />);
     expect(container.textContent).not.toContain("admin role");
     expect(container.textContent).not.toContain("Access denied");
+  });
+
+  test("carries the request id when one is present (#5068)", () => {
+    // The copy stays fixed — see the component doc — but the id is not copy.
+    const { container } = render(
+      <MfaRequiredPlaceholder feature="AI Provider" requestId="req-mfa-x" />,
+    );
+    const line = container.querySelector('[data-testid="feature-gate-request-id"]');
+    if (!line) throw new Error("MFA placeholder rendered no request-id line");
+    expect(line.textContent).toContain("req-mfa-x");
+    // Still the enrollment copy, not the server's generic 403 sentence.
+    expect(container.textContent).toContain("Enroll an authenticator app or passkey");
   });
 });
 
@@ -228,5 +262,26 @@ describe("EnterpriseUpsell", () => {
     expect(container.textContent).toContain(
       "Proactive monitoring is available only on Atlas Cloud (the hosted SaaS).",
     );
+  });
+
+  test("carries the request id on BOTH arms (#5068)", () => {
+    // `enterprise_required` is evaluated before the `FeatureGate` branch, so
+    // this is the gated 403 most likely to arrive unexpectedly — an
+    // entitlement lookup that misfired for a paying workspace. Both arms,
+    // because the hosted-only branch is the one a self-hosted operator hits
+    // and it is a separate block of markup.
+    for (const [mode, feature] of [
+      ["self-hosted", "Proactive Chat"],
+      ["saas", "SSO"],
+    ] as const) {
+      mockDeployMode = mode;
+      const { container } = render(
+        <EnterpriseUpsell feature={feature} requestId="req-ee-x" />,
+      );
+      const line = container.querySelector('[data-testid="feature-gate-request-id"]');
+      if (!line) throw new Error(`no request-id line on the ${mode} upsell arm`);
+      expect(line.textContent).toContain("req-ee-x");
+      cleanup();
+    }
   });
 });

--- a/packages/web/src/ui/__tests__/feature-disabled.test.tsx
+++ b/packages/web/src/ui/__tests__/feature-disabled.test.tsx
@@ -17,7 +17,9 @@ void mock.module("@/ui/hooks/use-deploy-mode", () => ({
 import {
   EnterpriseUpsell,
   FeatureGate,
+  GATE_STATUSES,
   MfaRequiredPlaceholder,
+  type GateStatus,
 } from "../components/admin/feature-disabled";
 
 describe("FeatureGate — canned copy (no server message)", () => {
@@ -93,23 +95,36 @@ describe("FeatureGate — the server's message displaces the guess (#5068)", () 
     );
   });
 
-  test("401 ADDS the server message and keeps the sign-in line", () => {
-    // 401 is the one status whose canned line is not a guess at the cause but
-    // the affordance — it is true whatever the server said. Displacing it
-    // leaves an accurate diagnosis with no next step, which is why this arm
-    // appends where the other three replace.
+  test("401 prefers the server message over the sign-in line", () => {
+    // Fixtures are the shapes `managed.ts` / `simple-key.ts` / `byot.ts`
+    // actually emit: bare fragments with NO terminal punctuation. An earlier
+    // pass appended the canned line to them and shipped "Not signed in Please
+    // sign in to access the admin console." on 100% of real 401s — a fixture
+    // ending in a period was the only reason that looked fine.
+    for (const message of ["Not signed in", "Session expired (idle timeout)"]) {
+      const { container } = render(
+        <FeatureGate status={401} feature="Audit Log" message={message} />,
+      );
+      expect(container.textContent).toContain("Authentication required");
+      expect(container.textContent).toContain(message);
+      expect(container.textContent).not.toContain(
+        "Please sign in to access the admin console.",
+      );
+      cleanup();
+    }
+  });
+
+  test("401 does not tell a BANNED account to sign in", () => {
+    // The case that killed the append outright: `managed.ts:83` answers 401
+    // with "Account is banned", and signing in is precisely what will not
+    // help. Same for either key-based ATLAS_AUTH_MODE, where there is no
+    // sign-in at all. The canned line is not an affordance that survives every
+    // cause — it is one more guess, and the server's beats it.
     const { container } = render(
-      <FeatureGate
-        status={401}
-        feature="Audit Log"
-        message="Your session expired."
-      />,
+      <FeatureGate status={401} feature="Audit Log" message="Account is banned" />,
     );
-    expect(container.textContent).toContain("Authentication required");
-    expect(container.textContent).toContain("Your session expired.");
-    expect(container.textContent).toContain(
-      "Please sign in to access the admin console.",
-    );
+    expect(container.textContent).toContain("Account is banned");
+    expect(container.textContent).not.toContain("sign in");
   });
 
   test("503 replaces the whole unexplained-outage line, headline included", () => {
@@ -128,17 +143,28 @@ describe("FeatureGate — the server's message displaces the guess (#5068)", () 
     expect(container.textContent).not.toContain("Retry in a moment");
   });
 
-  test("a blank server message does not render an empty description", () => {
+  test("a blank server message does not render an empty description — on ANY arm", () => {
     // `serverMessage` normalizes blanks away, but `FeatureGate` takes a bare
     // `string | undefined` and any caller can hand it one. Icon + headline
     // over an empty <p> is the blank-chrome failure `buildFetchError` exists
-    // to prevent, and the `??` guard is nullish-only.
-    const { container } = render(
-      <FeatureGate status={404} feature="Users" message="" />,
-    );
-    expect(container.textContent).toContain(
-      "Enable this feature in your server configuration to use this page.",
-    );
+    // to prevent, and it is guarded by `||` — a nullish `??` would let ""
+    // through. Every arm, because the guard was falsified on exactly one of
+    // four and swapping the other three back to `??` changed nothing visible.
+    const canned: Record<GateStatus, string> = {
+      401: "Please sign in to access the admin console.",
+      403: "You need the admin role to access this page.",
+      404: "Enable this feature in your server configuration to use this page.",
+      503: "Retry in a moment",
+    };
+    for (const status of GATE_STATUSES) {
+      for (const blank of ["", "   "]) {
+        const { container } = render(
+          <FeatureGate status={status} feature="Users" message={blank} />,
+        );
+        expect(container.textContent).toContain(canned[status]);
+        cleanup();
+      }
+    }
   });
 });
 
@@ -159,10 +185,25 @@ describe("FeatureGate — request id (#5068)", () => {
       if (!line) throw new Error(`no request-id line on the ${status} gate`);
       // Read the id off ITS OWN element, not the container: `toContain` on the
       // whole page passes for an id rendered anywhere, including inside a
-      // description that happened to quote it.
-      expect(line.textContent).toContain(REQUEST_ID);
+      // description that happened to quote it. Exact text, not `toContain`,
+      // so dropping the "Request ID:" label — leaving a bare uuid an operator
+      // has no reason to recognize — fails here.
+      expect(line.textContent).toBe(`Request ID: ${REQUEST_ID}`);
     });
   }
+
+  test("a blank id renders no line rather than a bare label", () => {
+    // `extractFetchError` accepts any string, so "   " reaches here. The label
+    // over nothing is the same blank-chrome class the message guard prevents.
+    for (const blank of ["", "   "]) {
+      const { container } = render(
+        <FeatureGate status={403} feature="Users" requestId={blank} />,
+      );
+      expect(container.querySelector('[data-testid="feature-gate-request-id"]')).toBeNull();
+      expect(container.textContent).not.toContain("Request ID");
+      cleanup();
+    }
+  });
 
   test("renders the id alongside a server message rather than instead of it", () => {
     const { container } = render(

--- a/packages/web/src/ui/__tests__/feature-disabled.test.tsx
+++ b/packages/web/src/ui/__tests__/feature-disabled.test.tsx
@@ -150,13 +150,16 @@ describe("FeatureGate — the server's message displaces the guess (#5068)", () 
     // to prevent, and it is guarded by `||` — a nullish `??` would let ""
     // through. Every arm, because the guard was falsified on exactly one of
     // four and swapping the other three back to `??` changed nothing visible.
+    // Hardcoded, NOT `GATE_STATUSES`: iterating the constant means the
+    // coverage shrinks with it, so dropping 503 from the set would silently
+    // stop testing 503. The set itself is pinned separately below.
     const canned: Record<GateStatus, string> = {
       401: "Please sign in to access the admin console.",
       403: "You need the admin role to access this page.",
       404: "Enable this feature in your server configuration to use this page.",
       503: "Retry in a moment",
     };
-    for (const status of GATE_STATUSES) {
+    for (const status of [401, 403, 404, 503] as const) {
       for (const blank of ["", "   "]) {
         const { container } = render(
           <FeatureGate status={status} feature="Users" message={blank} />,
@@ -165,6 +168,15 @@ describe("FeatureGate — the server's message displaces the guess (#5068)", () 
         cleanup();
       }
     }
+  });
+});
+
+describe("FeatureGate — the gated status set", () => {
+  test("is exactly 401/403/404/503", () => {
+    // The one place a change to the set fails loudly. Every other loop in this
+    // file hardcodes the four so its coverage cannot shrink along with the
+    // constant; this is where widening or narrowing has to be a decision.
+    expect([...GATE_STATUSES]).toEqual([401, 403, 404, 503]);
   });
 });
 

--- a/packages/web/src/ui/__tests__/feature-disabled.test.tsx
+++ b/packages/web/src/ui/__tests__/feature-disabled.test.tsx
@@ -20,7 +20,9 @@ import {
   MfaRequiredPlaceholder,
 } from "../components/admin/feature-disabled";
 
-describe("FeatureGate", () => {
+describe("FeatureGate — canned copy (no server message)", () => {
+  // These four are the fallback contract: with an empty response body there is
+  // nothing to say but the status-derived guess, so the guess must survive.
   test("renders 404 — feature not enabled", () => {
     const { container } = render(<FeatureGate status={404} feature="Scheduled Tasks" />);
     expect(container.textContent).toContain("Scheduled Tasks not enabled");
@@ -44,6 +46,113 @@ describe("FeatureGate", () => {
     expect(container.textContent).toContain("Internal database not configured");
     expect(container.textContent).toContain("DATABASE_URL");
     expect(container.textContent).toContain("Custom Domains");
+  });
+
+  test("renders no request-id line when the response carried no id", () => {
+    const { container } = render(<FeatureGate status={403} feature="Users" />);
+    expect(container.querySelector('[data-testid="feature-gate-request-id"]')).toBeNull();
+    expect(container.textContent).not.toContain("Request ID");
+  });
+});
+
+describe("FeatureGate — the server's message displaces the guess (#5068)", () => {
+  // Paired with the block above: each test here asserts the server's sentence
+  // is on screen AND that the canned sentence it replaced is not. Only the
+  // second half falsifies a gate that renders both.
+  test("404 prefers the server message over the config-file line", () => {
+    const { container } = render(
+      <FeatureGate
+        status={404}
+        feature="Company Brain"
+        message="No internal database configured."
+      />,
+    );
+    expect(container.textContent).toContain("Company Brain not enabled");
+    expect(container.textContent).toContain("No internal database configured.");
+    expect(container.textContent).not.toContain(
+      "Enable this feature in your server configuration",
+    );
+  });
+
+  test("403 prefers the server message over the admin-role line", () => {
+    const { container } = render(
+      <FeatureGate status={403} feature="Users" message="Platform admin role required." />,
+    );
+    expect(container.textContent).toContain("Access denied");
+    expect(container.textContent).toContain("Platform admin role required.");
+    expect(container.textContent).not.toContain(
+      "You need the admin role to access this page.",
+    );
+  });
+
+  test("401 prefers the server message over the sign-in line", () => {
+    const { container } = render(
+      <FeatureGate
+        status={401}
+        feature="Audit Log"
+        message="Your session expired. Sign in again to continue."
+      />,
+    );
+    expect(container.textContent).toContain("Authentication required");
+    expect(container.textContent).toContain("Your session expired.");
+    expect(container.textContent).not.toContain(
+      "Please sign in to access the admin console.",
+    );
+  });
+
+  test("503 drops the DATABASE_URL guess from the HEADLINE too, not just the body", () => {
+    // A `permissions_unavailable` 503 has nothing to do with the database. If
+    // only the description gave way, the headline would still send an operator
+    // to check a variable that is already set — which is the whole failure this
+    // arm exists to prevent, and it is invisible to a description-only
+    // assertion.
+    const { container } = render(
+      <FeatureGate
+        status={503}
+        feature="Custom Domains"
+        message="Authorization service is temporarily unavailable."
+      />,
+    );
+    expect(container.textContent).toContain("Custom Domains is unavailable");
+    expect(container.textContent).toContain(
+      "Authorization service is temporarily unavailable.",
+    );
+    expect(container.textContent).not.toContain("Internal database not configured");
+    expect(container.textContent).not.toContain("DATABASE_URL");
+  });
+});
+
+describe("FeatureGate — request id (#5068)", () => {
+  const REQUEST_ID = "8f0c1e2a-4b6d-4f1a-9c3e-77d2b5a10e94";
+
+  // Every gated status, not just the one the bug was reported on: a gate that
+  // an operator did not expect is un-diagnosable without the correlation id,
+  // and 401/403 are the two most likely to arrive unexpectedly.
+  for (const status of [401, 403, 404, 503] as const) {
+    test(`renders the request id on ${status}`, () => {
+      const { container } = render(
+        <FeatureGate status={status} feature="Users" requestId={REQUEST_ID} />,
+      );
+      const line = container.querySelector('[data-testid="feature-gate-request-id"]');
+      expect(line).not.toBeNull();
+      // Read the id off ITS OWN element, not the container: `toContain` on the
+      // whole page passes for an id rendered anywhere, including inside a
+      // description that happened to quote it.
+      expect(line!.textContent).toContain(REQUEST_ID);
+    });
+  }
+
+  test("renders the id alongside a server message rather than instead of it", () => {
+    const { container } = render(
+      <FeatureGate
+        status={404}
+        feature="Company Brain"
+        message="No internal database configured."
+        requestId={REQUEST_ID}
+      />,
+    );
+    expect(container.textContent).toContain("No internal database configured.");
+    expect(container.textContent).toContain(REQUEST_ID);
   });
 });
 

--- a/packages/web/src/ui/__tests__/feature-disabled.test.tsx
+++ b/packages/web/src/ui/__tests__/feature-disabled.test.tsx
@@ -14,6 +14,7 @@ void mock.module("@/ui/hooks/use-deploy-mode", () => ({
   }),
 }));
 
+import { unexplainedFailure } from "@/ui/lib/fetch-error";
 import {
   EnterpriseUpsell,
   FeatureGate,
@@ -53,9 +54,14 @@ describe("FeatureGate — canned copy (no server message)", () => {
     // to set an already-set variable is the misdirection.
     const { container } = render(<FeatureGate status={503} feature="Custom Domains" />);
     expect(container.textContent).toContain("Custom Domains is unavailable");
-    expect(container.textContent).toContain("Retry in a moment");
     expect(container.textContent).not.toContain("DATABASE_URL");
     expect(container.textContent).not.toContain("Internal database not configured");
+    // Compared to the SHARED helper, deliberately by construction: sharing one
+    // source with `friendlyError` is the invariant, and a substring match let
+    // the gate drift back to a hand-written literal and stay green. The copy
+    // itself is pinned independently, as a full literal, in fetch-error.test.
+    const description = container.querySelectorAll("p")[1];
+    expect(description?.textContent).toBe(unexplainedFailure(503));
   });
 
   test("renders no request-id line when the response carried no id", () => {
@@ -204,6 +210,18 @@ describe("FeatureGate — request id (#5068)", () => {
     });
   }
 
+  test("renders the id trimmed, not as the caller padded it", () => {
+    // The guard trims, so a padded id correctly renders a line — but the
+    // padding used to leak into the text, which breaks copy/paste into a
+    // support ticket and is invisible to a clean fixture.
+    const { container } = render(
+      <FeatureGate status={403} feature="Users" requestId="  req-x  " />,
+    );
+    const line = container.querySelector('[data-testid="feature-gate-request-id"]');
+    if (!line) throw new Error("no request-id line");
+    expect(line.textContent).toBe("Request ID: req-x");
+  });
+
   test("a blank id renders no line rather than a bare label", () => {
     // `extractFetchError` accepts any string, so "   " reaches here. The label
     // over nothing is the same blank-chrome class the message guard prevents.
@@ -315,6 +333,18 @@ describe("EnterpriseUpsell", () => {
     expect(container.textContent).toContain(
       "Proactive monitoring is available only on Atlas Cloud (the hosted SaaS).",
     );
+  });
+
+  test("a blank server message keeps the canned upsell copy", () => {
+    // `FeatureGate`'s identical normalization is pinned on all four arms; this
+    // one shipped unfalsified. "   " is truthy, so `||` alone would render the
+    // headline over an empty <p>.
+    mockDeployMode = "self-hosted";
+    for (const blank of ["", "   "]) {
+      const { container } = render(<EnterpriseUpsell feature="SSO" message={blank} />);
+      expect(container.textContent).toContain("contact sales");
+      cleanup();
+    }
   });
 
   test("carries the request id on BOTH arms (#5068)", () => {

--- a/packages/web/src/ui/__tests__/fetch-error.test.ts
+++ b/packages/web/src/ui/__tests__/fetch-error.test.ts
@@ -236,6 +236,54 @@ describe("serverMessage", () => {
     // is client-authored, so a gate must not present it as the server's word.
     expect(serverMessage({ message: "Network error" })).toBeUndefined();
   });
+
+  test("recognizes buildFetchError's placeholder too, not just extractFetchError's", () => {
+    // The module mints TWO synthetic messages that keep their status, and a
+    // predicate that knows one is fooled by the other. This spelling is
+    // `buildFetchError`'s production substitute; treating it as server copy
+    // puts "Request failed (403)" where the gate's canned guidance belongs —
+    // the same defect, through the other door.
+    expect(serverMessage({ message: "Request failed (403)", status: 403 })).toBeUndefined();
+    // Same mismatched-status boundary as the `HTTP {status}` spelling.
+    expect(serverMessage({ message: "Request failed (404)", status: 403 })).toBe(
+      "Request failed (404)",
+    );
+  });
+
+  test("a whitespace-only server message reaches the placeholder path in production", async () => {
+    // Not a hypothetical: `extractFetchError` admits "   " (it tests
+    // `length > 0`, untrimmed), `buildFetchError` trims it to empty, and in
+    // production substitutes `Request failed ({status})` with the status
+    // preserved. Dev throws instead, so this arm is the only warning a
+    // production build ever gets.
+    // Next's types declare NODE_ENV readonly; write through a widened view,
+    // as the `buildFetchError` block below already does.
+    const mutableEnv = process.env as Record<string, string | undefined>;
+    const prev = mutableEnv.NODE_ENV;
+    mutableEnv.NODE_ENV = "production";
+    try {
+      const err = await extractFetchError(mockResponse(404, { message: "   " }));
+      expect(err.message).toBe("Request failed (404)");
+      expect(err.status).toBe(404);
+      expect(serverMessage(err)).toBeUndefined();
+    } finally {
+      mutableEnv.NODE_ENV = prev;
+    }
+  });
+
+  test("treats a blank message as no message rather than passing '' through", () => {
+    // A caller writing `message ?? canned` would render an empty <p> — icon
+    // and headline over nothing. `buildFetchError` refuses to construct this,
+    // but `FetchError` is a bare interface anything can build.
+    expect(serverMessage({ message: "", status: 403 })).toBeUndefined();
+    expect(serverMessage({ message: "   ", status: 403 })).toBeUndefined();
+  });
+
+  test("trims the message it does return", () => {
+    expect(serverMessage({ message: "  Admin role required.  ", status: 403 })).toBe(
+      "Admin role required.",
+    );
+  });
 });
 
 describe("friendlyError", () => {
@@ -329,6 +377,20 @@ describe("friendlyError", () => {
         requestId: "req-mfa",
       }),
     ).toBe("Two-factor required. (Request ID: req-mfa)");
+  });
+
+  test("a blank message falls through to canned copy instead of a blank banner", () => {
+    // Behaviour this gained when the precedence check moved into
+    // `serverMessage`: the old `!isHttpStatusFallback(...)` test was true for
+    // `""`, so `ErrorBanner` rendered alert chrome with no copy —
+    // indistinguishable from a successful render. Pinned here so a refactor
+    // back to a bare `message !== undefined` check can't quietly restore it.
+    expect(friendlyError({ message: "", status: 403 })).toBe(
+      "Access denied. You may need additional permissions to view this page.",
+    );
+    expect(friendlyError({ message: "   ", status: 404 })).toBe(
+      "This feature is not enabled on this server.",
+    );
   });
 
   test("routes schema_mismatch to a version-drift specific message", () => {

--- a/packages/web/src/ui/__tests__/fetch-error.test.ts
+++ b/packages/web/src/ui/__tests__/fetch-error.test.ts
@@ -4,6 +4,7 @@ import {
   extractFetchError,
   friendlyError,
   friendlyErrorOrNull,
+  gateProps,
   serverMessage,
 } from "../lib/fetch-error";
 
@@ -283,6 +284,30 @@ describe("serverMessage", () => {
     expect(serverMessage({ message: "  Admin role required.  ", status: 403 })).toBe(
       "Admin role required.",
     );
+  });
+});
+
+describe("gateProps", () => {
+  // The pairing the three gated placeholders take. It exists so "which two
+  // fields, derived how" is decided once rather than per call site — #5068 was
+  // one call site forgetting, and the review then found a second with no test.
+  test("derives the server message and the id together", () => {
+    expect(
+      gateProps({
+        message: "No internal database configured.",
+        status: 404,
+        requestId: "req-1",
+      }),
+    ).toEqual({ message: "No internal database configured.", requestId: "req-1" });
+  });
+
+  test("passes NO message through when the body carried none", () => {
+    // The whole reason the helper exists: a spread of `{message: err.message}`
+    // would put "HTTP 404" where the placeholder's canned guidance belongs.
+    expect(gateProps({ message: "HTTP 404", status: 404, requestId: "req-2" })).toEqual({
+      message: undefined,
+      requestId: "req-2",
+    });
   });
 });
 

--- a/packages/web/src/ui/__tests__/fetch-error.test.ts
+++ b/packages/web/src/ui/__tests__/fetch-error.test.ts
@@ -4,6 +4,7 @@ import {
   extractFetchError,
   friendlyError,
   friendlyErrorOrNull,
+  serverMessage,
 } from "../lib/fetch-error";
 
 function mockResponse(status: number, body?: unknown, headers?: Record<string, string>): Response {
@@ -196,6 +197,44 @@ describe("extractFetchError", () => {
     });
     const err = await extractFetchError(res);
     expect(err.stale).toBeUndefined();
+  });
+});
+
+describe("serverMessage", () => {
+  // The distinction `FeatureGate` / `EnterpriseUpsell` need and that a
+  // truthiness check on `.message` cannot make: did the SERVER write this
+  // string, or did `extractFetchError` synthesize it from the status?
+  test("returns the body's message when the server sent one", () => {
+    expect(
+      serverMessage({ message: "No internal database configured.", status: 404 }),
+    ).toBe("No internal database configured.");
+  });
+
+  test("returns undefined for the placeholder extractFetchError actually substitutes", async () => {
+    // Round-tripped through `extractFetchError` rather than hand-written, so
+    // the sentinel here is whatever that function really produces. A literal
+    // `"HTTP 404"` fixture would keep passing if the substitution changed
+    // shape, and then every gate would start rendering the new spelling.
+    const err = await extractFetchError(mockResponse(404));
+    expect(serverMessage(err)).toBeUndefined();
+  });
+
+  test("does not swallow a real message that merely mentions its own status", () => {
+    expect(
+      serverMessage({ message: "HTTP 404 responses are cached upstream.", status: 404 }),
+    ).toBe("HTTP 404 responses are cached upstream.");
+  });
+
+  test("only the MATCHING status/message pair is treated as synthetic", () => {
+    // "HTTP 404" on a 403 was written by a person; the substitution can only
+    // ever produce the status it is attached to.
+    expect(serverMessage({ message: "HTTP 404", status: 403 })).toBe("HTTP 404");
+  });
+
+  test("returns undefined when there is no status — nothing reached a server", () => {
+    // The network-failure / non-JSON-body / schema-mismatch path. Its message
+    // is client-authored, so a gate must not present it as the server's word.
+    expect(serverMessage({ message: "Network error" })).toBeUndefined();
   });
 });
 

--- a/packages/web/src/ui/__tests__/fetch-error.test.ts
+++ b/packages/web/src/ui/__tests__/fetch-error.test.ts
@@ -5,6 +5,7 @@ import {
   friendlyError,
   friendlyErrorOrNull,
   gateProps,
+  isPlaceholderMessage,
   serverMessage,
   unexplainedFailure,
 } from "../lib/fetch-error";
@@ -273,6 +274,30 @@ describe("serverMessage", () => {
     }
   });
 
+  test("recognizes a PADDED placeholder — the distinction is drawn on the trimmed string", () => {
+    // Every sibling guard on this path trims; this is the one that decides
+    // provenance, so a padded `"  HTTP 403  "` slipping through would read as
+    // server prose to the gate. Defensive rather than live (`buildFetchError`
+    // trims), but it is the fourth site of a distinction that has been drawn
+    // inconsistently twice, and each time that produced a defect.
+    expect(serverMessage({ message: "  HTTP 403  ", status: 403 })).toBeUndefined();
+    expect(
+      serverMessage({ message: "  Request failed (403)  ", status: 403 }),
+    ).toBeUndefined();
+  });
+
+  test("recognizes the status-less spelling too, at the one arm that can reach it", () => {
+    // `buildFetchError`'s third placeholder. `serverMessage` never sees it
+    // (it early-returns on a missing status), but `friendlyError`'s catch-all
+    // does, and it would otherwise render as if a human had written it.
+    expect(isPlaceholderMessage({ message: "Request failed (unknown)" })).toBe(true);
+    expect(friendlyError({ message: "Request failed (unknown)" })).toBe(
+      unexplainedFailure(undefined),
+    );
+    // Not every status-less message is a placeholder — the complement.
+    expect(isPlaceholderMessage({ message: "Network error" })).toBe(false);
+  });
+
   test("treats a blank message as no message rather than passing '' through", () => {
     // A caller writing `message ?? canned` would render an empty <p> — icon
     // and headline over nothing. `buildFetchError` refuses to construct this,
@@ -406,15 +431,42 @@ describe("friendlyError", () => {
   });
 
   test("an empty-bodied 500 gets actionable copy, not the status echo", () => {
-    // The arm that could never fire before: an empty body arrives as the
-    // placeholder `"HTTP 500"`, which is non-blank, so a `.trim()` guard was
-    // always truthy and the banner rendered "HTTP 500". Only `serverMessage`
-    // catches the placeholder as well as the blank.
+    // The arm a `.trim()` guard alone could never reach: an empty body arrives
+    // as the placeholder `"HTTP 500"`, which is non-blank, so the banner
+    // rendered "HTTP 500". The placeholder is caught by `isPlaceholderMessage`
+    // and the blank by the `.trim()` — NOT by `serverMessage`, which would
+    // also discard the client-authored status-less messages this arm exists to
+    // show. (That regression was live for one edit; see the arm's comment.)
     expect(friendlyError({ message: "HTTP 500", status: 500, requestId: "req-y" })).toBe(
       "The server returned an error (500) with no explanation — it may be restarting or behind an unhealthy proxy. Retry in a moment; if it persists, check the API service logs. (Request ID: req-y)",
     );
-    expect(friendlyError({ message: "HTTP 429", status: 429 })).toContain("Retry in a moment");
-    expect(friendlyError({ message: "HTTP 409", status: 409 })).toContain("(409)");
+  });
+
+  test("an unexplained 4xx does NOT get the restarting-replica guess", () => {
+    // The 503 arm's original sin was diagnosing one cause from the status
+    // alone. Extending its copy to the catch-all would reintroduce that a
+    // level up: a 409 conflict is deterministic (retrying reproduces it), a
+    // 429 came from a rate limiter that is working, and a 400 is a client
+    // fault. Edge-generated 4xx with no JSON body is this arm's real
+    // population.
+    for (const status of [400, 409, 429]) {
+      const msg = friendlyError({ message: `HTTP ${status}`, status });
+      expect(msg).toContain(`(${status})`);
+      expect(msg).not.toContain("restarting");
+      expect(msg).not.toContain("Retry in a moment");
+    }
+    // 5xx keeps it — the boundary is the point, so assert both sides.
+    expect(friendlyError({ message: "HTTP 502", status: 502 })).toContain("restarting");
+  });
+
+  test("unexplainedFailure never renders the word 'undefined' at a reader", () => {
+    // Reachable: a hand-built `{ message: "   " }` with no status routes here,
+    // and a naive `(${status})` interpolation produced "an error (undefined)".
+    // Status-less also means no response was read, so "the server returned"
+    // would be a claim about something that never happened.
+    expect(unexplainedFailure(undefined)).not.toContain("undefined");
+    expect(unexplainedFailure(undefined)).not.toContain("The server returned");
+    expect(friendlyError({ message: "   " })).toBe(unexplainedFailure(undefined));
   });
 
   test("a real message on an unmapped status still passes through verbatim", () => {

--- a/packages/web/src/ui/__tests__/fetch-error.test.ts
+++ b/packages/web/src/ui/__tests__/fetch-error.test.ts
@@ -6,6 +6,7 @@ import {
   friendlyErrorOrNull,
   gateProps,
   serverMessage,
+  unexplainedFailure,
 } from "../lib/fetch-error";
 
 function mockResponse(status: number, body?: unknown, headers?: Record<string, string>): Response {
@@ -367,9 +368,9 @@ describe("friendlyError", () => {
     );
   });
 
-  test("falls back to canned 503 copy when body is empty", () => {
+  test("falls back to the unexplained-outage copy on an empty-bodied 503", () => {
     expect(friendlyError({ message: "HTTP 503", status: 503 })).toBe(
-      "A required service is unavailable. Check server configuration.",
+      unexplainedFailure(503),
     );
   });
 
@@ -402,6 +403,36 @@ describe("friendlyError", () => {
         requestId: "req-mfa",
       }),
     ).toBe("Two-factor required. (Request ID: req-mfa)");
+  });
+
+  test("an empty-bodied 500 gets actionable copy, not the status echo", () => {
+    // The arm that could never fire before: an empty body arrives as the
+    // placeholder `"HTTP 500"`, which is non-blank, so a `.trim()` guard was
+    // always truthy and the banner rendered "HTTP 500". Only `serverMessage`
+    // catches the placeholder as well as the blank.
+    expect(friendlyError({ message: "HTTP 500", status: 500, requestId: "req-y" })).toBe(
+      "The server returned an error (500) with no explanation — it may be restarting or behind an unhealthy proxy. Retry in a moment; if it persists, check the API service logs. (Request ID: req-y)",
+    );
+    expect(friendlyError({ message: "HTTP 429", status: 429 })).toContain("Retry in a moment");
+    expect(friendlyError({ message: "HTTP 409", status: 409 })).toContain("(409)");
+  });
+
+  test("a real message on an unmapped status still passes through verbatim", () => {
+    // The complement — without it, an arm that returned the generic
+    // unconditionally would pass the test above.
+    expect(friendlyError({ message: "Rate limit exceeded.", status: 429 })).toBe(
+      "Rate limit exceeded.",
+    );
+  });
+
+  test("the 503 copy matches the gate's, so one status has one diagnosis", () => {
+    // These lived one file apart and disagreed: the gate had been corrected to
+    // stop blaming DATABASE_URL for a restarting replica while this still said
+    // "Check server configuration".
+    expect(friendlyError({ message: "HTTP 503", status: 503 })).toBe(unexplainedFailure(503));
+    expect(friendlyError({ message: "HTTP 503", status: 503 })).not.toContain(
+      "Check server configuration",
+    );
   });
 
   test("a blank message falls through to canned copy instead of a blank banner", () => {

--- a/packages/web/src/ui/__tests__/mutation-errors.test.ts
+++ b/packages/web/src/ui/__tests__/mutation-errors.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { combineMutationErrors } from "../lib/mutation-errors";
-import type { FetchError } from "../lib/fetch-error";
+import { serverMessage, type FetchError } from "../lib/fetch-error";
 
 function err(message: string, overrides: Partial<FetchError> = {}): FetchError {
   return { message, ...overrides };
@@ -61,5 +61,33 @@ describe("combineMutationErrors", () => {
       code: "enterprise_required",
       requestId: "req-abc",
     });
+  });
+
+  test("does not decorate a synthesized placeholder into something that reads as server prose (#5068)", () => {
+    // `"HTTP 403"` suffixed to `"HTTP 403 (+1 more)"` no longer matches
+    // `serverMessage`'s sentinels, so every downstream surface takes it for
+    // the server's own words — and since #5068 the gated placeholders render
+    // exactly that string as their only line of copy. The combiner is the one
+    // place that transforms a message, so it is the one place that has to
+    // know. Reachable today from `custom-domain`, `residency`, `cache`,
+    // `sandbox` and `email-provider`, all of which combine then gate.
+    const combined = combineMutationErrors([
+      err("HTTP 403", { status: 403, requestId: "req-x" }),
+      err("something else", { status: 500 }),
+    ]);
+    expect(combined?.message).toBe("Request failed (+1 more)");
+    expect(serverMessage(combined!)).toBe("Request failed (+1 more)");
+    // The status echo must not survive into the combined message at all.
+    expect(combined?.message).not.toContain("HTTP 403");
+  });
+
+  test("still builds the suffix onto a REAL server message", () => {
+    // The complement — without it the fix above could throw away every
+    // message and still pass.
+    const combined = combineMutationErrors([
+      err("Platform admin role required.", { status: 403 }),
+      err("other", { status: 500 }),
+    ]);
+    expect(combined?.message).toBe("Platform admin role required. (+1 more)");
   });
 });

--- a/packages/web/src/ui/__tests__/mutation-errors.test.tsx
+++ b/packages/web/src/ui/__tests__/mutation-errors.test.tsx
@@ -1,6 +1,20 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, test, mock } from "bun:test";
+import { render } from "@testing-library/react";
+
+// `EnterpriseUpsell` reads useDeployMode (→ useAdminFetch → useAtlasConfig);
+// the end-to-end arm below renders it without a provider, so stub the hook to
+// a stable mode. SSO is not SaaS-exclusive, so the mode never flips the copy.
+void mock.module("@/ui/hooks/use-deploy-mode", () => ({
+  useDeployMode: () => ({
+    deployMode: "self-hosted",
+    loading: false,
+    error: null,
+    resolved: true,
+  }),
+}));
 import { combineMutationErrors } from "../lib/mutation-errors";
 import { serverMessage, type FetchError } from "../lib/fetch-error";
+import { MutationErrorSurface } from "../components/admin/mutation-error-surface";
 
 function err(message: string, overrides: Partial<FetchError> = {}): FetchError {
   return { message, ...overrides };
@@ -63,22 +77,42 @@ describe("combineMutationErrors", () => {
     });
   });
 
-  test("does not decorate a synthesized placeholder into something that reads as server prose (#5068)", () => {
-    // `"HTTP 403"` suffixed to `"HTTP 403 (+1 more)"` no longer matches
-    // `serverMessage`'s sentinels, so every downstream surface takes it for
-    // the server's own words — and since #5068 the gated placeholders render
-    // exactly that string as their only line of copy. The combiner is the one
-    // place that transforms a message, so it is the one place that has to
-    // know. Reachable today from `custom-domain`, `residency`, `cache`,
-    // `sandbox` and `email-provider`, all of which combine then gate.
+  test("leaves a synthesized placeholder UNDECORATED so it stays recognizable (#5068)", () => {
+    // Provenance is recovered by string-comparing against the two spellings
+    // this module mints, so ANY transform destroys it. `"HTTP 403 (+1 more)"`
+    // matches no sentinel — but neither does `"Request failed (+1 more)"`, so
+    // re-wording is not a fix. `serverMessage` returning undefined is the
+    // property that matters, and it is the only one a downstream surface can
+    // act on. The combiner is the codebase's one message transform, so it is
+    // the one place that has to know. Reachable from every
+    // `combineMutationErrors` consumer — all six feed `MutationErrorSurface`.
     const combined = combineMutationErrors([
       err("HTTP 403", { status: 403, requestId: "req-x" }),
       err("something else", { status: 500 }),
     ]);
-    expect(combined?.message).toBe("Request failed (+1 more)");
-    expect(serverMessage(combined!)).toBe("Request failed (+1 more)");
-    // The status echo must not survive into the combined message at all.
-    expect(combined?.message).not.toContain("HTTP 403");
+    expect(combined?.message).toBe("HTTP 403");
+    expect(serverMessage(combined!)).toBeUndefined();
+    // The count is what gets dropped — cosmetic, and the price of a correct
+    // diagnosis. Assert it so the trade is visible rather than assumed.
+    expect(combined?.message).not.toContain("+1 more");
+    expect(combined?.requestId).toBe("req-x");
+  });
+
+  test("a placeholder primary still renders the gate's CANNED copy end-to-end", () => {
+    // The string assertions above are necessary and not sufficient: what makes
+    // this a regression-vs-main is what an admin reads. Before this arm, the
+    // combiner→gate boundary had no test at all, which is how two successive
+    // fixes to the same defect both looked complete.
+    const combined = combineMutationErrors([
+      err("HTTP 403", { status: 403, code: "enterprise_required" }),
+      err("something else", { status: 500 }),
+    ]);
+    const { container } = render(
+      <MutationErrorSurface error={combined} feature="SSO" />,
+    );
+    expect(container.textContent).toContain("contact sales");
+    expect(container.textContent).not.toContain("+1 more");
+    expect(container.textContent).not.toContain("HTTP 403");
   });
 
   test("still builds the suffix onto a REAL server message", () => {

--- a/packages/web/src/ui/__tests__/mutation-errors.test.tsx
+++ b/packages/web/src/ui/__tests__/mutation-errors.test.tsx
@@ -88,7 +88,7 @@ describe("combineMutationErrors", () => {
     // `combineMutationErrors` consumer — all six feed `MutationErrorSurface`.
     const combined = combineMutationErrors([
       err("HTTP 403", { status: 403, requestId: "req-x" }),
-      err("something else", { status: 500 }),
+      err("HTTP 500", { status: 500 }),
     ]);
     expect(combined?.message).toBe("HTTP 403");
     expect(serverMessage(combined!)).toBeUndefined();
@@ -98,14 +98,40 @@ describe("combineMutationErrors", () => {
     expect(combined?.requestId).toBe("req-x");
   });
 
-  test("a placeholder primary still renders the gate's CANNED copy end-to-end", () => {
+  test("a placeholder never shadows a sibling's real message or its requestId", () => {
+    // The combined error is the SOLE surface on all six consumers — there is
+    // no per-mutation banner behind it. So returning the placeholder as-is
+    // when a sibling actually explained itself discards that explanation and
+    // its correlation id with no signal at all, which is worse than the
+    // status echo it was avoiding. Demote the un-explanatory instead.
+    const combined = combineMutationErrors([
+      err("HTTP 403", { status: 403, code: "enterprise_required" }),
+      err("Migration failed: disk full on region eu-west", { status: 500, requestId: "req-b" }),
+    ]);
+    expect(combined?.message).toBe("Migration failed: disk full on region eu-west (+1 more)");
+    expect(combined?.requestId).toBe("req-b");
+    // ...and the demotion is total: the placeholder's status/code must not
+    // ride along, or the gate would still render an enterprise upsell.
+    expect(combined?.status).toBe(500);
+    expect(combined?.code).toBeUndefined();
+  });
+
+  test("skips blank and de-dupes on the trimmed message", () => {
+    // Both `.trim()`s shipped unfalsified. A whitespace-only primary produced
+    // a gate description of "(+1 more)" — the blank-chrome class, and the
+    // motivating case the code comment names.
+    expect(combineMutationErrors([err("   "), err("real")])?.message).toBe("real");
+    expect(combineMutationErrors([err("a"), err(" a ")])?.message).toBe("a");
+  });
+
+  test("an ALL-placeholder set still renders the gate's CANNED copy end-to-end", () => {
     // The string assertions above are necessary and not sufficient: what makes
     // this a regression-vs-main is what an admin reads. Before this arm, the
     // combiner→gate boundary had no test at all, which is how two successive
     // fixes to the same defect both looked complete.
     const combined = combineMutationErrors([
       err("HTTP 403", { status: 403, code: "enterprise_required" }),
-      err("something else", { status: 500 }),
+      err("HTTP 500", { status: 500 }),
     ]);
     const { container } = render(
       <MutationErrorSurface error={combined} feature="SSO" />,

--- a/packages/web/src/ui/components/admin-content-wrapper.tsx
+++ b/packages/web/src/ui/components/admin-content-wrapper.tsx
@@ -14,7 +14,7 @@ import { ErrorBanner } from "@/ui/components/admin/error-banner";
 import { LoadingState } from "@/ui/components/admin/loading-state";
 import { EmptyState } from "@/ui/components/admin/empty-state";
 import { friendlyError, type FetchError } from "@/ui/hooks/use-admin-fetch";
-import { serverMessage } from "@/ui/lib/fetch-error";
+import { gateProps } from "@/ui/lib/fetch-error";
 
 /**
  * Detect an `EnterpriseError` that was serialized over HTTP.
@@ -77,13 +77,7 @@ export function AdminContentWrapper({
     // Render a distinct upsell so non-EE admins see "this feature needs an
     // enterprise plan" rather than a generic "Access denied" or error banner.
     if (isEnterpriseRequired(error)) {
-      return (
-        <EnterpriseUpsell
-          feature={feature}
-          message={serverMessage(error)}
-          requestId={error.requestId}
-        />
-      );
+      return <EnterpriseUpsell feature={feature} {...gateProps(error)} />;
     }
     // #2486 — MFA-required 403s used to render the misleading
     // "You need the admin role" copy from the generic 403 path because
@@ -96,17 +90,10 @@ export function AdminContentWrapper({
     if (isGateStatus(error.status)) {
       // #5068 — the gate used to take status + feature only, discarding the
       // server's own explanation and the correlation id on every gated
-      // response. `serverMessage`, not `error.message`: the latter is a
+      // response. `gateProps`, not `error.message`: the latter is a
       // synthesized placeholder on an empty body, which would displace the
       // gate's canned copy with a status echo.
-      return (
-        <FeatureGate
-          status={error.status}
-          feature={feature}
-          message={serverMessage(error)}
-          requestId={error.requestId}
-        />
-      );
+      return <FeatureGate status={error.status} feature={feature} {...gateProps(error)} />;
     }
   }
 

--- a/packages/web/src/ui/components/admin-content-wrapper.tsx
+++ b/packages/web/src/ui/components/admin-content-wrapper.tsx
@@ -13,6 +13,7 @@ import { ErrorBanner } from "@/ui/components/admin/error-banner";
 import { LoadingState } from "@/ui/components/admin/loading-state";
 import { EmptyState } from "@/ui/components/admin/empty-state";
 import { friendlyError, type FetchError } from "@/ui/hooks/use-admin-fetch";
+import { serverMessage } from "@/ui/lib/fetch-error";
 
 /**
  * Detect an `EnterpriseError` that was serialized over HTTP.
@@ -75,7 +76,7 @@ export function AdminContentWrapper({
     // Render a distinct upsell so non-EE admins see "this feature needs an
     // enterprise plan" rather than a generic "Access denied" or error banner.
     if (isEnterpriseRequired(error)) {
-      return <EnterpriseUpsell feature={feature} message={error.message} />;
+      return <EnterpriseUpsell feature={feature} message={serverMessage(error)} />;
     }
     // #2486 — MFA-required 403s used to render the misleading
     // "You need the admin role" copy from the generic 403 path because
@@ -86,7 +87,19 @@ export function AdminContentWrapper({
       return <MfaRequiredPlaceholder feature={feature} />;
     }
     if (error.status && [401, 403, 404, 503].includes(error.status)) {
-      return <FeatureGate status={error.status as 401 | 403 | 404 | 503} feature={feature} />;
+      // #5068 — the gate used to take status + feature only, discarding the
+      // server's own explanation and the correlation id on every gated
+      // response. `serverMessage`, not `error.message`: the latter is the
+      // `HTTP {status}` placeholder on an empty body, which would displace
+      // the gate's canned copy with a status echo.
+      return (
+        <FeatureGate
+          status={error.status as 401 | 403 | 404 | 503}
+          feature={feature}
+          message={serverMessage(error)}
+          requestId={error.requestId}
+        />
+      );
     }
   }
 

--- a/packages/web/src/ui/components/admin-content-wrapper.tsx
+++ b/packages/web/src/ui/components/admin-content-wrapper.tsx
@@ -6,6 +6,7 @@ import { Search } from "lucide-react";
 import {
   EnterpriseUpsell,
   FeatureGate,
+  isGateStatus,
   MfaRequiredPlaceholder,
 } from "@/ui/components/admin/feature-disabled";
 import type { FeatureName } from "@/ui/components/admin/feature-registry";
@@ -76,7 +77,13 @@ export function AdminContentWrapper({
     // Render a distinct upsell so non-EE admins see "this feature needs an
     // enterprise plan" rather than a generic "Access denied" or error banner.
     if (isEnterpriseRequired(error)) {
-      return <EnterpriseUpsell feature={feature} message={serverMessage(error)} />;
+      return (
+        <EnterpriseUpsell
+          feature={feature}
+          message={serverMessage(error)}
+          requestId={error.requestId}
+        />
+      );
     }
     // #2486 — MFA-required 403s used to render the misleading
     // "You need the admin role" copy from the generic 403 path because
@@ -84,17 +91,17 @@ export function AdminContentWrapper({
     // to a neutral placeholder; the layout-level full-screen gate
     // overlays this on every /admin/* route except the enrollment page.
     if (isMfaRequired(error)) {
-      return <MfaRequiredPlaceholder feature={feature} />;
+      return <MfaRequiredPlaceholder feature={feature} requestId={error.requestId} />;
     }
-    if (error.status && [401, 403, 404, 503].includes(error.status)) {
+    if (isGateStatus(error.status)) {
       // #5068 — the gate used to take status + feature only, discarding the
       // server's own explanation and the correlation id on every gated
-      // response. `serverMessage`, not `error.message`: the latter is the
-      // `HTTP {status}` placeholder on an empty body, which would displace
-      // the gate's canned copy with a status echo.
+      // response. `serverMessage`, not `error.message`: the latter is a
+      // synthesized placeholder on an empty body, which would displace the
+      // gate's canned copy with a status echo.
       return (
         <FeatureGate
-          status={error.status as 401 | 403 | 404 | 503}
+          status={error.status}
           feature={feature}
           message={serverMessage(error)}
           requestId={error.requestId}

--- a/packages/web/src/ui/components/admin/__tests__/mutation-error-surface.test.tsx
+++ b/packages/web/src/ui/components/admin/__tests__/mutation-error-surface.test.tsx
@@ -63,29 +63,72 @@ describe("MutationErrorSurface", () => {
   });
 
   test("FeatureGate status codes route to FeatureGate (banner variant)", () => {
-    const error: FetchError = { message: "Forbidden", status: 403 };
+    // The status-derived headline is what proves the routing; the description
+    // now belongs to the server (#5068), so it can't stand in as the marker.
+    const error: FetchError = {
+      message: "Admin role required.",
+      status: 403,
+      code: "forbidden_role",
+    };
     const { container } = render(
       <MutationErrorSurface error={error} feature="SCIM" />,
     );
     expect(container.textContent).toContain("Access denied");
-    expect(container.textContent).toContain("admin role");
+    expect(container.textContent).toContain("Admin role required.");
   });
 
   test("401 routes to FeatureGate sign-in copy", () => {
-    const error: FetchError = { message: "Unauthorized", status: 401 };
+    const error: FetchError = { message: "No user ID in session.", status: 401 };
     const { container } = render(
       <MutationErrorSurface error={error} feature="SCIM" />,
     );
     expect(container.textContent).toContain("Authentication required");
   });
 
-  test("503 routes to FeatureGate internal-db copy", () => {
-    const error: FetchError = { message: "Unavailable", status: 503 };
+  test("503 with no server message keeps the internal-db copy", () => {
+    // `HTTP 503` is what `extractFetchError` leaves behind on an empty body —
+    // the only shape that legitimately falls back. Writing an invented
+    // one-word message here instead would assert the fallback on an input that
+    // no longer takes it, and pass for the wrong reason.
+    const error: FetchError = { message: "HTTP 503", status: 503 };
     const { container } = render(
       <MutationErrorSurface error={error} feature="Custom Domains" />,
     );
     expect(container.textContent).toContain("Internal database not configured");
     expect(container.textContent).toContain("Custom Domains");
+  });
+
+  test("503 with a server message routes to FeatureGate carrying it (#5068)", () => {
+    const error: FetchError = {
+      message: "Authorization service is temporarily unavailable.",
+      status: 503,
+      code: "permissions_unavailable",
+      requestId: "req-503-mut",
+    };
+    const { container } = render(
+      <MutationErrorSurface error={error} feature="Custom Domains" />,
+    );
+    expect(container.textContent).toContain(
+      "Authorization service is temporarily unavailable.",
+    );
+    expect(container.textContent).not.toContain("Internal database not configured");
+    expect(container.textContent).toContain("req-503-mut");
+  });
+
+  test("inline enterprise upsell drops the HTTP placeholder rather than reading it out", () => {
+    // The inline variant renders its message inline with the headline, so an
+    // empty `enterprise_required` body used to produce
+    // "SSO requires Enterprise. HTTP 403 Learn more".
+    const error: FetchError = {
+      message: "HTTP 403",
+      status: 403,
+      code: "enterprise_required",
+    };
+    const { container } = render(
+      <MutationErrorSurface error={error} feature="SSO" variant="inline" />,
+    );
+    expect(container.textContent).toContain("SSO requires Enterprise.");
+    expect(container.textContent).not.toContain("HTTP 403");
   });
 
   test("enterprise_required without a status still routes to EnterpriseUpsell", () => {

--- a/packages/web/src/ui/components/admin/__tests__/mutation-error-surface.test.tsx
+++ b/packages/web/src/ui/components/admin/__tests__/mutation-error-surface.test.tsx
@@ -86,9 +86,7 @@ describe("MutationErrorSurface", () => {
     // Without this the fixture is inert — the test passed identically with
     // `message` dropped from the props.
     expect(container.textContent).toContain("No user ID in session.");
-    // 401 appends rather than displaces: the sign-in affordance stays true
-    // whatever the server said.
-    expect(container.textContent).toContain(
+    expect(container.textContent).not.toContain(
       "Please sign in to access the admin console.",
     );
   });

--- a/packages/web/src/ui/components/admin/__tests__/mutation-error-surface.test.tsx
+++ b/packages/web/src/ui/components/admin/__tests__/mutation-error-surface.test.tsx
@@ -77,15 +77,23 @@ describe("MutationErrorSurface", () => {
     expect(container.textContent).toContain("Admin role required.");
   });
 
-  test("401 routes to FeatureGate sign-in copy", () => {
+  test("401 routes to FeatureGate sign-in copy, carrying the server's message", () => {
     const error: FetchError = { message: "No user ID in session.", status: 401 };
     const { container } = render(
       <MutationErrorSurface error={error} feature="SCIM" />,
     );
     expect(container.textContent).toContain("Authentication required");
+    // Without this the fixture is inert — the test passed identically with
+    // `message` dropped from the props.
+    expect(container.textContent).toContain("No user ID in session.");
+    // 401 appends rather than displaces: the sign-in affordance stays true
+    // whatever the server said.
+    expect(container.textContent).toContain(
+      "Please sign in to access the admin console.",
+    );
   });
 
-  test("503 with no server message keeps the internal-db copy", () => {
+  test("503 with no server message keeps the unexplained-outage copy", () => {
     // `HTTP 503` is what `extractFetchError` leaves behind on an empty body —
     // the only shape that legitimately falls back. Writing an invented
     // one-word message here instead would assert the fallback on an input that
@@ -94,8 +102,8 @@ describe("MutationErrorSurface", () => {
     const { container } = render(
       <MutationErrorSurface error={error} feature="Custom Domains" />,
     );
-    expect(container.textContent).toContain("Internal database not configured");
-    expect(container.textContent).toContain("Custom Domains");
+    expect(container.textContent).toContain("Custom Domains is unavailable");
+    expect(container.textContent).toContain("Retry in a moment");
   });
 
   test("503 with a server message routes to FeatureGate carrying it (#5068)", () => {
@@ -129,6 +137,43 @@ describe("MutationErrorSurface", () => {
     );
     expect(container.textContent).toContain("SSO requires Enterprise.");
     expect(container.textContent).not.toContain("HTTP 403");
+  });
+
+  test("BANNER enterprise upsell drops the HTTP placeholder too", () => {
+    // The inline sibling above had this arm and the banner one did not, so
+    // reverting the banner call site to `message={error.message}` survived
+    // the whole suite — every other enterprise fixture carries a real body,
+    // where `authored` and `error.message` are indistinguishable.
+    const error: FetchError = {
+      message: "HTTP 403",
+      status: 403,
+      code: "enterprise_required",
+    };
+    const { container } = render(
+      <MutationErrorSurface error={error} feature="SSO" />,
+    );
+    expect(container.textContent).toContain("SSO requires an enterprise plan");
+    expect(container.textContent).toContain("contact sales");
+    expect(container.textContent).not.toContain("HTTP 403");
+  });
+
+  test("the enterprise upsell carries the request id, like every other gated surface", () => {
+    // `enterprise_required` is evaluated one branch BEFORE the gate, so it
+    // was the class of 403 most likely to arrive unexpectedly — a paying
+    // workspace whose entitlement lookup misfired — and the only one that
+    // reached the operator with no log handle.
+    const error: FetchError = {
+      message: "Enterprise tier required to use SSO.",
+      status: 403,
+      code: "enterprise_required",
+      requestId: "req-ee-gate",
+    };
+    const { container } = render(
+      <MutationErrorSurface error={error} feature="SSO" />,
+    );
+    const line = container.querySelector('[data-testid="feature-gate-request-id"]');
+    if (!line) throw new Error("enterprise upsell rendered no request-id line");
+    expect(line.textContent).toContain("req-ee-gate");
   });
 
   test("enterprise_required without a status still routes to EnterpriseUpsell", () => {

--- a/packages/web/src/ui/components/admin/entity-version-history.tsx
+++ b/packages/web/src/ui/components/admin/entity-version-history.tsx
@@ -367,7 +367,7 @@ export function EntityVersionHistory({ entityName, onRollback }: EntityVersionHi
   };
 
   if (loading) return <LoadingState message="Loading version history..." />;
-  if (error) return <div className="p-6"><ErrorBanner message={error.message} /></div>;
+  if (error) return <div className="p-6"><ErrorBanner message={friendlyError(error)} /></div>;
   if (versions.length === 0) {
     return (
       <EmptyState icon={RotateCcw} message="No version history">

--- a/packages/web/src/ui/components/admin/feature-disabled.tsx
+++ b/packages/web/src/ui/components/admin/feature-disabled.tsx
@@ -133,7 +133,10 @@ export function isGateStatus(status: number | undefined): status is GateStatus {
  * never decides whether they get a log handle.
  */
 export function GateRequestId({ requestId }: { requestId?: string }) {
-  if (!requestId) return null;
+  // `.trim()` for the same reason `serverMessage` trims: `extractFetchError`
+  // accepts any string, so "   " would render the label over nothing — the
+  // blank-chrome class, one field over.
+  if (!requestId?.trim()) return null;
   return (
     <p
       data-testid="feature-gate-request-id"
@@ -183,15 +186,23 @@ function GateBody({
  * - 401 → authentication required
  * - 403 → insufficient role
  *
- * Each arm prefers the server's own `message` over its canned copy, because
+ * Every arm prefers the server's own `message` over its canned copy, because
  * the canned line is a guess at the cause from the status alone and the
  * server knows. The canned copy is the fallback for an empty response body —
- * which is why callers must pass `serverMessage(err)` and never `err.message`
- * (see that helper: the latter is a synthesized placeholder on an empty body,
- * and rendering it replaces real guidance with a status echo).
+ * which is why callers should use `gateProps(err)` rather than hand-passing
+ * `err.message` (see `serverMessage`: the latter is a synthesized placeholder
+ * on an empty body, and rendering it replaces real guidance with a status
+ * echo).
  *
- * 401 is the exception: its canned line is the *affordance*, not a guess, so
- * the server's message is appended to it rather than displacing it.
+ * 401 briefly *appended* its canned sign-in line instead, on the theory that
+ * the affordance stays true whatever the server said. It does not, and the
+ * concatenation was the giveaway: every 401 message the API actually emits is
+ * a bare fragment (`managed.ts`, `simple-key.ts`, `byot.ts` — "Not signed
+ * in", "Account is banned", "API key required"), so the shipped line read
+ * "Not signed in Please sign in to access the admin console." And for a
+ * banned account, or either key-based `ATLAS_AUTH_MODE`, signing in is
+ * exactly what will not help. The headline carries the affordance; the
+ * description belongs to whoever knows the cause.
  *
  * ⚠️ This makes the `message` field of every gated 401/403/404/503 response
  * user-facing prose on ~60 admin pages. It was rendered nowhere before #5068.
@@ -212,6 +223,14 @@ export function FeatureGate({
   /** Correlation id from the response body, for log lookup. */
   requestId?: string;
 }) {
+  // Normalize once, here, rather than guarding at each arm. `serverMessage`
+  // already trims blanks away, but this prop is a bare `string | undefined`
+  // that any caller can hand "   " — and a whitespace message is truthy, so
+  // even the `||` guards below would render the icon and headline over an
+  // empty <p>. That is the blank-chrome failure `buildFetchError` exists to
+  // prevent, arriving one layer lower.
+  const authored = message?.trim() || undefined;
+
   if (status === 503) {
     // This arm used to assert one cause — "Internal database not configured /
     // Set DATABASE_URL" — on every 503. No route emits that: a missing
@@ -231,7 +250,7 @@ export function FeatureGate({
         icon={ServerOff}
         title={`${feature} is unavailable`}
         description={
-          message ||
+          authored ??
           "The server returned 503 with no explanation — it may be restarting or behind an unhealthy proxy. Retry in a moment; if it persists, check the API service logs."
         }
         requestId={requestId}
@@ -245,29 +264,28 @@ export function FeatureGate({
         icon={Ban}
         title={`${feature} not enabled`}
         description={
-          message || "Enable this feature in your server configuration to use this page."
+          authored ?? "Enable this feature in your server configuration to use this page."
         }
         requestId={requestId}
       />
     );
   }
 
-  const SIGN_IN = "Please sign in to access the admin console.";
+  // Exhaustiveness: 404 and 503 returned above, so only 401 | 403 may remain.
+  // Widening `GATE_STATUSES` without adding an arm is a compile error here
+  // rather than a new status silently rendering "Access denied" — which is a
+  // worse failure than the un-narrowed casts this replaced, because it
+  // reaches a user with a wrong diagnosis.
+  const authStatus: Exclude<GateStatus, 404 | 503> = status;
   return (
     <GateBody
       icon={ShieldX}
-      title={status === 401 ? "Authentication required" : "Access denied"}
+      title={authStatus === 401 ? "Authentication required" : "Access denied"}
       description={
-        status === 401
-          ? // 401 is the one status whose canned line is not a guess at the
-            // cause but the *affordance* — it stays true whatever the server
-            // said, so it is appended rather than displaced. Otherwise a
-            // server that answers "No user ID in session." leaves the user
-            // with an accurate diagnosis and no next step.
-            message
-            ? `${message} ${SIGN_IN}`
-            : SIGN_IN
-          : message || "You need the admin role to access this page."
+        authored ??
+        (authStatus === 401
+          ? "Please sign in to access the admin console."
+          : "You need the admin role to access this page.")
       }
       requestId={requestId}
     />

--- a/packages/web/src/ui/components/admin/feature-disabled.tsx
+++ b/packages/web/src/ui/components/admin/feature-disabled.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { Ban, Cloud, DatabaseZap, ShieldCheck, ShieldX } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import { Ban, Cloud, DatabaseZap, ServerOff, ShieldCheck, ShieldX } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   isSaasExclusiveFeature,
@@ -100,66 +101,124 @@ export function EnterpriseUpsell({
 }
 
 /**
+ * The shared body of every {@link FeatureGate} arm: icon, headline, one line
+ * of description, and — when the response carried one — the correlation id.
+ *
+ * Extracted so the id renders identically on all four statuses. Before #5068
+ * each arm was its own copy of this markup and the id had nowhere to go.
+ */
+function GateBody({
+  icon: Icon,
+  title,
+  description,
+  requestId,
+}: {
+  icon: LucideIcon;
+  title: string;
+  description: string;
+  requestId?: string;
+}) {
+  return (
+    <div className="flex h-full items-center justify-center">
+      <div className="max-w-sm text-center">
+        <Icon className="mx-auto size-10 text-muted-foreground/50" aria-hidden="true" />
+        <p className="mt-3 text-sm font-medium">{title}</p>
+        <p className="mt-1 text-xs text-muted-foreground">{description}</p>
+        {requestId && (
+          // A gate an operator did not expect (a 403 they believe they should
+          // pass, a 404 on a feature they configured) is un-diagnosable
+          // without this — `ErrorBanner` has appended it to every non-gated
+          // error for as long as it has existed.
+          <p
+            data-testid="feature-gate-request-id"
+            className="mt-2 font-mono text-[11px] text-muted-foreground/70"
+          >
+            Request ID: {requestId}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/**
  * Shown when an admin page gets a 401/403/404/503 status.
  *
  * Evaluation order (matches code):
- * - 503 → internal database not configured (DATABASE_URL missing)
+ * - 503 → service unavailable (internal database missing, authz outage, …)
  * - 404 → feature not enabled (enterprise config)
  * - 401 → authentication required
  * - 403 → insufficient role
+ *
+ * Every arm prefers the server's own `message` over its canned copy: the
+ * canned line is a guess at the cause from the status alone, and the server
+ * knows. The canned copy remains the fallback for an empty response body —
+ * which is why callers must pass `serverMessage(err)` rather than
+ * `err.message` (see that helper: the latter is `HTTP {status}` on an empty
+ * body, and rendering it would replace real guidance with a status echo).
  */
 export function FeatureGate({
   status,
   feature,
   message,
+  requestId,
 }: {
   status: 401 | 403 | 404 | 503;
   feature: FeatureName;
-  /** Optional override for the description text. */
+  /** The server's description of *this* refusal. Pass `serverMessage(err)`. */
   message?: string;
+  /** Correlation id from the response body, for log lookup. */
+  requestId?: string;
 }) {
   if (status === 503) {
-    return (
-      <div className="flex h-full items-center justify-center">
-        <div className="text-center">
-          <DatabaseZap className="mx-auto size-10 text-muted-foreground/50" />
-          <p className="mt-3 text-sm font-medium">Internal database not configured</p>
-          <p className="mt-1 text-xs text-muted-foreground">
-            Set DATABASE_URL to enable {feature}.
-          </p>
-        </div>
-      </div>
+    // Missing DATABASE_URL is one cause of a 503 here; `permissions_unavailable`
+    // (the authz service being down) is another, and "Internal database not
+    // configured" is simply false for it. So when the server explained itself
+    // the headline drops its guess too — not just the description. With no
+    // message the DATABASE_URL hint stays: it is still the likeliest cause and
+    // the only actionable thing we can say.
+    return message ? (
+      <GateBody
+        icon={ServerOff}
+        title={`${feature} is unavailable`}
+        description={message}
+        requestId={requestId}
+      />
+    ) : (
+      <GateBody
+        icon={DatabaseZap}
+        title="Internal database not configured"
+        description={`Set DATABASE_URL to enable ${feature}.`}
+        requestId={requestId}
+      />
     );
   }
 
   if (status === 404) {
     return (
-      <div className="flex h-full items-center justify-center">
-        <div className="text-center">
-          <Ban className="mx-auto size-10 text-muted-foreground/50" />
-          <p className="mt-3 text-sm font-medium">{feature} not enabled</p>
-          <p className="mt-1 max-w-sm text-xs text-muted-foreground">
-            {message ?? "Enable this feature in your server configuration to use this page."}
-          </p>
-        </div>
-      </div>
+      <GateBody
+        icon={Ban}
+        title={`${feature} not enabled`}
+        description={
+          message ?? "Enable this feature in your server configuration to use this page."
+        }
+        requestId={requestId}
+      />
     );
   }
 
   return (
-    <div className="flex h-full items-center justify-center">
-      <div className="text-center">
-        <ShieldX className="mx-auto size-10 text-muted-foreground/50" />
-        <p className="mt-3 text-sm font-medium">
-          {status === 401 ? "Authentication required" : "Access denied"}
-        </p>
-        <p className="mt-1 text-xs text-muted-foreground">
-          {status === 401
-            ? "Please sign in to access the admin console."
-            : "You need the admin role to access this page."}
-        </p>
-      </div>
-    </div>
+    <GateBody
+      icon={ShieldX}
+      title={status === 401 ? "Authentication required" : "Access denied"}
+      description={
+        message ??
+        (status === 401
+          ? "Please sign in to access the admin console."
+          : "You need the admin role to access this page.")
+      }
+      requestId={requestId}
+    />
   );
 }
 

--- a/packages/web/src/ui/components/admin/feature-disabled.tsx
+++ b/packages/web/src/ui/components/admin/feature-disabled.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { LucideIcon } from "lucide-react";
-import { Ban, Cloud, DatabaseZap, ServerOff, ShieldCheck, ShieldX } from "lucide-react";
+import { Ban, Cloud, ServerOff, ShieldCheck, ShieldX } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   isSaasExclusiveFeature,
@@ -30,10 +30,13 @@ import { useDeployMode } from "@/ui/hooks/use-deploy-mode";
 export function EnterpriseUpsell({
   feature,
   message,
+  requestId,
 }: {
   feature: FeatureName;
-  /** Optional override for the description text (usually the server message). */
+  /** The server's description of this refusal. Pass `serverMessage(err)`. */
   message?: string;
+  /** Correlation id from the response body, for log lookup. */
+  requestId?: string;
 }) {
   // Only SaaS-exclusive features need the authoritative deploy mode; for every
   // other feature `hostedOnly` is false regardless, so skip the settings fetch
@@ -65,6 +68,7 @@ export function EnterpriseUpsell({
               </a>
             </Button>
           </div>
+          <GateRequestId requestId={requestId} />
         </div>
       </div>
     );
@@ -95,14 +99,54 @@ export function EnterpriseUpsell({
             </a>
           </Button>
         </div>
+        <GateRequestId requestId={requestId} />
       </div>
     </div>
   );
 }
 
 /**
+ * The statuses that route to {@link FeatureGate} rather than a red error
+ * banner: a refusal the operator is meant to act on, not a fault.
+ *
+ * One definition, because the set was previously written out at each call
+ * site next to an `as 401 | 403 | 404 | 503` cast that TypeScript was told to
+ * trust. Widening the union without touching every `includes` list compiled
+ * and silently gated nothing new. `isGateStatus` narrows, so the casts are
+ * gone and the two can no longer disagree.
+ */
+export const GATE_STATUSES = [401, 403, 404, 503] as const;
+export type GateStatus = (typeof GATE_STATUSES)[number];
+
+export function isGateStatus(status: number | undefined): status is GateStatus {
+  return status !== undefined && (GATE_STATUSES as readonly number[]).includes(status);
+}
+
+/**
+ * The correlation id, rendered under whichever gated placeholder is showing.
+ *
+ * A gate an operator did not expect — a 403 they believe they should pass, a
+ * 404 on a feature they configured, an entitlement that should be live — is
+ * un-diagnosable without this, and `ErrorBanner` has appended it to every
+ * *non*-gated error for as long as it has existed. All three placeholders on
+ * the gated path render it (#5068), so which branch an operator lands on
+ * never decides whether they get a log handle.
+ */
+export function GateRequestId({ requestId }: { requestId?: string }) {
+  if (!requestId) return null;
+  return (
+    <p
+      data-testid="feature-gate-request-id"
+      className="mt-2 font-mono text-[11px] text-muted-foreground/70"
+    >
+      Request ID: {requestId}
+    </p>
+  );
+}
+
+/**
  * The shared body of every {@link FeatureGate} arm: icon, headline, one line
- * of description, and — when the response carried one — the correlation id.
+ * of description, and the correlation id.
  *
  * Extracted so the id renders identically on all four statuses. Before #5068
  * each arm was its own copy of this markup and the id had nowhere to go.
@@ -124,18 +168,7 @@ function GateBody({
         <Icon className="mx-auto size-10 text-muted-foreground/50" aria-hidden="true" />
         <p className="mt-3 text-sm font-medium">{title}</p>
         <p className="mt-1 text-xs text-muted-foreground">{description}</p>
-        {requestId && (
-          // A gate an operator did not expect (a 403 they believe they should
-          // pass, a 404 on a feature they configured) is un-diagnosable
-          // without this — `ErrorBanner` has appended it to every non-gated
-          // error for as long as it has existed.
-          <p
-            data-testid="feature-gate-request-id"
-            className="mt-2 font-mono text-[11px] text-muted-foreground/70"
-          >
-            Request ID: {requestId}
-          </p>
-        )}
+        <GateRequestId requestId={requestId} />
       </div>
     </div>
   );
@@ -145,17 +178,26 @@ function GateBody({
  * Shown when an admin page gets a 401/403/404/503 status.
  *
  * Evaluation order (matches code):
- * - 503 → service unavailable (internal database missing, authz outage, …)
- * - 404 → feature not enabled (enterprise config)
+ * - 503 → unavailable (authz outage, billing check, restarting service, …)
+ * - 404 → feature not enabled (enterprise config, no internal database)
  * - 401 → authentication required
  * - 403 → insufficient role
  *
- * Every arm prefers the server's own `message` over its canned copy: the
- * canned line is a guess at the cause from the status alone, and the server
- * knows. The canned copy remains the fallback for an empty response body —
- * which is why callers must pass `serverMessage(err)` rather than
- * `err.message` (see that helper: the latter is `HTTP {status}` on an empty
- * body, and rendering it would replace real guidance with a status echo).
+ * Each arm prefers the server's own `message` over its canned copy, because
+ * the canned line is a guess at the cause from the status alone and the
+ * server knows. The canned copy is the fallback for an empty response body —
+ * which is why callers must pass `serverMessage(err)` and never `err.message`
+ * (see that helper: the latter is a synthesized placeholder on an empty body,
+ * and rendering it replaces real guidance with a status echo).
+ *
+ * 401 is the exception: its canned line is the *affordance*, not a guess, so
+ * the server's message is appended to it rather than displacing it.
+ *
+ * ⚠️ This makes the `message` field of every gated 401/403/404/503 response
+ * user-facing prose on ~60 admin pages. It was rendered nowhere before #5068.
+ * A route that interpolates a driver error, a connection string, or a caught
+ * `err.message` into a gated status now puts it on an admin's screen — see
+ * CLAUDE.md § "No secrets in responses".
  */
 export function FeatureGate({
   status,
@@ -163,7 +205,7 @@ export function FeatureGate({
   message,
   requestId,
 }: {
-  status: 401 | 403 | 404 | 503;
+  status: GateStatus;
   feature: FeatureName;
   /** The server's description of *this* refusal. Pass `serverMessage(err)`. */
   message?: string;
@@ -171,24 +213,27 @@ export function FeatureGate({
   requestId?: string;
 }) {
   if (status === 503) {
-    // Missing DATABASE_URL is one cause of a 503 here; `permissions_unavailable`
-    // (the authz service being down) is another, and "Internal database not
-    // configured" is simply false for it. So when the server explained itself
-    // the headline drops its guess too — not just the description. With no
-    // message the DATABASE_URL hint stays: it is still the likeliest cause and
-    // the only actionable thing we can say.
-    return message ? (
+    // This arm used to assert one cause — "Internal database not configured /
+    // Set DATABASE_URL" — on every 503. No route emits that: a missing
+    // internal DB answers 404 `not_available` (`requireOrgContext`), and the
+    // 503s that exist are things like `permissions_unavailable`, an authz
+    // outage the database line is simply false for. (The stale `503:
+    // "Internal database not configured"` entries in several routers'
+    // OpenAPI blocks describe handlers that return 404.)
+    //
+    // What actually reaches the no-message branch is an infrastructure 503
+    // with an HTML body — a restarting service, an unhealthy proxy — where
+    // `extractFetchError` finds no message at all. Sending that operator to
+    // set a variable which is already set is the misdirection, not the
+    // absence of a guess.
+    return (
       <GateBody
         icon={ServerOff}
         title={`${feature} is unavailable`}
-        description={message}
-        requestId={requestId}
-      />
-    ) : (
-      <GateBody
-        icon={DatabaseZap}
-        title="Internal database not configured"
-        description={`Set DATABASE_URL to enable ${feature}.`}
+        description={
+          message ||
+          "The server returned 503 with no explanation — it may be restarting or behind an unhealthy proxy. Retry in a moment; if it persists, check the API service logs."
+        }
         requestId={requestId}
       />
     );
@@ -200,22 +245,29 @@ export function FeatureGate({
         icon={Ban}
         title={`${feature} not enabled`}
         description={
-          message ?? "Enable this feature in your server configuration to use this page."
+          message || "Enable this feature in your server configuration to use this page."
         }
         requestId={requestId}
       />
     );
   }
 
+  const SIGN_IN = "Please sign in to access the admin console.";
   return (
     <GateBody
       icon={ShieldX}
       title={status === 401 ? "Authentication required" : "Access denied"}
       description={
-        message ??
-        (status === 401
-          ? "Please sign in to access the admin console."
-          : "You need the admin role to access this page.")
+        status === 401
+          ? // 401 is the one status whose canned line is not a guess at the
+            // cause but the *affordance* — it stays true whatever the server
+            // said, so it is appended rather than displaced. Otherwise a
+            // server that answers "No user ID in session." leaves the user
+            // with an accurate diagnosis and no next step.
+            message
+            ? `${message} ${SIGN_IN}`
+            : SIGN_IN
+          : message || "You need the admin role to access this page."
       }
       requestId={requestId}
     />
@@ -233,16 +285,30 @@ export function FeatureGate({
  * placeholder before the user sees it; the inline copy is the carve-out
  * for the enrollment page itself (`/admin/account-security`), which the
  * layout intentionally leaves un-gated so the user can finish setup.
+ *
+ * The copy stays fixed on purpose — the server's 403 message is the generic
+ * two-factor line and the enrollment CTA is the whole value here, so #5068's
+ * "prefer the server's words" does NOT apply. The correlation id does: an
+ * admin who *has* enrolled and still hits this needs something to hand an
+ * operator.
  */
-export function MfaRequiredPlaceholder({ feature }: { feature: FeatureName }) {
+export function MfaRequiredPlaceholder({
+  feature,
+  requestId,
+}: {
+  feature: FeatureName;
+  /** Correlation id from the response body, for log lookup. */
+  requestId?: string;
+}) {
   return (
     <div className="flex h-full items-center justify-center">
-      <div className="text-center">
+      <div className="max-w-sm text-center">
         <ShieldCheck className="mx-auto size-10 text-primary/70" aria-hidden="true" />
         <p className="mt-3 text-sm font-medium">Two-factor required</p>
-        <p className="mt-1 max-w-sm text-xs text-muted-foreground">
+        <p className="mt-1 text-xs text-muted-foreground">
           Enroll an authenticator app or passkey to access {feature}.
         </p>
+        <GateRequestId requestId={requestId} />
       </div>
     </div>
   );

--- a/packages/web/src/ui/components/admin/feature-disabled.tsx
+++ b/packages/web/src/ui/components/admin/feature-disabled.tsx
@@ -243,15 +243,20 @@ export function FeatureGate({
 
   if (status === 503) {
     // This arm used to assert one cause — "Internal database not configured /
-    // Set DATABASE_URL" — on every 503. No route the admin console consumes
-    // emits that: on admin routes a missing internal DB answers 404
-    // `not_available` (`requireOrgContext`), and the 503s that exist are
-    // things like `permissions_unavailable`, an authz outage the database
-    // line is simply false for. (The API's one DATABASE_URL 503 lives in
-    // `sub-processor-subscriptions.ts`, a public legal endpoint with no admin
-    // surface. The `503: "Internal database not configured"` entries in
-    // `platform-residency.ts` and `admin-domains.ts` are stale — those
-    // handlers return 404.)
+    // Set DATABASE_URL" — on every 503, and it is the wrong place to say it.
+    //
+    // Not because no such 503 exists: `no_internal_db` from
+    // `ee/platform/residency.ts` and `ee/platform/domains.ts` maps to 503
+    // (`shared-residency.ts`, `shared-domains.ts`), and `/platform/residency`
+    // consumes one. But every one of those carries its own message
+    // ("Internal database is required for data residency."), so `serverMessage`
+    // renders it verbatim through the branch above and this fallback is never
+    // what an operator with a missing DATABASE_URL reads.
+    //
+    // What reaches HERE is a 503 with no message at all — an infrastructure
+    // one with an HTML body, a restarting service, an unhealthy proxy — plus
+    // authz outages like `permissions_unavailable`. Sending that operator to
+    // set a variable which is already set is the misdirection.
     //
     // What actually reaches the no-message branch is an infrastructure 503
     // with an HTML body — a restarting service, an unhealthy proxy — where

--- a/packages/web/src/ui/components/admin/feature-disabled.tsx
+++ b/packages/web/src/ui/components/admin/feature-disabled.tsx
@@ -8,6 +8,7 @@ import {
   type FeatureName,
 } from "@/ui/components/admin/feature-registry";
 import { useDeployMode } from "@/ui/hooks/use-deploy-mode";
+import { unexplainedFailure } from "@/ui/lib/fetch-error";
 
 /**
  * Dedicated upsell shown when an admin page returns an
@@ -44,6 +45,9 @@ export function EnterpriseUpsell({
   const isSaasExclusive = isSaasExclusiveFeature(feature);
   const { deployMode } = useDeployMode({ enabled: isSaasExclusive });
   const hostedOnly = isSaasExclusive && deployMode === "self-hosted";
+  // Same normalization, same reason, as `FeatureGate`: "   " is truthy, so a
+  // whitespace message would render the headline over an empty <p>.
+  const authored = message?.trim() || undefined;
 
   if (hostedOnly) {
     return (
@@ -54,7 +58,7 @@ export function EnterpriseUpsell({
             {feature} is an Atlas Cloud feature
           </p>
           <p className="mt-1 text-xs text-muted-foreground">
-            {message ||
+            {authored ??
               `${feature} is available only on Atlas Cloud (the hosted SaaS) and can't be enabled on a self-hosted deployment.`}
           </p>
           <div className="mt-4 flex justify-center">
@@ -85,7 +89,7 @@ export function EnterpriseUpsell({
           {feature} requires an enterprise plan
         </p>
         <p className="mt-1 text-xs text-muted-foreground">
-          {message ||
+          {authored ??
             `${feature} is part of Atlas Enterprise. Upgrade your plan or contact sales to enable it for your workspace.`}
         </p>
         <div className="mt-4 flex justify-center">
@@ -109,11 +113,12 @@ export function EnterpriseUpsell({
  * The statuses that route to {@link FeatureGate} rather than a red error
  * banner: a refusal the operator is meant to act on, not a fault.
  *
- * One definition, because the set was previously written out at each call
- * site next to an `as 401 | 403 | 404 | 503` cast that TypeScript was told to
- * trust. Widening the union without touching every `includes` list compiled
- * and silently gated nothing new. `isGateStatus` narrows, so the casts are
- * gone and the two can no longer disagree.
+ * One definition, because the set was previously written out at five call
+ * sites — three of them beside an `as` cast TypeScript was told to trust, and
+ * they did not all spell the same list. Widening the union without touching
+ * every `includes` list compiled and silently gated nothing new.
+ * `isGateStatus` narrows, so the casts are gone and the copies cannot
+ * disagree.
  */
 export const GATE_STATUSES = [401, 403, 404, 503] as const;
 export type GateStatus = (typeof GATE_STATUSES)[number];
@@ -127,10 +132,13 @@ export function isGateStatus(status: number | undefined): status is GateStatus {
  *
  * A gate an operator did not expect — a 403 they believe they should pass, a
  * 404 on a feature they configured, an entitlement that should be live — is
- * un-diagnosable without this, and `ErrorBanner` has appended it to every
- * *non*-gated error for as long as it has existed. All three placeholders on
- * the gated path render it (#5068), so which branch an operator lands on
- * never decides whether they get a log handle.
+ * un-diagnosable without this. `friendlyError` appends it to non-gated errors;
+ * the gated placeholders had nowhere to put it, so it was simply dropped.
+ *
+ * All three FULL-SURFACE placeholders now render it (#5068). The one gated
+ * surface that still does not is `MutationErrorSurface`'s inline
+ * `enterprise_required` variant, which is a single line of text with no room
+ * for it.
  */
 export function GateRequestId({ requestId }: { requestId?: string }) {
   // `.trim()` for the same reason `serverMessage` trims: `extractFetchError`
@@ -142,7 +150,7 @@ export function GateRequestId({ requestId }: { requestId?: string }) {
       data-testid="feature-gate-request-id"
       className="mt-2 font-mono text-[11px] text-muted-foreground/70"
     >
-      Request ID: {requestId}
+      Request ID: {requestId.trim()}
     </p>
   );
 }
@@ -196,16 +204,18 @@ function GateBody({
  *
  * 401 briefly *appended* its canned sign-in line instead, on the theory that
  * the affordance stays true whatever the server said. It does not, and the
- * concatenation was the giveaway: every 401 message the API actually emits is
- * a bare fragment (`managed.ts`, `simple-key.ts`, `byot.ts` — "Not signed
- * in", "Account is banned", "API key required"), so the shipped line read
- * "Not signed in Please sign in to access the admin console." And for a
- * banned account, or either key-based `ATLAS_AUTH_MODE`, signing in is
- * exactly what will not help. The headline carries the affordance; the
- * description belongs to whoever knows the cause.
+ * concatenation was the giveaway: most 401 messages the API emits are bare
+ * fragments with no terminal punctuation (`managed.ts` — "Not signed in",
+ * "Account is banned", "Session expired (idle timeout)"; `byot.ts` — "JWT
+ * missing sub claim"), so the shipped line read "Not signed in Please sign in
+ * to access the admin console." And for a banned account, or either
+ * key-based `ATLAS_AUTH_MODE`, signing in is exactly what will not help. The
+ * headline carries the affordance; the description belongs to whoever knows
+ * the cause.
  *
  * ⚠️ This makes the `message` field of every gated 401/403/404/503 response
- * user-facing prose on ~60 admin pages. It was rendered nowhere before #5068.
+ * user-facing prose on ~60 admin pages. Before #5068 it reached the screen on
+ * `enterprise_required` 403s only.
  * A route that interpolates a driver error, a connection string, or a caught
  * `err.message` into a gated status now puts it on an admin's screen — see
  * CLAUDE.md § "No secrets in responses".
@@ -233,12 +243,15 @@ export function FeatureGate({
 
   if (status === 503) {
     // This arm used to assert one cause — "Internal database not configured /
-    // Set DATABASE_URL" — on every 503. No route emits that: a missing
-    // internal DB answers 404 `not_available` (`requireOrgContext`), and the
-    // 503s that exist are things like `permissions_unavailable`, an authz
-    // outage the database line is simply false for. (The stale `503:
-    // "Internal database not configured"` entries in several routers'
-    // OpenAPI blocks describe handlers that return 404.)
+    // Set DATABASE_URL" — on every 503. No route the admin console consumes
+    // emits that: on admin routes a missing internal DB answers 404
+    // `not_available` (`requireOrgContext`), and the 503s that exist are
+    // things like `permissions_unavailable`, an authz outage the database
+    // line is simply false for. (The API's one DATABASE_URL 503 lives in
+    // `sub-processor-subscriptions.ts`, a public legal endpoint with no admin
+    // surface. The `503: "Internal database not configured"` entries in
+    // `platform-residency.ts` and `admin-domains.ts` are stale — those
+    // handlers return 404.)
     //
     // What actually reaches the no-message branch is an infrastructure 503
     // with an HTML body — a restarting service, an unhealthy proxy — where
@@ -250,8 +263,7 @@ export function FeatureGate({
         icon={ServerOff}
         title={`${feature} is unavailable`}
         description={
-          authored ??
-          "The server returned 503 with no explanation — it may be restarting or behind an unhealthy proxy. Retry in a moment; if it persists, check the API service logs."
+          authored ?? unexplainedFailure(503)
         }
         requestId={requestId}
       />
@@ -272,11 +284,18 @@ export function FeatureGate({
   }
 
   // Exhaustiveness: 404 and 503 returned above, so only 401 | 403 may remain.
-  // Widening `GATE_STATUSES` without adding an arm is a compile error here
-  // rather than a new status silently rendering "Access denied" — which is a
-  // worse failure than the un-narrowed casts this replaced, because it
-  // reaches a user with a wrong diagnosis.
-  const authStatus: Exclude<GateStatus, 404 | 503> = status;
+  // Widening `GATE_STATUSES` without adding an arm is a compile error here,
+  // rather than a new status silently rendering "Access denied" — a wrong
+  // diagnosis on screen, which is worse than the un-narrowed casts this
+  // replaced.
+  //
+  // The literals are the whole point. `Exclude<GateStatus, 404 | 503>` reads
+  // better and is worthless: it is computed FROM `GateStatus`, so widening the
+  // tuple widens the annotation in lockstep and the assignment stays valid
+  // forever. That was this file's own version of a fixture agreeing with
+  // itself by construction, at the type level — verified by adding 429 to
+  // `GATE_STATUSES` and watching tsgo exit 0.
+  const authStatus: 401 | 403 = status;
   return (
     <GateBody
       icon={ShieldX}

--- a/packages/web/src/ui/components/admin/mutation-error-surface.tsx
+++ b/packages/web/src/ui/components/admin/mutation-error-surface.tsx
@@ -4,6 +4,7 @@ import { ErrorBanner } from "@/ui/components/admin/error-banner";
 import {
   EnterpriseUpsell,
   FeatureGate,
+  isGateStatus,
 } from "@/ui/components/admin/feature-disabled";
 import { InlineError } from "@/ui/components/admin/compact";
 import type { FeatureName } from "@/ui/components/admin/feature-registry";
@@ -126,13 +127,15 @@ export function MutationErrorSurface({
   }
 
   if (isEnterpriseRequired) {
-    return <EnterpriseUpsell feature={feature} message={authored} />;
+    return (
+      <EnterpriseUpsell feature={feature} message={authored} requestId={error.requestId} />
+    );
   }
 
-  if (error.status && [401, 403, 404, 503].includes(error.status)) {
+  if (isGateStatus(error.status)) {
     return (
       <FeatureGate
-        status={error.status as 401 | 403 | 404 | 503}
+        status={error.status}
         feature={feature}
         message={authored}
         requestId={error.requestId}

--- a/packages/web/src/ui/components/admin/mutation-error-surface.tsx
+++ b/packages/web/src/ui/components/admin/mutation-error-surface.tsx
@@ -8,7 +8,7 @@ import {
 } from "@/ui/components/admin/feature-disabled";
 import { InlineError } from "@/ui/components/admin/compact";
 import type { FeatureName } from "@/ui/components/admin/feature-registry";
-import { friendlyError, serverMessage, type FetchError } from "@/ui/lib/fetch-error";
+import { friendlyError, gateProps, serverMessage, type FetchError } from "@/ui/lib/fetch-error";
 
 type Variant = "banner" | "inline";
 
@@ -127,20 +127,11 @@ export function MutationErrorSurface({
   }
 
   if (isEnterpriseRequired) {
-    return (
-      <EnterpriseUpsell feature={feature} message={authored} requestId={error.requestId} />
-    );
+    return <EnterpriseUpsell feature={feature} {...gateProps(error)} />;
   }
 
   if (isGateStatus(error.status)) {
-    return (
-      <FeatureGate
-        status={error.status}
-        feature={feature}
-        message={authored}
-        requestId={error.requestId}
-      />
-    );
+    return <FeatureGate status={error.status} feature={feature} {...gateProps(error)} />;
   }
 
   return <ErrorBanner message={friendlyError(error)} onRetry={onRetry} />;

--- a/packages/web/src/ui/components/admin/mutation-error-surface.tsx
+++ b/packages/web/src/ui/components/admin/mutation-error-surface.tsx
@@ -7,7 +7,7 @@ import {
 } from "@/ui/components/admin/feature-disabled";
 import { InlineError } from "@/ui/components/admin/compact";
 import type { FeatureName } from "@/ui/components/admin/feature-registry";
-import { friendlyError, type FetchError } from "@/ui/lib/fetch-error";
+import { friendlyError, serverMessage, type FetchError } from "@/ui/lib/fetch-error";
 
 type Variant = "banner" | "inline";
 
@@ -84,10 +84,14 @@ export function MutationErrorSurface({
   if (!error) return null;
 
   const isEnterpriseRequired = error.code === "enterprise_required";
+  // The server's own words, or undefined when the body carried none. Never
+  // `error.message` directly: that is `HTTP {status}` on an empty body, and
+  // every consumer below treats this value as prose written for the user.
+  const authored = serverMessage(error);
 
   if (variant === "inline") {
     if (isEnterpriseRequired) {
-      // Pass `error.message` through when the server sent one. Banner variant
+      // Pass the server's message through when it sent one. Banner variant
       // gives it to `EnterpriseUpsell.message`; the inline variant has to
       // render it inline or the server's context-specific copy ("Enterprise
       // tier required on hosted plans — contact sales@…") is lost. The fixed
@@ -97,7 +101,7 @@ export function MutationErrorSurface({
           <span className="font-semibold">
             {feature} requires Enterprise.
           </span>{" "}
-          {error.message && <>{error.message} </>}
+          {authored && <>{authored} </>}
           <a
             href="https://www.useatlas.dev/enterprise"
             target="_blank"
@@ -122,7 +126,7 @@ export function MutationErrorSurface({
   }
 
   if (isEnterpriseRequired) {
-    return <EnterpriseUpsell feature={feature} message={error.message} />;
+    return <EnterpriseUpsell feature={feature} message={authored} />;
   }
 
   if (error.status && [401, 403, 404, 503].includes(error.status)) {
@@ -130,6 +134,8 @@ export function MutationErrorSurface({
       <FeatureGate
         status={error.status as 401 | 403 | 404 | 503}
         feature={feature}
+        message={authored}
+        requestId={error.requestId}
       />
     );
   }

--- a/packages/web/src/ui/components/admin/sso/edit-provider-dialog.tsx
+++ b/packages/web/src/ui/components/admin/sso/edit-provider-dialog.tsx
@@ -244,7 +244,7 @@ function EditProviderDialogInner({
         )}
 
         {detailError && (
-          <ErrorBanner message={detailError.message} />
+          <ErrorBanner message={friendlyError(detailError)} />
         )}
 
         {!detailLoading && !detailError && detail && (

--- a/packages/web/src/ui/lib/fetch-error.ts
+++ b/packages/web/src/ui/lib/fetch-error.ts
@@ -48,6 +48,18 @@ export interface FetchError {
 }
 
 /**
+ * The two messages this module mints when a response body supplies none.
+ *
+ * Functions rather than inline template literals so {@link isSynthesizedMessage}
+ * can be written in terms of the same builders the constructors use. Held
+ * apart as string literals, the predicate and its constructors were one
+ * careless edit away from disagreeing — and the whole `serverMessage` design
+ * rests on them agreeing.
+ */
+const httpStatusMessage = (status: number | string) => `HTTP ${status}`;
+const requestFailedMessage = (status: number | string) => `Request failed (${status})`;
+
+/**
  * Construct a {@link FetchError} with an empty-message invariant.
  *
  * `MutationErrorSurface` / `ErrorBanner` / `InlineError` render `error.message`
@@ -74,10 +86,7 @@ export function buildFetchError(input: {
 }): FetchError {
   const message = input.message?.trim();
   if (!message) {
-    // Placeholder #2 of the two — keep the spelling in step with
-    // `isSynthesizedMessage`, which is what stops surfaces from rendering it
-    // as if the server had written it.
-    const fallback = `Request failed (${input.status ?? "unknown"})`;
+    const fallback = requestFailedMessage(input.status ?? "unknown");
     if (process.env.NODE_ENV !== "production") {
       throw new Error(
         `[buildFetchError] refused to construct FetchError with empty message. ` +
@@ -189,8 +198,7 @@ export async function extractFetchError(res: Response): Promise<FetchError> {
   // always non-empty here (either the body field or the `HTTP ${status}`
   // fallback below), so the dev-throw branch never fires on happy paths.
   return buildFetchError({
-    // Placeholder #1 of the two — see `isSynthesizedMessage`.
-    message: message ?? `HTTP ${res.status}`,
+    message: message ?? httpStatusMessage(res.status),
     status: res.status,
     code,
     requestId,
@@ -240,9 +248,52 @@ export function friendlyErrorOrNull(err: FetchError | null | undefined): string 
  * blank-chrome failure that helper exists to prevent.
  */
 export function serverMessage(err: FetchError): string | undefined {
+  // `status === undefined` stands in for "no HTTP response", which is why a
+  // body `code` without a status reads as "no server message" here. That pair
+  // cannot occur — `extractFetchError` always sets a status, and the
+  // status-less producers (network catch, `schema_mismatch`) never set a
+  // code — so the approximation is exact in practice, not merely convenient.
   if (err.status === undefined) return undefined;
   if (isSynthesizedMessage(err.message, err.status)) return undefined;
   return err.message.trim() || undefined;
+}
+
+/**
+ * The two fields every gated placeholder — `FeatureGate`, `EnterpriseUpsell`,
+ * `MfaRequiredPlaceholder` — takes from a {@link FetchError}, derived once.
+ *
+ * Spread it: `<FeatureGate status={s} feature={f} {...gateProps(err)} />`.
+ *
+ * The placeholders stay purely presentational (plain props, unit-testable
+ * without a `FetchError`), but the decision of *which* two fields and *how*
+ * they are derived stops being replicated per call site. #5068 was one call
+ * site forgetting; the panel review then found a second call site with no test
+ * at all, which is how the same list of statuses had silently diverged there.
+ * Per-call-site discipline does not survive call site four.
+ */
+export interface GateErrorProps {
+  message?: string;
+  requestId?: string;
+}
+
+export function gateProps(err: FetchError): GateErrorProps {
+  return { message: serverMessage(err), requestId: err.requestId };
+}
+
+/**
+ * Is this error's `message` a placeholder this module minted, rather than
+ * text worth showing or transforming?
+ *
+ * The narrower sibling of {@link serverMessage}, for the one caller that must
+ * distinguish "synthesized" from "not the server's" — `combineMutationErrors`
+ * decorates a message with a "+N more" suffix, and a *client*-authored message
+ * ("Network error", a schema-mismatch sentence) is perfectly good to decorate
+ * even though no server wrote it. Only the placeholders are not: suffixing one
+ * yields `"HTTP 403 (+1 more)"`, which no longer matches the sentinels and so
+ * reads as server prose to every surface downstream.
+ */
+export function isPlaceholderMessage(err: FetchError): boolean {
+  return err.status !== undefined && isSynthesizedMessage(err.message, err.status);
 }
 
 /**
@@ -298,7 +349,12 @@ export function friendlyError(err: FetchError): string {
     msg = "This feature is not enabled on this server.";
   else if (err.status === 503)
     msg = "A required service is unavailable. Check server configuration.";
-  else msg = err.message;
+  // Every status without a friendly mapping — 500, 409, 429 — plus the
+  // status-less client failures. `.trim() ||` because a blank here produced
+  // alert chrome carrying nothing but "(Request ID: …)", or nothing at all,
+  // which is indistinguishable from a successful render. The four gated
+  // statuses were covered above; this is the same class on the rest.
+  else msg = err.message.trim() || `Request failed${err.status ? ` (${err.status})` : ""}. Retry; if it persists, check the API service logs.`;
   return appendRequestId(msg, err.requestId);
 }
 
@@ -306,25 +362,26 @@ export function friendlyError(err: FetchError): string {
  * Is this message one *this module* synthesized from the status, rather than
  * anything the server said?
  *
- * There are two spellings, minted in two places, and they must be listed
- * together or the surfaces that branch on "did the server explain itself"
- * recognize one and are fooled by the other:
+ * There are two spellings and they must be recognized together, or a surface
+ * branching on "did the server explain itself" catches one and is fooled by
+ * the other. Both are built by the functions above, which is the point: the
+ * predicate calls the same builders its constructors do, so the two cannot
+ * drift. A placeholder this predicate stops recognizing goes straight back to
+ * being rendered as if a human had written it.
  *
- * - `HTTP {status}` — {@link extractFetchError}, when the body had no
- *   `message` field. The common one.
- * - `Request failed ({status})` — {@link buildFetchError}'s production
- *   substitute for an empty message. Reachable from a real response:
- *   `extractFetchError` admits a whitespace-only `message` (it tests
- *   `length > 0`), which `buildFetchError` then trims to empty. In
- *   development that path throws instead, so this spelling only ever reaches
- *   a user in production — where the dev-throw cannot warn anyone.
+ * `Request failed ({status})` looks unreachable and is not: `extractFetchError`
+ * admits a whitespace-only body `message` (it tests `length > 0`, untrimmed),
+ * which `buildFetchError` then trims to empty and substitutes. In development
+ * that path throws instead, so this spelling only ever reaches a user in
+ * production — where the dev-throw cannot warn anyone.
  *
- * ⚠️ These strings are duplicated from their two construction sites. Change
- * one there and change it here; a placeholder this predicate no longer
- * recognizes goes back to being rendered as if a human had written it.
+ * A third spelling, `Request failed (unknown)`, exists for a status-less
+ * `buildFetchError`. It is covered by {@link serverMessage}'s
+ * `status === undefined` guard rather than by this predicate — relax that
+ * guard and this needs to grow.
  */
 function isSynthesizedMessage(message: string, status: number): boolean {
-  return message === `HTTP ${status}` || message === `Request failed (${status})`;
+  return message === httpStatusMessage(status) || message === requestFailedMessage(status);
 }
 
 function appendRequestId(message: string, requestId: string | undefined): string {

--- a/packages/web/src/ui/lib/fetch-error.ts
+++ b/packages/web/src/ui/lib/fetch-error.ts
@@ -60,6 +60,20 @@ const httpStatusMessage = (status: number | string) => `HTTP ${status}`;
 const requestFailedMessage = (status: number | string) => `Request failed (${status})`;
 
 /**
+ * What to say when the server refused and explained nothing.
+ *
+ * Exported so `FeatureGate`'s 503 arm and `friendlyError` give one answer
+ * rather than two. They disagreed for a while — the gate had been corrected to
+ * stop blaming DATABASE_URL for a restarting replica while this file still
+ * said "Check server configuration", so the same status read as two different
+ * diagnoses one file apart.
+ */
+export function unexplainedFailure(status: number | undefined): string {
+  const code = status === undefined ? "" : ` (${status})`;
+  return `The server returned an error${code} with no explanation — it may be restarting or behind an unhealthy proxy. Retry in a moment; if it persists, check the API service logs.`;
+}
+
+/**
  * Construct a {@link FetchError} with an empty-message invariant.
  *
  * `MutationErrorSurface` / `ErrorBanner` / `InlineError` render `error.message`
@@ -248,11 +262,13 @@ export function friendlyErrorOrNull(err: FetchError | null | undefined): string 
  * blank-chrome failure that helper exists to prevent.
  */
 export function serverMessage(err: FetchError): string | undefined {
-  // `status === undefined` stands in for "no HTTP response", which is why a
-  // body `code` without a status reads as "no server message" here. That pair
-  // cannot occur — `extractFetchError` always sets a status, and the
-  // status-less producers (network catch, `schema_mismatch`) never set a
-  // code — so the approximation is exact in practice, not merely convenient.
+  // `status === undefined` means no HTTP response was parsed, and every
+  // status-less producer in this codebase authors its own message client-side
+  // (the network catch, the non-JSON-body fallback, `schema_mismatch`, the
+  // hand-built errors in `use-admin-mutation` / `use-config-form` /
+  // `query-utils`). So a status-less error never carries server prose — which
+  // holds regardless of `code`. `schema_mismatch` in particular IS status-less
+  // *with* a code, and returning `undefined` for it is right, not a gap.
   if (err.status === undefined) return undefined;
   if (isSynthesizedMessage(err.message, err.status)) return undefined;
   return err.message.trim() || undefined;
@@ -268,8 +284,8 @@ export function serverMessage(err: FetchError): string | undefined {
  * without a `FetchError`), but the decision of *which* two fields and *how*
  * they are derived stops being replicated per call site. #5068 was one call
  * site forgetting; the panel review then found a second call site with no test
- * at all, which is how the same list of statuses had silently diverged there.
- * Per-call-site discipline does not survive call site four.
+ * at all, whose narrower status set turned out to be correct but was
+ * indistinguishable from an accident.
  */
 export interface GateErrorProps {
   message?: string;
@@ -347,14 +363,20 @@ export function friendlyError(err: FetchError): string {
     msg = "Access denied. You may need additional permissions to view this page.";
   else if (err.status === 404)
     msg = "This feature is not enabled on this server.";
-  else if (err.status === 503)
-    msg = "A required service is unavailable. Check server configuration.";
+  else if (err.status === 503) msg = unexplainedFailure(503);
   // Every status without a friendly mapping — 500, 409, 429 — plus the
-  // status-less client failures. `.trim() ||` because a blank here produced
-  // alert chrome carrying nothing but "(Request ID: …)", or nothing at all,
-  // which is indistinguishable from a successful render. The four gated
-  // statuses were covered above; this is the same class on the rest.
-  else msg = err.message.trim() || `Request failed${err.status ? ` (${err.status})` : ""}. Retry; if it persists, check the API service logs.`;
+  // status-less client failures.
+  //
+  // `isPlaceholderMessage`, not a bare `.trim()` and not `serverMessage`.
+  //
+  // A trim check could never fire for the statuses this arm was written for:
+  // an empty-bodied 500 arrives as the placeholder `"HTTP 500"`, which is
+  // non-blank, so the banner rendered the status echo. But `serverMessage` is
+  // too strong here — it discards every status-less message, and those are
+  // client-authored ("Network error", the schema-mismatch sentence) and are
+  // exactly what this arm should show. Only the placeholder and the blank are
+  // worth replacing.
+  else msg = (isPlaceholderMessage(err) ? "" : err.message.trim()) || unexplainedFailure(err.status);
   return appendRequestId(msg, err.requestId);
 }
 

--- a/packages/web/src/ui/lib/fetch-error.ts
+++ b/packages/web/src/ui/lib/fetch-error.ts
@@ -74,6 +74,9 @@ export function buildFetchError(input: {
 }): FetchError {
   const message = input.message?.trim();
   if (!message) {
+    // Placeholder #2 of the two — keep the spelling in step with
+    // `isSynthesizedMessage`, which is what stops surfaces from rendering it
+    // as if the server had written it.
     const fallback = `Request failed (${input.status ?? "unknown"})`;
     if (process.env.NODE_ENV !== "production") {
       throw new Error(
@@ -186,6 +189,7 @@ export async function extractFetchError(res: Response): Promise<FetchError> {
   // always non-empty here (either the body field or the `HTTP ${status}`
   // fallback below), so the dev-throw branch never fires on happy paths.
   return buildFetchError({
+    // Placeholder #1 of the two — see `isSynthesizedMessage`.
     message: message ?? `HTTP ${res.status}`,
     status: res.status,
     code,
@@ -216,22 +220,29 @@ export function friendlyErrorOrNull(err: FetchError | null | undefined): string 
 /**
  * The message the *server* authored, or `undefined` when it authored none.
  *
- * `extractFetchError` substitutes `HTTP {status}` when the response body
- * carried no `message` field, so a bare truthiness check on `err.message`
- * hands that synthetic string to any surface that treats a message as server
- * copy — "HTTP 403" rendered where a gate's canned explanation belongs. This
- * is the same precedence {@link friendlyError} applies before falling back to
- * its status copy, factored out so the gated surfaces (`FeatureGate`,
+ * This module mints two placeholder messages of its own when a body carries
+ * none, and both keep the status alongside them (see
+ * {@link isSynthesizedMessage}). So a bare truthiness check on `err.message`
+ * hands a placeholder to any surface that treats a message as server copy —
+ * "HTTP 403" rendered where a gate's canned explanation belongs. This is the
+ * same precedence {@link friendlyError} applies before falling back to its
+ * status copy, factored out so the gated surfaces (`FeatureGate`,
  * `EnterpriseUpsell`) draw the identical distinction instead of each
- * re-deriving the sentinel.
+ * re-deriving the sentinels.
  *
  * A `FetchError` with no `status` never got an HTTP response at all (network
  * failure) or failed client-side (non-JSON body, schema mismatch), so it has
  * no server message by definition.
+ *
+ * Blank is treated as absent. `buildFetchError` refuses to construct one, but
+ * `FetchError` is a bare interface that anything can build — and a caller that
+ * renders `message ?? canned` would put an empty `<p>` on screen, which is the
+ * blank-chrome failure that helper exists to prevent.
  */
 export function serverMessage(err: FetchError): string | undefined {
   if (err.status === undefined) return undefined;
-  return isHttpStatusFallback(err.message, err.status) ? undefined : err.message;
+  if (isSynthesizedMessage(err.message, err.status)) return undefined;
+  return err.message.trim() || undefined;
 }
 
 /**
@@ -240,9 +251,9 @@ export function serverMessage(err: FetchError): string | undefined {
  * Precedence: a non-empty server-typed message wins over the canned
  * status copy. `extractFetchError` only populates `message` from a real
  * body field, so any string here is server-authored — render it verbatim.
- * The status-code branches are the empty-body fallback;
- * `extractFetchError` substitutes `HTTP {status}` there, which
- * `isHttpStatusFallback` round-trips back to the friendly text.
+ * The status-code branches are the empty-body fallback, which
+ * {@link isSynthesizedMessage} recognizes and round-trips back to the
+ * friendly text.
  */
 export function friendlyError(err: FetchError): string {
   // Schema mismatch only wins for client-side parse failures (status undefined),
@@ -291,8 +302,29 @@ export function friendlyError(err: FetchError): string {
   return appendRequestId(msg, err.requestId);
 }
 
-function isHttpStatusFallback(message: string, status: number): boolean {
-  return message === `HTTP ${status}`;
+/**
+ * Is this message one *this module* synthesized from the status, rather than
+ * anything the server said?
+ *
+ * There are two spellings, minted in two places, and they must be listed
+ * together or the surfaces that branch on "did the server explain itself"
+ * recognize one and are fooled by the other:
+ *
+ * - `HTTP {status}` — {@link extractFetchError}, when the body had no
+ *   `message` field. The common one.
+ * - `Request failed ({status})` — {@link buildFetchError}'s production
+ *   substitute for an empty message. Reachable from a real response:
+ *   `extractFetchError` admits a whitespace-only `message` (it tests
+ *   `length > 0`), which `buildFetchError` then trims to empty. In
+ *   development that path throws instead, so this spelling only ever reaches
+ *   a user in production — where the dev-throw cannot warn anyone.
+ *
+ * ⚠️ These strings are duplicated from their two construction sites. Change
+ * one there and change it here; a placeholder this predicate no longer
+ * recognizes goes back to being rendered as if a human had written it.
+ */
+function isSynthesizedMessage(message: string, status: number): boolean {
+  return message === `HTTP ${status}` || message === `Request failed (${status})`;
 }
 
 function appendRequestId(message: string, requestId: string | undefined): string {

--- a/packages/web/src/ui/lib/fetch-error.ts
+++ b/packages/web/src/ui/lib/fetch-error.ts
@@ -63,14 +63,29 @@ const requestFailedMessage = (status: number | string) => `Request failed (${sta
  * What to say when the server refused and explained nothing.
  *
  * Exported so `FeatureGate`'s 503 arm and `friendlyError` give one answer
- * rather than two. They disagreed for a while — the gate had been corrected to
- * stop blaming DATABASE_URL for a restarting replica while this file still
- * said "Check server configuration", so the same status read as two different
- * diagnoses one file apart.
+ * rather than two. They disagreed for two commits — the gate had been
+ * corrected to stop blaming DATABASE_URL for a restarting replica while this
+ * file still said "Check server configuration", so the same status read as two
+ * different diagnoses one file apart.
+ *
+ * The restarting/proxy guess is 5xx-only, and that boundary is the point. An
+ * unexplained 409 is a conflict, which retrying in a moment reproduces; an
+ * unexplained 429 came from a rate limiter that is working; an unexplained 400
+ * is a client fault, and sending that operator to the API service logs is the
+ * same misdiagnosis-from-status-alone this whole change removed from the 503
+ * arm — one level up. Edge- and proxy-generated 4xx with no JSON body are
+ * exactly the population reaching the caller, so 4xx gets the neutral line.
  */
 export function unexplainedFailure(status: number | undefined): string {
-  const code = status === undefined ? "" : ` (${status})`;
-  return `The server returned an error${code} with no explanation — it may be restarting or behind an unhealthy proxy. Retry in a moment; if it persists, check the API service logs.`;
+  // No status means no HTTP response was parsed at all, so "the server
+  // returned" would be a claim about something that never happened.
+  if (status === undefined) {
+    return "The request failed and no response could be read. Check your network connection; if it persists, check the API service logs.";
+  }
+  if (status >= 500) {
+    return `The server returned an error (${status}) with no explanation — it may be restarting or behind an unhealthy proxy. Retry in a moment; if it persists, check the API service logs.`;
+  }
+  return `The server rejected the request (${status}) with no explanation. If it persists, check the API service logs.`;
 }
 
 /**
@@ -309,7 +324,15 @@ export function gateProps(err: FetchError): GateErrorProps {
  * reads as server prose to every surface downstream.
  */
 export function isPlaceholderMessage(err: FetchError): boolean {
-  return err.status !== undefined && isSynthesizedMessage(err.message, err.status);
+  if (err.status === undefined) {
+    // `serverMessage` never sees this case (it early-returns on a missing
+    // status), but `friendlyError`'s catch-all arm does, and it is where
+    // `buildFetchError`'s third spelling lands: a status-less empty message
+    // becomes `Request failed (unknown)`, which would otherwise render as if
+    // a human had written it.
+    return err.message.trim() === requestFailedMessage("unknown");
+  }
+  return isSynthesizedMessage(err.message, err.status);
 }
 
 /**
@@ -403,7 +426,11 @@ export function friendlyError(err: FetchError): string {
  * guard and this needs to grow.
  */
 function isSynthesizedMessage(message: string, status: number): boolean {
-  return message === httpStatusMessage(status) || message === requestFailedMessage(status);
+  // Trimmed, because every sibling guard on this path trims and this is the
+  // one that decides provenance. A padded `"  HTTP 403  "` slipping through
+  // reads as server prose to the gate — the defect, one space over.
+  const m = message.trim();
+  return m === httpStatusMessage(status) || m === requestFailedMessage(status);
 }
 
 function appendRequestId(message: string, requestId: string | undefined): string {

--- a/packages/web/src/ui/lib/fetch-error.ts
+++ b/packages/web/src/ui/lib/fetch-error.ts
@@ -214,6 +214,27 @@ export function friendlyErrorOrNull(err: FetchError | null | undefined): string 
 }
 
 /**
+ * The message the *server* authored, or `undefined` when it authored none.
+ *
+ * `extractFetchError` substitutes `HTTP {status}` when the response body
+ * carried no `message` field, so a bare truthiness check on `err.message`
+ * hands that synthetic string to any surface that treats a message as server
+ * copy — "HTTP 403" rendered where a gate's canned explanation belongs. This
+ * is the same precedence {@link friendlyError} applies before falling back to
+ * its status copy, factored out so the gated surfaces (`FeatureGate`,
+ * `EnterpriseUpsell`) draw the identical distinction instead of each
+ * re-deriving the sentinel.
+ *
+ * A `FetchError` with no `status` never got an HTTP response at all (network
+ * failure) or failed client-side (non-JSON body, schema mismatch), so it has
+ * no server message by definition.
+ */
+export function serverMessage(err: FetchError): string | undefined {
+  if (err.status === undefined) return undefined;
+  return isHttpStatusFallback(err.message, err.status) ? undefined : err.message;
+}
+
+/**
  * Convert a FetchError into a user-friendly message.
  *
  * Precedence: a non-empty server-typed message wins over the canned
@@ -255,9 +276,8 @@ export function friendlyError(err: FetchError): string {
   // populates `message` from a non-empty body field, so any string here is a
   // real server-typed message — render it. Canned text below covers the
   // empty-body path where the message was substituted to `HTTP {status}`.
-  if (err.status !== undefined && !isHttpStatusFallback(err.message, err.status)) {
-    return appendRequestId(err.message, err.requestId);
-  }
+  const authored = serverMessage(err);
+  if (authored) return appendRequestId(authored, err.requestId);
 
   let msg: string;
   if (err.status === 401) msg = "Not authenticated. Please sign in.";

--- a/packages/web/src/ui/lib/mutation-errors.ts
+++ b/packages/web/src/ui/lib/mutation-errors.ts
@@ -1,4 +1,4 @@
-import type { FetchError } from "@/ui/lib/fetch-error";
+import { isPlaceholderMessage, type FetchError } from "@/ui/lib/fetch-error";
 
 /**
  * Combine multiple mutation error slots into a single banner entry.
@@ -29,5 +29,17 @@ export function combineMutationErrors(
   if (unique.length === 0) return null;
   const primary = unique[0]!;
   if (unique.length === 1) return primary;
-  return { ...primary, message: `${primary.message} (+${unique.length - 1} more)` };
+  // Never build the "+N more" suffix onto a synthesized placeholder.
+  // `"HTTP 403"` decorated to `"HTTP 403 (+1 more)"` stops matching
+  // `serverMessage`'s sentinels, so it reads as server prose to every surface
+  // downstream — and since #5068 those surfaces render it as a gate's only
+  // line of copy, which is the status-echo-where-guidance-belongs defect this
+  // all exists to prevent. Dropping to the generic keeps the count visible
+  // without lying about where the text came from.
+  //
+  // `isPlaceholderMessage`, not `serverMessage`: a message with no status is
+  // client-authored ("Network error") but perfectly good to decorate, and
+  // `serverMessage` would discard it.
+  const base = isPlaceholderMessage(primary) ? "Request failed" : primary.message;
+  return { ...primary, message: `${base} (+${unique.length - 1} more)` };
 }

--- a/packages/web/src/ui/lib/mutation-errors.ts
+++ b/packages/web/src/ui/lib/mutation-errors.ts
@@ -20,26 +20,35 @@ export function combineMutationErrors(
   const seen = new Set<string>();
   const unique: FetchError[] = [];
   for (const err of errors) {
-    if (!err || err.message.length === 0) continue;
-    if (seen.has(err.message)) continue;
-    seen.add(err.message);
+    // Trimmed, to match every other blank guard on this path (`serverMessage`,
+    // `FeatureGate`, `GateRequestId`). A whitespace-only message that became
+    // primary rendered a gate description of "(+1 more)" — icon and headline
+    // over a parenthetical.
+    if (!err || err.message.trim().length === 0) continue;
+    if (seen.has(err.message.trim())) continue;
+    seen.add(err.message.trim());
     unique.push(err);
   }
 
   if (unique.length === 0) return null;
   const primary = unique[0]!;
   if (unique.length === 1) return primary;
-  // Never build the "+N more" suffix onto a synthesized placeholder.
-  // `"HTTP 403"` decorated to `"HTTP 403 (+1 more)"` stops matching
-  // `serverMessage`'s sentinels, so it reads as server prose to every surface
-  // downstream — and since #5068 those surfaces render it as a gate's only
-  // line of copy, which is the status-echo-where-guidance-belongs defect this
-  // all exists to prevent. Dropping to the generic keeps the count visible
-  // without lying about where the text came from.
+  // A placeholder is returned UNDECORATED — not re-worded, not suffixed.
+  //
+  // Any transform of `message` destroys its provenance, because provenance is
+  // recovered by string-comparing against the two spellings this module mints
+  // (`serverMessage`). `"HTTP 403"` suffixed to `"HTTP 403 (+1 more)"` matches
+  // neither, so every downstream surface takes it for the server's own words —
+  // and since #5068 the gated placeholders render exactly that as their only
+  // line of copy. Re-wording it to `"Request failed (+1 more)"` first does not
+  // help: that is equally unrecognized, and it replaces the enterprise upsell's
+  // "Upgrade your plan or contact sales…" with a sentence carrying strictly
+  // less than the canned copy it displaced. The count is cosmetic; the correct
+  // diagnosis is not.
   //
   // `isPlaceholderMessage`, not `serverMessage`: a message with no status is
-  // client-authored ("Network error") but perfectly good to decorate, and
-  // `serverMessage` would discard it.
-  const base = isPlaceholderMessage(primary) ? "Request failed" : primary.message;
-  return { ...primary, message: `${base} (+${unique.length - 1} more)` };
+  // client-authored ("Network error") and decorates fine, but `serverMessage`
+  // would discard it.
+  if (isPlaceholderMessage(primary)) return primary;
+  return { ...primary, message: `${primary.message} (+${unique.length - 1} more)` };
 }

--- a/packages/web/src/ui/lib/mutation-errors.ts
+++ b/packages/web/src/ui/lib/mutation-errors.ts
@@ -31,20 +31,27 @@ export function combineMutationErrors(
   }
 
   if (unique.length === 0) return null;
-  const primary = unique[0]!;
+  // Prefer an error that actually explains itself. A placeholder ("HTTP 403")
+  // as primary would shadow a sibling's real sentence AND its `requestId` —
+  // the surfaces below render the combined error and nothing else, so an
+  // operator would never learn the migration failed on disk space. Order is
+  // otherwise preserved; this only demotes the un-explanatory.
+  const primary = unique.find((e) => !isPlaceholderMessage(e)) ?? unique[0]!;
   if (unique.length === 1) return primary;
-  // A placeholder is returned UNDECORATED — not re-worded, not suffixed.
+  // Reached only when EVERY error is a placeholder, since a non-placeholder
+  // would have been chosen as primary. Return it undecorated — not re-worded,
+  // not suffixed.
   //
   // Any transform of `message` destroys its provenance, because provenance is
-  // recovered by string-comparing against the two spellings this module mints
-  // (`serverMessage`). `"HTTP 403"` suffixed to `"HTTP 403 (+1 more)"` matches
-  // neither, so every downstream surface takes it for the server's own words —
-  // and since #5068 the gated placeholders render exactly that as their only
-  // line of copy. Re-wording it to `"Request failed (+1 more)"` first does not
-  // help: that is equally unrecognized, and it replaces the enterprise upsell's
-  // "Upgrade your plan or contact sales…" with a sentence carrying strictly
-  // less than the canned copy it displaced. The count is cosmetic; the correct
-  // diagnosis is not.
+  // recovered by string-comparing against the two spellings `fetch-error.ts`
+  // mints (see `serverMessage`). `"HTTP 403"` suffixed to `"HTTP 403 (+1 more)"`
+  // matches neither, so every downstream surface takes it for the server's own
+  // words — and since #5068 the gated placeholders render exactly that as their
+  // only line of copy. Re-wording to `"Request failed (+1 more)"` first does
+  // not help: equally unrecognized, and it replaces the enterprise upsell's
+  // "Upgrade your plan or contact sales…" with strictly less than the canned
+  // copy it displaced. Losing the count is the price; losing the diagnosis is
+  // not worth paying.
   //
   // `isPlaceholderMessage`, not `serverMessage`: a message with no status is
   // client-authored ("Network error") and decorates fine, but `serverMessage`


### PR DESCRIPTION
`AdminContentWrapper` routed every gated 401/403/404/503 to `FeatureGate` with `status` + `feature` only, so the server's own explanation and the `requestId` were discarded on ~60 admin pages. The operator on `/admin/brain` read "Enable this feature in your server configuration" for what the server had called "No internal database configured.", and a 4xx nobody expected was uncorrelatable.

Closes #5068

## The fix

- **`serverMessage(err)`** in `fetch-error.ts` — the server's message, or `undefined` when this module synthesized a placeholder. `friendlyError` shares that one implementation instead of re-deriving the sentinel.
- **`gateProps(err)`** — the `{ message, requestId }` pair every gated placeholder takes, derived once and spread at all three call sites. The placeholders stay presentational; the "which two fields, derived how" decision stops being replicated per call site.
- **`FeatureGate`** prefers the server's message on all four statuses and renders the id. On 503 the headline gives way too — `permissions_unavailable` has nothing to do with `DATABASE_URL`.
- **`EnterpriseUpsell` and `MfaRequiredPlaceholder`** carry the id as well, via a shared `GateRequestId`. `enterprise_required` is evaluated one branch *before* the gate, so it was the 403 most likely to arrive unexpectedly and the only one left without a log handle.
- **`GATE_STATUSES` / `isGateStatus`** replace the gated-status set written out at five sites beside three `as` casts — which did not all spell the same list.
- Ten raw `<ErrorBanner message={err.message}>` sites now route through `friendlyError`, gaining the correlation id they were dropping. Zero remain in `packages/web`.

## Acceptance criteria

- [x] A gated 4xx/503 surfaces the server `message` when present, falling back to today's copy when absent
- [x] `requestId` is reachable from the gated surface, as it already is from `ErrorBanner`
- [x] A sweep of the `AdminContentWrapper` call sites confirms no page's copy regresses — 61 call sites; no test or doc outside this diff asserted the canned copy
- [x] `brain/__tests__/read-only-vitals.test.tsx`'s 404 arm re-tightened; the whole-container digit sweep it had dropped is restored

## Review notes — the panel took four rounds

`/review-panel` ran four rounds and **each round found a real defect in the previous round's fix.** That is unusual enough to record here, because it changes how the diff should be read.

| Round | Defect found |
|---|---|
| 1 | `serverMessage` knew one of this module's *two* placeholder spellings; `buildFetchError`'s `Request failed ({status})` is reachable in production via a whitespace-only body. The 503 fallback asserted a `DATABASE_URL` cause no route produces. |
| 2 | Round 1 made 401 *append* its canned sign-in line. Every 401 message the API emits is a bare fragment, so it shipped "Not signed in Please sign in to access the admin console." — and told a **banned account** to sign in. Reverted. |
| 3 | Round 2's combiner fix changed the *spelling*, not the class: `"Request failed (+1 more)"` is equally unrecognized, so the gate still rendered it in place of the canned copy. Round 2's exhaustiveness guard was tautological — `Exclude<GateStatus, …>` derives from the type it guards, so widening kept it assignable (verified: tsgo exit 0). |
| 4 | Round 3's `return primary` then **swallowed sibling errors** — a 500's server message and its `requestId` discarded with nothing on screen. And `unexplainedFailure` gave 4xx a 5xx diagnosis ("may be restarting… retry in a moment" for a 409 conflict), reintroducing the exact diagnose-from-status-alone that round 1 removed from the 503 arm. |

Both of round 4's findings are fixed. The user was asked before round 4 and approved one further round.

**Scope decisions recorded rather than deferred:**
- Declined adding a `serverMessage` field to `FetchError`. It would make the invariant structural, but costs a refactor across ~30 hand-built fixtures and every `friendlyError` consumer — and would force fixtures to duplicate `message` and `serverMessage`, which is the fixtures-agree-by-construction hazard. Both bugs it would have closed are closed by the two-spelling predicate. Worth a follow-up, not this PR.
- Declined making `FeatureGate` take `error?: FetchError`, to keep it presentational and unit-testable with plain props. `gateProps` is the enforcement instead.
- 503 is deliberately **excluded** from the gate sets in `analytics-panel.tsx` and `token-usage/tab.tsx`: a gate there replaces every chart, and unlike 401/403/404 a 503 can fail one of several parallel requests. Round 1 added it; round 2 showed the degradation. Now derived from `GATE_STATUSES` with the exclusion stated and typed.

**Known unpinned:** the `friendlyError` swaps in `entity-version-history.tsx` and `sso/edit-provider-dialog.tsx`. One-liners identical to the eight that are pinned; neither component has a test that renders it.

## Testing

Two new test files for the two page-level gate owners that had **no test at all** — `analytics-panel.tsx` (deleting both new props left the whole suite green) and `token-usage/tab.tsx` (all five mutations to it survived).

Verified by mutation, not just by green: the panel's round-3 sweep ran 58 mutations and round 4 ran 32 more; every survivor either got an assertion or is listed above as knowingly unpinned. Notable kills — reverting any *one* of the five analytics banners, re-admitting 503 to either narrowed gate set, and widening `GATE_STATUSES` (now a compile error, verified in both directions).

`scripts/ci-local.sh`: 33/33 gates green. Full web suite 328/328.