### PR TITLE
docs(agents): close the review panel's sibling blind spot

### DIFF
--- a/.claude/agents/README.md
+++ b/.claude/agents/README.md
@@ -19,6 +19,25 @@ agents: the existing `/code-review` and `/simplify` skills already cover Atlas's
 and remain the canonical generic passes. These four add the specialist axes a single generic
 pass spreads thin.
 
+### ⚠️ We use these for a different JOB than upstream, and the difference bites
+
+Upstream's toolkit reviews **someone else's finished PR, once**. `/review-panel` runs them as
+an **iterative convergence loop on the author's own in-progress work**, re-running until CLEAN.
+Those have different failure modes, and two upstream defaults are actively wrong for ours:
+
+- **"Review only the changed lines."** Correct for a one-shot review of a finished diff. In a
+  convergence loop it makes a defect's *adjacent twin* structurally invisible — the twin is an
+  unchanged line, so no reviewer can report it, round after round. `/review-panel` Step 2
+  therefore widens the scope to *changed lines plus the enclosing declaration*.
+- **Fully fresh context every round.** Correct for independence, and it is what stops a
+  reviewer rubber-stamping the implementer. But a one-shot review has no "previous round's
+  fix" to audit, so upstream has no notion of one — and round N cannot check round N−1's work
+  without being told what it was. Step 2 passes the prior fix commits in as an explicit audit
+  target while leaving everything else fresh.
+
+Neither is an upstream bug. They are defaults for a job we are not doing. Keep both divergences
+when re-vendoring — see "Updating from upstream" below.
+
 ## The panel
 
 | Agent | Axis | Tuned to |
@@ -43,3 +62,9 @@ findings, they do not edit code.
 When the upstream toolkit changes, re-diff the vendored copies and re-apply the Atlas tuning.
 These are pinned by copy, not by marketplace, so updates are intentional — keep the
 Atlas-specific standards blocks intact when pulling upstream methodology changes.
+
+⚠️ **Two things to re-apply every time, because upstream will keep asserting the opposite:**
+the widened review scope and the prior-fix audit target (see the job-mismatch section above).
+Both live in `/review-panel` Step 2 rather than in the agent files, so a clean re-vendor of the
+agents does not lose them — but a re-vendor that also "corrects" the command back to
+`review only this diff` restores the blind spot the widening exists to close.

--- a/.claude/commands/review-panel.md
+++ b/.claude/commands/review-panel.md
@@ -55,7 +55,15 @@ Every round:
 Final round only (or with `--final`):
 - `Agent(comment-analyzer)` — comment accuracy & idiom
 
-Each is read-only/advisory. Give every agent the same context: the base ref, the changed files, and "review only this diff against Atlas's CLAUDE.md standards; report findings with file:line + severity."
+Each is read-only/advisory. Give every agent the same context: the base ref, the changed files, and the scope rule below.
+
+**The scope is the changed lines PLUS their enclosing declaration.** Not "only the changed lines", and not the whole file. The enclosing declaration is the function, the object literal, the union, the interface — whatever construct the changed line sits inside, read whole.
+
+⚠️ **This widening is the single highest-yield change this command has had, and it is here because the narrow rule has a structural blind spot.** A defect and its twin are usually *adjacent*: in #5088 a `claims: … : 0` coalesce was fixed while `sourceClass: … : ""` and `proposedBy: … : ""` sat on the next two lines of the same object literal. Unchanged lines, therefore outside a strict diff scope, therefore invisible to the reviewer — for three consecutive rounds. A reviewer obeying "only the changed lines" *cannot* find that, no matter how good it is.
+
+Say it to the agent in those words, because "review the diff" reads as the narrow rule by default.
+
+**On a re-review (round 2+), also pass the previous round's fix commits and name them the primary target.** Fresh context is what keeps the panel from rubber-stamping, but it also means round N does not know what round N−1 fixed unless you say so. Give the SHAs and one line each on what they claimed to fix; ask the reviewer to audit those fixes specifically, and to check whether each fix's *class* was closed or only its instance. In #5088 this was improvised by hand at round 4 and that round found more than rounds 2 and 3 combined.
 
 **Step 3: Collect, dedupe, prioritize**
 
@@ -94,6 +102,48 @@ The test for (b) is *"does the smallest correct fix add a new thing?"* — not *
 ⚠️ **This step does not exist to shrink diffs, and choosing "follow-up" is not the default answer for (b).** In #5033 a round-1 finding — the tier guard refused irreversibly with no operator trace — was fixed inline, which took the diff from ~400 to ~1,900 lines and produced rounds 2 and 3. **That was the right outcome.** The fix added a savepoint primitive; round 2 found it could roll back an entire publish, and round 3 found round 2's `SAVEPOINT` itself unguarded. Capping the rounds would have shipped a diagnostic capable of rolling back a customer's publish.
 
 So the point is not fewer rounds. It is that a fix which triples the diff should be a **visible decision with a recorded reason**, made when the growth is proposed rather than discovered three rounds later — and a PR that grew that way should say so, because the reviewer's read of it changes.
+
+**Step 5b: SWEEP FOR SIBLINGS before you write the fix**
+
+⚠️ **A finding names a CLASS. Fixing only the reported instance is what makes a
+round cap bind.** Before writing each fix, spend one grep asking *"where else does
+this exact shape appear?"* — the same file first, then the module, then the twin
+half of whatever pair you are in. Fix every instance in the same commit.
+
+The shapes worth sweeping for, because they are what actually recurred:
+
+- **The adjacent field.** A coalesce, a narrowing, a default, a guard — check the
+  lines above and below it in the same literal or the same parameter list.
+- **The mirror half.** Almost every subsystem has two of something: two verbs
+  (approve/reject), two positions, two kinds, two arms of a union, a client half
+  and a server half. If the fix landed on one, the other is the first place to
+  look — and if a test landed on one, the other is where it is missing.
+- **The other caller.** A guard added at one call site of a shared helper is
+  usually missing at the rest.
+
+Report the sweep in one line per finding — *"same shape at X, Y; fixed"* or
+*"swept the module, no other instance"* — so a later round can see the class was
+closed rather than the instance.
+
+**This is measured, not theoretical.** #5088 took five rounds, and four of them
+found the previous round's fix had a twin nobody looked at: round 1's bug four
+lines away on the `computed` branch; round 2's per-side fix covering only the
+both-zero case; round 3's pin covering 4 of an arm's 7 fields; round 3's `claims`
+guard with two identically-broken fields directly beneath it. Every one of those
+was a one-grep sweep away at the moment the fix was written.
+
+**Step 5c: Verify the commit message against the commit**
+
+Before pushing, check that every fix the message claims is actually in the diff:
+
+```bash
+git show --stat HEAD          # do the files match what the message says it fixed?
+```
+
+⚠️ Cheap, mechanical, and it catches a failure with no other detector. Two of
+#5088's commit messages claimed fixes that were never in the tree — one named a
+file absent from the commit entirely. A message asserting a fix over a hole no
+test can see is worse than a silent hole: it stops anyone looking.
 
 **Step 6: Every must-fix's FIX needs a falsifier before the round is closed**
 
@@ -141,7 +191,26 @@ post-commit ordering — #5027 needed a delayed-settle fake and a `setTimeout`
 handle recorder to reach two of its arms. Pay it there especially; those are the
 arms nothing else can see.
 
+⚠️ **RUN the mutant. A falsifier you only reasoned about is not one**, and your
+own is the one most likely to be too weak — you write it knowing the fix, so you
+naturally aim it at the failure you already fixed. Two from #5088, both of which
+looked airtight and both of which passed against the broken code:
+
+- A duplicate-React-key test that rendered two colliding rows and asserted both
+  appeared. React renders both children on a first pass; the harm needs the list
+  to **change**. The real falsifier previews the second row, decides the first
+  away, and asserts the survivor keeps its own state.
+- A `never`-default test asserting on a 500's response body — in a file that
+  mocks `runEffect` away, so the body is a constant `text/plain` for *every*
+  cause. The assertion could not fail while the status was 500. It now asserts
+  the defect's cause.
+
+The second one is the general shape: **an assertion that cannot fail is not an
+assertion.** Ask what value would make it go red, and check that value is
+reachable.
+
 **Rules:**
 - Read-only. The panel reports; it never edits code.
-- Fresh context per agent — never let the implementer "review" its own diff in-context; that rubber-stamps.
+- Scope is the changed lines **plus their enclosing declaration** (Step 2). The strict-diff reading has a blind spot for adjacent twins and it has cost real rounds.
+- Fresh context per agent — never let the implementer "review" its own diff in-context; that rubber-stamps. On round 2+, fresh context **plus** the previous round's fix commits named as the audit target.
 - This is the specialist layer. The repo's `/code-review` and `/simplify` remain the canonical generic passes — don't duplicate them here.

--- a/.claude/commands/ship-issue.md
+++ b/.claude/commands/ship-issue.md
@@ -56,9 +56,11 @@ Use `cd packages/api && bun run scripts/test-isolated.ts --affected` for the fas
 ```
 /review-panel
 ```
-- Verdict **CHANGES REQUESTED** → **triage the must-fix findings first** (`/review-panel` Step 5: local defect → fix inline; new machinery → decide in-PR vs follow-up explicitly and record the reason in the PR body), then fix, then re-run `/review-panel` on the new diff.
+- Verdict **CHANGES REQUESTED** → **triage the must-fix findings first** (`/review-panel` Step 5: local defect → fix inline; new machinery → decide in-PR vs follow-up explicitly and record the reason in the PR body), then **sweep for siblings** (Step 5b — a finding names a class, and fixing only the reported instance is the main reason rounds multiply), then fix, then re-run `/review-panel` on the new diff.
+- **Re-runs are not fresh rounds.** Pass the previous round's fix commits into the panel and name them the primary audit target (`/review-panel` Step 2). Reviewers keep fresh context; what they must not have is fresh *ignorance of what you just changed*.
 - Repeat until **CLEAN**, capped at **3 rounds**. If it can't converge in 3 (usually a spec ambiguity), STOP and ask the human.
 - The cap is on ROUNDS, not on scope. A round-2 fix that adds real machinery *should* earn a round 3 — don't skip the re-review to stay under the cap. If the work genuinely needs a fourth round, that is the STOP-and-ask case, not a reason to merge unreviewed.
+- **When you STOP and ask, report the yield curve, not just the count.** A declining count (30 → 18 → 11) is a loop converging and the cap is a formality. A flat or rising one is a loop that is *not* converging, and the human needs to know which they are approving another round of. #5088 ran 30 → 18 → 11 → 21, and that rise was the real signal — the fixes kept having unswept twins, so each round manufactured the next round's work.
 
 **Step 4 — CI gate**
 


### PR DESCRIPTION
## Summary

#5091 took **five review-panel rounds**, and four of them found that the previous round's fix had a twin nobody looked at. This changes the panel so that stops being the default outcome.

**The reviewers were not the problem.** Every finding across all five rounds was real and mutation-verified; no round produced noise. The *scope rule* was the problem, and it is an instruction, not a model.

### What changed

**`.claude/commands/review-panel.md`**

- **Scope widened** from "only the changed lines" to *changed lines **plus their enclosing declaration*** — the function, object literal, union, or interface the changed line sits inside, read whole. A defect and its twin are usually adjacent: #5088 fixed a `claims: … : 0` coalesce while `sourceClass: … : ""` and `proposedBy: … : ""` sat on the next two lines of the same object literal. Unchanged lines, therefore outside a strict diff scope, therefore unreportable — for three consecutive rounds. A reviewer obeying the narrow rule *cannot* find that.
- **Round 2+ passes the previous round's fix commits** and names them the primary audit target. Fresh context is what stops a reviewer rubber-stamping the implementer; it also means round N cannot audit round N−1 unless told what changed. This was improvised by hand at round 4 of #5088, and that round found more than rounds 2 and 3 combined.
- **New Step 5b — sweep for siblings.** A finding names a *class*; fixing only the reported instance is the main reason rounds multiply. One grep before writing each fix, over the three shapes that actually recurred: the adjacent field, the mirror half (approve/reject, client/server, two arms of a union), the other caller.
- **New Step 5c — verify the commit message against the commit.** `git show --stat`. Two of #5088's commit messages claimed fixes that were never in the tree, one naming a file absent from the commit entirely.
- **Step 6 now says RUN the mutant.** Your own falsifier is the one most likely to be too weak, because you aim it at the failure you already fixed. Both of #5088's weak ones are recorded as worked examples, along with the general rule: an assertion that cannot fail is not an assertion.

**`.claude/commands/ship-issue.md`** — the panel step requires the sibling sweep and the fix-audit target, and asks for the **yield curve** when the 3-round cap fires. #5088 ran 30 → 18 → 11 → 21; a rising count is a loop manufacturing its own next round, and a human approving a fourth round should be told which kind they have.

**`.claude/agents/README.md`** — records the job mismatch. Upstream's `pr-review-toolkit` reviews *someone else's finished PR, once*; we run it as an *iterative convergence loop on the author's own in-progress work*. Neither divergence is an upstream bug — they are defaults for a job we are not doing — and both are flagged under "Updating from upstream" so a clean re-vendor cannot silently restore the blind spot.

`/ship-milestone` and `/ship-batch` needed no edit: both delegate to `/ship-issue` and inherit this.

## Test Plan

- [ ] Manual testing — n/a
- [ ] Unit tests added/updated — n/a
- [ ] E2E tests added/updated — n/a

Documentation-only: three markdown files under `.claude/`, no source, no dependencies, no generated artifacts. `scripts/ci-local.sh` run on the branch.

## Checklist

- [x] Types pass — no TypeScript touched
- [x] Tests pass (`bun run test`)
- [x] Lint passes (`bun run lint`)
- [x] Deps consistent — no dependency changes
- [ ] Labels added (type + area)
- [ ] CHANGELOG.md updated — not user-facing; agent tooling only

---
_Generated by [Claude Code](https://claude.ai/code/session_015oRn9sJ3BN2cu3Kc1gNcw1)_