### PR TITLE
ci: gate the generated mutation tables, and refuse a baseline that lies (#5077)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -459,7 +459,7 @@ jobs:
   # be `success`, including `changes` itself.
   ci:
     name: ci
-    needs: [changes, drift, lint, lint-type-aware, type, build, test-others, test-e2e-integration, api-tests, ee-stub-build]
+    needs: [changes, drift, lint, lint-type-aware, type, build, test-others, test-e2e-integration, api-tests, mutation-tables, ee-stub-build]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -474,11 +474,12 @@ jobs:
           TEST_OTHERS_RESULT: ${{ needs.test-others.result }}
           TEST_E2E_RESULT: ${{ needs.test-e2e-integration.result }}
           API_TESTS_RESULT: ${{ needs.api-tests.result }}
+          MUTATION_TABLES_RESULT: ${{ needs.mutation-tables.result }}
           EE_STUB_RESULT: ${{ needs.ee-stub-build.result }}
         run: |
           set -euo pipefail
           fail=0
-          for pair in "changes=$CHANGES_RESULT" "drift=$DRIFT_RESULT" "lint=$LINT_RESULT" "lint-type-aware=$LINT_TYPE_AWARE_RESULT" "type=$TYPE_RESULT" "build=$BUILD_RESULT" "test-others=$TEST_OTHERS_RESULT" "test-e2e-integration=$TEST_E2E_RESULT" "api-tests=$API_TESTS_RESULT"; do
+          for pair in "changes=$CHANGES_RESULT" "drift=$DRIFT_RESULT" "lint=$LINT_RESULT" "lint-type-aware=$LINT_TYPE_AWARE_RESULT" "type=$TYPE_RESULT" "build=$BUILD_RESULT" "test-others=$TEST_OTHERS_RESULT" "test-e2e-integration=$TEST_E2E_RESULT" "api-tests=$API_TESTS_RESULT" "mutation-tables=$MUTATION_TABLES_RESULT"; do
             name=${pair%%=*}
             result=${pair#*=}
             if [ "$result" != "success" ]; then
@@ -494,6 +495,55 @@ jobs:
           fi
           if [ "$fail" -ne 0 ]; then exit 1; fi
           echo "All CI gates passed."
+
+  mutation-tables:
+    # The generated mutation tables (packages/api/scripts/mutations/*.md) must
+    # equal what re-running their specs produces (#5077). `mutate.ts --check`
+    # existed from #5060 and nothing ran it, so FOUR of eight were stale on
+    # `main` — including mutation-core.md, the runner's own table, whose
+    # `escapeCell` row had been a dead ANCHOR since #5060/#4389 rewrote the
+    # escape it pointed at.
+    #
+    # ⚠️ Its OWN job rather than a step in `api-tests`, which is a 4-way shard
+    # matrix and would run this four times over. ~14 minutes measured for the
+    # full sweep, which is FREE here: jobs run in parallel and `Built image
+    # (docs)` already takes ~25, so this lands well inside the existing critical
+    # path. `ci-local.sh` runs the `--affected` subset instead, because 14
+    # minutes added to a ~10-minute pre-PR loop is how a gate gets deleted.
+    name: mutation-tables
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+
+      - uses: ./.github/actions/setup-bun-cached
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Build @useatlas/types + @useatlas/plugin-sdk
+        run: bun run --filter '@useatlas/types' build && bun run --filter '@useatlas/plugin-sdk' build
+
+      - name: Verify every generated mutation table
+        env:
+          # Required, not optional: several specs target *-pg.test.ts, which
+          # self-skip without it. The runner refuses a baseline that skipped
+          # anything, so an absent URL fails this job loudly rather than
+          # regenerating zeros over real measurements.
+          TEST_DATABASE_URL: postgresql://atlas:atlas@localhost:5432/atlas
+        run: bash scripts/check-mutation-tables.sh --all
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: atlas
+          POSTGRES_PASSWORD: atlas
+          POSTGRES_DB: atlas
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U atlas"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
 
   api-tests:
     name: api-tests (${{ matrix.shard }}/4)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,6 +248,13 @@ jobs:
       - name: Adversarial fixtures for the brain-fact promotion gate (#4769)
         run: bash scripts/__tests__/check-brain-fact-promotion.test.sh
 
+      # ⚠️ Enumerated here because this workflow lists each fixture suite BY NAME
+      # while ci-local.sh globs the directory — so a new suite runs locally and
+      # silently never runs in CI. This was the only one of thirteen missing.
+      # It builds throwaway trees and needs no Postgres; ~2 seconds.
+      - name: Adversarial fixtures for the mutation-tables gate (#5077)
+        run: bash scripts/__tests__/check-mutation-tables.test.sh
+
       - name: Check test-file discipline (1.5.4 / #2796)
         run: bash scripts/check-test-discipline.sh
 

--- a/packages/api/scripts/mutate.ts
+++ b/packages/api/scripts/mutate.ts
@@ -290,29 +290,6 @@ async function measure(
           continue;
         }
 
-        // ⚠️ THE SAME DEFLATION, one loop over. Guardrail 4 refuses a baseline
-        // that skipped; this refuses a MUTATED RUN that skipped, and the twin
-        // was missing from the first cut. A mutation can break a `beforeAll` or
-        // the condition feeding a `describeIfPg`, and the resulting `fail` is
-        // then measured against a `total` from a baseline that ran a different
-        // population — a deflated count rendered as an honest number, which is
-        // the whole defect this change exists to close. `isWholeSuite` cannot
-        // see it either: it is built for the INFLATION case.
-        if (outcome.skip !== 0 || outcome.todo !== 0) {
-          const missing = outcome.skip + outcome.todo;
-          cells.set(target.name, {
-            kind: "error",
-            fail: 0,
-            flag: `SKIPPED ${missing} — count would be deflated`,
-          });
-          console.error(
-            `${position} ${RED}SKIP${RESET}   ${mutation.label} @ ${target.name}: ` +
-              `${missing} test(s) did not run under the mutation, so the count is not comparable ` +
-              "to the baseline.",
-          );
-          continue;
-        }
-
         const whole = isWholeSuite(outcome.fail, total);
         cells.set(target.name, {
           kind: "count",

--- a/packages/api/scripts/mutate.ts
+++ b/packages/api/scripts/mutate.ts
@@ -430,13 +430,19 @@ for (const target of targets) {
     // "this is NOT the usual cause" and sent the operator hunting a `.skip`
     // that does not exist. `check-mutation-tables.sh` already uses `-z`; these
     // two must agree.
-    const pgHint =
-      process.env.TEST_DATABASE_URL === undefined || process.env.TEST_DATABASE_URL === ""
+    // ⚠️ ONLY the deflation arms get the -pg hint. A RED or ERRORED baseline
+    // told to "find the .skip/.todo" sends the operator hunting something that
+    // is not there — measured on this very change, when a dead Postgres made
+    // two suites RED and the runner blamed a skip.
+    const deflation = problem.kind === "deflated" || problem.kind === "unaccounted";
+    const pgHint = !deflation
+      ? ""
+      : process.env.TEST_DATABASE_URL === undefined || process.env.TEST_DATABASE_URL === ""
         ? "\n         TEST_DATABASE_URL is UNSET (or empty), which is almost certainly the " +
           "cause: *-pg.test.ts self-skips without it. Start Postgres (bun run db:up) and set it."
         : "\n         TEST_DATABASE_URL is set, so this is NOT the usual -pg cause — find the " +
           ".skip/.todo in the target before trusting any number from it.";
-    fail(`baseline for ${target.name} (${target.file}) ${problem}${pgHint}`);
+    fail(`baseline for ${target.name} (${target.file}) ${problem.message}${pgHint}`);
   }
   baselines.set(target.name, outcome.pass);
   timeouts.set(target.name, options.timeoutMs ?? suiteTimeoutMs(outcome.durationMs));

--- a/packages/api/scripts/mutate.ts
+++ b/packages/api/scripts/mutate.ts
@@ -198,6 +198,7 @@ async function runTarget(target: MutationTarget, timeoutMs: number): Promise<Sui
     return {
       pass: 0,
       fail: 0,
+      skip: 0,
       durationMs: result.durationMs,
       error: timedOut
         ? `timed out after ${Math.round(timeoutMs / 1000)}s — the mutation HANGS the suite rather than failing it`
@@ -335,6 +336,37 @@ for (const target of targets) {
       `baseline for ${target.name} (${target.file}) is RED — ${outcome.fail} failing. ` +
         "Every mutation count would be this breakage plus the mutation's, which is " +
         "indistinguishable from a strong result. Fix the tree first.",
+    );
+  }
+  // ⚠️ GUARDRAIL 4 — a baseline that SKIPPED tests is not a baseline (#5077).
+  //
+  // The three guardrails in the header all assume every test in the target ran.
+  // A skipped test cannot be killed by a mutation, so each one silently deflates
+  // the cell it would have contributed to — and unlike a red baseline, which
+  // inflates and is caught above, this one DEFLATES and reads as honest.
+  //
+  // The measured instance is the one #5077 was filed for: with `TEST_DATABASE_URL`
+  // unset, `identity-consumers-pg.test.ts` reports 6 pass / 72 skip / 0 fail, so
+  // `subject-cmp.md` regenerated its real kills (3, 1, 1, 37, 29, 3, 66) as ZEROS
+  // over a suite recorded as 6 instead of 78, with no warning anywhere.
+  //
+  // ⚠️ FAIL rather than flag-the-column, and fail BEFORE any mutation runs. The
+  // write path is the dangerous one — `--check` merely reports a false "stale",
+  // while a regenerate CLOBBERS numbers that were real — and both come through
+  // here, so one guard at the baseline closes both. It also generalises past the
+  // `-pg` case: any `.skip`/`.todo` a target picks up for any reason lands the
+  // same deflation, and this refuses all of them rather than the one cause.
+  if (outcome.skip !== 0) {
+    fail(
+      `baseline for ${target.name} (${target.file}) SKIPPED ${outcome.skip} of ` +
+        `${outcome.pass + outcome.skip} tests. A skipped test cannot be killed by a mutation, ` +
+        "so every count in this table would be silently deflated and the generated file would " +
+        "overwrite real numbers with zeros.\n" +
+        (process.env.TEST_DATABASE_URL === undefined
+          ? "         TEST_DATABASE_URL is UNSET, which is almost certainly the cause: " +
+            "*-pg.test.ts self-skips without it. Start Postgres (bun run db:up) and set it."
+          : "         TEST_DATABASE_URL is set, so this is NOT the usual -pg cause — find " +
+            "the .skip/.todo in the target before trusting any number from it."),
     );
   }
   baselines.set(target.name, outcome.pass);

--- a/packages/api/scripts/mutate.ts
+++ b/packages/api/scripts/mutate.ts
@@ -56,7 +56,9 @@ import { dirname, relative, resolve } from "node:path";
 import { runFileWithSignalRetry } from "./signal-retry";
 import {
   AnchorError,
+  anchorFailures,
   applyMutation,
+  baselineProblem,
   diskStore,
   isWholeSuite,
   parseBunSummary,
@@ -198,7 +200,15 @@ for (const signal of ["SIGINT", "SIGTERM"] as const) {
  * infinite), and an unbounded wait stalls the whole run in the one state where
  * the operator's instinct — Ctrl-C — lands between apply and restore.
  */
-async function runTarget(target: MutationTarget, timeoutMs: number): Promise<SuiteOutcome & { durationMs: number }> {
+async function runTarget(
+  target: MutationTarget,
+  timeoutMs: number,
+  // ⚠️ The baseline runs through here too, and there is NO mutation applied
+  // then — so the timeout text below must not say there is. Measured: a loaded
+  // machine timed out a 113ms baseline and the runner reported "the mutation
+  // HANGS the suite", sending the operator to audit a spec that was fine.
+  phase: "baseline" | "mutation" = "mutation",
+): Promise<SuiteOutcome & { durationMs: number }> {
   const abs = resolve(ROOT, target.file);
   const result = await runFileWithSignalRetry(
     abs,
@@ -215,9 +225,14 @@ async function runTarget(target: MutationTarget, timeoutMs: number): Promise<Sui
       pass: 0,
       fail: 0,
       skip: 0,
+      todo: 0,
+      ran: null,
       durationMs: result.durationMs,
       error: timedOut
-        ? `timed out after ${Math.round(timeoutMs / 1000)}s — the mutation HANGS the suite rather than failing it`
+        ? phase === "baseline"
+          ? `timed out after ${Math.round(timeoutMs / 1000)}s on the UNMUTATED tree — no mutation ` +
+            "was applied, so the suite is slower than the floor or the machine is loaded"
+          : `timed out after ${Math.round(timeoutMs / 1000)}s — the mutation HANGS the suite rather than failing it`
         : `killed by ${result.signalCode}`,
     };
   }
@@ -254,6 +269,9 @@ async function measure(
           kind: "error",
           fail: 0,
           flag: `ANCHOR: ${err.matches} matches`,
+          // Machine-readable, so the run can REFUSE this rather than rendering
+          // it as a stable byte that `--check` then blesses forever.
+          anchorFailed: true,
         });
       }
       continue;
@@ -268,6 +286,29 @@ async function measure(
           cells.set(target.name, { kind: "error", fail: 0, flag: outcome.error });
           console.error(
             `${position} ${RED}ERROR${RESET}  ${mutation.label} @ ${target.name}: ${outcome.error}`,
+          );
+          continue;
+        }
+
+        // ⚠️ THE SAME DEFLATION, one loop over. Guardrail 4 refuses a baseline
+        // that skipped; this refuses a MUTATED RUN that skipped, and the twin
+        // was missing from the first cut. A mutation can break a `beforeAll` or
+        // the condition feeding a `describeIfPg`, and the resulting `fail` is
+        // then measured against a `total` from a baseline that ran a different
+        // population — a deflated count rendered as an honest number, which is
+        // the whole defect this change exists to close. `isWholeSuite` cannot
+        // see it either: it is built for the INFLATION case.
+        if (outcome.skip !== 0 || outcome.todo !== 0) {
+          const missing = outcome.skip + outcome.todo;
+          cells.set(target.name, {
+            kind: "error",
+            fail: 0,
+            flag: `SKIPPED ${missing} — count would be deflated`,
+          });
+          console.error(
+            `${position} ${RED}SKIP${RESET}   ${mutation.label} @ ${target.name}: ` +
+              `${missing} test(s) did not run under the mutation, so the count is not comparable ` +
+              "to the baseline.",
           );
           continue;
         }
@@ -307,19 +348,27 @@ async function measure(
 const options = parseArgs(process.argv.slice(2));
 const spec = await loadSpec(options.specPath);
 
+const problems = validateSpec(spec);
+if (problems.length > 0) fail(`invalid spec:\n  - ${problems.join("\n  - ")}`);
+
 if (options.files) {
-  // Every file whose change could alter this spec's table: the suites that get
-  // run, and the sources that get mutated. The spec itself is added by the
-  // caller — it knows its own path and does not need us to echo it.
+  // ⚠️ AFTER `validateSpec`, not before. A spec with an empty `edits` array is
+  // a validation problem AND emits a dependency list missing that source file —
+  // so `--affected` would not select it, `--check` would never run, and the log
+  // would read "nothing to verify", which is indistinguishable from a clean run.
+  // A broken spec must fail loudly here rather than quietly under-select.
   const deps = new Set<string>();
   for (const t of spec.targets) deps.add(t.file);
   for (const m of spec.mutations) for (const e of m.edits) deps.add(e.file);
+  // ⚠️ The GENERATED TABLE is a dependency of its own verdict. Without it, a
+  // hand-edited `.md` — bumping a number so it "matches" — selects no spec and
+  // the gate prints "nothing to verify". That hand-edit is #5060's original
+  // threat model, so omitting it left the gate blind to the exact input it was
+  // built for.
+  deps.add(spec.out);
   for (const f of [...deps].sort()) console.log(f);
   process.exit(0);
 }
-
-const problems = validateSpec(spec);
-if (problems.length > 0) fail(`invalid spec:\n  - ${problems.join("\n  - ")}`);
 
 const targets =
   options.targets.length === 0
@@ -354,47 +403,40 @@ const timeouts = new Map<string, number>();
 for (const target of targets) {
   // The baseline itself gets the floor: there is no measured duration to scale
   // off yet, and a baseline that hangs must not hang the run either.
-  const outcome = await runTarget(target, options.timeoutMs ?? SUITE_TIMEOUT_FLOOR_MS);
-  if (outcome.error !== undefined) {
-    fail(`baseline for ${target.name} (${target.file}) did not run: ${outcome.error}`);
-  }
-  if (outcome.fail !== 0) {
-    fail(
-      `baseline for ${target.name} (${target.file}) is RED — ${outcome.fail} failing. ` +
-        "Every mutation count would be this breakage plus the mutation's, which is " +
-        "indistinguishable from a strong result. Fix the tree first.",
-    );
-  }
-  // ⚠️ GUARDRAIL 4 — a baseline that SKIPPED tests is not a baseline (#5077).
+  const outcome = await runTarget(target, options.timeoutMs ?? SUITE_TIMEOUT_FLOOR_MS, "baseline");
+  // ⚠️ GUARDRAIL 4 — every way a baseline can lie, in ONE tested function.
   //
   // The three guardrails in the header all assume every test in the target ran.
-  // A skipped test cannot be killed by a mutation, so each one silently deflates
-  // the cell it would have contributed to — and unlike a red baseline, which
-  // inflates and is caught above, this one DEFLATES and reads as honest.
+  // A red baseline INFLATES and was always caught; a deflated one reads as
+  // honest, which is the #5077 case: with `TEST_DATABASE_URL` unset,
+  // `identity-consumers-pg.test.ts` reports 6 pass / 72 skip / 0 fail, so
+  // `subject-cmp.md` regenerated its real kills as ZEROS over a suite recorded
+  // as 6 rather than 78, with no warning anywhere.
   //
-  // The measured instance is the one #5077 was filed for: with `TEST_DATABASE_URL`
-  // unset, `identity-consumers-pg.test.ts` reports 6 pass / 72 skip / 0 fail, so
-  // `subject-cmp.md` regenerated its real kills (3, 1, 1, 37, 29, 3, 66) as ZEROS
-  // over a suite recorded as 6 instead of 78, with no warning anywhere.
+  // ⚠️ The decision lives in `mutation-core.ts` as `baselineProblem`, NOT
+  // inline here, and that is this module's own stated split — guardrails 1-3
+  // are pure tested functions and only the PROCESS is in this file. Written
+  // inline, guardrail 4 could be deleted whole and every test stayed green and
+  // every table regenerated byte-identically. Measured, and the reason it moved.
   //
-  // ⚠️ FAIL rather than flag-the-column, and fail BEFORE any mutation runs. The
-  // write path is the dangerous one — `--check` merely reports a false "stale",
-  // while a regenerate CLOBBERS numbers that were real — and both come through
-  // here, so one guard at the baseline closes both. It also generalises past the
-  // `-pg` case: any `.skip`/`.todo` a target picks up for any reason lands the
-  // same deflation, and this refuses all of them rather than the one cause.
-  if (outcome.skip !== 0) {
-    fail(
-      `baseline for ${target.name} (${target.file}) SKIPPED ${outcome.skip} of ` +
-        `${outcome.pass + outcome.skip} tests. A skipped test cannot be killed by a mutation, ` +
-        "so every count in this table would be silently deflated and the generated file would " +
-        "overwrite real numbers with zeros.\n" +
-        (process.env.TEST_DATABASE_URL === undefined
-          ? "         TEST_DATABASE_URL is UNSET, which is almost certainly the cause: " +
-            "*-pg.test.ts self-skips without it. Start Postgres (bun run db:up) and set it."
-          : "         TEST_DATABASE_URL is set, so this is NOT the usual -pg cause — find " +
-            "the .skip/.todo in the target before trusting any number from it."),
-    );
+  // Fails BEFORE any mutation runs, so one guard closes both directions:
+  // `--check` cannot report a false "stale", and a regenerate cannot clobber
+  // numbers that were real.
+  const problem = baselineProblem(outcome);
+  if (problem !== null) {
+    // ⚠️ Truthiness, not `=== undefined`. The suites gate on
+    // `TEST_DB_URL ? describe : describe.skip`, so an EXPORTED-EMPTY variable
+    // skips them for the ordinary `-pg` reason while `=== undefined` reported
+    // "this is NOT the usual cause" and sent the operator hunting a `.skip`
+    // that does not exist. `check-mutation-tables.sh` already uses `-z`; these
+    // two must agree.
+    const pgHint =
+      process.env.TEST_DATABASE_URL === undefined || process.env.TEST_DATABASE_URL === ""
+        ? "\n         TEST_DATABASE_URL is UNSET (or empty), which is almost certainly the " +
+          "cause: *-pg.test.ts self-skips without it. Start Postgres (bun run db:up) and set it."
+        : "\n         TEST_DATABASE_URL is set, so this is NOT the usual -pg cause — find the " +
+          ".skip/.todo in the target before trusting any number from it.";
+    fail(`baseline for ${target.name} (${target.file}) ${problem}${pgHint}`);
   }
   baselines.set(target.name, outcome.pass);
   timeouts.set(target.name, options.timeoutMs ?? suiteTimeoutMs(outcome.durationMs));
@@ -411,6 +453,34 @@ try {
   // measure() restores per mutation; this covers a throw between apply and the
   // inner finally, and costs nothing when the map is already empty.
   restoreAll(diskStore, backups);
+}
+
+// ⚠️ A DEAD ANCHOR IS NOT A RESULT, and it must never become a committed byte.
+//
+// Guardrail 2 calls a 0-match "a number for a mutation that was never
+// performed, which is worse than reporting nothing" — but `--check` compares
+// BYTES, so once `⚠️ ANCHOR: 0 matches` is in the file it IS the expected
+// output and the table passes forever. Measured on the change that added this:
+// a new field on `SuiteOutcome` rotted the anchor mirroring that literal, the
+// table regenerated with a tombstone where a measured `2` had been, and
+// `--check` said `CHECK OK`. The gate would have ratcheted rot in as green.
+//
+// `measure()` still keeps going after an `AnchorError` — one bad anchor should
+// not cost the other twenty measurements — so this refuses at the END, naming
+// every rotted row at once.
+//
+// ⚠️ Deliberately NOT gated on `--check`. The write path is the one that
+// PRODUCES the tombstone; refusing only on check would let a regenerate commit
+// it and the next check bless it.
+const dead = anchorFailures(rows);
+if (dead.length > 0) {
+  fail(
+    `${dead.length} mutation(s) in ${options.specPath} have a DEAD ANCHOR — their oldString no ` +
+      "longer matches the source exactly once, so they measured nothing:\n" +
+      dead.map((label) => `           - ${label}`).join("\n") +
+      "\n         Repair the anchors in the spec. Writing this table would record a tombstone " +
+      "where a real number belongs, and every later --check would accept it as current.",
+  );
 }
 
 const markdown = render(spec, targets, mutations, baselines, rows, options.specPath);

--- a/packages/api/scripts/mutate.ts
+++ b/packages/api/scripts/mutate.ts
@@ -92,6 +92,19 @@ interface Options {
   readonly only: readonly string[];
   readonly targets: readonly string[];
   readonly check: boolean;
+  /**
+   * Print the files this spec's verdict DEPENDS ON, then exit. Runs nothing.
+   *
+   * Exists so `check-mutation-tables.sh` can verify only the specs a branch
+   * could actually have invalidated. The full sweep is 832s measured — more
+   * than the entire rest of `/ci` — so a gate that always ran everything would
+   * be disabled inside a week, and a disabled gate catches nothing.
+   *
+   * Derived from the loaded spec rather than grepped, because the paths are
+   * behind `SOURCE`-style consts that a regex would miss — and a dependency
+   * list that silently misses a file is a gate that silently stops gating.
+   */
+  readonly files: boolean;
   /** Overrides the baseline-derived per-suite timeout. */
   readonly timeoutMs?: number;
 }
@@ -101,6 +114,7 @@ function parseArgs(argv: readonly string[]): Options {
   const only: string[] = [];
   const targets: string[] = [];
   let check = false;
+  let files = false;
   let timeoutMs: number | undefined;
 
   for (let i = 0; i < argv.length; i++) {
@@ -116,6 +130,8 @@ function parseArgs(argv: readonly string[]): Options {
       timeoutMs = parsed;
     } else if (arg === "--check") {
       check = true;
+    } else if (arg === "--files") {
+      files = true;
     } else if (arg !== undefined && arg.startsWith("--")) {
       fail(`Unknown flag: ${arg}`);
     } else if (specPath === undefined) {
@@ -128,10 +144,10 @@ function parseArgs(argv: readonly string[]): Options {
   if (specPath === undefined) {
     fail(
       "Usage: bun run scripts/mutate.ts <spec.mutations.ts> " +
-        "[--only <label>] [--target <name>] [--timeout <ms>] [--check]",
+        "[--only <label>] [--target <name>] [--timeout <ms>] [--check] [--files]",
     );
   }
-  return { specPath, only, targets, check, timeoutMs };
+  return { specPath, only, targets, check, files, timeoutMs };
 }
 
 async function loadSpec(specPath: string): Promise<MutationSpec> {
@@ -290,6 +306,17 @@ async function measure(
 
 const options = parseArgs(process.argv.slice(2));
 const spec = await loadSpec(options.specPath);
+
+if (options.files) {
+  // Every file whose change could alter this spec's table: the suites that get
+  // run, and the sources that get mutated. The spec itself is added by the
+  // caller — it knows its own path and does not need us to echo it.
+  const deps = new Set<string>();
+  for (const t of spec.targets) deps.add(t.file);
+  for (const m of spec.mutations) for (const e of m.edits) deps.add(e.file);
+  for (const f of [...deps].sort()) console.log(f);
+  process.exit(0);
+}
 
 const problems = validateSpec(spec);
 if (problems.length > 0) fail(`invalid spec:\n  - ${problems.join("\n  - ")}`);

--- a/packages/api/scripts/mutation-core.ts
+++ b/packages/api/scripts/mutation-core.ts
@@ -303,7 +303,7 @@ export interface Cell {
    * `--check` said `CHECK OK`.
    *
    * So a rotted anchor is a distinct, machine-readable state, and
-   * {@link anyAnchorFailure} is what {@link module:mutate} refuses on. A
+   * {@link anchorFailures} is what {@link module:mutate} refuses on. A
    * timeout flag must stay merely a flag — that is a real measurement of a real
    * hang — which is exactly the distinction a substring match could not draw.
    */
@@ -393,14 +393,6 @@ export function baselineProblem(outcome: SuiteOutcome): BaselineProblem | null {
         "mutation's, which is indistinguishable from a strong result. Fix the tree first.",
     };
   }
-  if (outcome.pass === 0) {
-    return {
-      kind: "empty",
-      message:
-        "ran ZERO tests. A baseline of nothing is not a baseline: every cell would render an " +
-        "honest-looking 0 meaning 'the suite does not catch this'. Check the target's path.",
-    };
-  }
   const accounted = outcome.pass + outcome.fail + outcome.skip + outcome.todo;
   if (outcome.ran !== null && accounted !== outcome.ran) {
     const missing = outcome.ran - accounted;
@@ -424,6 +416,27 @@ export function baselineProblem(outcome: SuiteOutcome): BaselineProblem | null {
       message:
         `${what} of ${total} tests. A skipped test cannot be killed by a mutation, so every count ` +
         "would be silently deflated and the generated file would overwrite real numbers with zeros.",
+    };
+  }
+  // ⚠️ LAST, and the ordering is the finding. Placed before the deflation arms
+  // it swallowed THREE OF FIVE `-pg` targets: a suite with no non-`-pg` tests
+  // reports `0 pass / 29 skip`, which is a DEFLATED baseline, but `pass === 0`
+  // claimed it first and printed "check the target's path" — sending an
+  // operator after a path that is fine while Postgres is down. That is the
+  // misdirecting diagnostic `182eb6536` removed, reintroduced by the fix for it
+  // and on the more common shape; `identity-consumers-pg` was only diagnosed
+  // correctly because it happens to carry six unrelated tests.
+  //
+  // "Ran nothing AND explains why" beats "ran nothing", so every arm that can
+  // explain goes first. Reaching here means the suite genuinely discovered no
+  // tests at all.
+  if (outcome.pass === 0) {
+    return {
+      kind: "empty",
+      message:
+        "ran ZERO tests, and reported no skips, todos or unaccounted tests to explain it. A " +
+        "baseline of nothing is not a baseline: every cell would render an honest-looking 0 " +
+        "meaning 'the suite does not catch this'. Check the target's path.",
     };
   }
   return null;

--- a/packages/api/scripts/mutation-core.ts
+++ b/packages/api/scripts/mutation-core.ts
@@ -114,6 +114,24 @@ export function restoreAll(store: FileStore, backups: Map<string, string>): void
 export interface SuiteOutcome {
   readonly pass: number;
   readonly fail: number;
+  /**
+   * Tests bun reported as SKIPPED.
+   *
+   * ⚠️ **Parsed because its absence was this runner's worst silent failure.** A
+   * skipped test cannot be killed by a mutation, so every skip deflates the
+   * cell it would have contributed to — and the baseline guard only ever
+   * rejected `fail !== 0`, which a mostly-skipped suite passes with room to
+   * spare. Measured: `identity-consumers-pg.test.ts` without
+   * `TEST_DATABASE_URL` reports **6 pass, 72 skip, 0 fail**, so the baseline
+   * records a denominator of 6 instead of 78 and the `-pg` column regenerates
+   * as zeros over real numbers.
+   *
+   * ⚠️ Note it is 6 and not 0 — that file carries six non-`-pg` tests. A guard
+   * spelled `pass > 0` therefore does NOT catch this, which is why the signal
+   * has to be the skip count itself. That is a correction to #5077's own
+   * diagnosis, which reads the failure as a zeroed suite.
+   */
+  readonly skip: number;
   /** Set when bun printed no summary at all — a compile or import error. */
   readonly error?: string;
 }
@@ -125,10 +143,17 @@ export interface SuiteOutcome {
  * `(fail)` — cannot be mistaken for the summary. A missing summary means the
  * file never ran, and that must surface as an error rather than as `0 fail`,
  * which would read as "the suite does not catch this".
+ *
+ * ⚠️ `skip` DEFAULTS TO 0 when the line is absent, and that asymmetry with
+ * `pass`/`fail` is deliberate: bun omits the skip line entirely when nothing
+ * skipped, so treating its absence as a parse failure would make every healthy
+ * run an error. `pass`/`fail` are always printed, so THEIR absence still means
+ * no run happened.
  */
 export function parseBunSummary(output: string): SuiteOutcome {
   const pass = /^\s*(\d+)\s+pass\b/m.exec(output);
   const fails = /^\s*(\d+)\s+fail\b/m.exec(output);
+  const skips = /^\s*(\d+)\s+skip\b/m.exec(output);
   if (pass === null || fails === null) {
     const firstError = output
       .split("\n")
@@ -137,10 +162,15 @@ export function parseBunSummary(output: string): SuiteOutcome {
     return {
       pass: 0,
       fail: 0,
+      skip: 0,
       error: firstError ?? "bun printed no pass/fail summary (compile or import error)",
     };
   }
-  return { pass: Number(pass[1]), fail: Number(fails[1]) };
+  return {
+    pass: Number(pass[1]),
+    fail: Number(fails[1]),
+    skip: skips === null ? 0 : Number(skips[1]),
+  };
 }
 
 /**

--- a/packages/api/scripts/mutation-core.ts
+++ b/packages/api/scripts/mutation-core.ts
@@ -132,6 +132,26 @@ export interface SuiteOutcome {
    * diagnosis, which reads the failure as a zeroed suite.
    */
   readonly skip: number;
+  /**
+   * Tests bun reported as TODO.
+   *
+   * ⚠️ **Its own bucket, because bun does not fold it into `skip` and the first
+   * cut of the guard therefore missed it entirely** — with a comment claiming
+   * `.todo` was covered, which is worse than no comment. A `test.todo` does not
+   * run even when it HAS a body, so it deflates the denominator exactly like a
+   * `.skip`. Measured: a 2-test file with one `test.todo` published as *1 test*
+   * with every cell deflated, and the guard silent.
+   */
+  readonly todo: number;
+  /**
+   * What bun's `Ran N tests` line said, or `null` when it printed none.
+   *
+   * The ACCOUNTING check behind {@link baselineProblem}'s third arm, and the
+   * reason that function does not enumerate buckets: `filtered out` is a fourth
+   * one, and there is no reason to believe it is the last. Comparing the sum
+   * against the total closes every bucket at once, now and later.
+   */
+  readonly ran: number | null;
   /** Set when bun printed no summary at all — a compile or import error. */
   readonly error?: string;
 }
@@ -154,6 +174,8 @@ export function parseBunSummary(output: string): SuiteOutcome {
   const pass = /^\s*(\d+)\s+pass\b/m.exec(output);
   const fails = /^\s*(\d+)\s+fail\b/m.exec(output);
   const skips = /^\s*(\d+)\s+skip\b/m.exec(output);
+  const todos = /^\s*(\d+)\s+todo\b/m.exec(output);
+  const ran = /^Ran (\d+) tests?\b/m.exec(output);
   if (pass === null || fails === null) {
     const firstError = output
       .split("\n")
@@ -163,6 +185,8 @@ export function parseBunSummary(output: string): SuiteOutcome {
       pass: 0,
       fail: 0,
       skip: 0,
+      todo: 0,
+      ran: null,
       error: firstError ?? "bun printed no pass/fail summary (compile or import error)",
     };
   }
@@ -170,6 +194,8 @@ export function parseBunSummary(output: string): SuiteOutcome {
     pass: Number(pass[1]),
     fail: Number(fails[1]),
     skip: skips === null ? 0 : Number(skips[1]),
+    todo: todos === null ? 0 : Number(todos[1]),
+    ran: ran === null ? null : Number(ran[1]),
   };
 }
 
@@ -263,11 +289,119 @@ export interface Cell {
   readonly fail: number;
   /** Present when `kind` is `error`, or when the count tripped the ratio. */
   readonly flag?: string;
+  /**
+   * The cell measured NOTHING because the mutation's anchor did not resolve.
+   *
+   * ⚠️ **Its own field rather than a substring of {@link flag}, because the
+   * gate has to act on it and `flag` is free-form prose.** Guardrail 2 calls a
+   * 0-match *"a number for a mutation that was never performed, which is worse
+   * than reporting nothing"* — but `--check` compares BYTES, so once
+   * `⚠️ ANCHOR: 0 matches` is in the committed table it becomes the expected
+   * output and the table passes forever. Measured on this very change: adding a
+   * field to `SuiteOutcome` rotted the anchor mirroring that literal, the table
+   * regenerated with a tombstone where a measured `2` had been, and
+   * `--check` said `CHECK OK`.
+   *
+   * So a rotted anchor is a distinct, machine-readable state, and
+   * {@link anyAnchorFailure} is what {@link module:mutate} refuses on. A
+   * timeout flag must stay merely a flag — that is a real measurement of a real
+   * hang — which is exactly the distinction a substring match could not draw.
+   */
+  readonly anchorFailed?: true;
 }
 
 export function renderCell(cell: Cell): string {
   if (cell.kind === "error") return `⚠️ ${cell.flag ?? "ERROR"}`;
   return cell.flag === undefined ? String(cell.fail) : `${cell.fail} ⚠️`;
+}
+
+/**
+ * Every mutation label whose cells recorded a dead anchor.
+ *
+ * Returned as a LIST rather than a boolean so the runner can name all of them
+ * in one pass — `measure()` deliberately keeps going after an `AnchorError` so
+ * one bad anchor does not cost the other twenty measurements, and the same
+ * courtesy should extend to repairing them.
+ */
+export function anchorFailures(rows: ReadonlyMap<string, ReadonlyMap<string, Cell>>): string[] {
+  const dead: string[] = [];
+  for (const [label, cells] of rows) {
+    for (const cell of cells.values()) {
+      if (cell.anchorFailed === true) {
+        dead.push(label);
+        break;
+      }
+    }
+  }
+  return dead;
+}
+
+/**
+ * Why this outcome cannot serve as a BASELINE, or `null` if it can.
+ *
+ * ⚠️ **A pure function in this file rather than an inline block in
+ * `mutate.ts`, because that is this module's stated split** — *"the logic
+ * behind all three [guardrails] lives in `mutation-core.ts` and is unit-tested;
+ * [mutate.ts] is the process around it"*. Guardrail 4 was written inline, and
+ * the consequence was measurable: deleting the entire guard left every test
+ * green and regenerated every table byte-identically. A guardrail that its own
+ * suite cannot see is the shape this whole runner exists to refuse.
+ *
+ * ## The three ways a baseline lies, and why counting buckets is not enough
+ *
+ * `pass` becomes the published suite size (`render`'s *"Suite sizes: N tests"*)
+ * and `isWholeSuite`'s denominator, so a deflated baseline silently deflates
+ * every cell measured against it.
+ *
+ * 1. **RED** — inflates. Already caught before this existed.
+ * 2. **EMPTY** — `0 pass` with no error is a target whose file was renamed or
+ *    emptied. Every cell then renders an honest-looking `0` meaning *"the suite
+ *    does not catch this"*.
+ * 3. **UNACCOUNTED** — the buckets do not sum to what bun says it ran. This is
+ *    the general form of #5077, and it is deliberately NOT spelled as
+ *    `skip !== 0`: bun prints `todo` on its own summary line and does not fold
+ *    it into `skip`, so a `test.todo` deflates the denominator exactly like a
+ *    `.skip` and slipped straight past the first cut of this guard. `filtered
+ *    out` is a third bucket with the same effect. Checking the SUM against
+ *    `Ran N tests` closes every bucket bun has now and every one it adds later,
+ *    rather than chasing its release notes.
+ */
+export function baselineProblem(outcome: SuiteOutcome): string | null {
+  if (outcome.error !== undefined) return `did not run: ${outcome.error}`;
+  if (outcome.fail !== 0) {
+    return (
+      `is RED — ${outcome.fail} failing. Every mutation count would be this breakage plus the ` +
+      "mutation's, which is indistinguishable from a strong result. Fix the tree first."
+    );
+  }
+  if (outcome.pass === 0) {
+    return (
+      "ran ZERO tests. A baseline of nothing is not a baseline: every cell would render an " +
+      "honest-looking 0 meaning 'the suite does not catch this'. Check the target's path."
+    );
+  }
+  const accounted = outcome.pass + outcome.fail + outcome.skip + outcome.todo;
+  if (outcome.ran !== null && accounted !== outcome.ran) {
+    const missing = outcome.ran - accounted;
+    return (
+      `ran ${outcome.ran} tests but only ${accounted} are accounted for (${missing} unclassified). ` +
+      "A test that did not run cannot be killed by a mutation, so every count would be deflated."
+    );
+  }
+  if (outcome.skip !== 0 || outcome.todo !== 0) {
+    const total = accounted;
+    const what =
+      outcome.todo === 0
+        ? `SKIPPED ${outcome.skip}`
+        : outcome.skip === 0
+          ? `marked TODO on ${outcome.todo}`
+          : `SKIPPED ${outcome.skip} and marked TODO on ${outcome.todo}`;
+    return (
+      `${what} of ${total} tests. A skipped test cannot be killed by a mutation, so every count ` +
+      "would be silently deflated and the generated file would overwrite real numbers with zeros."
+    );
+  }
+  return null;
 }
 
 /**

--- a/packages/api/scripts/mutation-core.ts
+++ b/packages/api/scripts/mutation-core.ts
@@ -366,27 +366,50 @@ export function anchorFailures(rows: ReadonlyMap<string, ReadonlyMap<string, Cel
  *    `Ran N tests` closes every bucket bun has now and every one it adds later,
  *    rather than chasing its release notes.
  */
-export function baselineProblem(outcome: SuiteOutcome): string | null {
-  if (outcome.error !== undefined) return `did not run: ${outcome.error}`;
+export interface BaselineProblem {
+  /**
+   * ⚠️ Present so the CALLER can decide which remediation to print.
+   *
+   * The first cut returned a bare string and `mutate.ts` appended the
+   * TEST_DATABASE_URL hint to all of them — so a suite that was simply RED got
+   * told to "find the .skip/.todo in the target", sending an operator hunting a
+   * skip that does not exist. That is the same misdirecting-diagnostic defect
+   * the empty-string env check fixed one arm over, reintroduced by the fix for
+   * it. Only `deflated` and `unaccounted` are about tests that did not run.
+   */
+  readonly kind: "errored" | "red" | "empty" | "unaccounted" | "deflated";
+  readonly message: string;
+}
+
+export function baselineProblem(outcome: SuiteOutcome): BaselineProblem | null {
+  if (outcome.error !== undefined) {
+    return { kind: "errored", message: `did not run: ${outcome.error}` };
+  }
   if (outcome.fail !== 0) {
-    return (
-      `is RED — ${outcome.fail} failing. Every mutation count would be this breakage plus the ` +
-      "mutation's, which is indistinguishable from a strong result. Fix the tree first."
-    );
+    return {
+      kind: "red",
+      message:
+        `is RED — ${outcome.fail} failing. Every mutation count would be this breakage plus the ` +
+        "mutation's, which is indistinguishable from a strong result. Fix the tree first.",
+    };
   }
   if (outcome.pass === 0) {
-    return (
-      "ran ZERO tests. A baseline of nothing is not a baseline: every cell would render an " +
-      "honest-looking 0 meaning 'the suite does not catch this'. Check the target's path."
-    );
+    return {
+      kind: "empty",
+      message:
+        "ran ZERO tests. A baseline of nothing is not a baseline: every cell would render an " +
+        "honest-looking 0 meaning 'the suite does not catch this'. Check the target's path.",
+    };
   }
   const accounted = outcome.pass + outcome.fail + outcome.skip + outcome.todo;
   if (outcome.ran !== null && accounted !== outcome.ran) {
     const missing = outcome.ran - accounted;
-    return (
-      `ran ${outcome.ran} tests but only ${accounted} are accounted for (${missing} unclassified). ` +
-      "A test that did not run cannot be killed by a mutation, so every count would be deflated."
-    );
+    return {
+      kind: "unaccounted",
+      message:
+        `ran ${outcome.ran} tests but only ${accounted} are accounted for (${missing} unclassified). ` +
+        "A test that did not run cannot be killed by a mutation, so every count would be deflated.",
+    };
   }
   if (outcome.skip !== 0 || outcome.todo !== 0) {
     const total = accounted;
@@ -396,10 +419,12 @@ export function baselineProblem(outcome: SuiteOutcome): string | null {
         : outcome.skip === 0
           ? `marked TODO on ${outcome.todo}`
           : `SKIPPED ${outcome.skip} and marked TODO on ${outcome.todo}`;
-    return (
-      `${what} of ${total} tests. A skipped test cannot be killed by a mutation, so every count ` +
-      "would be silently deflated and the generated file would overwrite real numbers with zeros."
-    );
+    return {
+      kind: "deflated",
+      message:
+        `${what} of ${total} tests. A skipped test cannot be killed by a mutation, so every count ` +
+        "would be silently deflated and the generated file would overwrite real numbers with zeros.",
+    };
   }
   return null;
 }

--- a/packages/api/scripts/mutations/cardinality.md
+++ b/packages/api/scripts/mutations/cardinality.md
@@ -17,10 +17,10 @@ Every number is the count of tests that FAIL in that suite under that mutation, 
 
 | Mutation | cardinality-pg.test.ts | cardinality.test.ts | correction.test.ts | brain-facts.test.ts | reconcile.test.ts |
 |---|---|---|---|---|---|
-| the collision reads a per-ROW cardinality again (the both-sides clause restored) | 9 | 0 | 0 | 4 | 0 |
+| the collision reads a per-ROW cardinality again (the both-sides clause restored) | ⚠️ ANCHOR: 0 matches | ⚠️ ANCHOR: 0 matches | ⚠️ ANCHOR: 0 matches | ⚠️ ANCHOR: 0 matches | ⚠️ ANCHOR: 0 matches |
 | `cardinalitySingleSql` stops filtering entries to `approved` | 1 | 1 | 0 | 2 | 0 |
-| `cardinalitySingleSql` reads `single` from anywhere in the workspace | 2 | 1 | 0 | 1 | 0 |
-| the producer path may write `approved` instead of `pending` | 3 | 1 | 1 | 0 | 0 |
+| `cardinalitySingleSql` reads `single` from anywhere in the workspace | ⚠️ ANCHOR: 0 matches | ⚠️ ANCHOR: 0 matches | ⚠️ ANCHOR: 0 matches | ⚠️ ANCHOR: 0 matches | ⚠️ ANCHOR: 0 matches |
+| the producer path may write `approved` instead of `pending` | 7 | 1 | 1 | 0 | 0 |
 | the producer path accepts a `multi` proposal | 1 | 5 | 0 | 0 | 0 |
 | the rejection memory is dropped (`ON CONFLICT DO NOTHING` → `DO UPDATE`) | 1 | 1 | 1 | 0 | 0 |
 | the repeat gate counts CORRECTIONS instead of distinct subjects | 1 | 2 | 0 | 0 | 0 |
@@ -37,7 +37,7 @@ Every number is the count of tests that FAIL in that suite under that mutation, 
 | `logDegeneratePredicate`'s call is removed | 0 | 0 | 1 | 0 | 0 |
 | the proposer runs INSIDE the correction's transaction | 0 | 0 | 7 | 0 | 0 |
 
-Suite sizes: **cardinality-pg.test.ts** 23 tests (`src/lib/brain/__tests__/cardinality-pg.test.ts`) · **cardinality.test.ts** 38 tests (`src/lib/brain/__tests__/cardinality.test.ts`) · **correction.test.ts** 61 tests (`src/lib/brain/__tests__/correction.test.ts`) · **brain-facts.test.ts** 60 tests (`src/lib/content-mode/adapters/__tests__/brain-facts.test.ts`) · **reconcile.test.ts** 70 tests (`src/lib/brain/__tests__/reconcile.test.ts`).
+Suite sizes: **cardinality-pg.test.ts** 27 tests (`src/lib/brain/__tests__/cardinality-pg.test.ts`) · **cardinality.test.ts** 38 tests (`src/lib/brain/__tests__/cardinality.test.ts`) · **correction.test.ts** 61 tests (`src/lib/brain/__tests__/correction.test.ts`) · **brain-facts.test.ts** 60 tests (`src/lib/content-mode/adapters/__tests__/brain-facts.test.ts`) · **reconcile.test.ts** 70 tests (`src/lib/brain/__tests__/reconcile.test.ts`).
 
 ## Notes
 
@@ -60,3 +60,10 @@ Suite sizes: **cardinality-pg.test.ts** 23 tests (`src/lib/brain/__tests__/cardi
 - **`logDegeneratePredicate` fires for every verb, not only `supersede`** — A `retract` or a vouch would then log *superseded a claim whose predicate normalizes away* about a verb that superseded nothing. The guard is the whole content of the line.
 - **`logDegeneratePredicate`'s call is removed** — The case is legal and permanent (`identityKey`'s ⚠️), produces no proposal, and without this line produces no record either — a supersede that vanished.
 - **the proposer runs INSIDE the correction's transaction** — Stands in for the placement change rather than reproducing it literally (the real one cannot be expressed as a local edit). What it removes is the proposer's access to the committed `supersedes` edge — which is why the placement is post-commit rather than a `SAVEPOINT`.
+
+## ⚠️ Flagged
+
+A `whole-suite` flag means the count reached ~every test in the file. That is usually a mutation that broke SETUP rather than the behaviour under test, and the honest count is much smaller. An `ANCHOR` flag means nothing was mutated at all.
+
+- **the collision reads a per-ROW cardinality again (the both-sides clause restored)** — cardinality-pg.test.ts: ANCHOR: 0 matches; cardinality.test.ts: ANCHOR: 0 matches; correction.test.ts: ANCHOR: 0 matches; brain-facts.test.ts: ANCHOR: 0 matches; reconcile.test.ts: ANCHOR: 0 matches
+- **`cardinalitySingleSql` reads `single` from anywhere in the workspace** — cardinality-pg.test.ts: ANCHOR: 0 matches; cardinality.test.ts: ANCHOR: 0 matches; correction.test.ts: ANCHOR: 0 matches; brain-facts.test.ts: ANCHOR: 0 matches; reconcile.test.ts: ANCHOR: 0 matches

--- a/packages/api/scripts/mutations/cardinality.md
+++ b/packages/api/scripts/mutations/cardinality.md
@@ -17,9 +17,9 @@ Every number is the count of tests that FAIL in that suite under that mutation, 
 
 | Mutation | cardinality-pg.test.ts | cardinality.test.ts | correction.test.ts | brain-facts.test.ts | reconcile.test.ts |
 |---|---|---|---|---|---|
-| the collision reads a per-ROW cardinality again (the both-sides clause restored) | ⚠️ ANCHOR: 0 matches | ⚠️ ANCHOR: 0 matches | ⚠️ ANCHOR: 0 matches | ⚠️ ANCHOR: 0 matches | ⚠️ ANCHOR: 0 matches |
+| the collision reads a per-ROW cardinality again (the both-sides clause restored) | 9 | 0 | 0 | 4 | 0 |
 | `cardinalitySingleSql` stops filtering entries to `approved` | 1 | 1 | 0 | 2 | 0 |
-| `cardinalitySingleSql` reads `single` from anywhere in the workspace | ⚠️ ANCHOR: 0 matches | ⚠️ ANCHOR: 0 matches | ⚠️ ANCHOR: 0 matches | ⚠️ ANCHOR: 0 matches | ⚠️ ANCHOR: 0 matches |
+| `cardinalitySingleSql` reads `single` from anywhere in the workspace | 2 | 1 | 0 | 1 | 0 |
 | the producer path may write `approved` instead of `pending` | 7 | 1 | 1 | 0 | 0 |
 | the producer path accepts a `multi` proposal | 1 | 5 | 0 | 0 | 0 |
 | the rejection memory is dropped (`ON CONFLICT DO NOTHING` → `DO UPDATE`) | 1 | 1 | 1 | 0 | 0 |
@@ -60,10 +60,3 @@ Suite sizes: **cardinality-pg.test.ts** 27 tests (`src/lib/brain/__tests__/cardi
 - **`logDegeneratePredicate` fires for every verb, not only `supersede`** — A `retract` or a vouch would then log *superseded a claim whose predicate normalizes away* about a verb that superseded nothing. The guard is the whole content of the line.
 - **`logDegeneratePredicate`'s call is removed** — The case is legal and permanent (`identityKey`'s ⚠️), produces no proposal, and without this line produces no record either — a supersede that vanished.
 - **the proposer runs INSIDE the correction's transaction** — Stands in for the placement change rather than reproducing it literally (the real one cannot be expressed as a local edit). What it removes is the proposer's access to the committed `supersedes` edge — which is why the placement is post-commit rather than a `SAVEPOINT`.
-
-## ⚠️ Flagged
-
-A `whole-suite` flag means the count reached ~every test in the file. That is usually a mutation that broke SETUP rather than the behaviour under test, and the honest count is much smaller. An `ANCHOR` flag means nothing was mutated at all.
-
-- **the collision reads a per-ROW cardinality again (the both-sides clause restored)** — cardinality-pg.test.ts: ANCHOR: 0 matches; cardinality.test.ts: ANCHOR: 0 matches; correction.test.ts: ANCHOR: 0 matches; brain-facts.test.ts: ANCHOR: 0 matches; reconcile.test.ts: ANCHOR: 0 matches
-- **`cardinalitySingleSql` reads `single` from anywhere in the workspace** — cardinality-pg.test.ts: ANCHOR: 0 matches; cardinality.test.ts: ANCHOR: 0 matches; correction.test.ts: ANCHOR: 0 matches; brain-facts.test.ts: ANCHOR: 0 matches; reconcile.test.ts: ANCHOR: 0 matches

--- a/packages/api/scripts/mutations/cardinality.mutations.ts
+++ b/packages/api/scripts/mutations/cardinality.mutations.ts
@@ -57,7 +57,7 @@ human behind it.
       edits: [
         {
           file: "src/lib/content-mode/adapters/brain-facts.ts",
-          oldString: "  return `${collisionCorePredicate(d, p)}\n     AND ${cardinalitySingleSql(d)}`;",
+          oldString: "  return `${collisionCorePredicate(d, p, exprs)}\n     AND ${exprs.cardinalitySingle(d)}`;",
           newString:
             "  return `${collisionCorePredicate(d, p)}\n     AND ${p}.predicate_cardinality = 'single'\n     AND ${d}.predicate_cardinality = 'single'`;",
         },
@@ -80,7 +80,7 @@ human behind it.
       edits: [
         {
           file: CARDINALITY,
-          oldString: "          AND c.predicate_key = ${alias}.predicate_key\n",
+          oldString: "          AND c.predicate_key = ${predicateKeyExpr}\n",
           newString: "",
         },
       ],

--- a/packages/api/scripts/mutations/identity-corpus.md
+++ b/packages/api/scripts/mutations/identity-corpus.md
@@ -37,10 +37,10 @@ Every number is the count of tests that FAIL in that suite under that mutation, 
 | `TENSION_CANDIDATES_SQL` repointed at the surface columns | 7 | 1 |
 | the tension call site binds raw surfaces | 7 | 1 |
 | `INSERT_TENSION_EDGE_SQL`'s endpoints swapped | 10 | 0 |
-| `supersessionCollisionJoin` repointed at the surface columns | ⚠️ ANCHOR: 0 matches | ⚠️ ANCHOR: 0 matches |
+| `supersessionCollisionJoin` repointed at the surface columns | 1 | 0 |
 | `supersessionCollisionPredicate` back on `object_key <> object_key` | 3 | 0 |
-| `subject_key =` dropped from the collision join | ⚠️ ANCHOR: 0 matches | ⚠️ ANCHOR: 0 matches |
-| `predicate_key =` dropped from the collision join | ⚠️ ANCHOR: 0 matches | ⚠️ ANCHOR: 0 matches |
+| `subject_key =` dropped from the collision join | 1 | 0 |
+| `predicate_key =` dropped from the collision join | 1 | 0 |
 | `comparableDifferentSql` loses its `split_part` tag equality arm | 1 | 0 |
 
 Suite sizes: **identity-consumers-pg.test.ts** 76 tests (`src/lib/brain/__tests__/identity-consumers-pg.test.ts`) · **reconcile.test.ts** 70 tests (`src/lib/brain/__tests__/reconcile.test.ts`).
@@ -65,11 +65,3 @@ Suite sizes: **identity-consumers-pg.test.ts** 76 tests (`src/lib/brain/__tests_
 - **`subject_key =` dropped from the collision join** — ⚠️ A WIDENING, and the direction that costs a stamp: two tiers priced differently would collide. Dies on `subject-differs`, whose objects are money precisely so the OBJECT arm does not block it first.
 - **`predicate_key =` dropped from the collision join** — ⚠️ The same widening one slot over, and the one the repo most needed: the whole supersession section of `promotion-pg.test.ts` runs on a single predicate, so deleting this arm broke no test anywhere before `predicate-differs` existed.
 - **`comparableDifferentSql` loses its `split_part` tag equality arm** — `number:499` and `money:USD:499` are unequal STRINGS that nothing proves are different VALUES. Dies on `cross-type-rival` here, and on `object-cmp-pg.test.ts`'s per-row parity tests at the SQL level.
-
-## ⚠️ Flagged
-
-A `whole-suite` flag means the count reached ~every test in the file. That is usually a mutation that broke SETUP rather than the behaviour under test, and the honest count is much smaller. An `ANCHOR` flag means nothing was mutated at all.
-
-- **`supersessionCollisionJoin` repointed at the surface columns** — identity-consumers-pg.test.ts: ANCHOR: 0 matches; reconcile.test.ts: ANCHOR: 0 matches
-- **`subject_key =` dropped from the collision join** — identity-consumers-pg.test.ts: ANCHOR: 0 matches; reconcile.test.ts: ANCHOR: 0 matches
-- **`predicate_key =` dropped from the collision join** — identity-consumers-pg.test.ts: ANCHOR: 0 matches; reconcile.test.ts: ANCHOR: 0 matches

--- a/packages/api/scripts/mutations/identity-corpus.md
+++ b/packages/api/scripts/mutations/identity-corpus.md
@@ -37,10 +37,10 @@ Every number is the count of tests that FAIL in that suite under that mutation, 
 | `TENSION_CANDIDATES_SQL` repointed at the surface columns | 7 | 1 |
 | the tension call site binds raw surfaces | 7 | 1 |
 | `INSERT_TENSION_EDGE_SQL`'s endpoints swapped | 10 | 0 |
-| `supersessionCollisionJoin` repointed at the surface columns | 1 | 0 |
+| `supersessionCollisionJoin` repointed at the surface columns | ⚠️ ANCHOR: 0 matches | ⚠️ ANCHOR: 0 matches |
 | `supersessionCollisionPredicate` back on `object_key <> object_key` | 3 | 0 |
-| `subject_key =` dropped from the collision join | 1 | 0 |
-| `predicate_key =` dropped from the collision join | 1 | 0 |
+| `subject_key =` dropped from the collision join | ⚠️ ANCHOR: 0 matches | ⚠️ ANCHOR: 0 matches |
+| `predicate_key =` dropped from the collision join | ⚠️ ANCHOR: 0 matches | ⚠️ ANCHOR: 0 matches |
 | `comparableDifferentSql` loses its `split_part` tag equality arm | 1 | 0 |
 
 Suite sizes: **identity-consumers-pg.test.ts** 76 tests (`src/lib/brain/__tests__/identity-consumers-pg.test.ts`) · **reconcile.test.ts** 70 tests (`src/lib/brain/__tests__/reconcile.test.ts`).
@@ -65,3 +65,11 @@ Suite sizes: **identity-consumers-pg.test.ts** 76 tests (`src/lib/brain/__tests_
 - **`subject_key =` dropped from the collision join** — ⚠️ A WIDENING, and the direction that costs a stamp: two tiers priced differently would collide. Dies on `subject-differs`, whose objects are money precisely so the OBJECT arm does not block it first.
 - **`predicate_key =` dropped from the collision join** — ⚠️ The same widening one slot over, and the one the repo most needed: the whole supersession section of `promotion-pg.test.ts` runs on a single predicate, so deleting this arm broke no test anywhere before `predicate-differs` existed.
 - **`comparableDifferentSql` loses its `split_part` tag equality arm** — `number:499` and `money:USD:499` are unequal STRINGS that nothing proves are different VALUES. Dies on `cross-type-rival` here, and on `object-cmp-pg.test.ts`'s per-row parity tests at the SQL level.
+
+## ⚠️ Flagged
+
+A `whole-suite` flag means the count reached ~every test in the file. That is usually a mutation that broke SETUP rather than the behaviour under test, and the honest count is much smaller. An `ANCHOR` flag means nothing was mutated at all.
+
+- **`supersessionCollisionJoin` repointed at the surface columns** — identity-consumers-pg.test.ts: ANCHOR: 0 matches; reconcile.test.ts: ANCHOR: 0 matches
+- **`subject_key =` dropped from the collision join** — identity-consumers-pg.test.ts: ANCHOR: 0 matches; reconcile.test.ts: ANCHOR: 0 matches
+- **`predicate_key =` dropped from the collision join** — identity-consumers-pg.test.ts: ANCHOR: 0 matches; reconcile.test.ts: ANCHOR: 0 matches

--- a/packages/api/scripts/mutations/identity-corpus.mutations.ts
+++ b/packages/api/scripts/mutations/identity-corpus.mutations.ts
@@ -255,8 +255,10 @@ else, so a row non-zero there is one a default local run still catches.
       edits: [
         {
           file: ADAPTER,
+          // Re-anchored: #5086 parameterised the slots through `CollisionExprs`,
+          // so the join no longer names the key columns literally.
           oldString:
-            "  return `${p}.workspace_id = ${d}.workspace_id\n     AND ${p}.subject_key = ${d}.subject_key\n     AND ${p}.predicate_key = ${d}.predicate_key",
+            "  return `${p}.workspace_id = ${d}.workspace_id\n     AND ${exprs.subjectSlot(p)} = ${exprs.subjectSlot(d)}\n     AND ${exprs.predicateSlot(p)} = ${exprs.predicateSlot(d)}",
           newString:
             "  return `${p}.workspace_id = ${d}.workspace_id\n     AND ${p}.subject = ${d}.subject\n     AND ${p}.predicate = ${d}.predicate",
         },
@@ -279,7 +281,7 @@ else, so a row non-zero there is one a default local run still catches.
       edits: [
         {
           file: ADAPTER,
-          oldString: "     AND ${p}.subject_key = ${d}.subject_key\n",
+          oldString: "     AND ${exprs.subjectSlot(p)} = ${exprs.subjectSlot(d)}\n",
           newString: "",
         },
       ],
@@ -290,7 +292,7 @@ else, so a row non-zero there is one a default local run still catches.
       edits: [
         {
           file: ADAPTER,
-          oldString: "     AND ${p}.predicate_key = ${d}.predicate_key\n",
+          oldString: "     AND ${exprs.predicateSlot(p)} = ${exprs.predicateSlot(d)}\n",
           newString: "",
         },
       ],

--- a/packages/api/scripts/mutations/mutation-core.md
+++ b/packages/api/scripts/mutations/mutation-core.md
@@ -18,7 +18,7 @@ Every number is the count of tests that FAIL in that suite under that mutation, 
 | the anchor check is removed entirely | 4 |
 | `applyMutation` snapshots lazily instead of before any write | 2 |
 | `restoreAll` forgets to clear the backup map | 2 |
-| `parseBunSummary` reports `0 fail` for a suite that never ran | ⚠️ ANCHOR: 0 matches |
+| `parseBunSummary` reports `0 fail` for a suite that never ran | 2 |
 | `parseBunSummary` stops anchoring the count to a line start | 1 |
 | `parseBunSummary` stops anchoring the PASS count to a line start | 1 |
 | `isWholeSuite` only fires on an exact total (`>=` ratio → `>= total`) | 1 |
@@ -33,7 +33,7 @@ Every number is the count of tests that FAIL in that suite under that mutation, 
 | `render` drops the DO-NOT-EDIT header | 1 |
 | `render` drops the suite-size line | 1 |
 
-Suite sizes: **mutate-core.test.ts** 46 tests (`src/__tests__/mutate-core.test.ts`).
+Suite sizes: **mutate-core.test.ts** 58 tests (`src/__tests__/mutate-core.test.ts`).
 
 ## Notes
 
@@ -53,5 +53,4 @@ Suite sizes: **mutate-core.test.ts** 46 tests (`src/__tests__/mutate-core.test.t
 
 A `whole-suite` flag means the count reached ~every test in the file. That is usually a mutation that broke SETUP rather than the behaviour under test, and the honest count is much smaller. An `ANCHOR` flag means nothing was mutated at all.
 
-- **`parseBunSummary` reports `0 fail` for a suite that never ran** — mutate-core.test.ts: ANCHOR: 0 matches
 - **`countOccurrences` loops forever on an empty needle (guard removed)** — mutate-core.test.ts: timed out after 30s — the mutation HANGS the suite rather than failing it

--- a/packages/api/scripts/mutations/mutation-core.md
+++ b/packages/api/scripts/mutations/mutation-core.md
@@ -33,7 +33,7 @@ Every number is the count of tests that FAIL in that suite under that mutation, 
 | `render` drops the DO-NOT-EDIT header | 1 |
 | `render` drops the suite-size line | 1 |
 
-Suite sizes: **mutate-core.test.ts** 58 tests (`src/__tests__/mutate-core.test.ts`).
+Suite sizes: **mutate-core.test.ts** 59 tests (`src/__tests__/mutate-core.test.ts`).
 
 ## Notes
 

--- a/packages/api/scripts/mutations/mutation-core.md
+++ b/packages/api/scripts/mutations/mutation-core.md
@@ -18,7 +18,7 @@ Every number is the count of tests that FAIL in that suite under that mutation, 
 | the anchor check is removed entirely | 4 |
 | `applyMutation` snapshots lazily instead of before any write | 2 |
 | `restoreAll` forgets to clear the backup map | 2 |
-| `parseBunSummary` reports `0 fail` for a suite that never ran | 2 |
+| `parseBunSummary` reports `0 fail` for a suite that never ran | ⚠️ ANCHOR: 0 matches |
 | `parseBunSummary` stops anchoring the count to a line start | 1 |
 | `parseBunSummary` stops anchoring the PASS count to a line start | 1 |
 | `isWholeSuite` only fires on an exact total (`>=` ratio → `>= total`) | 1 |
@@ -28,12 +28,12 @@ Every number is the count of tests that FAIL in that suite under that mutation, 
 | `countOccurrences` loops forever on an empty needle (guard removed) | ⚠️ timed out after 30s — the mutation HANGS the suite rather than failing it |
 | an errored cell renders as its `fail` number instead of a warning | 2 |
 | `render` defaults an unmeasured cell to `0` instead of a dash | 1 |
-| `escapeCell` stops escaping `\|` | 1 |
+| `escapeCell` stops escaping `\|` | 2 |
 | `render` stamps the output with a date (determinism lost) | 1 |
 | `render` drops the DO-NOT-EDIT header | 1 |
 | `render` drops the suite-size line | 1 |
 
-Suite sizes: **mutate-core.test.ts** 41 tests (`src/__tests__/mutate-core.test.ts`).
+Suite sizes: **mutate-core.test.ts** 46 tests (`src/__tests__/mutate-core.test.ts`).
 
 ## Notes
 
@@ -53,4 +53,5 @@ Suite sizes: **mutate-core.test.ts** 41 tests (`src/__tests__/mutate-core.test.t
 
 A `whole-suite` flag means the count reached ~every test in the file. That is usually a mutation that broke SETUP rather than the behaviour under test, and the honest count is much smaller. An `ANCHOR` flag means nothing was mutated at all.
 
+- **`parseBunSummary` reports `0 fail` for a suite that never ran** — mutate-core.test.ts: ANCHOR: 0 matches
 - **`countOccurrences` loops forever on an empty needle (guard removed)** — mutate-core.test.ts: timed out after 30s — the mutation HANGS the suite rather than failing it

--- a/packages/api/scripts/mutations/mutation-core.mutations.ts
+++ b/packages/api/scripts/mutations/mutation-core.mutations.ts
@@ -79,12 +79,8 @@ it, and that header is exactly what stops a reviewer looking closer.
       edits: [
         {
           file: SOURCE,
-          oldString: `    return {
-      pass: 0,
-      fail: 0,
-      error: firstError ?? "bun printed no pass/fail summary (compile or import error)",
-    };`,
-          newString: `    return { pass: 0, fail: 0 };`,
+          oldString: "    return {\n      pass: 0,\n      fail: 0,\n      skip: 0,\n      todo: 0,\n      ran: null,\n      error: firstError ?? \"bun printed no pass/fail summary (compile or import error)\",\n    };",
+          newString: `    return { pass: 0, fail: 0, skip: 0, todo: 0, ran: null };`,
         },
       ],
       note: "The single most misleading cell the table can contain: a compile error rendered as *the suite does not catch this mutation*.",

--- a/packages/api/scripts/mutations/mutation-core.mutations.ts
+++ b/packages/api/scripts/mutations/mutation-core.mutations.ts
@@ -191,7 +191,7 @@ it, and that header is exactly what stops a reviewer looking closer.
       edits: [
         {
           file: SOURCE,
-          oldString: '  return text.replace(/\\|/g, "\\\\|");',
+          oldString: "  return text.replace(/\\\\?\\|/g, (match) => (match.startsWith(\"\\\\\") ? \"\\\\\\\\\\\\|\" : \"\\\\|\"));",
           newString: "  return text;",
         },
       ],

--- a/packages/api/scripts/mutations/object-cmp.md
+++ b/packages/api/scripts/mutations/object-cmp.md
@@ -15,12 +15,12 @@ Every number is the count of tests that FAIL in that suite under that mutation, 
 
 | Mutation | object-cmp.test.ts |
 |---|---|
-| `DECIMAL_RE` loses its anchors (`^…$`) | 22 |
+| `DECIMAL_RE` loses its anchors (`^…$`) | 23 |
 | `parseSurface` returns `{tag:"number", payload: trimmed}` for any unmatched surface — the raw-surface collapse | 13 |
 | `canonicalCurrency` loses its upper-case fold | 4 |
-| `canonicalCurrency` drops the `ISO_4217` membership test (back to any three letters) | 4 |
+| `canonicalCurrency` drops the `ISO_4217` membership test (back to any three letters) | 5 |
 | `canonicalInstant` loses its calendar round-trip | 2 |
-| `canonicalDate` loses its calendar round-trip | 2 |
+| `canonicalDate` loses its calendar round-trip | 4 |
 | `canonicalDecimal` loses its trailing-zero trim | 2 |
 | a declaration OVERRIDES the surface instead of narrowing it | 4 |
 | `comparableValueWithReason` collapses `declaration-rejected` into `abstained` | 3 |
@@ -32,7 +32,7 @@ Every number is the count of tests that FAIL in that suite under that mutation, 
 | `comparableDifferentSql` loses its known-tag `IN` arm | 0 |
 | `comparableDifferentSql` loses its `strpos(…) > 0` separator arms | 0 |
 
-Suite sizes: **object-cmp.test.ts** 59 tests (`src/lib/brain/__tests__/object-cmp.test.ts`).
+Suite sizes: **object-cmp.test.ts** 64 tests (`src/lib/brain/__tests__/object-cmp.test.ts`).
 
 ## Notes
 

--- a/packages/api/src/__tests__/mutate-core.test.ts
+++ b/packages/api/src/__tests__/mutate-core.test.ts
@@ -305,20 +305,20 @@ describe("⚠️ baselineProblem — every way a baseline can lie (#5077)", () =
   });
 
   test("RED — the inflation case, which was the only one guarded before", () => {
-    expect(baselineProblem({ ...ok, fail: 3, ran: 67 })).toContain("RED");
+    expect(baselineProblem({ ...ok, fail: 3, ran: 67 })).toMatchObject({ kind: "red" });
   });
 
   test("EMPTY — zero tests is not a baseline", () => {
     // Reachable by renaming or emptying a target file, or by a rotted
     // `target.file` path. Every cell would then render an honest-looking 0
     // meaning "the suite does not catch this".
-    expect(baselineProblem({ ...ok, pass: 0, ran: 0 })).toContain("ZERO");
+    expect(baselineProblem({ ...ok, pass: 0, ran: 0 })).toMatchObject({ kind: "empty" });
   });
 
   test("SKIPPED — #5077's own case", () => {
     const problem = baselineProblem({ pass: 6, fail: 0, skip: 72, todo: 0, ran: 78 });
-    expect(problem).toContain("SKIPPED 72");
-    expect(problem).toContain("deflated");
+    expect(problem?.kind).toBe("deflated");
+    expect(problem?.message).toContain("SKIPPED 72");
   });
 
   test("⚠️ TODO — bun does not fold it into skip, and the first cut missed it", () => {
@@ -327,8 +327,8 @@ describe("⚠️ baselineProblem — every way a baseline can lie (#5077)", () =
     // todo published as 1 test, every cell deflated, guard silent — while the
     // guard's own comment claimed `.todo` was covered.
     const problem = baselineProblem({ pass: 1, fail: 0, skip: 0, todo: 1, ran: 2 });
-    expect(problem).not.toBeNull();
-    expect(problem).toContain("TODO");
+    expect(problem?.kind).toBe("deflated");
+    expect(problem?.message).toContain("TODO");
   });
 
   test("UNACCOUNTED — a bucket bun invents tomorrow is caught without naming it", () => {
@@ -336,13 +336,27 @@ describe("⚠️ baselineProblem — every way a baseline can lie (#5077)", () =
     // `Ran N` rather than enumerating buckets. `filtered out` is a fourth one
     // that already exists; this arm closes it and every future sibling.
     const problem = baselineProblem({ pass: 5, fail: 0, skip: 0, todo: 0, ran: 9 });
-    expect(problem).toContain("4 unclassified");
+    expect(problem?.kind).toBe("unaccounted");
+    expect(problem?.message).toContain("4 unclassified");
+  });
+
+  test("⚠️ RED and DEFLATED are different KINDS, so only one gets the -pg hint", () => {
+    // The caller prints "find the .skip/.todo in the target" for a deflated
+    // baseline. Appended to a RED one it sends an operator hunting a skip that
+    // does not exist — measured when a dead Postgres made two suites RED and
+    // the runner blamed a skip. The kind is what keeps the two apart.
+    expect(baselineProblem({ pass: 0, fail: 2, skip: 0, todo: 0, ran: 2 })?.kind).toBe("red");
+    expect(baselineProblem({ pass: 1, fail: 0, skip: 1, todo: 0, ran: 2 })?.kind).toBe("deflated");
+    // …and an unreadable suite is neither.
+    expect(baselineProblem({ pass: 0, fail: 0, skip: 0, todo: 0, ran: null, error: "boom" })?.kind).toBe(
+      "errored",
+    );
   });
 
   test("the accounting arm fires BEFORE the skip arm, so the message names the real gap", () => {
     // Both are true here. The unaccounted one is the more general statement and
     // must win, or an operator reads "SKIPPED 1" and misses the other three.
-    expect(baselineProblem({ pass: 1, fail: 0, skip: 1, todo: 0, ran: 5 })).toContain("unclassified");
+    expect(baselineProblem({ pass: 1, fail: 0, skip: 1, todo: 0, ran: 5 })?.kind).toBe("unaccounted");
   });
 });
 

--- a/packages/api/src/__tests__/mutate-core.test.ts
+++ b/packages/api/src/__tests__/mutate-core.test.ts
@@ -308,6 +308,20 @@ describe("⚠️ baselineProblem — every way a baseline can lie (#5077)", () =
     expect(baselineProblem({ ...ok, fail: 3, ran: 67 })).toMatchObject({ kind: "red" });
   });
 
+  test("⚠️ a -pg suite with NO non-pg tests is DEFLATED, not EMPTY", () => {
+    // The falsifier that was missing, and the reason the defect survived: the
+    // EMPTY test below uses `ran: 0`, the single input where arm order cannot
+    // matter. THREE OF FIVE `-pg` targets look like this with Postgres down —
+    // `cardinality-pg` reports 0 pass / 29 skip — and while `pass === 0` was
+    // checked first they were told to "check the target's path" instead of to
+    // start Postgres. Only the deflation kinds carry that hint.
+    expect(baselineProblem({ pass: 0, fail: 0, skip: 29, todo: 0, ran: 29 })?.kind).toBe("deflated");
+    // …and a suite claiming zero pass while `Ran N` proves 78 were discovered
+    // is UNACCOUNTED: the message must not say "ran ZERO tests" over data that
+    // contradicts it.
+    expect(baselineProblem({ pass: 0, fail: 0, skip: 0, todo: 0, ran: 78 })?.kind).toBe("unaccounted");
+  });
+
   test("EMPTY — zero tests is not a baseline", () => {
     // Reachable by renaming or emptying a target file, or by a rotted
     // `target.file` path. Every cell would then render an honest-looking 0

--- a/packages/api/src/__tests__/mutate-core.test.ts
+++ b/packages/api/src/__tests__/mutate-core.test.ts
@@ -209,8 +209,8 @@ describe("restore", () => {
 
 describe("parseBunSummary", () => {
   test("reads the summary block", () => {
-    expect(parseBunSummary("\n 58 pass\n 0 fail\n 200 expect() calls\n")).toEqual({ pass: 58, fail: 0 });
-    expect(parseBunSummary("\n 55 pass\n 3 fail\n")).toEqual({ pass: 55, fail: 3 });
+    expect(parseBunSummary("\n 58 pass\n 0 fail\n 200 expect() calls\n")).toEqual({ pass: 58, fail: 0, skip: 0 });
+    expect(parseBunSummary("\n 55 pass\n 3 fail\n")).toEqual({ pass: 55, fail: 3, skip: 0 });
   });
 
   test("a count EARLIER in the output cannot be mistaken for the summary", () => {
@@ -224,12 +224,12 @@ describe("parseBunSummary", () => {
       " 56 pass",
       " 2 fail",
     ].join("\n");
-    expect(parseBunSummary(output)).toEqual({ pass: 56, fail: 2 });
+    expect(parseBunSummary(output)).toEqual({ pass: 56, fail: 2, skip: 0 });
   });
 
   test("a pass count mid-line is likewise not mistaken for the summary", () => {
     const output = ["(fail) mutate > reports 9 pass rows", " 56 pass", " 2 fail"].join("\n");
-    expect(parseBunSummary(output)).toEqual({ pass: 56, fail: 2 });
+    expect(parseBunSummary(output)).toEqual({ pass: 56, fail: 2, skip: 0 });
   });
 
   test("a suite that never ran reports an ERROR, not `0 fail`", () => {
@@ -243,6 +243,49 @@ describe("parseBunSummary", () => {
 
   test("empty output reports an error rather than silently passing", () => {
     expect(parseBunSummary("").error).toBeDefined();
+  });
+
+  // ⚠️ The skip count is the signal behind `mutate.ts`'s guardrail 4 (#5077).
+  // Without it the runner accepted a self-skipped `-pg` suite as a green
+  // baseline and regenerated a whole column as zeros over real numbers.
+  test("reads the SKIP count — a skipped test cannot be killed by a mutation", () => {
+    // bun's real summary for `identity-consumers-pg.test.ts` with no
+    // TEST_DATABASE_URL: the exact shape that caused #5077.
+    expect(parseBunSummary("\n 6 pass\n 72 skip\n 0 fail\n 49 expect() calls\n")).toEqual({
+      pass: 6,
+      fail: 0,
+      skip: 72,
+    });
+  });
+
+  test("⚠️ the deflated baseline is 6 pass, NOT 0 — `pass > 0` would not catch it", () => {
+    // The correction to #5077's own diagnosis, and the reason the guard reads
+    // `skip` rather than `pass`. That file carries six non-`-pg` tests, so a
+    // suite whose 72 real tests all vanished still reports a positive pass count
+    // and a zero fail count — indistinguishable from health by every signal the
+    // runner had before this.
+    const deflated = parseBunSummary("\n 6 pass\n 72 skip\n 0 fail\n");
+    expect(deflated.pass).toBeGreaterThan(0);
+    expect(deflated.fail).toBe(0);
+    // …so the ONLY thing separating it from a healthy run is this:
+    expect(deflated.skip).toBeGreaterThan(0);
+  });
+
+  test("a healthy run reports skip 0 — an absent line is not an absent verdict", () => {
+    // bun omits the skip line entirely when nothing skipped, so it must default
+    // rather than fail the parse the way a missing pass/fail line does. Without
+    // this the guard would refuse every healthy suite and get reverted within a
+    // day.
+    expect(parseBunSummary("\n 64 pass\n 0 fail\n").skip).toBe(0);
+  });
+
+  test("a skip count mid-line is not mistaken for the summary either", () => {
+    // The anchoring the pass/fail arms already have, extended to the new one: a
+    // test whose NAME contains `12 skip` must not become the summary.
+    const output = ["(fail) mutate > reports 12 skip rows", " 56 pass", " 3 skip", " 2 fail"].join(
+      "\n",
+    );
+    expect(parseBunSummary(output)).toEqual({ pass: 56, fail: 2, skip: 3 });
   });
 });
 

--- a/packages/api/src/__tests__/mutate-core.test.ts
+++ b/packages/api/src/__tests__/mutate-core.test.ts
@@ -18,7 +18,9 @@
 import { describe, expect, test } from "bun:test";
 import {
   AnchorError,
+  anchorFailures,
   applyMutation,
+  baselineProblem,
   countOccurrences,
   escapeCell,
   isWholeSuite,
@@ -209,8 +211,8 @@ describe("restore", () => {
 
 describe("parseBunSummary", () => {
   test("reads the summary block", () => {
-    expect(parseBunSummary("\n 58 pass\n 0 fail\n 200 expect() calls\n")).toEqual({ pass: 58, fail: 0, skip: 0 });
-    expect(parseBunSummary("\n 55 pass\n 3 fail\n")).toEqual({ pass: 55, fail: 3, skip: 0 });
+    expect(parseBunSummary("\n 58 pass\n 0 fail\n 200 expect() calls\n")).toEqual({ pass: 58, fail: 0, skip: 0, todo: 0, ran: null });
+    expect(parseBunSummary("\n 55 pass\n 3 fail\n")).toEqual({ pass: 55, fail: 3, skip: 0, todo: 0, ran: null });
   });
 
   test("a count EARLIER in the output cannot be mistaken for the summary", () => {
@@ -224,12 +226,12 @@ describe("parseBunSummary", () => {
       " 56 pass",
       " 2 fail",
     ].join("\n");
-    expect(parseBunSummary(output)).toEqual({ pass: 56, fail: 2, skip: 0 });
+    expect(parseBunSummary(output)).toEqual({ pass: 56, fail: 2, skip: 0, todo: 0, ran: null });
   });
 
   test("a pass count mid-line is likewise not mistaken for the summary", () => {
     const output = ["(fail) mutate > reports 9 pass rows", " 56 pass", " 2 fail"].join("\n");
-    expect(parseBunSummary(output)).toEqual({ pass: 56, fail: 2, skip: 0 });
+    expect(parseBunSummary(output)).toEqual({ pass: 56, fail: 2, skip: 0, todo: 0, ran: null });
   });
 
   test("a suite that never ran reports an ERROR, not `0 fail`", () => {
@@ -255,6 +257,8 @@ describe("parseBunSummary", () => {
       pass: 6,
       fail: 0,
       skip: 72,
+      todo: 0,
+      ran: null,
     });
   });
 
@@ -285,7 +289,90 @@ describe("parseBunSummary", () => {
     const output = ["(fail) mutate > reports 12 skip rows", " 56 pass", " 3 skip", " 2 fail"].join(
       "\n",
     );
-    expect(parseBunSummary(output)).toEqual({ pass: 56, fail: 2, skip: 3 });
+    expect(parseBunSummary(output)).toEqual({ pass: 56, fail: 2, skip: 3, todo: 0, ran: null });
+  });
+});
+
+describe("⚠️ baselineProblem — every way a baseline can lie (#5077)", () => {
+  const ok = { pass: 64, fail: 0, skip: 0, todo: 0, ran: 64 };
+
+  test("POSITIVE CONTROL: a clean baseline has no problem", () => {
+    // A refusal test alone is satisfied by a function that refuses everything.
+    expect(baselineProblem(ok)).toBeNull();
+    // …and a suite with no `Ran N` line at all is still acceptable: the
+    // accounting arm is a cross-check, not a requirement.
+    expect(baselineProblem({ ...ok, ran: null })).toBeNull();
+  });
+
+  test("RED — the inflation case, which was the only one guarded before", () => {
+    expect(baselineProblem({ ...ok, fail: 3, ran: 67 })).toContain("RED");
+  });
+
+  test("EMPTY — zero tests is not a baseline", () => {
+    // Reachable by renaming or emptying a target file, or by a rotted
+    // `target.file` path. Every cell would then render an honest-looking 0
+    // meaning "the suite does not catch this".
+    expect(baselineProblem({ ...ok, pass: 0, ran: 0 })).toContain("ZERO");
+  });
+
+  test("SKIPPED — #5077's own case", () => {
+    const problem = baselineProblem({ pass: 6, fail: 0, skip: 72, todo: 0, ran: 78 });
+    expect(problem).toContain("SKIPPED 72");
+    expect(problem).toContain("deflated");
+  });
+
+  test("⚠️ TODO — bun does not fold it into skip, and the first cut missed it", () => {
+    // A `test.todo` does not run even WITH a body, so it deflates the
+    // denominator exactly like a `.skip`. Measured: a 2-test file with one
+    // todo published as 1 test, every cell deflated, guard silent — while the
+    // guard's own comment claimed `.todo` was covered.
+    const problem = baselineProblem({ pass: 1, fail: 0, skip: 0, todo: 1, ran: 2 });
+    expect(problem).not.toBeNull();
+    expect(problem).toContain("TODO");
+  });
+
+  test("UNACCOUNTED — a bucket bun invents tomorrow is caught without naming it", () => {
+    // The general form, and the reason the guard cross-checks the SUM against
+    // `Ran N` rather than enumerating buckets. `filtered out` is a fourth one
+    // that already exists; this arm closes it and every future sibling.
+    const problem = baselineProblem({ pass: 5, fail: 0, skip: 0, todo: 0, ran: 9 });
+    expect(problem).toContain("4 unclassified");
+  });
+
+  test("the accounting arm fires BEFORE the skip arm, so the message names the real gap", () => {
+    // Both are true here. The unaccounted one is the more general statement and
+    // must win, or an operator reads "SKIPPED 1" and misses the other three.
+    expect(baselineProblem({ pass: 1, fail: 0, skip: 1, todo: 0, ran: 5 })).toContain("unclassified");
+  });
+});
+
+describe("⚠️ anchorFailures — a dead anchor must never become a committed byte", () => {
+  const count = (fail: number): Cell => ({ kind: "count", fail });
+  const anchor = (): Cell => ({ kind: "error", fail: 0, flag: "ANCHOR: 0 matches", anchorFailed: true });
+  const timeout = (): Cell => ({ kind: "error", fail: 0, flag: "timed out after 30s" });
+
+  test("POSITIVE CONTROL: a table of real counts reports nothing", () => {
+    expect(anchorFailures(new Map([["m1", new Map([["t", count(3)]])]]))).toEqual([]);
+  });
+
+  test("names the mutation whose anchor rotted", () => {
+    const rows = new Map([
+      ["healthy", new Map([["t", count(3)]])],
+      ["rotted", new Map([["t", anchor()]])],
+    ]);
+    expect(anchorFailures(rows)).toEqual(["rotted"]);
+  });
+
+  test("⚠️ a TIMEOUT is not an anchor failure — that is a real measurement", () => {
+    // The distinction a substring match on the flag could not draw, and the
+    // reason `anchorFailed` is its own field rather than prose. A hang is a
+    // genuine result about a genuine mutation; a dead anchor measured nothing.
+    expect(anchorFailures(new Map([["slow", new Map([["t", timeout()]])]]))).toEqual([]);
+  });
+
+  test("reports each mutation once even when several targets rotted", () => {
+    const rows = new Map([["rotted", new Map([["a", anchor()], ["b", anchor()]])]]);
+    expect(anchorFailures(rows)).toEqual(["rotted"]);
   });
 });
 

--- a/scripts/__tests__/check-mutation-tables.test.sh
+++ b/scripts/__tests__/check-mutation-tables.test.sh
@@ -14,11 +14,17 @@
 # Locks in, in the order they would hurt:
 #   1. a hand-edited generated table is CAUGHT             (the #5060 threat model)
 #   2. a target carrying `.skip` is REFUSED                (guardrail 4, #5077)
-#   3. a target carrying `.todo` is REFUSED                (bun's other bucket)
-#   4. a DEAD ANCHOR is refused, not rendered as a byte    (the tombstone trap)
-#   5. an unresolvable base WIDENS rather than passing     (the fail-safe)
-#   6. TEST_DATABASE_URL unset exits 3, not 0              (SKIP, never PASS)
-#   7. POSITIVE CONTROL: a current table passes            (or the above is vacuous)
+#   3. an unresolvable base WIDENS rather than passing     (the fail-safe)
+#   4. TEST_DATABASE_URL unset exits 3, not 0              (SKIP, never PASS)
+#   5. POSITIVE CONTROL: a current table passes            (or the above is vacuous)
+#
+# ⚠️ EVERY fixture here was proven sensitive by DELETING the guard it pins and
+# confirming it goes red. Two more (`.todo` refused, dead anchor refused) were
+# written, measured VACUOUS — their trees generate no table, so `--check` exits
+# 1 with "is stale" whether or not the guard exists — and REMOVED rather than
+# shipped green. They need a tree carrying a committed tombstone, and
+# `check()` needs to assert on a discriminating phrase rather than on an exit
+# code five failure modes share. Tracked in the #5077 follow-up.
 
 set -euo pipefail
 
@@ -128,18 +134,6 @@ test.skip("b", () => { expect(answer()).toBe(42); });'
 T=$(make_tree "$SKIP_TARGET" '"  return 42;"' \
    'bun run scripts/mutate.ts scripts/mutations/f.mutations.ts >/dev/null 2>&1 || true')
 check 1 "a target carrying .skip is REFUSED" "$T" --all
-
-TODO_TARGET='import { expect, test } from "bun:test";
-import { answer } from "./subject";
-test("a", () => { expect(answer()).toBe(42); });
-test.todo("b", () => { expect(answer()).toBe(42); });'
-T=$(make_tree "$TODO_TARGET" '"  return 42;"' 'true')
-check 1 "a target carrying .todo is REFUSED (bun's other bucket)" "$T" --all
-
-# 4. The tombstone trap: a dead anchor must be refused, never rendered as a
-# stable byte that --check then blesses forever.
-T=$(make_tree "$GOOD_TARGET" '"  return 12345;"' 'true')
-check 1 "a DEAD ANCHOR is refused rather than written as a cell" "$T" --all
 
 # 5. The fail-safe. An unresolvable base must WIDEN to --all (and then catch the
 # hand-edit), never quietly select nothing and exit 0.

--- a/scripts/__tests__/check-mutation-tables.test.sh
+++ b/scripts/__tests__/check-mutation-tables.test.sh
@@ -1,0 +1,163 @@
+#!/bin/bash
+# Adversarial fixture suite for scripts/check-mutation-tables.sh (#5077).
+#
+# The gate's whole value is a NEGATIVE — "it does not silently verify nothing" —
+# and every one of its false-clean paths is reachable only under conditions
+# nobody hits by accident: an unresolvable base ref, an empty selection, a
+# dependency the selector cannot see. None of that is exercised by running the
+# gate against the real repo, where the honest answer takes 14 minutes.
+#
+# So each fixture builds a throwaway packages/api tree with ONE two-test target
+# and ONE spec, points the gate at it via MUTATION_SPEC_GLOB, and runs the real
+# script end to end — the real `mutate.ts`, the real git plumbing, no mocks.
+#
+# Locks in, in the order they would hurt:
+#   1. a hand-edited generated table is CAUGHT             (the #5060 threat model)
+#   2. a target carrying `.skip` is REFUSED                (guardrail 4, #5077)
+#   3. a target carrying `.todo` is REFUSED                (bun's other bucket)
+#   4. a DEAD ANCHOR is refused, not rendered as a byte    (the tombstone trap)
+#   5. an unresolvable base WIDENS rather than passing     (the fail-safe)
+#   6. TEST_DATABASE_URL unset exits 3, not 0              (SKIP, never PASS)
+#   7. POSITIVE CONTROL: a current table passes            (or the above is vacuous)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SCRIPT="$SCRIPT_DIR/check-mutation-tables.sh"
+
+if [ ! -f "$SCRIPT" ]; then
+  echo "::error::script under test not found at $SCRIPT" >&2
+  exit 2
+fi
+
+PASS=0
+FAIL=0
+
+# A throwaway packages/api containing a real runnable target + spec.
+#   $1 target body   $2 the mutation's oldString   $3 extra setup run in the api dir
+make_tree() {
+  local target_body="$1" old_string="$2" extra="${3:-}"
+  local tmp; tmp="$(mktemp -d)"
+  mkdir -p "$tmp/packages/api/scripts/mutations" "$tmp/packages/api/src"
+  # ⚠️ COPY the runner, never symlink it. `mutate.ts` derives its ROOT from
+  # `import.meta.dir`, which resolves THROUGH a symlink back to the real
+  # packages/api — so a symlinked runner looks for the fixture spec in the real
+  # tree, fails to load it, and every fixture below then "fails" for the wrong
+  # reason. Measured: six of seven fixtures passed green while asserting
+  # nothing but `Cannot find module`. An assertion that cannot fail is not an
+  # assertion, and this comment is here because the first cut of this file was
+  # exactly that.
+  cp "$REPO_ROOT/packages/api/scripts/mutate.ts"        "$tmp/packages/api/scripts/"
+  cp "$REPO_ROOT/packages/api/scripts/mutation-core.ts" "$tmp/packages/api/scripts/"
+  cp "$REPO_ROOT/packages/api/scripts/mutation-spec.ts" "$tmp/packages/api/scripts/"
+  cp "$REPO_ROOT/packages/api/scripts/signal-retry.ts"  "$tmp/packages/api/scripts/"
+  ln -s "$REPO_ROOT/node_modules"                       "$tmp/node_modules"
+  mkdir -p "$tmp/scripts"
+  cp "$SCRIPT" "$tmp/scripts/check-mutation-tables.sh"
+
+  cat >"$tmp/packages/api/src/subject.ts" <<'TS'
+export function answer(): number {
+  return 42;
+}
+TS
+  printf '%s\n' "$target_body" >"$tmp/packages/api/src/subject.test.ts"
+
+  cat >"$tmp/packages/api/scripts/mutations/f.mutations.ts" <<SPEC
+import type { MutationSpec } from "../mutation-spec";
+const spec: MutationSpec = {
+  title: "fixture",
+  out: "scripts/mutations/f.md",
+  targets: [{ name: "subject", file: "src/subject.test.ts" }],
+  mutations: [
+    { label: "answer returns the wrong number", edits: [{ file: "src/subject.ts", oldString: ${old_string}, newString: "  return 0;" }] },
+  ],
+};
+export default spec;
+SPEC
+
+  ( cd "$tmp" && git init --quiet -b main && git config user.email t@t.t && git config user.name t \
+      && git add -A >/dev/null && git commit --quiet -m base )
+  if [ -n "$extra" ]; then ( cd "$tmp/packages/api" && eval "$extra" ); fi
+  echo "$tmp"
+}
+
+# ⚠️ THREE tests, only two of which depend on `answer()`. With 2-of-2 the
+# mutation takes the WHOLE suite, `isWholeSuite` flags it, and the cell renders
+# `2 ⚠️` rather than `2` — so the hand-edit fixtures below silently sed nothing
+# and pass while asserting nothing. 2-of-3 stays under the ratio.
+GOOD_TARGET='import { expect, test } from "bun:test";
+import { answer } from "./subject";
+test("a", () => { expect(answer()).toBe(42); });
+test("b", () => { expect(answer()).toBe(42); });
+test("c", () => { expect(1).toBe(1); });'
+
+check() { # check EXPECTED_EXIT NAME TREE [ARGS...]
+  local expected="$1" name="$2" tmp="$3"; shift 3
+  local rc=0 out
+  out=$( cd "$tmp" && TEST_DATABASE_URL="${TEST_DATABASE_URL:-x}" \
+         MUTATION_SPEC_GLOB="scripts/mutations/f.mutations.ts" \
+         bash scripts/check-mutation-tables.sh "$@" 2>&1 ) || rc=$?
+  if [ "$rc" = "$expected" ]; then
+    echo "  ok    $name (exit $rc)"; PASS=$((PASS + 1))
+  else
+    echo "  FAIL  $name — expected exit $expected, got $rc"; echo "$out" | sed 's/^/        /' | tail -12
+    FAIL=$((FAIL + 1))
+  fi
+  rm -rf "$tmp"
+}
+
+echo ":: check-mutation-tables.sh adversarial fixtures"
+
+# 7. POSITIVE CONTROL first — everything below is vacuous without it.
+T=$(make_tree "$GOOD_TARGET" '"  return 42;"' \
+   'bun run scripts/mutate.ts scripts/mutations/f.mutations.ts >/dev/null 2>&1')
+check 0 "POSITIVE CONTROL — a freshly generated table passes" "$T" --all
+
+# 1. The #5060 threat model: a hand-edited number.
+T=$(make_tree "$GOOD_TARGET" '"  return 42;"' \
+   'bun run scripts/mutate.ts scripts/mutations/f.mutations.ts >/dev/null 2>&1; grep -q "| 2 |" scripts/mutations/f.md && sed -i "s/| 2 |/| 99 |/" scripts/mutations/f.md')
+check 1 "a hand-edited generated table is caught" "$T" --all
+
+# 2 + 3. Guardrail 4, both buckets. A skipped/todo test cannot be killed, so the
+# count deflates — and bun does NOT fold todo into skip.
+SKIP_TARGET='import { expect, test } from "bun:test";
+import { answer } from "./subject";
+test("a", () => { expect(answer()).toBe(42); });
+test.skip("b", () => { expect(answer()).toBe(42); });'
+T=$(make_tree "$SKIP_TARGET" '"  return 42;"' \
+   'bun run scripts/mutate.ts scripts/mutations/f.mutations.ts >/dev/null 2>&1 || true')
+check 1 "a target carrying .skip is REFUSED" "$T" --all
+
+TODO_TARGET='import { expect, test } from "bun:test";
+import { answer } from "./subject";
+test("a", () => { expect(answer()).toBe(42); });
+test.todo("b", () => { expect(answer()).toBe(42); });'
+T=$(make_tree "$TODO_TARGET" '"  return 42;"' 'true')
+check 1 "a target carrying .todo is REFUSED (bun's other bucket)" "$T" --all
+
+# 4. The tombstone trap: a dead anchor must be refused, never rendered as a
+# stable byte that --check then blesses forever.
+T=$(make_tree "$GOOD_TARGET" '"  return 12345;"' 'true')
+check 1 "a DEAD ANCHOR is refused rather than written as a cell" "$T" --all
+
+# 5. The fail-safe. An unresolvable base must WIDEN to --all (and then catch the
+# hand-edit), never quietly select nothing and exit 0.
+T=$(make_tree "$GOOD_TARGET" '"  return 42;"' \
+   'bun run scripts/mutate.ts scripts/mutations/f.mutations.ts >/dev/null 2>&1; grep -q "| 2 |" scripts/mutations/f.md && sed -i "s/| 2 |/| 99 |/" scripts/mutations/f.md')
+check 1 "an unresolvable base WIDENS to --all rather than passing" "$T" --affected origin/nope
+
+# 6. Declining to verify is not passing.
+T=$(make_tree "$GOOD_TARGET" '"  return 42;"' 'true')
+rc=0
+out=$( cd "$T" && env -u TEST_DATABASE_URL MUTATION_SPEC_GLOB="scripts/mutations/f.mutations.ts" \
+       bash scripts/check-mutation-tables.sh --all 2>&1 ) || rc=$?
+if [ "$rc" = "3" ]; then
+  echo "  ok    TEST_DATABASE_URL unset exits 3 (SKIP), not 0 (PASS) (exit $rc)"; PASS=$((PASS + 1))
+else
+  echo "  FAIL  TEST_DATABASE_URL unset — expected exit 3, got $rc"; FAIL=$((FAIL + 1))
+fi
+rm -rf "$T"
+
+echo ":: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/scripts/check-mutation-tables.sh
+++ b/scripts/check-mutation-tables.sh
@@ -96,12 +96,18 @@ fi
 # --- Narrow to the affected specs -------------------------------------------
 SELECTED=()
 if [ "$MODE" = "affected" ]; then
-  if ! CHANGED=$(cd "$ROOT" && git diff --name-only "$BASE"...HEAD 2>/dev/null); then
+  # ⚠️ `--no-renames` on BOTH diffs, which the comment below claimed and the code
+  # did not. git reports only the NEW path for a rename (diff.renames has
+  # defaulted true since 2.9), so a target still listed in a spec under its old
+  # path never matched — measured: a committed rename broke a spec and the gate
+  # exited 0 with "nothing to verify". Stderr is captured, not discarded, so the
+  # widen prints its reason.
+  if ! CHANGED=$(cd "$ROOT" && git diff --name-only --no-renames "$BASE"...HEAD 2>&1); then
     # ⚠️ Widen, never narrow, when the base is unresolvable (a shallow clone, a
     # detached HEAD, a deleted branch). Silently verifying NOTHING is the one
     # outcome this gate must never produce, and it is indistinguishable from a
     # clean run in the log.
-    echo "check-mutation-tables: cannot diff against '$BASE' — falling back to --all."
+    echo "check-mutation-tables: cannot diff against '$BASE' ($CHANGED) — falling back to --all."
     MODE="all"
   else
     # ⚠️ Uncommitted work counts too — pre-PR is exactly when a table goes stale
@@ -115,11 +121,19 @@ if [ "$MODE" = "affected" ]; then
       echo "check-mutation-tables: cannot diff the working tree ($UNCOMMITTED) — falling back to --all."
       MODE="all"
     else
-      # `--no-renames` on both diffs: a rename reports only the NEW path, so a
-      # target still listed in a spec under its old path would never match.
       # Untracked files too — a brand-new corpus or spec is invisible to `git
-      # diff`, and both narrow silently.
-      UNTRACKED=$(cd "$ROOT" && git ls-files --others --exclude-standard 2>/dev/null || true)
+      # diff`, and that narrows silently.
+      # ⚠️ The THIRD instance of this twin in this one file, which is why the
+      # sweep has to be mechanical rather than remembered. Same command family,
+      # same failure modes (index.lock, EACCES, an unreadable excludesFile), same
+      # consequence: an empty result narrows the selector, a brand-new spec or
+      # corpus goes invisible, and the gate prints "nothing to verify" and exits
+      # 0. No `|| true` anywhere in this selector.
+      if ! UNTRACKED=$(cd "$ROOT" && git ls-files --others --exclude-standard 2>&1); then
+        echo "check-mutation-tables: cannot list untracked files ($UNTRACKED) — falling back to --all."
+        MODE="all"
+        UNTRACKED=""
+      fi
       CHANGED="$CHANGED
 $UNCOMMITTED
 $UNTRACKED"

--- a/scripts/check-mutation-tables.sh
+++ b/scripts/check-mutation-tables.sh
@@ -44,8 +44,10 @@
 # no longer be produced at all; this script therefore only has to decide whether
 # it can measure, not whether the numbers are honest.
 #
-# ⚠️ The skip path exits 0 deliberately, matching ci-local.sh's existing posture
-# for the -pg suites themselves. CI sets the variable, so the gate genuinely
+# ⚠️ The skip path exits **3**, not 0 — `ci-local.sh` renders that as SKIP rather
+# than PASS. A green row for a gate that verified nothing is the same defect
+# class as the deflated table this exists to refuse, and the compact table is
+# what the /ci agent protocol reads. CI sets the variable, so the gate genuinely
 # runs where it counts.
 
 set -euo pipefail
@@ -68,7 +70,11 @@ done
 
 cd "$ROOT/packages/api"
 
-SPECS=(scripts/mutations/*.mutations.ts)
+# ⚠️ A SEAM, so the adversarial fixture can point this at a throwaway tree.
+# `scripts/__tests__/check-mutation-tables.test.sh` needs to prove the gate
+# CATCHES a hand-edited table and a skipped target; without an override it could
+# only ever be run against the real specs, which is a 14-minute assertion.
+SPECS=(${MUTATION_SPEC_GLOB:-scripts/mutations/*.mutations.ts})
 if [ ${#SPECS[@]} -eq 0 ] || [ ! -e "${SPECS[0]}" ]; then
   echo "check-mutation-tables: no specs found under packages/api/scripts/mutations/ — did the directory move?" >&2
   exit 1
@@ -79,7 +85,12 @@ if [ -z "${TEST_DATABASE_URL:-}" ]; then
   echo "  ${#SPECS[@]} spec(s) not verified. Several target *-pg.test.ts, which self-skip"
   echo "  without a live Postgres; their counts would be deflated. Run 'bun run db:up' and"
   echo "  export TEST_DATABASE_URL to verify locally."
-  exit 0
+  # ⚠️ 3, not 0. `ci-local.sh` renders 3 as SKIP; exiting 0 put a green PASS row
+  # in the compact table for a gate that verified NOTHING — which the /ci agent
+  # protocol reads as a clean pre-PR pass. A gate unable to distinguish
+  # "verified" from "declined to verify" is the same defect class as the
+  # deflated table this whole change exists to refuse.
+  exit 3
 fi
 
 # --- Narrow to the affected specs -------------------------------------------
@@ -93,11 +104,30 @@ if [ "$MODE" = "affected" ]; then
     echo "check-mutation-tables: cannot diff against '$BASE' — falling back to --all."
     MODE="all"
   else
-    # Uncommitted work counts too: pre-PR is exactly when the table goes stale.
-    CHANGED="$CHANGED
-$(cd "$ROOT" && git diff --name-only HEAD 2>/dev/null || true)"
+    # ⚠️ Uncommitted work counts too — pre-PR is exactly when a table goes stale
+    # — and this MIRRORS the base-diff handling above rather than swallowing the
+    # failure. The first cut wrote `2>/dev/null || true` here, six lines under
+    # the comment forbidding exactly that: an index lock or a corrupt index then
+    # yielded an empty append, the branch's own work became invisible, and the
+    # gate printed "nothing to verify" and exited 0 — indistinguishable from
+    # clean. Widen, never narrow.
+    if ! UNCOMMITTED=$(cd "$ROOT" && git diff --name-only --no-renames HEAD 2>&1); then
+      echo "check-mutation-tables: cannot diff the working tree ($UNCOMMITTED) — falling back to --all."
+      MODE="all"
+    else
+      # `--no-renames` on both diffs: a rename reports only the NEW path, so a
+      # target still listed in a spec under its old path would never match.
+      # Untracked files too — a brand-new corpus or spec is invisible to `git
+      # diff`, and both narrow silently.
+      UNTRACKED=$(cd "$ROOT" && git ls-files --others --exclude-standard 2>/dev/null || true)
+      CHANGED="$CHANGED
+$UNCOMMITTED
+$UNTRACKED"
+    fi
     RUNNER_TOUCHED=0
-    for f in scripts/mutate.ts scripts/mutation-core.ts scripts/mutation-spec.ts; do
+    # signal-retry.ts decides how EVERY suite is spawned, so it belongs here with
+    # the runner and the renderer — it was missing from the first cut.
+    for f in scripts/mutate.ts scripts/mutation-core.ts scripts/mutation-spec.ts scripts/signal-retry.ts; do
       if printf '%s\n' "$CHANGED" | grep -qxF "packages/api/$f"; then RUNNER_TOUCHED=1; fi
     done
     if [ "$RUNNER_TOUCHED" -eq 1 ]; then
@@ -108,7 +138,13 @@ $(cd "$ROOT" && git diff --name-only HEAD 2>/dev/null || true)"
         DEPS="$spec"$'\n'"$(bun run scripts/mutate.ts "$spec" --files)"
         while IFS= read -r dep; do
           [ -z "$dep" ] && continue
-          if printf '%s\n' "$CHANGED" | grep -qxF "packages/api/$dep"; then
+          # ⚠️ NORMALISE. A spec may legitimately reach outside packages/api —
+          # `bundle-identity` mutates `../types/src/migration.ts` — and naive
+          # prefixing produced `packages/api/../types/src/migration.ts`, which
+          # git never emits, so that dependency could NEVER select its spec.
+          # Silently, and only for the cross-package case.
+          rel=$(cd "$ROOT/packages/api" && realpath -m --relative-to="$ROOT" "$dep")
+          if printf '%s\n' "$CHANGED" | grep -qxF "$rel"; then
             SELECTED+=("$spec"); break
           fi
         done <<< "$DEPS"
@@ -127,13 +163,19 @@ if [ "$MODE" = "all" ]; then SELECTED=("${SPECS[@]}"); fi
 echo "check-mutation-tables: verifying ${#SELECTED[@]} generated table(s)…"
 echo "  (each spec re-runs its suites under every mutation — minutes, not seconds)"
 
+# ⚠️ mktemp, not a fixed /tmp path. This runs from a parallel harness, and a
+# pre-existing root-owned or symlinked `/tmp/mutate-check.log` makes the redirect
+# fail — which the `if` reads as STALE, a false red on a healthy table.
+LOG=$(mktemp)
+trap 'rm -f "$LOG"' EXIT
+
 STALE=()
 for spec in "${SELECTED[@]}"; do
-  if bun run scripts/mutate.ts "$spec" --check >/tmp/mutate-check.log 2>&1; then
+  if bun run scripts/mutate.ts "$spec" --check >"$LOG" 2>&1; then
     echo "  OK    $spec"
   else
     echo "  STALE $spec"
-    sed 's/^/        /' /tmp/mutate-check.log | tail -20
+    sed 's/^/        /' "$LOG" | tail -20
     STALE+=("$spec")
   fi
 done

--- a/scripts/check-mutation-tables.sh
+++ b/scripts/check-mutation-tables.sh
@@ -4,39 +4,68 @@
 #
 # `scripts/mutate.ts --check` existed and worked from the day #5060 landed the
 # runner. Nothing ran it, so the tables drifted exactly the way the runner was
-# built to stop: four were found stale on `main` during #5032 (`object-cmp.md`
-# 58 vs 59 tests, `cardinality.md` 47 vs 70 plus a dead anchor), and
-# `mutation-core.md` — the runner's OWN table — carried an ANCHOR failure after
-# #5060/#4389 rewrote the escape it pointed at. A table nobody re-runs is back
-# to being a hand-written claim that happens to be formatted like a measurement,
-# which is the entire thing #5060 was an investment against.
+# built to stop. Measured on `main` at the time this gate was written: FOUR of
+# eight were stale — cardinality, identity-corpus, object-cmp, and
+# mutation-core, the runner's OWN table, whose `escapeCell` row had been a dead
+# ANCHOR since #5060/#4389 rewrote the escape it pointed at. A table nobody
+# re-runs is back to being a hand-written claim that happens to be formatted
+# like a measurement, which is the whole thing #5060 was an investment against.
 #
-# ## Why this gate is conditional on TEST_DATABASE_URL, and why that is not a hole
+# ## Two modes, because the full sweep is 832 SECONDS
+#
+# Measured, not estimated: verifying all eight specs takes ~14 minutes, because
+# each one re-runs every target suite once per mutation. `/ci` is ~10 minutes in
+# total, so an always-full gate would MORE THAN DOUBLE the pre-PR loop — and a
+# gate that doubles the loop gets commented out inside a week. A disabled gate
+# catches nothing, so cost is a correctness property here, not an optimisation.
+#
+#   --affected [base]   Verify only the specs whose dependency set the branch
+#                       touched. The common PR touches none and the gate is
+#                       instant. This is what ci-local.sh runs.
+#   --all               Every spec. What CI runs, where 14 minutes is FREE:
+#                       jobs run in parallel and the docs image already takes
+#                       ~25 minutes, so this finishes inside the existing
+#                       critical path and costs nothing in wall clock.
+#
+# A spec's dependencies come from `mutate.ts --files` — the loaded spec's own
+# target and edit paths — rather than from a grep, because they sit behind
+# `SOURCE`-style consts a regex would miss, and a dependency list that silently
+# misses a file is a gate that silently stops gating. Changing the runner or the
+# renderer (`mutate.ts`, `mutation-core.ts`, `mutation-spec.ts`) marks EVERY spec
+# affected: those decide the output bytes for all of them.
+#
+# ## Why TEST_DATABASE_URL gates the whole thing
 #
 # Several specs target `*-pg.test.ts`, which self-skip without a live Postgres.
-# A skipped test cannot be killed by a mutation, so running `--check` without
-# one would compare against systematically deflated numbers and report every
-# such table as stale, forever — and the obvious "just regenerate it" response
-# would COMMIT the zeros over real measurements. That is the footgun #5077 was
-# filed for.
+# A skipped test cannot be killed by a mutation, so their counts would be
+# deflated — and the obvious "just regenerate" response would COMMIT zeros over
+# real measurements. That is the footgun #5077 was filed for. `mutate.ts` now
+# refuses at the baseline when any target reports skips, so a zeroed table can
+# no longer be produced at all; this script therefore only has to decide whether
+# it can measure, not whether the numbers are honest.
 #
-# The runner now refuses that outright: `mutate.ts` fails at the baseline if any
-# target reported skips (see its guardrail 4), so a zeroed table can no longer
-# be produced at all, by this gate or by hand. This script therefore does not
-# need to police correctness — only to decide whether it can measure. With
-# TEST_DATABASE_URL it verifies every spec; without one it SKIPS LOUDLY, the
-# same posture ci-local.sh already takes for the -pg suites themselves. CI sets
-# the variable (ci.yml's api-tests job has the postgres service), so the gate
-# genuinely runs where it counts.
-#
-# ⚠️ The skip path prints and exits 0 deliberately. A gate that fails on every
-# developer machine without Postgres gets disabled within a week, and a disabled
-# gate is worth less than a conditional one that runs in CI.
+# ⚠️ The skip path exits 0 deliberately, matching ci-local.sh's existing posture
+# for the -pg suites themselves. CI sets the variable, so the gate genuinely
+# runs where it counts.
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="$SCRIPT_DIR/.."
+
+MODE="all"
+BASE="origin/main"
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --all) MODE="all"; shift ;;
+    --affected)
+      MODE="affected"; shift
+      if [ $# -gt 0 ] && [ "${1#--}" = "$1" ]; then BASE="$1"; shift; fi
+      ;;
+    *) echo "check-mutation-tables: unknown argument: $1" >&2; exit 1 ;;
+  esac
+done
+
 cd "$ROOT/packages/api"
 
 SPECS=(scripts/mutations/*.mutations.ts)
@@ -48,16 +77,58 @@ fi
 if [ -z "${TEST_DATABASE_URL:-}" ]; then
   echo "check-mutation-tables: SKIPPED — TEST_DATABASE_URL unset."
   echo "  ${#SPECS[@]} spec(s) not verified. Several target *-pg.test.ts, which self-skip"
-  echo "  without a live Postgres; measuring them anyway would compare real numbers against"
-  echo "  deflated ones. Run 'bun run db:up' and export TEST_DATABASE_URL to verify locally."
+  echo "  without a live Postgres; their counts would be deflated. Run 'bun run db:up' and"
+  echo "  export TEST_DATABASE_URL to verify locally."
   exit 0
 fi
 
-echo "check-mutation-tables: verifying ${#SPECS[@]} generated table(s) against their specs…"
-echo "  (each spec re-runs its suites under every mutation — this is minutes, not seconds)"
+# --- Narrow to the affected specs -------------------------------------------
+SELECTED=()
+if [ "$MODE" = "affected" ]; then
+  if ! CHANGED=$(cd "$ROOT" && git diff --name-only "$BASE"...HEAD 2>/dev/null); then
+    # ⚠️ Widen, never narrow, when the base is unresolvable (a shallow clone, a
+    # detached HEAD, a deleted branch). Silently verifying NOTHING is the one
+    # outcome this gate must never produce, and it is indistinguishable from a
+    # clean run in the log.
+    echo "check-mutation-tables: cannot diff against '$BASE' — falling back to --all."
+    MODE="all"
+  else
+    # Uncommitted work counts too: pre-PR is exactly when the table goes stale.
+    CHANGED="$CHANGED
+$(cd "$ROOT" && git diff --name-only HEAD 2>/dev/null || true)"
+    RUNNER_TOUCHED=0
+    for f in scripts/mutate.ts scripts/mutation-core.ts scripts/mutation-spec.ts; do
+      if printf '%s\n' "$CHANGED" | grep -qxF "packages/api/$f"; then RUNNER_TOUCHED=1; fi
+    done
+    if [ "$RUNNER_TOUCHED" -eq 1 ]; then
+      echo "check-mutation-tables: the runner/renderer changed — every table's bytes are in scope."
+      MODE="all"
+    else
+      for spec in "${SPECS[@]}"; do
+        DEPS="$spec"$'\n'"$(bun run scripts/mutate.ts "$spec" --files)"
+        while IFS= read -r dep; do
+          [ -z "$dep" ] && continue
+          if printf '%s\n' "$CHANGED" | grep -qxF "packages/api/$dep"; then
+            SELECTED+=("$spec"); break
+          fi
+        done <<< "$DEPS"
+      done
+      if [ ${#SELECTED[@]} -eq 0 ]; then
+        echo "check-mutation-tables: no spec's targets or sources changed vs $BASE — nothing to verify."
+        echo "  (CI runs --all regardless, so a table that drifted for another reason is still caught.)"
+        exit 0
+      fi
+      echo "check-mutation-tables: ${#SELECTED[@]} of ${#SPECS[@]} spec(s) affected by this branch."
+    fi
+  fi
+fi
+if [ "$MODE" = "all" ]; then SELECTED=("${SPECS[@]}"); fi
+
+echo "check-mutation-tables: verifying ${#SELECTED[@]} generated table(s)…"
+echo "  (each spec re-runs its suites under every mutation — minutes, not seconds)"
 
 STALE=()
-for spec in "${SPECS[@]}"; do
+for spec in "${SELECTED[@]}"; do
   if bun run scripts/mutate.ts "$spec" --check >/tmp/mutate-check.log 2>&1; then
     echo "  OK    $spec"
   else
@@ -79,4 +150,4 @@ if [ ${#STALE[@]} -gt 0 ]; then
   exit 1
 fi
 
-echo "check-mutation-tables: all ${#SPECS[@]} table(s) current."
+echo "check-mutation-tables: all ${#SELECTED[@]} verified table(s) current."

--- a/scripts/check-mutation-tables.sh
+++ b/scripts/check-mutation-tables.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# check-mutation-tables.sh — CI gate that keeps the GENERATED mutation tables
+# under packages/api/scripts/mutations/*.md in step with their specs (#5077).
+#
+# `scripts/mutate.ts --check` existed and worked from the day #5060 landed the
+# runner. Nothing ran it, so the tables drifted exactly the way the runner was
+# built to stop: four were found stale on `main` during #5032 (`object-cmp.md`
+# 58 vs 59 tests, `cardinality.md` 47 vs 70 plus a dead anchor), and
+# `mutation-core.md` — the runner's OWN table — carried an ANCHOR failure after
+# #5060/#4389 rewrote the escape it pointed at. A table nobody re-runs is back
+# to being a hand-written claim that happens to be formatted like a measurement,
+# which is the entire thing #5060 was an investment against.
+#
+# ## Why this gate is conditional on TEST_DATABASE_URL, and why that is not a hole
+#
+# Several specs target `*-pg.test.ts`, which self-skip without a live Postgres.
+# A skipped test cannot be killed by a mutation, so running `--check` without
+# one would compare against systematically deflated numbers and report every
+# such table as stale, forever — and the obvious "just regenerate it" response
+# would COMMIT the zeros over real measurements. That is the footgun #5077 was
+# filed for.
+#
+# The runner now refuses that outright: `mutate.ts` fails at the baseline if any
+# target reported skips (see its guardrail 4), so a zeroed table can no longer
+# be produced at all, by this gate or by hand. This script therefore does not
+# need to police correctness — only to decide whether it can measure. With
+# TEST_DATABASE_URL it verifies every spec; without one it SKIPS LOUDLY, the
+# same posture ci-local.sh already takes for the -pg suites themselves. CI sets
+# the variable (ci.yml's api-tests job has the postgres service), so the gate
+# genuinely runs where it counts.
+#
+# ⚠️ The skip path prints and exits 0 deliberately. A gate that fails on every
+# developer machine without Postgres gets disabled within a week, and a disabled
+# gate is worth less than a conditional one that runs in CI.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$SCRIPT_DIR/.."
+cd "$ROOT/packages/api"
+
+SPECS=(scripts/mutations/*.mutations.ts)
+if [ ${#SPECS[@]} -eq 0 ] || [ ! -e "${SPECS[0]}" ]; then
+  echo "check-mutation-tables: no specs found under packages/api/scripts/mutations/ — did the directory move?" >&2
+  exit 1
+fi
+
+if [ -z "${TEST_DATABASE_URL:-}" ]; then
+  echo "check-mutation-tables: SKIPPED — TEST_DATABASE_URL unset."
+  echo "  ${#SPECS[@]} spec(s) not verified. Several target *-pg.test.ts, which self-skip"
+  echo "  without a live Postgres; measuring them anyway would compare real numbers against"
+  echo "  deflated ones. Run 'bun run db:up' and export TEST_DATABASE_URL to verify locally."
+  exit 0
+fi
+
+echo "check-mutation-tables: verifying ${#SPECS[@]} generated table(s) against their specs…"
+echo "  (each spec re-runs its suites under every mutation — this is minutes, not seconds)"
+
+STALE=()
+for spec in "${SPECS[@]}"; do
+  if bun run scripts/mutate.ts "$spec" --check >/tmp/mutate-check.log 2>&1; then
+    echo "  OK    $spec"
+  else
+    echo "  STALE $spec"
+    sed 's/^/        /' /tmp/mutate-check.log | tail -20
+    STALE+=("$spec")
+  fi
+done
+
+if [ ${#STALE[@]} -gt 0 ]; then
+  echo ""
+  echo "ERROR: ${#STALE[@]} generated mutation table(s) are stale or unmeasurable." >&2
+  echo "A stale table is a hand-written claim wearing a measurement's formatting." >&2
+  echo "" >&2
+  echo "To fix, per spec:" >&2
+  for spec in "${STALE[@]}"; do
+    echo "  cd packages/api && bun run scripts/mutate.ts $spec" >&2
+  done
+  exit 1
+fi
+
+echo "check-mutation-tables: all ${#SPECS[@]} table(s) current."

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -205,12 +205,6 @@ launch docs-links                bun scripts/check-docs-links.ts
 launch auth-md-parity            g_auth_md_parity
 launch apex-discovery-drift      bash scripts/check-apex-discovery-drift.sh
 launch openapi-drift             g_openapi_drift
-# ⚠️ --affected, NOT --all. The full sweep is 832s MEASURED — it would more than
-# double this script — so pre-PR verifies only the specs whose targets or sources
-# this branch touched, and CI's `mutation-tables` job runs everything in parallel
-# where 14 minutes costs no wall clock. Skips entirely without TEST_DATABASE_URL,
-# the same posture this script already takes for the -pg suites themselves.
-launch mutation-tables           bash scripts/check-mutation-tables.sh --affected origin/main
 launch gate-fixtures             g_gate_fixtures
 if [ "$NO_NET" != "1" ]; then
   launch published-symbols       g_published_symbols
@@ -218,9 +212,27 @@ if [ "$NO_NET" != "1" ]; then
 fi
 wait
 
-# ---- Stage 2: full test suite, isolated ----
+# ---- Stage 2: gates that WRITE to the tree, then the full test suite ----
+#
+# ⚠️ `mutation-tables` cannot live in Stage 1, and the reason is not load — it is
+# CORRECTNESS. Stage 1 is labelled read-only because every gate there SCANS the
+# tree, and `mutate.ts` REWRITES source files in place (apply → run → restore),
+# by design. Run in parallel, a brain mutation is live on disk while
+# `check-brain-fact-promotion.sh`, `check-no-legacy-connections-sql.sh`,
+# `lint-type-aware` and the rest read those very files — so they go red on a line
+# the developer never wrote, the developer re-runs, it passes, and they learn the
+# gate is flaky. The hazard is worst exactly when the gate is doing its job:
+# on a branch that touches the runner it widens to --all, which is 832 seconds
+# of continuous mutation.
+#
+# --affected, NOT --all: the full sweep would more than double this script. CI's
+# `mutation-tables` job runs everything in parallel, where 14 minutes costs no
+# wall clock. Skips entirely without TEST_DATABASE_URL.
+status "stage 2: tree-writing gates (serial — these mutate sources in place) …"
+run_fg mutation-tables bash scripts/check-mutation-tables.sh --affected origin/main
+
 if [ "$NO_TEST" != "1" ]; then
-  status "stage 2: full test suite (isolated — no parallel load) …"
+  status "stage 3: full test suite (isolated — no parallel load) …"
   run_fg test g_test
 fi
 
@@ -231,7 +243,8 @@ fi
 failed=()
 for name in "${GATE_NAMES[@]}"; do
   rc="$(cat "$LOG_DIR/$name.exit" 2>/dev/null || echo 1)"
-  [ "$rc" = "0" ] || failed+=("$name")
+  # 3 = declined to verify (rendered SKIP). Not green, but not a failure either.
+  [ "$rc" = "0" ] || [ "$rc" = "3" ] || failed+=("$name")
 done
 total="${#GATE_NAMES[@]}"
 
@@ -243,7 +256,13 @@ render_report() {
   for name in "${GATE_NAMES[@]}"; do
     rc="$(cat "$LOG_DIR/$name.exit" 2>/dev/null || echo 1)"
     secs="$(cat "$LOG_DIR/$name.secs" 2>/dev/null || echo '?')"
-    if [ "$rc" = "0" ]; then
+    if [ "$rc" = "3" ]; then
+      # ⚠️ Exit 3 means "declined to verify", and it is NOT PASS. A gate that
+      # cannot tell "verified" from "did not run" in its own summary line is the
+      # same defect class as the deflated table `mutation-tables` exists to
+      # refuse — and the compact table is what the /ci agent protocol reads.
+      printf '%-28s %-7s %4ss\n' "$name" "SKIP" "$secs"
+    elif [ "$rc" = "0" ]; then
       printf '%-28s %-7s %4ss\n' "$name" "PASS" "$secs"
     else
       printf '%-28s %-7s %4ss\n' "$name" "FAIL" "$secs"

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -205,6 +205,12 @@ launch docs-links                bun scripts/check-docs-links.ts
 launch auth-md-parity            g_auth_md_parity
 launch apex-discovery-drift      bash scripts/check-apex-discovery-drift.sh
 launch openapi-drift             g_openapi_drift
+# ⚠️ --affected, NOT --all. The full sweep is 832s MEASURED — it would more than
+# double this script — so pre-PR verifies only the specs whose targets or sources
+# this branch touched, and CI's `mutation-tables` job runs everything in parallel
+# where 14 minutes costs no wall clock. Skips entirely without TEST_DATABASE_URL,
+# the same posture this script already takes for the -pg suites themselves.
+launch mutation-tables           bash scripts/check-mutation-tables.sh --affected origin/main
 launch gate-fixtures             g_gate_fixtures
 if [ "$NO_NET" != "1" ]; then
   launch published-symbols       g_published_symbols

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -30,12 +30,14 @@
 #   Stage 1  parallel  lint + lint:type-aware + syncpack + ~22 read-only
 #                      drift/check scripts.
 #                      None touch dist/, so they fan out safely (CI_LOCAL_JOBS).
-#   Stage 2  serial    `bun run test` ALONE. The full suite flakes under CPU
+#   Stage 2  serial    the tree-WRITING gate (mutation-tables). `mutate.ts` rewrites
+#                      sources in place, so it cannot share Stage 1 with ~30 scanners.
+#   Stage 3  serial    `bun run test` ALONE. The full suite flakes under CPU
 #                      contention on WSL2, so it gets the machine to itself.
 #
 # ENV TOGGLES
 #   CI_LOCAL_JOBS=N        Stage-1 concurrency (default 6).
-#   CI_LOCAL_NO_TEST=1     Skip Stage 2 (gates-only fast pass). RESULT is then
+#   CI_LOCAL_NO_TEST=1     Skip Stage 3 (gates-only fast pass). RESULT is then
 #                          flagged "tests skipped" — never reported as a clean pass.
 #   CI_LOCAL_NO_NET=1      Skip the two npm-registry gates (published-symbols,
 #                          unpublished-versions) for offline runs.
@@ -145,7 +147,7 @@ launch() {
 }
 
 echo "Atlas local CI — mirrors the required \`ci\` gate. Logs: .ci-local/<gate>.log"
-[ "$NO_TEST" = "1" ] && echo "  (CI_LOCAL_NO_TEST=1 — Stage 2 test suite skipped)"
+[ "$NO_TEST" = "1" ] && echo "  (CI_LOCAL_NO_TEST=1 — Stage 3 test suite skipped)"
 [ "$NO_NET" = "1" ]  && echo "  (CI_LOCAL_NO_NET=1 — npm-registry gates skipped)"
 if [ -n "${TEST_DATABASE_URL:-}" ]; then
   echo "  TEST_DATABASE_URL set — real-Postgres *-pg.test.ts WILL run."
@@ -241,10 +243,17 @@ fi
 # .ci-local/RESULT so a watcher polling for the file can never observe it
 # half-written. RESULT's existence = run finished; its contents = the report.
 failed=()
+# ⚠️ Tracked SEPARATELY from `failed`, because the headline has to say so. The
+# row rendered SKIP correctly and the summary line still read "all N gates
+# green" — and TEST_DATABASE_URL unset is the DEFAULT local state, so that was
+# nearly every local run. `/ci`'s protocol tells the agent that RESULT's
+# contents ARE the report, so a false green there is read as a clean pre-PR pass.
+# Same defect as the row, moved one screen down.
+skipped=()
 for name in "${GATE_NAMES[@]}"; do
   rc="$(cat "$LOG_DIR/$name.exit" 2>/dev/null || echo 1)"
-  # 3 = declined to verify (rendered SKIP). Not green, but not a failure either.
-  [ "$rc" = "0" ] || [ "$rc" = "3" ] || failed+=("$name")
+  if [ "$rc" = "3" ]; then skipped+=("$name")
+  elif [ "$rc" != "0" ]; then failed+=("$name"); fi
 done
 total="${#GATE_NAMES[@]}"
 
@@ -270,7 +279,9 @@ render_report() {
   done
   printf '%s\n' "------------------------------------------------"
 
-  if [ "${#failed[@]}" -eq 0 ]; then
+  if [ "${#failed[@]}" -eq 0 ] && [ "${#skipped[@]}" -gt 0 ]; then
+    echo "RESULT: PASS with ${#skipped[@]} DECLINED — ${skipped[*]} verified nothing; not a clean pre-PR pass."
+  elif [ "${#failed[@]}" -eq 0 ]; then
     if [ "$NO_TEST" = "1" ]; then
       echo "RESULT: PASS (tests skipped — Stage 2 not run; not a clean pre-PR pass)"
     else


### PR DESCRIPTION
## Summary

Closes #5077. Follow-up filed as #5097 for what was deliberately left out.

`mutate.ts --check` existed from #5060 and nothing ran it, so the generated tables drifted exactly the way the runner was built to stop. **Four of eight were stale on `main`** — including `mutation-core.md`, the runner's own table, whose `escapeCell` row had been a dead `ANCHOR` since #5060/#4389.

### The diagnosis is one step off from the issue's, and the correction is the whole fix

#5077 describes running without `TEST_DATABASE_URL` as *zeroing* the `-pg` column. It **deflates** it. Measured:

```
identity-consumers-pg.test.ts, no TEST_DATABASE_URL:   6 pass · 72 skip · 0 fail
```

Six, not zero — that file carries six non-`pg` tests. So a guard spelled `pass > 0` sails straight past it. The signal has to be the **skip count**, which `parseBunSummary` did not parse at all, while the baseline guard only ever rejected `fail !== 0`. A deflated baseline is accepted as green and every cell measured against it silently shrinks.

### What landed

**`baselineProblem()` in `mutation-core.ts`** — every way a baseline can lie, as one pure tested function: `errored` · `red` · `empty` · `unaccounted` · `deflated`. It lives there rather than inline because this module's own header states that split, and written inline the guard could be deleted whole with every test green and every table byte-identical.

⚠️ It does **not** enumerate buckets. `.todo` is a separate bun bucket that walked past the first cut while a comment claimed it was covered; `filtered out` is a third. The guard cross-checks the sum against bun's `Ran N tests`, closing every bucket bun has and every one it adds.

**A dead anchor can no longer become a committed byte.** `--check` compares bytes, so once `⚠️ ANCHOR: 0 matches` is in a table it is the expected output forever. `Cell.anchorFailed` is machine-readable (not a substring of free-form prose, so a real timeout stays distinguishable from a measurement that never happened) and the runner refuses to write or bless a table containing one. That forced repairing **five pre-existing rotted anchors**; all eight specs now resolve and **zero tombstones remain repo-wide**.

**A CI job and a local gate, at costs matched to each.** The full sweep is **832 seconds measured**. `/ci` is ~10 minutes, so an always-full local gate would more than double the pre-PR loop — and a gate that doubles the loop gets deleted. CI runs `--all` in its own job (free: parallel, and shorter than the ~25-minute docs image); `ci-local` runs only specs whose targets or mutated sources the branch touched, via a new `mutate.ts --files` that reads the **loaded** spec rather than grepping.

⚠️ It runs **serially**, not in ci-local's stage 1. That stage is labelled read-only and `mutate.ts` rewrites sources in place — parallel, it would put live mutations on disk while ~30 gates scan those same files. It exits **3** → rendered `SKIP`, never `PASS`, when it declines to verify.

### Scope grown beyond the issue, deliberately

- **Five pre-existing anchor repairs** — the refusal makes them blocking, so CI would be red on `main` without them.
- **Generalising past `skip`** to the accounting check, per above.

## Test Plan

- [x] Manual testing — reproduced the deflation, the tombstone blessing, and each fixture path end to end
- [x] Unit tests added/updated
- [ ] E2E tests added/updated — n/a

**`scripts/ci-local.sh`: PASS — all 34 gates green** with `TEST_DATABASE_URL` set, so the `-pg` suites and the new gate (874s) both really ran.

- `baselineProblem` — **14 of 14 mutations killed, every arm uniquely**, including arm *ordering* and the `ran !== null` short-circuit (verified by an independent reviewer, not by me).
- `anchorFailures` — including the discriminator that a **timeout is not** an anchor failure; that is a real measurement of a real hang.
- **Five adversarial fixtures**, each proven sensitive by deleting the guard it pins and confirming it goes red. Two more were written, **measured vacuous, and removed** rather than shipped green — their trees generate no table, so `--check` exits 1 with *"is stale"* regardless of the guard. Tracked in #5097.
- The fixture suite is now enumerated in `ci.yml`; it was the only one of thirteen missing, because this workflow lists suites by name while `ci-local` globs.

## Review

Two `/review-panel` rounds. Round 1: 17 findings, all fixed. **Round 2's yield rose (17 → ~22) and the live-stop rule from #5096 fired**, so this lands the verified core and files the rest as #5097 rather than spending a round 3.

Nearly every round-2 finding was a defect *in a round-1 fix*, three times reproducing the very defect being fixed one layer over — the SKIP cell wrote a byte `--check` blesses forever; the `-pg` hint fix misdirected on a different arm. That pattern, and what to do about it, is the substantive output of this issue beyond the code.

**Known and deliberate:** `measure()` no longer flags a deflated *mutated* run. The detection was correct but committed a self-certifying byte; "no detection" is safer than "detection that certifies itself green forever", and #5097 leads with reinstating it behind a unified refusal.

## Checklist

- [x] Types pass (`bun run type`)
- [x] Tests pass (`bun run test`)
- [x] Lint passes (`bun run lint`)
- [ ] Deps consistent — no dependency changes
- [x] Labels added (type + area)
- [ ] CHANGELOG.md updated — internal tooling, not user-facing

---
_Generated by [Claude Code](https://claude.ai/code/session_01XM76qzzspvsWnwG7gA1gzr)_