### PR TITLE
feat(brain): the blast-radius counterfactual — collision slot expressions as a parameter, not a fork

### DIFF
--- a/packages/api/src/lib/brain/__tests__/collision-sql-pinned.test.ts
+++ b/packages/api/src/lib/brain/__tests__/collision-sql-pinned.test.ts
@@ -1,0 +1,456 @@
+/**
+ * The collision statements, pinned BYTE FOR BYTE against what `main` emitted
+ * before #5025 parameterized them.
+ *
+ * ## What this file is for, stated narrowly
+ *
+ * #5025's blast-radius preview asks a counterfactual — *what would collide if I
+ * approved this?* — and `supersessionCollisionJoin`'s header forbids the obvious
+ * way to build one: *two spellings of "what collides" is a disclosure that lists
+ * one set while the transaction stamps another*. So the arms stayed
+ * single-spelled and the COLUMNS became a parameter ({@link CollisionExprs}),
+ * with {@link STORED_COLLISION_EXPRS} as every existing caller's default.
+ *
+ * That refactor's entire safety claim is *"the shipped statements are
+ * unchanged"* — and that is exactly the class of claim that is cheap to believe,
+ * invisible when wrong, and lands on a predicate that stamps `valid_to`. A
+ * `toContain` or a shape assertion cannot falsify it: a default that silently
+ * dropped the cardinality gate still contains every substring anyone would think
+ * to check. Only the whole string can.
+ *
+ * The literals below were captured by RUNNING `main`'s modules — not
+ * transcribed — so a transcription error cannot make this test pass against a
+ * statement `main` never emitted.
+ *
+ * ## What it is NOT, and how to change it
+ *
+ * It is not a claim that the collision rule is frozen. A future slice that
+ * genuinely changes an arm SHOULD fail here, read the diff, and update the
+ * literal in the same commit — that is the review moment this file exists to
+ * force. What it refuses is a change that arrives as a side effect of a
+ * refactor nobody meant to be observable.
+ *
+ * Deliberately NOT `toMatchSnapshot()`: an auto-written snapshot updates itself
+ * on `--update-snapshots`, which turns the review moment above into a keystroke.
+ */
+
+import { describe, expect, it } from "bun:test";
+import {
+  CARDINALITY_HELD_BACK_COUNT_SQL,
+  SUPERSEDE_STAMP_EXPLICIT_SQL,
+  SUPERSEDE_STAMP_SQL,
+  SUPERSESSION_TARGETS_SQL,
+  STORED_COLLISION_EXPRS,
+  TIER_HELD_BACK_COUNT_SQL,
+  cardinalityHeldBackCountSql,
+  supersessionCollisionJoin,
+  supersessionCollisionPredicate,
+} from "@atlas/api/lib/content-mode/adapters/brain-facts";
+import { WILL_SUPERSEDE_TOTAL_SQL, willSupersedePairsSql } from "@atlas/api/lib/brain/oversight";
+import { cardinalitySingleSql } from "@atlas/api/lib/brain/cardinality";
+
+const PINNED_CARDINALITY_HELD_BACK_COUNT_SQL =
+  `
+  SELECT COUNT(*)::int AS held_back
+    FROM brain_facts d
+    JOIN brain_facts p
+      ON p.workspace_id = d.workspace_id
+     AND p.subject_key = d.subject_key
+     AND p.predicate_key = d.predicate_key
+     AND (p.object_cmp <> d.object_cmp
+      AND split_part(p.object_cmp, ':', 1) = split_part(d.object_cmp, ':', 1)
+      AND split_part(p.object_cmp, ':', 1) IN ('money', 'number', 'date', 'time', 'bool', 'entity')
+      AND strpos(p.object_cmp, ':') > 0
+      AND strpos(d.object_cmp, ':') > 0)
+     AND ((p.subject_cmp <> d.subject_cmp
+      AND split_part(p.subject_cmp, ':', 1) = split_part(d.subject_cmp, ':', 1)
+      AND split_part(p.subject_cmp, ':', 1) IN ('money', 'number', 'date', 'time', 'bool', 'entity')
+      AND strpos(p.subject_cmp, ':') > 0
+      AND strpos(d.subject_cmp, ':') > 0)) IS NOT TRUE
+     AND p.status = 'published'
+     AND p.invalidated_at IS NULL
+     AND p.valid_to IS NULL
+   WHERE d.workspace_id = $1
+     AND d.status = 'draft' AND d.invalidated_at IS NULL
+     AND d.id = ANY($2::uuid[])
+     AND (NOT jsonb_exists(p.provenance, 'source')
+      OR p.provenance->>'source' = ANY (ARRAY['slack', 'zoom', 'outlook', 'human']::text[]))
+     AND (NOT jsonb_exists(d.provenance, 'source')
+      OR d.provenance->>'source' = ANY (ARRAY['slack', 'zoom', 'outlook', 'human']::text[]))
+     AND NOT EXISTS (
+       SELECT 1 FROM brain_predicate_cardinality c
+        WHERE c.workspace_id = d.workspace_id
+          AND c.predicate_key = d.predicate_key
+          AND c.cardinality = 'single'
+          AND c.status = 'approved')
+`;
+
+const PINNED_TIER_HELD_BACK_COUNT_SQL =
+  `
+  SELECT COUNT(*)::int AS held_back
+    FROM brain_facts d
+    JOIN brain_facts p
+      ON p.workspace_id = d.workspace_id
+     AND p.subject_key = d.subject_key
+     AND p.predicate_key = d.predicate_key
+     AND (p.object_cmp <> d.object_cmp
+      AND split_part(p.object_cmp, ':', 1) = split_part(d.object_cmp, ':', 1)
+      AND split_part(p.object_cmp, ':', 1) IN ('money', 'number', 'date', 'time', 'bool', 'entity')
+      AND strpos(p.object_cmp, ':') > 0
+      AND strpos(d.object_cmp, ':') > 0)
+     AND ((p.subject_cmp <> d.subject_cmp
+      AND split_part(p.subject_cmp, ':', 1) = split_part(d.subject_cmp, ':', 1)
+      AND split_part(p.subject_cmp, ':', 1) IN ('money', 'number', 'date', 'time', 'bool', 'entity')
+      AND strpos(p.subject_cmp, ':') > 0
+      AND strpos(d.subject_cmp, ':') > 0)) IS NOT TRUE
+     AND p.status = 'published'
+     AND p.invalidated_at IS NULL
+     AND p.valid_to IS NULL
+     AND EXISTS (
+       SELECT 1 FROM brain_predicate_cardinality c
+        WHERE c.workspace_id = d.workspace_id
+          AND c.predicate_key = d.predicate_key
+          AND c.cardinality = 'single'
+          AND c.status = 'approved')
+   WHERE d.workspace_id = $1
+     AND d.status = 'draft' AND d.invalidated_at IS NULL
+     AND d.id = ANY($2::uuid[])
+     AND ((NOT jsonb_exists(p.provenance, 'source')
+      OR p.provenance->>'source' = ANY (ARRAY['slack', 'zoom', 'outlook', 'human']::text[])) AND (NOT jsonb_exists(d.provenance, 'source')
+      OR d.provenance->>'source' = ANY (ARRAY['slack', 'zoom', 'outlook', 'human']::text[]))) IS NOT TRUE
+`;
+
+const PINNED_SUPERSESSION_TARGETS_SQL =
+  `
+  SELECT d.id::text AS draft_id, p.id::text AS superseded_id
+    FROM brain_facts d
+    JOIN brain_facts p
+      ON p.workspace_id = d.workspace_id
+     AND p.subject_key = d.subject_key
+     AND p.predicate_key = d.predicate_key
+     AND (p.object_cmp <> d.object_cmp
+      AND split_part(p.object_cmp, ':', 1) = split_part(d.object_cmp, ':', 1)
+      AND split_part(p.object_cmp, ':', 1) IN ('money', 'number', 'date', 'time', 'bool', 'entity')
+      AND strpos(p.object_cmp, ':') > 0
+      AND strpos(d.object_cmp, ':') > 0)
+     AND ((p.subject_cmp <> d.subject_cmp
+      AND split_part(p.subject_cmp, ':', 1) = split_part(d.subject_cmp, ':', 1)
+      AND split_part(p.subject_cmp, ':', 1) IN ('money', 'number', 'date', 'time', 'bool', 'entity')
+      AND strpos(p.subject_cmp, ':') > 0
+      AND strpos(d.subject_cmp, ':') > 0)) IS NOT TRUE
+     AND p.status = 'published'
+     AND p.invalidated_at IS NULL
+     AND p.valid_to IS NULL
+     AND EXISTS (
+       SELECT 1 FROM brain_predicate_cardinality c
+        WHERE c.workspace_id = d.workspace_id
+          AND c.predicate_key = d.predicate_key
+          AND c.cardinality = 'single'
+          AND c.status = 'approved')
+     AND (NOT jsonb_exists(p.provenance, 'source')
+      OR p.provenance->>'source' = ANY (ARRAY['slack', 'zoom', 'outlook', 'human']::text[]))
+     AND (NOT jsonb_exists(d.provenance, 'source')
+      OR d.provenance->>'source' = ANY (ARRAY['slack', 'zoom', 'outlook', 'human']::text[]))
+   WHERE d.workspace_id = $1
+     AND d.status = 'draft' AND d.invalidated_at IS NULL
+     AND d.id = ANY($2::uuid[])
+   ORDER BY d.ingested_at, d.id, p.ingested_at, p.id
+`;
+
+const PINNED_SUPERSEDE_STAMP_SQL =
+  `
+  UPDATE brain_facts p
+     SET valid_to = now(), updated_at = now()
+   WHERE p.workspace_id = $1
+     AND p.id = ANY($2::uuid[])
+     AND p.status = 'published'
+     AND p.invalidated_at IS NULL
+     AND p.valid_to IS NULL
+     AND EXISTS (
+       SELECT 1
+         FROM brain_facts d
+        WHERE d.workspace_id = $1
+          AND d.id = ANY($3::uuid[])
+          AND p.workspace_id = d.workspace_id
+     AND p.subject_key = d.subject_key
+     AND p.predicate_key = d.predicate_key
+     AND (p.object_cmp <> d.object_cmp
+      AND split_part(p.object_cmp, ':', 1) = split_part(d.object_cmp, ':', 1)
+      AND split_part(p.object_cmp, ':', 1) IN ('money', 'number', 'date', 'time', 'bool', 'entity')
+      AND strpos(p.object_cmp, ':') > 0
+      AND strpos(d.object_cmp, ':') > 0)
+     AND ((p.subject_cmp <> d.subject_cmp
+      AND split_part(p.subject_cmp, ':', 1) = split_part(d.subject_cmp, ':', 1)
+      AND split_part(p.subject_cmp, ':', 1) IN ('money', 'number', 'date', 'time', 'bool', 'entity')
+      AND strpos(p.subject_cmp, ':') > 0
+      AND strpos(d.subject_cmp, ':') > 0)) IS NOT TRUE
+     AND p.status = 'published'
+     AND p.invalidated_at IS NULL
+     AND p.valid_to IS NULL
+     AND EXISTS (
+       SELECT 1 FROM brain_predicate_cardinality c
+        WHERE c.workspace_id = d.workspace_id
+          AND c.predicate_key = d.predicate_key
+          AND c.cardinality = 'single'
+          AND c.status = 'approved')
+     AND (NOT jsonb_exists(p.provenance, 'source')
+      OR p.provenance->>'source' = ANY (ARRAY['slack', 'zoom', 'outlook', 'human']::text[]))
+     AND (NOT jsonb_exists(d.provenance, 'source')
+      OR d.provenance->>'source' = ANY (ARRAY['slack', 'zoom', 'outlook', 'human']::text[])))
+   RETURNING p.id::text AS id
+`;
+
+const PINNED_SUPERSEDE_STAMP_EXPLICIT_SQL =
+  `
+  UPDATE brain_facts p
+     SET valid_to = now(), updated_at = now()
+   WHERE p.workspace_id = $1
+     AND p.id = ANY($2::uuid[])
+     AND p.status = 'published'
+     AND p.invalidated_at IS NULL
+     AND p.valid_to IS NULL
+   RETURNING p.id::text AS id
+`;
+
+const PINNED_WILL_SUPERSEDE_TOTAL_SQL =
+  `SELECT COUNT(*)::int AS will_supersede_total
+    FROM brain_facts d
+    JOIN brain_facts p
+      ON p.workspace_id = d.workspace_id
+     AND p.subject_key = d.subject_key
+     AND p.predicate_key = d.predicate_key
+     AND (p.object_cmp <> d.object_cmp
+      AND split_part(p.object_cmp, ':', 1) = split_part(d.object_cmp, ':', 1)
+      AND split_part(p.object_cmp, ':', 1) IN ('money', 'number', 'date', 'time', 'bool', 'entity')
+      AND strpos(p.object_cmp, ':') > 0
+      AND strpos(d.object_cmp, ':') > 0)
+     AND ((p.subject_cmp <> d.subject_cmp
+      AND split_part(p.subject_cmp, ':', 1) = split_part(d.subject_cmp, ':', 1)
+      AND split_part(p.subject_cmp, ':', 1) IN ('money', 'number', 'date', 'time', 'bool', 'entity')
+      AND strpos(p.subject_cmp, ':') > 0
+      AND strpos(d.subject_cmp, ':') > 0)) IS NOT TRUE
+     AND p.status = 'published'
+     AND p.invalidated_at IS NULL
+     AND p.valid_to IS NULL
+     AND EXISTS (
+       SELECT 1 FROM brain_predicate_cardinality c
+        WHERE c.workspace_id = d.workspace_id
+          AND c.predicate_key = d.predicate_key
+          AND c.cardinality = 'single'
+          AND c.status = 'approved')
+     AND (NOT jsonb_exists(p.provenance, 'source')
+      OR p.provenance->>'source' = ANY (ARRAY['slack', 'zoom', 'outlook', 'human']::text[]))
+     AND (NOT jsonb_exists(d.provenance, 'source')
+      OR d.provenance->>'source' = ANY (ARRAY['slack', 'zoom', 'outlook', 'human']::text[]))
+   WHERE d.workspace_id = $1
+     AND d.status = 'draft' AND d.invalidated_at IS NULL`;
+
+const PINNED_JOIN =
+  `JOIN brain_facts p
+      ON p.workspace_id = d.workspace_id
+     AND p.subject_key = d.subject_key
+     AND p.predicate_key = d.predicate_key
+     AND (p.object_cmp <> d.object_cmp
+      AND split_part(p.object_cmp, ':', 1) = split_part(d.object_cmp, ':', 1)
+      AND split_part(p.object_cmp, ':', 1) IN ('money', 'number', 'date', 'time', 'bool', 'entity')
+      AND strpos(p.object_cmp, ':') > 0
+      AND strpos(d.object_cmp, ':') > 0)
+     AND ((p.subject_cmp <> d.subject_cmp
+      AND split_part(p.subject_cmp, ':', 1) = split_part(d.subject_cmp, ':', 1)
+      AND split_part(p.subject_cmp, ':', 1) IN ('money', 'number', 'date', 'time', 'bool', 'entity')
+      AND strpos(p.subject_cmp, ':') > 0
+      AND strpos(d.subject_cmp, ':') > 0)) IS NOT TRUE
+     AND p.status = 'published'
+     AND p.invalidated_at IS NULL
+     AND p.valid_to IS NULL
+     AND EXISTS (
+       SELECT 1 FROM brain_predicate_cardinality c
+        WHERE c.workspace_id = d.workspace_id
+          AND c.predicate_key = d.predicate_key
+          AND c.cardinality = 'single'
+          AND c.status = 'approved')
+     AND (NOT jsonb_exists(p.provenance, 'source')
+      OR p.provenance->>'source' = ANY (ARRAY['slack', 'zoom', 'outlook', 'human']::text[]))
+     AND (NOT jsonb_exists(d.provenance, 'source')
+      OR d.provenance->>'source' = ANY (ARRAY['slack', 'zoom', 'outlook', 'human']::text[]))`;
+
+const PINNED_PREDICATE =
+  `p.workspace_id = d.workspace_id
+     AND p.subject_key = d.subject_key
+     AND p.predicate_key = d.predicate_key
+     AND (p.object_cmp <> d.object_cmp
+      AND split_part(p.object_cmp, ':', 1) = split_part(d.object_cmp, ':', 1)
+      AND split_part(p.object_cmp, ':', 1) IN ('money', 'number', 'date', 'time', 'bool', 'entity')
+      AND strpos(p.object_cmp, ':') > 0
+      AND strpos(d.object_cmp, ':') > 0)
+     AND ((p.subject_cmp <> d.subject_cmp
+      AND split_part(p.subject_cmp, ':', 1) = split_part(d.subject_cmp, ':', 1)
+      AND split_part(p.subject_cmp, ':', 1) IN ('money', 'number', 'date', 'time', 'bool', 'entity')
+      AND strpos(p.subject_cmp, ':') > 0
+      AND strpos(d.subject_cmp, ':') > 0)) IS NOT TRUE
+     AND p.status = 'published'
+     AND p.invalidated_at IS NULL
+     AND p.valid_to IS NULL
+     AND EXISTS (
+       SELECT 1 FROM brain_predicate_cardinality c
+        WHERE c.workspace_id = d.workspace_id
+          AND c.predicate_key = d.predicate_key
+          AND c.cardinality = 'single'
+          AND c.status = 'approved')
+     AND (NOT jsonb_exists(p.provenance, 'source')
+      OR p.provenance->>'source' = ANY (ARRAY['slack', 'zoom', 'outlook', 'human']::text[]))
+     AND (NOT jsonb_exists(d.provenance, 'source')
+      OR d.provenance->>'source' = ANY (ARRAY['slack', 'zoom', 'outlook', 'human']::text[]))`;
+
+const PINNED_CARDINALITY =
+  `EXISTS (
+       SELECT 1 FROM brain_predicate_cardinality c
+        WHERE c.workspace_id = d.workspace_id
+          AND c.predicate_key = d.predicate_key
+          AND c.cardinality = 'single'
+          AND c.status = 'approved')`;
+
+const PINNED_PAIRS =
+  `SELECT d.id::text AS draft_id,
+         d.subject || ' ' || d.predicate || ' ' || d.object AS draft_label,
+         p.id::text AS superseded_id,
+         p.subject || ' ' || p.predicate || ' ' || p.object AS superseded_label,
+         COUNT(*) OVER ()::int AS scoped_total
+    FROM brain_facts d
+    JOIN brain_facts p
+      ON p.workspace_id = d.workspace_id
+     AND p.subject_key = d.subject_key
+     AND p.predicate_key = d.predicate_key
+     AND (p.object_cmp <> d.object_cmp
+      AND split_part(p.object_cmp, ':', 1) = split_part(d.object_cmp, ':', 1)
+      AND split_part(p.object_cmp, ':', 1) IN ('money', 'number', 'date', 'time', 'bool', 'entity')
+      AND strpos(p.object_cmp, ':') > 0
+      AND strpos(d.object_cmp, ':') > 0)
+     AND ((p.subject_cmp <> d.subject_cmp
+      AND split_part(p.subject_cmp, ':', 1) = split_part(d.subject_cmp, ':', 1)
+      AND split_part(p.subject_cmp, ':', 1) IN ('money', 'number', 'date', 'time', 'bool', 'entity')
+      AND strpos(p.subject_cmp, ':') > 0
+      AND strpos(d.subject_cmp, ':') > 0)) IS NOT TRUE
+     AND p.status = 'published'
+     AND p.invalidated_at IS NULL
+     AND p.valid_to IS NULL
+     AND EXISTS (
+       SELECT 1 FROM brain_predicate_cardinality c
+        WHERE c.workspace_id = d.workspace_id
+          AND c.predicate_key = d.predicate_key
+          AND c.cardinality = 'single'
+          AND c.status = 'approved')
+     AND (NOT jsonb_exists(p.provenance, 'source')
+      OR p.provenance->>'source' = ANY (ARRAY['slack', 'zoom', 'outlook', 'human']::text[]))
+     AND (NOT jsonb_exists(d.provenance, 'source')
+      OR d.provenance->>'source' = ANY (ARRAY['slack', 'zoom', 'outlook', 'human']::text[]))
+   WHERE A
+     AND B
+     AND d.status = 'draft' AND d.invalidated_at IS NULL
+   ORDER BY d.ingested_at, d.id, p.ingested_at, p.id
+   LIMIT $3`;
+
+describe("the shipped collision statements are unchanged by #5025's parameterization", () => {
+  it("CARDINALITY_HELD_BACK_COUNT_SQL — #5027's mutation rows still address this text", () => {
+    expect(CARDINALITY_HELD_BACK_COUNT_SQL).toBe(PINNED_CARDINALITY_HELD_BACK_COUNT_SQL);
+  });
+
+  it("TIER_HELD_BACK_COUNT_SQL — #5033's `IS NOT TRUE` polarity survives verbatim", () => {
+    expect(TIER_HELD_BACK_COUNT_SQL).toBe(PINNED_TIER_HELD_BACK_COUNT_SQL);
+  });
+
+  it("SUPERSESSION_TARGETS_SQL — what publish actually stamps", () => {
+    expect(SUPERSESSION_TARGETS_SQL).toBe(PINNED_SUPERSESSION_TARGETS_SQL);
+  });
+
+  it("SUPERSEDE_STAMP_SQL and its explicit twin", () => {
+    expect(SUPERSEDE_STAMP_SQL).toBe(PINNED_SUPERSEDE_STAMP_SQL);
+    expect(SUPERSEDE_STAMP_EXPLICIT_SQL).toBe(PINNED_SUPERSEDE_STAMP_EXPLICIT_SQL);
+  });
+
+  it("the oversight disclosure — the pair that must agree with the stamp", () => {
+    expect(WILL_SUPERSEDE_TOTAL_SQL).toBe(PINNED_WILL_SUPERSEDE_TOTAL_SQL);
+    expect(willSupersedePairsSql("A", "B", 3)).toBe(PINNED_PAIRS);
+  });
+
+  it("the two exported builders at their defaults", () => {
+    expect(supersessionCollisionJoin("d", "p")).toBe(PINNED_JOIN);
+    expect(supersessionCollisionPredicate("d", "p")).toBe(PINNED_PREDICATE);
+  });
+
+  it("cardinalitySingleSql at its default predicate-key expression", () => {
+    expect(cardinalitySingleSql("d")).toBe(PINNED_CARDINALITY);
+  });
+});
+
+describe("the default IS the stored parameterization, not merely equivalent to it", () => {
+  // The pins above prove the DEFAULT path is unchanged. These prove the two
+  // spellings coincide — so a future caller that passes STORED_COLLISION_EXPRS
+  // explicitly (which the preview module does, to say out loud which
+  // counterfactual it is not taking) cannot drift from the omitted form.
+  it("passing STORED_COLLISION_EXPRS explicitly emits the same string as omitting it", () => {
+    expect(supersessionCollisionPredicate("d", "p", STORED_COLLISION_EXPRS)).toBe(
+      supersessionCollisionPredicate("d", "p"),
+    );
+    expect(supersessionCollisionJoin("d", "p", STORED_COLLISION_EXPRS)).toBe(
+      supersessionCollisionJoin("d", "p"),
+    );
+  });
+
+  it("STORED_COLLISION_EXPRS reads the stored columns and nothing else", () => {
+    expect(STORED_COLLISION_EXPRS.subjectKey("x")).toBe("x.subject_key");
+    expect(STORED_COLLISION_EXPRS.predicateKey("x")).toBe("x.predicate_key");
+    expect(STORED_COLLISION_EXPRS.cardinalitySingle("x")).toBe(cardinalitySingleSql("x"));
+  });
+
+  it("the held-back builder at the publish gate's own scope IS the exported constant", () => {
+    // The reuse #5025's issue requires, made checkable: the preview calls this
+    // builder with a predicate scope, and the publish gate's constant is the
+    // same builder with an id-list scope. One statement, two scopes.
+    expect(cardinalityHeldBackCountSql("d.id = ANY($2::uuid[])")).toBe(
+      CARDINALITY_HELD_BACK_COUNT_SQL,
+    );
+  });
+});
+
+describe("the counterfactual seam cannot weaken the rule it evaluates", () => {
+  // The justification for parameterizing at all is that what varies is WHICH
+  // VALUE each side's slot is read from, never WHICH CONJUNCTS must hold. If a
+  // caller could drop the tier guard or the homonym suppression through this
+  // seam, it would be the second spelling the header forbids after all.
+  const hypothetical = {
+    ...STORED_COLLISION_EXPRS,
+    predicateKey: (a: string) => `CASE WHEN ${a}.predicate_key = $9 THEN $10 ELSE ${a}.predicate_key END`,
+  };
+
+  it("a substituted slot expression keeps every conjunct", () => {
+    const sql = supersessionCollisionPredicate("d", "p", hypothetical);
+    // The tier guard, on BOTH sides (#5033).
+    expect(sql).toContain("jsonb_exists(p.provenance, 'source')");
+    expect(sql).toContain("jsonb_exists(d.provenance, 'source')");
+    // The homonym suppression and its inverted polarity (#5032).
+    expect(sql).toContain("IS NOT TRUE");
+    expect(sql).toContain("subject_cmp");
+    // The cardinality gate (#5027).
+    expect(sql).toContain("brain_predicate_cardinality");
+    // The published row's live-and-current state.
+    expect(sql).toContain("p.valid_to IS NULL");
+    expect(sql).toContain("p.invalidated_at IS NULL");
+    // And the substitution actually landed on both sides of the slot arm.
+    expect(sql).toContain("CASE WHEN p.predicate_key = $9");
+    expect(sql).toContain("CASE WHEN d.predicate_key = $9");
+  });
+
+  it("the object position has no slot expression to substitute", () => {
+    // ⚠️ The load-bearing absence. `object_key` appears nowhere in the
+    // collision — the object is compared through `object_cmp`, which no alias
+    // moves. A preview that rendered "0 pairs" for an object-position alias
+    // would be reporting a structural impossibility as an empty result.
+    expect(supersessionCollisionPredicate("d", "p")).not.toContain("object_key");
+    expect(Object.keys(STORED_COLLISION_EXPRS).sort()).toEqual([
+      "cardinalitySingle",
+      "predicateKey",
+      "subjectKey",
+    ]);
+  });
+});

--- a/packages/api/src/lib/brain/__tests__/collision-sql-pinned.test.ts
+++ b/packages/api/src/lib/brain/__tests__/collision-sql-pinned.test.ts
@@ -398,8 +398,8 @@ describe("the default IS the stored parameterization, not merely equivalent to i
   });
 
   it("STORED_COLLISION_EXPRS reads the stored columns and nothing else", () => {
-    expect(STORED_COLLISION_EXPRS.subjectKey("x")).toBe("x.subject_key");
-    expect(STORED_COLLISION_EXPRS.predicateKey("x")).toBe("x.predicate_key");
+    expect(STORED_COLLISION_EXPRS.subjectSlot("x")).toBe("x.subject_key");
+    expect(STORED_COLLISION_EXPRS.predicateSlot("x")).toBe("x.predicate_key");
     expect(STORED_COLLISION_EXPRS.cardinalitySingle("x")).toBe(cardinalitySingleSql("x"));
   });
 
@@ -420,7 +420,7 @@ describe("the counterfactual seam cannot weaken the rule it evaluates", () => {
   // seam, it would be the second spelling the header forbids after all.
   const hypothetical = {
     ...STORED_COLLISION_EXPRS,
-    predicateKey: (a: string) => `CASE WHEN ${a}.predicate_key = $9 THEN $10 ELSE ${a}.predicate_key END`,
+    predicateSlot: (a: string) => `CASE WHEN ${a}.predicate_key = $9 THEN $10 ELSE ${a}.predicate_key END`,
   };
 
   it("a substituted slot expression keeps every conjunct", () => {
@@ -449,8 +449,8 @@ describe("the counterfactual seam cannot weaken the rule it evaluates", () => {
     expect(supersessionCollisionPredicate("d", "p")).not.toContain("object_key");
     expect(Object.keys(STORED_COLLISION_EXPRS).sort()).toEqual([
       "cardinalitySingle",
-      "predicateKey",
-      "subjectKey",
+      "predicateSlot",
+      "subjectSlot",
     ]);
   });
 });

--- a/packages/api/src/lib/brain/__tests__/vocabulary-preview-pg.test.ts
+++ b/packages/api/src/lib/brain/__tests__/vocabulary-preview-pg.test.ts
@@ -423,9 +423,25 @@ describeIfPg("the blast-radius preview against a real schema (#5086)", () => {
 
       expect(after - before).toBe(radius.arming.total);
       expect(radius.arming.total).toBeGreaterThan(0);
-      // The other predicate's pair is still held back, so the flip's blast
-      // radius must NOT have counted it.
-      expect(await supersedesNow()).toBe(after);
+      // ⚠️ The flip is the ONLY kind whose `total` and `pairs` come from two
+      // DIFFERENT statements, so it is the only one where they can disagree.
+      // If `cardinalityFlipExpr` drifted `OR` → `AND`, the delta returns no
+      // pairs while the imported total stays positive → `withheld = total`,
+      // i.e. "N pairs are hidden from you by ACL" shown to an owner who can see
+      // everything. Nothing else in the suite would fail.
+      expect(radius.arming.pairs).toHaveLength(radius.arming.total);
+      expect(radius.arming.withheld).toBe(0);
+      expect(radius.arming.countsConsistent).toBe(true);
+      // ⚠️ NOT `expect(await supersedesNow()).toBe(after)` — that re-read the
+      // same query against an unchanged database and compared it to itself. The
+      // scoping is already caught by the equality above (a globally-TRUE gate
+      // makes `arming.total` 2 against a real delta of 1); what is asserted here
+      // is the complement, that the OTHER predicate's pair is still held back.
+      const otherHeld = await pool.query(
+        cardinalityHeldBackCountSql("d.predicate_key = $2"),
+        [WS, "budget is"],
+      );
+      expect(Number((otherHeld.rows[0] as { held_back: number }).held_back)).toBeGreaterThan(0);
     }, PG_TEST_TIMEOUT_MS);
   });
 
@@ -517,46 +533,166 @@ describeIfPg("the blast-radius preview against a real schema (#5086)", () => {
 
   it("a `{\"source\": null}` pair is excluded by the JOIN, not by the exclusion arm", async () => {
     // ⚠️ The falsifier for an OVERCLAIM this module's docstrings originally
-    // made. `supersedableTierSql` is SQL NULL for this provenance, which is the
-    // shape that makes `NOT (…)` the repo's recurring bug — but here the tier
-    // guard is carried by the JOIN as well, so such a pair never reaches the
-    // exclusion at all and the two spellings are extensionally identical.
+    // made. `supersedableTierSql` is SQL NULL for this provenance, the shape
+    // that makes `NOT (…)` the repo's recurring bug — but the tier guard is
+    // carried by the JOIN as well, so such a pair never reaches the exclusion
+    // and the two spellings are extensionally identical.
     //
-    // Measured rather than reasoned, because the docstring that claimed
-    // otherwise was reasoned.
-    // Both rows share ONE predicate, so the identity arms are already TRUE and
-    // the tier guard is the only arm left to decide the pair. An earlier cut
-    // probed two DIFFERENT predicates before approving the alias — where the
-    // slot arm is plainly FALSE, so the predicate returned `false` and the
-    // probe measured the wrong thing entirely.
-    const published = await land({ subject: "widget", predicate: "priced at", object: "10 USD" });
+    // ⚠️⚠️ The FIRST cut of this test was vacuous, and vacuous in the subtler
+    // way: it landed both rows under `priced at` and then previewed
+    // `is priced at → priced at`. No row was keyed `is priced at`, so the
+    // hypothetical CASE was the identity on every row, `joinExprs ≡
+    // excludeExprs`, and `arming.total === 0` held BY CONSTRUCTION — with the
+    // tier guard deleted, with the exclusion spelled `NOT (…)`, and with
+    // `provenance` untouched. It measured nothing about the preview.
+    //
+    // The shape below is a genuine cross-vocabulary pair, asserted TWICE on the
+    // same fixture: positive before the provenance mutation, zero after. That
+    // is what makes the zero attributable to the tier guard.
+    const published = await land({ subject: "widget", predicate: "is priced at", object: "10 USD" });
     await publish(published);
     const draft = await land({ subject: "widget", predicate: "priced at", object: "12 USD" });
     await curate("priced at");
+
+    const request = {
+      kind: "alias-approval",
+      position: "predicate",
+      fromNorm: "is priced at",
+      toNorm: "priced at",
+    } as const;
+
+    // The positive control: this pair IS armable while both rows carry a
+    // recognised source.
+    const before = await loadBlastRadius(pool, owner(), request);
+    expect(
+      before.arming.total,
+      "the fixture must be armable before the provenance is nulled, or the zero below proves nothing",
+    ).toBeGreaterThan(0);
+
     await pool.query(
       `UPDATE brain_facts SET provenance = jsonb_set(provenance, '{source}', 'null'::jsonb)
         WHERE id = ANY($1::uuid[])`,
       [[published, draft]],
     );
 
-    // The tier guard is NULL on both sides, so the pair is not supersedable...
-    const tierProbe = await pool.query(
-      `SELECT (${supersessionCollisionPredicate("d", "p")}) AS collides
-         FROM brain_facts d JOIN brain_facts p ON p.id = $2::uuid
-        WHERE d.id = $1::uuid`,
-      [draft, published],
-    );
-    expect((tierProbe.rows[0] as { collides: boolean | null }).collides).toBeNull();
+    // ⚠️ NO separate "is the tier arm NULL" probe here, and its absence is
+    // deliberate. Two earlier drafts tried one and both measured the wrong
+    // thing: evaluating `supersessionCollisionPredicate` over this pair returns
+    // FALSE rather than NULL, because the two rows sit in DIFFERENT predicate
+    // slots until the alias is approved, so the identity arm is false and
+    // `FALSE AND NULL` is FALSE. A probe that has to be set up differently from
+    // the fixture it explains is measuring a different pair.
+    //
+    // The before/after on ONE fixture is the attribution, and it is stronger:
+    // the only thing that changed between the two calls is the provenance.
+    const after = await loadBlastRadius(pool, owner(), request);
+    expect(after.arming.total).toBe(0);
+  }, PG_TEST_TIMEOUT_MS);
 
-    // ...and the counterfactual JOIN carries the same guard, so the preview
-    // reports zero for the pair regardless of how the exclusion is spelled.
+  // ── 4b. the subtree walk, past the seed ─────────────────────────────────
+
+  it("a REMOVAL walks the whole subtree, not just the removed norm", async () => {
+    // ⚠️ Every other removal fixture approves ONE edge, whose subtree is the
+    // seed alone — so the recursive arm never returns a row in any test, in any
+    // suite. Measured: reversing the walk's direction (`e.from_norm` →
+    // `e.to_norm`) survives them all. This is the arm the whole "removal
+    // re-derives from the SURFACE" design exists for.
+    //
+    // Chain: `list price → is priced at → priced at`. Removing `is priced at`'s
+    // edge must return BOTH `is priced at` and its child `list price` to the
+    // `is priced at` slot — the grandchild is the row a seed-only substitution
+    // misses.
+    const published = await land({ subject: "widget", predicate: "priced at", object: "10 USD" });
+    await publish(published);
+    await land({ subject: "widget", predicate: "list price", object: "12 USD" });
+    await curate("priced at");
+
+    await approve("is priced at", "priced at");
+    await approve("list price", "is priced at");
+
+    const before = await supersedesNow();
+    expect(before, "the grandchild must be colliding through the chain").toBeGreaterThan(0);
+
+    const radius = await loadBlastRadius(pool, owner(), {
+      kind: "alias-removal",
+      position: "predicate",
+      fromNorm: "is priced at",
+    });
+
+    // The grandchild is in the disarming set — it resolves through the removed
+    // norm even though no edge names it.
+    expect(radius.disarming.total).toBe(before);
+    expect(radius.disarming.countsConsistent).toBe(true);
+  }, PG_TEST_TIMEOUT_MS);
+
+  // ── 4c. the pair projection's orientation ───────────────────────────────
+
+  it("a pair's draft label is the DRAFT's claim, not the published one", async () => {
+    // ⚠️ No test anywhere asserted a pair's CONTENT — `radius.arming.pairs`
+    // appeared zero times in this file. Measured: swapping `d.subject || …` for
+    // `p.subject || …` in `draft_label` survives the entire suite, and the
+    // preview would then tell an approver the superseded claim is the incoming
+    // one — the disclosure read backwards, on the surface whose entire job is
+    // the disclosure. `pairsSelect` is also the one projection NOT byte-pinned.
+    const published = await land({ subject: "widget", predicate: "priced at", object: "10 USD" });
+    await publish(published);
+    await land({ subject: "widget", predicate: "is priced at", object: "12 USD" });
+    await curate("priced at");
+
     const radius = await loadBlastRadius(pool, owner(), {
       kind: "alias-approval",
       position: "predicate",
       fromNorm: "is priced at",
       toNorm: "priced at",
     });
-    expect(radius.arming.total).toBe(0);
+
+    expect(radius.arming.pairs).toHaveLength(1);
+    const pair = radius.arming.pairs[0]!;
+    // The DRAFT is the incoming `12 USD` claim; the SUPERSEDED side is the
+    // published `10 USD` one. Reversed, an approver reads the retirement
+    // backwards.
+    expect(pair.draftLabel).toBe("widget is priced at 12 USD");
+    expect(pair.supersededLabel).toBe("widget priced at 10 USD");
+    // And no key rides along on the projection.
+    expect(JSON.stringify(pair)).not.toContain("_key");
+  }, PG_TEST_TIMEOUT_MS);
+
+  // ── 4d. a restricted reader ─────────────────────────────────────────────
+
+  it("withholds a pair whose PUBLISHED side the reader cannot see, and counts it", async () => {
+    // Nothing measured that the reader scoping works against real SQL — the
+    // unit tests only assert `visible_to &&` appears as a substring.
+    const published = await land({ subject: "widget", predicate: "priced at", object: "10 USD" });
+    await publish(published);
+    await land({ subject: "widget", predicate: "is priced at", object: "12 USD" });
+    await curate("priced at");
+    // Narrow the published row to an audience the reader below does not hold.
+    await pool.query(`UPDATE brain_facts SET visible_to = ARRAY['audience:secret'] WHERE id = $1::uuid`, [
+      published,
+    ]);
+
+    const restricted: BrainPrincipalContext = {
+      origin: "authenticated",
+      workspaceId: WS,
+      userId: "user-restricted",
+      role: "member",
+      audienceIds: [],
+    };
+    const radius = await loadBlastRadius(pool, restricted, {
+      kind: "alias-approval",
+      position: "predicate",
+      fromNorm: "is priced at",
+      toNorm: "priced at",
+    });
+
+    // The supersession happens regardless of who is looking — the unscoped
+    // total sees it...
+    expect(radius.arming.total).toBe(1);
+    // ...but the reader may not read the published side, so no pair is listed
+    // and the difference is disclosed as `withheld` rather than omitted.
+    expect(radius.arming.pairs).toHaveLength(0);
+    expect(radius.arming.withheld).toBe(1);
+    expect(radius.arming.countsConsistent).toBe(true);
   }, PG_TEST_TIMEOUT_MS);
 
   // ── 5. the fourth arm of the union ──────────────────────────────────────

--- a/packages/api/src/lib/brain/__tests__/vocabulary-preview-pg.test.ts
+++ b/packages/api/src/lib/brain/__tests__/vocabulary-preview-pg.test.ts
@@ -1,0 +1,603 @@
+/**
+ * The blast-radius preview against a real schema (#5025 / #5086, ADR-0037 §6).
+ *
+ * `vocabulary-preview.test.ts` pins the SQL shapes and the refusals. This file
+ * is where the only claim that actually matters can be made, because it is a
+ * claim about two statements agreeing with a WRITE:
+ *
+ *   **the preview equals what the decision actually does.**
+ *
+ * ## What "equals" means here, stated precisely because the AC's wording is loose
+ *
+ * #5025's AC reads *"the preview total equals what the re-key actually
+ * changes"*. Taken literally that compares a PAIR count to a ROW count, which
+ * are different quantities — the re-key moves keys, the preview counts
+ * supersedable pairs. The property that carries the AC's intent, and the one
+ * asserted below, is the DELTA:
+ *
+ *   `supersedesAfter − supersedesBefore  ==  preview.arming.total`
+ *   `supersedesBefore − supersedesAfter  ==  preview.disarming.total`
+ *
+ * measured through `WILL_SUPERSEDE_TOTAL_SQL` — the publish gate's own
+ * disclosure, not a restatement — taken before and after the real decide seam
+ * runs. That is one level up from `oversight.ts:800-803`: the preview and the
+ * transaction agree because the preview PREDICTED the transaction, rather than
+ * because both were built from the same string.
+ *
+ * ## The fixtures are landed under the EMPTY vocabulary, deliberately
+ *
+ * `vocabulary-rekey-pg.test.ts`'s reason, and it is the same trap: landing rows
+ * under the post-approval vocabulary makes the re-key a no-op and every
+ * assertion vacuously true.
+ *
+ * ## A fixture per arm of the request union
+ *
+ * #5030's lesson — *a disjunction needs a fixture per arm, and the gap is found
+ * by MEASURING rather than by reading*. The union has four arms
+ * (alias-approval, alias-removal, cardinality-flip, cardinality-removal) and
+ * three positions, and the object position's arm is a structural claim rather
+ * than a count.
+ */
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
+import { Pool } from "pg";
+import { runMigrations } from "@atlas/api/lib/db/migrate";
+import { MANAGED_AUTH_MIGRATIONS, _resetPool } from "@atlas/api/lib/db/internal";
+import { identityVocabulary, type SlotPosition } from "@atlas/api/lib/brain/identity";
+import {
+  decideAliasProposal,
+  proposeAliasEdge,
+} from "@atlas/api/lib/brain/vocabulary-decide";
+import { declarePredicateCardinality } from "@atlas/api/lib/brain/cardinality";
+import { reconcileFacts, type ReconcileEpisodeRef } from "@atlas/api/lib/brain/reconcile";
+import {
+  WILL_SUPERSEDE_TOTAL_SQL,
+} from "@atlas/api/lib/brain/oversight";
+import {
+  STORED_COLLISION_EXPRS,
+  cardinalityHeldBackCountSql,
+  supersedingDraftPredicate,
+  supersessionCollisionPredicate,
+} from "@atlas/api/lib/content-mode/adapters/brain-facts";
+import { loadBlastRadius } from "@atlas/api/lib/brain/vocabulary-preview";
+import type { BrainPrincipalContext } from "@atlas/api/lib/brain/acl";
+
+const TEST_DB_URL = process.env.TEST_DATABASE_URL;
+const describeIfPg = TEST_DB_URL ? describe : describe.skip;
+const PG_TEST_TIMEOUT_MS = 60_000;
+
+const WS = "ws-preview-5086";
+
+describeIfPg("the blast-radius preview against a real schema (#5086)", () => {
+  let pool: Pool;
+  const schemaName = `brain_5086_${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
+  let priorDatabaseUrl: string | undefined;
+
+  beforeAll(async () => {
+    priorDatabaseUrl = process.env.DATABASE_URL;
+    process.env.DATABASE_URL = TEST_DB_URL;
+    pool = new Pool({
+      connectionString: TEST_DB_URL,
+      options: `-c search_path="${schemaName}",public`,
+    });
+    const bootstrap = new Pool({ connectionString: TEST_DB_URL });
+    try {
+      await bootstrap.query(`CREATE SCHEMA IF NOT EXISTS "${schemaName}"`);
+    } finally {
+      await bootstrap.end();
+    }
+    await runMigrations(pool, { skip: MANAGED_AUTH_MIGRATIONS });
+    _resetPool(pool);
+  }, PG_TEST_TIMEOUT_MS);
+
+  afterAll(async () => {
+    _resetPool(null);
+    if (priorDatabaseUrl === undefined) delete process.env.DATABASE_URL;
+    else process.env.DATABASE_URL = priorDatabaseUrl;
+    if (pool) {
+      await pool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+      await pool.end();
+    }
+  }, PG_TEST_TIMEOUT_MS);
+
+  afterEach(async () => {
+    // Targets BEFORE edges — `fk_brain_vocabulary_target_edge` is RESTRICT.
+    await pool.query("DELETE FROM brain_vocabulary_target");
+    await pool.query("DELETE FROM brain_vocabulary_edge");
+    await pool.query("DELETE FROM brain_vocabulary_proposal");
+    await pool.query("DELETE FROM brain_predicate_cardinality");
+    await pool.query("DELETE FROM brain_edges");
+    await pool.query("DELETE FROM brain_facts");
+    await pool.query("DELETE FROM brain_episodes");
+  });
+
+  // ── helpers ─────────────────────────────────────────────────────────────
+
+  const owner = (workspaceId = WS): BrainPrincipalContext => ({
+    origin: "authenticated",
+    workspaceId,
+    userId: "user-owner",
+    role: "owner",
+    audienceIds: ["org"],
+  });
+
+  let episodeSeq = 0;
+  async function seedEpisode(workspaceId: string): Promise<ReconcileEpisodeRef> {
+    const occurredAt = new Date("2026-06-21T09:00:00.000Z");
+    const sourceId = `C01:5086.${episodeSeq++}`;
+    const { rows } = await pool.query<{ id: string }>(
+      `INSERT INTO brain_episodes
+         (workspace_id, source, source_id, source_actor, body, occurred_at, visible_to)
+       VALUES ($1, 'slack', $2, 'U123', 'evidence', $3::timestamptz, ARRAY['org'])
+       RETURNING id`,
+      [workspaceId, sourceId, occurredAt.toISOString()],
+    );
+    return {
+      id: rows[0]!.id,
+      workspaceId,
+      source: "slack",
+      sourceId,
+      sourceActor: "U123",
+      occurredAt,
+      visibleTo: ["org"],
+    };
+  }
+
+  interface Claim {
+    readonly subject: string;
+    readonly predicate: string;
+    readonly object: string;
+  }
+
+  /**
+   * Land one claim through the real ingest stage, under the EMPTY vocabulary.
+   *
+   * ⚠️ **Asserts the object parses to a COMPARABLE VALUE, and that assertion is
+   * the difference between this suite and a vacuous one.** The collision
+   * requires the two objects to be PROVABLY DIFFERENT (#5030), which is
+   * `object_cmp <> object_cmp` under a shared known tag — and a bare name
+   * ABSTAINS, leaving `object_cmp` NULL. Measured: `bob`, `carol`, `berlin`,
+   * `munich` all abstain; `10`, `20`, `10 USD`, `12 USD` resolve.
+   *
+   * A fixture built from names therefore collides with NOTHING, so every
+   * before/after count is 0 and every assertion of the form
+   * `after - before === radius.total` holds at `0 === 0`. Four tests in the
+   * first cut of this file were exactly that, and the object-position test was
+   * the dangerous one: it "proved" an object alias arms nothing while the
+   * fixture made every alias arm nothing.
+   */
+  async function land(claim: Claim, workspaceId = WS): Promise<string> {
+    const episode = await seedEpisode(workspaceId);
+    const report = await reconcileFacts({
+      vocabulary: identityVocabulary,
+      episode,
+      candidates: [{ ...claim, predicateCardinality: "single" }],
+      producer: "preview-5086",
+      extractedAt: new Date("2026-06-21T10:00:00.000Z"),
+    });
+    expect(
+      report.outcomes[0],
+      `"${claim.subject} ${claim.predicate} ${claim.object}" was refused, not landed`,
+    ).not.toMatchObject({ kind: "blocked" });
+    const { rows } = await pool.query<{ id: string; object_cmp: string | null }>(
+      `SELECT id::text AS id, object_cmp FROM brain_facts
+        WHERE workspace_id = $1 AND subject = $2 AND predicate = $3 AND object = $4`,
+      [workspaceId, claim.subject, claim.predicate, claim.object],
+    );
+    expect(rows).toHaveLength(1);
+    expect(
+      rows[0]!.object_cmp,
+      `"${claim.object}" abstained — it has no comparable value, so this row can never be ` +
+        "provably different from anything and every collision count below would be a vacuous 0",
+    ).not.toBeNull();
+    return rows[0]!.id;
+  }
+
+  /** Promote one row to `published` — the side a draft supersedes. */
+  async function publish(id: string): Promise<void> {
+    await pool.query(`UPDATE brain_facts SET status = 'published' WHERE id = $1::uuid`, [id]);
+  }
+
+  /** The publish gate's OWN disclosure — never a restatement of it. */
+  async function supersedesNow(workspaceId = WS): Promise<number> {
+    const { rows } = await pool.query(WILL_SUPERSEDE_TOTAL_SQL, [workspaceId]);
+    return Number((rows[0] as { will_supersede_total: number }).will_supersede_total);
+  }
+
+  async function approve(
+    fromNorm: string,
+    toNorm: string,
+    position: SlotPosition = "predicate",
+    workspaceId = WS,
+  ): Promise<string> {
+    const queued = await proposeAliasEdge(workspaceId, {
+      position,
+      fromNorm,
+      toNorm,
+      directed: true,
+      sourceClass: "human",
+      confidence: 1,
+      proposedBy: "user-owner",
+    });
+    expect(queued.kind).toBe("queued");
+    if (queued.kind !== "queued") throw new Error("unreachable");
+    const decided = await decideAliasProposal({
+      id: queued.id,
+      workspaceId,
+      decision: "approved",
+      approver: { kind: "human", ctx: owner(workspaceId) },
+    });
+    expect(decided.kind, `approving ${fromNorm} → ${toNorm} did not land`).toBe("approved");
+    return queued.id;
+  }
+
+  async function removeEdge(proposalId: string, workspaceId = WS): Promise<void> {
+    const decided = await decideAliasProposal({
+      id: proposalId,
+      workspaceId,
+      decision: "rejected",
+      approver: { kind: "human", ctx: owner(workspaceId) },
+    });
+    expect(decided).toMatchObject({ kind: "rejected", removedEdge: true });
+  }
+
+  /**
+   * Curate one canonical predicate `single`, through the real seam.
+   *
+   * ONE call, not propose-then-decide: `declarePredicateCardinality` is the
+   * direct-human-authoring path (ADR-0037 §3(d)3) and writes `approved` in one
+   * step, *because the human IS the approval*. Routing the fixture through
+   * `decidePredicateCardinality` instead would be exercising the PRODUCER path,
+   * which writes `pending` — and a pending row is deliberately invisible to
+   * `cardinalitySingleSql`, so every fixture below would have silently
+   * collided with nothing.
+   */
+  async function curate(predicateSurface: string, workspaceId = WS): Promise<void> {
+    const declared = await declarePredicateCardinality(pool, workspaceId, {
+      predicateKey: predicateSurface,
+      cardinality: "single",
+      authoredBy: "user-owner",
+    });
+    expect(declared.ok, `declaring ${predicateSurface} single failed`).toBe(true);
+  }
+
+  // ── 1. the parity property ──────────────────────────────────────────────
+
+  describe("the preview equals what the decision actually does", () => {
+    it("an ALIAS approval arms exactly the pairs the preview promised", async () => {
+      // Two spellings of one predicate, in one subject slot, with provably
+      // different objects. Today they key apart, so nothing collides.
+      const published = await land({
+        subject: "widget",
+        predicate: "is priced at",
+        object: "10 USD",
+      });
+      await publish(published);
+      await land({ subject: "widget", predicate: "priced at", object: "12 USD" });
+      // The merged slot's canonical predicate must be curated, or the
+      // cardinality gate holds the pair back and the merge arms nothing.
+      await curate("priced at");
+
+      const before = await supersedesNow();
+      const radius = await loadBlastRadius(pool, owner(), {
+        kind: "alias-approval",
+        position: "predicate",
+        fromNorm: "is priced at",
+        toNorm: "priced at",
+      });
+
+      await approve("is priced at", "priced at");
+      const after = await supersedesNow();
+
+      // THE property. Not "the preview returned a plausible number" — the
+      // preview predicted the transaction, and the transaction is measured
+      // through its own disclosure statement.
+      expect(after - before).toBe(radius.arming.total);
+      // And the preview was not trivially zero, which would satisfy the
+      // equation while proving nothing.
+      expect(radius.arming.total).toBeGreaterThan(0);
+      expect(radius.disarming.total).toBe(0);
+    }, PG_TEST_TIMEOUT_MS);
+
+    it("…and follows the CARDINALITY lookup to the merged slot (the compound case)", async () => {
+      // ⚠️ The fixture the test above CANNOT express, found by mutation: there,
+      // the moving row is the PUBLISHED one and the draft already sits on the
+      // curated predicate, so the stored cardinality lookup and the
+      // re-pointed one agree and deleting the re-point kills nothing.
+      //
+      // Here the DRAFT is the row that moves. `is priced at` is uncurated, so
+      // the stored lookup says "not single" and the pair cannot collide today;
+      // `priced at` IS curated, so after the merge it can. This is exactly the
+      // case ADR-0037 §6's amendment exists for — *supersession is armed for
+      // claims that were safe a moment earlier* — and a bundle that moved only
+      // the slot arm reports it as zero.
+      const published = await land({ subject: "widget", predicate: "priced at", object: "10 USD" });
+      await publish(published);
+      await land({ subject: "widget", predicate: "is priced at", object: "12 USD" });
+      await curate("priced at");
+
+      const before = await supersedesNow();
+      expect(before, "the draft's own predicate is uncurated, so nothing collides yet").toBe(0);
+
+      const radius = await loadBlastRadius(pool, owner(), {
+        kind: "alias-approval",
+        position: "predicate",
+        fromNorm: "is priced at",
+        toNorm: "priced at",
+      });
+      await approve("is priced at", "priced at");
+      const after = await supersedesNow();
+
+      expect(after - before).toBe(radius.arming.total);
+      expect(radius.arming.total).toBeGreaterThan(0);
+    }, PG_TEST_TIMEOUT_MS);
+
+    it("…and resolves the target through an EXISTING chain, not to the norm as typed", async () => {
+      // ⚠️ Mutation survivor: substituting `toNorm` instead of its effective
+      // target passes every single-edge fixture, because with no chain the two
+      // are the same string. `approvalKeyExpr`'s ⚠️ names this; only a
+      // two-level chain measures it.
+      //
+      // `priced at → unit price` is already approved, so approving
+      // `is priced at → priced at` lands the merged population on **unit
+      // price**, and a preview keyed on `priced at` computes a slot the re-key
+      // never writes.
+      const published = await land({ subject: "widget", predicate: "unit price", object: "10 USD" });
+      await publish(published);
+      await land({ subject: "widget", predicate: "is priced at", object: "12 USD" });
+      await curate("unit price");
+      await approve("priced at", "unit price");
+
+      const before = await supersedesNow();
+      expect(before, "the draft is not yet in the merged slot").toBe(0);
+
+      const radius = await loadBlastRadius(pool, owner(), {
+        kind: "alias-approval",
+        position: "predicate",
+        fromNorm: "is priced at",
+        toNorm: "priced at",
+      });
+      await approve("is priced at", "priced at");
+      const after = await supersedesNow();
+
+      expect(after - before).toBe(radius.arming.total);
+      expect(radius.arming.total).toBeGreaterThan(0);
+    }, PG_TEST_TIMEOUT_MS);
+
+    it("an ALIAS removal disarms exactly the pairs the preview promised", async () => {
+      const published = await land({
+        subject: "widget",
+        predicate: "is priced at",
+        object: "10 USD",
+      });
+      await publish(published);
+      await land({ subject: "widget", predicate: "priced at", object: "12 USD" });
+      await curate("priced at");
+      const proposalId = await approve("is priced at", "priced at");
+
+      const before = await supersedesNow();
+      expect(before, "the fixture must be colliding before the removal").toBeGreaterThan(0);
+
+      const radius = await loadBlastRadius(pool, owner(), {
+        kind: "alias-removal",
+        position: "predicate",
+        fromNorm: "is priced at",
+      });
+
+      await removeEdge(proposalId);
+      const after = await supersedesNow();
+
+      // The mirror. This is the arm a key-to-key substitution gets WRONG —
+      // `REKEY_DRIFTED_FACTS_SQL`'s header says why, and the removal
+      // counterfactual re-derives from the surface for exactly this test.
+      expect(before - after).toBe(radius.disarming.total);
+      expect(radius.disarming.total).toBeGreaterThan(0);
+      expect(radius.arming.total).toBe(0);
+    }, PG_TEST_TIMEOUT_MS);
+
+    it("a CARDINALITY flip arms exactly the pairs the preview promised", async () => {
+      const published = await land({ subject: "alice", predicate: "headcount is", object: "10" });
+      await publish(published);
+      await land({ subject: "alice", predicate: "headcount is", object: "20" });
+
+      // ⚠️ A SECOND collidable-but-uncurated predicate, and it is not scenery.
+      // Mutation survivor: forcing the flip's cardinality gate to `TRUE`
+      // globally — rather than scoping it to the one key — passes every
+      // single-predicate fixture, because with nothing else in the workspace
+      // "all predicates" and "this predicate" are the same set. This row is
+      // what makes the flip's scoping measurable.
+      const otherPublished = await land({ subject: "dan", predicate: "budget is", object: "100 USD" });
+      await publish(otherPublished);
+      await land({ subject: "dan", predicate: "budget is", object: "200 USD" });
+
+      const before = await supersedesNow();
+      expect(before, "an uncurated predicate supersedes nothing").toBe(0);
+
+      const radius = await loadBlastRadius(pool, owner(), {
+        kind: "cardinality-flip",
+        predicateSurface: "headcount is",
+      });
+
+      await curate("headcount is");
+      const after = await supersedesNow();
+
+      expect(after - before).toBe(radius.arming.total);
+      expect(radius.arming.total).toBeGreaterThan(0);
+      // The other predicate's pair is still held back, so the flip's blast
+      // radius must NOT have counted it.
+      expect(await supersedesNow()).toBe(after);
+    }, PG_TEST_TIMEOUT_MS);
+  });
+
+  // ── 2. the imported statement and the delta agree ───────────────────────
+
+  it("the imported held-back count and the delta spelling agree on a real corpus", async () => {
+    // #5025's handoff requires the flip's total to IMPORT
+    // `CARDINALITY_HELD_BACK_COUNT_SQL` rather than re-derive the cardinality
+    // half. That reuse is only meaningful if the two spellings answer the same
+    // question — asserted here rather than claimed in a docstring.
+    const published = await land({ subject: "alice", predicate: "headcount is", object: "10" });
+    await publish(published);
+    await land({ subject: "alice", predicate: "headcount is", object: "20" });
+    const otherPublished = await land({ subject: "dan", predicate: "budget is", object: "100 USD" });
+    await publish(otherPublished);
+    await land({ subject: "dan", predicate: "budget is", object: "200 USD" });
+
+    const imported = await pool.query(cardinalityHeldBackCountSql("d.predicate_key = $2"), [
+      WS,
+      "headcount is",
+    ]);
+    const importedTotal = Number((imported.rows[0] as { held_back: number }).held_back);
+
+    // The delta spelling, built from the same public seam the preview uses.
+    const flipExprs = {
+      ...STORED_COLLISION_EXPRS,
+      cardinalitySingle: (alias: string) =>
+        `(${alias}.predicate_key = $2 OR ${STORED_COLLISION_EXPRS.cardinalitySingle(alias)})`,
+    };
+    const delta = await pool.query(
+      `SELECT COUNT(*)::int AS n
+         FROM brain_facts d
+         JOIN brain_facts p ON ${supersessionCollisionPredicate("d", "p", flipExprs)}
+        WHERE d.workspace_id = $1
+          AND ${supersedingDraftPredicate("d")}
+          AND (${supersessionCollisionPredicate("d", "p")}) IS NOT TRUE
+          AND d.predicate_key = $2`,
+      [WS, "headcount is"],
+    );
+    const deltaTotal = Number((delta.rows[0] as { n: number }).n);
+
+    expect(importedTotal).toBe(deltaTotal);
+    // Non-vacuous, and scoped: the OTHER predicate's collidable pair must not
+    // be in either count, or the agreement would hold for the wrong reason.
+    expect(importedTotal).toBeGreaterThan(0);
+  }, PG_TEST_TIMEOUT_MS);
+
+  // ── 3. the object position, as a structural claim ───────────────────────
+
+  it("an OBJECT-position alias arms nothing, and the preview says why rather than returning 0", async () => {
+    // The finding the design pass did not have: the collision joins on
+    // `subject_key`, `predicate_key` and `object_cmp` — `object_key` is nowhere
+    // in it. Proved against the real schema by merging two object surfaces and
+    // measuring the gate's own disclosure across the approval.
+    // ⚠️ TYPED objects, and this is the whole design of the test. With
+    // abstaining objects (`nova` / `project atlas`) the pair could not collide
+    // for a reason that has nothing to do with the object POSITION, so
+    // `after === before` would hold at `0 === 0` and prove nothing. Typed
+    // objects make the pair genuinely collidable, so the count is positive on
+    // BOTH sides and the invariance is a real measurement.
+    const published = await land({ subject: "widget", predicate: "ships in", object: "10" });
+    await publish(published);
+    await land({ subject: "widget", predicate: "ships in", object: "20" });
+    await curate("ships in");
+
+    const before = await supersedesNow();
+    expect(before, "the fixture must be genuinely collidable, or the invariance is vacuous").toBeGreaterThan(0);
+
+    const radius = await loadBlastRadius(pool, owner(), {
+      kind: "alias-approval",
+      position: "object",
+      fromNorm: "10",
+      toNorm: "20",
+    });
+    await approve("10", "20", "object");
+    const after = await supersedesNow();
+
+    // The structural claim, measured: merging two object SURFACES moved
+    // `object_key`, which the collision does not read — so the supersession
+    // count is unchanged, and unchanged at a NON-ZERO value.
+    expect(after).toBe(before);
+    // ...and the preview reported a REASON rather than a zero, which is the
+    // whole point — "0 pairs" and "this position cannot produce pairs" are the
+    // same number and opposite facts.
+    expect(radius.structurallyEmpty).toBe("object-position");
+  }, PG_TEST_TIMEOUT_MS);
+
+  // ── 4. the IS NOT TRUE equivalence, measured rather than claimed ────────
+
+  it("a `{\"source\": null}` pair is excluded by the JOIN, not by the exclusion arm", async () => {
+    // ⚠️ The falsifier for an OVERCLAIM this module's docstrings originally
+    // made. `supersedableTierSql` is SQL NULL for this provenance, which is the
+    // shape that makes `NOT (…)` the repo's recurring bug — but here the tier
+    // guard is carried by the JOIN as well, so such a pair never reaches the
+    // exclusion at all and the two spellings are extensionally identical.
+    //
+    // Measured rather than reasoned, because the docstring that claimed
+    // otherwise was reasoned.
+    // Both rows share ONE predicate, so the identity arms are already TRUE and
+    // the tier guard is the only arm left to decide the pair. An earlier cut
+    // probed two DIFFERENT predicates before approving the alias — where the
+    // slot arm is plainly FALSE, so the predicate returned `false` and the
+    // probe measured the wrong thing entirely.
+    const published = await land({ subject: "widget", predicate: "priced at", object: "10 USD" });
+    await publish(published);
+    const draft = await land({ subject: "widget", predicate: "priced at", object: "12 USD" });
+    await curate("priced at");
+    await pool.query(
+      `UPDATE brain_facts SET provenance = jsonb_set(provenance, '{source}', 'null'::jsonb)
+        WHERE id = ANY($1::uuid[])`,
+      [[published, draft]],
+    );
+
+    // The tier guard is NULL on both sides, so the pair is not supersedable...
+    const tierProbe = await pool.query(
+      `SELECT (${supersessionCollisionPredicate("d", "p")}) AS collides
+         FROM brain_facts d JOIN brain_facts p ON p.id = $2::uuid
+        WHERE d.id = $1::uuid`,
+      [draft, published],
+    );
+    expect((tierProbe.rows[0] as { collides: boolean | null }).collides).toBeNull();
+
+    // ...and the counterfactual JOIN carries the same guard, so the preview
+    // reports zero for the pair regardless of how the exclusion is spelled.
+    const radius = await loadBlastRadius(pool, owner(), {
+      kind: "alias-approval",
+      position: "predicate",
+      fromNorm: "is priced at",
+      toNorm: "priced at",
+    });
+    expect(radius.arming.total).toBe(0);
+  }, PG_TEST_TIMEOUT_MS);
+
+  // ── 5. the fourth arm of the union ──────────────────────────────────────
+
+  it("a CARDINALITY removal disarms exactly the pairs the preview promised", async () => {
+    const published = await land({ subject: "alice", predicate: "headcount is", object: "10" });
+    await publish(published);
+    await land({ subject: "alice", predicate: "headcount is", object: "20" });
+    await curate("headcount is");
+
+    const before = await supersedesNow();
+    expect(before, "the curated fixture must be colliding").toBeGreaterThan(0);
+
+    const radius = await loadBlastRadius(pool, owner(), {
+      kind: "cardinality-removal",
+      predicateSurface: "headcount is",
+    });
+    expect(radius.disarming.total).toBe(before);
+    expect(radius.arming.total).toBe(0);
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("a SUBJECT-position alias arms pairs — the position the predicate fixtures cannot probe", async () => {
+    // Round 2 of #5024's panel: a suite whose fixtures all share one value of a
+    // parameter cannot probe that parameter at all. Every fixture above is at
+    // the predicate position.
+    const published = await land({ subject: "acme", predicate: "headcount is", object: "10" });
+    await publish(published);
+    await land({ subject: "acme corp", predicate: "headcount is", object: "20" });
+    await curate("headcount is");
+
+    const before = await supersedesNow();
+    const radius = await loadBlastRadius(pool, owner(), {
+      kind: "alias-approval",
+      position: "subject",
+      fromNorm: "acme corp",
+      toNorm: "acme",
+    });
+    await approve("acme corp", "acme", "subject");
+    const after = await supersedesNow();
+
+    expect(after - before).toBe(radius.arming.total);
+    expect(radius.arming.total).toBeGreaterThan(0);
+  }, PG_TEST_TIMEOUT_MS);
+});

--- a/packages/api/src/lib/brain/__tests__/vocabulary-preview-pg.test.ts
+++ b/packages/api/src/lib/brain/__tests__/vocabulary-preview-pg.test.ts
@@ -59,7 +59,11 @@ import {
   supersedingDraftPredicate,
   supersessionCollisionPredicate,
 } from "@atlas/api/lib/content-mode/adapters/brain-facts";
-import { loadBlastRadius } from "@atlas/api/lib/brain/vocabulary-preview";
+import {
+  loadBlastRadius,
+  type BlastRadius,
+  type StructurallyEmptyReason,
+} from "@atlas/api/lib/brain/vocabulary-preview";
 import type { BrainPrincipalContext } from "@atlas/api/lib/brain/acl";
 
 const TEST_DB_URL = process.env.TEST_DATABASE_URL;
@@ -67,6 +71,29 @@ const describeIfPg = TEST_DB_URL ? describe : describe.skip;
 const PG_TEST_TIMEOUT_MS = 60_000;
 
 const WS = "ws-preview-5086";
+
+/**
+ * Narrow a radius to the computed branch.
+ *
+ * The union exists so a renderer cannot read `floor` on a branch where it is
+ * meaningless; these tests pay the same one-line cost the future call site
+ * will, which is the point of the shape.
+ */
+function computed(radius: BlastRadius): Extract<BlastRadius, { kind: "computed" }> {
+  expect(radius.kind, `expected a computed radius, got ${JSON.stringify(radius)}`).toBe("computed");
+  if (radius.kind !== "computed") throw new Error("unreachable");
+  return radius;
+}
+
+/** Narrow a radius to the structurally-empty branch and return its reason. */
+function emptyReason(radius: BlastRadius): StructurallyEmptyReason {
+  expect(radius.kind, `expected a structurally-empty radius, got ${JSON.stringify(radius)}`).toBe(
+    "structurally-empty",
+  );
+  if (radius.kind !== "structurally-empty") throw new Error("unreachable");
+  return radius.reason;
+}
+
 
 describeIfPg("the blast-radius preview against a real schema (#5086)", () => {
   let pool: Pool;
@@ -292,11 +319,11 @@ describeIfPg("the blast-radius preview against a real schema (#5086)", () => {
       // THE property. Not "the preview returned a plausible number" — the
       // preview predicted the transaction, and the transaction is measured
       // through its own disclosure statement.
-      expect(after - before).toBe(radius.arming.total);
+      expect(after - before).toBe(computed(radius).arming.total);
       // And the preview was not trivially zero, which would satisfy the
       // equation while proving nothing.
-      expect(radius.arming.total).toBeGreaterThan(0);
-      expect(radius.disarming.total).toBe(0);
+      expect(computed(radius).arming.total).toBeGreaterThan(0);
+      expect(computed(radius).disarming.total).toBe(0);
     }, PG_TEST_TIMEOUT_MS);
 
     it("…and follows the CARDINALITY lookup to the merged slot (the compound case)", async () => {
@@ -328,8 +355,8 @@ describeIfPg("the blast-radius preview against a real schema (#5086)", () => {
       await approve("is priced at", "priced at");
       const after = await supersedesNow();
 
-      expect(after - before).toBe(radius.arming.total);
-      expect(radius.arming.total).toBeGreaterThan(0);
+      expect(after - before).toBe(computed(radius).arming.total);
+      expect(computed(radius).arming.total).toBeGreaterThan(0);
     }, PG_TEST_TIMEOUT_MS);
 
     it("…and resolves the target through an EXISTING chain, not to the norm as typed", async () => {
@@ -360,8 +387,8 @@ describeIfPg("the blast-radius preview against a real schema (#5086)", () => {
       await approve("is priced at", "priced at");
       const after = await supersedesNow();
 
-      expect(after - before).toBe(radius.arming.total);
-      expect(radius.arming.total).toBeGreaterThan(0);
+      expect(after - before).toBe(computed(radius).arming.total);
+      expect(computed(radius).arming.total).toBeGreaterThan(0);
     }, PG_TEST_TIMEOUT_MS);
 
     it("an ALIAS removal disarms exactly the pairs the preview promised", async () => {
@@ -390,9 +417,9 @@ describeIfPg("the blast-radius preview against a real schema (#5086)", () => {
       // The mirror. This is the arm a key-to-key substitution gets WRONG —
       // `REKEY_DRIFTED_FACTS_SQL`'s header says why, and the removal
       // counterfactual re-derives from the surface for exactly this test.
-      expect(before - after).toBe(radius.disarming.total);
-      expect(radius.disarming.total).toBeGreaterThan(0);
-      expect(radius.arming.total).toBe(0);
+      expect(before - after).toBe(computed(radius).disarming.total);
+      expect(computed(radius).disarming.total).toBeGreaterThan(0);
+      expect(computed(radius).arming.total).toBe(0);
     }, PG_TEST_TIMEOUT_MS);
 
     it("a CARDINALITY flip arms exactly the pairs the preview promised", async () => {
@@ -421,17 +448,22 @@ describeIfPg("the blast-radius preview against a real schema (#5086)", () => {
       await curate("headcount is");
       const after = await supersedesNow();
 
-      expect(after - before).toBe(radius.arming.total);
-      expect(radius.arming.total).toBeGreaterThan(0);
+      expect(after - before).toBe(computed(radius).arming.total);
+      expect(computed(radius).arming.total).toBeGreaterThan(0);
       // ⚠️ The flip is the ONLY kind whose `total` and `pairs` come from two
       // DIFFERENT statements, so it is the only one where they can disagree.
       // If `cardinalityFlipExpr` drifted `OR` → `AND`, the delta returns no
       // pairs while the imported total stays positive → `withheld = total`,
       // i.e. "N pairs are hidden from you by ACL" shown to an owner who can see
       // everything. Nothing else in the suite would fail.
-      expect(radius.arming.pairs).toHaveLength(radius.arming.total);
-      expect(radius.arming.withheld).toBe(0);
-      expect(radius.arming.countsConsistent).toBe(true);
+      expect(computed(radius).arming.pairs).toHaveLength(computed(radius).arming.total);
+      expect(computed(radius).arming.withheld).toBe(0);
+      expect(computed(radius).arming.countsConsistent).toBe(true);
+      // The provably-empty direction, asserted like every sibling arm does.
+      // Applying `armingTotalOverride` to BOTH directions was otherwise killed
+      // only incidentally, by a statement-count assertion in the unit suite —
+      // never by a claim about the number a client renders.
+      expect(computed(radius).disarming.total).toBe(0);
       // ⚠️ NOT `expect(await supersedesNow()).toBe(after)` — that re-read the
       // same query against an unchanged database and compared it to itself. The
       // scoping is already caught by the equality above (a globally-TRUE gate
@@ -526,7 +558,7 @@ describeIfPg("the blast-radius preview against a real schema (#5086)", () => {
     // ...and the preview reported a REASON rather than a zero, which is the
     // whole point — "0 pairs" and "this position cannot produce pairs" are the
     // same number and opposite facts.
-    expect(radius.structurallyEmpty).toBe("object-position");
+    expect(emptyReason(radius)).toBe("object-position");
   }, PG_TEST_TIMEOUT_MS);
 
   // ── 4. the IS NOT TRUE equivalence, measured rather than claimed ────────
@@ -565,7 +597,7 @@ describeIfPg("the blast-radius preview against a real schema (#5086)", () => {
     // recognised source.
     const before = await loadBlastRadius(pool, owner(), request);
     expect(
-      before.arming.total,
+      computed(before).arming.total,
       "the fixture must be armable before the provenance is nulled, or the zero below proves nothing",
     ).toBeGreaterThan(0);
 
@@ -586,7 +618,7 @@ describeIfPg("the blast-radius preview against a real schema (#5086)", () => {
     // The before/after on ONE fixture is the attribution, and it is stronger:
     // the only thing that changed between the two calls is the provenance.
     const after = await loadBlastRadius(pool, owner(), request);
-    expect(after.arming.total).toBe(0);
+    expect(computed(after).arming.total).toBe(0);
   }, PG_TEST_TIMEOUT_MS);
 
   // ── 4b. the subtree walk, past the seed ─────────────────────────────────
@@ -607,7 +639,7 @@ describeIfPg("the blast-radius preview against a real schema (#5086)", () => {
     await land({ subject: "widget", predicate: "list price", object: "12 USD" });
     await curate("priced at");
 
-    await approve("is priced at", "priced at");
+    const proposalId = await approve("is priced at", "priced at");
     await approve("list price", "is priced at");
 
     const before = await supersedesNow();
@@ -621,14 +653,24 @@ describeIfPg("the blast-radius preview against a real schema (#5086)", () => {
 
     // The grandchild is in the disarming set — it resolves through the removed
     // norm even though no edge names it.
-    expect(radius.disarming.total).toBe(before);
-    expect(radius.disarming.countsConsistent).toBe(true);
+    expect(computed(radius).disarming.total).toBe(before);
+    expect(computed(radius).disarming.countsConsistent).toBe(true);
+    expect(computed(radius).subtreeTruncated).toBe(false);
+
+    // ⚠️ And the loop is CLOSED. Every sibling removal fixture asserts
+    // `before − after === disarming.total`; this was the only one that compared
+    // the preview to a before-state and never ran the decision — so a
+    // multi-level over-claim would have been invisible here, in the one fixture
+    // that exists to cover multiple levels.
+    await removeEdge(proposalId);
+    const after = await supersedesNow();
+    expect(before - after).toBe(computed(radius).disarming.total);
   }, PG_TEST_TIMEOUT_MS);
 
   // ── 4c. the pair projection's orientation ───────────────────────────────
 
   it("a pair's draft label is the DRAFT's claim, not the published one", async () => {
-    // ⚠️ No test anywhere asserted a pair's CONTENT — `radius.arming.pairs`
+    // ⚠️ No test anywhere asserted a pair's CONTENT — `computed(radius).arming.pairs`
     // appeared zero times in this file. Measured: swapping `d.subject || …` for
     // `p.subject || …` in `draft_label` survives the entire suite, and the
     // preview would then tell an approver the superseded claim is the incoming
@@ -646,8 +688,8 @@ describeIfPg("the blast-radius preview against a real schema (#5086)", () => {
       toNorm: "priced at",
     });
 
-    expect(radius.arming.pairs).toHaveLength(1);
-    const pair = radius.arming.pairs[0]!;
+    expect(computed(radius).arming.pairs).toHaveLength(1);
+    const pair = computed(radius).arming.pairs[0]!;
     // The DRAFT is the incoming `12 USD` claim; the SUPERSEDED side is the
     // published `10 USD` one. Reversed, an approver reads the retirement
     // backwards.
@@ -658,6 +700,43 @@ describeIfPg("the blast-radius preview against a real schema (#5086)", () => {
   }, PG_TEST_TIMEOUT_MS);
 
   // ── 4d. a restricted reader ─────────────────────────────────────────────
+
+  it("withholds a pair whose DRAFT side the reader cannot see, and counts it", async () => {
+    // ⚠️ The MIRROR of the test below, and it is the one that was missing.
+    // `principalTokens` seeds `org` unconditionally, and the draft's
+    // `visible_to` is `['org']` — so in the published-side fixture the draft is
+    // always visible and its gate is never load-bearing. Measured: rebuilding
+    // the DRAFT clause against alias `p` (arity preserved, so no bind error)
+    // passed all 13 pg tests. The projection emits the draft's full claim body,
+    // so this is a disclosure path.
+    const published = await land({ subject: "widget", predicate: "priced at", object: "10 USD" });
+    await publish(published);
+    const draft = await land({ subject: "widget", predicate: "is priced at", object: "12 USD" });
+    await curate("priced at");
+    await pool.query(`UPDATE brain_facts SET visible_to = ARRAY['audience:secret'] WHERE id = $1::uuid`, [
+      draft,
+    ]);
+
+    const restricted: BrainPrincipalContext = {
+      origin: "authenticated",
+      workspaceId: WS,
+      userId: "user-restricted",
+      role: "member",
+      audienceIds: [],
+    };
+    const radius = computed(
+      await loadBlastRadius(pool, restricted, {
+        kind: "alias-approval",
+        position: "predicate",
+        fromNorm: "is priced at",
+        toNorm: "priced at",
+      }),
+    );
+
+    expect(radius.arming.total).toBe(1);
+    expect(radius.arming.pairs).toHaveLength(0);
+    expect(radius.arming.withheld).toBe(1);
+  }, PG_TEST_TIMEOUT_MS);
 
   it("withholds a pair whose PUBLISHED side the reader cannot see, and counts it", async () => {
     // Nothing measured that the reader scoping works against real SQL — the
@@ -687,12 +766,52 @@ describeIfPg("the blast-radius preview against a real schema (#5086)", () => {
 
     // The supersession happens regardless of who is looking — the unscoped
     // total sees it...
-    expect(radius.arming.total).toBe(1);
+    expect(computed(radius).arming.total).toBe(1);
     // ...but the reader may not read the published side, so no pair is listed
     // and the difference is disclosed as `withheld` rather than omitted.
-    expect(radius.arming.pairs).toHaveLength(0);
-    expect(radius.arming.withheld).toBe(1);
-    expect(radius.arming.countsConsistent).toBe(true);
+    expect(computed(radius).arming.pairs).toHaveLength(0);
+    expect(computed(radius).arming.withheld).toBe(1);
+    expect(computed(radius).arming.countsConsistent).toBe(true);
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("a chain DEEPER than the bound is reported as truncated, not as a complete walk", async () => {
+    // ⚠️ The mutation nothing could kill: `bool_or(depth >= N)` → `> N`
+    // survived all 59 tests, because the recursive arm stops at `depth < N` so
+    // N is the maximum depth ever emitted and the mutant can never be true. The
+    // walk would truncate silently, `subtreeTruncated` would stay false, and an
+    // admin would withdraw an arbitration whose scope was understated.
+    //
+    // With the shipped bound of 64 no fixture can reach it, so the bound is
+    // INJECTED. That is the only reason `BlastRadiusOptions.maxChainDepth`
+    // exists; production never passes it.
+    const published = await land({ subject: "widget", predicate: "priced at", object: "10 USD" });
+    await publish(published);
+    await land({ subject: "widget", predicate: "level three", object: "12 USD" });
+    await curate("priced at");
+
+    // level three → level two → level one → priced at  (depth 3 from the seed)
+    await approve("level one", "priced at");
+    await approve("level two", "level one");
+    await approve("level three", "level two");
+
+    const shallow = computed(
+      await loadBlastRadius(
+        pool,
+        owner(),
+        { kind: "alias-removal", position: "predicate", fromNorm: "level one" },
+        { maxChainDepth: 2 },
+      ),
+    );
+    expect(shallow.subtreeTruncated, "a walk bounded below the real depth is truncated").toBe(true);
+
+    const full = computed(
+      await loadBlastRadius(pool, owner(), {
+        kind: "alias-removal",
+        position: "predicate",
+        fromNorm: "level one",
+      }),
+    );
+    expect(full.subtreeTruncated, "the shipped bound covers this chain").toBe(false);
   }, PG_TEST_TIMEOUT_MS);
 
   // ── 5. the fourth arm of the union ──────────────────────────────────────
@@ -710,8 +829,8 @@ describeIfPg("the blast-radius preview against a real schema (#5086)", () => {
       kind: "cardinality-removal",
       predicateSurface: "headcount is",
     });
-    expect(radius.disarming.total).toBe(before);
-    expect(radius.arming.total).toBe(0);
+    expect(computed(radius).disarming.total).toBe(before);
+    expect(computed(radius).arming.total).toBe(0);
   }, PG_TEST_TIMEOUT_MS);
 
   it("a SUBJECT-position alias arms pairs — the position the predicate fixtures cannot probe", async () => {
@@ -733,7 +852,7 @@ describeIfPg("the blast-radius preview against a real schema (#5086)", () => {
     await approve("acme corp", "acme", "subject");
     const after = await supersedesNow();
 
-    expect(after - before).toBe(radius.arming.total);
-    expect(radius.arming.total).toBeGreaterThan(0);
+    expect(after - before).toBe(computed(radius).arming.total);
+    expect(computed(radius).arming.total).toBeGreaterThan(0);
   }, PG_TEST_TIMEOUT_MS);
 });

--- a/packages/api/src/lib/brain/__tests__/vocabulary-preview.test.ts
+++ b/packages/api/src/lib/brain/__tests__/vocabulary-preview.test.ts
@@ -32,6 +32,7 @@
 import { describe, expect, it } from "bun:test";
 import {
   BLAST_RADIUS_PAIR_MAX,
+  assertPlaceholdersBelowAclBase,
   loadBlastRadius,
   type BlastRadius,
   type BlastRadiusRequest,
@@ -132,6 +133,17 @@ function halves(sql: string): { join: string; exclude: string } {
   expect(at, "a delta statement must have a WHERE clause to split on").toBeGreaterThan(0);
   return { join: sql.slice(0, at), exclude: sql.slice(at) };
 }
+
+/**
+ * Answer the "does this edge exist" probe affirmatively.
+ *
+ * ⚠️ Matched on the probe's full projection, not on `brain_vocabulary_edge`
+ * alone — the removal delta's own recursive CTE walks that same table, so the
+ * looser predicate also captured the delta statements and fed them `{hit: 1}`
+ * where a count was expected.
+ */
+const EDGE_EXISTS = "SELECT 1 AS hit FROM brain_vocabulary_edge";
+const edgeExists = (sql: string) => (sql.includes(EDGE_EXISTS) ? [{ hit: 1 }] : undefined);
 
 const APPROVE_PREDICATE: BlastRadiusRequest = {
   kind: "alias-approval",
@@ -290,7 +302,7 @@ describe("the object position is structurally empty, not zero", () => {
 describe("removal re-derives from the SURFACE, because the key column cannot tell the populations apart", () => {
   it("substitutes on a subtree membership test over the normalized surface", async () => {
     const captures: Capture[] = [];
-    await loadBlastRadius(reader(captures), ctx(), {
+    await loadBlastRadius(reader(captures, edgeExists), ctx(), {
       kind: "alias-removal",
       position: "predicate",
       fromNorm: "is priced at",
@@ -314,7 +326,7 @@ describe("removal re-derives from the SURFACE, because the key column cannot tel
 
   it("bounds the walk so a corrupt cyclic store cannot spin an admin request", async () => {
     const captures: Capture[] = [];
-    await loadBlastRadius(reader(captures), ctx(), {
+    await loadBlastRadius(reader(captures, edgeExists), ctx(), {
       kind: "alias-removal",
       position: "subject",
       fromNorm: "acme",
@@ -724,7 +736,9 @@ describe("subtreeTruncated — a scope blind spot, not a count disagreement", ()
   it("is set when the walk hit the bound, and leaves countsConsistent alone", async () => {
     const radius = computed(
       await loadBlastRadius(
-        reader([], (sql) => (sql.includes("AS hit") ? [{ hit: true }] : undefined)),
+        reader([], (sql) =>
+          sql.includes(EDGE_EXISTS) ? [{ hit: 1 }] : sql.includes("AS hit") ? [{ hit: true }] : undefined,
+        ),
         ctx(),
         removal,
       ),
@@ -738,7 +752,9 @@ describe("subtreeTruncated — a scope blind spot, not a count disagreement", ()
   it("is false on a complete walk", async () => {
     const radius = computed(
       await loadBlastRadius(
-        reader([], (sql) => (sql.includes("AS hit") ? [{ hit: false }] : undefined)),
+        reader([], (sql) =>
+          sql.includes(EDGE_EXISTS) ? [{ hit: 1 }] : sql.includes("AS hit") ? [{ hit: false }] : undefined,
+        ),
         ctx(),
         removal,
       ),
@@ -750,20 +766,46 @@ describe("subtreeTruncated — a scope blind spot, not a count disagreement", ()
     ["an unreadable probe", "maybe"],
     ["a NULL probe — bool_or over an empty CTE, or a probe that lost its seed", null],
   ] as const) {
-    it(`fails CLOSED on ${label}`, async () => {
-      // `false` is the only value that may answer "the walk was complete".
-      // `null` used to take that arm UNLOGGED, while the same module maps
-      // `Number(null)` to NaN forty lines down for exactly this reason.
+    it(`routes ${label} to countsConsistent, NOT to subtreeTruncated`, async () => {
+      // ⚠️ The distinction, and it is the one round 2 collapsed. An unreadable
+      // probe and a genuine bound hit are two different facts:
+      // `subtreeTruncated`'s docstring asserts the SECOND specifically ("the
+      // walk hit MAX_CHAIN_DEPTH"), so reporting a driver or query-shape drift
+      // through it told an approver their approved-edge graph was cyclic or
+      // deeper than 64 — sending them to inspect a vocabulary that may be
+      // perfectly healthy.
+      //
+      // A drifted probe IS statement drift, which is what `countsConsistent`
+      // already means. `false` remains the only value that answers "the walk
+      // was complete"; `null` used to take that arm unlogged.
       const radius = computed(
         await loadBlastRadius(
-          reader([], (sql) => (sql.includes("AS hit") ? [{ hit }] : undefined)),
+          reader([], (sql) =>
+            sql.includes(EDGE_EXISTS) ? [{ hit: 1 }] : sql.includes("AS hit") ? [{ hit }] : undefined,
+          ),
           ctx(),
           removal,
         ),
       );
-      expect(radius.subtreeTruncated).toBe(true);
+      expect(radius.subtreeTruncated, "nothing established that the graph is deep").toBe(false);
+      expect(radius.arming.countsConsistent, "but the numbers are not trustworthy").toBe(false);
+      expect(radius.disarming.countsConsistent).toBe(false);
     });
   }
+
+  it("a genuine bound hit sets subtreeTruncated and leaves countsConsistent alone", async () => {
+    const radius = computed(
+      await loadBlastRadius(
+        reader([], (sql) =>
+          sql.includes(EDGE_EXISTS) ? [{ hit: 1 }] : sql.includes("AS hit") ? [{ hit: true }] : undefined,
+        ),
+        ctx(),
+        removal,
+      ),
+    );
+    expect(radius.subtreeTruncated).toBe(true);
+    expect(radius.disarming.countsConsistent).toBe(true);
+  });
 });
 
 describe("the closure refusals — both were untested, and a no-op survived each", () => {
@@ -838,5 +880,112 @@ describe("the curated probe reads only APPROVED entries", () => {
     const probe = captures.find((c) => c.sql.includes("AS hit"));
     expect(probe, "the curated probe must run").toBeDefined();
     expect(probe!.sql).toContain("status = 'approved'");
+  });
+});
+
+describe("a removal with nothing to remove is a REASON, not computed zeros", () => {
+  it("reports no-such-edge rather than `floor: true` over two empty sides", async () => {
+    // ⚠️ The alias kinds had no analogue of `not-curated`, and the result was
+    // worse than the case that member exists for: with no approved edge the
+    // subtree is the seed alone and `removalKeyExpr` maps those rows onto the
+    // key they already carry, so `hypothetical ≡ stored`, both deltas are
+    // empty, and the caller got a COMPUTED radius of zeros. A renderer then
+    // says "at least 0 today, and every future claim in this slot" for a
+    // decision that does nothing at all.
+    const captures: Capture[] = [];
+    const radius = await loadBlastRadius(reader(captures), ctx(), {
+      kind: "alias-removal",
+      position: "predicate",
+      fromNorm: "never aliased",
+    });
+
+    expect(emptyReason(radius)).toBe("no-such-edge");
+    // And the question was never asked — no delta, and no depth probe either.
+    expect(deltaStatements(captures)).toHaveLength(0);
+  });
+
+  it("an existing edge still computes", async () => {
+    // The positive control. Without it the probe could refuse everything and
+    // the assertion above would still pass.
+    const radius = await loadBlastRadius(
+      reader([], edgeExists),
+      ctx(),
+      { kind: "alias-removal", position: "predicate", fromNorm: "is priced at" },
+    );
+    expect(radius.kind).toBe("computed");
+  });
+});
+
+describe("the placeholder guard", () => {
+  // ⚠️ Deleting this guard's body survived the entire suite: no legal request
+  // can construct a plan that trips it, because it exists to catch a FUTURE
+  // edit in which an expression's hand-written `$n` literal and the plan's
+  // `params` array drift apart. So it is exercised directly.
+  //
+  // The failure it converts into a refusal is silent and under-disclosing: an
+  // expression referencing a placeholder at or above the ACL base binds the
+  // reader's principal-token array as a slot key, joins nothing, and reports
+  // "this decision changes nothing" on an admin console.
+  it("refuses an expression that reaches into the reader's range", () => {
+    expect(() => assertPlaceholdersBelowAclBase("x = $4", 4, "ws", "arming", "req-1")).toThrow(
+      /references \$4, at or above the ACL base \$4/,
+    );
+  });
+
+  it("names the request, so the 500 can be correlated", () => {
+    // The sibling refusal (`readCount`) carries the requestId; this one was
+    // added in the same round and did not, which is the rule it was fixed to.
+    expect(() => assertPlaceholdersBelowAclBase("x = $9", 3, "ws", "arming", "req-7")).toThrow(
+      /request req-7/,
+    );
+    expect(() => assertPlaceholdersBelowAclBase("x = $9", 3, "ws", "arming")).toThrow(
+      /request unknown/,
+    );
+  });
+
+  it("admits a plan whose highest placeholder is below the base", () => {
+    expect(() => assertPlaceholdersBelowAclBase("a = $2 AND b = $3", 4, "ws", "arming")).not.toThrow();
+  });
+
+  it("admits a plan with no placeholders at all", () => {
+    expect(() => assertPlaceholdersBelowAclBase("a = b", 2, "ws", "disarming")).not.toThrow();
+  });
+});
+
+describe("the injectable depth bound can only NARROW", () => {
+  // ⚠️ `maxChainDepth` sits on an exported options bag beside `requestId` and
+  // is interpolated RAW into SQL at two sites, so a future route spreading a
+  // parsed query into this call would hand a client control of statement text.
+  // The clamp makes the seam incapable of widening past the shipped bound, of
+  // going non-positive, and of being non-integral.
+  async function emittedBound(maxChainDepth: number): Promise<string> {
+    const captures: Capture[] = [];
+    await loadBlastRadius(
+      reader(captures, edgeExists),
+      ctx(),
+      { kind: "alias-removal", position: "predicate", fromNorm: "is priced at" },
+      { maxChainDepth },
+    );
+    const sql = deltaStatements(captures)[0];
+    expect(sql).toBeDefined();
+    return sql as string;
+  }
+
+  it("cannot widen past the shipped bound", async () => {
+    expect(await emittedBound(9999)).toContain("s.depth < 64");
+  });
+
+  it("clamps a non-positive value to 1 rather than emitting it", async () => {
+    const sql = await emittedBound(-5);
+    expect(sql).toContain("s.depth < 1");
+    expect(sql).not.toContain("s.depth < -5");
+  });
+
+  it("truncates a fractional value", async () => {
+    expect(await emittedBound(3.9)).toContain("s.depth < 3");
+  });
+
+  it("honours a legitimate narrowing", async () => {
+    expect(await emittedBound(2)).toContain("s.depth < 2");
   });
 });

--- a/packages/api/src/lib/brain/__tests__/vocabulary-preview.test.ts
+++ b/packages/api/src/lib/brain/__tests__/vocabulary-preview.test.ts
@@ -1,0 +1,414 @@
+/**
+ * The blast-radius preview (#5025, ADR-0037 §6) — unit coverage.
+ *
+ * Every claim worth pinning here is about a SQL SHAPE or a REFUSAL, because
+ * those are the two classes a green build hides. Whether the emitted statements
+ * return the right rows against a real schema is `vocabulary-preview-pg.test.ts`'s
+ * job, and the parity property that matters most — *the preview total equals
+ * what the re-key actually changes* — can only be asserted there.
+ *
+ * The negatives this file exists for, in the order they would hurt:
+ *
+ *   - **the exclusion arm is `IS NOT TRUE`, never `NOT (…)`.** Third site in the
+ *     repo; first one where a bare negation UNDER-discloses an irreversible
+ *     consequence, by dropping every `{"source": null}` provenance through the
+ *     three-valued hole.
+ *   - **a predicate-position alias re-points the CARDINALITY lookup too.** The
+ *     compound case ADR-0037 §6's amendment exists for is exactly the case a
+ *     bundle that moved only the slot arm would report as zero.
+ *   - **an object-position alias is `structurallyEmpty`, not zero.** "0 pairs"
+ *     and "this position cannot produce pairs" are the same number and opposite
+ *     facts.
+ *   - **an unresolvable reader THROWS.** An empty pair list renders as "this
+ *     approval arms nothing", the false all-clear the surface exists to prevent.
+ *   - **no key reaches the returned value.** ADR-0037 §6's prohibition, and the
+ *     request type takes a SURFACE for the same reason.
+ */
+
+import { describe, expect, it } from "bun:test";
+import {
+  BLAST_RADIUS_PAIR_MAX,
+  loadBlastRadius,
+  type BlastRadiusRequest,
+} from "@atlas/api/lib/brain/vocabulary-preview";
+import { BrainReaderUnresolvedError } from "@atlas/api/lib/brain/reader-context";
+import type { BrainCandidateReader } from "@atlas/api/lib/brain/candidates";
+import type { BrainPrincipalContext } from "@atlas/api/lib/brain/acl";
+
+const WS = "ws-preview";
+
+function ctx(
+  partial: Partial<Extract<BrainPrincipalContext, { origin: "authenticated" }>> = {},
+): BrainPrincipalContext {
+  return {
+    origin: "authenticated",
+    workspaceId: WS,
+    userId: "user-1",
+    role: "admin",
+    audienceIds: [],
+    ...partial,
+  };
+}
+
+interface Capture {
+  readonly sql: string;
+  readonly params: readonly unknown[];
+}
+
+/**
+ * A recording reader that answers every statement with an empty result unless a
+ * responder says otherwise.
+ *
+ * `COUNT(*)` statements must answer SOMETHING or the module throws — which is
+ * itself a pinned behaviour below — so the default responder returns a zero
+ * count for anything selecting one, and `[]` for everything else.
+ */
+function reader(
+  captures: Capture[],
+  responder?: (sql: string) => readonly unknown[] | undefined,
+): BrainCandidateReader {
+  return {
+    query: async (sql: string, params?: unknown[]) => {
+      captures.push({ sql, params: params ?? [] });
+      const custom = responder?.(sql);
+      if (custom !== undefined) return { rows: custom };
+      if (sql.includes("delta_total")) return { rows: [{ delta_total: 0 }] };
+      if (sql.includes("held_back")) return { rows: [{ held_back: 0 }] };
+      return { rows: [] };
+    },
+  };
+}
+
+/** Only the statements that compute a delta — not the closure/probe reads. */
+function deltaStatements(captures: readonly Capture[]): readonly string[] {
+  return captures
+    .map((c) => c.sql)
+    .filter((sql) => sql.includes("FROM brain_facts d") && sql.includes("JOIN brain_facts p"));
+}
+
+const APPROVE_PREDICATE: BlastRadiusRequest = {
+  kind: "alias-approval",
+  position: "predicate",
+  fromNorm: "is priced at",
+  toNorm: "priced at",
+};
+
+describe("the exclusion arm's polarity", () => {
+  it("negates the other vocabulary with IS NOT TRUE and never a bare NOT", async () => {
+    const captures: Capture[] = [];
+    await loadBlastRadius(reader(captures), ctx(), APPROVE_PREDICATE);
+
+    const deltas = deltaStatements(captures);
+    expect(deltas.length).toBeGreaterThan(0);
+    for (const sql of deltas) {
+      // The exclusion is the whole collision predicate wrapped in `IS NOT TRUE`.
+      expect(sql).toContain(") IS NOT TRUE");
+      // ⚠️ The failure this pins: `NOT (` immediately wrapping the collision
+      // would compile, read naturally, and silently drop every row whose
+      // provenance is `{"source": null}` — the population `brain-facts.ts`
+      // twice calls the subtlest one — out of a disclosure that must be
+      // complete. `NOT EXISTS` inside the cardinality gate is a different and
+      // legitimate construct, so the assertion targets the wrapper shape.
+      expect(sql).not.toContain("AND NOT (p.workspace_id");
+      expect(sql).not.toContain("AND NOT (d.workspace_id");
+    }
+  });
+});
+
+describe("a predicate-position alias moves the cardinality lookup with the slot", () => {
+  it("re-points brain_predicate_cardinality at the hypothetical key", async () => {
+    const captures: Capture[] = [];
+    await loadBlastRadius(reader(captures), ctx(), APPROVE_PREDICATE);
+
+    const arming = deltaStatements(captures)[0];
+    expect(arming).toBeDefined();
+    // The slot arm is substituted...
+    expect(arming).toContain("CASE WHEN d.predicate_key = $2 THEN $3");
+    // ...AND the cardinality lookup joins on the same substituted expression,
+    // not on the stored column. A bundle that moved only the slot would emit
+    // `c.predicate_key = d.predicate_key` here and report the compound case as
+    // zero.
+    expect(arming).toContain(
+      "c.predicate_key = (CASE WHEN d.predicate_key = $2 THEN $3 ELSE d.predicate_key END)",
+    );
+  });
+
+  it("a SUBJECT-position alias leaves the cardinality lookup on the stored column", async () => {
+    // The complement, and it is what makes the assertion above meaningful
+    // rather than a tautology about string interpolation: a subject alias does
+    // not move `predicate_key`, so re-pointing the gate there would be wrong in
+    // the over-disclosing direction.
+    const captures: Capture[] = [];
+    await loadBlastRadius(reader(captures), ctx(), {
+      kind: "alias-approval",
+      position: "subject",
+      fromNorm: "acme",
+      toNorm: "acme corp",
+    });
+
+    const arming = deltaStatements(captures)[0];
+    expect(arming).toContain("CASE WHEN d.subject_key = $2 THEN $3");
+    expect(arming).toContain("c.predicate_key = d.predicate_key");
+    expect(arming).not.toContain("CASE WHEN d.predicate_key");
+  });
+});
+
+describe("the object position is structurally empty, not zero", () => {
+  it("reports a reason and runs no delta statement at all", async () => {
+    const captures: Capture[] = [];
+    const radius = await loadBlastRadius(reader(captures), ctx(), {
+      kind: "alias-approval",
+      position: "object",
+      fromNorm: "nova",
+      toNorm: "project atlas",
+    });
+
+    expect(radius.structurallyEmpty).toBe("object-position");
+    expect(radius.arming.total).toBe(0);
+    expect(radius.disarming.total).toBe(0);
+    // Not merely "the answer was 0" — the question was never asked, because
+    // `object_key` is not in the collision.
+    expect(deltaStatements(captures)).toHaveLength(0);
+  });
+
+  it("the same holds for an object-position REMOVAL", async () => {
+    const captures: Capture[] = [];
+    const radius = await loadBlastRadius(reader(captures), ctx(), {
+      kind: "alias-removal",
+      position: "object",
+      fromNorm: "nova",
+    });
+    expect(radius.structurallyEmpty).toBe("object-position");
+    expect(deltaStatements(captures)).toHaveLength(0);
+  });
+});
+
+describe("removal re-derives from the SURFACE, because the key column cannot tell the populations apart", () => {
+  it("substitutes on a subtree membership test over the normalized surface", async () => {
+    const captures: Capture[] = [];
+    await loadBlastRadius(reader(captures), ctx(), {
+      kind: "alias-removal",
+      position: "predicate",
+      fromNorm: "is priced at",
+    });
+
+    const sql = deltaStatements(captures)[0];
+    expect(sql).toBeDefined();
+    // The recursive walk down the approved-edge graph...
+    expect(sql).toContain("WITH RECURSIVE subtree AS");
+    expect(sql).toContain("e.to_norm = s.node");
+    // ...and the membership test built from `identityKeySql`, the same
+    // expression the re-key runs. A `lower()` here would be a third
+    // implementation of `lexicalNorm` and the one that disagrees.
+    expect(sql).toContain("IN (SELECT node FROM subtree)");
+    expect(sql).toContain("translate(d.predicate");
+    // ⚠️ NOT a key-to-key rewrite. `REKEY_DRIFTED_FACTS_SQL`'s header: of the
+    // rows keyed `R`, only those whose norm chains through `a` move — and
+    // sharing a key is precisely what the key column records.
+    expect(sql).not.toContain("CASE WHEN d.predicate_key = $2 THEN");
+  });
+
+  it("bounds the walk so a corrupt cyclic store cannot spin an admin request", async () => {
+    const captures: Capture[] = [];
+    await loadBlastRadius(reader(captures), ctx(), {
+      kind: "alias-removal",
+      position: "subject",
+      fromNorm: "acme",
+    });
+    expect(deltaStatements(captures)[0]).toContain("s.depth < 64");
+  });
+});
+
+describe("the cardinality flip imports the held-back count rather than re-deriving it", () => {
+  it("the arming total IS CARDINALITY_HELD_BACK_COUNT_SQL at a predicate scope", async () => {
+    const captures: Capture[] = [];
+    await loadBlastRadius(reader(captures), ctx(), {
+      kind: "cardinality-flip",
+      predicateSurface: "reports to",
+    });
+
+    const totals = captures.filter((c) => c.sql.includes("held_back"));
+    expect(totals).toHaveLength(1);
+    const sql = totals[0]!.sql;
+    // #5027's statement, scoped to one predicate instead of one batch.
+    expect(sql).toContain("AS held_back");
+    expect(sql).toContain("d.predicate_key = $2");
+    expect(sql).not.toContain("d.id = ANY(");
+    // And it carries the arms the flip must not lose.
+    expect(sql).toContain("jsonb_exists(p.provenance, 'source')");
+    expect(sql).toContain("NOT EXISTS (");
+  });
+
+  it("un-curating asks the opposite question and can arm nothing", async () => {
+    const captures: Capture[] = [];
+    const radius = await loadBlastRadius(
+      reader(captures, (sql) =>
+        sql.includes("brain_predicate_cardinality\n        WHERE") ? [{ hit: 1 }] : undefined,
+      ),
+      ctx(),
+      { kind: "cardinality-removal", predicateSurface: "reports to" },
+    );
+
+    // A removal's hypothetical SUBTRACTS the key from the gate, so the arming
+    // side joins on a strictly narrower rule than it excludes — provably empty.
+    expect(radius.arming.total).toBe(0);
+    const deltas = deltaStatements(captures);
+    expect(deltas.some((s) => s.includes("IS DISTINCT FROM $2"))).toBe(true);
+    // No imported held-back statement: that count answers "what would curating
+    // arm", which is not this decision's question.
+    expect(captures.some((c) => c.sql.includes("AS held_back"))).toBe(false);
+  });
+
+  it("an already-curated predicate has nothing to flip", async () => {
+    const captures: Capture[] = [];
+    const radius = await loadBlastRadius(
+      reader(captures, (sql) => (sql.includes("AS hit") ? [{ hit: 1 }] : undefined)),
+      ctx(),
+      { kind: "cardinality-flip", predicateSurface: "reports to" },
+    );
+    expect(radius.structurallyEmpty).toBe("already-single");
+    expect(deltaStatements(captures)).toHaveLength(0);
+  });
+
+  it("an uncurated predicate has nothing to un-curate, and says so DIFFERENTLY", async () => {
+    // The two reasons render as opposite sentences. Collapsing them would tell
+    // an approver their un-curation is a no-op *because the predicate is
+    // already single*.
+    const captures: Capture[] = [];
+    const radius = await loadBlastRadius(reader(captures), ctx(), {
+      kind: "cardinality-removal",
+      predicateSurface: "reports to",
+    });
+    expect(radius.structurallyEmpty).toBe("not-curated");
+  });
+});
+
+describe("the reader boundary", () => {
+  it("throws rather than answering an unresolvable reader with an empty radius", async () => {
+    const unresolved: BrainPrincipalContext = { origin: "unresolved", workspaceId: WS };
+    await expect(
+      loadBlastRadius(reader([]), unresolved, APPROVE_PREDICATE),
+    ).rejects.toBeInstanceOf(BrainReaderUnresolvedError);
+  });
+
+  it("gates BOTH sides of every pair on the reader's own predicate", async () => {
+    const captures: Capture[] = [];
+    await loadBlastRadius(reader(captures), ctx(), APPROVE_PREDICATE);
+
+    const pairs = captures.filter((c) => c.sql.includes("draft_label"));
+    expect(pairs.length).toBeGreaterThan(0);
+    for (const c of pairs) {
+      // "something you cannot see will replace X" and "Y will replace something
+      // you cannot see" each disclose half a claim's history.
+      expect(c.sql).toContain("d.visible_to &&");
+      expect(c.sql).toContain("p.visible_to &&");
+    }
+  });
+
+  it("the UNSCOPED total carries no reader predicate", async () => {
+    // `withheld` is only honest if the total is workspace-wide. A total that
+    // silently agreed with the scoped pairs would report 0 withheld always.
+    const captures: Capture[] = [];
+    await loadBlastRadius(reader(captures), ctx(), APPROVE_PREDICATE);
+    const totals = captures.filter((c) => c.sql.includes("delta_total"));
+    expect(totals.length).toBeGreaterThan(0);
+    for (const c of totals) expect(c.sql).not.toContain("visible_to &&");
+  });
+
+  it("refuses a total that did not read back as a number", async () => {
+    // A degraded 0 would render as "this approval arms nothing" — a confident
+    // false all-clear fabricated from query drift.
+    await expect(
+      loadBlastRadius(
+        reader([], (sql) => (sql.includes("delta_total") ? [{ delta_total: "not-a-number" }] : undefined)),
+        ctx(),
+        APPROVE_PREDICATE,
+      ),
+    ).rejects.toThrow(/refusing to disclose a blast radius/);
+  });
+});
+
+describe("the payload", () => {
+  it("carries labels and never a key", async () => {
+    const row = {
+      draft_id: "d1",
+      draft_label: "acme priced at 12",
+      superseded_id: "p1",
+      superseded_label: "acme priced at 10",
+      scoped_total: 1,
+    };
+    const radius = await loadBlastRadius(
+      reader([], (sql) =>
+        sql.includes("draft_label") ? [row] : sql.includes("delta_total") ? [{ delta_total: 3 }] : undefined,
+      ),
+      ctx(),
+      APPROVE_PREDICATE,
+    );
+
+    const serialized = JSON.stringify(radius);
+    // ADR-0037 §6's prohibition — `keys-not-on-the-wire.test.ts` is the repo-wide
+    // guard; this is the local one, on the surface that holds the keys in scope.
+    expect(serialized).not.toContain("predicate_key");
+    expect(serialized).not.toContain("subject_key");
+    expect(serialized).not.toContain("predicateKey");
+    expect(radius.arming.pairs[0]?.draftLabel).toBe("acme priced at 12");
+  });
+
+  it("reports the workspace-wide remainder as `withheld`", async () => {
+    const radius = await loadBlastRadius(
+      reader([], (sql) =>
+        sql.includes("draft_label")
+          ? [
+              {
+                draft_id: "d1",
+                draft_label: "a b c",
+                superseded_id: "p1",
+                superseded_label: "a b d",
+                scoped_total: 1,
+              },
+            ]
+          : sql.includes("delta_total")
+            ? [{ delta_total: 5 }]
+            : undefined,
+      ),
+      ctx(),
+      APPROVE_PREDICATE,
+    );
+    expect(radius.arming.total).toBe(5);
+    expect(radius.arming.withheld).toBe(4);
+    expect(radius.arming.truncated).toBe(false);
+  });
+
+  it("reports a clipped page as truncated and never folds it into withheld", async () => {
+    const rows = Array.from({ length: BLAST_RADIUS_PAIR_MAX + 1 }, (_, i) => ({
+      draft_id: `d${i}`,
+      draft_label: "a b c",
+      superseded_id: `p${i}`,
+      superseded_label: "a b d",
+      scoped_total: BLAST_RADIUS_PAIR_MAX + 1,
+    }));
+    const radius = await loadBlastRadius(
+      reader([], (sql) =>
+        sql.includes("draft_label")
+          ? rows
+          : sql.includes("delta_total")
+            ? [{ delta_total: BLAST_RADIUS_PAIR_MAX + 1 }]
+            : undefined,
+      ),
+      ctx(),
+      APPROVE_PREDICATE,
+    );
+    expect(radius.arming.truncated).toBe(true);
+    expect(radius.arming.pairs).toHaveLength(BLAST_RADIUS_PAIR_MAX);
+    // Truncation dressed as an ACL boundary is what the wire type forbids.
+    expect(radius.arming.withheld).toBe(0);
+  });
+
+  it("always reports the count as a FLOOR", async () => {
+    // A flip is not a batch: it applies to every future claim in the slot. The
+    // surface renders "at least N today, and every future claim in this slot",
+    // and this flag is what makes that assertable rather than conventional.
+    const radius = await loadBlastRadius(reader([]), ctx(), APPROVE_PREDICATE);
+    expect(radius.floor).toBe(true);
+  });
+});

--- a/packages/api/src/lib/brain/__tests__/vocabulary-preview.test.ts
+++ b/packages/api/src/lib/brain/__tests__/vocabulary-preview.test.ts
@@ -33,13 +33,38 @@ import { describe, expect, it } from "bun:test";
 import {
   BLAST_RADIUS_PAIR_MAX,
   loadBlastRadius,
+  type BlastRadius,
   type BlastRadiusRequest,
+  type StructurallyEmptyReason,
 } from "@atlas/api/lib/brain/vocabulary-preview";
 import { BrainReaderUnresolvedError } from "@atlas/api/lib/brain/reader-context";
 import type { BrainCandidateReader } from "@atlas/api/lib/brain/candidates";
 import type { BrainPrincipalContext } from "@atlas/api/lib/brain/acl";
 
 const WS = "ws-preview";
+
+/**
+ * Narrow a radius to the computed branch.
+ *
+ * The union exists so a renderer cannot read `floor` on a branch where it is
+ * meaningless; these tests pay the same one-line cost the future call site
+ * will, which is the point of the shape.
+ */
+function computed(radius: BlastRadius): Extract<BlastRadius, { kind: "computed" }> {
+  expect(radius.kind, `expected a computed radius, got ${JSON.stringify(radius)}`).toBe("computed");
+  if (radius.kind !== "computed") throw new Error("unreachable");
+  return radius;
+}
+
+/** Narrow a radius to the structurally-empty branch and return its reason. */
+function emptyReason(radius: BlastRadius): StructurallyEmptyReason {
+  expect(radius.kind, `expected a structurally-empty radius, got ${JSON.stringify(radius)}`).toBe(
+    "structurally-empty",
+  );
+  if (radius.kind !== "structurally-empty") throw new Error("unreachable");
+  return radius.reason;
+}
+
 
 function ctx(
   partial: Partial<Extract<BrainPrincipalContext, { origin: "authenticated" }>> = {},
@@ -179,8 +204,8 @@ describe("the exclusion arm's spelling", () => {
       APPROVE_PREDICATE,
     );
 
-    expect(radius.arming.total).toBe(7);
-    expect(radius.disarming.total).toBe(3);
+    expect(computed(radius).arming.total).toBe(7);
+    expect(computed(radius).disarming.total).toBe(3);
   });
 
   it("no statement joins on AND excludes the same vocabulary — that is a self-difference", async () => {
@@ -242,11 +267,11 @@ describe("the object position is structurally empty, not zero", () => {
       toNorm: "project atlas",
     });
 
-    expect(radius.structurallyEmpty).toBe("object-position");
-    expect(radius.arming.total).toBe(0);
-    expect(radius.disarming.total).toBe(0);
-    // Not merely "the answer was 0" — the question was never asked, because
-    // `object_key` is not in the collision.
+    expect(emptyReason(radius)).toBe("object-position");
+    // ⚠️ There is nothing to assert about totals, and that is the union's whole
+    // point: on this branch the numbers do not EXIST, so a renderer cannot read
+    // "at least 0 today, and every future claim in this slot" off a response
+    // that means "this position cannot produce pairs".
     expect(deltaStatements(captures)).toHaveLength(0);
   });
 
@@ -257,7 +282,7 @@ describe("the object position is structurally empty, not zero", () => {
       position: "object",
       fromNorm: "nova",
     });
-    expect(radius.structurallyEmpty).toBe("object-position");
+    expect(emptyReason(radius)).toBe("object-position");
     expect(deltaStatements(captures)).toHaveLength(0);
   });
 });
@@ -343,7 +368,7 @@ describe("the cardinality flip imports the held-back count rather than re-derivi
     // `arming.total === 0` against real rows), and what is asserted HERE is the
     // shape that makes it empty: the arming side joins on a rule strictly
     // NARROWER than the one it excludes, so the difference cannot contain a row.
-    expect(radius.disarming.total).toBe(11);
+    expect(computed(radius).disarming.total).toBe(11);
     const deltas = deltaStatements(captures);
     const unflip = "IS DISTINCT FROM $2";
     const arming = deltas.filter((sql) => halves(sql).join.includes(unflip));
@@ -366,7 +391,7 @@ describe("the cardinality flip imports the held-back count rather than re-derivi
       ctx(),
       { kind: "cardinality-flip", predicateSurface: "reports to" },
     );
-    expect(radius.structurallyEmpty).toBe("already-single");
+    expect(emptyReason(radius)).toBe("already-single");
     expect(deltaStatements(captures)).toHaveLength(0);
   });
 
@@ -379,7 +404,7 @@ describe("the cardinality flip imports the held-back count rather than re-derivi
       kind: "cardinality-removal",
       predicateSurface: "reports to",
     });
-    expect(radius.structurallyEmpty).toBe("not-curated");
+    expect(emptyReason(radius)).toBe("not-curated");
   });
 });
 
@@ -457,7 +482,7 @@ describe("the payload", () => {
     expect(serialized).not.toContain("predicate_key");
     expect(serialized).not.toContain("subject_key");
     expect(serialized).not.toContain("predicateKey");
-    expect(radius.arming.pairs[0]?.draftLabel).toBe("acme priced at 12");
+    expect(computed(radius).arming.pairs[0]?.draftLabel).toBe("acme priced at 12");
   });
 
   it("reports the workspace-wide remainder as `withheld`", async () => {
@@ -480,9 +505,9 @@ describe("the payload", () => {
       ctx(),
       APPROVE_PREDICATE,
     );
-    expect(radius.arming.total).toBe(5);
-    expect(radius.arming.withheld).toBe(4);
-    expect(radius.arming.truncated).toBe(false);
+    expect(computed(radius).arming.total).toBe(5);
+    expect(computed(radius).arming.withheld).toBe(4);
+    expect(computed(radius).arming.truncated).toBe(false);
   });
 
   it("reports a clipped page as truncated and never folds it into withheld", async () => {
@@ -504,10 +529,10 @@ describe("the payload", () => {
       ctx(),
       APPROVE_PREDICATE,
     );
-    expect(radius.arming.truncated).toBe(true);
-    expect(radius.arming.pairs).toHaveLength(BLAST_RADIUS_PAIR_MAX);
+    expect(computed(radius).arming.truncated).toBe(true);
+    expect(computed(radius).arming.pairs).toHaveLength(BLAST_RADIUS_PAIR_MAX);
     // Truncation dressed as an ACL boundary is what the wire type forbids.
-    expect(radius.arming.withheld).toBe(0);
+    expect(computed(radius).arming.withheld).toBe(0);
   });
 
   it("always reports the count as a FLOOR", async () => {
@@ -515,7 +540,7 @@ describe("the payload", () => {
     // surface renders "at least N today, and every future claim in this slot",
     // and this flag is what makes that assertable rather than conventional.
     const radius = await loadBlastRadius(reader([]), ctx(), APPROVE_PREDICATE);
-    expect(radius.floor).toBe(true);
+    expect(computed(radius).floor).toBe(true);
   });
 });
 
@@ -539,9 +564,9 @@ describe("an unkeyable surface is a disclosed REASON, never a zero", () => {
         toNorm: "priced at",
       });
 
-      expect(radius.structurallyEmpty).toBe("unkeyable-surface");
-      expect(radius.arming.total).toBe(0);
-      // Not merely zero — the question was never asked.
+      expect(emptyReason(radius)).toBe("unkeyable-surface");
+      // Not merely zero — the question was never asked, and the branch carries
+      // no number a renderer could mistake for one.
       expect(deltaStatements(captures)).toHaveLength(0);
     });
   }
@@ -551,7 +576,7 @@ describe("an unkeyable surface is a disclosed REASON, never a zero", () => {
       kind: "cardinality-flip",
       predicateSurface: "-",
     });
-    expect(radius.structurallyEmpty).toBe("unkeyable-surface");
+    expect(emptyReason(radius)).toBe("unkeyable-surface");
   });
 
   it("an unresolvable reader is refused BEFORE the unkeyable check", async () => {
@@ -603,8 +628,8 @@ describe("countsConsistent — the half the clamp alone does not carry", () => {
       ctx(),
       APPROVE_PREDICATE,
     );
-    expect(radius.arming.countsConsistent).toBe(true);
-    expect(radius.arming.withheld).toBe(2);
+    expect(computed(radius).arming.countsConsistent).toBe(true);
+    expect(computed(radius).arming.withheld).toBe(2);
   });
 
   it("is CLEARED when the scoped count exceeds the workspace count", async () => {
@@ -621,8 +646,8 @@ describe("countsConsistent — the half the clamp alone does not carry", () => {
       ctx(),
       APPROVE_PREDICATE,
     );
-    expect(radius.arming.withheld).toBe(0);
-    expect(radius.arming.countsConsistent).toBe(false);
+    expect(computed(radius).arming.withheld).toBe(0);
+    expect(computed(radius).arming.countsConsistent).toBe(false);
   });
 
   it("is CLEARED when a row will not narrow — a dropped row is not an ACL-withheld one", async () => {
@@ -640,8 +665,13 @@ describe("countsConsistent — the half the clamp alone does not carry", () => {
       ctx(),
       APPROVE_PREDICATE,
     );
-    expect(radius.arming.pairs).toHaveLength(1);
-    expect(radius.arming.countsConsistent).toBe(false);
+    expect(computed(radius).arming.pairs).toHaveLength(1);
+    expect(computed(radius).arming.countsConsistent).toBe(false);
+    // ⚠️ `truncated` too — it is the wire flag that must never be folded into
+    // `withheld`, and three floor/derivation mutations survived for want of one
+    // assertion on it: dropping `|| scopedTotal > pairs.length`, and deleting
+    // either floor.
+    expect(computed(radius).arming.truncated).toBe(true);
   });
 
   it("is CLEARED when the scoped window will not parse", async () => {
@@ -656,7 +686,7 @@ describe("countsConsistent — the half the clamp alone does not carry", () => {
       ctx(),
       APPROVE_PREDICATE,
     );
-    expect(radius.arming.countsConsistent).toBe(false);
+    expect(computed(radius).arming.countsConsistent).toBe(false);
   });
 
   it("a NULL window is treated as drift, not as a finite zero", async () => {
@@ -674,28 +704,139 @@ describe("countsConsistent — the half the clamp alone does not carry", () => {
       ctx(),
       APPROVE_PREDICATE,
     );
-    expect(radius.arming.countsConsistent).toBe(false);
+    expect(computed(radius).arming.countsConsistent).toBe(false);
   });
 
-  it("is CLEARED when the removal subtree walk hit the depth bound", async () => {
-    // A truncated walk understates the disarming set — an admin could withdraw
-    // an arbitration whose scope was understated by an order of magnitude with
-    // every counter reading trustworthy.
-    const radius = await loadBlastRadius(
-      reader([], (sql) => (sql.includes("AS hit") ? [{ hit: true }] : undefined)),
-      ctx(),
-      { kind: "alias-removal", position: "predicate", fromNorm: "is priced at" },
+});
+
+describe("subtreeTruncated — a scope blind spot, not a count disagreement", () => {
+  // ⚠️ It used to clear `countsConsistent` on both sides. A truncated walk is
+  // ONE statement asking about a smaller population than requested, not two
+  // statements disagreeing — different sentences, different actions, so a
+  // different field. The same argument that split `not-curated` from
+  // `already-single`.
+  const removal = {
+    kind: "alias-removal",
+    position: "predicate",
+    fromNorm: "is priced at",
+  } as const;
+
+  it("is set when the walk hit the bound, and leaves countsConsistent alone", async () => {
+    const radius = computed(
+      await loadBlastRadius(
+        reader([], (sql) => (sql.includes("AS hit") ? [{ hit: true }] : undefined)),
+        ctx(),
+        removal,
+      ),
     );
-    expect(radius.disarming.countsConsistent).toBe(false);
-    expect(radius.arming.countsConsistent).toBe(false);
+    expect(radius.subtreeTruncated).toBe(true);
+    // The two statements did NOT disagree — nothing about the counts is wrong,
+    // they simply describe less than was asked about.
+    expect(radius.disarming.countsConsistent).toBe(true);
   });
 
-  it("an unreadable depth probe fails CLOSED", async () => {
-    const radius = await loadBlastRadius(
-      reader([], (sql) => (sql.includes("AS hit") ? [{ hit: "maybe" }] : undefined)),
-      ctx(),
-      { kind: "alias-removal", position: "predicate", fromNorm: "is priced at" },
+  it("is false on a complete walk", async () => {
+    const radius = computed(
+      await loadBlastRadius(
+        reader([], (sql) => (sql.includes("AS hit") ? [{ hit: false }] : undefined)),
+        ctx(),
+        removal,
+      ),
     );
-    expect(radius.disarming.countsConsistent).toBe(false);
+    expect(radius.subtreeTruncated).toBe(false);
+  });
+
+  for (const [label, hit] of [
+    ["an unreadable probe", "maybe"],
+    ["a NULL probe — bool_or over an empty CTE, or a probe that lost its seed", null],
+  ] as const) {
+    it(`fails CLOSED on ${label}`, async () => {
+      // `false` is the only value that may answer "the walk was complete".
+      // `null` used to take that arm UNLOGGED, while the same module maps
+      // `Number(null)` to NaN forty lines down for exactly this reason.
+      const radius = computed(
+        await loadBlastRadius(
+          reader([], (sql) => (sql.includes("AS hit") ? [{ hit }] : undefined)),
+          ctx(),
+          removal,
+        ),
+      );
+      expect(radius.subtreeTruncated).toBe(true);
+    });
+  }
+});
+
+describe("the closure refusals — both were untested, and a no-op survived each", () => {
+  // `resolveEffectiveTarget`'s two throws had zero coverage: replacing either
+  // guard with a no-op survived all 59 tests. The second is documented as
+  // REACHABLE — 0189's CHECKs do not constrain `effective_target` to being a
+  // norm, and the region importer rebuilds that table.
+  const closureRow = (value: unknown) => (sql: string) =>
+    sql.includes("brain_vocabulary_target") ? [{ effective_target: value }] : undefined;
+
+  it("refuses when the closure column did not read back as a string (query-shape drift)", async () => {
+    await expect(
+      loadBlastRadius(reader([], closureRow(42)), ctx(), APPROVE_PREDICATE),
+    ).rejects.toThrow(/did not read back as a string/);
+  });
+
+  it("refuses when the stored target NORMS AWAY — corruption, not drift", async () => {
+    // ⚠️ The arm that used to be unreachable. Its sibling tested
+    // `stored.trim() === ""` and claimed that was "unreachable from Postgres",
+    // but 0189's CHECK is `effective_target <> ''` — and `'   ' <> ''` is TRUE,
+    // so a whitespace-only target is storable and was being reported as a
+    // QUERY-SHAPE problem. An operator was sent to look at the SELECT, the
+    // driver and the migration state for a bad row.
+    for (const degenerate of ["   ", "-", "___"]) {
+      await expect(
+        loadBlastRadius(reader([], closureRow(degenerate)), ctx(), APPROVE_PREDICATE),
+        `"${degenerate}" must be reported as a corrupt closure, not as query drift`,
+      ).rejects.toThrow(/norms away/);
+    }
+  });
+
+  it("an empty string is the one shape the CHECK does reject, and still refuses", async () => {
+    await expect(
+      loadBlastRadius(reader([], closureRow("")), ctx(), APPROVE_PREDICATE),
+    ).rejects.toThrow(/norms away|did not read back/);
+  });
+});
+
+describe("the refusals name THIS surface", () => {
+  it("an unresolvable reader is refused as `vocabulary-preview`, not as `oversight`", async () => {
+    // ⚠️ The sole justification for adding a `BrainReadSurface` member was that
+    // both previews produced byte-identical refusals. Reverting the constant to
+    // "oversight" survived all 59 tests — the string appeared in no test in the
+    // repo, so the distinction the change bought was the one thing unchecked.
+    const unresolved: BrainPrincipalContext = {
+      origin: "unresolved",
+      workspaceId: WS,
+      userId: null,
+      role: null,
+      audienceIds: [],
+    };
+    await expect(
+      loadBlastRadius(reader([]), unresolved, APPROVE_PREDICATE),
+    ).rejects.toThrow(/brain vocabulary-preview:/);
+  });
+});
+
+describe("the curated probe reads only APPROVED entries", () => {
+  it("a PENDING cardinality row does not make a flip structurally empty", async () => {
+    // Dropping `AND status = 'approved'` from the probe survived all 59 tests:
+    // the unit suite mocked the whole response and the pg suite only ever
+    // seeded approved rows. With that mutation a PENDING proposal — which
+    // `cardinalitySingleSql` deliberately ignores, because a repeat-gated
+    // heuristic must never stamp `valid_to` with no human in the loop — makes
+    // the flip report `already-single`: a fabricated structural empty on the
+    // surface whose entire job is telling those apart.
+    const captures: Capture[] = [];
+    await loadBlastRadius(reader(captures), ctx(), {
+      kind: "cardinality-flip",
+      predicateSurface: "reports to",
+    });
+    const probe = captures.find((c) => c.sql.includes("AS hit"));
+    expect(probe, "the curated probe must run").toBeDefined();
+    expect(probe!.sql).toContain("status = 'approved'");
   });
 });

--- a/packages/api/src/lib/brain/__tests__/vocabulary-preview.test.ts
+++ b/packages/api/src/lib/brain/__tests__/vocabulary-preview.test.ts
@@ -9,10 +9,14 @@
  *
  * The negatives this file exists for, in the order they would hurt:
  *
- *   - **the exclusion arm is `IS NOT TRUE`, never `NOT (…)`.** Third site in the
- *     repo; first one where a bare negation UNDER-discloses an irreversible
- *     consequence, by dropping every `{"source": null}` provenance through the
- *     three-valued hole.
+ *   - **the exclusion arm is spelled `IS NOT TRUE`.** A DEFENSIVE spelling, and
+ *     the test below says so rather than claiming a kill it does not make: the
+ *     two spellings are extensionally identical today, because every
+ *     NULL-capable arm of the exclusion is shared with the JOIN and joining
+ *     forces each one TRUE. `vocabulary-preview-pg.test.ts` measures that
+ *     against a real `{"source": null}` pair. What this pins is the SPELLING,
+ *     so the day an exclusion-only nullable arm appears the guard is already
+ *     there.
  *   - **a predicate-position alias re-points the CARDINALITY lookup too.** The
  *     compound case ADR-0037 §6's amendment exists for is exactly the case a
  *     bundle that moved only the slot arm would report as zero.
@@ -93,22 +97,25 @@ const APPROVE_PREDICATE: BlastRadiusRequest = {
   toNorm: "priced at",
 };
 
-describe("the exclusion arm's polarity", () => {
-  it("negates the other vocabulary with IS NOT TRUE and never a bare NOT", async () => {
+describe("the exclusion arm's spelling", () => {
+  // ⚠️ Scope note, because this test is easy to over-read and an earlier draft
+  // of its name did: it pins a SPELLING, not a behavioural kill. `NOT (…)`
+  // would return the same set today — every NULL-capable arm of the exclusion
+  // (tier, `object_cmp`, a NULL slot key) is shared with the JOIN, and a row
+  // only reaches the exclusion by joining, which forces each shared arm TRUE.
+  // `vocabulary-preview-pg.test.ts` measures that against a real
+  // `{"source": null}` pair. The spelling is kept because the equivalence holds
+  // only while the exclusion has no nullable arm of its own.
+  it("negates the other vocabulary with IS NOT TRUE rather than a bare NOT", async () => {
     const captures: Capture[] = [];
     await loadBlastRadius(reader(captures), ctx(), APPROVE_PREDICATE);
 
     const deltas = deltaStatements(captures);
     expect(deltas.length).toBeGreaterThan(0);
     for (const sql of deltas) {
-      // The exclusion is the whole collision predicate wrapped in `IS NOT TRUE`.
       expect(sql).toContain(") IS NOT TRUE");
-      // ⚠️ The failure this pins: `NOT (` immediately wrapping the collision
-      // would compile, read naturally, and silently drop every row whose
-      // provenance is `{"source": null}` — the population `brain-facts.ts`
-      // twice calls the subtlest one — out of a disclosure that must be
-      // complete. `NOT EXISTS` inside the cardinality gate is a different and
-      // legitimate construct, so the assertion targets the wrapper shape.
+      // `NOT EXISTS` inside the cardinality gate is a different and legitimate
+      // construct, so the assertion targets the wrapper shape specifically.
       expect(sql).not.toContain("AND NOT (p.workspace_id");
       expect(sql).not.toContain("AND NOT (d.workspace_id");
     }
@@ -285,7 +292,13 @@ describe("the cardinality flip imports the held-back count rather than re-derivi
 
 describe("the reader boundary", () => {
   it("throws rather than answering an unresolvable reader with an empty radius", async () => {
-    const unresolved: BrainPrincipalContext = { origin: "unresolved", workspaceId: WS };
+    const unresolved: BrainPrincipalContext = {
+      origin: "unresolved",
+      workspaceId: WS,
+      userId: null,
+      role: null,
+      audienceIds: [],
+    };
     await expect(
       loadBlastRadius(reader([]), unresolved, APPROVE_PREDICATE),
     ).rejects.toBeInstanceOf(BrainReaderUnresolvedError);

--- a/packages/api/src/lib/brain/__tests__/vocabulary-preview.test.ts
+++ b/packages/api/src/lib/brain/__tests__/vocabulary-preview.test.ts
@@ -90,6 +90,24 @@ function deltaStatements(captures: readonly Capture[]): readonly string[] {
     .filter((sql) => sql.includes("FROM brain_facts d") && sql.includes("JOIN brain_facts p"));
 }
 
+/**
+ * Split a delta statement into its JOIN half and its EXCLUSION half.
+ *
+ * ⚠️ Without this every `toContain` in the file is blind to WHICH SIDE of the
+ * delta a substitution landed on — `deltaSql` puts both vocabularies into one
+ * string. Measured: swapping `joinExprs`/`excludeExprs` (arming and disarming
+ * exchanged) passed all 31 unit tests, and replacing the entire exclusion arm
+ * with `AND TRUE` passed all 19 in this file. That is #5035's lesson in its
+ * purest form — a pin derived from source text cannot falsify a change in what
+ * that text means — and the fix is to assert POSITIONALLY.
+ */
+function halves(sql: string): { join: string; exclude: string } {
+  const marker = "\n   WHERE";
+  const at = sql.indexOf(marker);
+  expect(at, "a delta statement must have a WHERE clause to split on").toBeGreaterThan(0);
+  return { join: sql.slice(0, at), exclude: sql.slice(at) };
+}
+
 const APPROVE_PREDICATE: BlastRadiusRequest = {
   kind: "alias-approval",
   position: "predicate",
@@ -113,11 +131,65 @@ describe("the exclusion arm's spelling", () => {
     const deltas = deltaStatements(captures);
     expect(deltas.length).toBeGreaterThan(0);
     for (const sql of deltas) {
-      expect(sql).toContain(") IS NOT TRUE");
-      // `NOT EXISTS` inside the cardinality gate is a different and legitimate
-      // construct, so the assertion targets the wrapper shape specifically.
-      expect(sql).not.toContain("AND NOT (p.workspace_id");
-      expect(sql).not.toContain("AND NOT (d.workspace_id");
+      // ⚠️ Asserted on the EXCLUSION half only. A bare `toContain(") IS NOT
+      // TRUE")` over the whole statement is vacuous — `subjectNotDifferentSql`
+      // already emits `)) IS NOT TRUE` inside every collision predicate, so the
+      // assertion passed on a statement with NO exclusion arm at all. Measured.
+      const { exclude } = halves(sql);
+      expect(exclude).toContain(") IS NOT TRUE");
+      expect(exclude).not.toContain("AND NOT (p.workspace_id");
+      expect(exclude).not.toContain("AND NOT (d.workspace_id");
+    }
+  });
+
+  it("the exclusion arm actually EXISTS — the delta is a difference, not a listing", async () => {
+    // The mutation the assertion above could not see: replacing the whole
+    // exclusion with `AND TRUE` makes `arming` report every colliding pair
+    // rather than the NEW ones. That is an over-disclosure that reads as a
+    // catastrophic blast radius, and it passed every test in this file.
+    const captures: Capture[] = [];
+    await loadBlastRadius(reader(captures), ctx(), APPROVE_PREDICATE);
+
+    for (const sql of deltaStatements(captures)) {
+      const { exclude } = halves(sql);
+      // The exclusion must name the FULL collision predicate of the other
+      // vocabulary, not merely be present.
+      expect(exclude).toContain("p.workspace_id = d.workspace_id");
+      expect(exclude).toContain("brain_predicate_cardinality");
+      expect(exclude).not.toContain("AND TRUE");
+    }
+  });
+
+  it("ARMING is the side that joins on the hypothetical — asserted through the RESULT", async () => {
+    // ⚠️ A counting assertion is NOT enough, and this is the second draft.
+    // "Exactly two statements JOIN on the hypothetical" stays true when
+    // `joinExprs`/`excludeExprs` are exchanged — the same statements exist,
+    // attributed to the opposite direction — so the swap survived it. Measured.
+    //
+    // Answering the two vocabularies with DIFFERENT counts is what ties a
+    // statement to the side that reported it. Under the swap, `arming` reports
+    // the stored side's number and this fails.
+    const SUB = "CASE WHEN d.predicate_key = $2";
+    const radius = await loadBlastRadius(
+      reader([], (sql) => {
+        if (!sql.includes("delta_total")) return undefined;
+        return halves(sql).join.includes(SUB) ? [{ delta_total: 7 }] : [{ delta_total: 3 }];
+      }),
+      ctx(),
+      APPROVE_PREDICATE,
+    );
+
+    expect(radius.arming.total).toBe(7);
+    expect(radius.disarming.total).toBe(3);
+  });
+
+  it("no statement joins on AND excludes the same vocabulary — that is a self-difference", async () => {
+    const captures: Capture[] = [];
+    await loadBlastRadius(reader(captures), ctx(), APPROVE_PREDICATE);
+    const SUB = "CASE WHEN d.predicate_key = $2";
+    for (const sql of deltaStatements(captures)) {
+      const { join, exclude } = halves(sql);
+      expect(join.includes(SUB) && exclude.includes(SUB)).toBe(false);
     }
   });
 });
@@ -249,18 +321,39 @@ describe("the cardinality flip imports the held-back count rather than re-derivi
   it("un-curating asks the opposite question and can arm nothing", async () => {
     const captures: Capture[] = [];
     const radius = await loadBlastRadius(
-      reader(captures, (sql) =>
-        sql.includes("brain_predicate_cardinality\n        WHERE") ? [{ hit: 1 }] : undefined,
-      ),
+      reader(captures, (sql) => {
+        if (sql.includes("AS hit")) return [{ hit: 1 }];
+        if (sql.includes("delta_total")) return [{ delta_total: 11 }];
+        return undefined;
+      }),
       ctx(),
       { kind: "cardinality-removal", predicateSurface: "reports to" },
     );
 
-    // A removal's hypothetical SUBTRACTS the key from the gate, so the arming
-    // side joins on a strictly narrower rule than it excludes — provably empty.
-    expect(radius.arming.total).toBe(0);
+    // ⚠️ The value assertion that used to live here (`arming.total === 0`) is
+    // NOT expressible at this level, and finding that out is why the responder
+    // now answers non-zero. A mock does not evaluate SQL — it returned whatever
+    // it was told — so `0 === 0` held under every implementation, including one
+    // whose arming side joins on the broadest possible rule. Feeding it 11 made
+    // the test fail, which is the correct outcome: the emptiness is a property
+    // of the STATEMENT and only a real database can decide it.
+    //
+    // So the value lives in `vocabulary-preview-pg.test.ts` ("a CARDINALITY
+    // removal disarms exactly the pairs the preview promised", which asserts
+    // `arming.total === 0` against real rows), and what is asserted HERE is the
+    // shape that makes it empty: the arming side joins on a rule strictly
+    // NARROWER than the one it excludes, so the difference cannot contain a row.
+    expect(radius.disarming.total).toBe(11);
     const deltas = deltaStatements(captures);
-    expect(deltas.some((s) => s.includes("IS DISTINCT FROM $2"))).toBe(true);
+    const unflip = "IS DISTINCT FROM $2";
+    const arming = deltas.filter((sql) => halves(sql).join.includes(unflip));
+    expect(arming.length).toBeGreaterThan(0);
+    for (const sql of arming) {
+      const { join, exclude } = halves(sql);
+      // JOIN carries the subtracted gate; the exclusion carries the stored one.
+      expect(join).toContain(unflip);
+      expect(exclude).not.toContain(unflip);
+    }
     // No imported held-back statement: that count answers "what would curating
     // arm", which is not this decision's question.
     expect(captures.some((c) => c.sql.includes("AS held_back"))).toBe(false);
@@ -423,5 +516,186 @@ describe("the payload", () => {
     // and this flag is what makes that assertable rather than conventional.
     const radius = await loadBlastRadius(reader([]), ctx(), APPROVE_PREDICATE);
     expect(radius.floor).toBe(true);
+  });
+});
+
+describe("an unkeyable surface is a disclosed REASON, never a zero", () => {
+  // ⚠️ The path that used to return `structurallyEmpty: null` with two zeroed
+  // sides — and `null` is documented as "the question was asked and answered",
+  // so a request that was never computable rendered as "at least 0 today, and
+  // every future claim in this slot". The module's signature failure, produced
+  // by the module, on the one path nothing logged.
+  //
+  // `-`, `___` and `  ` all norm away, and `reconcile.ts`'s MALFORMED_CLAIM
+  // guard tests `trim() === ""` — so it admits `-` and `___`, which is why
+  // these rows exist in real corpora rather than being a hypothetical.
+  for (const surface of ["-", "___", "  "]) {
+    it(`refuses to compute for ${JSON.stringify(surface)} and says why`, async () => {
+      const captures: Capture[] = [];
+      const radius = await loadBlastRadius(reader(captures), ctx(), {
+        kind: "alias-approval",
+        position: "predicate",
+        fromNorm: surface,
+        toNorm: "priced at",
+      });
+
+      expect(radius.structurallyEmpty).toBe("unkeyable-surface");
+      expect(radius.arming.total).toBe(0);
+      // Not merely zero — the question was never asked.
+      expect(deltaStatements(captures)).toHaveLength(0);
+    });
+  }
+
+  it("the same for a cardinality flip on a degenerate predicate", async () => {
+    const radius = await loadBlastRadius(reader([]), ctx(), {
+      kind: "cardinality-flip",
+      predicateSurface: "-",
+    });
+    expect(radius.structurallyEmpty).toBe("unkeyable-surface");
+  });
+
+  it("an unresolvable reader is refused BEFORE the unkeyable check", async () => {
+    // The ordering that used to be wrong: the fail-closed gate lived inside
+    // `loadBlastRadiusSide`, i.e. after both early returns, so an unresolvable
+    // reader asking about a degenerate norm got a clean zero instead of a
+    // refusal. The gate is reachable only on the paths that did not need it.
+    const unresolved: BrainPrincipalContext = {
+      origin: "unresolved",
+      workspaceId: WS,
+      userId: null,
+      role: null,
+      audienceIds: [],
+    };
+    await expect(
+      loadBlastRadius(reader([]), unresolved, {
+        kind: "alias-approval",
+        position: "predicate",
+        fromNorm: "-",
+        toNorm: "priced at",
+      }),
+    ).rejects.toBeInstanceOf(BrainReaderUnresolvedError);
+  });
+});
+
+describe("countsConsistent — the half the clamp alone does not carry", () => {
+  // `loadFactOversight` ships this flag precisely because "silently clamping
+  // the delta to zero renders as 'nothing is hidden from you', which is the
+  // pre-#4825 defect reproduced by its own fix." This module clamped, logged,
+  // and shipped nothing — so a client rendered `withheld: 0` off two statements
+  // that had just disagreed.
+  const pairRow = (i: number, scopedTotal: unknown) => ({
+    draft_id: `d${i}`,
+    draft_label: "a b c",
+    superseded_id: `p${i}`,
+    superseded_label: "a b d",
+    scoped_total: scopedTotal,
+  });
+
+  it("is true on a clean read", async () => {
+    const radius = await loadBlastRadius(
+      reader([], (sql) =>
+        sql.includes("draft_label")
+          ? [pairRow(1, 1)]
+          : sql.includes("delta_total")
+            ? [{ delta_total: 3 }]
+            : undefined,
+      ),
+      ctx(),
+      APPROVE_PREDICATE,
+    );
+    expect(radius.arming.countsConsistent).toBe(true);
+    expect(radius.arming.withheld).toBe(2);
+  });
+
+  it("is CLEARED when the scoped count exceeds the workspace count", async () => {
+    // The inversion. `withheld` clamps to 0, which reads as "nothing is hidden
+    // from you" — true only if the two statements agreed, and they did not.
+    const radius = await loadBlastRadius(
+      reader([], (sql) =>
+        sql.includes("draft_label")
+          ? [pairRow(1, 9)]
+          : sql.includes("delta_total")
+            ? [{ delta_total: 1 }]
+            : undefined,
+      ),
+      ctx(),
+      APPROVE_PREDICATE,
+    );
+    expect(radius.arming.withheld).toBe(0);
+    expect(radius.arming.countsConsistent).toBe(false);
+  });
+
+  it("is CLEARED when a row will not narrow — a dropped row is not an ACL-withheld one", async () => {
+    // On the unclipped path the first floor does not apply, so a row that
+    // failed to PARSE falls through and re-emerges inside `withheld`: "you lack
+    // permission to see this" for a row that simply would not read.
+    const radius = await loadBlastRadius(
+      reader([], (sql) =>
+        sql.includes("draft_label")
+          ? [pairRow(1, 2), { draft_id: 42, draft_label: null }]
+          : sql.includes("delta_total")
+            ? [{ delta_total: 2 }]
+            : undefined,
+      ),
+      ctx(),
+      APPROVE_PREDICATE,
+    );
+    expect(radius.arming.pairs).toHaveLength(1);
+    expect(radius.arming.countsConsistent).toBe(false);
+  });
+
+  it("is CLEARED when the scoped window will not parse", async () => {
+    const radius = await loadBlastRadius(
+      reader([], (sql) =>
+        sql.includes("draft_label")
+          ? [pairRow(1, "not-a-number")]
+          : sql.includes("delta_total")
+            ? [{ delta_total: 5 }]
+            : undefined,
+      ),
+      ctx(),
+      APPROVE_PREDICATE,
+    );
+    expect(radius.arming.countsConsistent).toBe(false);
+  });
+
+  it("a NULL window is treated as drift, not as a finite zero", async () => {
+    // `Number(null)` is a finite 0, which would skip both the max() and the
+    // drift counter — the one shape of window drift that would otherwise go
+    // entirely unlogged and unflagged.
+    const radius = await loadBlastRadius(
+      reader([], (sql) =>
+        sql.includes("draft_label")
+          ? [pairRow(1, null)]
+          : sql.includes("delta_total")
+            ? [{ delta_total: 4 }]
+            : undefined,
+      ),
+      ctx(),
+      APPROVE_PREDICATE,
+    );
+    expect(radius.arming.countsConsistent).toBe(false);
+  });
+
+  it("is CLEARED when the removal subtree walk hit the depth bound", async () => {
+    // A truncated walk understates the disarming set — an admin could withdraw
+    // an arbitration whose scope was understated by an order of magnitude with
+    // every counter reading trustworthy.
+    const radius = await loadBlastRadius(
+      reader([], (sql) => (sql.includes("AS hit") ? [{ hit: true }] : undefined)),
+      ctx(),
+      { kind: "alias-removal", position: "predicate", fromNorm: "is priced at" },
+    );
+    expect(radius.disarming.countsConsistent).toBe(false);
+    expect(radius.arming.countsConsistent).toBe(false);
+  });
+
+  it("an unreadable depth probe fails CLOSED", async () => {
+    const radius = await loadBlastRadius(
+      reader([], (sql) => (sql.includes("AS hit") ? [{ hit: "maybe" }] : undefined)),
+      ctx(),
+      { kind: "alias-removal", position: "predicate", fromNorm: "is priced at" },
+    );
+    expect(radius.disarming.countsConsistent).toBe(false);
   });
 });

--- a/packages/api/src/lib/brain/cardinality.ts
+++ b/packages/api/src/lib/brain/cardinality.ts
@@ -259,12 +259,34 @@ export type CardinalityWriteResult =
  *
  * `alias` is interpolated; callers pass a plain identifier they control — the
  * same contract as `brainFactStatusClause` and `comparableDifferentSql`.
+ *
+ * ## `predicateKeyExpr` — the COUNTERFACTUAL seam (#5025)
+ *
+ * #5025's blast-radius preview asks *"what would supersede if I approved this
+ * alias?"*, and a predicate-position alias moves a claim's `predicate_key`. The
+ * lookup has to follow it: after `is priced at → priced at` the merged slot's
+ * cardinality is the one curated on **`priced at`**, so a preview that kept
+ * reading the stored column would answer about the slot the claim is leaving.
+ *
+ * Defaulted to `${alias}.predicate_key`, so every shipped caller emits the
+ * byte-identical string it emitted before the parameter existed —
+ * `collision-sql-pinned.test.ts` asserts exactly that against a literal, which
+ * is what makes this a parameterization rather than the second spelling of
+ * "what collides" that `supersessionCollisionJoin`'s header forbids.
+ *
+ * ⚠️ The `workspace_id` arm is NOT parameterized and must not become so. A
+ * counterfactual is about which SLOT a claim occupies inside one workspace; a
+ * vocabulary never moves a row across workspaces, and a seam that let it would
+ * make a preview disclose another tenant's curation.
  */
-export function cardinalitySingleSql(alias: string): string {
+export function cardinalitySingleSql(
+  alias: string,
+  predicateKeyExpr: string = `${alias}.predicate_key`,
+): string {
   return `EXISTS (
        SELECT 1 FROM brain_predicate_cardinality c
         WHERE c.workspace_id = ${alias}.workspace_id
-          AND c.predicate_key = ${alias}.predicate_key
+          AND c.predicate_key = ${predicateKeyExpr}
           AND c.cardinality = 'single'
           AND c.status = 'approved')`;
 }

--- a/packages/api/src/lib/brain/reader-context.ts
+++ b/packages/api/src/lib/brain/reader-context.ts
@@ -84,7 +84,20 @@ const log = createLogger("brain-reader-context");
 export class BrainReaderIdentityError extends Error {}
 
 /** Closed diagnostic vocabulary for which surface refused a read. */
-export type BrainReadSurface = "read" | "review" | "search" | "oversight" | "correction";
+export type BrainReadSurface =
+  | "read"
+  | "review"
+  | "search"
+  | "oversight"
+  | "correction"
+  /**
+   * The Claim Vocabulary blast-radius preview (#5086). Its own member rather
+   * than reusing `"oversight"`: both modules refuse with this class, and one
+   * shared literal made the two messages byte-identical — so an operator could
+   * not tell the publish preview from the counterfactual preview, which are two
+   * different fixes. Diagnostics only, never branched on.
+   */
+  | "vocabulary-preview";
 
 /**
  * The reader's identity could not be turned into a usable principal set, so

--- a/packages/api/src/lib/brain/vocabulary-preview.ts
+++ b/packages/api/src/lib/brain/vocabulary-preview.ts
@@ -1,0 +1,887 @@
+/**
+ * The blast-radius preview — *what becomes supersedable if I approve this?*
+ * (#5025, ADR-0037 §6).
+ *
+ * `lib/brain/oversight.ts` answers *what will the next publish supersede under
+ * the vocabulary as it stands*. This module answers a **counterfactual** over a
+ * vocabulary that does not exist yet, and #5025's own issue flags the difference
+ * as the design decision to settle before writing the AC-2 parity test: the
+ * SHAPE is `loadSupersessionPreview`'s, the QUESTION is not.
+ *
+ * ## It is a parameterization, not a fork, and the seam is the columns
+ *
+ * `oversight.ts:800-803`'s anti-drift rule — *a disclosure that restates the
+ * rule drifts from it; import the same join the re-key will run* — rules out
+ * copying the collision arms with two columns swapped. So `brain-facts.ts` grew
+ * {@link CollisionExprs}: the collision's CONJUNCTS stay single-spelled and its
+ * SLOT EXPRESSIONS became a parameter. Every statement here is
+ * `supersessionCollisionPredicate` evaluated twice over the same two rows —
+ * once against the stored columns, once against the hypothetical ones — so a
+ * caller cannot reach a rule with the tier guard, the cardinality gate or the
+ * homonym suppression absent. `collision-sql-pinned.test.ts` holds the shipped
+ * statements byte-for-byte and proves the default parameterization is the
+ * stored one.
+ *
+ * ## The delta is TWO-SIDED, and that is what makes removal expressible
+ *
+ * #5025's grill checkpoint adds an *In force* pane where an approved edge is
+ * removable **behind the same preview approval uses** — *a removal is a re-key
+ * too*. Rather than a second function, the preview is a DELTA between two
+ * vocabularies:
+ *
+ *   - **arming** — pairs that do not supersede today and would after. The
+ *     dangerous set for an approval, and the one AC 2 calls *newly-supersedable
+ *     rather than merely newly-colliding*.
+ *   - **disarming** — pairs that supersede today and would not after. Empty for
+ *     an approval (a merge only creates collisions) and the informative set for
+ *     a removal, where it is the arbitration a human is about to withdraw.
+ *
+ * One code path computes both by swapping which side of the delta the JOIN runs
+ * on. The alternative — an `approve` preview and a `remove` preview — is two
+ * spellings of one question, which is the shape this file exists to avoid.
+ *
+ * ## ⚠️ The exclusion arm is `IS NOT TRUE`, never `NOT (…)`
+ *
+ * The delta's second half asks *and it does NOT collide under the other
+ * vocabulary*, and `supersedableTierSql` is SQL **NULL** — not `false` — for a
+ * `{"source": null}` provenance. `NOT (NULL)` is NULL, so a bare negation drops
+ * exactly the population `brain-facts.ts` twice records as the subtlest one out
+ * of a disclosure whose entire job is to be complete. The repo has already paid
+ * for this distinction on `TIER_HELD_BACK_COUNT_SQL` and on `objectNotSameSql`;
+ * this is the third site and it is the one where the failure is an
+ * UNDER-disclosure of an irreversible consequence.
+ *
+ * ## ⚠️ The object position has NO supersession blast radius
+ *
+ * The collision joins on `subject_key`, `predicate_key` and `object_cmp`.
+ * `object_key` appears nowhere in it — an object-position alias moves
+ * `object_key`, which is a CORROBORATION arm (`reconcile.ts`'s `objectSameSql`)
+ * — so approving one changes what corroborates and what earns a tension edge,
+ * and changes nothing about what supersedes.
+ *
+ * That is reported as {@link BlastRadius.structurallyEmpty} rather than as a
+ * zero, because *"0 pairs"* and *"this position cannot produce pairs"* are the
+ * same number and opposite facts, and an approver reading the first will
+ * reasonably conclude the alias is harmless when what is true is that its harm
+ * is of a different kind. The same trap the M1 dogfood fell into: the sync
+ * reported green because the flag was on, and only a row count separated that
+ * from a source never connected.
+ *
+ * ## Counts are FLOORS and say so
+ *
+ * `WILL_SUPERSEDE_TOTAL_SQL`'s deliberate over-statement is inherited (it counts
+ * colliding live drafts including ones the promotion classifier will refuse) —
+ * kept, because replicating the refusal rules in SQL is the second spelling
+ * `oversight.ts:806-811` declines. On top of that, a cardinality flip is **not a
+ * batch**: it applies to every future claim in the slot, forever. So every count
+ * this module returns is a floor, {@link BlastRadius.floor} says so in the type,
+ * and the surface renders *"at least N today, and every future claim in this
+ * slot"* rather than *"N pairs"*.
+ */
+
+import { createLogger } from "@atlas/api/lib/logger";
+import type { BrainCandidateReader } from "@atlas/api/lib/brain/candidates";
+import { aclVisibilityClause, type BrainPrincipalContext } from "@atlas/api/lib/brain/acl";
+import { BrainReaderUnresolvedError } from "@atlas/api/lib/brain/reader-context";
+import {
+  identityKey,
+  identityKeySql,
+  lexicalNorm,
+  type SlotPosition,
+} from "@atlas/api/lib/brain/identity";
+import { MAX_CHAIN_DEPTH } from "@atlas/api/lib/brain/vocabulary";
+import { cardinalitySingleSql } from "@atlas/api/lib/brain/cardinality";
+import {
+  STORED_COLLISION_EXPRS,
+  cardinalityHeldBackCountSql,
+  supersedingDraftPredicate,
+  supersessionCollisionPredicate,
+  type CollisionExprs,
+} from "@atlas/api/lib/content-mode/adapters/brain-facts";
+
+const log = createLogger("brain-vocabulary-preview");
+
+/** Which read surface refused, for {@link BrainReaderUnresolvedError}. */
+const PREVIEW_SURFACE = "oversight";
+
+/**
+ * Most pairs one preview enumerates — {@link WILL_SUPERSEDE_PAIR_MAX}'s bound
+ * and posture. Overrun is reported as `truncated`, never silent, and never
+ * laundered into `withheld`, which means something else entirely.
+ */
+export const BLAST_RADIUS_PAIR_MAX = 50;
+
+/**
+ * One pair a decision would arm or disarm.
+ *
+ * Labels, never keys. ADR-0037 §6 forbids projecting a key beside its claim
+ * (`keys-not-on-the-wire.test.ts` is the guard), and a consumer that can branch
+ * on a key is what makes an alias un-removable. The SURFACE is what an approver
+ * reads anyway.
+ */
+export interface BlastRadiusPair {
+  readonly draftId: string;
+  readonly draftLabel: string;
+  readonly supersededId: string;
+  readonly supersededLabel: string;
+}
+
+/**
+ * Why a preview can produce no pairs AT ALL, as distinct from producing none.
+ *
+ * A nullable reason rather than a boolean, because the two known causes are not
+ * interchangeable and a surface must be able to say which. `null` means the
+ * question was asked and answered.
+ */
+export type StructurallyEmptyReason =
+  /**
+   * An object-position alias. The collision does not read `object_key`, so no
+   * object alias can arm or disarm a supersession — see the module header.
+   */
+  | "object-position"
+  /**
+   * A predicate that is already curated `single`. There is nothing to flip, so
+   * the flip preview has no counterfactual to compute.
+   */
+  | "already-single"
+  /**
+   * A predicate with no approved `single` entry, asked about a REMOVAL. Its own
+   * member rather than reusing `already-single`, because the two render as
+   * opposite sentences to an approver and a surface that mapped both to one
+   * string would tell someone their un-curation is a no-op *because the
+   * predicate is already single*.
+   */
+  | "not-curated";
+
+/** The counterfactual's answer. */
+export interface BlastRadius {
+  /**
+   * Pairs a decision would make supersedable — content-free count plus a
+   * reader-scoped bounded sample.
+   */
+  readonly arming: BlastRadiusSide;
+  /** Pairs a decision would make safe again. Empty for every approval. */
+  readonly disarming: BlastRadiusSide;
+  /**
+   * ALWAYS true today, and a field rather than a comment because the surface
+   * must render the floor wording and a boolean is what makes that assertable.
+   * See the module header for the two independent reasons.
+   */
+  readonly floor: true;
+  /** Non-null when the counterfactual cannot produce pairs by construction. */
+  readonly structurallyEmpty: StructurallyEmptyReason | null;
+}
+
+export interface BlastRadiusSide {
+  /** Unscoped, workspace-wide. A number, never content. */
+  readonly total: number;
+  /** Reader-scoped on BOTH sides. See {@link loadBlastRadiusSide}. */
+  readonly pairs: readonly BlastRadiusPair[];
+  /** `total − scopedTotal`: pairs that happen regardless, listing rows this reader may not read. */
+  readonly withheld: number;
+  /** The page overran {@link BLAST_RADIUS_PAIR_MAX}. Never folded into `withheld`. */
+  readonly truncated: boolean;
+}
+
+const EMPTY_SIDE: BlastRadiusSide = Object.freeze({
+  total: 0,
+  pairs: [],
+  withheld: 0,
+  truncated: false,
+});
+
+// ---------------------------------------------------------------------------
+// The hypothetical vocabularies
+// ---------------------------------------------------------------------------
+
+/**
+ * The slot column for one position — the only three a counterfactual may move.
+ *
+ * A mapped type rather than a string concatenation, on `SLOT_COLUMNS`'
+ * precedent in `vocabulary-decide.ts`: `object: "subject_key"` is the
+ * cross-position slip ADR-0037 §6 calls unrecoverable, and it should not
+ * compile.
+ */
+const SLOT_KEY_COLUMN: { readonly [P in SlotPosition]: `${P}_key` } = {
+  subject: "subject_key",
+  predicate: "predicate_key",
+  object: "object_key",
+};
+
+/** The retained surface column for one position. */
+const SLOT_SURFACE_COLUMN: { readonly [P in SlotPosition]: P } = {
+  subject: "subject",
+  predicate: "predicate",
+  object: "object",
+};
+
+/**
+ * The APPROVAL counterfactual: rows keyed `$fromKey` move to `$toKey`.
+ *
+ * Well-defined key-to-key, and that is a quotation rather than an assumption —
+ * `REKEY_DRIFTED_FACTS_SQL`'s header states it: *adding `a → b` moves exactly
+ * the rows keyed `a` onto `b`*. Every norm that currently resolves to `from`
+ * (`from` itself and its descendants) shares the key `from`, so one CASE covers
+ * the whole moving population.
+ *
+ * ⚠️ `$toKey` is `to`'s CURRENT EFFECTIVE TARGET, not `to`. If `to → z` is
+ * already approved the closure lands the merged population on `z`, and a
+ * preview that used `to` would compute a slot the re-key never writes. Resolved
+ * against the closure by {@link resolveEffectiveTarget} rather than assumed.
+ */
+function approvalKeyExpr(
+  position: SlotPosition,
+  fromKeyParam: number,
+  toKeyParam: number,
+): (alias: string) => string {
+  const column = SLOT_KEY_COLUMN[position];
+  return (alias) =>
+    `(CASE WHEN ${alias}.${column} = $${fromKeyParam} THEN $${toKeyParam} ` +
+    `ELSE ${alias}.${column} END)`;
+}
+
+/**
+ * The REMOVAL counterfactual, and it is NOT the approval one inverted.
+ *
+ * `REKEY_DRIFTED_FACTS_SQL`'s header is explicit about why: *removal is not
+ * well-defined key-to-key. Dropping `a`'s parent makes `a` a root again, so of
+ * the rows keyed `R`, those whose norm chains through `a` become `a` and the
+ * rest stay `R` — and the key column cannot tell the two populations apart,
+ * because sharing a key is precisely what it records. Only the retained surface
+ * can.*
+ *
+ * So this expression re-derives from the SURFACE, exactly as the re-key does,
+ * and the population is the SUBTREE of `from` in the approved-edge graph:
+ * post-removal every descendant of `from` chains up to `from` and stops there,
+ * because `from`'s own parent is the edge being dropped.
+ *
+ * `identityKeySql` — the same expression the re-key runs — is what makes the
+ * comparison meaningful; a hand-written `lower()` here would be the third
+ * implementation of `lexicalNorm` and the one that disagrees.
+ */
+function removalKeyExpr(
+  position: SlotPosition,
+  subtreeCte: string,
+  fromKeyParam: number,
+): (alias: string) => string {
+  const column = SLOT_KEY_COLUMN[position];
+  const surface = SLOT_SURFACE_COLUMN[position];
+  return (alias) =>
+    `(CASE WHEN ${identityKeySql(`${alias}.${surface}`)} IN (SELECT node FROM ${subtreeCte}) ` +
+    `THEN $${fromKeyParam} ELSE ${alias}.${column} END)`;
+}
+
+/**
+ * Every norm that resolves THROUGH `from` — `from` and its descendants in the
+ * approved-edge graph.
+ *
+ * Bounded by {@link MAX_CHAIN_DEPTH} for `vocabulary.ts`'s liveness reason: an
+ * at-most-one-parent acyclic store cannot produce a chain longer than its node
+ * count, so reaching the bound is a corruption signal rather than a design
+ * limit. A preview that spun on a corrupt store would hang an admin request
+ * with no signal, which is the shape `IDENTITY_MUTATION_LOCK_TIMEOUT_SQL`
+ * exists to prevent one seam over.
+ *
+ * ⚠️ The bound TRUNCATES here rather than raising, and the asymmetry with
+ * `recomputeEffectiveTargets` is deliberate: that function WRITES a closure, so
+ * a truncated walk would commit keys nobody approved. This one only DISCLOSES,
+ * and a truncated walk understates the blast radius — which is logged by
+ * {@link loadBlastRadius}'s caller through the corruption the closure rebuild
+ * will independently refuse. A preview must never be the thing that takes a
+ * workspace's admin console down.
+ */
+function subtreeCteSql(
+  cteName: string,
+  workspaceParam: number,
+  positionParam: number,
+  fromNormParam: number,
+): string {
+  return `${cteName} AS (
+       SELECT $${fromNormParam}::text AS node, 1 AS depth
+       UNION ALL
+       SELECT e.from_norm, s.depth + 1
+         FROM ${cteName} s
+         JOIN brain_vocabulary_edge e
+           ON e.workspace_id = $${workspaceParam}::text
+          AND e.slot_position = $${positionParam}::text
+          AND e.to_norm = s.node
+        WHERE s.depth < ${MAX_CHAIN_DEPTH}
+     )`;
+}
+
+/**
+ * The CARDINALITY-FLIP counterfactual: one predicate key reads `single`.
+ *
+ * A whole expression rather than a flag, because the gate must answer TRUE for
+ * a key that has no `approved` row yet while still answering the stored lookup
+ * for every other key in the workspace — a preview scoped to one predicate that
+ * disabled the gate globally would count collisions in slots the flip does not
+ * touch.
+ *
+ * The disjunct is ORDERED with the cheap equality first, and the stored `EXISTS`
+ * second, so the correlated subquery is skipped for the flip's own rows.
+ */
+function cardinalityFlipExpr(predicateKeyParam: number): CollisionExprs {
+  return {
+    ...STORED_COLLISION_EXPRS,
+    cardinalitySingle: (alias) =>
+      `(${alias}.predicate_key = $${predicateKeyParam} ` +
+      `OR ${STORED_COLLISION_EXPRS.cardinalitySingle(alias)})`,
+  };
+}
+
+/**
+ * The UN-curation counterfactual: one predicate key stops reading `single`.
+ *
+ * The *In force* pane's removal for a cardinality entry, and it is not
+ * {@link cardinalityFlipExpr} inverted — it is the gate with one key subtracted
+ * rather than one key added, because every OTHER curated predicate in the
+ * workspace must keep answering the stored lookup.
+ *
+ * `IS DISTINCT FROM`, not `<>`. `predicate_key` is nullable on disk (a surface
+ * that norms away — `identityKey`'s ⚠️, permanent and legal), and `NULL <> $k`
+ * is NULL, which would make the whole conjunct NULL and drop the row through the
+ * three-valued hole rather than excluding it on the merits. A NULL-keyed row
+ * never matched the stored `EXISTS` either, so the two spellings agree on the
+ * OUTCOME here — but only by coincidence, and the coincidence is exactly what
+ * stops holding when someone edits the stored gate.
+ */
+function cardinalityUnflipExpr(predicateKeyParam: number): CollisionExprs {
+  return {
+    ...STORED_COLLISION_EXPRS,
+    cardinalitySingle: (alias) =>
+      `(${alias}.predicate_key IS DISTINCT FROM $${predicateKeyParam} ` +
+      `AND ${STORED_COLLISION_EXPRS.cardinalitySingle(alias)})`,
+  };
+}
+
+/**
+ * An alias approval or removal at ONE position, as a full expression bundle.
+ *
+ * Spelled as an exhaustive switch rather than a computed key
+ * (`{ [pos === "subject" ? "subjectKey" : "predicateKey"]: … }`), which needed
+ * an `as CollisionExprs` — and that cast is load-bearing in the wrong
+ * direction: it tells the compiler the record is complete, so a fourth
+ * `SlotPosition`, or a typo in either property name, produces a bundle silently
+ * missing an expression and a counterfactual that quietly reads the stored
+ * column it was supposed to move.
+ *
+ * ## The predicate arm moves TWO expressions, and missing the second is silent
+ *
+ * A predicate-position alias moves `predicate_key`, and the cardinality gate is
+ * a lookup ON that key. After `is priced at → priced at` the merged slot's
+ * cardinality is the one curated on **`priced at`** — so a bundle that
+ * re-pointed only the slot arm would ask whether the claim's OLD predicate is
+ * curated while joining on its NEW one. That answers about the slot the claim is
+ * leaving, and it fails in the under-disclosing direction: the compound case
+ * ADR-0037 §6's amendment exists for (*"approving `is priced at → priced at`
+ * moves that predicate's whole population into a slot where, if `priced at` is
+ * curated `single`, supersession is now armed for claims that were safe a moment
+ * earlier"*) is exactly the case it would report as zero.
+ */
+function aliasExprs(
+  position: SlotPosition,
+  keyExpr: (alias: string) => string,
+): CollisionExprs {
+  switch (position) {
+    case "subject":
+      return { ...STORED_COLLISION_EXPRS, subjectKey: keyExpr };
+    case "predicate":
+      return {
+        ...STORED_COLLISION_EXPRS,
+        predicateKey: keyExpr,
+        cardinalitySingle: (alias) => cardinalitySingleSql(alias, keyExpr(alias)),
+      };
+    case "object":
+      // Unreachable: `structurallyEmptyReason` returns `object-position` before
+      // any plan is built. Thrown rather than falling through to the stored
+      // bundle, because a silent identity counterfactual would render as "this
+      // alias changes nothing" — which is TRUE for supersession and false for
+      // what an approver would take it to mean.
+      throw new Error(
+        "loadBlastRadius: an object-position alias has no supersession counterfactual — the " +
+          "collision does not read `object_key`. This is reported as structurallyEmpty " +
+          '"object-position" before a plan is built, so reaching here is an ordering regression.',
+      );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// The delta
+// ---------------------------------------------------------------------------
+
+/** Which half of the delta a statement computes. */
+export type DeltaDirection = "arming" | "disarming";
+
+/**
+ * One side of the delta, as SQL.
+ *
+ * `joinExprs` is the vocabulary the pair must collide UNDER; `excludeExprs` is
+ * the one it must NOT collide under. For `arming` those are (hypothetical,
+ * stored); for `disarming` they are (stored, hypothetical). Both come from
+ * `supersessionCollisionPredicate`, so both carry every conjunct.
+ *
+ * ⚠️ `IS NOT TRUE` on the exclusion, never `NOT (…)`. See the module header —
+ * this is the third site in the repo where the distinction decides whether the
+ * subtlest population is visible, and the first where getting it wrong
+ * UNDER-discloses an irreversible consequence.
+ */
+function deltaSql(opts: {
+  readonly select: string;
+  readonly joinExprs: CollisionExprs;
+  readonly excludeExprs: CollisionExprs;
+  readonly workspaceParam: number;
+  readonly extraWhere?: string;
+  readonly ctes?: readonly string[];
+  readonly tail?: string;
+}): string {
+  const ctes = opts.ctes && opts.ctes.length > 0 ? `WITH RECURSIVE ${opts.ctes.join(",\n     ")}\n` : "";
+  const extra = opts.extraWhere ? `\n     AND ${opts.extraWhere}` : "";
+  return `${ctes}SELECT ${opts.select}
+    FROM brain_facts d
+    JOIN brain_facts p
+      ON ${supersessionCollisionPredicate("d", "p", opts.joinExprs)}
+   WHERE d.workspace_id = $${opts.workspaceParam}
+     AND ${supersedingDraftPredicate("d")}
+     AND (${supersessionCollisionPredicate("d", "p", opts.excludeExprs)}) IS NOT TRUE${extra}${opts.tail ?? ""}`;
+}
+
+/** The content-free count. */
+const TOTAL_SELECT = "COUNT(*)::int AS delta_total";
+
+/**
+ * The reader-scoped pair projection, BOTH sides gated.
+ *
+ * Requiring both sides is `willSupersedePairsSql`'s decision and it transfers
+ * unchanged: *"something you cannot see will replace X"* and *"Y will replace
+ * something you cannot see"* each disclose half a claim's history to a reader
+ * the grant excluded from the other half.
+ */
+function pairsSelect(): string {
+  return `d.id::text AS draft_id,
+         d.subject || ' ' || d.predicate || ' ' || d.object AS draft_label,
+         p.id::text AS superseded_id,
+         p.subject || ' ' || p.predicate || ' ' || p.object AS superseded_label,
+         COUNT(*) OVER ()::int AS scoped_total`;
+}
+
+// ---------------------------------------------------------------------------
+// Loading
+// ---------------------------------------------------------------------------
+
+/** What a caller asks a preview about. */
+export type BlastRadiusRequest =
+  /** Approving `fromNorm → toNorm` at `position`. */
+  | {
+      readonly kind: "alias-approval";
+      readonly position: SlotPosition;
+      readonly fromNorm: string;
+      readonly toNorm: string;
+    }
+  /** Removing the approved edge whose child is `fromNorm` at `position`. */
+  | {
+      readonly kind: "alias-removal";
+      readonly position: SlotPosition;
+      readonly fromNorm: string;
+    }
+  /**
+   * Curating `predicateSurface`'s canonical predicate `single`.
+   *
+   * Takes the SURFACE, not the key. The key is derived here, and it never
+   * travels back out — `PredicateCardinalityRecord`'s ⚠️ and
+   * `keys-not-on-the-wire.test.ts` are the same prohibition, and a request type
+   * that accepted a key would be the seam through which one reaches a route
+   * body.
+   */
+  | { readonly kind: "cardinality-flip"; readonly predicateSurface: string }
+  /** Un-curating one — the *In force* pane's removal for a cardinality entry. */
+  | { readonly kind: "cardinality-removal"; readonly predicateSurface: string };
+
+/**
+ * Compute a decision's blast radius, both directions.
+ *
+ * @throws {BrainReaderUnresolvedError} when the reader has no usable principals
+ *   — `loadSupersessionPreview`'s posture. A preview that answered an
+ *   unresolvable reader with an empty pair list would render as *"this approval
+ *   supersedes nothing"*, the exact false all-clear this surface exists to
+ *   prevent.
+ */
+export async function loadBlastRadius(
+  db: BrainCandidateReader,
+  ctx: BrainPrincipalContext,
+  request: BlastRadiusRequest,
+  requestId?: string,
+): Promise<BlastRadius> {
+  const workspaceId = ctx.workspaceId;
+
+  const structurallyEmpty = await structurallyEmptyReason(db, workspaceId, request);
+  if (structurallyEmpty !== null) {
+    return {
+      arming: EMPTY_SIDE,
+      disarming: EMPTY_SIDE,
+      floor: true,
+      structurallyEmpty,
+    };
+  }
+
+  const plan = await planCounterfactual(db, workspaceId, request);
+  if (plan === null) {
+    // The decision names nothing this workspace holds — an unaliased norm, a
+    // predicate with no facts. Reported as an ordinary empty radius rather than
+    // as an error: it is a legitimate answer to "what would this change", and
+    // the authoring path refuses a zero-population pair separately and with a
+    // reason (`vocabulary-author.ts`).
+    return { arming: EMPTY_SIDE, disarming: EMPTY_SIDE, floor: true, structurallyEmpty: null };
+  }
+
+  const [arming, disarming] = await Promise.all([
+    loadBlastRadiusSide(db, ctx, plan, "arming", requestId),
+    loadBlastRadiusSide(db, ctx, plan, "disarming", requestId),
+  ]);
+
+  return { arming, disarming, floor: true, structurallyEmpty: null };
+}
+
+/**
+ * The resolved counterfactual — parameters bound, expressions built.
+ *
+ * Split from {@link loadBlastRadius} so the two delta directions share one
+ * resolution: computing `$toKey` twice would be two closure reads that could
+ * straddle a concurrent approval, and the two halves of one delta must describe
+ * ONE pair of vocabularies or their difference is meaningless.
+ */
+interface CounterfactualPlan {
+  readonly hypothetical: CollisionExprs;
+  /** Everything after `$1` (the workspace id), in order. */
+  readonly params: readonly unknown[];
+  readonly ctes: readonly string[];
+  /** Narrows the draft side, e.g. to one predicate's slot. */
+  readonly extraWhere?: string;
+  /** The imported held-back count, when this request's arming side has one. */
+  readonly importedTotalSql?: string;
+  readonly importedTotalParams?: readonly unknown[];
+}
+
+async function planCounterfactual(
+  db: BrainCandidateReader,
+  workspaceId: string,
+  request: BlastRadiusRequest,
+): Promise<CounterfactualPlan | null> {
+  switch (request.kind) {
+    case "alias-approval": {
+      const fromKey = identityKey(request.fromNorm);
+      const toNorm = lexicalNorm(request.toNorm);
+      if (fromKey === null || toNorm === "") return null;
+      // `to`'s CURRENT effective target — see `approvalKeyExpr`'s ⚠️.
+      const toKey = await resolveEffectiveTarget(db, workspaceId, request.position, toNorm);
+      if (toKey === null) return null;
+      return {
+        hypothetical: aliasExprs(request.position, approvalKeyExpr(request.position, 2, 3)),
+        params: [fromKey, toKey],
+        ctes: [],
+      };
+    }
+    case "alias-removal": {
+      const fromKey = identityKey(request.fromNorm);
+      if (fromKey === null) return null;
+      return {
+        hypothetical: aliasExprs(request.position, removalKeyExpr(request.position, "subtree", 2)),
+        // `$2` is BOTH the substituted key and the subtree seed, and they are the
+        // same string rather than two values that happen to match: `fromNorm` is
+        // already a norm, and `identityKey` is idempotent on one, so
+        // `identityKey(fromNorm) === fromNorm`. Bound once so a future edit
+        // cannot make the walk start somewhere the substitution does not land.
+        params: [fromKey, request.position],
+        ctes: [subtreeCteSql("subtree", 1, 3, 2)],
+      };
+    }
+    case "cardinality-flip":
+    case "cardinality-removal": {
+      const predicateKey = identityKey(request.predicateSurface);
+      if (predicateKey === null) return null;
+      return {
+        // A flip ADDS this key to the gate; a removal SUBTRACTS it. Both are
+        // "the vocabulary after the decision", and the delta's direction swap
+        // supplies "the vocabulary today" — so a removal's arming side is
+        // provably empty (un-curating cannot create a collision) and its
+        // disarming side is the arbitration the approver is withdrawing.
+        hypothetical:
+          request.kind === "cardinality-flip"
+            ? cardinalityFlipExpr(2)
+            : cardinalityUnflipExpr(2),
+        params: [predicateKey],
+        ctes: [],
+        extraWhere: `d.predicate_key = $2`,
+        // The literal reuse #5025's handoff requires: the arming total is
+        // `CARDINALITY_HELD_BACK_COUNT_SQL`'s own question at a predicate scope
+        // rather than a batch scope. `vocabulary-preview-pg.test.ts` asserts
+        // this statement and the delta agree on a real corpus, so the reuse is
+        // CHECKED rather than claimed.
+        importedTotalSql:
+          request.kind === "cardinality-flip"
+            ? cardinalityHeldBackCountSql("d.predicate_key = $2")
+            : undefined,
+        importedTotalParams: request.kind === "cardinality-flip" ? [predicateKey] : undefined,
+      };
+    }
+  }
+}
+
+/**
+ * A norm's effective target under the CURRENT closure, or itself.
+ *
+ * Reads `brain_vocabulary_target` rather than walking the edges: the closure is
+ * what `alias` reads, so this is the same answer the re-key will compute. Its
+ * absence means the norm is unaliased, which is `identityAlias` and therefore
+ * the norm itself — `loadClaimVocabulary`'s empty/absent equivalence, one layer
+ * down.
+ */
+async function resolveEffectiveTarget(
+  db: BrainCandidateReader,
+  workspaceId: string,
+  position: SlotPosition,
+  norm: string,
+): Promise<string | null> {
+  const { rows } = await db.query(
+    `SELECT effective_target FROM brain_vocabulary_target
+      WHERE workspace_id = $1 AND slot_position = $2 AND norm = $3`,
+    [workspaceId, position, norm],
+  );
+  const row = rows[0] as { effective_target?: unknown } | undefined;
+  const target = typeof row?.effective_target === "string" ? row.effective_target : norm;
+  // Re-normed for `slotKey`'s reason: the vocabulary's answer is a data table's
+  // and not a proof, and an entry authored as `"Priced At"` would otherwise make
+  // this preview compute a key that joins nothing — a confident zero.
+  return identityKey(target);
+}
+
+/**
+ * Is this counterfactual incapable of producing pairs by construction?
+ *
+ * Asked BEFORE any delta statement runs, so the answer is a reason rather than
+ * an empty result the caller has to interpret.
+ */
+async function structurallyEmptyReason(
+  db: BrainCandidateReader,
+  workspaceId: string,
+  request: BlastRadiusRequest,
+): Promise<StructurallyEmptyReason | null> {
+  if (
+    (request.kind === "alias-approval" || request.kind === "alias-removal") &&
+    request.position === "object"
+  ) {
+    return "object-position";
+  }
+  if (request.kind === "cardinality-flip" || request.kind === "cardinality-removal") {
+    const predicateKey = identityKey(request.predicateSurface);
+    if (predicateKey === null) return null;
+    const { rows } = await db.query(
+      `SELECT 1 AS hit FROM brain_predicate_cardinality
+        WHERE workspace_id = $1 AND predicate_key = $2
+          AND cardinality = 'single' AND status = 'approved'`,
+      [workspaceId, predicateKey],
+    );
+    // The two kinds read the SAME probe and branch on opposite answers: a flip
+    // has nothing to compute when the entry already exists, and a removal has
+    // nothing to compute when it does not. One statement rather than two so the
+    // "is this predicate curated" question has one spelling.
+    const curated = rows.length > 0;
+    if (request.kind === "cardinality-flip" && curated) return "already-single";
+    if (request.kind === "cardinality-removal" && !curated) return "not-curated";
+  }
+  return null;
+}
+
+/**
+ * One direction of the delta: the unscoped total and the reader-scoped sample.
+ *
+ * Two statements, one request — `loadSupersessionPreview`'s shape, and
+ * `withheld` is their difference. The clamping, the window-drift floors and the
+ * `truncated` derivation are that function's, restated here only where the
+ * parameter list differs; where the logic is identical it is identical on
+ * purpose, and `vocabulary-preview.test.ts` runs the same drift fixtures
+ * against both.
+ */
+async function loadBlastRadiusSide(
+  db: BrainCandidateReader,
+  ctx: BrainPrincipalContext,
+  plan: CounterfactualPlan,
+  direction: DeltaDirection,
+  requestId?: string,
+): Promise<BlastRadiusSide> {
+  const workspaceId = ctx.workspaceId;
+  const joinExprs = direction === "arming" ? plan.hypothetical : STORED_COLLISION_EXPRS;
+  const excludeExprs = direction === "arming" ? STORED_COLLISION_EXPRS : plan.hypothetical;
+
+  // The plan's own params occupy $2..$N; the reader's ACL params follow.
+  const aclBase = 2 + plan.params.length;
+  const draftAcl = aclVisibilityClause(ctx, {
+    table: "brain_facts",
+    alias: "d",
+    paramIndex: aclBase,
+    requestId,
+  });
+  if (draftAcl.decision === "deny-all") {
+    throw new BrainReaderUnresolvedError(workspaceId, ctx.origin, PREVIEW_SURFACE);
+  }
+  const publishedAcl = aclVisibilityClause(ctx, {
+    table: "brain_facts",
+    alias: "p",
+    paramIndex: draftAcl.nextParamIndex,
+    requestId,
+  });
+  if (publishedAcl.decision === "deny-all") {
+    // Unreachable — same context, same table, and the first clause resolved.
+    // Kept because a silent empty list under a deny renders as "this approval
+    // arms nothing", the false all-clear this module exists to prevent.
+    throw new BrainReaderUnresolvedError(workspaceId, ctx.origin, PREVIEW_SURFACE);
+  }
+  const limitParam = publishedAcl.nextParamIndex;
+
+  const useImported = direction === "arming" && plan.importedTotalSql !== undefined;
+  const totalSql = useImported
+    ? (plan.importedTotalSql as string)
+    : deltaSql({
+        select: TOTAL_SELECT,
+        joinExprs,
+        excludeExprs,
+        workspaceParam: 1,
+        extraWhere: plan.extraWhere,
+        ctes: plan.ctes,
+      });
+  const totalParams = useImported
+    ? [workspaceId, ...(plan.importedTotalParams ?? [])]
+    : [workspaceId, ...plan.params];
+
+  const pairsSql = deltaSql({
+    select: pairsSelect(),
+    joinExprs,
+    excludeExprs,
+    workspaceParam: 1,
+    extraWhere: [plan.extraWhere, draftAcl.sql, publishedAcl.sql].filter(Boolean).join("\n     AND "),
+    ctes: plan.ctes,
+    tail: `\n   ORDER BY d.ingested_at, d.id, p.ingested_at, p.id\n   LIMIT $${limitParam}`,
+  });
+
+  const [totalResult, pairsResult] = await Promise.all([
+    db.query(totalSql, totalParams),
+    db.query(pairsSql, [
+      workspaceId,
+      ...plan.params,
+      ...draftAcl.params,
+      ...publishedAcl.params,
+      BLAST_RADIUS_PAIR_MAX + 1,
+    ]),
+  ]);
+
+  const total = readCount(totalResult.rows[0], useImported ? "held_back" : "delta_total");
+  if (total === null) {
+    // A THROW, not a degraded 0 — `loadSupersessionPreview`'s reason exactly: 0
+    // renders as "this decision arms nothing", a confident false all-clear
+    // fabricated from query drift, on the surface whose whole job is this
+    // disclosure. `COUNT(*)` cannot return NULL, so this is unreachable from
+    // Postgres.
+    throw new Error(
+      `brain vocabulary preview: the ${direction} total did not read back as a number for ` +
+        `workspace ${workspaceId} — refusing to disclose a blast radius Atlas cannot establish`,
+    );
+  }
+
+  const { pairs, scopedTotal, truncated } = readPairs(
+    pairsResult.rows,
+    workspaceId,
+    direction,
+    requestId,
+  );
+
+  if (scopedTotal > total) {
+    log.warn(
+      { workspaceId, requestId, direction, scopedTotal, total },
+      "brain vocabulary preview: the reader-scoped delta exceeds the workspace delta — a brief ingest race, or the two statements disagree; reporting 0 withheld",
+    );
+  }
+
+  return { total, pairs, withheld: Math.max(0, total - scopedTotal), truncated };
+}
+
+/** One `COUNT(*)::int` column, or `null` when it did not read back as one. */
+function readCount(raw: unknown, column: string): number | null {
+  const value = (raw as Record<string, unknown> | undefined)?.[column];
+  const n =
+    typeof value === "number"
+      ? value
+      : typeof value === "string" && value.trim() !== ""
+        ? Number(value)
+        : Number.NaN;
+  return Number.isFinite(n) && n >= 0 ? Math.trunc(n) : null;
+}
+
+/**
+ * Narrow the pair page, carrying `loadSupersessionPreview`'s floors verbatim.
+ *
+ * A row whose window will not parse is COUNTED — the floor is what keeps that
+ * drift from silently relabelling clipped rows as ACL-withheld, which the wire
+ * type forbids. `null` is mapped to NaN explicitly because `Number(null)` is a
+ * finite 0, the one shape of window drift that would otherwise go unlogged.
+ */
+function readPairs(
+  rawRows: readonly unknown[],
+  workspaceId: string,
+  direction: DeltaDirection,
+  requestId?: string,
+): { pairs: BlastRadiusPair[]; scopedTotal: number; truncated: boolean } {
+  const clipped = rawRows.length > BLAST_RADIUS_PAIR_MAX;
+  const pairs: BlastRadiusPair[] = [];
+  let scopedTotal = 0;
+  let droppedRows = 0;
+  let windowDriftRows = 0;
+
+  for (const raw of clipped ? rawRows.slice(0, BLAST_RADIUS_PAIR_MAX) : rawRows) {
+    if (typeof raw !== "object" || raw === null) {
+      droppedRows++;
+      continue;
+    }
+    const r = raw as Record<string, unknown>;
+    if (
+      typeof r.draft_id !== "string" ||
+      typeof r.draft_label !== "string" ||
+      typeof r.superseded_id !== "string" ||
+      typeof r.superseded_label !== "string"
+    ) {
+      droppedRows++;
+      continue;
+    }
+    const windowed =
+      typeof r.scoped_total === "number"
+        ? r.scoped_total
+        : r.scoped_total == null
+          ? Number.NaN
+          : Number(r.scoped_total);
+    if (Number.isFinite(windowed) && windowed > scopedTotal) scopedTotal = Math.trunc(windowed);
+    else if (!Number.isFinite(windowed)) windowDriftRows++;
+    pairs.push({
+      draftId: r.draft_id,
+      draftLabel: r.draft_label,
+      supersededId: r.superseded_id,
+      supersededLabel: r.superseded_label,
+    });
+  }
+
+  if (droppedRows > 0) {
+    log.warn(
+      { workspaceId, requestId, direction, droppedRows, kept: pairs.length },
+      "brain vocabulary preview: delta pair rows came back with an unreadable column — the sample understates the blast radius; the query shape changed",
+    );
+  }
+  if (windowDriftRows > 0) {
+    log.warn(
+      { workspaceId, requestId, direction, windowDriftRows },
+      "brain vocabulary preview: the scoped window did not read back as a number on some rows — truncation may be under-reported; the query shape changed",
+    );
+  }
+
+  if (clipped && scopedTotal < rawRows.length) scopedTotal = rawRows.length;
+  if (scopedTotal < pairs.length) scopedTotal = pairs.length;
+
+  return { pairs, scopedTotal, truncated: clipped || scopedTotal > pairs.length };
+}

--- a/packages/api/src/lib/brain/vocabulary-preview.ts
+++ b/packages/api/src/lib/brain/vocabulary-preview.ts
@@ -105,6 +105,7 @@
 
 import { createLogger } from "@atlas/api/lib/logger";
 import type { BrainCandidateReader } from "@atlas/api/lib/brain/candidates";
+import type { BrainFactWillSupersedePair } from "@useatlas/types";
 import { aclVisibilityClause, type BrainPrincipalContext } from "@atlas/api/lib/brain/acl";
 import { BrainReaderUnresolvedError } from "@atlas/api/lib/brain/reader-context";
 import {
@@ -149,17 +150,18 @@ export const BLAST_RADIUS_PAIR_MAX = 50;
 /**
  * One pair a decision would arm or disarm.
  *
+ * ⚠️ An ALIAS of the wire type, not a copy. It was a field-for-field duplicate
+ * of `BrainFactWillSupersedePair` — same four fields, same semantics, same
+ * rationale docstring — which is the SSOT violation CLAUDE.md names. No route
+ * serializes it YET, and that is the argument for fixing it now rather than
+ * deferring: the moment one does, the duplicate becomes a wire contract and the
+ * drift is permanent.
+ *
  * Labels, never keys. ADR-0037 §6 forbids projecting a key beside its claim
  * (`keys-not-on-the-wire.test.ts` is the guard), and a consumer that can branch
- * on a key is what makes an alias un-removable. The SURFACE is what an approver
- * reads anyway.
+ * on a key is what makes an alias un-removable.
  */
-export interface BlastRadiusPair {
-  readonly draftId: string;
-  readonly draftLabel: string;
-  readonly supersededId: string;
-  readonly supersededLabel: string;
-}
+export type BlastRadiusPair = BrainFactWillSupersedePair;
 
 /**
  * Why a preview can produce no pairs AT ALL, as distinct from producing none.
@@ -209,24 +211,60 @@ export type StructurallyEmptyReason =
    */
   | "unkeyable-surface";
 
-/** The counterfactual's answer. */
-export interface BlastRadius {
-  /**
-   * Pairs a decision would make supersedable — content-free count plus a
-   * reader-scoped bounded sample.
-   */
-  readonly arming: BlastRadiusSide;
-  /** Pairs a decision would make safe again. Empty for every approval. */
-  readonly disarming: BlastRadiusSide;
-  /**
-   * ALWAYS true today, and a field rather than a comment because the surface
-   * must render the floor wording and a boolean is what makes that assertable.
-   * See the module header for the two independent reasons.
-   */
-  readonly floor: true;
-  /** Non-null when the counterfactual cannot produce pairs by construction. */
-  readonly structurallyEmpty: StructurallyEmptyReason | null;
-}
+/**
+ * The counterfactual's answer — a DISCRIMINATED UNION, and the discrimination
+ * is the module's thesis made unrepresentable rather than argued.
+ *
+ * ⚠️ It used to be one record carrying `arming`, `disarming`, `floor: true` AND
+ * a nullable `structurallyEmpty`, with a shared `EMPTY_SIDE` filling the fields
+ * that had no meaning. Every field was readable on every branch — so a renderer
+ * that read `floor` before checking `structurallyEmpty` produced *"at least 0
+ * today, and every future claim in this slot"* for an object-position alias.
+ * That sentence is false (no future claim in that slot can supersede) and it is
+ * precisely the confident false all-clear the module header spends four
+ * paragraphs on, reachable by reading two fields in the wrong order.
+ *
+ * Split, the numbers do not exist on the branch where they are meaningless and
+ * `EMPTY_SIDE` disappears entirely. The cost is one `switch` at the single
+ * future call site; the module is unwired, so this is the cheapest this change
+ * will ever be.
+ */
+export type BlastRadius =
+  /** The counterfactual cannot produce pairs BY CONSTRUCTION. No numbers. */
+  | { readonly kind: "structurally-empty"; readonly reason: StructurallyEmptyReason }
+  /** The question was asked and answered. */
+  | {
+      readonly kind: "computed";
+      /**
+       * Pairs the decision would make supersedable — content-free count plus a
+       * reader-scoped bounded sample.
+       */
+      readonly arming: BlastRadiusSide;
+      /** Pairs it would make safe again. Empty for every approval. */
+      readonly disarming: BlastRadiusSide;
+      /**
+       * ALWAYS true, and a field rather than a comment because the surface must
+       * render the floor wording and a literal type is what makes that
+       * assertable. See the module header for the two independent reasons.
+       */
+      readonly floor: true;
+      /**
+       * The alias subtree walk hit {@link MAX_CHAIN_DEPTH}, so BOTH sides
+       * describe a smaller population than was asked about.
+       *
+       * ⚠️ Its own field on the RADIUS rather than folded into
+       * {@link BlastRadiusSide.countsConsistent}, and the distinction is the one
+       * this module already made when it split `not-curated` from
+       * `already-single`: a truncated walk is not two statements disagreeing, it
+       * is one statement asking about a smaller population. Those render as
+       * different sentences and demand different actions from an approver —
+       * *"these numbers may not agree"* versus *"we could not see your whole
+       * alias subtree"* — so they are different fields. Smeared across both
+       * sides it also became impossible to tell a side-local disagreement from a
+       * radius-wide blind spot.
+       */
+      readonly subtreeTruncated: boolean;
+    };
 
 export interface BlastRadiusSide {
   /** Unscoped, workspace-wide. A number, never content. */
@@ -262,16 +300,6 @@ export interface BlastRadiusSide {
    */
   readonly countsConsistent: boolean;
 }
-
-const EMPTY_SIDE: BlastRadiusSide = Object.freeze({
-  total: 0,
-  pairs: [],
-  withheld: 0,
-  truncated: false,
-  // A structurally-empty side is not a DEGRADED one: nothing was computed, so
-  // nothing disagreed. The reason travels on `structurallyEmpty`.
-  countsConsistent: true,
-});
 
 // ---------------------------------------------------------------------------
 // The hypothetical vocabularies
@@ -409,6 +437,7 @@ function subtreeCteSql(
   workspaceParam: number,
   positionParam: number,
   fromNormParam: number,
+  depth: number,
 ): string {
   return `${cteName} AS (
        SELECT $${fromNormParam}::text AS node, 1 AS depth
@@ -419,7 +448,7 @@ function subtreeCteSql(
            ON e.workspace_id = $${workspaceParam}::text
           AND e.slot_position = $${positionParam}::text
           AND e.to_norm = s.node
-        WHERE s.depth < ${MAX_CHAIN_DEPTH}
+        WHERE s.depth < ${depth}
      )`;
 }
 
@@ -513,18 +542,33 @@ function aliasExprs(
 // The delta
 // ---------------------------------------------------------------------------
 
-/** Which half of the delta a statement computes. */
 /**
- * Did the subtree walk reach {@link MAX_CHAIN_DEPTH}?
+ * The CTE name, spelled ONCE.
+ *
+ * {@link subtreeTruncatedSql} takes the CTE definition as a parameter but reads
+ * `FROM subtree` in its body, so a rename at one of the three sites was a
+ * runtime SQL error nothing would catch until production.
+ */
+const SUBTREE_CTE = "subtree";
+
+/** The walk's depth bound — the shipped constant unless a test injects one. */
+function maxDepth(opts: BlastRadiusOptions): number {
+  return opts.maxChainDepth ?? MAX_CHAIN_DEPTH;
+}
+
+/**
+ * Did the subtree walk reach its depth bound?
  *
  * Asked as its own statement rather than folded into the delta, because the
  * delta's shape is fixed by {@link deltaSql} and a `bool_or` column would have
  * to survive both the count and the pairs projection. One extra round trip on a
  * human-paced admin preview, and only for a removal.
  */
-function subtreeTruncatedSql(cte: string): string {
-  return `WITH RECURSIVE ${cte} SELECT bool_or(depth >= ${MAX_CHAIN_DEPTH}) AS hit FROM subtree`;
+function subtreeTruncatedSql(cte: string, depth: number): string {
+  return `WITH RECURSIVE ${cte} SELECT bool_or(depth >= ${depth}) AS hit FROM ${SUBTREE_CTE}`;
 }
+
+/** Which half of the delta a statement computes. */
 
 export type DeltaDirection = "arming" | "disarming";
 
@@ -585,6 +629,21 @@ function pairsSelect(): string {
 // Loading
 // ---------------------------------------------------------------------------
 
+/**
+ * Per-call knobs.
+ *
+ * `maxChainDepth` is injectable ONLY so the depth bound is falsifiable: with
+ * the shipped 64 no fixture can reach it, and a mutation weakening the probe's
+ * threshold (`>=` to `>`) was measured surviving all 59 tests — the walk would
+ * truncate silently and `subtreeTruncated` would stay false, which is the exact
+ * failure the probe exists to prevent. Production never passes it.
+ */
+export interface BlastRadiusOptions {
+  readonly requestId?: string;
+  /** Test seam. Defaults to {@link MAX_CHAIN_DEPTH}. */
+  readonly maxChainDepth?: number;
+}
+
 /** What a caller asks a preview about. */
 export type BlastRadiusRequest =
   /** Approving `fromNorm → toNorm` at `position`. */
@@ -626,7 +685,7 @@ export async function loadBlastRadius(
   db: BrainCandidateReader,
   ctx: BrainPrincipalContext,
   request: BlastRadiusRequest,
-  requestId?: string,
+  opts: BlastRadiusOptions = {},
 ): Promise<BlastRadius> {
   const workspaceId = ctx.workspaceId;
 
@@ -637,45 +696,42 @@ export async function loadBlastRadius(
   // degenerate norm received a clean `{total: 0}` instead of the refusal this
   // function's own `@throws` contract promises. The fail-closed gate was
   // reachable only on the paths that did not need it.
-  assertReaderResolvable(ctx, requestId);
+  assertReaderResolvable(ctx, opts.requestId);
 
   const structurallyEmpty = await structurallyEmptyReason(db, workspaceId, request);
   if (structurallyEmpty !== null) {
-    return {
-      arming: EMPTY_SIDE,
-      disarming: EMPTY_SIDE,
-      floor: true,
-      structurallyEmpty,
-    };
+    return { kind: "structurally-empty", reason: structurallyEmpty };
   }
 
-  const plan = await planCounterfactual(db, workspaceId, request, requestId);
-  if (plan === null) {
-    // ⚠️ A DISCLOSED REASON, never a bare zero. The earlier version returned
-    // `structurallyEmpty: null` here with a comment describing two causes that
-    // cannot reach this branch — "an unaliased norm" resolves to itself rather
-    // than to null, and "a predicate with no facts" never consults
-    // `brain_facts` at all. What actually reaches it is a surface that norms
-    // away, and reporting that as "asked and answered, zero" is the confident
-    // false all-clear the module header argues against at length.
+  const plan = await planCounterfactual(db, workspaceId, request, opts);
+  if (typeof plan === "string") {
+    // ⚠️ A REASON, carried out of `planCounterfactual` rather than manufactured
+    // here. It used to return a bare `null` from six sites and this caller
+    // stamped `"unkeyable-surface"` on all of them — so an object-position
+    // request (reachable if `structurallyEmptyReason` is ever reordered or a
+    // second caller appears) rendered as *"this surface does not key"*, which
+    // is a factually wrong reason in the under-disclosing direction, with a log
+    // line asserting something untrue. `"object-position"` and
+    // `"unkeyable-surface"` are opposite facts.
     log.warn(
-      { workspaceId, requestId, kind: request.kind },
-      "brain vocabulary preview: the decision named a surface that does not key — disclosing an unkeyable-surface reason rather than a zero blast radius",
+      { workspaceId, requestId: opts.requestId, kind: request.kind, reason: plan },
+      "brain vocabulary preview: the decision could not be turned into a counterfactual — disclosing a reason rather than a zero blast radius",
     );
-    return {
-      arming: EMPTY_SIDE,
-      disarming: EMPTY_SIDE,
-      floor: true,
-      structurallyEmpty: "unkeyable-surface",
-    };
+    return { kind: "structurally-empty", reason: plan };
   }
 
   const [arming, disarming] = await Promise.all([
-    loadBlastRadiusSide(db, ctx, plan, "arming", requestId),
-    loadBlastRadiusSide(db, ctx, plan, "disarming", requestId),
+    loadBlastRadiusSide(db, ctx, plan, "arming", opts),
+    loadBlastRadiusSide(db, ctx, plan, "disarming", opts),
   ]);
 
-  return { arming, disarming, floor: true, structurallyEmpty: null };
+  return {
+    kind: "computed",
+    arming,
+    disarming,
+    floor: true,
+    subtreeTruncated: plan.subtreeTruncated,
+  };
 }
 
 /**
@@ -743,20 +799,29 @@ async function planCounterfactual(
   db: BrainCandidateReader,
   workspaceId: string,
   request: BlastRadiusRequest,
-  requestId?: string,
-): Promise<CounterfactualPlan | null> {
+  opts: BlastRadiusOptions,
+): Promise<CounterfactualPlan | StructurallyEmptyReason> {
   switch (request.kind) {
     case "alias-approval": {
       const fromKey = identityKey(request.fromNorm);
       const toNorm = lexicalNorm(request.toNorm);
-      if (fromKey === null || toNorm === "") return null;
+      if (fromKey === null || toNorm === "") return "unkeyable-surface";
       // `to`'s CURRENT effective target — see `approvalKeyExpr`'s ⚠️.
       // Narrowed HERE — the one call site that already knows the answer,
       // because `structurallyEmptyReason` returned non-null for `object` and
       // `loadBlastRadius` returned before reaching this function.
-      if (!isCollidingSlot(request.position)) return null;
-      const toKey = await resolveEffectiveTarget(db, workspaceId, request.position, toNorm, requestId);
-      if (toKey === null) return null;
+      if (!isCollidingSlot(request.position)) return "object-position";
+      // `resolveEffectiveTarget` cannot answer null here — `toNorm` is a
+      // non-empty norm and `lexicalNorm` is idempotent — so the arm that used
+      // to sit here was dead AND fed the overloaded null channel. It refuses
+      // loudly on the two corrupt-closure shapes instead.
+      const toKey = await resolveEffectiveTarget(
+        db,
+        workspaceId,
+        request.position,
+        toNorm,
+        opts.requestId,
+      );
       return {
         hypothetical: aliasExprs(request.position, approvalKeyExpr(request.position, 2, 3)),
         params: [fromKey, toKey],
@@ -765,25 +830,25 @@ async function planCounterfactual(
       };
     }
     case "alias-removal": {
-      if (!isCollidingSlot(request.position)) return null;
+      if (!isCollidingSlot(request.position)) return "object-position";
       const fromKey = identityKey(request.fromNorm);
-      if (fromKey === null) return null;
+      if (fromKey === null) return "unkeyable-surface";
       return {
-        hypothetical: aliasExprs(request.position, removalKeyExpr(request.position, "subtree", 2)),
+        hypothetical: aliasExprs(request.position, removalKeyExpr(request.position, SUBTREE_CTE, 2)),
         // `$2` is BOTH the substituted key and the subtree seed, and they are the
         // same string rather than two values that happen to match: `fromNorm` is
         // already a norm, and `identityKey` is idempotent on one, so
         // `identityKey(fromNorm) === fromNorm`. Bound once so a future edit
         // cannot make the walk start somewhere the substitution does not land.
         params: [fromKey, request.position],
-        ctes: [subtreeCteSql("subtree", 1, 3, 2)],
-        subtreeTruncated: await subtreeHitBound(db, workspaceId, request.position, fromKey, requestId),
+        ctes: [subtreeCteSql(SUBTREE_CTE, 1, 3, 2, maxDepth(opts))],
+        subtreeTruncated: await subtreeHitBound(db, workspaceId, request.position, fromKey, opts),
       };
     }
     case "cardinality-flip":
     case "cardinality-removal": {
       const canonicalKey = identityKey(request.predicateSurface);
-      if (canonicalKey === null) return null;
+      if (canonicalKey === null) return "unkeyable-surface";
       return {
         // A flip ADDS this key to the gate; a removal SUBTRACTS it. Both are
         // "the vocabulary after the decision", and the delta's direction swap
@@ -848,27 +913,34 @@ async function planCounterfactual(
 async function subtreeHitBound(
   db: BrainCandidateReader,
   workspaceId: string,
-  position: SlotPosition,
+  position: CollidingSlot,
   fromKey: string,
-  requestId?: string,
+  opts: BlastRadiusOptions,
 ): Promise<boolean> {
-  const { rows } = await db.query(subtreeTruncatedSql(subtreeCteSql("subtree", 1, 3, 2)), [
-    workspaceId,
-    fromKey,
-    position,
-  ]);
+  const depth = maxDepth(opts);
+  const { rows } = await db.query(
+    subtreeTruncatedSql(subtreeCteSql(SUBTREE_CTE, 1, 3, 2, depth), depth),
+    [workspaceId, fromKey, position],
+  );
   const hit = (rows[0] as { hit?: unknown } | undefined)?.hit;
   if (hit === true) {
     log.warn(
-      { workspaceId, requestId, position, fromNorm: fromKey, maxChainDepth: MAX_CHAIN_DEPTH },
+      { workspaceId, requestId: opts.requestId, position, fromNorm: fromKey, maxChainDepth: depth },
       "brain vocabulary preview: the alias subtree walk hit the depth bound — the approved-edge graph is cyclic or deeper than the bound, so this removal's disarming set is TRUNCATED and understates the blast radius",
     );
     return true;
   }
-  if (hit === false || hit === null) return false;
+  // ⚠️ `false` is the ONLY value that may answer "the walk was complete".
+  // `null` used to take this arm unlogged — a `bool_or` over an empty CTE, a
+  // probe that lost its seed row, a driver mapping an aggregate to null — each
+  // means the probe told us nothing, and each was recorded as "complete". The
+  // same file argues exactly this for `Number(null)` forty lines down; two
+  // treatments of SQL NULL in one module, and the silent one was on the side
+  // that decides whether an approver is shown a trustworthy number.
+  if (hit === false) return false;
   log.warn(
-    { workspaceId, requestId, position, hit: typeof hit },
-    "brain vocabulary preview: the subtree depth probe did not read back as a boolean — clearing countsConsistent rather than assuming the walk was complete",
+    { workspaceId, requestId: opts.requestId, position, hit: hit === null ? "null" : typeof hit },
+    "brain vocabulary preview: the subtree depth probe did not read back as a boolean — treating the walk as TRUNCATED rather than assuming it was complete",
   );
   return true;
 }
@@ -876,7 +948,7 @@ async function subtreeHitBound(
 async function resolveEffectiveTarget(
   db: BrainCandidateReader,
   workspaceId: string,
-  position: SlotPosition,
+  position: CollidingSlot,
   norm: string,
   requestId?: string,
 ): Promise<string | null> {
@@ -900,7 +972,17 @@ async function resolveEffectiveTarget(
   if (row === undefined) return identityKey(norm);
 
   const stored = row.effective_target;
-  if (typeof stored !== "string" || stored.trim() === "") {
+  // ⚠️ QUERY SHAPE ONLY — `typeof`, and deliberately NOT `|| stored.trim() ===
+  // ""`. That extra clause read as harmless and was a second collapse inside
+  // the fix for the first one: 0189's CHECK is `effective_target <> ''`, and
+  // `'   ' <> ''` is TRUE, so a whitespace-only target is STORABLE (0189's
+  // header says outright that normal form is not enforced on this table). It
+  // therefore intercepted a genuinely corrupt row and reported it as driver /
+  // migration drift, sending an operator to look at the SELECT — while making
+  // the "closure is corrupt" arm below, written for exactly this row,
+  // unreachable. Every non-empty string now falls through to `identityKey`,
+  // which answers `null` for every degenerate spelling.
+  if (typeof stored !== "string") {
     log.error(
       { workspaceId, position, norm, requestId },
       "brain vocabulary preview: brain_vocabulary_target.effective_target did not read back as a string — the closure query shape changed",
@@ -986,7 +1068,7 @@ async function loadBlastRadiusSide(
   ctx: BrainPrincipalContext,
   plan: CounterfactualPlan,
   direction: DeltaDirection,
-  requestId?: string,
+  opts: BlastRadiusOptions,
 ): Promise<BlastRadiusSide> {
   const workspaceId = ctx.workspaceId;
   const joinExprs = direction === "arming" ? plan.hypothetical : STORED_COLLISION_EXPRS;
@@ -998,7 +1080,7 @@ async function loadBlastRadiusSide(
     table: "brain_facts",
     alias: "d",
     paramIndex: aclBase,
-    requestId,
+    requestId: opts.requestId,
   });
   if (draftAcl.decision === "deny-all") {
     throw new BrainReaderUnresolvedError(workspaceId, ctx.origin, PREVIEW_SURFACE);
@@ -1007,7 +1089,7 @@ async function loadBlastRadiusSide(
     table: "brain_facts",
     alias: "p",
     paramIndex: draftAcl.nextParamIndex,
-    requestId,
+    requestId: opts.requestId,
   });
   if (publishedAcl.decision === "deny-all") {
     // Unreachable — same context, same table, and the first clause resolved.
@@ -1017,21 +1099,37 @@ async function loadBlastRadiusSide(
   }
   const limitParam = publishedAcl.nextParamIndex;
 
+  // ⚠️ The plan's expressions carry HAND-WRITTEN placeholder literals (`$2`,
+  // `$3`) while `aclBase` is derived from `plan.params.length`. They agree
+  // today — verified for all four kinds — and the failure mode if they ever
+  // stop is silent and in the under-disclosing direction: an expression
+  // referencing a placeholder at or above `aclBase` would compare a slot key
+  // against an ACL principal token, join nothing, and report "this approval
+  // arms nothing" on an admin console.
+  //
+  // A `ParamBuilder` is the mechanical answer (`AclClause.nextParamIndex` is
+  // that answer one seam over) and was judged more machinery than this earns.
+  // This is the four-line version: loud, at the seam, rather than a zero.
+  assertPlaceholdersBelowAclBase(pairsSqlPlaceholderSource(plan), aclBase, workspaceId, direction);
+
   // Narrowed once, so the statement, its params and its result column travel
   // together and no `as` is needed to re-assert what the check established.
   const override = direction === "arming" ? plan.armingTotalOverride : undefined;
-  const totalSql =
-    override?.sql ??
-    deltaSql({
-      select: TOTAL_SELECT,
-      joinExprs,
-      excludeExprs,
-      workspaceParam: 1,
-      ctes: plan.ctes,
-    });
-  const totalParams = override
-    ? [workspaceId, ...override.params]
-    : [workspaceId, ...plan.params];
+  // ONE presence test, not two. `override?.sql ?? …` and `override ? … : …`
+  // coincide only because `sql` is a required non-nullish string — which is the
+  // same inconsistently-read optional the regrouping was meant to close.
+  const { sql: totalSql, params: totalParams } = override
+    ? { sql: override.sql, params: [workspaceId, ...override.params] }
+    : {
+        sql: deltaSql({
+          select: TOTAL_SELECT,
+          joinExprs,
+          excludeExprs,
+          workspaceParam: 1,
+          ctes: plan.ctes,
+        }),
+        params: [workspaceId, ...plan.params],
+      };
 
   const pairsSql = deltaSql({
     select: pairsSelect(),
@@ -1056,6 +1154,14 @@ async function loadBlastRadiusSide(
 
   const total = readCount(totalResult.rows[0], override?.column ?? "delta_total");
   if (total === null) {
+    // LOGGED before it throws, with the requestId — the two refusals in
+    // `resolveEffectiveTarget` do, and this is the one an operator is most
+    // likely to actually hit (two statements, drift on either). CLAUDE.md:
+    // request ids on all 500s.
+    log.error(
+      { workspaceId, requestId: opts.requestId, direction, column: override?.column ?? "delta_total" },
+      "brain vocabulary preview: the delta total did not read back as a number — refusing rather than disclosing a blast radius Atlas cannot establish",
+    );
     // A THROW, not a degraded 0 — `loadSupersessionPreview`'s reason exactly: 0
     // renders as "this decision arms nothing", a confident false all-clear
     // fabricated from query drift, on the surface whose whole job is this
@@ -1063,7 +1169,8 @@ async function loadBlastRadiusSide(
     // Postgres.
     throw new Error(
       `brain vocabulary preview: the ${direction} total did not read back as a number for ` +
-        `workspace ${workspaceId} — refusing to disclose a blast radius Atlas cannot establish`,
+        `workspace ${workspaceId} (request ${opts.requestId ?? "unknown"}) — refusing to disclose ` +
+        `a blast radius Atlas cannot establish`,
     );
   }
 
@@ -1071,13 +1178,13 @@ async function loadBlastRadiusSide(
     pairsResult.rows,
     workspaceId,
     direction,
-    requestId,
+    opts.requestId,
   );
 
   const inverted = scopedTotal > total;
   if (inverted) {
     log.warn(
-      { workspaceId, requestId, direction, scopedTotal, total },
+      { workspaceId, requestId: opts.requestId, direction, scopedTotal, total },
       "brain vocabulary preview: the reader-scoped delta exceeds the workspace delta — a brief ingest race, or the two statements disagree; reporting 0 withheld and clearing countsConsistent",
     );
   }
@@ -1090,8 +1197,52 @@ async function loadBlastRadiusSide(
     // The clamp above is `loadSupersessionPreview`'s; this flag is the half that
     // module ships and this one had dropped. Without it the clamp renders as
     // "nothing is hidden from you" off two statements that just disagreed.
-    countsConsistent: !inverted && !drifted && !plan.subtreeTruncated,
+    // ⚠️ NOT `&& !plan.subtreeTruncated` any more. A truncated walk is a
+    // radius-wide scope blind spot, not a side-local count disagreement, and it
+    // now travels on `BlastRadius.subtreeTruncated` where it renders as its own
+    // sentence. Smearing it here made the two indistinguishable to a consumer.
+    countsConsistent: !inverted && !drifted,
   };
+}
+
+/**
+ * Every `$n` the plan's own expressions reference, as one string to scan.
+ *
+ * Built from the plan rather than from the emitted statement so the check does
+ * not accidentally read the ACL clause's own placeholders — which are legal at
+ * and above `aclBase` by construction.
+ */
+function pairsSqlPlaceholderSource(plan: CounterfactualPlan): string {
+  const probe = "__x";
+  return [
+    plan.hypothetical.subjectSlot(probe),
+    plan.hypothetical.predicateSlot(probe),
+    plan.hypothetical.cardinalitySingle(probe),
+    ...plan.ctes,
+  ].join(" ");
+}
+
+/** Refuse a plan whose expressions reach into the reader's placeholder range. */
+function assertPlaceholdersBelowAclBase(
+  source: string,
+  aclBase: number,
+  workspaceId: string,
+  direction: DeltaDirection,
+): void {
+  const refs = [...source.matchAll(/\$(\d+)/g)].map((m) => Number(m[1]));
+  const highest = refs.length === 0 ? 0 : Math.max(...refs);
+  if (highest >= aclBase) {
+    log.error(
+      { workspaceId, direction, highest, aclBase },
+      "brain vocabulary preview: a counterfactual expression references a placeholder inside the reader's range — the ACL clause and the slot substitution would bind the same parameter",
+    );
+    throw new Error(
+      `brain vocabulary preview: the ${direction} counterfactual references $${highest}, at or above ` +
+        `the ACL base $${aclBase} (workspace ${workspaceId}). The plan's placeholder literals and its ` +
+        `\`params\` array have drifted, so the reader's visibility predicate would bind against a slot ` +
+        `key — joining nothing and reporting that this decision changes nothing. Refusing.`,
+    );
+  }
 }
 
 /** One `COUNT(*)::int` column, or `null` when it did not read back as one. */

--- a/packages/api/src/lib/brain/vocabulary-preview.ts
+++ b/packages/api/src/lib/brain/vocabulary-preview.ts
@@ -40,16 +40,33 @@
  * on. The alternative — an `approve` preview and a `remove` preview — is two
  * spellings of one question, which is the shape this file exists to avoid.
  *
- * ## ⚠️ The exclusion arm is `IS NOT TRUE`, never `NOT (…)`
+ * ## The exclusion arm is `IS NOT TRUE`, and the honest claim is narrower than
+ * ## it first looks
  *
  * The delta's second half asks *and it does NOT collide under the other
  * vocabulary*, and `supersedableTierSql` is SQL **NULL** — not `false` — for a
- * `{"source": null}` provenance. `NOT (NULL)` is NULL, so a bare negation drops
- * exactly the population `brain-facts.ts` twice records as the subtlest one out
- * of a disclosure whose entire job is to be complete. The repo has already paid
- * for this distinction on `TIER_HELD_BACK_COUNT_SQL` and on `objectNotSameSql`;
- * this is the third site and it is the one where the failure is an
- * UNDER-disclosure of an irreversible consequence.
+ * `{"source": null}` provenance, which is the shape that makes `NOT (…)` the
+ * repo's recurring bug (`TIER_HELD_BACK_COUNT_SQL`, `objectNotSameSql`).
+ *
+ * ⚠️ **Here the two spellings are extensionally IDENTICAL, and saying otherwise
+ * would be the overclaim this file is least entitled to make.** Measured, not
+ * reasoned: every arm of the exclusion that can be NULL — the tier guard, the
+ * `object_cmp` comparison, a NULL slot key — is SHARED with the JOIN predicate,
+ * and a row only reaches the exclusion by joining, which forces each shared arm
+ * to TRUE. A NULL slot key stays NULL through the substitution too (`CASE WHEN
+ * NULL = $x` takes the ELSE branch), so it cannot join either. So the exclusion
+ * is two-valued for every row that ever evaluates it, and `NOT (…)` would
+ * return the same set today. `vocabulary-preview-pg.test.ts` seeds a
+ * `{"source": null}` pair and shows it is excluded by the JOIN rather than by
+ * this arm — the falsifier for the equivalence, not for the spelling.
+ *
+ * The spelling stays anyway, and the reason is a CHANGE rather than a value:
+ * the equivalence holds only while the exclusion's NULL-capable arms are a
+ * subset of the join's. An exclusion-only arm — the obvious one being a scope
+ * narrowing that reads a nullable column the join does not — breaks it silently
+ * and in the under-disclosing direction. A defensive spelling that costs
+ * nothing and stops being a no-op exactly when someone stops thinking about it
+ * is worth keeping; a docstring calling it load-bearing when it is not is not.
  *
  * ## ⚠️ The object position has NO supersession blast radius
  *
@@ -421,10 +438,11 @@ export type DeltaDirection = "arming" | "disarming";
  * stored); for `disarming` they are (stored, hypothetical). Both come from
  * `supersessionCollisionPredicate`, so both carry every conjunct.
  *
- * ⚠️ `IS NOT TRUE` on the exclusion, never `NOT (…)`. See the module header —
- * this is the third site in the repo where the distinction decides whether the
- * subtlest population is visible, and the first where getting it wrong
- * UNDER-discloses an irreversible consequence.
+ * `IS NOT TRUE` on the exclusion rather than `NOT (…)` — a DEFENSIVE spelling,
+ * not a load-bearing one. The module header carries the measurement: the two
+ * are extensionally identical today because every NULL-capable arm of the
+ * exclusion is shared with the join, and it is an exclusion-ONLY nullable arm
+ * that would break the equivalence.
  */
 function deltaSql(opts: {
   readonly select: string;
@@ -611,7 +629,20 @@ async function planCounterfactual(
             : cardinalityUnflipExpr(2),
         params: [predicateKey],
         ctes: [],
-        extraWhere: `d.predicate_key = $2`,
+        // ⚠️ NO `extraWhere: d.predicate_key = $2`, and its absence is the
+        // decision rather than an omission. It was there, and it was a SECOND
+        // mechanism doing the gate's job: given `d.predicate_key = $2`, the
+        // expression `(d.predicate_key = $2 OR stored)` is just `TRUE`, so the
+        // scope came entirely from the WHERE and the gate could be replaced by
+        // `TRUE` with no test noticing — measured, as a surviving mutation.
+        //
+        // The gate alone is sufficient AND self-scoping: for a pair in any
+        // other predicate the hypothetical and the stored expression coincide,
+        // so `hyp ∧ ¬stored` is empty for it. One mechanism, and it is the one
+        // a mutation can reach. The cost is that the delta scans the
+        // workspace's drafts rather than one predicate's — a human-paced
+        // preview on an admin surface, and the same posture
+        // `REKEY_DRIFTED_FACTS_SQL` takes on a far hotter path.
         // The literal reuse #5025's handoff requires: the arming total is
         // `CARDINALITY_HELD_BACK_COUNT_SQL`'s own question at a predicate scope
         // rather than a batch scope. `vocabulary-preview-pg.test.ts` asserts

--- a/packages/api/src/lib/brain/vocabulary-preview.ts
+++ b/packages/api/src/lib/brain/vocabulary-preview.ts
@@ -16,11 +16,18 @@
  * {@link CollisionExprs}: the collision's CONJUNCTS stay single-spelled and its
  * SLOT EXPRESSIONS became a parameter. Every statement here is
  * `supersessionCollisionPredicate` evaluated twice over the same two rows —
- * once against the stored columns, once against the hypothetical ones — so a
- * caller cannot reach a rule with the tier guard, the cardinality gate or the
- * homonym suppression absent. `collision-sql-pinned.test.ts` holds the shipped
- * statements byte-for-byte and proves the default parameterization is the
- * stored one.
+ * once against the stored columns, once against the hypothetical ones.
+ *
+ * ⚠️ Be precise about what that buys, because the comfortable version is false.
+ * FOUR conjuncts are structurally unreachable through {@link CollisionExprs} —
+ * the tier guard, the homonym suppression, the `object_cmp` arm and the
+ * published row's live-and-current arms. THREE are caller-supplied: both slot
+ * expressions and the cardinality gate. `cardinalityFlipExpr` below forces that
+ * gate TRUE for one predicate on purpose, so "a caller cannot drop the
+ * cardinality gate" is disproved by this very file. The discipline on those
+ * three is `collision-sql-pinned.test.ts` — which holds the shipped statements
+ * byte-for-byte and proves the DEFAULT parameterization is the stored one — plus
+ * review. See `brain-facts.ts`'s table.
  *
  * ## The delta is TWO-SIDED, and that is what makes removal expressible
  *
@@ -118,8 +125,19 @@ import {
 
 const log = createLogger("brain-vocabulary-preview");
 
-/** Which read surface refused, for {@link BrainReaderUnresolvedError}. */
-const PREVIEW_SURFACE = "oversight";
+/**
+ * Which read surface refused, for {@link BrainReaderUnresolvedError}.
+ *
+ * ⚠️ Its own member rather than reusing `"oversight"`. The constant was named
+ * `PREVIEW_SURFACE` and assigned `"oversight"` — the SAME literal
+ * `lib/brain/oversight.ts` uses — so both modules produced the byte-identical
+ * refusal `brain oversight: reader identity resolved to no usable principals`.
+ * An operator triaging a burst of them could not tell the publish preview from
+ * the blast-radius preview: two surfaces, two different fixes, one message.
+ * `BrainReadSurface` is diagnostics-only and explicitly "never branched on", so
+ * extending it costs nothing and buys the distinction.
+ */
+const PREVIEW_SURFACE = "vocabulary-preview";
 
 /**
  * Most pairs one preview enumerates — {@link WILL_SUPERSEDE_PAIR_MAX}'s bound
@@ -168,7 +186,28 @@ export type StructurallyEmptyReason =
    * string would tell someone their un-curation is a no-op *because the
    * predicate is already single*.
    */
-  | "not-curated";
+  | "not-curated"
+  /**
+   * The decision names a surface that does not KEY — it norms away to nothing
+   * (`-`, `___`, `  `), so it occupies no slot and can join nothing.
+   *
+   * ⚠️ **This member exists because its absence was a defect, and the defect
+   * was this module's own signature failure.** The path used to return
+   * `structurallyEmpty: null` with two zeroed sides — and `null` is documented
+   * above as *"the question was asked and answered"* — so a request that was
+   * never computable rendered as *"at least 0 today, and every future claim in
+   * this slot"*. That is the confident false all-clear the module header spends
+   * four paragraphs arguing against, produced by the module itself, on the one
+   * path nothing logged.
+   *
+   * A disclosed REASON rather than a throw, because `identityKey`'s ⚠️ calls a
+   * surface that norms away **permanent and legal** rather than an error:
+   * `reconcile.ts`'s `MALFORMED_CLAIM` guard tests `trim() === ""` and so admits
+   * `-` and `___`, which means such rows exist in real corpora. A corrupt stored
+   * closure target is the DIFFERENT case, and {@link resolveEffectiveTarget}
+   * refuses that one rather than routing it here.
+   */
+  | "unkeyable-surface";
 
 /** The counterfactual's answer. */
 export interface BlastRadius {
@@ -198,6 +237,30 @@ export interface BlastRadiusSide {
   readonly withheld: number;
   /** The page overran {@link BLAST_RADIUS_PAIR_MAX}. Never folded into `withheld`. */
   readonly truncated: boolean;
+  /**
+   * Whether the two statements behind this side agree well enough for the
+   * numbers above to be rendered as facts.
+   *
+   * ⚠️ **Its absence was a defect, and the module header claimed the opposite.**
+   * The header said the clamping and floors were inherited from
+   * `loadSupersessionPreview` — true of the clamp, false of the half that
+   * matters: `loadFactOversight` ships `countsConsistent` precisely because
+   * *"silently clamping the delta to zero renders as 'nothing is hidden from
+   * you', which is the pre-#4825 defect reproduced by its own fix."* This module
+   * clamped and logged and shipped nothing, so a client rendered
+   * `withheld: 0` — "no pairs are hidden from you" — off two statements that had
+   * just disagreed.
+   *
+   * Cleared by: an inverted delta (`scopedTotal > total`), a row whose columns
+   * would not narrow, a window that would not parse, and a subtree walk that hit
+   * {@link MAX_CHAIN_DEPTH}. Every one of those understates the blast radius,
+   * which is the direction that gets a belief retired.
+   *
+   * The cardinality flip is the most exposed: its `total` comes from a DIFFERENT
+   * statement than its pairs, so the two are structurally more able to disagree
+   * than the sibling's, not less.
+   */
+  readonly countsConsistent: boolean;
 }
 
 const EMPTY_SIDE: BlastRadiusSide = Object.freeze({
@@ -205,6 +268,9 @@ const EMPTY_SIDE: BlastRadiusSide = Object.freeze({
   pairs: [],
   withheld: 0,
   truncated: false,
+  // A structurally-empty side is not a DEGRADED one: nothing was computed, so
+  // nothing disagreed. The reason travels on `structurallyEmpty`.
+  countsConsistent: true,
 });
 
 // ---------------------------------------------------------------------------
@@ -233,6 +299,24 @@ const SLOT_SURFACE_COLUMN: { readonly [P in SlotPosition]: P } = {
 };
 
 /**
+ * A slot position that can actually produce a collision.
+ *
+ * ⚠️ The object position is excluded AT THE TYPE, not detected at runtime.
+ * `aliasExprs` used to carry an `object` arm that threw, with five lines
+ * explaining that `structurallyEmptyReason` runs first — i.e. an ordering
+ * guarantee between two independent functions, enforced by a comment. Narrowing
+ * here moves it to the compiler: "an object-position plan was built" becomes
+ * unrepresentable rather than merely detected, and the throw and its
+ * justification both disappear.
+ */
+type CollidingSlot = Exclude<SlotPosition, "object">;
+
+/** Narrow a position to one that can collide. */
+function isCollidingSlot(position: SlotPosition): position is CollidingSlot {
+  return position !== "object";
+}
+
+/**
  * The APPROVAL counterfactual: rows keyed `$fromKey` move to `$toKey`.
  *
  * Well-defined key-to-key, and that is a quotation rather than an assumption —
@@ -247,7 +331,7 @@ const SLOT_SURFACE_COLUMN: { readonly [P in SlotPosition]: P } = {
  * against the closure by {@link resolveEffectiveTarget} rather than assumed.
  */
 function approvalKeyExpr(
-  position: SlotPosition,
+  position: CollidingSlot,
   fromKeyParam: number,
   toKeyParam: number,
 ): (alias: string) => string {
@@ -277,7 +361,7 @@ function approvalKeyExpr(
  * implementation of `lexicalNorm` and the one that disagrees.
  */
 function removalKeyExpr(
-  position: SlotPosition,
+  position: CollidingSlot,
   subtreeCte: string,
   fromKeyParam: number,
 ): (alias: string) => string {
@@ -302,10 +386,23 @@ function removalKeyExpr(
  * ⚠️ The bound TRUNCATES here rather than raising, and the asymmetry with
  * `recomputeEffectiveTargets` is deliberate: that function WRITES a closure, so
  * a truncated walk would commit keys nobody approved. This one only DISCLOSES,
- * and a truncated walk understates the blast radius — which is logged by
- * {@link loadBlastRadius}'s caller through the corruption the closure rebuild
- * will independently refuse. A preview must never be the thing that takes a
- * workspace's admin console down.
+ * and a preview must never be the thing that takes a workspace's admin console
+ * down.
+ *
+ * ⚠️ **But a truncated walk UNDERSTATES the blast radius, so it cannot be
+ * silent.** An earlier version of this comment said the condition was *"logged
+ * by `loadBlastRadius`'s caller through the corruption the closure rebuild will
+ * independently refuse"* — three things wrong with that sentence, and it is the
+ * kind this file is least entitled to: there is no caller (the module is
+ * unwired); a rebuild running at some LATER approval is not a signal on THIS
+ * request; and `truncated` means page overrun only, so nothing on the response
+ * carried it. An admin could withdraw an arbitration whose scope was understated
+ * by an order of magnitude with every counter reading trustworthy.
+ *
+ * So the bound is PROBED ({@link subtreeTruncatedSql}) and clears
+ * {@link BlastRadiusSide.countsConsistent}. Note the bound is also not purely a
+ * corruption signal: `vocabulary.ts` records that a rebuild fails when edges are
+ * cyclic **or deeper than** the bound, so depth alone can trip it.
  */
 function subtreeCteSql(
   cteName: string,
@@ -376,7 +473,7 @@ function cardinalityUnflipExpr(predicateKeyParam: number): CollisionExprs {
  * An alias approval or removal at ONE position, as a full expression bundle.
  *
  * Spelled as an exhaustive switch rather than a computed key
- * (`{ [pos === "subject" ? "subjectKey" : "predicateKey"]: … }`), which needed
+ * (a computed member name chosen by a ternary on the position), which needed
  * an `as CollisionExprs` — and that cast is load-bearing in the wrong
  * direction: it tells the compiler the record is complete, so a fourth
  * `SlotPosition`, or a typo in either property name, produces a bundle silently
@@ -397,29 +494,18 @@ function cardinalityUnflipExpr(predicateKeyParam: number): CollisionExprs {
  * earlier"*) is exactly the case it would report as zero.
  */
 function aliasExprs(
-  position: SlotPosition,
+  position: CollidingSlot,
   keyExpr: (alias: string) => string,
 ): CollisionExprs {
   switch (position) {
     case "subject":
-      return { ...STORED_COLLISION_EXPRS, subjectKey: keyExpr };
+      return { ...STORED_COLLISION_EXPRS, subjectSlot: keyExpr };
     case "predicate":
       return {
         ...STORED_COLLISION_EXPRS,
-        predicateKey: keyExpr,
+        predicateSlot: keyExpr,
         cardinalitySingle: (alias) => cardinalitySingleSql(alias, keyExpr(alias)),
       };
-    case "object":
-      // Unreachable: `structurallyEmptyReason` returns `object-position` before
-      // any plan is built. Thrown rather than falling through to the stored
-      // bundle, because a silent identity counterfactual would render as "this
-      // alias changes nothing" — which is TRUE for supersession and false for
-      // what an approver would take it to mean.
-      throw new Error(
-        "loadBlastRadius: an object-position alias has no supersession counterfactual — the " +
-          "collision does not read `object_key`. This is reported as structurallyEmpty " +
-          '"object-position" before a plan is built, so reaching here is an ordering regression.',
-      );
   }
 }
 
@@ -428,6 +514,18 @@ function aliasExprs(
 // ---------------------------------------------------------------------------
 
 /** Which half of the delta a statement computes. */
+/**
+ * Did the subtree walk reach {@link MAX_CHAIN_DEPTH}?
+ *
+ * Asked as its own statement rather than folded into the delta, because the
+ * delta's shape is fixed by {@link deltaSql} and a `bool_or` column would have
+ * to survive both the count and the pairs projection. One extra round trip on a
+ * human-paced admin preview, and only for a removal.
+ */
+function subtreeTruncatedSql(cte: string): string {
+  return `WITH RECURSIVE ${cte} SELECT bool_or(depth >= ${MAX_CHAIN_DEPTH}) AS hit FROM subtree`;
+}
+
 export type DeltaDirection = "arming" | "disarming";
 
 /**
@@ -532,6 +630,15 @@ export async function loadBlastRadius(
 ): Promise<BlastRadius> {
   const workspaceId = ctx.workspaceId;
 
+  // RESOLVE THE READER FIRST, before any early return.
+  //
+  // ⚠️ This call used to sit inside `loadBlastRadiusSide`, i.e. AFTER both
+  // early returns — so a reader with an unresolvable identity asking about a
+  // degenerate norm received a clean `{total: 0}` instead of the refusal this
+  // function's own `@throws` contract promises. The fail-closed gate was
+  // reachable only on the paths that did not need it.
+  assertReaderResolvable(ctx, requestId);
+
   const structurallyEmpty = await structurallyEmptyReason(db, workspaceId, request);
   if (structurallyEmpty !== null) {
     return {
@@ -542,14 +649,25 @@ export async function loadBlastRadius(
     };
   }
 
-  const plan = await planCounterfactual(db, workspaceId, request);
+  const plan = await planCounterfactual(db, workspaceId, request, requestId);
   if (plan === null) {
-    // The decision names nothing this workspace holds — an unaliased norm, a
-    // predicate with no facts. Reported as an ordinary empty radius rather than
-    // as an error: it is a legitimate answer to "what would this change", and
-    // the authoring path refuses a zero-population pair separately and with a
-    // reason (`vocabulary-author.ts`).
-    return { arming: EMPTY_SIDE, disarming: EMPTY_SIDE, floor: true, structurallyEmpty: null };
+    // ⚠️ A DISCLOSED REASON, never a bare zero. The earlier version returned
+    // `structurallyEmpty: null` here with a comment describing two causes that
+    // cannot reach this branch — "an unaliased norm" resolves to itself rather
+    // than to null, and "a predicate with no facts" never consults
+    // `brain_facts` at all. What actually reaches it is a surface that norms
+    // away, and reporting that as "asked and answered, zero" is the confident
+    // false all-clear the module header argues against at length.
+    log.warn(
+      { workspaceId, requestId, kind: request.kind },
+      "brain vocabulary preview: the decision named a surface that does not key — disclosing an unkeyable-surface reason rather than a zero blast radius",
+    );
+    return {
+      arming: EMPTY_SIDE,
+      disarming: EMPTY_SIDE,
+      floor: true,
+      structurallyEmpty: "unkeyable-surface",
+    };
   }
 
   const [arming, disarming] = await Promise.all([
@@ -558,6 +676,30 @@ export async function loadBlastRadius(
   ]);
 
   return { arming, disarming, floor: true, structurallyEmpty: null };
+}
+
+/**
+ * Refuse an unresolvable reader BEFORE any early return.
+ *
+ * `aclVisibilityClause`'s `deny-all` is the same condition
+ * {@link loadBlastRadiusSide} checks per statement; this is that check hoisted
+ * so it cannot be skipped by a request that never reaches a statement. Built on
+ * a throwaway alias and param index — the clause is discarded, only its
+ * DECISION is read — because the real clauses must be built with the plan's
+ * arity, which is not known yet.
+ *
+ * @throws {BrainReaderUnresolvedError}
+ */
+function assertReaderResolvable(ctx: BrainPrincipalContext, requestId?: string): void {
+  const probe = aclVisibilityClause(ctx, {
+    table: "brain_facts",
+    alias: "d",
+    paramIndex: 1,
+    requestId,
+  });
+  if (probe.decision === "deny-all") {
+    throw new BrainReaderUnresolvedError(ctx.workspaceId, ctx.origin, PREVIEW_SURFACE);
+  }
 }
 
 /**
@@ -573,17 +715,35 @@ interface CounterfactualPlan {
   /** Everything after `$1` (the workspace id), in order. */
   readonly params: readonly unknown[];
   readonly ctes: readonly string[];
-  /** Narrows the draft side, e.g. to one predicate's slot. */
-  readonly extraWhere?: string;
-  /** The imported held-back count, when this request's arming side has one. */
-  readonly importedTotalSql?: string;
-  readonly importedTotalParams?: readonly unknown[];
+  /**
+   * The subtree walk hit {@link MAX_CHAIN_DEPTH}, so the removal's disarming set
+   * is INCOMPLETE. Clears `countsConsistent` on both sides — a preview that
+   * cannot see the whole subtree cannot be trusted about either direction.
+   */
+  readonly subtreeTruncated: boolean;
+  /**
+   * An ARMING-side total that comes from a different statement.
+   *
+   * ONE optional record rather than three loose ones. As two independent
+   * optionals plus a column name derived from a boolean at the read site, the
+   * type admitted `{sql, params: undefined}` — which fell back to `[workspaceId]`
+   * and failed at Postgres on the statement's own `$2` — and forced an
+   * `as string` re-assertion because a `boolean` cannot narrow a sibling field.
+   * Grouped, the presence check narrows all three and the cast disappears.
+   */
+  readonly armingTotalOverride?: {
+    readonly sql: string;
+    readonly params: readonly unknown[];
+    /** The result column. Lives WITH the statement, not with its consumer. */
+    readonly column: string;
+  };
 }
 
 async function planCounterfactual(
   db: BrainCandidateReader,
   workspaceId: string,
   request: BlastRadiusRequest,
+  requestId?: string,
 ): Promise<CounterfactualPlan | null> {
   switch (request.kind) {
     case "alias-approval": {
@@ -591,15 +751,21 @@ async function planCounterfactual(
       const toNorm = lexicalNorm(request.toNorm);
       if (fromKey === null || toNorm === "") return null;
       // `to`'s CURRENT effective target — see `approvalKeyExpr`'s ⚠️.
-      const toKey = await resolveEffectiveTarget(db, workspaceId, request.position, toNorm);
+      // Narrowed HERE — the one call site that already knows the answer,
+      // because `structurallyEmptyReason` returned non-null for `object` and
+      // `loadBlastRadius` returned before reaching this function.
+      if (!isCollidingSlot(request.position)) return null;
+      const toKey = await resolveEffectiveTarget(db, workspaceId, request.position, toNorm, requestId);
       if (toKey === null) return null;
       return {
         hypothetical: aliasExprs(request.position, approvalKeyExpr(request.position, 2, 3)),
         params: [fromKey, toKey],
         ctes: [],
+        subtreeTruncated: false,
       };
     }
     case "alias-removal": {
+      if (!isCollidingSlot(request.position)) return null;
       const fromKey = identityKey(request.fromNorm);
       if (fromKey === null) return null;
       return {
@@ -611,12 +777,13 @@ async function planCounterfactual(
         // cannot make the walk start somewhere the substitution does not land.
         params: [fromKey, request.position],
         ctes: [subtreeCteSql("subtree", 1, 3, 2)],
+        subtreeTruncated: await subtreeHitBound(db, workspaceId, request.position, fromKey, requestId),
       };
     }
     case "cardinality-flip":
     case "cardinality-removal": {
-      const predicateKey = identityKey(request.predicateSurface);
-      if (predicateKey === null) return null;
+      const canonicalKey = identityKey(request.predicateSurface);
+      if (canonicalKey === null) return null;
       return {
         // A flip ADDS this key to the gate; a removal SUBTRACTS it. Both are
         // "the vocabulary after the decision", and the delta's direction swap
@@ -627,8 +794,9 @@ async function planCounterfactual(
           request.kind === "cardinality-flip"
             ? cardinalityFlipExpr(2)
             : cardinalityUnflipExpr(2),
-        params: [predicateKey],
+        params: [canonicalKey],
         ctes: [],
+        subtreeTruncated: false,
         // ⚠️ NO `extraWhere: d.predicate_key = $2`, and its absence is the
         // decision rather than an omission. It was there, and it was a SECOND
         // mechanism doing the gate's job: given `d.predicate_key = $2`, the
@@ -648,11 +816,14 @@ async function planCounterfactual(
         // rather than a batch scope. `vocabulary-preview-pg.test.ts` asserts
         // this statement and the delta agree on a real corpus, so the reuse is
         // CHECKED rather than claimed.
-        importedTotalSql:
+        armingTotalOverride:
           request.kind === "cardinality-flip"
-            ? cardinalityHeldBackCountSql("d.predicate_key = $2")
+            ? {
+                sql: cardinalityHeldBackCountSql("d.predicate_key = $2"),
+                params: [canonicalKey],
+                column: "held_back",
+              }
             : undefined,
-        importedTotalParams: request.kind === "cardinality-flip" ? [predicateKey] : undefined,
       };
     }
   }
@@ -667,23 +838,100 @@ async function planCounterfactual(
  * the norm itself — `loadClaimVocabulary`'s empty/absent equivalence, one layer
  * down.
  */
+/**
+ * Probe whether the removal's subtree walk reaches the depth bound.
+ *
+ * Answers `true` on an unreadable result rather than `false`: the flag's only
+ * job is to CLEAR `countsConsistent`, so the fail-closed direction is to say
+ * "do not trust these numbers" when the probe itself could not be read.
+ */
+async function subtreeHitBound(
+  db: BrainCandidateReader,
+  workspaceId: string,
+  position: SlotPosition,
+  fromKey: string,
+  requestId?: string,
+): Promise<boolean> {
+  const { rows } = await db.query(subtreeTruncatedSql(subtreeCteSql("subtree", 1, 3, 2)), [
+    workspaceId,
+    fromKey,
+    position,
+  ]);
+  const hit = (rows[0] as { hit?: unknown } | undefined)?.hit;
+  if (hit === true) {
+    log.warn(
+      { workspaceId, requestId, position, fromNorm: fromKey, maxChainDepth: MAX_CHAIN_DEPTH },
+      "brain vocabulary preview: the alias subtree walk hit the depth bound — the approved-edge graph is cyclic or deeper than the bound, so this removal's disarming set is TRUNCATED and understates the blast radius",
+    );
+    return true;
+  }
+  if (hit === false || hit === null) return false;
+  log.warn(
+    { workspaceId, requestId, position, hit: typeof hit },
+    "brain vocabulary preview: the subtree depth probe did not read back as a boolean — clearing countsConsistent rather than assuming the walk was complete",
+  );
+  return true;
+}
+
 async function resolveEffectiveTarget(
   db: BrainCandidateReader,
   workspaceId: string,
   position: SlotPosition,
   norm: string,
+  requestId?: string,
 ): Promise<string | null> {
   const { rows } = await db.query(
     `SELECT effective_target FROM brain_vocabulary_target
       WHERE workspace_id = $1 AND slot_position = $2 AND norm = $3`,
     [workspaceId, position, norm],
   );
-  const row = rows[0] as { effective_target?: unknown } | undefined;
-  const target = typeof row?.effective_target === "string" ? row.effective_target : norm;
+  // Branch on ROW PRESENCE, never on value shape. One ternary used to collapse
+  // two opposite facts: *no row* (legitimately unaliased — `alias` is total, so
+  // the norm is its own target) and *row present, column unreadable* (the
+  // column is `NOT NULL` with a `<> ''` CHECK, so this is unreachable from
+  // Postgres and therefore a query-shape change).
+  //
+  // ⚠️ Collapsed, the drift case answered with the UN-ALIASED norm — which is
+  // precisely `approvalKeyExpr`'s ⚠️: a slot the re-key never writes, joining
+  // nothing, so every approval preview in the workspace reports zero arming
+  // pairs forever with no log line. That is the same defect class `readCount`
+  // throws on 130 lines below, and it was handled the opposite way.
+  const row = rows[0] as Record<string, unknown> | undefined;
+  if (row === undefined) return identityKey(norm);
+
+  const stored = row.effective_target;
+  if (typeof stored !== "string" || stored.trim() === "") {
+    log.error(
+      { workspaceId, position, norm, requestId },
+      "brain vocabulary preview: brain_vocabulary_target.effective_target did not read back as a string — the closure query shape changed",
+    );
+    throw new Error(
+      `brain vocabulary preview: brain_vocabulary_target.effective_target did not read back as a ` +
+        `string for ${position}/"${norm}" in workspace ${workspaceId}. The column is NOT NULL with a ` +
+        `non-empty CHECK, so this is unreachable from Postgres and the query shape has changed — ` +
+        `refusing to compute a counterfactual against an unresolved target, which would report every ` +
+        `approval as arming nothing.`,
+    );
+  }
+
   // Re-normed for `slotKey`'s reason: the vocabulary's answer is a data table's
   // and not a proof, and an entry authored as `"Priced At"` would otherwise make
   // this preview compute a key that joins nothing — a confident zero.
-  return identityKey(target);
+  const key = identityKey(stored);
+  if (key === null) {
+    log.error(
+      { workspaceId, position, norm, requestId },
+      "brain vocabulary preview: the stored effective target norms away — the closure is corrupt",
+    );
+    throw new Error(
+      `brain vocabulary preview: the stored effective target "${stored}" for ${position}/"${norm}" in ` +
+        `workspace ${workspaceId} norms away to nothing. A closure target that keys nothing is corrupt ` +
+        `— 0189's CHECKs do not constrain it to being a norm, and the region importer rebuilds this ` +
+        `table — so it is refused rather than folded into an unkeyable-surface answer, which would ` +
+        `report store corruption as an ordinary property of the request.`,
+    );
+  }
+  return key;
 }
 
 /**
@@ -704,13 +952,13 @@ async function structurallyEmptyReason(
     return "object-position";
   }
   if (request.kind === "cardinality-flip" || request.kind === "cardinality-removal") {
-    const predicateKey = identityKey(request.predicateSurface);
-    if (predicateKey === null) return null;
+    const canonicalKey = identityKey(request.predicateSurface);
+    if (canonicalKey === null) return null;
     const { rows } = await db.query(
       `SELECT 1 AS hit FROM brain_predicate_cardinality
         WHERE workspace_id = $1 AND predicate_key = $2
           AND cardinality = 'single' AND status = 'approved'`,
-      [workspaceId, predicateKey],
+      [workspaceId, canonicalKey],
     );
     // The two kinds read the SAME probe and branch on opposite answers: a flip
     // has nothing to compute when the entry already exists, and a removal has
@@ -769,19 +1017,20 @@ async function loadBlastRadiusSide(
   }
   const limitParam = publishedAcl.nextParamIndex;
 
-  const useImported = direction === "arming" && plan.importedTotalSql !== undefined;
-  const totalSql = useImported
-    ? (plan.importedTotalSql as string)
-    : deltaSql({
-        select: TOTAL_SELECT,
-        joinExprs,
-        excludeExprs,
-        workspaceParam: 1,
-        extraWhere: plan.extraWhere,
-        ctes: plan.ctes,
-      });
-  const totalParams = useImported
-    ? [workspaceId, ...(plan.importedTotalParams ?? [])]
+  // Narrowed once, so the statement, its params and its result column travel
+  // together and no `as` is needed to re-assert what the check established.
+  const override = direction === "arming" ? plan.armingTotalOverride : undefined;
+  const totalSql =
+    override?.sql ??
+    deltaSql({
+      select: TOTAL_SELECT,
+      joinExprs,
+      excludeExprs,
+      workspaceParam: 1,
+      ctes: plan.ctes,
+    });
+  const totalParams = override
+    ? [workspaceId, ...override.params]
     : [workspaceId, ...plan.params];
 
   const pairsSql = deltaSql({
@@ -789,7 +1038,7 @@ async function loadBlastRadiusSide(
     joinExprs,
     excludeExprs,
     workspaceParam: 1,
-    extraWhere: [plan.extraWhere, draftAcl.sql, publishedAcl.sql].filter(Boolean).join("\n     AND "),
+    extraWhere: [draftAcl.sql, publishedAcl.sql].join("\n     AND "),
     ctes: plan.ctes,
     tail: `\n   ORDER BY d.ingested_at, d.id, p.ingested_at, p.id\n   LIMIT $${limitParam}`,
   });
@@ -805,7 +1054,7 @@ async function loadBlastRadiusSide(
     ]),
   ]);
 
-  const total = readCount(totalResult.rows[0], useImported ? "held_back" : "delta_total");
+  const total = readCount(totalResult.rows[0], override?.column ?? "delta_total");
   if (total === null) {
     // A THROW, not a degraded 0 — `loadSupersessionPreview`'s reason exactly: 0
     // renders as "this decision arms nothing", a confident false all-clear
@@ -818,21 +1067,31 @@ async function loadBlastRadiusSide(
     );
   }
 
-  const { pairs, scopedTotal, truncated } = readPairs(
+  const { pairs, scopedTotal, truncated, drifted } = readPairs(
     pairsResult.rows,
     workspaceId,
     direction,
     requestId,
   );
 
-  if (scopedTotal > total) {
+  const inverted = scopedTotal > total;
+  if (inverted) {
     log.warn(
       { workspaceId, requestId, direction, scopedTotal, total },
-      "brain vocabulary preview: the reader-scoped delta exceeds the workspace delta — a brief ingest race, or the two statements disagree; reporting 0 withheld",
+      "brain vocabulary preview: the reader-scoped delta exceeds the workspace delta — a brief ingest race, or the two statements disagree; reporting 0 withheld and clearing countsConsistent",
     );
   }
 
-  return { total, pairs, withheld: Math.max(0, total - scopedTotal), truncated };
+  return {
+    total,
+    pairs,
+    withheld: Math.max(0, total - scopedTotal),
+    truncated,
+    // The clamp above is `loadSupersessionPreview`'s; this flag is the half that
+    // module ships and this one had dropped. Without it the clamp renders as
+    // "nothing is hidden from you" off two statements that just disagreed.
+    countsConsistent: !inverted && !drifted && !plan.subtreeTruncated,
+  };
 }
 
 /** One `COUNT(*)::int` column, or `null` when it did not read back as one. */
@@ -860,7 +1119,7 @@ function readPairs(
   workspaceId: string,
   direction: DeltaDirection,
   requestId?: string,
-): { pairs: BlastRadiusPair[]; scopedTotal: number; truncated: boolean } {
+): { pairs: BlastRadiusPair[]; scopedTotal: number; truncated: boolean; drifted: boolean } {
   const clipped = rawRows.length > BLAST_RADIUS_PAIR_MAX;
   const pairs: BlastRadiusPair[] = [];
   let scopedTotal = 0;
@@ -914,5 +1173,16 @@ function readPairs(
   if (clipped && scopedTotal < rawRows.length) scopedTotal = rawRows.length;
   if (scopedTotal < pairs.length) scopedTotal = pairs.length;
 
-  return { pairs, scopedTotal, truncated: clipped || scopedTotal > pairs.length };
+  // ⚠️ `drifted` is what stops a DROPPED row being reported to the approver as
+  // an ACL-WITHHELD one. On the unclipped path the first floor does not apply,
+  // so a row that failed to PARSE falls through to `scopedTotal = pairs.length`
+  // and re-emerges inside `withheld` — i.e. "you lack permission to see this"
+  // for a row that simply would not narrow. Both cases log, but the number the
+  // human reads is wrong, and only this flag says so on the wire.
+  return {
+    pairs,
+    scopedTotal,
+    truncated: clipped || scopedTotal > pairs.length,
+    drifted: droppedRows > 0 || windowDriftRows > 0,
+  };
 }

--- a/packages/api/src/lib/brain/vocabulary-preview.ts
+++ b/packages/api/src/lib/brain/vocabulary-preview.ts
@@ -83,8 +83,8 @@
  * — so approving one changes what corroborates and what earns a tension edge,
  * and changes nothing about what supersedes.
  *
- * That is reported as {@link BlastRadius.structurallyEmpty} rather than as a
- * zero, because *"0 pairs"* and *"this position cannot produce pairs"* are the
+ * That is reported as a `structurally-empty` {@link BlastRadius} carrying a
+ * reason, rather than as a zero, because *"0 pairs"* and *"this position cannot produce pairs"* are the
  * same number and opposite facts, and an approver reading the first will
  * reasonably conclude the alias is harmless when what is true is that its harm
  * is of a different kind. The same trap the M1 dogfood fell into: the sync
@@ -209,7 +209,26 @@ export type StructurallyEmptyReason =
    * closure target is the DIFFERENT case, and {@link resolveEffectiveTarget}
    * refuses that one rather than routing it here.
    */
-  | "unkeyable-surface";
+  | "unkeyable-surface"
+  /**
+   * An `alias-removal` naming a norm with no approved parent edge.
+   *
+   * ⚠️ Added because the alias kinds had NO analogue of `not-curated`, and the
+   * consequence was strictly worse than the one that member exists to prevent.
+   * With no edge, the removal's subtree is `{fromNorm}` and `removalKeyExpr`
+   * maps those rows onto the key they already carry — so `hypothetical ≡
+   * stored`, both deltas are empty, and the caller received a **computed**
+   * radius of zeros with `floor: true`. A renderer then says *"at least 0
+   * today, and every future claim in this slot"* for a decision that does
+   * nothing at all.
+   *
+   * `not-curated`'s own docstring argues it had to be its own member because
+   * collapsing it *"would tell someone their un-curation is a no-op"*. This is
+   * that same sentence for the alias path, and it was routed to `computed`
+   * zeros rather than merely mislabelled — which is why it is a reason and not
+   * a rewording.
+   */
+  | "no-such-edge";
 
 /**
  * The counterfactual's answer — a DISCRIMINATED UNION, and the discrimination
@@ -273,7 +292,15 @@ export interface BlastRadiusSide {
   readonly pairs: readonly BlastRadiusPair[];
   /** `total − scopedTotal`: pairs that happen regardless, listing rows this reader may not read. */
   readonly withheld: number;
-  /** The page overran {@link BLAST_RADIUS_PAIR_MAX}. Never folded into `withheld`. */
+  /**
+   * The sample lists fewer pairs than the reader is entitled to — either the
+   * page overran {@link BLAST_RADIUS_PAIR_MAX}, or rows failed to narrow and
+   * were dropped. `countsConsistent` distinguishes the two.
+   *
+   * Never folded into `withheld`, which means something else entirely: pairs
+   * the ACL withheld. Truncation dressed as an ACL boundary is what the wire
+   * type forbids.
+   */
   readonly truncated: boolean;
   /**
    * Whether the two statements behind this side agree well enough for the
@@ -290,9 +317,14 @@ export interface BlastRadiusSide {
    * just disagreed.
    *
    * Cleared by: an inverted delta (`scopedTotal > total`), a row whose columns
-   * would not narrow, a window that would not parse, and a subtree walk that hit
-   * {@link MAX_CHAIN_DEPTH}. Every one of those understates the blast radius,
-   * which is the direction that gets a belief retired.
+   * would not narrow, a window that would not parse, and a depth probe that did
+   * not answer. Every one of those is two statements failing to agree.
+   *
+   * ⚠️ **NOT cleared by a truncated subtree walk** — that is a SCOPE fact and
+   * travels on {@link BlastRadius.subtreeTruncated}. A consumer gating trust on
+   * this flag alone will believe it saw the whole alias subtree when it did
+   * not, so a renderer must read both. Four docstrings in this module asserted
+   * the old behaviour after it changed; that is what this sentence replaces.
    *
    * The cardinality flip is the most exposed: its `total` comes from a DIFFERENT
    * statement than its pairs, so the two are structurally more able to disagree
@@ -427,8 +459,9 @@ function removalKeyExpr(
  * carried it. An admin could withdraw an arbitration whose scope was understated
  * by an order of magnitude with every counter reading trustworthy.
  *
- * So the bound is PROBED ({@link subtreeTruncatedSql}) and clears
- * {@link BlastRadiusSide.countsConsistent}. Note the bound is also not purely a
+ * So the bound is PROBED ({@link subtreeTruncatedSql}) and travels on
+ * {@link BlastRadius.subtreeTruncated} — a scope statement, not a count
+ * disagreement. Note the bound is also not purely a
  * corruption signal: `vocabulary.ts` records that a rebuild fails when edges are
  * cyclic **or deeper than** the bound, so depth alone can trip it.
  */
@@ -551,9 +584,24 @@ function aliasExprs(
  */
 const SUBTREE_CTE = "subtree";
 
-/** The walk's depth bound — the shipped constant unless a test injects one. */
+/** No walk was performed — every kind but `alias-removal`. */
+const NO_SUBTREE: SubtreeProbe = Object.freeze({ truncated: false, probeDrifted: false });
+
+/**
+ * The walk's depth bound — the shipped constant unless a test injects one.
+ *
+ * ⚠️ CLAMPED, and interpolated raw into SQL at two sites. `maxChainDepth` sits
+ * on an EXPORTED options bag beside `requestId`, so a future route spreading a
+ * parsed query string into this call would hand a client control of a value
+ * that reaches the statement text. The clamp makes the seam incapable of
+ * injecting, of widening past the shipped bound, and of producing a
+ * non-integral depth — it can only ever NARROW, which is the whole production
+ * invariant.
+ */
 function maxDepth(opts: BlastRadiusOptions): number {
-  return opts.maxChainDepth ?? MAX_CHAIN_DEPTH;
+  const requested = opts.maxChainDepth;
+  if (requested === undefined) return MAX_CHAIN_DEPTH;
+  return Math.min(Math.max(1, Math.trunc(requested)), MAX_CHAIN_DEPTH);
 }
 
 /**
@@ -730,7 +778,7 @@ export async function loadBlastRadius(
     arming,
     disarming,
     floor: true,
-    subtreeTruncated: plan.subtreeTruncated,
+    subtreeTruncated: plan.subtree.truncated,
   };
 }
 
@@ -768,15 +816,30 @@ function assertReaderResolvable(ctx: BrainPrincipalContext, requestId?: string):
  */
 interface CounterfactualPlan {
   readonly hypothetical: CollisionExprs;
-  /** Everything after `$1` (the workspace id), in order. */
-  readonly params: readonly unknown[];
+  /**
+   * Everything after `$1` (the workspace id), in order.
+   *
+   * `readonly string[]`, not `unknown[]`. Every kind binds strings, and the
+   * wider type was actively hiding a hole: round 2 deleted the caller's
+   * `toKey === null` check on the strength of a prose argument, and
+   * `unknown[]` accepted the `string | null` silently. A NULL here binds `$3`,
+   * the approval CASE moves the whole population onto a NULL key, both deltas
+   * return 0, and the surface reports "this approval arms nothing" — the
+   * module's own named worst outcome, with no log line. The invariant went from
+   * CHECKED to DOCUMENTED, in the file whose thesis is that this is the
+   * anti-pattern. One word puts the compiler back in the room.
+   */
+  readonly params: readonly string[];
   readonly ctes: readonly string[];
   /**
-   * The subtree walk hit {@link MAX_CHAIN_DEPTH}, so the removal's disarming set
-   * is INCOMPLETE. Clears `countsConsistent` on both sides — a preview that
-   * cannot see the whole subtree cannot be trusted about either direction.
+   * What the depth probe established about the removal's subtree walk.
+   *
+   * `truncated` travels to {@link BlastRadius.subtreeTruncated} — a radius-wide
+   * SCOPE statement. `probeDrifted` clears
+   * {@link BlastRadiusSide.countsConsistent} instead, because an unreadable
+   * probe is statement drift and says nothing about the graph's depth.
    */
-  readonly subtreeTruncated: boolean;
+  readonly subtree: SubtreeProbe;
   /**
    * An ARMING-side total that comes from a different statement.
    *
@@ -803,18 +866,22 @@ async function planCounterfactual(
 ): Promise<CounterfactualPlan | StructurallyEmptyReason> {
   switch (request.kind) {
     case "alias-approval": {
+      // POSITION FIRST, matching the removal arm below. Both guards are
+      // unreachable today (`structurallyEmptyReason` runs before this
+      // function), and the whole reason they exist is the hypothetical where
+      // that stops being true — under which two arms answering DIFFERENT
+      // reasons for one request shape is exactly the confusion they were added
+      // to prevent. Position is the structural fact; keyability is the
+      // request-content fact.
+      if (!isCollidingSlot(request.position)) return "object-position";
       const fromKey = identityKey(request.fromNorm);
       const toNorm = lexicalNorm(request.toNorm);
       if (fromKey === null || toNorm === "") return "unkeyable-surface";
       // `to`'s CURRENT effective target — see `approvalKeyExpr`'s ⚠️.
-      // Narrowed HERE — the one call site that already knows the answer,
-      // because `structurallyEmptyReason` returned non-null for `object` and
-      // `loadBlastRadius` returned before reaching this function.
-      if (!isCollidingSlot(request.position)) return "object-position";
-      // `resolveEffectiveTarget` cannot answer null here — `toNorm` is a
-      // non-empty norm and `lexicalNorm` is idempotent — so the arm that used
-      // to sit here was dead AND fed the overloaded null channel. It refuses
-      // loudly on the two corrupt-closure shapes instead.
+      // `resolveEffectiveTarget` returns `string`: `toNorm` is a non-empty norm
+      // and `lexicalNorm` is idempotent, so the null arm that used to sit here
+      // was dead AND fed the overloaded null channel. It refuses loudly on the
+      // two corrupt-closure shapes instead.
       const toKey = await resolveEffectiveTarget(
         db,
         workspaceId,
@@ -826,7 +893,7 @@ async function planCounterfactual(
         hypothetical: aliasExprs(request.position, approvalKeyExpr(request.position, 2, 3)),
         params: [fromKey, toKey],
         ctes: [],
-        subtreeTruncated: false,
+        subtree: NO_SUBTREE,
       };
     }
     case "alias-removal": {
@@ -842,7 +909,7 @@ async function planCounterfactual(
         // cannot make the walk start somewhere the substitution does not land.
         params: [fromKey, request.position],
         ctes: [subtreeCteSql(SUBTREE_CTE, 1, 3, 2, maxDepth(opts))],
-        subtreeTruncated: await subtreeHitBound(db, workspaceId, request.position, fromKey, opts),
+        subtree: await subtreeHitBound(db, workspaceId, request.position, fromKey, opts),
       };
     }
     case "cardinality-flip":
@@ -861,7 +928,7 @@ async function planCounterfactual(
             : cardinalityUnflipExpr(2),
         params: [canonicalKey],
         ctes: [],
-        subtreeTruncated: false,
+        subtree: NO_SUBTREE,
         // ⚠️ NO `extraWhere: d.predicate_key = $2`, and its absence is the
         // decision rather than an omission. It was there, and it was a SECOND
         // mechanism doing the gate's job: given `d.predicate_key = $2`, the
@@ -916,7 +983,7 @@ async function subtreeHitBound(
   position: CollidingSlot,
   fromKey: string,
   opts: BlastRadiusOptions,
-): Promise<boolean> {
+): Promise<SubtreeProbe> {
   const depth = maxDepth(opts);
   const { rows } = await db.query(
     subtreeTruncatedSql(subtreeCteSql(SUBTREE_CTE, 1, 3, 2, depth), depth),
@@ -928,7 +995,7 @@ async function subtreeHitBound(
       { workspaceId, requestId: opts.requestId, position, fromNorm: fromKey, maxChainDepth: depth },
       "brain vocabulary preview: the alias subtree walk hit the depth bound — the approved-edge graph is cyclic or deeper than the bound, so this removal's disarming set is TRUNCATED and understates the blast radius",
     );
-    return true;
+    return { truncated: true, probeDrifted: false };
   }
   // ⚠️ `false` is the ONLY value that may answer "the walk was complete".
   // `null` used to take this arm unlogged — a `bool_or` over an empty CTE, a
@@ -937,12 +1004,29 @@ async function subtreeHitBound(
   // same file argues exactly this for `Number(null)` forty lines down; two
   // treatments of SQL NULL in one module, and the silent one was on the side
   // that decides whether an approver is shown a trustworthy number.
-  if (hit === false) return false;
+  if (hit === false) return { truncated: false, probeDrifted: false };
   log.warn(
     { workspaceId, requestId: opts.requestId, position, hit: hit === null ? "null" : typeof hit },
-    "brain vocabulary preview: the subtree depth probe did not read back as a boolean — treating the walk as TRUNCATED rather than assuming it was complete",
+    "brain vocabulary preview: the subtree depth probe did not read back as a boolean — the numbers cannot be trusted, but nothing establishes that the graph is deep or cyclic",
   );
-  return true;
+  // ⚠️ NOT `truncated: true`. An unreadable probe and a genuine bound hit are
+  // two different facts, and `BlastRadius.subtreeTruncated`'s docstring asserts
+  // the SECOND one specifically ("the walk hit MAX_CHAIN_DEPTH"). Collapsing
+  // them told an approver their approved-edge graph was cyclic or deeper than
+  // 64 whenever a driver or a query shape drifted — sending them to inspect a
+  // vocabulary that may be perfectly healthy. A drifted probe is statement
+  // drift, which is exactly what `countsConsistent` already means, so it goes
+  // there. Same distinction the module drew between `not-curated` and
+  // `already-single`.
+  return { truncated: false, probeDrifted: true };
+}
+
+/** What the depth probe established — two facts, deliberately not one boolean. */
+interface SubtreeProbe {
+  /** The walk provably reached its bound. */
+  readonly truncated: boolean;
+  /** The probe did not answer, so nothing about the walk is established. */
+  readonly probeDrifted: boolean;
 }
 
 async function resolveEffectiveTarget(
@@ -951,7 +1035,7 @@ async function resolveEffectiveTarget(
   position: CollidingSlot,
   norm: string,
   requestId?: string,
-): Promise<string | null> {
+): Promise<string> {
   const { rows } = await db.query(
     `SELECT effective_target FROM brain_vocabulary_target
       WHERE workspace_id = $1 AND slot_position = $2 AND norm = $3`,
@@ -969,7 +1053,12 @@ async function resolveEffectiveTarget(
   // pairs forever with no log line. That is the same defect class `readCount`
   // throws on 130 lines below, and it was handled the opposite way.
   const row = rows[0] as Record<string, unknown> | undefined;
-  if (row === undefined) return identityKey(norm);
+  // `?? norm` is honest rather than defensive: the only caller guarantees a
+  // non-empty norm and `lexicalNorm` is idempotent, so `identityKey` cannot
+  // answer null here. Returning `string` is what lets the plan's `params` be
+  // `string[]`, which is what puts the guarantee under the compiler instead of
+  // in a comment two functions away.
+  if (row === undefined) return identityKey(norm) ?? norm;
 
   const stored = row.effective_target;
   // ⚠️ QUERY SHAPE ONLY — `typeof`, and deliberately NOT `|| stored.trim() ===
@@ -1033,6 +1122,20 @@ async function structurallyEmptyReason(
   ) {
     return "object-position";
   }
+  if (request.kind === "alias-removal") {
+    const fromKey = identityKey(request.fromNorm);
+    if (fromKey === null) return "unkeyable-surface";
+    const { rows } = await db.query(
+      `SELECT 1 AS hit FROM brain_vocabulary_edge
+        WHERE workspace_id = $1 AND slot_position = $2 AND from_norm = $3`,
+      [workspaceId, request.position, fromKey],
+    );
+    // The same probe shape the cardinality kinds use one branch down: ask the
+    // store whether there is anything to undo, rather than inferring it from an
+    // empty delta.
+    if (rows.length === 0) return "no-such-edge";
+  }
+
   if (request.kind === "cardinality-flip" || request.kind === "cardinality-removal") {
     const canonicalKey = identityKey(request.predicateSurface);
     if (canonicalKey === null) return null;
@@ -1110,7 +1213,13 @@ async function loadBlastRadiusSide(
   // A `ParamBuilder` is the mechanical answer (`AclClause.nextParamIndex` is
   // that answer one seam over) and was judged more machinery than this earns.
   // This is the four-line version: loud, at the seam, rather than a zero.
-  assertPlaceholdersBelowAclBase(pairsSqlPlaceholderSource(plan), aclBase, workspaceId, direction);
+  assertPlaceholdersBelowAclBase(
+    pairsSqlPlaceholderSource(plan),
+    aclBase,
+    workspaceId,
+    direction,
+    opts.requestId,
+  );
 
   // Narrowed once, so the statement, its params and its result column travel
   // together and no `as` is needed to re-assert what the check established.
@@ -1118,9 +1227,10 @@ async function loadBlastRadiusSide(
   // ONE presence test, not two. `override?.sql ?? …` and `override ? … : …`
   // coincide only because `sql` is a required non-nullish string — which is the
   // same inconsistently-read optional the regrouping was meant to close.
-  const { sql: totalSql, params: totalParams } = override
-    ? { sql: override.sql, params: [workspaceId, ...override.params] }
+  const { sql: totalSql, params: totalParams, column: totalColumn } = override
+    ? { sql: override.sql, params: [workspaceId, ...override.params], column: override.column }
     : {
+        column: "delta_total",
         sql: deltaSql({
           select: TOTAL_SELECT,
           joinExprs,
@@ -1152,14 +1262,14 @@ async function loadBlastRadiusSide(
     ]),
   ]);
 
-  const total = readCount(totalResult.rows[0], override?.column ?? "delta_total");
+  const total = readCount(totalResult.rows[0], totalColumn);
   if (total === null) {
     // LOGGED before it throws, with the requestId — the two refusals in
     // `resolveEffectiveTarget` do, and this is the one an operator is most
     // likely to actually hit (two statements, drift on either). CLAUDE.md:
     // request ids on all 500s.
     log.error(
-      { workspaceId, requestId: opts.requestId, direction, column: override?.column ?? "delta_total" },
+      { workspaceId, requestId: opts.requestId, direction, column: totalColumn },
       "brain vocabulary preview: the delta total did not read back as a number — refusing rather than disclosing a blast radius Atlas cannot establish",
     );
     // A THROW, not a degraded 0 — `loadSupersessionPreview`'s reason exactly: 0
@@ -1201,7 +1311,7 @@ async function loadBlastRadiusSide(
     // radius-wide scope blind spot, not a side-local count disagreement, and it
     // now travels on `BlastRadius.subtreeTruncated` where it renders as its own
     // sentence. Smearing it here made the two indistinguishable to a consumer.
-    countsConsistent: !inverted && !drifted,
+    countsConsistent: !inverted && !drifted && !plan.subtree.probeDrifted,
   };
 }
 
@@ -1214,40 +1324,60 @@ async function loadBlastRadiusSide(
  */
 function pairsSqlPlaceholderSource(plan: CounterfactualPlan): string {
   const probe = "__x";
-  return [
-    plan.hypothetical.subjectSlot(probe),
-    plan.hypothetical.predicateSlot(probe),
-    plan.hypothetical.cardinalitySingle(probe),
-    ...plan.ctes,
-  ].join(" ");
+  // `Object.values`, NOT a hand-enumeration of the three members. Enumerating
+  // them meant a FOURTH member on `CollisionExprs` would silently shrink this
+  // guard's coverage with no compile error — the guard would keep passing while
+  // covering less, which is the failure mode a guard must not have.
+  const exprs = Object.values(plan.hypothetical).map((build) => build(probe));
+  // ⚠️ `armingTotalOverride.sql` is deliberately NOT scanned: it carries no ACL
+  // clause, so it has no reader range to collide with. Stated because that is
+  // an invariant of the override rather than a property of this function.
+  return [...exprs, ...plan.ctes].join(" ");
 }
 
-/** Refuse a plan whose expressions reach into the reader's placeholder range. */
-function assertPlaceholdersBelowAclBase(
+/**
+ * Refuse a plan whose expressions reach into the reader's placeholder range.
+ *
+ * EXPORTED for its test. It is a pure function over a string and a number, and
+ * the alternative was leaving it uncovered: no legal `BlastRadiusRequest` can
+ * construct a plan that trips it (that is the point — it guards a FUTURE edit),
+ * so deleting its body survived the whole suite. A guard whose only failure
+ * mode is unreachable through the public API is one whose test has to reach it
+ * directly.
+ */
+export function assertPlaceholdersBelowAclBase(
   source: string,
   aclBase: number,
   workspaceId: string,
   direction: DeltaDirection,
+  requestId?: string,
 ): void {
   const refs = [...source.matchAll(/\$(\d+)/g)].map((m) => Number(m[1]));
   const highest = refs.length === 0 ? 0 : Math.max(...refs);
   if (highest >= aclBase) {
     log.error(
-      { workspaceId, direction, highest, aclBase },
+      { workspaceId, requestId, direction, highest, aclBase },
       "brain vocabulary preview: a counterfactual expression references a placeholder inside the reader's range — the ACL clause and the slot substitution would bind the same parameter",
     );
     throw new Error(
       `brain vocabulary preview: the ${direction} counterfactual references $${highest}, at or above ` +
-        `the ACL base $${aclBase} (workspace ${workspaceId}). The plan's placeholder literals and its ` +
+        `the ACL base $${aclBase} (workspace ${workspaceId}, request ${requestId ?? "unknown"}). ` +
+        `The plan's placeholder literals and its ` +
         `\`params\` array have drifted, so the reader's visibility predicate would bind against a slot ` +
         `key — joining nothing and reporting that this decision changes nothing. Refusing.`,
     );
   }
 }
 
-/** One `COUNT(*)::int` column, or `null` when it did not read back as one. */
-function readCount(raw: unknown, column: string): number | null {
-  const value = (raw as Record<string, unknown> | undefined)?.[column];
+/**
+ * A non-negative integer count, or `null` when the value did not read back as
+ * one.
+ *
+ * ONE spelling, used by both the total columns and the per-row window. `""` is
+ * refused explicitly — `Number("")` is a finite 0, which is the shape that
+ * reads as "no rows" when it means "the column drifted".
+ */
+function readNonNegativeInt(value: unknown): number | null {
   const n =
     typeof value === "number"
       ? value
@@ -1255,6 +1385,11 @@ function readCount(raw: unknown, column: string): number | null {
         ? Number(value)
         : Number.NaN;
   return Number.isFinite(n) && n >= 0 ? Math.trunc(n) : null;
+}
+
+/** One `COUNT(*)::int` column, or `null` when it did not read back as one. */
+function readCount(raw: unknown, column: string): number | null {
+  return readNonNegativeInt((raw as Record<string, unknown> | undefined)?.[column]);
 }
 
 /**
@@ -1292,14 +1427,16 @@ function readPairs(
       droppedRows++;
       continue;
     }
-    const windowed =
-      typeof r.scoped_total === "number"
-        ? r.scoped_total
-        : r.scoped_total == null
-          ? Number.NaN
-          : Number(r.scoped_total);
-    if (Number.isFinite(windowed) && windowed > scopedTotal) scopedTotal = Math.trunc(windowed);
-    else if (!Number.isFinite(windowed)) windowDriftRows++;
+    // ⚠️ The SAME narrowing `readCount` applies, rather than a looser twin.
+    // The looser one accepted `""` (`Number("") === 0`, finite) and negative
+    // values as trustworthy, so a `scoped_total` column drifting to empty
+    // string left `scopedTotal` at 0, `withheld` computed off a number nothing
+    // established, and `countsConsistent` saying the numbers were facts —
+    // while `readCount` forty lines up refuses both. Two treatments of one
+    // question is the asymmetry this module keeps having to remove.
+    const windowed = readNonNegativeInt(r.scoped_total);
+    if (windowed !== null && windowed > scopedTotal) scopedTotal = windowed;
+    else if (windowed === null) windowDriftRows++;
     pairs.push({
       draftId: r.draft_id,
       draftLabel: r.draft_label,

--- a/packages/api/src/lib/brain/vocabulary.ts
+++ b/packages/api/src/lib/brain/vocabulary.ts
@@ -278,7 +278,7 @@ async function lockWorkspaceVocabulary(
  * WHICH cycle lengths get the good error, and is a behaviour change rather than
  * a tuning knob.
  */
-const MAX_CHAIN_DEPTH = 64;
+export const MAX_CHAIN_DEPTH = 64;
 
 /** One approved edge, as callers supply it. */
 export interface AliasEdgeInput {

--- a/packages/api/src/lib/content-mode/adapters/brain-facts.ts
+++ b/packages/api/src/lib/content-mode/adapters/brain-facts.ts
@@ -637,13 +637,42 @@ export function supersessionCollisionJoin(
  * columns swapped, which is exactly the forbidden thing, or make the COLUMNS a
  * parameter while the ARMS stay single-spelled. This is the second.
  *
- * The distinction is worth being precise about, because it is the whole
- * justification: what varies here is **which value each side's slot is read
- * from**, never **which conjuncts must hold**. A caller cannot use this seam to
- * drop the tier guard, the cardinality gate or the homonym suppression — those
- * are not in this record and cannot be put into it. Every counterfactual is
- * therefore the same collision rule evaluated against a different slot
- * assignment, which is what makes the preview's parity claim meaningful at all.
+ * ## ⚠️ What this record makes UNREACHABLE, and what it only disciplines
+ *
+ * An earlier version of this paragraph claimed *"a caller cannot use this seam
+ * to drop the tier guard, the cardinality gate or the homonym suppression —
+ * those are not in this record and cannot be put into it."* **That is true of
+ * two of the three and false of the third — and the third is the one that
+ * actually varies.**
+ *
+ * | Conjunct | Reachable through this record? |
+ * |---|---|
+ * | tier guard (`supersedableTierSql`, both sides) | **No** — not a member |
+ * | homonym suppression (`subjectNotDifferentSql`) | **No** — not a member |
+ * | object comparable (`comparableDifferentSql`) | **No** — not a member |
+ * | the published row's live-and-current arms | **No** — not a member |
+ * | **cardinality gate** | **YES** — `cardinalitySingle` is a member |
+ * | **subject / predicate slot identity** | **YES** — both are members |
+ *
+ * `cardinalitySingle: () => "TRUE"` compiles and removes the gate from every
+ * statement built through {@link supersessionCollisionPredicate};
+ * `subjectSlot: () => "1"` renders `1 = 1` and deletes the subject-identity
+ * arm. The consumer proves it rather than merely admitting it —
+ * `cardinalityFlipExpr` (`lib/brain/vocabulary-preview.ts`) forces the gate TRUE
+ * for one predicate ON PURPOSE, which is exactly the shape an accident takes.
+ *
+ * So the honest claim is narrower: **four conjuncts are structurally out of
+ * reach; three are caller-supplied, and their discipline is the pinned test
+ * plus review.** The strong version was the more comfortable sentence, and it is
+ * the one a reviewer would have trusted instead of checking.
+ *
+ * The members are named `…Slot` rather than `…Key` for a second reason:
+ * `keys-not-on-the-wire.test.ts`'s ORM arm is deliberately over-broad: it fires
+ * on the camel-cased spelling of any identity-key column ANYWHERE in a file
+ * outside its declaration sites, comments included. These members build SQL slot
+ * EXPRESSIONS rather than projecting key columns, so the accurate name is also
+ * the one that keeps that guard's exemption list short — and a short exemption
+ * list is the whole guard.
  *
  * ## The default is byte-identical, and that is pinned rather than asserted
  *
@@ -673,10 +702,15 @@ export function supersessionCollisionJoin(
  * number and opposite facts.
  */
 export interface CollisionExprs {
-  /** The subject slot. `${alias}.subject_key` when stored. */
-  readonly subjectKey: (alias: string) => string;
-  /** The predicate slot. `${alias}.predicate_key` when stored. */
-  readonly predicateKey: (alias: string) => string;
+  /**
+   * The subject slot. `${alias}.subject_key` when stored.
+   *
+   * Applied to BOTH aliases (`p` and `d`) — see {@link cardinalitySingle} for
+   * the member whose calling convention differs.
+   */
+  readonly subjectSlot: (alias: string) => string;
+  /** The predicate slot. `${alias}.predicate_key` when stored. Applied to BOTH aliases. */
+  readonly predicateSlot: (alias: string) => string;
   /**
    * The cardinality gate, taking the DRAFT alias.
    *
@@ -685,6 +719,13 @@ export interface CollisionExprs {
    * real lookup re-pointed at the hypothetical predicate key, while a
    * cardinality flip needs the gate to read TRUE for one specific key that has
    * no approved row yet. Neither is expressible as a flag.
+   *
+   * ⚠️ **Called with the DRAFT alias only**, unlike its two siblings, and the
+   * three share one type so nothing says so but this line. A gate written on
+   * the assumption it will also see the published side compiles and is silently
+   * wrong — it would answer about one row while the caller believes it answered
+   * about the slot. One lookup is sufficient precisely because the predicate
+   * already equates both sides' keys; see {@link cardinalitySingleSql}'s ⚠️.
    */
   readonly cardinalitySingle: (alias: string) => string;
 }
@@ -697,8 +738,8 @@ export interface CollisionExprs {
  * equivalent to it.
  */
 export const STORED_COLLISION_EXPRS: CollisionExprs = Object.freeze({
-  subjectKey: (alias: string) => `${alias}.subject_key`,
-  predicateKey: (alias: string) => `${alias}.predicate_key`,
+  subjectSlot: (alias: string) => `${alias}.subject_key`,
+  predicateSlot: (alias: string) => `${alias}.predicate_key`,
   cardinalitySingle: (alias: string) => cardinalitySingleSql(alias),
 });
 
@@ -815,8 +856,8 @@ function collisionCorePredicate(
   exprs: CollisionExprs = STORED_COLLISION_EXPRS,
 ): string {
   return `${p}.workspace_id = ${d}.workspace_id
-     AND ${exprs.subjectKey(p)} = ${exprs.subjectKey(d)}
-     AND ${exprs.predicateKey(p)} = ${exprs.predicateKey(d)}
+     AND ${exprs.subjectSlot(p)} = ${exprs.subjectSlot(d)}
+     AND ${exprs.predicateSlot(p)} = ${exprs.predicateSlot(d)}
      AND ${comparableDifferentSql(`${p}.object_cmp`, `${d}.object_cmp`)}
      AND ${subjectNotDifferentSql(`${p}.subject_cmp`, `${d}.subject_cmp`)}
      AND ${p}.status = 'published'

--- a/packages/api/src/lib/content-mode/adapters/brain-facts.ts
+++ b/packages/api/src/lib/content-mode/adapters/brain-facts.ts
@@ -614,10 +614,93 @@ function supersedableTierSql(alias: string): string {
  * `d` / `p` are interpolated; callers pass plain identifiers they control —
  * same contract as `brainFactStatusClause`.
  */
-export function supersessionCollisionJoin(d: string, p: string): string {
+export function supersessionCollisionJoin(
+  d: string,
+  p: string,
+  exprs: CollisionExprs = STORED_COLLISION_EXPRS,
+): string {
   return `JOIN brain_facts ${p}
-      ON ${supersessionCollisionPredicate(d, p)}`;
+      ON ${supersessionCollisionPredicate(d, p, exprs)}`;
 }
+
+/**
+ * The three expressions a collision is evaluated AGAINST, rather than the arms
+ * it is built FROM (#5025).
+ *
+ * ## Why this exists, and why it is not the second spelling the header forbids
+ *
+ * `supersessionCollisionJoin` forbids a second spelling of *what collides*,
+ * because a disclosure that lists one set while the transaction stamps another
+ * is silent supersession through drift. #5025's blast-radius preview asks a
+ * question that is genuinely different — *what would collide if I approved
+ * this?* — and there were only two ways to express it: copy the arms with two
+ * columns swapped, which is exactly the forbidden thing, or make the COLUMNS a
+ * parameter while the ARMS stay single-spelled. This is the second.
+ *
+ * The distinction is worth being precise about, because it is the whole
+ * justification: what varies here is **which value each side's slot is read
+ * from**, never **which conjuncts must hold**. A caller cannot use this seam to
+ * drop the tier guard, the cardinality gate or the homonym suppression — those
+ * are not in this record and cannot be put into it. Every counterfactual is
+ * therefore the same collision rule evaluated against a different slot
+ * assignment, which is what makes the preview's parity claim meaningful at all.
+ *
+ * ## The default is byte-identical, and that is pinned rather than asserted
+ *
+ * {@link STORED_COLLISION_EXPRS} reproduces the stored columns exactly, so every
+ * statement that existed before this parameter emits the same string it always
+ * did. `collision-sql-pinned.test.ts` compares the four shipped statements to
+ * literal snapshots — a falsifier rather than a claim, because "this refactor
+ * changed nothing" is precisely the assertion that is cheap to believe and
+ * expensive to be wrong about on a predicate that stamps `valid_to`.
+ *
+ * ## What is deliberately ABSENT
+ *
+ * No `objectCmp` and no `subjectCmp`. A vocabulary approval does not move them:
+ * `object_cmp` / `subject_cmp` are the typed comparable values #5030 and #5032
+ * derive from the surface's PARSE, and aliasing two surfaces together changes
+ * neither parse. Admitting them as parameters would invite a counterfactual that
+ * claims an alias makes two objects provably different, which no alias can do.
+ *
+ * ⚠️ **The object POSITION therefore has no supersession blast radius at all.**
+ * The collision joins on `subject_key`, `predicate_key` and `object_cmp` —
+ * `object_key` appears nowhere in it. An object-position alias moves
+ * `object_key`, which is a CORROBORATION arm (`reconcile.ts`'s
+ * `objectSameSql`), so approving one changes what corroborates and what earns a
+ * tension edge, and changes nothing about what supersedes. `lib/brain/
+ * vocabulary-preview.ts` discloses that in words rather than rendering a zero,
+ * because "0 pairs" and "this position cannot produce pairs" are the same
+ * number and opposite facts.
+ */
+export interface CollisionExprs {
+  /** The subject slot. `${alias}.subject_key` when stored. */
+  readonly subjectKey: (alias: string) => string;
+  /** The predicate slot. `${alias}.predicate_key` when stored. */
+  readonly predicateKey: (alias: string) => string;
+  /**
+   * The cardinality gate, taking the DRAFT alias.
+   *
+   * A whole expression rather than a `single: boolean`, because the two
+   * counterfactuals need different things from it: an alias approval needs the
+   * real lookup re-pointed at the hypothetical predicate key, while a
+   * cardinality flip needs the gate to read TRUE for one specific key that has
+   * no approved row yet. Neither is expressible as a flag.
+   */
+  readonly cardinalitySingle: (alias: string) => string;
+}
+
+/**
+ * The stored columns — the collision as every shipped statement asks it.
+ *
+ * `cardinalitySingle` is {@link cardinalitySingleSql} at its own default, so the
+ * emitted string is identical to the pre-parameter one rather than merely
+ * equivalent to it.
+ */
+export const STORED_COLLISION_EXPRS: CollisionExprs = Object.freeze({
+  subjectKey: (alias: string) => `${alias}.subject_key`,
+  predicateKey: (alias: string) => `${alias}.predicate_key`,
+  cardinalitySingle: (alias: string) => cardinalitySingleSql(alias),
+});
 
 /**
  * The same collision, as a bare predicate rather than a JOIN's `ON` clause.
@@ -634,8 +717,12 @@ export function supersessionCollisionJoin(d: string, p: string): string {
  * building the `JOIN` from the predicate keeps that convenience without letting
  * it become a second copy.
  */
-export function supersessionCollisionPredicate(d: string, p: string): string {
-  return `${collisionIdentityPredicate(d, p)}
+export function supersessionCollisionPredicate(
+  d: string,
+  p: string,
+  exprs: CollisionExprs = STORED_COLLISION_EXPRS,
+): string {
+  return `${collisionIdentityPredicate(d, p, exprs)}
      AND ${supersedableTierSql(p)}
      AND ${supersedableTierSql(d)}`;
 }
@@ -675,9 +762,13 @@ export function supersessionCollisionPredicate(d: string, p: string): string {
  * collided but for the TIER", and a pair the cardinality arm excluded never
  * collided at all.
  */
-function collisionIdentityPredicate(d: string, p: string): string {
-  return `${collisionCorePredicate(d, p)}
-     AND ${cardinalitySingleSql(d)}`;
+function collisionIdentityPredicate(
+  d: string,
+  p: string,
+  exprs: CollisionExprs = STORED_COLLISION_EXPRS,
+): string {
+  return `${collisionCorePredicate(d, p, exprs)}
+     AND ${exprs.cardinalitySingle(d)}`;
 }
 
 /**
@@ -718,10 +809,14 @@ function collisionIdentityPredicate(d: string, p: string): string {
  * `IS NOT TRUE` and never a `NOT (…)`, and for why supersession is the LEAST
  * important of the three consumers this arm serves.
  */
-function collisionCorePredicate(d: string, p: string): string {
+function collisionCorePredicate(
+  d: string,
+  p: string,
+  exprs: CollisionExprs = STORED_COLLISION_EXPRS,
+): string {
   return `${p}.workspace_id = ${d}.workspace_id
-     AND ${p}.subject_key = ${d}.subject_key
-     AND ${p}.predicate_key = ${d}.predicate_key
+     AND ${exprs.subjectKey(p)} = ${exprs.subjectKey(d)}
+     AND ${exprs.predicateKey(p)} = ${exprs.predicateKey(d)}
      AND ${comparableDifferentSql(`${p}.object_cmp`, `${d}.object_cmp`)}
      AND ${subjectNotDifferentSql(`${p}.subject_cmp`, `${d}.subject_cmp`)}
      AND ${p}.status = 'published'
@@ -774,19 +869,38 @@ function collisionCorePredicate(d: string, p: string): string {
  * cannot drop a row into the three-valued hole `supersedableTierSql`'s
  * `{"source": null}` provenance falls into. {@link cardinalitySingleSql} is an
  * `EXISTS`; {@link supersedableTierSql} is a comparison.
+ *
+ * ## The draft scope is a PARAMETER since #5025, and the constant is its default
+ *
+ * The publish gate asks this of one batch (`d.id = ANY($2::uuid[])`). #5025's
+ * cardinality-flip preview asks the identical question of one PREDICATE — *how
+ * many beliefs would curating this predicate retire?* — and its issue is
+ * explicit that it must **import this statement rather than re-derive the
+ * cardinality half**, on {@link supersessionCollisionJoin}'s standing rule.
+ *
+ * So the scope moved into {@link cardinalityHeldBackCountSql} and this constant
+ * became that builder at the publish gate's own scope. The emitted string is
+ * unchanged — `collision-sql-pinned.test.ts` holds it against a literal — so
+ * #5027's mutation rows still address the statement they were measured on.
  */
-export const CARDINALITY_HELD_BACK_COUNT_SQL = `
+export function cardinalityHeldBackCountSql(draftScopeSql: string): string {
+  return `
   SELECT COUNT(*)::int AS held_back
     FROM brain_facts d
     JOIN brain_facts p
       ON ${collisionCorePredicate("d", "p")}
    WHERE d.workspace_id = $1
      AND ${supersedingDraftPredicate("d")}
-     AND d.id = ANY($2::uuid[])
+     AND ${draftScopeSql}
      AND ${supersedableTierSql("p")}
      AND ${supersedableTierSql("d")}
      AND NOT ${cardinalitySingleSql("d")}
 `;
+}
+
+export const CARDINALITY_HELD_BACK_COUNT_SQL = cardinalityHeldBackCountSql(
+  "d.id = ANY($2::uuid[])",
+);
 
 /**
  * How many provable collisions this publish is HOLDING BACK on tier grounds

--- a/packages/api/src/lib/content-mode/adapters/brain-facts.ts
+++ b/packages/api/src/lib/content-mode/adapters/brain-facts.ts
@@ -668,11 +668,14 @@ export function supersessionCollisionJoin(
  *
  * The members are named `…Slot` rather than `…Key` for a second reason:
  * `keys-not-on-the-wire.test.ts`'s ORM arm is deliberately over-broad: it fires
- * on the camel-cased spelling of any identity-key column ANYWHERE in a file
- * outside its declaration sites, comments included. These members build SQL slot
- * EXPRESSIONS rather than projecting key columns, so the accurate name is also
- * the one that keeps that guard's exemption list short — and a short exemption
- * list is the whole guard.
+ * on the camel-cased spelling of any identity-key column anywhere in a file
+ * outside its declaration sites. (Comments are NOT included — the arm runs
+ * `stripComments` first. An earlier version of this sentence said they were,
+ * which is the same comfortable-and-unchecked shape three other claims in this
+ * slice were corrected for, reintroduced in the fix for them.) These members
+ * build SQL slot EXPRESSIONS rather than projecting key columns, so the accurate
+ * name is also the one that keeps that guard's exemption list short — and a
+ * short exemption list is the whole guard.
  *
  * ## The default is byte-identical, and that is pinned rather than asserted
  *


### PR DESCRIPTION
## Summary

Closes #5086 — child 1 of 3 under the #5025 umbrella. API-only, and a **no-op until its successors consume it**: the shape every M4 slice took.

`loadSupersessionPreview` answers *what will the next publish supersede under the vocabulary as it stands*. This answers a **counterfactual over a vocabulary that does not exist yet**, for four decisions: alias approval, alias removal, cardinality flip, cardinality un-curation.

**The design decision #5025's 2026-08-05 pass left open is settled as the parameterization, and enforced rather than intended.** `oversight.ts:800-803` forbids restating the collision rule, so the conjuncts stay single-spelled and the **slot expressions** became a parameter (`CollisionExprs`). The delta is two-sided — `arming` and `disarming`, one code path with the JOIN side swapped — which is what makes the In-force pane's *"the same blast-radius preview approval uses"* true by construction rather than by discipline.

⚠️ **Be precise about what that record enforces**, because the comfortable claim is false and this PR shipped it twice before a reviewer caught it: **four** conjuncts are structurally unreachable (tier guard, homonym suppression, `object_cmp` arm, the published row's live-and-current arms); **three** are caller-supplied (both slot expressions and the cardinality gate). `cardinalityFlipExpr` forces that gate `TRUE` on purpose, so this file disproves the strong version itself. The discipline on those three is the byte-pinned test plus review, and `brain-facts.ts` now carries the table.

### Four findings the design pass and both grill checkpoints did not have

Each was found by writing the SQL, and three revise ACs on #5025 (recorded in [its 2026-08-08 checkpoint](https://github.com/AtlasDevHQ/atlas/issues/5025#issuecomment-5228156017)):

1. **A predicate-position alias moves the CARDINALITY lookup with the slot.** The compound case ADR-0037 §6's amendment exists for is *exactly* what a bundle re-pointing only the slot arm reports as zero.
2. ⚠️ **The OBJECT position has no supersession blast radius at all.** The collision joins on `subject_key`, `predicate_key`, `object_cmp` — `object_key` is nowhere in it. Reported as a reason, never a zero, because *"0 pairs"* and *"this position cannot produce pairs"* are the same number and opposite facts. **What it should show instead — the corroboration/tension change — is NOT built**; it is an unchecked AC on #5088.
3. **Removal is not approval inverted.** `REKEY_DRIFTED_FACTS_SQL` already says why, so removal re-derives from the *surface* over the removed norm's subtree.
4. **The exclusion arm's `IS NOT TRUE` is DEFENSIVE, not load-bearing** — measured. Every NULL-capable arm of the exclusion is shared with the JOIN, so `NOT (…)` returns the same set today. The spelling stays because the equivalence dies the moment an exclusion-only nullable arm appears.

## Test Plan

- [x] Unit tests added/updated
- [ ] Manual testing — not applicable; no route or UI in this slice
- [ ] E2E tests added/updated — not applicable

**The parity property**, which can only be asserted against a real schema: `supersedesAfter − supersedesBefore == arming.total`, measured through the publish gate's own `WILL_SUPERSEDE_TOTAL_SQL` before and after the real decide seam runs. The preview and the transaction agree because the preview **predicted** the transaction, not because both were built from one string.

#5025's AC says *"the preview total equals what the re-key actually changes"*, which taken literally compares a pair count to a row count. The file says so and asserts the delta that carries the intent.

**Mutation-checked throughout**: 6 → 11 → 8 → 6 mutations across the rounds, all killed. Two needed the bound made injectable (`bool_or(depth >= N)` → `> N` was *unkillable by construction* — the recursive arm stops at `depth < N`) and the placeholder guard exported (no legal request can reach it).

## Review panel — 3 rounds, and the round cap was hit

`silent-failure-hunter` · `type-design-analyzer` · `pr-test-analyzer`, fresh context, in parallel. **Every round found a defect inside the previous round's fix** — the sixth consecutive slice in this arc to do so, and worth reading as evidence rather than as noise:

| Round | What the fix broke |
|---|---|
| 1 → 2 | `resolveEffectiveTarget`'s new arm tested `trim() === ""` and called it unreachable. 0189's CHECK is `effective_target <> ''`, and `'   ' <> ''` is TRUE — so store corruption was reported as **driver drift**, and the arm written for that row became unreachable. |
| 1 → 2 | `isCollidingSlot` turned a loud throw into a **mislabelled reason**: an object-position request would render as `unkeyable-surface`. Narrowing removed the alarm, not the ordering dependency. |
| 2 → 3 | `assertPlaceholdersBelowAclBase` omitted `requestId` — the exact thing the *same round* fixed in `readCount` one item earlier. |
| 2 → 3 | `subtreeTruncated` carried two facts under a docstring asserting one, so a driver drift told an approver their edge graph was cyclic. |

**Four separate overclaims in my own prose** were caught this way, one of them introduced by the fix for the first three. The largest hole was in none of the eight fixes: round 2 deleted a null check on a prose argument without narrowing the return type, taking an invariant from **checked to documented** in the module whose thesis is that this is the anti-pattern. `params` is `readonly string[]` now.

⚠️ **Round 3's fixes are unreviewed, and `comment-analyzer` never ran.** The cap was reached, I stopped and asked, and the maintainer chose to proceed to CI and PR rather than open a fourth round. Recording it here because it changes how this diff should be read.

## Two things worth carrying forward

- **`--affected` cannot select `keys-not-on-the-wire.test.ts`.** It discovers inputs by filesystem grep, so no source-graph tool can route a change to it; only full `bun test` reaches it. It went red on this branch and nothing in the diff could have caught it. This will recur for every future file naming a key column.
- **`-pg` suites skip silently without `TEST_DATABASE_URL`** — an early "23/23 green" in this work was green-by-absence. Every result quoted above ran against a real Postgres 16.

## Checklist

- [x] Types pass (`bun run type`)
- [x] Tests pass (`bun run test`) — `/ci` **33/33**, 1,043 API files, `-pg` suites verified running
- [x] Lint passes (`bun run lint`) + type-aware gate
- [ ] Deps consistent — no dependency changes
- [ ] Labels added (type + area) — `feature`, `area: api`, `architecture`, `ready-for-agent` on #5086
- [ ] CHANGELOG.md updated — not user-facing; no route, no UI

---
_Generated by [Claude Code](https://claude.ai/code/session_01MXj2Sz6361r3GABq4oZKA6)_