### PR TITLE
fix(mutations): repair the cardinality anchor #5102 killed, and remeasure

### DIFF
--- a/packages/api/scripts/mutations/cardinality.md
+++ b/packages/api/scripts/mutations/cardinality.md
@@ -27,17 +27,17 @@ Every number is the count of tests that FAIL in that suite under that mutation, 
 | the repeat gate drops its provable-difference arm | 1 | 1 | 0 | 0 | 0 |
 | the repeat gate counts machine supersessions too | 1 | 1 | 0 | 0 | 0 |
 | the repeat threshold drops to 1 | 1 | 1 | 0 | 0 | 0 |
-| `INSERT_FACT_SQL` feeds `predicate_cardinality` again | 0 | 0 | 5 | 0 | 27 |
-| `retract` feeds the proposer too | 0 | 0 | 2 | 0 | 0 |
+| `INSERT_FACT_SQL` feeds `predicate_cardinality` again | 0 | 0 | 8 | 0 | 27 |
+| `retract` feeds the proposer too | 0 | 0 | 9 | 0 | 0 |
 | the post-commit proposer loses its deadline | 0 | 0 | 5 | 0 | 0 |
 | the deadline's timer is never cleared | 0 | 0 | 1 | 0 | 0 |
 | the post-deadline continuation is deleted | 0 | 0 | 2 | 0 | 0 |
 | the late-SUCCESS arm's guard is inverted | 0 | 0 | 1 | 0 | 0 |
 | `logDegeneratePredicate` fires for every verb, not only `supersede` | 0 | 0 | 3 | 0 | 0 |
-| `logDegeneratePredicate`'s call is removed | 0 | 0 | 1 | 0 | 0 |
-| the proposer runs INSIDE the correction's transaction | 0 | 0 | 7 | 0 | 0 |
+| `logDegeneratePredicate`'s call is removed | 0 | 0 | 3 | 0 | 0 |
+| the proposer runs INSIDE the correction's transaction | 0 | 0 | 8 | 0 | 0 |
 
-Suite sizes: **cardinality-pg.test.ts** 27 tests (`src/lib/brain/__tests__/cardinality-pg.test.ts`) · **cardinality.test.ts** 38 tests (`src/lib/brain/__tests__/cardinality.test.ts`) · **correction.test.ts** 61 tests (`src/lib/brain/__tests__/correction.test.ts`) · **brain-facts.test.ts** 60 tests (`src/lib/content-mode/adapters/__tests__/brain-facts.test.ts`) · **reconcile.test.ts** 70 tests (`src/lib/brain/__tests__/reconcile.test.ts`).
+Suite sizes: **cardinality-pg.test.ts** 27 tests (`src/lib/brain/__tests__/cardinality-pg.test.ts`) · **cardinality.test.ts** 38 tests (`src/lib/brain/__tests__/cardinality.test.ts`) · **correction.test.ts** 84 tests (`src/lib/brain/__tests__/correction.test.ts`) · **brain-facts.test.ts** 60 tests (`src/lib/content-mode/adapters/__tests__/brain-facts.test.ts`) · **reconcile.test.ts** 70 tests (`src/lib/brain/__tests__/reconcile.test.ts`).
 
 ## Notes
 

--- a/packages/api/scripts/mutations/cardinality.mutations.ts
+++ b/packages/api/scripts/mutations/cardinality.mutations.ts
@@ -315,8 +315,19 @@ human behind it.
       edits: [
         {
           file: CORRECTION,
+          // ⚠️ Re-anchored by #5037, which threaded a `cause` discriminant through
+          // this call and turned it from one line into an object literal. The old
+          // anchor then matched nothing and the mutation MEASURED NOTHING —
+          // caught by `--check`'s dead-anchor arm rather than by anyone reading
+          // the diff, which is the arm #5077 added for exactly this and the
+          // reason it refuses to write a table it cannot measure.
           oldString: `    if (verb === "supersede") {
-      logDegeneratePredicate({ workspaceId: ctx.workspaceId, factId: result.factId, requestId });
+      logDegeneratePredicate({
+        workspaceId: ctx.workspaceId,
+        factId: result.factId,
+        requestId,
+        cause: supersededPredicateCause,
+      });
     }`,
           newString: "    void verb;",
         },


### PR DESCRIPTION
## Summary

`mutation-tables` has been red on `main` since #5102 merged. This fixes it.

#5102 threaded a `cause` discriminant through `logDegeneratePredicate`, turning its call from one line into a five-line object literal. Mutation specs anchor on exact source text, so the `` `logDegeneratePredicate`'s call is removed `` mutation stopped matching and **measured nothing**.

⚠️ **The edit changed no behaviour at that call site — only its SHAPE.** A behaviour-preserving reformat was enough to silently switch a mutation off. That is worth stating plainly, because nothing about reading that diff would suggest it: the call does exactly what it did before, and the guard it feeds quietly stopped existing.

Caught by `--check`'s dead-anchor arm, which refused to write the table rather than record a tombstone every later `--check` would accept as current — #5077's argument, working on a live case.

## Test Plan

- [x] Unit tests added/updated — table remeasured
- [ ] Manual testing
- [ ] E2E tests added/updated

Verified with the real gate, not a proxy:

```
$ bash scripts/check-mutation-tables.sh --affected origin/main
  OK    scripts/mutations/cardinality.mutations.ts
check-mutation-tables: all 1 verified table(s) current.
```

**The remeasured diff is gains, not losses** — checked specifically for the dangerous case, a mutant that used to die and now survives. There is none; no count dropped. The rises are #5102's 23 added tests:

| mutation | before | after |
|---|---|---|
| `` `logDegeneratePredicate`'s call is removed `` | *measured nothing* | **3** |
| `` `retract` feeds the proposer too `` | 2 | **9** |
| `` `INSERT_FACT_SQL` feeds `predicate_cardinality` again `` | 5 | **8** |
| the proposer runs INSIDE the correction's transaction | 7 | **8** |
| `correction.test.ts` suite size | 61 | **84** |

## Checklist

- [x] Types pass — no source changes
- [x] Tests pass — mutation gate green on the affected spec
- [x] Lint passes
- [ ] Deps consistent — no dependency changes
- [ ] Labels added
- [ ] CHANGELOG.md updated — internal test-infrastructure fix

## ⚠️ The wiring gap this exposed

**`mutation-tables` is not a required check.** #5102 auto-merged past it while it was red on *all three* of its head SHAs. The gate detected a real defect, refused to certify what it could not measure, and reported failure every time — and none of that blocked the merge.

Everything that makes that gate trustworthy (refusing to bless a byte, exiting SKIP rather than PASS when it cannot measure) is undercut by it not being enforced. Adding it to branch protection is a one-line config change and worth doing, but that is a repo-settings decision rather than something this PR should make.

---
_Generated by [Claude Code](https://claude.ai/code/session_012q481BajTLRt3M1tMfsWLd)_