### PR TITLE
feat(brain): make the slot keys total — tighten MALFORMED_CLAIM, then SET NOT NULL

### DIFF
--- a/.claude/commands/review-panel.md
+++ b/.claude/commands/review-panel.md
@@ -174,6 +174,25 @@ The shapes worth sweeping for, because they are what actually recurred:
   look — and if a test landed on one, the other is where it is missing.
 - **The other caller.** A guard added at one call site of a shared helper is
   usually missing at the rest.
+- **The PROSE COPY of the same claim, including generated and public ones.** A
+  finding about *what the code says to a human* — a message naming the wrong
+  cause, a remedy that cannot work, an error blaming the wrong party — almost
+  always has a twin outside the code: an OpenAPI `description`, a docstring, a
+  migration header, a `RAISE NOTICE`, a route's response contract. Fixing the
+  code and leaving the contract is fixing the instance.
+
+  ⚠️ **Generated artifacts are the half that gets missed, because the sweep is a
+  grep over source and the copy lives in a build output.** #5047 spent a round
+  removing wrong-subsystem blame from a refusal — then regenerated
+  `apps/docs/openapi.json` and found the same blame sitting in the 409's public
+  `description`, naming one of two causes and one remedy that is unfollowable for
+  the other. That description is what a caller actually reads, so the defect had
+  survived in the one place it mattered most. It was caught by a drift gate
+  failing for an unrelated reason, not by the sweep.
+
+  So when a finding is about wording, grep the generated surfaces too — and if
+  the fix changes a route, a schema or a migration, REGENERATE before deciding
+  the class is closed.
 
 Report the sweep in one line per finding — *"same shape at X, Y; fixed"* or
 *"swept the module, no other instance"* — so a later round can see the class was

--- a/.claude/commands/ship-issue.md
+++ b/.claude/commands/ship-issue.md
@@ -124,7 +124,77 @@ So the local pre-flight is the cheap subset — `--affected`, `lint`, `type` —
 - you are touching `scripts/mutations/**` or the mutation gate itself, which remote CI does not exercise the same way;
 - you are about to `/release`, where the mutation gate and the full serial battery are the point.
 
-⚠️ **Never kill `ci-local.sh` mid-run.** `mutate.ts` rewrites source files in place and reverts them at the end, so an interrupted run leaves a MUTATED source file in the tree — silently, and it will be committed by the next `git commit -o` that names it. If you must stop one, `git status` afterwards and restore anything it left behind.
+⚠️ **THE MUTATION-GATE TRIGGER ABOVE IS WRITTEN ON THE WRONG THING, and this is
+the one pre-flight gap that actually costs remote round-trips.** `mutation-tables`
+does not break when you touch `scripts/mutations/**`. It breaks when you touch
+anything a spec **TARGETS** — and the commonest way to do that is to **RENAME OR
+REWRITE A TEST**, which goes nowhere near that directory. The generated tables
+record *"first test to die"* BY NAME plus a count per suite, so renaming a test
+makes them stale, and a refactor that moves the code a mutation anchors on kills
+the anchor outright.
+
+So add one cheap command to the pre-flight whenever the branch renamed a test,
+deleted a function, or reshaped a block a mutation might anchor on:
+
+```bash
+TEST_DATABASE_URL=… bash scripts/check-mutation-tables.sh --affected origin/main
+```
+
+It reports which specs the branch touched and exits instantly when the answer is
+none, which is the common PR. **It is NOT free when the answer is non-zero** —
+it re-runs whole `-pg` suites once per mutation, tens of minutes — so run it in
+the BACKGROUND and carry on; do not block the loop on it, and do not put it in
+the default pre-flight.
+
+Measured on #5047: the branch renamed tests across five suites and deleted one
+function. `mutation-tables` failed remote CI **twice**, and the second failure
+cost a full CI round-trip that a background `--affected` run started at PR time
+would have pre-empted. Three anchors were dead, and one of them had been
+re-anchored once already by the previous issue for the same reason.
+
+⚠️ **A DEAD ANCHOR IS NOT ALWAYS RE-ANCHORABLE, and reaching for a replacement
+mutation is how a tombstone gets into a table.** If the PR deleted the code a
+mutation targets, there is nothing to move the anchor to: DELETE the mutation and
+say why. Do not invent a successor pointing at whatever replaced it unless that
+successor is genuinely killable — a defensive arm for a state your change just
+made unreachable measures `0` in every suite, and `mutate.ts`'s header calls a
+published `0` a claim. Recording one asserts *"no test covers this"* where the
+truth is *"no input reaches this"*, which is precisely the tombstone the
+dead-anchor arm refuses to write. Point the replacement at the guard that made
+the state unreachable instead — that one has a test and a real number.
+
+⚠️ **NEVER COMMIT WHILE A MUTATION RUN IS LIVE — and that includes obeying a
+hook that tells you to.** `ci-local.sh`, `check-mutation-tables.sh` and a bare
+`mutate.ts` all rewrite source files in place and revert them at the end, so a
+dirty tree during one is EXPECTED and committing it ships sabotaged source that
+reads as a legitimate change in review. Check before every commit in this window:
+
+```bash
+pgrep -f "[m]utate.ts" >/dev/null && echo "MUTATION RUN LIVE — do not commit"
+```
+
+Measured on #5047: a stop hook asked for a commit four times during a 40-minute
+regeneration, while `git status` showed a different mutated file each time
+(`extract.ts`, then `alias-proposal.ts`, then `cardinality.ts`) as the runner
+worked through its list. The hook is not wrong in general; it is wrong in this
+window, and the `pgrep` is how you tell the two apart.
+
+⚠️ **Never kill `ci-local.sh` — or any mutation run — mid-run.** `mutate.ts`
+rewrites source files in place and reverts them at the end, so an interrupted run
+leaves a MUTATED source file in the tree — silently, and it will be committed by
+the next `git commit -o` that names it. **A foreground `Bash` timeout counts as
+killing it**: #5047 lost a `--affected` run to the 10-minute cap, which is why
+these belong in the background. If you must stop one, `git status` afterwards and
+restore anything it left behind.
+
+⚠️ **A `-pg` baseline reported RED may be a DEAD DATABASE, not a real failure.**
+The runner aborts when a baseline suite is already failing, because a mutation
+count against a broken tree is breakage-plus-mutation and indistinguishable from
+a strong result. That guard is right, but it cannot tell a genuine regression
+from a Postgres that fell over — and the mutation load is heavy enough to do
+that. #5047 saw six specs report *"baseline is RED — 2 failing"*; every one was
+`connect ENOENT /tmp/.s.PGSQL.5432`. Before believing a baseline failure, check
+the server is up and re-run one suite directly.
 
 `/ci` uses a **launch-and-watch protocol** (see `ci.md`): the wrapper runs in the background and YOU poll `.ci-local/RESULT` on a loop — never end the turn "waiting for the CI report". A lost subagent hand-off here used to stall the whole ship loop until a human poked it; `.ci-local/RESULT` on disk is the completion signal, not any agent's reply.
 

--- a/.claude/commands/ship-issue.md
+++ b/.claude/commands/ship-issue.md
@@ -170,8 +170,18 @@ dirty tree during one is EXPECTED and committing it ships sabotaged source that
 reads as a legitimate change in review. Check before every commit in this window:
 
 ```bash
-pgrep -f "[m]utate.ts" >/dev/null && echo "MUTATION RUN LIVE — do not commit"
+ps -o pid=,args= -C bun | grep 'mutate\.ts' && echo "MUTATION RUN LIVE — do not commit"
 ```
+
+⚠️ **`pgrep -f` is the obvious spelling and it FALSE-POSITIVES, including on the
+bracket trick (`[m]utate.ts`).** `-f` matches other processes' full command
+lines, and your own shell's command line is one of them — so the moment the
+pattern appears anywhere else in the command you are running, the check reports a
+live run that does not exist. Measured on #5047 in the most pointed way
+available: the check fired while committing, because the COMMIT MESSAGE
+documented the check, putting the literal string in the shell's argv. A guard
+that cries wolf gets ignored, which is worse than no guard. `-C bun` matches on
+the EXECUTABLE, so a shell can never satisfy it.
 
 Measured on #5047: a stop hook asked for a commit four times during a 40-minute
 regeneration, while `git status` showed a different mutated file each time

--- a/.claude/commands/ship-issue.md
+++ b/.claude/commands/ship-issue.md
@@ -60,21 +60,49 @@ Use `cd packages/api && bun run scripts/test-isolated.ts --affected` for the fas
 
   ⚠️ **Fixing the reported instance and not the class is THE reason rounds multiply, and the class has members in two directions.** The grep finds siblings in space; the delta table finds siblings in the input domain at one site. #5037 swept diligently for the first and lost three rounds to the second — one guard, edited three times, each edit closing the symptom a reviewer named and opening the input class beside it.
 - **Re-runs are not fresh rounds.** Pass the previous round's fix commits into the panel and name them the primary audit target (`/review-panel` Step 2). Reviewers keep fresh context; what they must not have is fresh *ignorance of what you just changed*.
-- Repeat until **CLEAN**, capped at **3 rounds**. If it can't converge in 3 (usually a spec ambiguity), STOP and ask the human.
-- The cap is on ROUNDS, not on scope. A round-2 fix that adds real machinery *should* earn a round 3 — don't skip the re-review to stay under the cap. If the work genuinely needs a fourth round, that is the STOP-and-ask case, not a reason to merge unreviewed.
-- ⚠️ **The yield curve is a LIVE stop, not a line in the final report.** After every round, compare its finding count to the previous round's. **If it did not fall, STOP and ask — immediately, that round.** Do not spend the next round to confirm what the rise already told you. A rising count means the fixes are manufacturing the next round's work, so another round buys more findings rather than fewer, and the cap is the wrong instrument for catching it: #5088 ran 30 → 18 → 11 → **21** and the stop-worthy signal was the 21, one full round before the cap conversation happened.
+
+⚠️ **"STOP" IN THIS STEP ENDS THE ROUNDS, NOT THE RUN. Read this before any stop rule below.**
+
+Every stop in Step 3 means *this diff gets no more review rounds* — fix what is
+confirmed, pay the closing round's costs, and **go to Step 5 and open the PR.**
+It does **not** mean park the issue and wait for a human. `/ship-issue` is the
+autonomous loop; the human boundaries are Step 5's HARD HALTS (a fork PR, a
+structurally missing required check) and a genuine blocker — a spec ambiguity you
+cannot resolve, a dependency that is not merged. A yield stop is none of those:
+it is a statement about the REVIEW, and the review's verdict travels in the PR
+body, where the reviewer reads it.
+
+The tell is one question: **does the stop reason make the work unshippable, or
+only unreviewable-further?** Only the first halts. A loop eating its own fixes
+still has a correct diff at the head of it — that is precisely why you stopped
+rather than churning it more.
+
+Measured on #5047, which is why this block exists: the ratio rule fired at round
+2 (~13 defect-in-prior-fix vs ~4 new surface), everything confirmed was fixed and
+1052/1052 tests were green — and the run then **parked with no PR at all**,
+because "STOP and ask the human" reads as a halt while the closing-round rule
+below says *"whichever way you leave the loop"* and #5077's precedent says the
+yield stop **merged**. Two readings of one word, with evidence in the file for
+both. The human had to ask why it was not done.
+
+So: below, "stop" means **stop the rounds**. Where a halt is meant, it says HALT
+and names the boundary.
+
+- Repeat until **CLEAN**, capped at **3 rounds**. If it can't converge in 3, stop the rounds. **HALT only if the reason is a spec ambiguity you cannot resolve** — that is a blocker, and shipping a diff whose requirements are unsettled is the one thing the cap must not do. Any other non-convergence ships with the curve reported.
+- The cap is on ROUNDS, not on scope. A round-2 fix that adds real machinery *should* earn a round 3 — don't skip the re-review to stay under the cap. If the work genuinely needs a fourth round, stop the rounds and say so in the PR body; that is not a reason to skip the panel's earlier verdicts, and it is not by itself a halt.
+- ⚠️ **The yield curve is a LIVE stop, not a line in the final report.** After every round, compare its finding count to the previous round's. **If it did not fall, stop the rounds — immediately, that round.** Do not spend the next round to confirm what the rise already told you. A rising count means the fixes are manufacturing the next round's work, so another round buys more findings rather than fewer, and the cap is the wrong instrument for catching it: #5088 ran 30 → 18 → 11 → **21** and the stop-worthy signal was the 21, one full round before the cap conversation happened.
 - ⚠️ **SPLIT the count two ways before you read it. A raw total conflates two situations that demand OPPOSITE responses.**
   - **NEW SURFACE** — the round looked somewhere no round had looked. Rising new-surface findings mean the review is getting *deeper*, and another round is earning its keep. #5033 is the precedent: a round-1 fix added a savepoint primitive, round 2 found it could roll back an entire publish, round 3 found round 2's `SAVEPOINT` unguarded. Capping there would have shipped a diagnostic capable of rolling back a customer's publish.
   - **DEFECT-IN-PRIOR-FIX** — the previous round's fix broke it, or failed to close the class it claimed to. Rising here means **the loop is eating itself**: each round manufactures the next one's work, and another round adds more than it removes.
 
-  Report both numbers, always: *"round 2: 22 findings — 6 new surface, 16 defect-in-prior-fix."* **The stop decision keys on the SECOND number.** A total that rose on new surface is a reason to continue; a total that rose on defect-in-prior-fix is a reason to stop and change how the fixes are being written, not to buy another round of the same.
+  Report both numbers, always: *"round 2: 22 findings — 6 new surface, 16 defect-in-prior-fix."* **The stop decision keys on the SECOND number.** A total that rose on new surface is a reason to continue; a total that rose on defect-in-prior-fix is a reason to stop the rounds and change how the fixes are being written, not to buy another round of the same. Changing how they are written is the NEXT issue's lesson — on this one, the rounds are over and the diff ships.
 
   ⚠️ **THE HARD STOP IS THE RATIO, NOT THE ROUND COUNT: if defect-in-prior-fix EXCEEDS new-surface in any round, stop that round.** The 3-round cap is the wrong instrument and always was — it bounds how long you spend, not whether you are making things better, and a loop can burn all three rounds cleaning up after itself. When the majority of a round's findings are defects the previous round's fixes introduced, more review cannot help: the fixes are the defect source, so another round adds work faster than it removes it.
 
   Measured on #5037: round 1 returned 21 findings, all new surface; round 2 returned ~26, of which ~20 were defects inside round 1's own fixes. The raw total *and* the ratio both said stop, one round before the cap would have. Under the old rule the cap allowed a third round, which would have been spent on the second round's fixes.
 
   ⚠️ This split exists because the raw rule shipped without it and gave the wrong reading first time out. #5077 ran 17 → ~22 and the rise looked like a loop failing; decomposed, it was almost entirely defects in round 1's own fixes — three of them reproducing the very defect being fixed, one layer over. Those two diagnoses point at different remedies and the total cannot tell them apart.
-- **When you do stop, report the CURVE, not just the count.** A declining count (30 → 18 → 11) is a loop converging and the cap is a formality; a flat or rising one is a loop that is not, and the human needs to know which they are approving another round of.
+- **When you do stop, report the CURVE, not just the count** — in the PR body, which is where a reviewer meets it, and in the Step 7 report. A declining count (30 → 18 → 11) is a loop converging and the cap is a formality; a flat or rising one is a loop that is not, and the reviewer needs to know which shape produced the diff in front of them. Reporting the curve is the whole obligation the stop creates: it is a disclosure, not a request for permission.
 - ⚠️ **A STOP IS A CLOSING ROUND. Do not stop without paying the closing round's costs.** Whichever way you leave the loop — CLEAN, the yield stop, or the 3-round cap — that round is the last one the diff gets, so it owes everything a final round owes: `comment-analyzer` run on this diff (`/review-panel` Step 2), and every named falsifier BUILT and RUN (Step 6). Stopping early is correct; stopping cheaply is not.
 
   Measured: #5077 stopped on the yield rule and **merged with no comment sweep at all**, because the sweep is gated on "a round with no must-fix" and that round never arrived. Two rules that did not know about each other, and a comment-heavy diff went out unreviewed on the one axis dedicated to it.
@@ -105,7 +133,11 @@ So the local pre-flight is the cheap subset — `--affected`, `lint`, `type` —
 ```
 /pr
 ```
-`/pr` branches/commits/pushes and opens the PR with `Closes #<N>`. Two gates must be green on the head SHA: the **internal `/review-panel`** (already run in Step 3) and **required CI**. Third-party review bots are now the *exception* — the panel is the review — so handle them only when one is actually on the PR. The settling point is the **first full CI completion**, not an open-ended wait for reviewers that may not exist.
+`/pr` branches/commits/pushes and opens the PR with `Closes #<N>`.
+
+⚠️ **If the Step-3 panel stopped early, the PR body owes the CURVE and the residue** — rounds with both numbers per round (`round 2: 17 — 4 new surface, 13 defect-in-prior-fix`), why the loop closed, and what was consciously left as a follow-up. That disclosure is what makes an early stop legitimate rather than a shortcut: the reviewer opening the PR is the human the stop rule wanted told, and the PR body is where they are standing.
+
+Two gates must be green on the head SHA: the **internal `/review-panel`** (already run in Step 3) and **required CI**. Third-party review bots are now the *exception* — the panel is the review — so handle them only when one is actually on the PR. The settling point is the **first full CI completion**, not an open-ended wait for reviewers that may not exist.
 
 1. **Wait for the first full CI run to complete** on the head SHA:
    ```bash
@@ -130,9 +162,11 @@ So the local pre-flight is the cheap subset — `--affected`, `lint`, `type` —
    - **Ambiguous / architecturally significant** → `AskUserQuestion`; don't guess.
    - **Approvability / "needs human review" / policy sign-off with no code ask** → **acknowledge only.** Quote it in the report. It does **NOT** block the merge and is **NOT** a halt — `main` deploys to staging, not prod. Never sit waiting on a human-approval verdict.
 
-**Converged** when, on the head SHA: required CI green, the Step-3 panel was clean, and **either** no external reviewer is present **or** every present reviewer is re-reviewed-clean / carries only an acknowledged non-actionable verdict → **merge.** Cap the reviewer back-and-forth at **3 rounds** like the panel; if it won't converge, STOP and ask.
+**Converged** when, on the head SHA: required CI green, **the Step-3 panel CLOSED** — reached CLEAN, *or* stopped on the yield/ratio rule or the 3-round cap with every confirmed must-fix fixed and the curve reported in the PR body — and **either** no external reviewer is present **or** every present reviewer is re-reviewed-clean / carries only an acknowledged non-actionable verdict → **merge.** Cap the reviewer back-and-forth at **3 rounds** like the panel; if it won't converge, stop the rounds and say so on the PR.
 
-**HARD HALTS (never autonomous):**
+⚠️ **"CLOSED", not "clean", and the difference is a bug this line used to carry.** Read as *the panel was clean*, a run that stopped on the yield rule could never satisfy it — the stop rule tells you to end the rounds before CLEAN arrives, and this line then says you are not converged, so the diff can never merge and the loop deadlocks with a finished branch and no PR. #5047 hit exactly that. A panel that stopped early has DONE its job; what it owes is the disclosure, not a verdict word.
+
+**HARD HALTS (never autonomous)** — and these are the whole list. A Step-3 yield stop is NOT one of them; see the disambiguation there. If a stop reason is not on this list and does not make the work unshippable, it ships:
 - **Fork PR** (`isCrossRepository: true`) → STOP, surface provenance, get human sign-off. Never `--admin` past `fork-pr-gate`.
 - A required check that's **structurally missing** (e.g. CodeQL on a fork) → stop sign, not an override.
 - `--admin` is only for a genuinely *broken* gate, not a *slow* one — wait for `gh pr checks --watch`.
@@ -150,7 +184,9 @@ git worktree remove ../atlas-wt-<slug>
 ⚠️ **Record rounds AND minutes per round in the ROADMAP entry.** Round counts have been recorded since #5027; wall clock never has, and without it there is no way to tell whether a change that makes rounds more thorough is buying fewer of them or just costing more. Two numbers per issue — `rounds: 3 (22m / 31m / 14m)` — is the whole ask, and it is what makes the Step 6 split above falsifiable.
 
 
-PR URL · issue closed · CI/merge status · panel rounds it took · **each external reviewer's verdict** (addressed / acknowledged) · anything you halted on.
+PR URL · issue closed · CI/merge status · panel rounds it took, with the CURVE if it stopped early · **each external reviewer's verdict** (addressed / acknowledged) · anything you halted on.
+
+⚠️ **"Anything you halted on" means a HARD HALT.** A yield stop is not a halt and does not belong in that slot — it belongs in the rounds/curve slot beside it. Reporting an early stop as a halt is how a finished, green, merged-ready branch gets described as blocked.
 
 ---
 

--- a/.claude/commands/ship-issue.md
+++ b/.claude/commands/ship-issue.md
@@ -64,7 +64,7 @@ Use `cd packages/api && bun run scripts/test-isolated.ts --affected` for the fas
 ⚠️ **"STOP" IN THIS STEP ENDS THE ROUNDS, NOT THE RUN. Read this before any stop rule below.**
 
 Every stop in Step 3 means *this diff gets no more review rounds* — fix what is
-confirmed, pay the closing round's costs, and **go to Step 5 and open the PR.**
+confirmed, pay the closing round's costs, and **continue to Step 4's pre-flight and Step 5's PR.**
 It does **not** mean park the issue and wait for a human. `/ship-issue` is the
 autonomous loop; the human boundaries are Step 5's HARD HALTS (a fork PR, a
 structurally missing required check) and a genuine blocker — a spec ambiguity you
@@ -121,7 +121,7 @@ So the local pre-flight is the cheap subset — `--affected`, `lint`, `type` —
 
 **Run the full `/ci` only when:**
 - remote CI is itself broken or unavailable, and you need a local answer;
-- you are touching `scripts/mutations/**` or the mutation gate itself, which remote CI does not exercise the same way;
+- you renamed or deleted a test, deleted a function, or reshaped a block a mutation anchors on — see the mutation-gate note below. Remote CI DOES run `mutation-tables`, so this is about pre-empting a round-trip rather than about coverage;
 - you are about to `/release`, where the mutation gate and the full serial battery are the point.
 
 ⚠️ **THE MUTATION-GATE TRIGGER ABOVE IS WRITTEN ON THE WRONG THING, and this is
@@ -172,6 +172,8 @@ reads as a legitimate change in review. Check before every commit in this window
 ```bash
 ps -o pid=,args= -C bun | grep 'mutate\.ts' && echo "MUTATION RUN LIVE — do not commit"
 ```
+
+(`ps -C` is procps — Linux. On BSD/macOS use `ps -eo comm=,args= | awk '$1=="bun"'`.)
 
 ⚠️ **`pgrep -f` is the obvious spelling and it FALSE-POSITIVES, including on the
 bracket trick (`[m]utate.ts`).** `-f` matches other processes' full command
@@ -247,6 +249,7 @@ Two gates must be green on the head SHA: the **internal `/review-panel`** (alrea
 ⚠️ **"CLOSED", not "clean", and the difference is a bug this line used to carry.** Read as *the panel was clean*, a run that stopped on the yield rule could never satisfy it — the stop rule tells you to end the rounds before CLEAN arrives, and this line then says you are not converged, so the diff can never merge and the loop deadlocks with a finished branch and no PR. #5047 hit exactly that. A panel that stopped early has DONE its job; what it owes is the disclosure, not a verdict word.
 
 **HARD HALTS (never autonomous)** — and these are the whole list. A Step-3 yield stop is NOT one of them; see the disambiguation there. If a stop reason is not on this list and does not make the work unshippable, it ships:
+- **A Step-3 spec ambiguity you cannot resolve, or a dependency that is not merged** → HALT and ask. These are the blockers the yield stop is not: they make the work unshippable rather than merely unreviewable-further.
 - **Fork PR** (`isCrossRepository: true`) → STOP, surface provenance, get human sign-off. Never `--admin` past `fork-pr-gate`.
 - A required check that's **structurally missing** (e.g. CodeQL on a fork) → stop sign, not an override.
 - `--admin` is only for a genuinely *broken* gate, not a *slow* one — wait for `gh pr checks --watch`.

--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -56606,6 +56606,31 @@
               }
             }
           },
+          "409": {
+            "description": "Bundle refused — a fact has no identity key at a position whose surface normalizes to a real one, so landing it would either retire a healthy belief or re-derive its key under this region's vocabulary, and neither is reversible (#5047). NOTHING WAS WRITTEN. Two causes with two different remedies, and the `message` says which: on a v3 bundle the key was supposed to travel and did not — re-export from the source region, checking it for identity drift and that it has applied migration 0194 — while on a v1/v2 bundle the key is computed at import, so a refusal means THIS region's vocabulary maps that norm away and the fix is a local `brain_vocabulary_target` entry, which re-exporting cannot change.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "requestId": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
           "500": {
             "description": "Internal server error",
             "content": {

--- a/packages/api/scripts/mutations/bundle-identity.md
+++ b/packages/api/scripts/mutations/bundle-identity.md
@@ -37,9 +37,9 @@ Every number is the count of tests that FAIL in that suite under that mutation, 
 
 | Mutation | roundtrip-pg | admin-migrate | export | object-cmp | v3 pin | logging |
 |---|---|---|---|---|---|---|
-| the importer RE-DERIVES a v3 fact's keys instead of carrying them | 1 | 0 | 0 | 0 | 0 | 0 |
+| the importer RE-DERIVES a v3 fact's keys instead of carrying them | 2 | 0 | 0 | 0 | 0 | 1 |
 | a store-local `entity:` id travels verbatim | 1 | 0 | 0 | 2 | 0 | 1 |
-| a LEGACY bundle's facts are left unkeyed | 1 | 0 | 0 | 0 | 0 | 0 |
+| a LEGACY bundle's facts are left unkeyed | 2 | 3 | 0 | 0 | 0 | 3 |
 | the legacy arm keys against an EMPTY vocabulary (the load deleted) | 1 | 0 | 0 | 0 | 0 | 2 |
 | `provisional` is never written for a nulled row | 1 | 0 | 0 | 0 | 0 | 0 |
 | `provisional` is written for EVERY imported row | 1 | 0 | 0 | 0 | 0 | 0 |
@@ -63,9 +63,9 @@ Every number is the count of tests that FAIL in that suite under that mutation, 
 | the required-sections gate reads `=== CURRENT` again | 0 | 1 | 0 | 0 | 0 | 0 |
 | the exporter stops projecting the identity columns | 1 | 0 | 0 | 0 | 1 | 0 |
 | the exporter feeds identity values through a cast instead of `textOrNull` | 0 | 0 | 2 | 0 | 0 | 0 |
-| the importer writes `predicate_cardinality` again (from the legacy field) | 1 | 0 | 0 | 0 | 1 | 0 |
+| the importer writes `predicate_cardinality` again (from the legacy field) | 6 | 0 | 0 | 0 | 1 | 0 |
 
-Suite sizes: **roundtrip-pg** 8 tests (`src/lib/residency/__tests__/migrate-roundtrip-pg.test.ts`) · **admin-migrate** 96 tests (`src/api/__tests__/admin-migrate.test.ts`) · **export** 24 tests (`src/lib/residency/__tests__/export.test.ts`) · **object-cmp** 64 tests (`src/lib/brain/__tests__/object-cmp.test.ts`) · **v3 pin** 6 tests (`src/lib/residency/__tests__/bundle-identity-v3.test.ts`) · **logging** 7 tests (`src/lib/residency/__tests__/migrate-identity-logging.test.ts`).
+Suite sizes: **roundtrip-pg** 11 tests (`src/lib/residency/__tests__/migrate-roundtrip-pg.test.ts`) · **admin-migrate** 96 tests (`src/api/__tests__/admin-migrate.test.ts`) · **export** 24 tests (`src/lib/residency/__tests__/export.test.ts`) · **object-cmp** 64 tests (`src/lib/brain/__tests__/object-cmp.test.ts`) · **v3 pin** 6 tests (`src/lib/residency/__tests__/bundle-identity-v3.test.ts`) · **logging** 8 tests (`src/lib/residency/__tests__/migrate-identity-logging.test.ts`).
 
 ## Notes
 

--- a/packages/api/scripts/mutations/bundle-identity.mutations.ts
+++ b/packages/api/scripts/mutations/bundle-identity.mutations.ts
@@ -79,12 +79,18 @@ comparison and the counts are the real ones.
       edits: [
         {
           file: IMPORT,
-          oldString: `    subjectKey: fact.subjectKey ?? null,
-    predicateKey: fact.predicateKey ?? null,
-    objectKey: fact.objectKey ?? null,`,
-          newString: `    subjectKey: slotKey(fact.subject, identityVocabulary.subject),
-    predicateKey: slotKey(fact.predicate, identityVocabulary.predicate),
-    objectKey: slotKey(fact.object, identityVocabulary.object),`,
+          // ⚠️ RE-ANCHORED by #5047, the second time this mutation has needed it.
+          // The carried arm now routes through `tombstonePlaceholder`, so the
+          // three lines are one indent deeper and the old anchor matched
+          // NOTHING — caught by `--check`'s dead-anchor arm, exactly as #5037's
+          // re-anchor of the `logDegeneratePredicate` mutations was, and the
+          // reason the runner refuses to write a table it could not measure.
+          oldString: `      subjectKey: fact.subjectKey ?? null,
+      predicateKey: fact.predicateKey ?? null,
+      objectKey: fact.objectKey ?? null,`,
+          newString: `      subjectKey: slotKey(fact.subject, identityVocabulary.subject),
+      predicateKey: slotKey(fact.predicate, identityVocabulary.predicate),
+      objectKey: slotKey(fact.object, identityVocabulary.object),`,
         },
         // The mutation has to compile: `identityVocabulary` is not otherwise
         // imported here. Adding the import is part of the mutation, not a

--- a/packages/api/scripts/mutations/cardinality.md
+++ b/packages/api/scripts/mutations/cardinality.md
@@ -28,16 +28,15 @@ Every number is the count of tests that FAIL in that suite under that mutation, 
 | the repeat gate counts machine supersessions too | 1 | 1 | 0 | 0 | 0 |
 | the repeat threshold drops to 1 | 1 | 1 | 0 | 0 | 0 |
 | `INSERT_FACT_SQL` feeds `predicate_cardinality` again | 0 | 0 | 8 | 0 | 27 |
-| `retract` feeds the proposer too | 0 | 0 | 9 | 0 | 0 |
+| `retract` feeds the proposer too | 0 | 0 | 3 | 0 | 0 |
 | the post-commit proposer loses its deadline | 0 | 0 | 5 | 0 | 0 |
 | the deadline's timer is never cleared | 0 | 0 | 1 | 0 | 0 |
 | the post-deadline continuation is deleted | 0 | 0 | 2 | 0 | 0 |
 | the late-SUCCESS arm's guard is inverted | 0 | 0 | 1 | 0 | 0 |
-| `logDegeneratePredicate` fires for every verb, not only `supersede` | 0 | 0 | 3 | 0 | 0 |
-| `logDegeneratePredicate`'s call is removed | 0 | 0 | 3 | 0 | 0 |
+| the supersede refusal gates on the failing POSITION instead of its CAUSE | 0 | 0 | 1 | 0 | 0 |
 | the proposer runs INSIDE the correction's transaction | 0 | 0 | 8 | 0 | 0 |
 
-Suite sizes: **cardinality-pg.test.ts** 27 tests (`src/lib/brain/__tests__/cardinality-pg.test.ts`) · **cardinality.test.ts** 38 tests (`src/lib/brain/__tests__/cardinality.test.ts`) · **correction.test.ts** 84 tests (`src/lib/brain/__tests__/correction.test.ts`) · **brain-facts.test.ts** 60 tests (`src/lib/content-mode/adapters/__tests__/brain-facts.test.ts`) · **reconcile.test.ts** 70 tests (`src/lib/brain/__tests__/reconcile.test.ts`).
+Suite sizes: **cardinality-pg.test.ts** 27 tests (`src/lib/brain/__tests__/cardinality-pg.test.ts`) · **cardinality.test.ts** 38 tests (`src/lib/brain/__tests__/cardinality.test.ts`) · **correction.test.ts** 87 tests (`src/lib/brain/__tests__/correction.test.ts`) · **brain-facts.test.ts** 60 tests (`src/lib/content-mode/adapters/__tests__/brain-facts.test.ts`) · **reconcile.test.ts** 72 tests (`src/lib/brain/__tests__/reconcile.test.ts`).
 
 ## Notes
 
@@ -57,6 +56,5 @@ Suite sizes: **cardinality-pg.test.ts** 27 tests (`src/lib/brain/__tests__/cardi
 - **the deadline's timer is never cleared** — Round 1's own defect, respelled as the edit that reproduces it: a `finally` attached to the TIMER PROMISE settles only when the timer fires, so `clearTimeout` was always a no-op and the fast path left a 5s timer armed per correction. Round 2 published this row as an honest `0` (`bun test` force-exits); round 3 falsified it with the technique already in `correction-audit.test.ts`, which had stayed green only because it drives `pin` — a verb that never reaches the proposer.
 - **the post-deadline continuation is deleted** — `Promise.race` marks the loser's rejection HANDLED, so a store error arriving after the deadline is dropped with no line and not even an unhandled rejection — while the only record an operator holds says the statement *may still commit*. Round 3 wrote this block and shipped nothing that could reach it: the hang knob never settles, so both arms were structurally unfalsifiable until a DELAYED-settle knob existed.
 - **the late-SUCCESS arm's guard is inverted** — Fires *COMPLETED after its deadline* on every ordinary supersede — alert fatigue on the happy path, and the reason the arm needs a prohibition as well as an assertion. Deleting the arm outright is the milder mutation; inverting it is the one a reader would call a typo.
-- **`logDegeneratePredicate` fires for every verb, not only `supersede`** — A `retract` or a vouch would then log *superseded a claim whose predicate normalizes away* about a verb that superseded nothing. The guard is the whole content of the line.
-- **`logDegeneratePredicate`'s call is removed** — The case is legal and permanent (`identityKey`'s ⚠️), produces no proposal, and without this line produces no record either — a supersede that vanished.
+- **the supersede refusal gates on the failing POSITION instead of its CAUSE** — This is the mutation #5047's review round found LIVE — the first cut of the guard gated on the position alone, on the argument that the object is the caller's own text where the slot is copied off the target. `slotKey` is `identityKey(alias(identityKey(surface)))`, so an object key is ALSO null when the workspace's object-position vocabulary maps a real norm to something that normalizes away: a human superseding with good text is then told their replacement *normalizes away to nothing*, on a request no retry can satisfy. Fix-your-correct-input, from a guard written to stop exactly that.
 - **the proposer runs INSIDE the correction's transaction** — Stands in for the placement change rather than reproducing it literally (the real one cannot be expressed as a local edit). What it removes is the proposer's access to the committed `supersedes` edge — which is why the placement is post-commit rather than a `SAVEPOINT`.

--- a/packages/api/scripts/mutations/cardinality.mutations.ts
+++ b/packages/api/scripts/mutations/cardinality.mutations.ts
@@ -299,40 +299,41 @@ human behind it.
       ],
       note: "Fires *COMPLETED after its deadline* on every ordinary supersede — alert fatigue on the happy path, and the reason the arm needs a prohibition as well as an assertion. Deleting the arm outright is the milder mutation; inverting it is the one a reader would call a typo.",
     },
+    // ⚠️ TWO MUTATIONS WERE DELETED HERE BY #5047, not re-anchored, and the
+    // difference matters. They mutated `logDegeneratePredicate` — its
+    // `verb === "supersede"` guard, and its call — and #5047 DELETED that
+    // function. A mutation whose target no longer exists cannot be repaired by
+    // moving its anchor; there is nothing to move it to.
+    //
+    // The reporter existed for a `supersede` that COMMITTED while closing no
+    // canonical predicate slot. #5047 makes that state unrepresentable: the
+    // replacement inherits the target's slot, `reconcile.ts` refuses a null slot
+    // key, and `brain_facts`' key columns are `NOT NULL` as of migration 0194.
+    // So the verb now REFUSES where it used to commit-and-report.
+    //
+    // No successor mutation was written for the arm that replaced it — the
+    // `log.error` at `correction.ts`'s post-commit block — and that omission is
+    // deliberate rather than lazy. That arm fires only if one of those three
+    // invariants moves, so it is unreachable by construction and a mutation on
+    // it would measure `0` for every suite. `mutate.ts`'s own header calls a
+    // published `0` a claim; recording one here would assert *"no test covers
+    // this"* when the truth is *"no input reaches this"*, which is the tombstone
+    // the dead-anchor arm exists to keep out of these tables.
+    //
+    // What IS measurable is the guard that made the state unreachable, so that
+    // is the mutation below.
     {
-      label: "`logDegeneratePredicate` fires for every verb, not only `supersede`",
+      label: "the supersede refusal gates on the failing POSITION instead of its CAUSE",
       edits: [
         {
           file: CORRECTION,
-          oldString: '    if (verb === "supersede") {\n      logDegeneratePredicate(',
-          newString: "    if (true) {\n      logDegeneratePredicate(",
+          oldString: `    (outcome.unkeyed ?? []).some(
+      (slot) => slot.role === "object" && slot.cause === "degenerate-surface",
+    )`,
+          newString: `    (outcome.unkeyed ?? []).some((slot) => slot.role === "object")`,
         },
       ],
-      note: "A `retract` or a vouch would then log *superseded a claim whose predicate normalizes away* about a verb that superseded nothing. The guard is the whole content of the line.",
-    },
-    {
-      label: "`logDegeneratePredicate`'s call is removed",
-      edits: [
-        {
-          file: CORRECTION,
-          // ⚠️ Re-anchored by #5037, which threaded a `cause` discriminant through
-          // this call and turned it from one line into an object literal. The old
-          // anchor then matched nothing and the mutation MEASURED NOTHING —
-          // caught by `--check`'s dead-anchor arm rather than by anyone reading
-          // the diff, which is the arm #5077 added for exactly this and the
-          // reason it refuses to write a table it cannot measure.
-          oldString: `    if (verb === "supersede") {
-      logDegeneratePredicate({
-        workspaceId: ctx.workspaceId,
-        factId: result.factId,
-        requestId,
-        cause: supersededPredicateCause,
-      });
-    }`,
-          newString: "    void verb;",
-        },
-      ],
-      note: "The case is legal and permanent (`identityKey`'s ⚠️), produces no proposal, and without this line produces no record either — a supersede that vanished.",
+      note: "This is the mutation #5047's review round found LIVE — the first cut of the guard gated on the position alone, on the argument that the object is the caller's own text where the slot is copied off the target. `slotKey` is `identityKey(alias(identityKey(surface)))`, so an object key is ALSO null when the workspace's object-position vocabulary maps a real norm to something that normalizes away: a human superseding with good text is then told their replacement *normalizes away to nothing*, on a request no retry can satisfy. Fix-your-correct-input, from a guard written to stop exactly that.",
     },
     {
       label: "the proposer runs INSIDE the correction's transaction",

--- a/packages/api/scripts/mutations/identity-corpus.md
+++ b/packages/api/scripts/mutations/identity-corpus.md
@@ -24,11 +24,11 @@ Every number is the count of tests that FAIL in that suite under that mutation, 
 
 | Mutation | identity-consumers-pg.test.ts | reconcile.test.ts |
 |---|---|---|
-| `lexicalNorm` loses its ASCII case fold | 20 | 6 |
-| `lexicalNorm` loses its edge trim | 3 | 1 |
+| `lexicalNorm` loses its ASCII case fold | 20 | 7 |
+| `lexicalNorm` loses its edge trim | 3 | 2 |
 | `identityAlias` given a global rule (`/^is /` stripped) | 3 | 0 |
 | `CORROBORATION_LOOKUP_SQL` repointed at the surface columns | 12 | 1 |
-| the corroboration call site binds raw surfaces instead of the keys | 12 | 3 |
+| the corroboration call site binds raw surfaces instead of the keys | 12 | 2 |
 | `CORROBORATION_LOOKUP_SQL`'s `object_key = $4` arm neutralized | 16 | 1 |
 | `CORROBORATION_LOOKUP_SQL`'s `object_cmp = $5` arm neutralized (arity-preserving) | 3 | 1 |
 | `objectSameSql` loses its difference VETO | 3 | 1 |
@@ -43,7 +43,7 @@ Every number is the count of tests that FAIL in that suite under that mutation, 
 | `predicate_key =` dropped from the collision join | 1 | 0 |
 | `comparableDifferentSql` loses its `split_part` tag equality arm | 1 | 0 |
 
-Suite sizes: **identity-consumers-pg.test.ts** 76 tests (`src/lib/brain/__tests__/identity-consumers-pg.test.ts`) · **reconcile.test.ts** 70 tests (`src/lib/brain/__tests__/reconcile.test.ts`).
+Suite sizes: **identity-consumers-pg.test.ts** 76 tests (`src/lib/brain/__tests__/identity-consumers-pg.test.ts`) · **reconcile.test.ts** 72 tests (`src/lib/brain/__tests__/reconcile.test.ts`).
 
 ## Notes
 

--- a/packages/api/scripts/mutations/subject-cmp.md
+++ b/packages/api/scripts/mutations/subject-cmp.md
@@ -61,7 +61,7 @@ Every number is the count of tests that FAIL in that suite under that mutation, 
 | the subject's comparable value built by BYPASSING the guarded seam | 20 | 5 | 0 | 0 |
 | the tension scan's trailing placeholders left un-renumbered | 66 | 1 | 0 | 0 |
 
-Suite sizes: **identity-consumers-pg.test.ts** 76 tests (`src/lib/brain/__tests__/identity-consumers-pg.test.ts`) · **reconcile.test.ts** 70 tests (`src/lib/brain/__tests__/reconcile.test.ts`) · **subject-cmp.test.ts** 9 tests (`src/lib/brain/__tests__/subject-cmp.test.ts`) · **brain-facts.test.ts** 60 tests (`src/lib/content-mode/adapters/__tests__/brain-facts.test.ts`).
+Suite sizes: **identity-consumers-pg.test.ts** 76 tests (`src/lib/brain/__tests__/identity-consumers-pg.test.ts`) · **reconcile.test.ts** 72 tests (`src/lib/brain/__tests__/reconcile.test.ts`) · **subject-cmp.test.ts** 9 tests (`src/lib/brain/__tests__/subject-cmp.test.ts`) · **brain-facts.test.ts** 60 tests (`src/lib/content-mode/adapters/__tests__/brain-facts.test.ts`).
 
 ## Notes
 

--- a/packages/api/src/api/routes/__tests__/admin-brain-facts.test.ts
+++ b/packages/api/src/api/routes/__tests__/admin-brain-facts.test.ts
@@ -170,6 +170,7 @@ const REFUSAL_REASONS = {
   targetNotCurrent: "TARGET_NOT_CURRENT",
   replacementMissing: "REPLACEMENT_MISSING",
   replacementIdentical: "REPLACEMENT_IDENTICAL",
+  replacementMalformed: "REPLACEMENT_MALFORMED",
   replacementUnpublishable: "REPLACEMENT_UNPUBLISHABLE",
 } as const satisfies typeof import("@atlas/api/lib/brain/correction").CORRECTION_REFUSAL_REASONS;
 let correctCalls: Array<Record<string, unknown>> = [];
@@ -1097,6 +1098,10 @@ describe("POST /{id}/correct", () => {
       notAuthorized: 403,
       replacementMissing: 400,
       replacementIdentical: 400,
+      // #5047 — a request-shape refusal, not a target-state one: the target is
+      // fine and the replacement TEXT asserts nothing, so the identical request
+      // can never succeed. That is what separates it from every 409 below.
+      replacementMalformed: 400,
       warehouseTarget: 409,
       // #4964 — rationale lives at `refusalStatus` in `admin-brain-facts.ts`,
       // so the argument has one home rather than two that can drift.

--- a/packages/api/src/api/routes/admin-brain-facts.ts
+++ b/packages/api/src/api/routes/admin-brain-facts.ts
@@ -346,6 +346,11 @@ function refusalStatus(reason: CorrectionRefusalReason): 400 | 403 | 409 {
       return 403;
     case CORRECTION_REFUSAL_REASONS.replacementMissing:
     case CORRECTION_REFUSAL_REASONS.replacementIdentical:
+    // `replacementMalformed` is a request-shape mistake and not a target-state
+    // one (#5047): the target is fine, the replacement TEXT asserts nothing.
+    // Retrying the identical request can never succeed, which is what separates
+    // it from every 409 below — those describe a target that can change.
+    case CORRECTION_REFUSAL_REASONS.replacementMalformed:
       return 400;
     // 409 and not 501/503: the client-observable contract is this arm's — "the
     // verb cannot apply to this target". For `unrecognizedSourceKind` it is not

--- a/packages/api/src/api/routes/admin-migrate.ts
+++ b/packages/api/src/api/routes/admin-migrate.ts
@@ -1000,7 +1000,12 @@ interface ImportedIdentity {
   readonly carryReasons: readonly RegionCarryOutcome["reason"][];
   /** A key this import COMPUTED came out null — the surface norms away. */
   readonly unkeyable: boolean;
-  /** A key this import CARRIED arrived null — the cause is the source region's. */
+  /**
+   * A key this import CARRIED arrived null AND that position's surface
+   * normalizes away — the only carried null that still LANDS, since #5047 makes
+   * the repairable kind refuse the bundle. The cause is the claim's own text,
+   * not the source region's.
+   */
   readonly nullKeys: boolean;
 }
 
@@ -1147,10 +1152,18 @@ export class RegionImportVocabularyTargetError extends Error {
  * belonged to, and publish then stamps `valid_to` across the merge — the
  * irreversible direction.
  *
- * So neither landing is safe, and the honest move is not to land. The cause is
- * source-side — export drift that nulls the column for the whole corpus is the
- * documented shape (see `importedIdentity`'s `nullKeys` note), or a source region
- * that has not yet applied 0194 — and both are fixed at the source and re-run.
+ * So neither landing is safe, and the honest move is not to land. WHICH
+ * subsystem to blame depends on the arm, and the two are not interchangeable:
+ *
+ *   - CARRIED (v3): the key was supposed to travel and did not. Source-side —
+ *     export drift that nulls the column for the whole corpus is the documented
+ *     shape, or a source region that has not yet applied 0194. Fixed at the
+ *     source and re-run. {@link RegionImportUnkeyableError}.
+ *   - COMPUTED (v1/v2): the key was derived HERE, so a null means this region's
+ *     own vocabulary maps a real norm to something that normalizes away.
+ *     Destination-side, fixed in `brain_vocabulary_target`, and re-exporting
+ *     cannot change it. {@link RegionImportVocabularyTargetError}.
+ *
  * Refusing is the only outcome here that writes nothing.
  *
  * That a single such row refuses a whole region migration is deliberate: at this
@@ -1264,12 +1277,15 @@ function importedIdentity(fact: ExportedBrainFact, source: IdentitySource): Impo
     comparableDropped: [subject.reason, object.reason].some(isLoss),
     carryReasons: [subject.reason, object.reason],
     // A carried key is never recomputed here, so this import cannot make one
-    // NULL — but it can LAND one, and that is the state an operator needs
-    // reported. The exporter's own drift path produces exactly it: a projection
-    // that stops returning `f.subject_key` exports `null` for every fact, this
-    // region accepts it (null is legitimate at all five positions), and the
-    // whole corpus lands unkeyed with a green 200 at both ends. Region A's log
-    // carries the only other signal, and nobody watching the CUTOVER reads it.
+    // NULL — it can only LAND one, and since #5047 it lands only the kind whose
+    // SURFACE also normalizes away. A null beside a KEYABLE surface refuses the
+    // whole bundle (`RegionImportUnkeyableError`, 409), because that row is
+    // repairable by the next drift re-key and both ways of landing it are not.
+    //
+    // So the exporter's drift path — a projection that stops returning
+    // `f.subject_key`, exporting `null` for every fact — no longer lands quietly
+    // with a green 200 at both ends; it IS the 409. What this counter is left
+    // reporting is the residue: rows that arrived null legitimately.
     unkeyable: false,
     nullKeys: [fact.subjectKey, fact.predicateKey, fact.objectKey].some((k) => (k ?? null) === null),
   };
@@ -2273,10 +2289,16 @@ adminMigrate.openapi(importRoute, async (c) => {
     });
     const detail = err instanceof Error ? err.message : String(err);
     log.error({ err: err instanceof Error ? err : new Error(String(err)), requestId, orgId }, "Migration import failed, rolled back");
-    // A refused bundle is not a server fault (#5047): the source region supplied
-    // no identity for a fact whose surface has one, which is fixed at the source
-    // and re-run. 409 rather than 400 because the request itself is well-formed
-    // — `validateBundle` passed — and rather than 500 because retrying THIS body
+    // A refused bundle is not a server fault (#5047). TWO causes with two
+    // different remedies, and the `message` carries the right one: a v3 bundle
+    // that supplied no identity for a keyable surface (source-side — re-export),
+    // or a v1/v2 bundle this region's own vocabulary cannot key (destination-side
+    // — fix the alias entry; re-exporting changes nothing). Naming only the first
+    // here is the unfollowable advice #5047 removed from the error message and
+    // from the OpenAPI description.
+    //
+    // 409 rather than 400 because the request itself is well-formed —
+    // `validateBundle` passed — and rather than 500 because retrying THIS body
     // can never succeed and nothing here is broken.
     if (
       err instanceof RegionImportUnkeyableError ||
@@ -2363,10 +2385,16 @@ internalMigrate.post("/import", async (c) => {
     });
     const detail = err instanceof Error ? err.message : String(err);
     log.error({ err: err instanceof Error ? err : new Error(String(err)), requestId, orgId }, "Internal import failed, rolled back");
-    // A refused bundle is not a server fault (#5047): the source region supplied
-    // no identity for a fact whose surface has one, which is fixed at the source
-    // and re-run. 409 rather than 400 because the request itself is well-formed
-    // — `validateBundle` passed — and rather than 500 because retrying THIS body
+    // A refused bundle is not a server fault (#5047). TWO causes with two
+    // different remedies, and the `message` carries the right one: a v3 bundle
+    // that supplied no identity for a keyable surface (source-side — re-export),
+    // or a v1/v2 bundle this region's own vocabulary cannot key (destination-side
+    // — fix the alias entry; re-exporting changes nothing). Naming only the first
+    // here is the unfollowable advice #5047 removed from the error message and
+    // from the OpenAPI description.
+    //
+    // 409 rather than 400 because the request itself is well-formed —
+    // `validateBundle` passed — and rather than 500 because retrying THIS body
     // can never succeed and nothing here is broken.
     if (
       err instanceof RegionImportUnkeyableError ||

--- a/packages/api/src/api/routes/admin-migrate.ts
+++ b/packages/api/src/api/routes/admin-migrate.ts
@@ -15,6 +15,8 @@ import { computeNextRun } from "@atlas/api/lib/scheduled-tasks";
 import { BRAIN_EDGE_TYPES, type BrainEdgeType } from "@atlas/api/lib/brain/types";
 import {
   SLOT_POSITIONS,
+  UNKEYABLE_KEY_PREFIX,
+  identityKey,
   isSlotPosition,
   lexicalNorm,
   slotKey,
@@ -860,6 +862,13 @@ const importRoute = createRoute({
       description: "Forbidden — admin role required",
       content: { "application/json": { schema: AuthErrorSchema } },
     },
+    409: {
+      description:
+        "Bundle refused — a fact carries no identity key at a position whose surface has one, " +
+        "so the source region's export is missing identity it holds (#5047). Nothing was written. " +
+        "Re-export from the source region and re-run.",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
     500: {
       description: "Internal server error",
       content: { "application/json": { schema: ErrorSchema } },
@@ -1035,50 +1044,112 @@ interface ImportedIdentity {
  * reads it as the latter.
  */
 /**
+ * Raised when a bundle carries no identity for a fact whose SURFACE has one
+ * (#5047). Refuses the import rather than landing the row.
+ *
+ * See {@link tombstonePlaceholder} for why this case and the degenerate-surface
+ * case cannot take the same treatment.
+ */
+export class RegionImportUnkeyableError extends Error {
+  constructor(
+    readonly factId: string,
+    readonly positions: readonly string[],
+  ) {
+    super(
+      `Region import refused: fact ${factId} arrived with no identity key at ${positions.join(", ")}, ` +
+        "but its surface at those positions normalizes to a real key — so the bundle is missing " +
+        "identity the source region has. Landing it would either invalidate a healthy belief " +
+        "(tombstone) or re-derive its key under THIS region's vocabulary, which can merge it into a " +
+        "slot it never belonged to and stamp `valid_to` across the merge at publish. Neither is " +
+        "reversible. Check the source region's export for identity drift — a projection that stopped " +
+        "returning the key columns exports null for every fact — and that the source region has " +
+        "applied migration 0194, whose backfill keys exactly these rows. Then re-export and re-run.",
+    );
+    this.name = "RegionImportUnkeyableError";
+  }
+}
+
+/**
  * The `NOT NULL` landing for a key this import could not supply (#5047).
  *
- * Migration 0194's policy, applied at the second key writer so the two agree:
- * a fact with no identity at some position is TOMBSTONED and the affected
- * columns take a PER-ROW placeholder. Read 0194's header for the argument; the
- * three points that matter at this call site:
+ * `brain_facts`' key columns are `NOT NULL` since migration 0194, so this writer
+ * can no longer pass a null through. What it does instead depends on WHY the key
+ * is absent, and the two causes are not the same event.
  *
- *   - The tombstone is the load-bearing half. All three slot consumers require
- *     `invalidated_at IS NULL`, so the row is outside every join by the
- *     tombstone rather than by its key — which is exactly where a NULL key left
- *     it before the constraint. The import's behaviour for these rows is
- *     unchanged.
- *   - The placeholder is per-row, which is what separates it from the shared
- *     sentinel migration 0187's header rejects: under a shared value every
- *     degenerate row joins every other one. `'-unkeyable:' || id` equals itself
- *     and nothing else, and no computed key can collide with it because
- *     `lexicalNorm` collapses `-` away and can neither start with nor contain
- *     one.
- *   - It is applied PER POSITION. A fact can be degenerate at one slot and
- *     perfectly keyed at the other two, and replacing the good keys would take a
- *     row that is merely valueless at one position and make it unreachable at
- *     all three.
+ * ## The surface normalizes away → TOMBSTONE with a per-row placeholder
  *
- * Refusing the import instead was the alternative and is worse in both
- * directions: a single degenerate legacy row would block a whole region
- * migration, and the operator has no in-product verb to repair one. The counters
- * this does not touch (`unkeyableFacts`, `nullKeyFacts`) are the signal, and
- * `importBundle` already logs them with both readings.
+ * The claim asserts nothing at that position and never could: no vocabulary, no
+ * re-key, and no source region can produce a key for `-` or `___`. This is
+ * exactly migration 0194's population, and this is 0194's treatment of it, so the
+ * two key writers agree about one state.
+ *
+ * The tombstone is the load-bearing half. All three slot consumers require
+ * `invalidated_at IS NULL`, so the row is outside every join by the tombstone
+ * rather than by its key — which is where a NULL key left it before the
+ * constraint. The placeholder is per-row ({@link UNKEYABLE_KEY_PREFIX}), which is
+ * what separates it from the shared sentinel 0187's header rejects.
+ *
+ * ## The surface has a key but none arrived → REFUSE the import
+ *
+ * ⚠️ **This arm exists because the first one is WRONG for this case, and getting
+ * that wrong is how a recoverable state becomes an unrecoverable one.**
+ *
+ * Such a row is repairable: its surface keys perfectly well, so
+ * `REKEY_DRIFTED_FACTS_SQL` computes a real key for it at the next alias decision
+ * and it rejoins every consumer. Before #5047 it landed live-but-unjoined, which
+ * is ADR-0037 §8's accepted under-match. Tombstoning it instead retires a healthy
+ * belief, and NOTHING in the product clears `invalidated_at` — the re-key would
+ * repair the key while the row stayed invisible forever.
+ *
+ * Computing the key here is the other tempting repair and is worse. §8 settles
+ * that a row-copy path never re-derives, because re-deriving under the
+ * DESTINATION's vocabulary can merge imported facts into a slot they never
+ * belonged to, and publish then stamps `valid_to` across the merge — the
+ * irreversible direction.
+ *
+ * So neither landing is safe, and the honest move is not to land. The cause is
+ * source-side — export drift that nulls the column for the whole corpus is the
+ * documented shape (see `importedIdentity`'s `nullKeys` note), or a source region
+ * that has not yet applied 0194 — and both are fixed at the source and re-run.
+ * Refusing is the only outcome here that writes nothing.
+ *
+ * That a single such row refuses a whole region migration is deliberate: at this
+ * position it is not "one odd claim" but evidence that the bundle's identity is
+ * not trustworthy, and the alternative is committing an invalidation no verb can
+ * undo. A genuinely degenerate row — the far commoner case — takes the first arm
+ * and does not block anything.
  */
 function tombstonePlaceholder(
-  factId: string,
+  fact: ExportedBrainFact,
   keys: {
     readonly subjectKey: string | null;
     readonly predicateKey: string | null;
     readonly objectKey: string | null;
   },
 ): Pick<ImportedIdentity, "subjectKey" | "predicateKey" | "objectKey" | "tombstoned"> {
-  const placeholder = `-unkeyable:${factId}`;
+  // Decided per POSITION off that position's own surface, never off the row: a
+  // fact can be degenerate at the object and healthy at the subject, and the two
+  // positions then want opposite answers.
+  const absent = (
+    [
+      ["subject", keys.subjectKey, fact.subject],
+      ["predicate", keys.predicateKey, fact.predicate],
+      ["object", keys.objectKey, fact.object],
+    ] as const
+  ).filter(([, key]) => key === null);
+  const repairable = absent.filter(([, , surface]) => identityKey(surface) !== null);
+  if (repairable.length > 0) {
+    throw new RegionImportUnkeyableError(
+      fact.id,
+      repairable.map(([position]) => position),
+    );
+  }
+  const placeholder = `${UNKEYABLE_KEY_PREFIX}${fact.id}`;
   return {
     subjectKey: keys.subjectKey ?? placeholder,
     predicateKey: keys.predicateKey ?? placeholder,
     objectKey: keys.objectKey ?? placeholder,
-    tombstoned:
-      keys.subjectKey === null || keys.predicateKey === null || keys.objectKey === null,
+    tombstoned: absent.length > 0,
   };
 }
 
@@ -1095,7 +1166,7 @@ function importedIdentity(fact: ExportedBrainFact, source: IdentitySource): Impo
       objectKey: slotKey(fact.object, vocabulary.object),
     };
     return {
-      ...tombstonePlaceholder(fact.id, keys),
+      ...tombstonePlaceholder(fact, keys),
       subjectCmp: null,
       objectCmp: null,
       comparableDropped: false,
@@ -1104,10 +1175,12 @@ function importedIdentity(fact: ExportedBrainFact, source: IdentitySource): Impo
       // its null-ness is this import's own fact and its cause is the surface.
       nullKeys: false,
       // `slotKey` is null for a surface that normalizes away (`-`, `___`), which
-      // is legal and permanent. The INGEST path warns about it and is described
-      // as "the only signal such a claim ever produces" — this is the second key
-      // writer, so it owes the same signal or an imported corpus loses one an
-      // identical locally-ingested corpus would have produced.
+      // is legal and permanent — and since #5047 the two key writers no longer do
+      // the same thing with it. INGEST REFUSES the claim outright
+      // (`reconcile.ts`'s `MALFORMED_CLAIM`); this path cannot, because the row
+      // already exists in the source region, so it TOMBSTONES it exactly as
+      // migration 0194 does. This counter is what makes that visible — see
+      // `tombstonedFacts` in the aggregate warn below.
       unkeyable: Object.values(keys).some((k) => k === null),
     };
   }
@@ -1121,7 +1194,7 @@ function importedIdentity(fact: ExportedBrainFact, source: IdentitySource): Impo
     // that survives that is landed by {@link tombstonePlaceholder} — the keys
     // are `NOT NULL` since #5047, and this arm CARRIES rather than computes, so
     // it has nothing better to write.
-    ...tombstonePlaceholder(fact.id, {
+    ...tombstonePlaceholder(fact, {
       subjectKey: fact.subjectKey ?? null,
       predicateKey: fact.predicateKey ?? null,
       objectKey: fact.objectKey ?? null,
@@ -1722,20 +1795,31 @@ export async function importBundle(
   //                otherwise is its absence. A version skew between two
   //                independently deployed regions produces exactly this.
   //   unkeyableFacts — a legacy surface that normalizes away, so no key exists.
-  //                Legal and permanent; the ingest path warns about it and calls
-  //                that "the only signal such a claim ever produces", and this
-  //                is the second key writer.
-  //   nullKeyFacts — a v3 fact that ARRIVED with a null key. The exporter's
-  //                drift path produces a whole corpus of them.
+  //                Legal and permanent. Ingest REFUSES such a claim since #5047;
+  //                this writer cannot, since the row already exists in the source
+  //                region, so it tombstones it as migration 0194 does.
+  //   nullKeyFacts — a v3 fact that ARRIVED with a null key. Only reaches here
+  //                when its surface ALSO normalizes away: a null key beside a
+  //                keyable surface refuses the import instead (#5047), because
+  //                that row is repairable and both ways of landing it are not.
+  //   tombstonedFacts — what the import DID: the row carries a placeholder key
+  //                and `invalidated_at`. The count to act on.
   //
   // ⚠️ The names carry their UNIT because the first two count POSITIONS (up to
-  // two per fact) and the last two count FACTS. Read against `brainFacts.imported`
+  // two per fact) and the last three count FACTS. Read against `brainFacts.imported`
   // without that, a ratio is nonsense in one direction and understated in the other.
   const identityLoss = {
     storeLocalPositions: 0,
     unreadablePositions: 0,
     unkeyableFacts: 0,
     nullKeyFacts: 0,
+    // What the import DID about the two above (#5047), as opposed to why the key
+    // was absent. Kept separate from them deliberately: those two say WHERE the
+    // null came from — computed here off a degenerate surface, or arrived null on
+    // the wire — and this says the row landed TOMBSTONED, which is the fact an
+    // operator has to act on. A fourth cause would otherwise land unmarked and
+    // untold at once.
+    tombstonedFacts: 0,
   };
 
   // bundle episode id → the id it actually resolved to in the target. Only
@@ -1898,6 +1982,7 @@ export async function importBundle(
       }
       if (identity.unkeyable) identityLoss.unkeyableFacts++;
       if (identity.nullKeys) identityLoss.nullKeyFacts++;
+      if (identity.tombstoned) identityLoss.tombstonedFacts++;
 
       await client.query(
         // `pre_widening_visible_to` travels or the target region re-opens the
@@ -2013,7 +2098,7 @@ export async function importBundle(
         brainFactsImported: result.brainFacts.imported,
         comparablePositions: result.brainFacts.imported * 2,
       },
-      "Region import WILL land identity losses when this transaction commits (#5035, ADR-0037 §8). `storeLocalPositions` is the RULE — a store-local entity id means nothing in this region, so those positions abstain until recomputed, and the rows carry `provenance.provisional` (find them with PROVISIONAL_PREDICATE). `unreadablePositions` is DRIFT and is the count to act on: the source region wrote a tag or payload this deployment cannot read, so that evidence is lost rather than deferred — check whether the two regions are on compatible releases. ⚠️ `nullKeyFacts` is AMBIGUOUS and both readings are here: a surface that normalizes away carries a null key legitimately and permanently (the v3 equivalent of `unkeyableFacts`, and nothing to act on), and so does a source-region projection that stopped returning the column. A count approaching `brainFactsImported` means the projection — check the source region's export log for its identity-drift line; a handful means normalized-away surfaces. `unkeyableFacts` is that same legal, permanent state on a legacy bundle. Units: the first two count POSITIONS, up to two per fact; the last two count FACTS",
+      "Region import WILL land identity losses when this transaction commits (#5035, ADR-0037 §8). `storeLocalPositions` is the RULE — a store-local entity id means nothing in this region, so those positions abstain until recomputed, and the rows carry `provenance.provisional` (find them with PROVISIONAL_PREDICATE). `unreadablePositions` is DRIFT and is the count to act on: the source region wrote a tag or payload this deployment cannot read, so that evidence is lost rather than deferred — check whether the two regions are on compatible releases. ⚠️ `tombstonedFacts` IS THE COUNT TO ACT ON FIRST (#5047): those facts had no identity at some position and the slot keys are NOT NULL, so they landed with a per-row placeholder key AND `invalidated_at` set — they are invisible to searchBrain and to the review queue, and no verb in the product restores them; only clearing `invalidated_at` by hand does. Their surfaces are retained verbatim, so the claim text is recoverable. Every one of them is a claim whose surface normalizes away (`-`, `___`), which is what migration 0194 did to the same population — a fact whose key merely FAILED TO ARRIVE while its surface keys fine refuses the whole import instead of landing (RegionImportUnkeyableError), because tombstoning a healthy belief and re-deriving its key under this region's vocabulary are both irreversible. `unkeyableFacts` counts those keyed HERE off a legacy bundle; `nullKeyFacts` counts those that arrived null on a v3 one. Units: the first two count POSITIONS, up to two per fact; the last three count FACTS",
     );
   }
 
@@ -2127,6 +2212,14 @@ adminMigrate.openapi(importRoute, async (c) => {
     });
     const detail = err instanceof Error ? err.message : String(err);
     log.error({ err: err instanceof Error ? err : new Error(String(err)), requestId, orgId }, "Migration import failed, rolled back");
+    // A refused bundle is not a server fault (#5047): the source region supplied
+    // no identity for a fact whose surface has one, which is fixed at the source
+    // and re-run. 409 rather than 400 because the request itself is well-formed
+    // — `validateBundle` passed — and rather than 500 because retrying THIS body
+    // can never succeed and nothing here is broken.
+    if (err instanceof RegionImportUnkeyableError) {
+      return c.json({ error: "import_refused", message: detail, requestId }, 409);
+    }
     return c.json({ error: "import_failed", message: `Import failed — all changes rolled back. ${detail}`, requestId }, 500);
   } finally {
     client.release();
@@ -2206,6 +2299,14 @@ internalMigrate.post("/import", async (c) => {
     });
     const detail = err instanceof Error ? err.message : String(err);
     log.error({ err: err instanceof Error ? err : new Error(String(err)), requestId, orgId }, "Internal import failed, rolled back");
+    // A refused bundle is not a server fault (#5047): the source region supplied
+    // no identity for a fact whose surface has one, which is fixed at the source
+    // and re-run. 409 rather than 400 because the request itself is well-formed
+    // — `validateBundle` passed — and rather than 500 because retrying THIS body
+    // can never succeed and nothing here is broken.
+    if (err instanceof RegionImportUnkeyableError) {
+      return c.json({ error: "import_refused", message: detail, requestId }, 409);
+    }
     return c.json({ error: "import_failed", message: `Import failed — all changes rolled back. ${detail}`, requestId }, 500);
   } finally {
     client.release();

--- a/packages/api/src/api/routes/admin-migrate.ts
+++ b/packages/api/src/api/routes/admin-migrate.ts
@@ -928,9 +928,31 @@ function isLoss(reason: RegionCarryOutcome["reason"]): boolean {
 
 /** The identity columns an imported fact lands with (#5035). */
 interface ImportedIdentity {
-  readonly subjectKey: string | null;
-  readonly predicateKey: string | null;
-  readonly objectKey: string | null;
+  /**
+   * NON-NULL since #5047 — `brain_facts`' three key columns are `NOT NULL` as of
+   * migration 0194, and this is the second key writer, so the type is what keeps
+   * that true here rather than a `23502` on the first offending row of an
+   * admin-triggered region import (ADR-0024, a production path).
+   *
+   * A null at any position is landed by {@link tombstonePlaceholder}, which is
+   * 0194's own policy for the same state. The type narrows AFTER that call and
+   * nowhere before it, so the two arms of {@link importedIdentity} cannot
+   * accidentally skip it.
+   */
+  readonly subjectKey: string;
+  readonly predicateKey: string;
+  readonly objectKey: string;
+  /**
+   * A key was replaced by a placeholder, so the row lands TOMBSTONED (#5047).
+   *
+   * Read at the INSERT, where it is `OR`ed into `invalidated_at`. Separate from
+   * {@link unkeyable} / {@link nullKeys} on purpose: those two are OPERATOR
+   * counters that say WHY the key was absent (computed here vs. arrived null),
+   * and this one says what the row DID about it. Collapsing them would make the
+   * import's log line and its write disagree the first time a fourth cause
+   * appears.
+   */
+  readonly tombstoned: boolean;
   /**
    * ⚠️ {@link RegionPortableComparable}, NOT `string | null` and not the wider
    * `ComparableValue`, and the narrowing is the whole guarantee this slice
@@ -1012,6 +1034,54 @@ interface ImportedIdentity {
  * imported"* rather than *"is worth recomputing"*, and #4772's review filter
  * reads it as the latter.
  */
+/**
+ * The `NOT NULL` landing for a key this import could not supply (#5047).
+ *
+ * Migration 0194's policy, applied at the second key writer so the two agree:
+ * a fact with no identity at some position is TOMBSTONED and the affected
+ * columns take a PER-ROW placeholder. Read 0194's header for the argument; the
+ * three points that matter at this call site:
+ *
+ *   - The tombstone is the load-bearing half. All three slot consumers require
+ *     `invalidated_at IS NULL`, so the row is outside every join by the
+ *     tombstone rather than by its key — which is exactly where a NULL key left
+ *     it before the constraint. The import's behaviour for these rows is
+ *     unchanged.
+ *   - The placeholder is per-row, which is what separates it from the shared
+ *     sentinel migration 0187's header rejects: under a shared value every
+ *     degenerate row joins every other one. `'-unkeyable:' || id` equals itself
+ *     and nothing else, and no computed key can collide with it because
+ *     `lexicalNorm` collapses `-` away and can neither start with nor contain
+ *     one.
+ *   - It is applied PER POSITION. A fact can be degenerate at one slot and
+ *     perfectly keyed at the other two, and replacing the good keys would take a
+ *     row that is merely valueless at one position and make it unreachable at
+ *     all three.
+ *
+ * Refusing the import instead was the alternative and is worse in both
+ * directions: a single degenerate legacy row would block a whole region
+ * migration, and the operator has no in-product verb to repair one. The counters
+ * this does not touch (`unkeyableFacts`, `nullKeyFacts`) are the signal, and
+ * `importBundle` already logs them with both readings.
+ */
+function tombstonePlaceholder(
+  factId: string,
+  keys: {
+    readonly subjectKey: string | null;
+    readonly predicateKey: string | null;
+    readonly objectKey: string | null;
+  },
+): Pick<ImportedIdentity, "subjectKey" | "predicateKey" | "objectKey" | "tombstoned"> {
+  const placeholder = `-unkeyable:${factId}`;
+  return {
+    subjectKey: keys.subjectKey ?? placeholder,
+    predicateKey: keys.predicateKey ?? placeholder,
+    objectKey: keys.objectKey ?? placeholder,
+    tombstoned:
+      keys.subjectKey === null || keys.predicateKey === null || keys.objectKey === null,
+  };
+}
+
 function importedIdentity(fact: ExportedBrainFact, source: IdentitySource): ImportedIdentity {
   if (!source.carried) {
     // A pre-#5035 bundle has no `_cmp` on the wire at all, so there is nothing
@@ -1025,7 +1095,7 @@ function importedIdentity(fact: ExportedBrainFact, source: IdentitySource): Impo
       objectKey: slotKey(fact.object, vocabulary.object),
     };
     return {
-      ...keys,
+      ...tombstonePlaceholder(fact.id, keys),
       subjectCmp: null,
       objectCmp: null,
       comparableDropped: false,
@@ -1047,10 +1117,15 @@ function importedIdentity(fact: ExportedBrainFact, source: IdentitySource): Impo
   return {
     // `?? null` normalizes ABSENT to NULL and is not a permissive fallback:
     // validation refuses a v3 fact missing any of the five, so the only shape
-    // that reaches here is the `string | null` the wire type declares.
-    subjectKey: fact.subjectKey ?? null,
-    predicateKey: fact.predicateKey ?? null,
-    objectKey: fact.objectKey ?? null,
+    // that reaches here is the `string | null` the wire type declares. A null
+    // that survives that is landed by {@link tombstonePlaceholder} — the keys
+    // are `NOT NULL` since #5047, and this arm CARRIES rather than computes, so
+    // it has nothing better to write.
+    ...tombstonePlaceholder(fact.id, {
+      subjectKey: fact.subjectKey ?? null,
+      predicateKey: fact.predicateKey ?? null,
+      objectKey: fact.objectKey ?? null,
+    }),
     subjectCmp: subject.value,
     objectCmp: object.value,
     // Derived from the REASONS through {@link isLoss}, not from the null-ness of
@@ -1856,7 +1931,24 @@ export async function importBundle(
         // the null-out is merely safe; with it, it is recoverable, and
         // `PROVISIONAL_PREDICATE` is the query that finds the rows.
         `INSERT INTO brain_facts (id, workspace_id, subject, predicate, object, subject_key, predicate_key, object_key, subject_cmp, object_cmp, valid_from, valid_to, ingested_at, invalidated_at, extracted_at, source_episode_id, provenance, status, visible_to, pre_widening_visible_to, created_at, updated_at)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16,
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13,
+                 -- invalidated_at is the one other column with a CASE, and for
+                 -- #5047's reason rather than #5035's. A fact whose key this
+                 -- import could not supply lands TOMBSTONED, matching migration
+                 -- 0194's treatment of the same state; the placeholder key beside
+                 -- it only satisfies the constraint, and the tombstone is what
+                 -- keeps the row out of all three slot consumers.
+                 --
+                 -- COALESCE and not an overwrite: a fact that arrived ALREADY
+                 -- tombstoned keeps the source region's timestamp, because when
+                 -- it stopped being a belief is a fact about the corpus and not
+                 -- about this import. now() and not a bind, so the stamp comes
+                 -- from the same clock the migration's does.
+                 -- (No backticks in this comment: the statement is a template
+                 -- literal, and one would end it.)
+                 CASE WHEN $24::boolean THEN COALESCE($14::timestamptz, now())
+                      ELSE $14::timestamptz END,
+                 $15, $16,
                  CASE WHEN $17::boolean
                       THEN jsonb_set($18::jsonb, '{provisional}', 'true'::jsonb, true)
                       ELSE $18::jsonb END,
@@ -1890,6 +1982,12 @@ export async function importBundle(
           fact.preWideningVisibleTo ?? null,
           fact.createdAt,
           fact.updatedAt,
+          // $24 — appended rather than inserted beside `invalidated_at`'s $14,
+          // which the CASE above reads. Renumbering the binds to put it there
+          // would move every placeholder after it, and this statement's column
+          // list and bind array are already the pair most exposed to that class
+          // of slip.
+          identity.tombstoned,
         ],
       );
       result.brainFacts.imported++;

--- a/packages/api/src/api/routes/admin-migrate.ts
+++ b/packages/api/src/api/routes/admin-migrate.ts
@@ -1070,6 +1070,41 @@ export class RegionImportUnkeyableError extends Error {
 }
 
 /**
+ * Raised when a LEGACY (v1/v2) bundle's fact keys to nothing because THIS
+ * region's vocabulary maps its norm away (#5047).
+ *
+ * Split from {@link RegionImportUnkeyableError} because the two name different
+ * subsystems, different regions and different remedies, and a shared message
+ * sends the operator somewhere they can do nothing. A v1/v2 bundle carries no
+ * key columns at all, so "re-export from the source" is unfollowable advice for
+ * this cause — the defect is a local alias entry.
+ *
+ * Reachable only through a hand-written or imported `brain_vocabulary_target`
+ * row: `vocabulary-decide.ts` refuses a `degenerate-norm` target at authoring
+ * and `validateBundle` refuses a non-norm edge at import. Raised anyway rather
+ * than assumed unreachable, for the reason `REKEY_DRIFTED_FACTS_SQL`'s own
+ * `IS NOT NULL` arm gives: testing the composed expression is what keeps this
+ * correct if that guard ever reopens, and the failure mode here is a permanent
+ * 409 on a whole tenant migration.
+ */
+export class RegionImportVocabularyTargetError extends Error {
+  constructor(
+    readonly factId: string,
+    readonly positions: readonly string[],
+  ) {
+    super(
+      `Region import refused: fact ${factId} could not be keyed at ${positions.join(", ")} — its ` +
+        "surface normalizes to a real key, but THIS region's vocabulary maps that norm to " +
+        "something that normalizes away, so the fact would have no identity. This is a " +
+        "destination-side configuration defect and re-exporting will not change it: inspect this " +
+        "workspace's `brain_vocabulary_target` rows for the positions named above, remove or " +
+        "correct the offending alias entry, then re-run the import.",
+    );
+    this.name = "RegionImportVocabularyTargetError";
+  }
+}
+
+/**
  * The `NOT NULL` landing for a key this import could not supply (#5047).
  *
  * `brain_facts`' key columns are `NOT NULL` since migration 0194, so this writer
@@ -1121,6 +1156,7 @@ export class RegionImportUnkeyableError extends Error {
  */
 function tombstonePlaceholder(
   fact: ExportedBrainFact,
+  source: IdentitySource,
   keys: {
     readonly subjectKey: string | null;
     readonly predicateKey: string | null;
@@ -1139,10 +1175,24 @@ function tombstonePlaceholder(
   ).filter(([, key]) => key === null);
   const repairable = absent.filter(([, , surface]) => identityKey(surface) !== null);
   if (repairable.length > 0) {
-    throw new RegionImportUnkeyableError(
-      fact.id,
-      repairable.map(([position]) => position),
-    );
+    // ⚠️ WHICH SUBSYSTEM IS AT FAULT DEPENDS ON WHICH ARM CALLED, and the first
+    // cut raised the source-region error from both — so a v1/v2 bundle, which
+    // carries no key columns on the wire AT ALL, told the operator to "re-export
+    // from the source region and check it has applied 0194". Re-exporting cannot
+    // change anything on that arm, and 0194 at the source is irrelevant: the
+    // whole migration wedges behind an instruction nobody can follow.
+    //
+    // On the CARRIED arm a repairable null means the key was supposed to arrive
+    // and did not — source-side. On the COMPUTED arm the key was derived right
+    // here by `slotKey(surface, vocabulary[position])`, and `slotKey` reaches
+    // null a second way: this region's own alias entry maps a real norm to
+    // something that normalizes away. That is a destination-side configuration
+    // defect and names a different table, a different region, and a different
+    // remedy.
+    const positions = repairable.map(([position]) => position);
+    throw source.carried
+      ? new RegionImportUnkeyableError(fact.id, positions)
+      : new RegionImportVocabularyTargetError(fact.id, positions);
   }
   const placeholder = `${UNKEYABLE_KEY_PREFIX}${fact.id}`;
   return {
@@ -1166,7 +1216,7 @@ function importedIdentity(fact: ExportedBrainFact, source: IdentitySource): Impo
       objectKey: slotKey(fact.object, vocabulary.object),
     };
     return {
-      ...tombstonePlaceholder(fact, keys),
+      ...tombstonePlaceholder(fact, source, keys),
       subjectCmp: null,
       objectCmp: null,
       comparableDropped: false,
@@ -1194,7 +1244,7 @@ function importedIdentity(fact: ExportedBrainFact, source: IdentitySource): Impo
     // that survives that is landed by {@link tombstonePlaceholder} — the keys
     // are `NOT NULL` since #5047, and this arm CARRIES rather than computes, so
     // it has nothing better to write.
-    ...tombstonePlaceholder(fact, {
+    ...tombstonePlaceholder(fact, source, {
       subjectKey: fact.subjectKey ?? null,
       predicateKey: fact.predicateKey ?? null,
       objectKey: fact.objectKey ?? null,
@@ -1982,7 +2032,13 @@ export async function importBundle(
       }
       if (identity.unkeyable) identityLoss.unkeyableFacts++;
       if (identity.nullKeys) identityLoss.nullKeyFacts++;
-      if (identity.tombstoned) identityLoss.tombstonedFacts++;
+      // NEWLY tombstoned only. `identity.tombstoned` drives the WRITE, which
+      // `COALESCE`s so a fact that arrived already tombstoned keeps the source
+      // region's timestamp — for that row this import retired nothing, and
+      // counting it would raise a false alarm pointing at manual DB surgery.
+      if (identity.tombstoned && (fact.invalidatedAt ?? null) === null) {
+        identityLoss.tombstonedFacts++;
+      }
 
       await client.query(
         // `pre_widening_visible_to` travels or the target region re-opens the
@@ -2217,7 +2273,10 @@ adminMigrate.openapi(importRoute, async (c) => {
     // and re-run. 409 rather than 400 because the request itself is well-formed
     // — `validateBundle` passed — and rather than 500 because retrying THIS body
     // can never succeed and nothing here is broken.
-    if (err instanceof RegionImportUnkeyableError) {
+    if (
+      err instanceof RegionImportUnkeyableError ||
+      err instanceof RegionImportVocabularyTargetError
+    ) {
       return c.json({ error: "import_refused", message: detail, requestId }, 409);
     }
     return c.json({ error: "import_failed", message: `Import failed — all changes rolled back. ${detail}`, requestId }, 500);
@@ -2304,7 +2363,10 @@ internalMigrate.post("/import", async (c) => {
     // and re-run. 409 rather than 400 because the request itself is well-formed
     // — `validateBundle` passed — and rather than 500 because retrying THIS body
     // can never succeed and nothing here is broken.
-    if (err instanceof RegionImportUnkeyableError) {
+    if (
+      err instanceof RegionImportUnkeyableError ||
+      err instanceof RegionImportVocabularyTargetError
+    ) {
       return c.json({ error: "import_refused", message: detail, requestId }, 409);
     }
     return c.json({ error: "import_failed", message: `Import failed — all changes rolled back. ${detail}`, requestId }, 500);

--- a/packages/api/src/api/routes/admin-migrate.ts
+++ b/packages/api/src/api/routes/admin-migrate.ts
@@ -864,9 +864,14 @@ const importRoute = createRoute({
     },
     409: {
       description:
-        "Bundle refused — a fact carries no identity key at a position whose surface has one, " +
-        "so the source region's export is missing identity it holds (#5047). Nothing was written. " +
-        "Re-export from the source region and re-run.",
+        "Bundle refused — a fact has no identity key at a position whose surface normalizes to a " +
+        "real one, so landing it would either retire a healthy belief or re-derive its key under " +
+        "this region's vocabulary, and neither is reversible (#5047). NOTHING WAS WRITTEN. Two " +
+        "causes with two different remedies, and the `message` says which: on a v3 bundle the key " +
+        "was supposed to travel and did not — re-export from the source region, checking it for " +
+        "identity drift and that it has applied migration 0194 — while on a v1/v2 bundle the key " +
+        "is computed at import, so a refusal means THIS region's vocabulary maps that norm away " +
+        "and the fix is a local `brain_vocabulary_target` entry, which re-exporting cannot change.",
       content: { "application/json": { schema: ErrorSchema } },
     },
     500: {

--- a/packages/api/src/lib/__tests__/workspace-capability-pg.test.ts
+++ b/packages/api/src/lib/__tests__/workspace-capability-pg.test.ts
@@ -131,8 +131,9 @@ describeIfPg("CAPABILITY_SQL against real Postgres", () => {
       // NOT NULL alone would admit `'{}'`, an empty claim wearing the shape of
       // a real one. `visible_to` is likewise gated non-empty.
       `INSERT INTO brain_facts
-         (workspace_id, subject, predicate, object, source_episode_id, provenance, status, visible_to)
-       VALUES ($1, 'atlas', 'ships', 'brain', $2, $3::jsonb, $4, ARRAY['org']::text[])`,
+         (workspace_id, subject, predicate, object, subject_key, predicate_key, object_key,
+          source_episode_id, provenance, status, visible_to)
+       VALUES ($1, 'atlas', 'ships', 'brain', 'atlas', 'ships', 'brain', $2, $3::jsonb, $4, ARRAY['org']::text[])`,
       [workspaceId, episodeId, JSON.stringify({ extractor: "workspace-capability-pg-test" }), status],
     );
   }

--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -27,7 +27,7 @@ function createTrackingPool(opts: { shouldThrow?: boolean } = {}) {
     pool: {
       query: queryFn,
       async connect() {
-        return { query: queryFn, release() {} };
+        return { query: queryFn, release() {}, on() {}, off() {} };
       },
       async end() {},
       on() {},
@@ -590,7 +590,7 @@ describe("migrateAuthTables", () => {
     const pool = {
       query: queryFn,
       async connect() {
-        return { query: queryFn, release() {} };
+        return { query: queryFn, release() {}, on() {}, off() {} };
       },
       async end() {},
       on() {},
@@ -630,7 +630,7 @@ describe("migrateAuthTables", () => {
     const pool = {
       query: queryFn,
       async connect() {
-        return { query: queryFn, release() {} };
+        return { query: queryFn, release() {}, on() {}, off() {} };
       },
       async end() {},
       on() {},
@@ -669,7 +669,7 @@ describe("migrateAuthTables", () => {
     const pool = {
       query: queryFn,
       async connect() {
-        return { query: queryFn, release() {} };
+        return { query: queryFn, release() {}, on() {}, off() {} };
       },
       async end() {},
       on() {},
@@ -706,7 +706,7 @@ describe("migrateAuthTables", () => {
     const pool = {
       query: queryFn,
       async connect() {
-        return { query: queryFn, release() {} };
+        return { query: queryFn, release() {}, on() {}, off() {} };
       },
       async end() {},
       on() {},
@@ -751,7 +751,7 @@ describe("migrateAuthTables", () => {
       return {
         query: queryFn,
         async connect() {
-          return { query: queryFn, release() {} };
+          return { query: queryFn, release() {}, on() {}, off() {} };
         },
       };
     }

--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -581,6 +581,7 @@ describe("migrateAuthTables", () => {
             // brain-owned table, so it is in the already-applied set for the
             // same reason as 0187–0192: Better Auth owns nothing it touches.
             { name: "0193_brain_fact_subject_cmp.sql" },
+            { name: "0194_brain_fact_slot_keys_not_null.sql" },
           ],
         };
       }

--- a/packages/api/src/lib/brain/__tests__/acl-visibility-pg.test.ts
+++ b/packages/api/src/lib/brain/__tests__/acl-visibility-pg.test.ts
@@ -33,6 +33,7 @@ import { Effect } from "effect";
 import { runMigrations } from "@atlas/api/lib/db/migrate";
 import { CONTENT_MODE_TABLES, makeService } from "@atlas/api/lib/content-mode";
 import { MANAGED_AUTH_MIGRATIONS } from "@atlas/api/lib/db/internal";
+import { identityAlias, slotKey } from "@atlas/api/lib/brain/identity";
 import {
   USER_PREFIX,
   aclVisibilityClause,
@@ -91,10 +92,16 @@ describeIfPg("brain ACL visibility predicate (real Postgres)", () => {
   }): Promise<string> {
     const { rows } = await pool.query<{ id: string }>(
       `INSERT INTO brain_facts
-         (workspace_id, subject, predicate, object, source_episode_id, provenance, status, visible_to)
-       VALUES ($1, $2, 'is', 'thing', $3, '{"actor":"test"}'::jsonb, $4, $5::text[])
+         (workspace_id, subject, predicate, object, subject_key, predicate_key, object_key,
+          source_episode_id, provenance, status, visible_to)
+       VALUES ($1, $2, 'is', 'thing', $6, 'is', 'thing', $3, '{"actor":"test"}'::jsonb, $4, $5::text[])
        RETURNING id`,
-      [opts.workspaceId, opts.subject, opts.episodeId, opts.status ?? "published", opts.visibleTo],
+      [opts.workspaceId, opts.subject, opts.episodeId, opts.status ?? "published", opts.visibleTo,
+        // The subject KEY, required since migration 0194 (#5047). Through
+        // `slotKey` rather than spelled in SQL, so the fixture keys its rows
+        // with the same function the ingest path uses.
+        slotKey(opts.subject, identityAlias),
+      ],
     );
     return rows[0]!.id;
   }

--- a/packages/api/src/lib/brain/__tests__/candidates-pg.test.ts
+++ b/packages/api/src/lib/brain/__tests__/candidates-pg.test.ts
@@ -798,6 +798,79 @@ describeIfPg("brain fact candidates (real Postgres)", () => {
   );
 
   it(
+    "a DEGENERATE replacement is refused, and the valid_to stamp rolls back with it (#5047)",
+    async () => {
+      // The acceptance criterion #5047 asks to be PINNED rather than assumed:
+      // `correct_fact`'s supersede verb inherits the tightened `MALFORMED_CLAIM`
+      // guard for free, because its replacement routes through `reconcileFacts`.
+      //
+      // The ordering is what makes it worth a live transaction.
+      // `SUPERSEDE_STAMP_EXPLICIT_SQL` runs FIRST inside `applySupersede`,
+      // before the replacement reconciles — so the target's `valid_to` is
+      // already closed by the time the guard refuses the candidate. If that did
+      // not roll back, a human typing `-` would retire a published belief in
+      // favour of a successor that was never stored, and supersession has no
+      // inverse verb anywhere in the product. The unit fake applies statements
+      // to in-memory state and models no rollback, so this is the only place the
+      // property can be observed.
+      //
+      // Before #5047 this input did not refuse at all: `null !== "ana"` clears
+      // the `replacementIdentical` guard, so it committed and installed a
+      // successor with no identity.
+      const ep = await seedEpisode({ sourceId: "degenerate-replacement-1" });
+      const oldId = await seedFact({
+        subject: "Degenerate",
+        predicate: "is owned by",
+        object: "Ana",
+        episodeId: ep,
+        status: "published",
+        cardinality: "single",
+      });
+
+      const outcome = await correctFact(
+        {
+          vocabulary: identityVocabulary,
+          ctx: reviewer(),
+          factId: oldId,
+          verb: "supersede",
+          replacement: { object: "-" },
+        },
+        { withTransaction: poolTx },
+      );
+      expect(outcome).toMatchObject({
+        kind: "refused",
+        reason: CORRECTION_REFUSAL_REASONS.replacementMalformed,
+      });
+
+      // The stamp rolled back — the target is still the current belief.
+      const target = await pool.query<{ valid_to: Date | null }>(
+        `SELECT valid_to FROM brain_facts WHERE id = $1`,
+        [oldId],
+      );
+      expect(
+        target.rows[0]!.valid_to,
+        "the target was retired in favour of a successor that was never stored",
+      ).toBeNull();
+      // …and nothing half-happened beside it: no successor row, no authored
+      // correction episode claiming one.
+      const successor = await pool.query(
+        `SELECT 1 FROM brain_facts WHERE workspace_id = $1 AND object = '-'`,
+        [WS],
+      );
+      expect(successor.rows).toHaveLength(0);
+      const episodes = await pool.query(
+        `SELECT 1 FROM brain_episodes
+          WHERE workspace_id = $1
+            AND source_id LIKE 'correction:%'
+            AND body::jsonb ->> 'factId' = $2`,
+        [WS, oldId],
+      );
+      expect(episodes.rows).toHaveLength(0);
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+
+  it(
     "a refusal AFTER the episode insert rolls the whole correction back",
     async () => {
       // The one refusal reachable past the episode write: the replacement

--- a/packages/api/src/lib/brain/__tests__/correction.test.ts
+++ b/packages/api/src/lib/brain/__tests__/correction.test.ts
@@ -1676,6 +1676,42 @@ describe("supersede", () => {
     }
   });
 
+  test("a VOCABULARY-caused object failure is a 500, not a 400 blaming the caller (#5047)", async () => {
+    // ⚠️ THE FALSIFIER FOR GATING ON THE POSITION INSTEAD OF THE CAUSE, which is
+    // what the first cut of this split did — and a fresh-context check caught it
+    // reproducing the defect it was written to fix.
+    //
+    // `slotKey` is `identityKey(alias(identityKey(surface)))`, so an object key
+    // is null for TWO reasons: the caller's text asserts nothing, or this
+    // workspace's object-position vocabulary maps a real norm to something that
+    // does. Only the first is the caller's to fix. Told "your replacement
+    // normalizes away to nothing" about the second, a human retypes correct text
+    // forever and no retry can succeed.
+    const store = new FakeCorrectionStore();
+    store.seedFact({ id: "f1", object: "Ana" });
+
+    await expect(
+      run(store, {
+        factId: "f1",
+        verb: "supersede",
+        replacement: { object: "Bo" },
+        // A vocabulary whose OBJECT position maps the norm `bo` to a string that
+        // normalizes away. Authoring refuses this today; a hand-written or
+        // imported closure row reaches it, which is why the guard tests the
+        // composed expression rather than trusting the authoring gate.
+        vocabulary: {
+          ...identityVocabulary,
+          object: (norm: string) => (norm === "bo" ? " - " : norm),
+        },
+      }),
+    ).rejects.toThrow(/reconcile blocked the replacement claim \(MALFORMED_CLAIM\)/);
+
+    // No successor was stored. The `valid_to` ROLLBACK is `candidates-pg.test.ts`'s
+    // — this fake applies its statements to in-memory state and models no
+    // rollback, so asserting it here would assert the fake.
+    expect(store.facts.find((f) => f.object === "Bo")).toBeUndefined();
+  });
+
   test("a replacement that merely CONTAINS separators is not degenerate", async () => {
     // The falsifier for the guard over-reaching. `-` is a separator, so a
     // refusal written on "contains a separator" rather than on "normalizes away"

--- a/packages/api/src/lib/brain/__tests__/correction.test.ts
+++ b/packages/api/src/lib/brain/__tests__/correction.test.ts
@@ -1624,16 +1624,20 @@ describe("supersede", () => {
       slot: { subject: null, predicate: null, object: null },
     });
 
-    const outcome = await run(store, {
+    const outcome = run(store, {
       factId: "unkeyed",
       verb: "supersede",
       replacement: { object: "Bo" },
     });
 
-    expect(outcome).toMatchObject({
-      kind: "refused",
-      reason: CORRECTION_REFUSAL_REASONS.replacementMalformed,
-    });
+    // A THROW, not a refusal — and which one it is, is the point. The unkeyed
+    // position here is the INHERITED slot, copied off the target row; the
+    // replacement's own text is fine. `REPLACEMENT_MALFORMED` would tell the
+    // human to retype input that is already correct, and no retry could ever
+    // succeed. A 500 with a `requestId` is the honest shape for a corpus state
+    // that #5047 makes impossible (target keys are `NOT NULL`, and 0194
+    // tombstoned the legacy rows, which `correctionTargetSql` then excludes).
+    await expect(outcome).rejects.toThrow(/reconcile blocked the replacement claim/);
     // No successor was installed. That the target's `valid_to` STAMP is rolled
     // back with the refusal is the other half and is pinned in
     // `candidates-pg.test.ts` — this fake applies its statements to in-memory
@@ -1925,17 +1929,13 @@ describe("cardinality proposer", () => {
     // only its stored identity is missing.
     expect(identityKey("is owned by")).not.toBeNull();
 
-    const outcome = await run(store, {
-      factId: "unkeyed",
-      verb: "supersede",
-      replacement: { object: "Bo" },
-    });
-
-    expect(outcome).toMatchObject({
-      kind: "refused",
-      reason: CORRECTION_REFUSAL_REASONS.replacementMalformed,
-    });
-    // The proposer is downstream of the commit, so a refusal must not reach it.
+    // A THROW rather than a refusal: the unkeyed position is the TARGET's
+    // inherited slot, not the human's replacement text. See the supersede suite
+    // for why that distinction decides the status code.
+    await expect(
+      run(store, { factId: "unkeyed", verb: "supersede", replacement: { object: "Bo" } }),
+    ).rejects.toThrow(/reconcile blocked the replacement claim/);
+    // The proposer is downstream of the commit, so a failure must not reach it.
     // Asserted on the statement rather than on the proposal list, because a
     // proposer that RAN and found nothing would leave the same empty list.
     expect(store.executed).not.toContain(CORRECTION_REPEAT_COUNT_SQL);
@@ -1952,16 +1952,9 @@ describe("cardinality proposer", () => {
     store.seedFact({ id: "degenerate", predicate: "-", object: "Ana", status: "published" });
     expect(identityKey("-")).toBeNull();
 
-    const outcome = await run(store, {
-      factId: "degenerate",
-      verb: "supersede",
-      replacement: { object: "Bo" },
-    });
-
-    expect(outcome).toMatchObject({
-      kind: "refused",
-      reason: CORRECTION_REFUSAL_REASONS.replacementMalformed,
-    });
+    await expect(
+      run(store, { factId: "degenerate", verb: "supersede", replacement: { object: "Bo" } }),
+    ).rejects.toThrow(/reconcile blocked the replacement claim/);
     expect(store.executed).not.toContain(CORRECTION_REPEAT_COUNT_SQL);
   });
 
@@ -2257,16 +2250,9 @@ describe("cardinality proposer", () => {
     const store = new FakeCorrectionStore();
     store.seedFact({ id: "old", predicate: "---", object: "Ana", status: "published" });
 
-    const outcome = await run(store, {
-      factId: "old",
-      verb: "supersede",
-      replacement: { object: "Bo" },
-    });
-
-    expect(outcome).toMatchObject({
-      kind: "refused",
-      reason: CORRECTION_REFUSAL_REASONS.replacementMalformed,
-    });
+    await expect(
+      run(store, { factId: "old", verb: "supersede", replacement: { object: "Bo" } }),
+    ).rejects.toThrow(/reconcile blocked the replacement claim/);
     expect(store.executed).not.toContain(CORRECTION_REPEAT_COUNT_SQL);
   });
 

--- a/packages/api/src/lib/brain/__tests__/correction.test.ts
+++ b/packages/api/src/lib/brain/__tests__/correction.test.ts
@@ -1604,18 +1604,19 @@ describe("supersede", () => {
     expect(replacement?.slot.object).toBe("bob");
   });
 
-  test("an UNKEYED target inherits its null slot rather than acquiring one (#5037)", async () => {
-    // The other arm of the inherit, and the one that says what "verbatim" means
-    // when there is nothing to copy. A region import leaves rows whose keys came
-    // from a foreign vocabulary, and rows written before #5020 have none at all.
+  test("an UNKEYED target REFUSES the supersede rather than installing an unkeyed successor (#5047)", async () => {
+    // #5037's other inherit arm, inverted by #5047. It used to carry the target's
+    // nulls into the successor on the argument that this kept the replacement
+    // exactly as un-collidable as the fact it replaced — the recoverable
+    // direction, and correct while an unkeyed row was a legal thing to be.
     //
-    // Deriving a key to fill the hole is the tempting repair and it is the wrong
-    // one: it would invent identity for a row that has none and move its
-    // successor into a LIVE slot, where it can collide with — and at the publish
-    // gate supersede — claims the unkeyed row never had any relationship to.
-    // Carrying the nulls keeps the successor exactly as un-collidable as the
-    // fact it replaces, which is today's behaviour for that row and the
-    // recoverable direction.
+    // It is not one any more. `brain_facts`' key columns are `NOT NULL` as of
+    // migration 0194, so this target cannot exist in the database at all, and
+    // the inherit channel is the one path that could still put a null in front
+    // of `reconcile.ts` — which now refuses it. The verb REFUSES instead of
+    // committing, which is the honest outcome: the alternative was retiring a
+    // published belief in favour of a successor nothing can ever corroborate,
+    // contradict, or supersede in turn.
     const store = new FakeCorrectionStore();
     store.seedFact({
       id: "unkeyed",
@@ -1629,14 +1630,63 @@ describe("supersede", () => {
       replacement: { object: "Bo" },
     });
 
+    expect(outcome).toMatchObject({
+      kind: "refused",
+      reason: CORRECTION_REFUSAL_REASONS.replacementMalformed,
+    });
+    // No successor was installed. That the target's `valid_to` STAMP is rolled
+    // back with the refusal is the other half and is pinned in
+    // `candidates-pg.test.ts` — this fake applies its statements to in-memory
+    // state and models no rollback, so asserting it here would assert the fake.
+    expect(store.facts.find((f) => f.object === "Bo")).toBeUndefined();
+  });
+
+  test("a DEGENERATE replacement refuses, and rolls the valid_to stamp back with it (#5047)", async () => {
+    // The case `replacementIdentical`'s docstring records as deliberately
+    // uncovered by that guard: `-` against a real target is `null !== "ana"`, so
+    // it passes the restatement check. Before #5047 it went on to close a
+    // published belief and stand up a successor with no identity.
+    //
+    // Closed at the INGEST seam rather than by a second refusal here — the
+    // acceptance criterion says the verb inherits the fix "for free", and this
+    // is the test it asks for rather than an assumption. What `applySupersede`
+    // adds is the TRANSLATION of reconcile's block into a typed refusal, so the
+    // human sees a 400 naming their text instead of a 500 about a seam contract.
+    for (const degenerate of ["-", "___", "  -_- "]) {
+      const store = new FakeCorrectionStore();
+      store.seedFact({ id: "f1", object: "Ana" });
+
+      const outcome = await run(store, {
+        factId: "f1",
+        verb: "supersede",
+        replacement: { object: degenerate },
+      });
+
+      expect(outcome, `"${degenerate}" was not refused`).toMatchObject({
+        kind: "refused",
+        reason: CORRECTION_REFUSAL_REASONS.replacementMalformed,
+      });
+      // No successor was stored. The `valid_to` rollback is
+      // `candidates-pg.test.ts`'s — see the sibling test above for why.
+      expect(store.facts).toHaveLength(1);
+    }
+  });
+
+  test("a replacement that merely CONTAINS separators is not degenerate", async () => {
+    // The falsifier for the guard over-reaching. `-` is a separator, so a
+    // refusal written on "contains a separator" rather than on "normalizes away"
+    // would reject `Ana-Maria` — an ordinary claim whose key is `ana maria`.
+    const store = new FakeCorrectionStore();
+    store.seedFact({ id: "f1", object: "Ana" });
+
+    const outcome = await run(store, {
+      factId: "f1",
+      verb: "supersede",
+      replacement: { object: "Ana-Maria" },
+    });
+
     expect(outcome.kind).toBe("corrected");
-    const replacement = store.facts.find((f) => f.object === "Bo");
-    expect(replacement?.slot.subject).toBeNull();
-    expect(replacement?.slot.predicate).toBeNull();
-    // The object still keys — it is derived, not inherited, so an unkeyed TARGET
-    // does not make an unkeyed successor at every position. This is what
-    // distinguishes "the slot was copied" from "the candidate lost its keys".
-    expect(replacement?.slot.object).toBe("bo");
+    expect(store.facts.find((f) => f.object === "Ana-Maria")?.slot.object).toBe("ana maria");
   });
 
   test("refuses a replacement that restates the object in a DIFFERENT SPELLING (#5020)", async () => {
@@ -1849,19 +1899,20 @@ describe("cardinality proposer", () => {
     ]);
   });
 
-  test("an UNKEYED target reports a CORPUS gap, not a degenerate surface (#5037)", async () => {
-    // The round-2 fix split one `log.debug` into two arms because a null
-    // `supersededKey` acquired a second cause — and shipped with nothing holding
-    // it. Deleting the whole `unkeyed-target` arm, or collapsing the discriminant
-    // to a constant, left every gate green.
+  test("an UNKEYED target is REFUSED, so the proposer is never reached (#5047)", async () => {
+    // What #5037's two-arm `logDegeneratePredicate` used to report, and why that
+    // reporter is gone rather than retested. It fired for a `supersede` that
+    // COMMITTED while closing no canonical predicate slot, which had two causes:
+    // an unkeyed TARGET row (this test) and a predicate SURFACE that normalizes
+    // away (the next one). Both are now unrepresentable at a committed
+    // supersede — the replacement inherits the target's slot, and reconcile
+    // refuses a null slot key — so the verb refuses and the post-commit reporter
+    // is never reached.
     //
-    // The severity is why it matters: `debug` is off in production, so before the
-    // split "this corpus has no identity and the cardinality proposer has gone
-    // silent" was indistinguishable from "healthy". A revert restores exactly
-    // that silence, invisibly.
-    //
-    // Keyed on the structured `cause` field rather than message prose, so a
-    // reworded message does not fail this but a re-collapsed one does.
+    // The severity argument that justified the warn is answered better by the
+    // refusal than it was by the log: the operator no longer has to READ
+    // anything to find out that this corpus cannot feed the cardinality
+    // proposer. The correction fails, loudly, at the request.
     const store = new FakeCorrectionStore();
     store.seedFact({
       id: "unkeyed",
@@ -1869,46 +1920,49 @@ describe("cardinality proposer", () => {
       status: "published",
       slot: { subject: null, predicate: null, object: null },
     });
-    // The discriminator's premise: the surface itself keys perfectly well, so
-    // "normalizes away" would be a false diagnosis of this row.
+    // The premise that made this row distinguishable from a degenerate surface:
+    // the surface itself keys perfectly well, so the row's own text is fine and
+    // only its stored identity is missing.
     expect(identityKey("is owned by")).not.toBeNull();
 
-    await run(store, { factId: "unkeyed", verb: "supersede", replacement: { object: "Bo" } });
+    const outcome = await run(store, {
+      factId: "unkeyed",
+      verb: "supersede",
+      replacement: { object: "Bo" },
+    });
 
-    const unkeyedWarns = warns().filter(
-      (c) => (c.payload as { cause?: string }).cause === "unkeyed-target",
-    );
-    expect(
-      unkeyedWarns,
-      "an unkeyed TARGET must WARN — debug is off in production, so the corpus-wide silence would be invisible",
-    ).toHaveLength(1);
-    // …and it must name both remaining causes rather than asserting one. The
-    // round-2 fix removed a prescription ("re-key the workspace") that provably
-    // cannot work when the vocabulary is what maps the norm away.
-    expect(unkeyedWarns[0]!.message).toContain("vocabulary");
-    expect(unkeyedWarns[0]!.message).toContain("never keyed");
-    // The prohibition arm: this row must NOT be reported as a degenerate surface.
-    expect(
-      logCalls.filter((c) => c.level === "debug" && c.message.includes("normalizes away")),
-    ).toEqual([]);
+    expect(outcome).toMatchObject({
+      kind: "refused",
+      reason: CORRECTION_REFUSAL_REASONS.replacementMalformed,
+    });
+    // The proposer is downstream of the commit, so a refusal must not reach it.
+    // Asserted on the statement rather than on the proposal list, because a
+    // proposer that RAN and found nothing would leave the same empty list.
+    expect(store.executed).not.toContain(CORRECTION_REPEAT_COUNT_SQL);
+    expect(store.cardinalityProposals).toEqual([]);
   });
 
-  test("a DEGENERATE predicate surface still reports as such, not as a corpus gap (#5037)", async () => {
-    // The control. Without it the assertion above is satisfied by an
-    // implementation that reports EVERY null key as `unkeyed-target`, which is
-    // the collapse in the other direction.
+  test("a DEGENERATE predicate surface is refused on the same terms — one guard, not two (#5047)", async () => {
+    // The control, kept for the reason #5037 wrote it: without a second case the
+    // assertion above is satisfied by an implementation that special-cases the
+    // unkeyed row. These two arrive at the guard by different roads — a stored
+    // null versus a surface that normalizes to one — and #5047's point is that
+    // they now reach the SAME verdict, where #5037 had to tell them apart.
     const store = new FakeCorrectionStore();
     store.seedFact({ id: "degenerate", predicate: "-", object: "Ana", status: "published" });
     expect(identityKey("-")).toBeNull();
 
-    await run(store, { factId: "degenerate", verb: "supersede", replacement: { object: "Bo" } });
+    const outcome = await run(store, {
+      factId: "degenerate",
+      verb: "supersede",
+      replacement: { object: "Bo" },
+    });
 
-    expect(warns().filter((c) => (c.payload as { cause?: string }).cause === "unkeyed-target")).toEqual(
-      [],
-    );
-    expect(
-      logCalls.filter((c) => c.level === "debug" && c.message.includes("normalizes away")),
-    ).toHaveLength(1);
+    expect(outcome).toMatchObject({
+      kind: "refused",
+      reason: CORRECTION_REFUSAL_REASONS.replacementMalformed,
+    });
+    expect(store.executed).not.toContain(CORRECTION_REPEAT_COUNT_SQL);
   });
 
   test("stays silent below the repeat threshold", async () => {
@@ -2194,15 +2248,12 @@ describe("cardinality proposer", () => {
     expect(warns().filter((c) => c.message.includes("cardinality repeat gate"))).toEqual([]);
   }, 5_000);
 
-  test("a supersede whose predicate NORMS AWAY leaves a trace, and no other verb does", async () => {
-    // `logDegeneratePredicate`'s whole reason for existing, and it was
-    // unobserved in both directions: deleting the call was green, and so was
-    // removing its `verb === "supersede"` guard so it fired for all four.
-    //
-    // The predicate `---` normalizes to nothing, so `slotKey` answers `null` —
-    // the same `null` the other three verbs send — and the proposer is skipped.
-    // Without the line that is a supersede producing no proposal and no record
-    // at all.
+  test("a supersede whose predicate NORMS AWAY is refused, and the proposer is skipped", async () => {
+    // `logDegeneratePredicate`'s case, now answered by the guard instead of by a
+    // log line. The predicate `---` normalizes to nothing, so the slot the
+    // replacement inherits is `(null, null)` and reconcile refuses the
+    // candidate — which is a better outcome than the line it replaces: the
+    // supersede used to COMMIT, produce no proposal, and say so only at `debug`.
     const store = new FakeCorrectionStore();
     store.seedFact({ id: "old", predicate: "---", object: "Ana", status: "published" });
 
@@ -2211,30 +2262,35 @@ describe("cardinality proposer", () => {
       verb: "supersede",
       replacement: { object: "Bo" },
     });
-    expect(outcome.kind).toBe("corrected");
-    expect(
-      logCalls.filter((c) => c.level === "debug" && c.message.includes("normalizes away")),
-    ).toHaveLength(1);
-    // …and the proposer was not reached, which is the behaviour the line
-    // documents rather than merely accompanies.
+
+    expect(outcome).toMatchObject({
+      kind: "refused",
+      reason: CORRECTION_REFUSAL_REASONS.replacementMalformed,
+    });
     expect(store.executed).not.toContain(CORRECTION_REPEAT_COUNT_SQL);
   });
 
   test.each(["retract", "re-authority", "pin"] as const)(
-    "%s never leaves that trace — only a supersede is evidence about cardinality",
+    "%s still applies to such a target — only a supersede supplies a claim to refuse",
     async (verb) => {
-      // The prohibition half. Without it, removing the `verb === \"supersede\"`
-      // guard is green: every verb would log "superseded a claim whose predicate
-      // normalizes away", including the ones that superseded nothing.
+      // The prohibition half, rewritten to assert what still HOLDS rather than
+      // the absence of a log line that no longer exists — an absence assertion
+      // against deleted machinery passes vacuously and pins nothing.
+      //
+      // The invariant is the one that makes `REPLACEMENT_MALFORMED` a
+      // supersede-only refusal: the other three verbs supply no claim, reconcile
+      // nothing, and therefore cannot be refused for a malformed one. A guard
+      // that widened to "the TARGET has no canonical predicate" would break
+      // every one of them on a corpus these verbs are meant to be able to clean
+      // up.
       const store = new FakeCorrectionStore();
       store.seedFact({ id: "old", predicate: "---", object: "Ana", status: "published" });
 
-      await run(store, { factId: "old", verb });
+      const outcome = await run(store, { factId: "old", verb });
 
-      expect(
-        logCalls.filter((c) => c.message.includes("normalizes away")),
-        `${verb} claimed it superseded a claim — that line is a supersede's alone`,
-      ).toEqual([]);
+      expect(outcome.kind, `${verb} was refused on a target it should still accept`).toBe(
+        "corrected",
+      );
     },
   );
 

--- a/packages/api/src/lib/brain/__tests__/extract-reconcile-pg.test.ts
+++ b/packages/api/src/lib/brain/__tests__/extract-reconcile-pg.test.ts
@@ -555,28 +555,32 @@ describeIfPg("brain extraction + reconcile (real Postgres)", () => {
   // tombstone, tenant — over one fixed claim, rather than varying the claim.
   // Identity is the corpus's axis; those are this file's.
 
-  it("keys a surface that norms away as NULL, and NULL corroborates nothing", async () => {
-    // `-` and `___` survive the MALFORMED_CLAIM guard (`trim` strips whitespace,
-    // not `_` or `-`), so they are storable claims with no slot. They must NOT
-    // share one: a stored `''` — or a NULL-safe join arm — would file every
-    // placeholder in the corpus under one key, and at `single` cardinality
-    // publishing either would stamp `valid_to` on the other.
+  it("REFUSES a surface that norms away — no row, so no shared slot to corrupt", async () => {
+    // `-` and `___` used to survive the `MALFORMED_CLAIM` guard (`trim` strips
+    // whitespace, not `_` or `-`) and become storable claims with no slot. This
+    // suite's job was to prove they did not SHARE one: a stored `''` — or a
+    // NULL-safe join arm — would file every placeholder in the corpus under one
+    // key, and at `single` cardinality publishing either would stamp `valid_to`
+    // on the other.
     //
-    // What the column read below pins is that `slotKey` returned `null` rather
-    // than `""` — NOT that no `DEFAULT ''` exists, since `INSERT_FACT_SQL` now
-    // binds `object_key` explicitly and an explicit NULL always beats a default.
-    // `identity-pg.test.ts` introspects the column for the default itself.
+    // #5047 removes the population instead of keeping it apart, which is the
+    // stronger version of the same guarantee: the guard refuses the candidate at
+    // ingest and migration 0194 makes the column `NOT NULL`, so there is no row
+    // to file anywhere. The refusal is asserted here — against a real database,
+    // and after the constraint — because a guard that let one through would now
+    // be a `23502` that fails the whole reconcile transaction, and no unit fake
+    // can see that.
     const first = await insertEpisode({ sourceId: "C01:key-6" });
     const second = await insertEpisode({ sourceId: "C01:key-7" });
 
-    await reconcileFacts({
+    const one = await reconcileFacts({
       vocabulary: identityVocabulary,
       episode: first,
       candidates: [candidate({ object: "-" })],
       producer: "p",
       extractedAt: new Date(),
     });
-    const report = await reconcileFacts({
+    const two = await reconcileFacts({
       vocabulary: identityVocabulary,
       episode: second,
       candidates: [candidate({ object: "___" })],
@@ -584,33 +588,35 @@ describeIfPg("brain extraction + reconcile (real Postgres)", () => {
       extractedAt: new Date(),
     });
 
-    expect(report.corroborated).toBe(0);
-    const stored = await facts();
-    expect(stored).toHaveLength(2);
-    // The degenerate SURFACES survive to the column verbatim — a reviewer has
-    // to be able to see what the producer emitted in order to repair it.
-    expect(stored.map((f) => f.object)).toEqual(["-", "___"]);
-    for (const slot of await slots()) {
-      expect(slot.object_key).toBeNull();
-      expect(slot.subject_key).toBe("deploy window");
-    }
+    expect(one.blocked.MALFORMED_CLAIM).toBe(1);
+    expect(two.blocked.MALFORMED_CLAIM).toBe(1);
+    expect(one.created + two.created).toBe(0);
+    // Nothing was stored, and — the half that needed the live transaction — the
+    // episodes committed cleanly rather than rolling back. A refusal is a
+    // per-candidate block, not an episode failure.
+    expect(await facts()).toHaveLength(0);
   });
 
-  it("a rival with NO object identity is not a rival — the object arm's falsifier", async () => {
-    // This is what makes `object_key <> $4` load-bearing rather than
-    // decorative, and it took a review to find: a live row in the same slot
-    // whose object is `-` has `object_key IS NULL`, so the corroboration
-    // lookup does not return it either (`object_key = $4` is unknown) and it
-    // survives to the rival scan. There the two spellings genuinely diverge —
-    // `object <> $4` is TRUE, `object_key <> $4` is unknown.
+  it("a live row with NO object identity is UNREPRESENTABLE — the object arm's falsifier, closed", async () => {
+    // What this used to prove: a live row in the same slot whose object is `-`
+    // has `object_key IS NULL`, so the corroboration lookup does not return it
+    // (`object_key = $4` is unknown) and it survives to the rival scan — where
+    // the two spellings genuinely diverge, `object <> $4` being TRUE while
+    // `object_key <> $4` is unknown. Wiring the edge would have been the worse
+    // outcome: a permanent advisory `in-tension-with` from a real claim to a
+    // placeholder that asserts nothing, shown to a reviewer as a contradiction
+    // to arbitrate.
     //
-    // Wiring the edge would be the worse outcome: a permanent advisory
-    // `in-tension-with` from a real claim to a placeholder that asserts
-    // nothing, shown to a reviewer as a contradiction to arbitrate.
+    // The rule it established is unchanged and is still why the scan compares
+    // KEYS and not surfaces. What changed is that the falsifying INPUT can no
+    // longer be built: the degenerate claim is refused at ingest (#5047). So the
+    // test now proves the closure — the degenerate claim never lands, and the
+    // real claim beside it is minted with no edge, because there is nothing in
+    // its slot to be in tension with.
     const first = await insertEpisode({ sourceId: "C01:key-10" });
     const second = await insertEpisode({ sourceId: "C01:key-11" });
 
-    await reconcileFacts({
+    const degenerate = await reconcileFacts({
       vocabulary: identityVocabulary,
       episode: first,
       candidates: [candidate({ object: "-", predicateCardinality: "single" })],
@@ -625,9 +631,11 @@ describeIfPg("brain extraction + reconcile (real Postgres)", () => {
       extractedAt: new Date(),
     });
 
-    // Two facts — the degenerate one could not corroborate — and NO edge.
+    expect(degenerate.blocked.MALFORMED_CLAIM).toBe(1);
+    // ONE fact — the degenerate one was refused rather than merely unable to
+    // corroborate — and NO edge.
     expect(report.outcomes[0]).toMatchObject({ kind: "created", tensionEdges: 0 });
-    expect(await facts()).toHaveLength(2);
+    expect(await facts()).toHaveLength(1);
     expect((await edges()).filter((e) => e.edge_type === "in-tension-with")).toHaveLength(0);
   });
 

--- a/packages/api/src/lib/brain/__tests__/grant-sweep-pg.test.ts
+++ b/packages/api/src/lib/brain/__tests__/grant-sweep-pg.test.ts
@@ -34,6 +34,7 @@ import { Pool } from "pg";
 import { runMigrations } from "@atlas/api/lib/db/migrate";
 import { MANAGED_AUTH_MIGRATIONS } from "@atlas/api/lib/db/internal";
 import { ACL_GATED_TABLES, parseGrant, type AclGatedTable } from "@atlas/api/lib/brain/acl";
+import { identityAlias, slotKey } from "@atlas/api/lib/brain/identity";
 import {
   MALFORMED_SAMPLE_CAP,
   grantScanSql,
@@ -138,9 +139,15 @@ describeIfPg("brain malformed-grant sweep (real Postgres)", () => {
   }): Promise<void> {
     await pool.query(
       `INSERT INTO brain_facts
-         (workspace_id, subject, predicate, object, source_episode_id, provenance, status, visible_to)
-       VALUES ($1, $2, 'is', 'thing', $3, '{"actor":"test"}'::jsonb, $4, $5::text[])`,
-      [opts.workspaceId, opts.subject, opts.episodeId, opts.status ?? "published", opts.visibleTo],
+         (workspace_id, subject, predicate, object, subject_key, predicate_key, object_key,
+          source_episode_id, provenance, status, visible_to)
+       VALUES ($1, $2, 'is', 'thing', $6, 'is', 'thing', $3, '{"actor":"test"}'::jsonb, $4, $5::text[])`,
+      [opts.workspaceId, opts.subject, opts.episodeId, opts.status ?? "published", opts.visibleTo,
+        // The subject KEY, required since migration 0194 (#5047). Through
+        // `slotKey` rather than spelled in SQL, so the fixture keys its rows
+        // with the same function the ingest path uses.
+        slotKey(opts.subject, identityAlias),
+      ],
     );
   }
 

--- a/packages/api/src/lib/brain/__tests__/identity-pg.test.ts
+++ b/packages/api/src/lib/brain/__tests__/identity-pg.test.ts
@@ -152,6 +152,30 @@ describeIfPg("claim identity against the live schema (#5019)", () => {
     }
     await runMigrations(pool, { skip: MANAGED_AUTH_MIGRATIONS });
 
+    // ⚠️ THE SLOT KEYS ARE RELAXED IN THIS SUITE'S OWN THROWAWAY SCHEMA, and
+    // that is what lets this file keep doing its job after #5047.
+    //
+    // Everything below pins migration 0187 — its expression against
+    // `lexicalNorm`, row by row — and 0187 ran when these columns were nullable.
+    // The technique is *null the keys, run the real file, compare*, which is
+    // meaningful precisely because 0187's `WHERE … IS NULL` is what makes it
+    // re-runnable. Migration 0194 makes both halves of that impossible: the
+    // seeds below name no key column, and `rerunBackfill` writes NULL on
+    // purpose.
+    //
+    // Dropping the constraint HERE, rather than rewriting the corpus to carry
+    // pre-computed keys, keeps the comparison honest: a seed that supplied the
+    // key would be asserting the TypeScript against itself, and the whole point
+    // of this file is that the migration is a SECOND implementation.
+    //
+    // It costs nothing this file was covering. The constraint has its own suite
+    // below, on a PRISTINE migrated schema — this one can no longer speak about
+    // nullability at all, which is why the assertion that used to live here
+    // moved rather than being deleted.
+    for (const column of ["subject_key", "predicate_key", "object_key"] as const) {
+      await pool.query(`ALTER TABLE brain_facts ALTER COLUMN ${column} DROP NOT NULL`);
+    }
+
     const { rows } = await pool.query<{ id: string }>(
       `INSERT INTO brain_episodes
          (workspace_id, source, source_id, source_actor, body, occurred_at, visible_to)
@@ -658,8 +682,46 @@ describeIfPg("claim identity against the live schema (#5019)", () => {
     PG_TEST_TIMEOUT_MS,
   );
 
+});
+
+/**
+ * The CONSTRAINT itself (#5047, migration 0194) — deliberately its own suite on
+ * its own PRISTINE schema.
+ *
+ * It cannot share the schema above: that one drops the `NOT NULL` so it can
+ * replay migration 0187, which predates it. A nullability assertion made there
+ * would read the relaxed column and pass no matter what 0194 does.
+ */
+describeIfPg("the slot-key NOT NULL constraint (#5047, migration 0194)", () => {
+  let pool: Pool;
+  const schemaName = `brain_notnull_${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
+
+  beforeAll(async () => {
+    pool = new Pool({
+      connectionString: TEST_DB_URL,
+      options: `-c search_path="${schemaName}",public`,
+    });
+    const bootstrap = new Pool({ connectionString: TEST_DB_URL });
+    try {
+      await bootstrap.query(`CREATE SCHEMA IF NOT EXISTS "${schemaName}"`);
+    } finally {
+      await bootstrap.end();
+    }
+    await runMigrations(pool, { skip: MANAGED_AUTH_MIGRATIONS });
+  }, PG_TEST_TIMEOUT_MS);
+
+  afterAll(async () => {
+    if (pool) {
+      try {
+        await pool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+      } finally {
+        await pool.end();
+      }
+    }
+  });
+
   it(
-    "leaves the key columns NULLABLE — the constraint has three prerequisites",
+    "the key columns are NOT NULL — all three prerequisites landed (#5047)",
     async () => {
       const { rows } = await pool.query<{
         column_name: string;
@@ -696,19 +758,28 @@ describeIfPg("claim identity against the live schema (#5019)", () => {
         ).toBeNull();
         expect(
           row.is_nullable,
-          `${row.column_name} is NOT NULL. 0187's header enumerates the three prerequisites: neither INSERT site names these columns yet (\`INSERT_FACT_SQL\`, #5020; the region import's 18-column INSERT, #5035), and \`identityKey\` returns NULL for a surface that norms away — which \`reconcile.ts\` admits today, so the constraint would turn a storable claim into a transaction-killing violation. Read the header, not this message, before flipping it`,
-        ).toBe("YES");
+          `${row.column_name} is NULLABLE. Migration 0194 makes all three \`NOT NULL\` — the third and last step of ADR-0037 §1's identity key — and a NULL key means a row that silently drops out of every slot consumer: a re-observation forks a duplicate draft instead of strengthening the fact, no tension edge is minted, and the publish gate reports "nothing to supersede" for a check it could not run. Reverting the constraint restores that state invisibly`,
+        ).toBe("NO");
       }
     },
     PG_TEST_TIMEOUT_MS,
   );
 
   it(
-    "admits an INSERT that names no key column — the constraint cannot have crept in",
+    "REFUSES an INSERT that names no key column — the positive control for the constraint",
     async () => {
-      // The positive control for the nullability assertion above: a metadata
-      // read passes if the column is absent from the result set for any reason,
-      // and `INSERT_FACT_SQL`'s exact shape is the thing that must keep working.
+      // The falsifier for the metadata read above, inverted by #5047. It used to
+      // assert the opposite — that `INSERT_FACT_SQL`'s pre-key shape still
+      // worked — because a metadata assertion passes if the column is absent
+      // from the result set for any reason, and something had to exercise the
+      // column itself.
+      //
+      // It still does exactly that job: a `SET NOT NULL` that silently failed to
+      // apply, or a `DEFAULT` quietly added to make the constraint satisfiable,
+      // both leave the read above green and are both caught here. The `DEFAULT`
+      // case is the one worth naming — 0187's header rejects `DEFAULT ''`
+      // because every unkeyed row would then join every other unkeyed row, and a
+      // default is the obvious way to make a stubborn `NOT NULL` land.
       const { rows } = await pool.query<{ id: string }>(
         `INSERT INTO brain_episodes
            (workspace_id, source, source_id, source_actor, body, occurred_at, visible_to)
@@ -716,28 +787,25 @@ describeIfPg("claim identity against the live schema (#5019)", () => {
          RETURNING id`,
         [WS],
       );
-      await pool.query(
-        `INSERT INTO brain_facts
-           (workspace_id, subject, predicate, object, source_episode_id, provenance, visible_to)
-         VALUES ($1, 'unkeyed subject', 'unkeyed predicate', 'unkeyed object', $2, $3::jsonb, ARRAY['org'])`,
-        [WS, rows[0]!.id, JSON.stringify({ source: "slack", actor: "U1" })],
-      );
 
-      const { rows: check } = await pool.query<{ subject_key: string | null }>(
-        `SELECT subject_key FROM brain_facts WHERE workspace_id = $1 AND subject = 'unkeyed subject'`,
+      await expect(
+        pool.query(
+          `INSERT INTO brain_facts
+             (workspace_id, subject, predicate, object, source_episode_id, provenance, visible_to)
+           VALUES ($1, 'unkeyed subject', 'unkeyed predicate', 'unkeyed object', $2, $3::jsonb, ARRAY['org'])`,
+          [WS, rows[0]!.id, JSON.stringify({ source: "slack", actor: "U1" })],
+        ),
+        "an INSERT naming no key column succeeded — either the constraint is not applied, or a DEFAULT was added to satisfy it, which would file every unkeyed row under one slot",
+      ).rejects.toThrow(/null value in column "(subject|predicate|object)_key"/);
+
+      // The row is absent rather than merely unkeyed — the statement did not
+      // half-apply.
+      const { rows: check } = await pool.query(
+        `SELECT 1 FROM brain_facts WHERE workspace_id = $1 AND subject = 'unkeyed subject'`,
         [WS],
       );
-      expect(check.length).toBe(1);
-      // No default, either — a `DEFAULT ''` would silently corrupt the corpus by
-      // making every unkeyed row join every other unkeyed row.
-      expect(
-        check[0]!.subject_key,
-        "an unkeyed INSERT produced a non-NULL key — a DEFAULT crept onto the column, and every unkeyed row now shares one slot",
-      ).toBeNull();
+      expect(check).toHaveLength(0);
 
-      await pool.query(`DELETE FROM brain_facts WHERE workspace_id = $1 AND subject = 'unkeyed subject'`, [
-        WS,
-      ]);
       await pool.query(`DELETE FROM brain_episodes WHERE workspace_id = $1 AND source_id = 'identity-unkeyed'`, [
         WS,
       ]);

--- a/packages/api/src/lib/brain/__tests__/identity-pg.test.ts
+++ b/packages/api/src/lib/brain/__tests__/identity-pg.test.ts
@@ -36,10 +36,13 @@
  *      migration text.
  *   6. **Was the slot index REPOINTED rather than added?** Zero net new
  *      indexes is a result, and a result nobody checks is a wish.
- *   7. **Are the columns still NULLABLE?** The constraint has THREE
- *      prerequisites, enumerated in 0187's header — landing it before them
- *      refuses every brain-fact write, every region import, or every claim
- *      whose surface norms away.
+ *   7. **Are the columns NOT NULL?** All three of 0187's prerequisites landed
+ *      (#5047, migration 0194), so this is now asserted rather than refused —
+ *      in a SEPARATE suite at the foot of this file, on a pristine migrated
+ *      schema. It cannot live in the suite above: that one DROPs the constraint
+ *      in its own scratch schema so it can replay 0187, which predates it, and a
+ *      nullability assertion made there would read the relaxed column and pass
+ *      whatever 0194 does.
  *
  * The migration is executed by READING THE FILE and running it, so there is no
  * copy of its SQL here to drift from it. `WHERE … IS NULL` is what makes that

--- a/packages/api/src/lib/brain/__tests__/identity.test.ts
+++ b/packages/api/src/lib/brain/__tests__/identity.test.ts
@@ -17,6 +17,7 @@ import {
   identityAlias,
   identityVocabulary,
   SLOT_POSITIONS,
+  UNKEYABLE_KEY_PREFIX,
   identityKey,
   lexicalNorm,
   slotKey,
@@ -264,6 +265,60 @@ describe("lexicalNorm", () => {
       expect(lexicalNorm("$499")).toBe("$499");
       expect(lexicalNorm("499 USD")).toBe("499 usd");
       expect(lexicalNorm("a.b/c")).toBe("a.b/c");
+    });
+  });
+
+  describe("UNKEYABLE_KEY_PREFIX — the placeholder namespace (#5047)", () => {
+    // ⚠️ THE PROPERTY THE WHOLE PLACEHOLDER SCHEME RESTS ON, and until #5047 it
+    // was an argument in a docstring rather than something anything checked.
+    //
+    // Migration 0194 and the region importer both write
+    // `${UNKEYABLE_KEY_PREFIX}${factId}` into a key column for a row whose
+    // surface normalizes away. That is only safe while no COMPUTED key can ever
+    // equal one — otherwise a real claim joins a placeholder, and at `single`
+    // cardinality publishing either stamps `valid_to` on the other. The safety
+    // comes entirely from `lexicalNorm`'s treatment of `-`, so this is where it
+    // is pinned.
+    it("starts with a character `lexicalNorm` can never emit", () => {
+      expect(UNKEYABLE_KEY_PREFIX.startsWith("-")).toBe(true);
+    });
+
+    it("is unreachable from lexicalNorm — no norm starts with or contains `-`", () => {
+      // `-` is in the separator class, so every run of it collapses to a space
+      // and the edge trim removes it. A change to `SEPARATOR_RUN` that stops
+      // treating `-` as a separator silently makes placeholders forgeable, and
+      // this is the assertion that says so.
+      const surfaces = [
+        "-",
+        "--",
+        "-unkeyable:01J",
+        `${UNKEYABLE_KEY_PREFIX}some-fact-id`,
+        "-leading",
+        "trailing-",
+        "a-b",
+        "a - b",
+        "_x_",
+        ...Object.values(PAIRED_SURFACES).flat(),
+        ...DEGENERATE_SURFACES,
+      ];
+      for (const surface of surfaces) {
+        const norm = lexicalNorm(surface);
+        expect(norm.includes("-"), `lexicalNorm("${surface}") = "${norm}" contains a hyphen`).toBe(
+          false,
+        );
+      }
+    });
+
+    it("is unreachable through the FULL composition, vocabulary included", () => {
+      // `slotKey` re-norms the vocabulary's answer, so even a vocabulary that
+      // deliberately targets the placeholder namespace cannot produce one — the
+      // outer `identityKey` strips the leading `-` again. This is the arm that
+      // matters once `alias` is a reviewed data table with hand-authored targets.
+      const forge = () => `${UNKEYABLE_KEY_PREFIX}aaaaaaaa-0000-4000-8000-000000000001`;
+      const key = slotKey("billing", forge);
+      expect(key).not.toBeNull();
+      expect(key?.startsWith("-")).toBe(false);
+      expect(key).toBe("unkeyable:aaaaaaaa 0000 4000 8000 000000000001");
     });
   });
 });

--- a/packages/api/src/lib/brain/__tests__/promotion-pg.test.ts
+++ b/packages/api/src/lib/brain/__tests__/promotion-pg.test.ts
@@ -161,8 +161,8 @@ describeIfPg("brain fact review gate (real Postgres)", () => {
   }): Promise<string> {
     const { rows } = await pool.query<{ id: string }>(
       `INSERT INTO brain_facts
-         (workspace_id, subject, predicate, object, source_episode_id, provenance, status, visible_to)
-       VALUES ($1, $2, 'is', 'thing', $3, '{"actor":"test"}'::jsonb, $4, $5::text[])
+         (workspace_id, subject, predicate, object, subject_key, predicate_key, object_key, source_episode_id, provenance, status, visible_to)
+       VALUES ($1, $2, 'is', 'thing', $6, 'is', 'thing', $3, '{"actor":"test"}'::jsonb, $4, $5::text[])
        RETURNING id`,
       [
         opts.workspaceId,
@@ -170,6 +170,13 @@ describeIfPg("brain fact review gate (real Postgres)", () => {
         opts.episodeId,
         opts.status ?? "draft",
         opts.visibleTo ?? ["org"],
+        // The subject KEY, required since migration 0194 (#5047). Computed with
+        // the real function rather than spelled `lower($2)` in SQL: several
+        // fixtures here use hyphenated subjects (`also-good`, `no-grant`), and
+        // `lexicalNorm` unifies separators where `lower()` does not — a fixture
+        // whose key disagrees with what the ingest path would have written is a
+        // corpus no production code could produce.
+        slotKey(opts.subject, identityAlias),
       ],
     );
     return rows[0]!.id;
@@ -222,8 +229,8 @@ describeIfPg("brain fact review gate (real Postgres)", () => {
         const ws = "ws-noprov";
         await expect(
           pool.query(
-            `INSERT INTO brain_facts (workspace_id, subject, predicate, object, provenance, visible_to)
-             VALUES ($1, 's', 'is', 'o', '{"a":1}'::jsonb, ARRAY['org'])`,
+            `INSERT INTO brain_facts (workspace_id, subject, predicate, object, subject_key, predicate_key, object_key, provenance, visible_to)
+             VALUES ($1, 's', 'is', 'o', 's', 'is', 'o', '{"a":1}'::jsonb, ARRAY['org'])`,
             [ws],
           ),
         ).rejects.toThrow(/source_episode_id/);
@@ -239,8 +246,8 @@ describeIfPg("brain fact review gate (real Postgres)", () => {
         await expect(
           pool.query(
             `INSERT INTO brain_facts
-               (workspace_id, subject, predicate, object, source_episode_id, provenance, visible_to)
-             VALUES ($1, 's', 'is', 'o', $2, '{}'::jsonb, ARRAY['org'])`,
+               (workspace_id, subject, predicate, object, subject_key, predicate_key, object_key, source_episode_id, provenance, visible_to)
+             VALUES ($1, 's', 'is', 'o', 's', 'is', 'o', $2, '{}'::jsonb, ARRAY['org'])`,
             [ws, ep],
           ),
         ).rejects.toThrow(/chk_brain_facts_provenance_nonempty/);
@@ -270,8 +277,8 @@ describeIfPg("brain fact review gate (real Postgres)", () => {
           await expect(
             pool.query(
               `INSERT INTO brain_facts
-                 (workspace_id, subject, predicate, object, source_episode_id, provenance, visible_to)
-               VALUES ($1, 's', 'is', 'o', $2, $3::jsonb, ARRAY['org'])`,
+                 (workspace_id, subject, predicate, object, subject_key, predicate_key, object_key, source_episode_id, provenance, visible_to)
+               VALUES ($1, 's', 'is', 'o', 's', 'is', 'o', $2, $3::jsonb, ARRAY['org'])`,
               [ws, ep, notAnObject],
             ),
           ).rejects.toThrow(/chk_brain_facts_provenance_nonempty/);
@@ -289,8 +296,8 @@ describeIfPg("brain fact review gate (real Postgres)", () => {
         await expect(
           pool.query(
             `INSERT INTO brain_facts
-               (workspace_id, subject, predicate, object, source_episode_id, provenance, visible_to)
-             VALUES ('ws-thief', 's', 'is', 'o', $1, '{"a":1}'::jsonb, ARRAY['org'])`,
+               (workspace_id, subject, predicate, object, subject_key, predicate_key, object_key, source_episode_id, provenance, visible_to)
+             VALUES ('ws-thief', 's', 'is', 'o', 's', 'is', 'o', $1, '{"a":1}'::jsonb, ARRAY['org'])`,
             [ep],
           ),
         ).rejects.toThrow(/fk_brain_facts_episode/);
@@ -309,8 +316,8 @@ describeIfPg("brain fact review gate (real Postgres)", () => {
         await expect(
           pool.query(
             `INSERT INTO brain_facts
-               (workspace_id, subject, predicate, object, source_episode_id, provenance, visible_to)
-             VALUES ($1, 's', 'is', 'o', $2, '{"a":1}'::jsonb, ARRAY[NULL, '']::text[])`,
+               (workspace_id, subject, predicate, object, subject_key, predicate_key, object_key, source_episode_id, provenance, visible_to)
+             VALUES ($1, 's', 'is', 'o', 's', 'is', 'o', $2, '{"a":1}'::jsonb, ARRAY[NULL, '']::text[])`,
             [ws, ep],
           ),
         ).rejects.toThrow(/chk_brain_facts_grant_nonempty/);
@@ -722,8 +729,8 @@ describeIfPg("brain fact review gate (real Postgres)", () => {
       const ep = await seedEpisode(ws, "archived");
       const { rows } = await pool.query<{ id: string }>(
         `INSERT INTO brain_facts
-           (workspace_id, subject, predicate, object, source_episode_id, provenance, status, visible_to)
-         VALUES ($1, 'retired', 'is', 'thing', $2, '{"a":1}'::jsonb, 'archived', ARRAY['org'])
+           (workspace_id, subject, predicate, object, subject_key, predicate_key, object_key, source_episode_id, provenance, status, visible_to)
+         VALUES ($1, 'retired', 'is', 'thing', 'retired', 'is', 'thing', $2, '{"a":1}'::jsonb, 'archived', ARRAY['org'])
          RETURNING id`,
         [ws, ep],
       );
@@ -1308,12 +1315,16 @@ describeIfPg("brain fact review gate (real Postgres)", () => {
       /** Defaults to org-wide; override for the ACL-withholding cases. */
       visibleTo?: readonly string[];
       /**
-       * Land the row UNKEYED — all three key columns NULL — which is what a
-       * region import produces today (`admin-migrate.ts`'s 18-column INSERT
-       * names none of them, #5035) and what every row written between migration
-       * 0187 and #5020 looked like before 0188's backfill repeat.
+       * Land the row as migration 0194 leaves a LEGACY DEGENERATE one (#5047):
+       * TOMBSTONED, with a per-row placeholder in every key column.
+       *
+       * This replaces the old `unkeyed` option, which landed all three keys
+       * NULL. That state modelled a region import's output and the 0187→#5020
+       * window, and it is now unrepresentable — the key columns are `NOT NULL`.
+       * What inherited its job is this: the population 0194 could not key, which
+       * is the only thing left in the corpus that carries no identity.
        */
-      unkeyed?: boolean;
+      tombstonedPlaceholder?: boolean;
       /**
        * The entity id a store resolved this object to, which is what makes the
        * object COMPARABLE and therefore what the publish gate now reads (#5030).
@@ -1378,11 +1389,12 @@ describeIfPg("brain fact review gate (real Postgres)", () => {
         opts.entityId === undefined
           ? (objectKey === null ? undefined : `ent:${objectKey}`)
           : (opts.entityId ?? undefined);
+      // 0194's per-row placeholder, minted once per seeded row so two of them
+      // can never share a slot (#5047).
+      const placeholderKey = `-unkeyable:${opts.workspaceId}:${opts.subject}:${opts.object}`;
       // Keyed like an ingested row (#5020): the collision join and the
       // corroboration lookup both match on `*_key`, so a seed that omitted them
-      // would be an UNKEYED row — a legitimate corpus state (0187's interval,
-      // and a region import until #5035) but not the one these tests are about,
-      // and one that collides with nothing. Derived through `slotKey`, the same
+      // would be rejected outright now that the columns are `NOT NULL`. Derived through `slotKey`, the same
       // function `INSERT_FACT_SQL` calls, rather than hand-written beside the
       // surface where the two could quietly disagree. (`INSERT_FACT_SQL` is a
       // string constant; the function is what `reconcile.ts` calls when binding
@@ -1391,9 +1403,9 @@ describeIfPg("brain fact review gate (real Postgres)", () => {
         `INSERT INTO brain_facts
            (workspace_id, subject, predicate, object, source_episode_id,
             provenance, status, visible_to,
-            subject_key, predicate_key, object_key, object_cmp)
+            subject_key, predicate_key, object_key, object_cmp, invalidated_at)
          VALUES ($1, $2, $3, $4, $5, $12::jsonb, $6, $10::text[],
-                 $7, $8, $9, $11)
+                 $7, $8, $9, $11, $13)
          RETURNING id`,
         [
           opts.workspaceId,
@@ -1402,28 +1414,37 @@ describeIfPg("brain fact review gate (real Postgres)", () => {
           opts.object,
           opts.episodeId,
           opts.status ?? "draft",
-          opts.unkeyed === true ? null : slotKey(opts.subject, identityAlias),
-          opts.unkeyed === true ? null : slotKey(predicate, identityAlias),
-          opts.unkeyed === true ? null : objectKey,
+          // 0194's shape for a row it could not key: a PER-ROW placeholder, in
+          // a namespace `lexicalNorm` can never emit (it collapses `-` away, so
+          // no computed key starts with one or contains one). Unique per call,
+          // because a shared value is the one-slot-for-every-placeholder hazard
+          // migration 0187's header rejects.
+          opts.tombstonedPlaceholder === true ? placeholderKey : slotKey(opts.subject, identityAlias),
+          opts.tombstonedPlaceholder === true ? placeholderKey : slotKey(predicate, identityAlias),
+          opts.tombstonedPlaceholder === true ? placeholderKey : objectKey,
           opts.visibleTo ?? ["org"],
           // Through `comparableValue`, the same function `reconcile.ts` calls,
           // rather than a hand-written `entity:…` literal beside the surface —
           // a fixture that spelled the tag itself would agree with a producer
           // that stopped emitting one.
-          opts.unkeyed === true
+          opts.tombstonedPlaceholder === true
             ? null
             : comparableValue({ surface: opts.object, entityId: resolvedEntity }),
           JSON.stringify(opts.provenance ?? { actor: "test" }),
+          // The tombstone, which is the load-bearing half of 0194's treatment:
+          // all three slot consumers require `invalidated_at IS NULL`, so the
+          // row is outside every join by this column rather than by its key.
+          opts.tombstonedPlaceholder === true ? new Date() : null,
         ],
       );
       // Declared AFTER the row lands, and through the shipped authoring door
       // rather than a raw INSERT, so a change to what the write path admits
       // reaches this suite instead of being routed around.
       //
-      // Unconditional, including for an `unkeyed` row: its NULL `predicate_key`
-      // matches no entry, which is the fail-closed behaviour those tests are
-      // about, and skipping the declaration would make them pass for the wrong
-      // reason.
+      // Unconditional, including for a tombstoned placeholder row: its
+      // placeholder `predicate_key` matches no entry, which is the fail-closed
+      // behaviour those tests are about, and skipping the declaration would make
+      // them pass for the wrong reason.
       const declared = await declarePredicateCardinality(pool, opts.workspaceId, {
         predicateKey: slotKey(predicate, identityAlias),
         cardinality: opts.cardinality ?? "single",
@@ -1982,31 +2003,35 @@ describeIfPg("brain fact review gate (real Postgres)", () => {
     );
 
     it(
-      "an UNKEYED row supersedes nothing and is superseded by nothing — fail-closed, in both directions",
+      "a TOMBSTONED PLACEHOLDER row supersedes nothing and is superseded by nothing (#5047)",
       async () => {
-        // The state that dominates the corpus this deploys onto, and the one
-        // the new seeder would otherwise have erased from the suite: a row a
-        // region import landed (#5035), or one written in the 0187→#5020 window
-        // that 0188's backfill has not reached. `=` and `<>` are both UNKNOWN
-        // against NULL, so such a row drops out of `supersessionCollisionJoin`
-        // entirely — from BOTH sides, which is the half the docstring claims
-        // and nothing pinned.
+        // The successor to this suite's UNKEYED test, which modelled a row with
+        // all three keys NULL — a region import's output, or one written in the
+        // 0187→#5020 window. That state is unrepresentable since migration 0194
+        // made the key columns `NOT NULL`, and what inherited its place is the
+        // population 0194 could not key: legacy rows whose SURFACE normalizes
+        // away, tombstoned and given a per-row placeholder.
         //
-        // Fail-closed is the right direction (no collision ⇒ no `valid_to`
-        // stamp ⇒ nothing irreversible), but it is not free: the pair below
-        // WOULD collide if either row were keyed, and the reviewer is shown an
-        // affirmative "this publish supersedes nothing".
-        const ws = "ws-5020-unkeyed";
-        const ep = await seedEpisode(ws, "unkeyed");
+        // The invariant is the same one, reached by a different mechanism, and
+        // that difference is the whole reason this test has to exist. The old
+        // row dropped out of `supersessionCollisionJoin` because `=` and `<>`
+        // are both UNKNOWN against NULL. A placeholder key is NOT null, so the
+        // `<>` arm is now genuinely TRUE against a real key — the exclusion is
+        // carried entirely by `invalidated_at IS NULL`. If 0194 had written the
+        // placeholder WITHOUT the tombstone, these rows would start colliding
+        // with real beliefs in their slot, and publishing would stamp `valid_to`
+        // across the pair.
+        const ws = "ws-5047-placeholder";
+        const ep = await seedEpisode(ws, "placeholder");
 
-        // (a) unkeyed PUBLISHED incumbent, keyed draft that would replace it.
-        const oldUnkeyed = await seedFact({
+        // (a) placeholder PUBLISHED incumbent, keyed draft that would replace it.
+        const oldPlaceholder = await seedFact({
           workspaceId: ws,
           episodeId: ep,
           subject: "alice",
           object: "bob",
           status: "published",
-          unkeyed: true,
+          tombstonedPlaceholder: true,
         });
         const draftKeyed = await seedFact({
           workspaceId: ws,
@@ -2014,7 +2039,7 @@ describeIfPg("brain fact review gate (real Postgres)", () => {
           subject: "alice",
           object: "carol",
         });
-        // (b) the converse — keyed incumbent, unkeyed draft.
+        // (b) the converse — keyed incumbent, placeholder draft.
         const oldKeyed = await seedFact({
           workspaceId: ws,
           episodeId: ep,
@@ -2022,12 +2047,12 @@ describeIfPg("brain fact review gate (real Postgres)", () => {
           object: "erin",
           status: "published",
         });
-        const draftUnkeyed = await seedFact({
+        const draftPlaceholder = await seedFact({
           workspaceId: ws,
           episodeId: ep,
           subject: "dana",
           object: "frank",
-          unkeyed: true,
+          tombstonedPlaceholder: true,
         });
 
         const reader = await resolvePrincipalContext(pool, {
@@ -2036,16 +2061,14 @@ describeIfPg("brain fact review gate (real Postgres)", () => {
           userId: "u1",
           resolvedRole: { role: "owner", orgId: ws },
         });
-        // Disclosed as "nothing to supersede", because the check could not run.
         expect(await loadSupersessionPreview(pool, reader)).toMatchObject({
           total: 0,
           pairs: [],
         });
 
         const report = await publish(ws);
-        expect(report.promoted).toBe(2);
         expect(report.superseded).toEqual([]);
-        for (const id of [oldUnkeyed, draftKeyed, oldKeyed, draftUnkeyed]) {
+        for (const id of [oldPlaceholder, draftKeyed, oldKeyed, draftPlaceholder]) {
           expect((await factState(id)).valid_to).toBeNull();
         }
         expect(await supersedesEdges(ws)).toEqual([]);
@@ -2054,21 +2077,23 @@ describeIfPg("brain fact review gate (real Postgres)", () => {
     );
 
     it(
-      "a PARTIALLY keyed row does not collide either — the `<>` arm's own NULL case",
+      "a placeholder in ONE slot position does not collide either — the same-slot case (#5047)",
       async () => {
-        // The unkeyed case above is decided by the `=` arms before the object
-        // arm is ever consulted, so it leaves `object_key <> object_key`
-        // unfalsified. This is that arm: both rows are in the SAME slot
-        // (`alice` / `manager`), and only the OBJECT key is NULL.
+        // The sharper half, and the successor to the PARTIALLY-keyed test. There
+        // the two rows shared a slot and only `object_key` was NULL, which
+        // falsified the object `<>` arm's NULL handling: under `IS DISTINCT
+        // FROM` the placeholder would have stamped `valid_to` on the real belief
+        // beside it.
         //
-        // Reachable straight off the ingest path — `reconcile.ts` stores
-        // `alice manager -` with two real keys and `object_key IS NULL`, and
-        // nothing in `classifyFactForPromotion` refuses it, so it is a
-        // promotable draft. Under a NULL-safe arm (`IS DISTINCT FROM`)
-        // publishing it would stamp `valid_to` on the real published belief in
-        // its slot — the irreversible write, spent on a placeholder.
-        const ws = "ws-5020-partial";
-        const ep = await seedEpisode(ws, "partial");
+        // The input has moved but the hazard has not. `reconcile.ts` will not
+        // store `alice manager -` any more (#5047 refuses it), so the row that
+        // reaches this shape is 0194's: same subject and predicate keys as the
+        // incumbent, a placeholder at the object, and a tombstone. It sits
+        // squarely in the incumbent's slot, its object key is non-null and
+        // unequal, and the ONLY thing keeping it out of the collision join is
+        // `invalidated_at IS NULL`.
+        const ws = "ws-5047-slot";
+        const ep = await seedEpisode(ws, "slot");
         const published = await seedFact({
           workspaceId: ws,
           episodeId: ep,
@@ -2076,14 +2101,20 @@ describeIfPg("brain fact review gate (real Postgres)", () => {
           object: "bob",
           status: "published",
         });
-        // `slotKey("-")` is null, so the seeder keys subject and predicate and
-        // leaves `object_key` NULL — exactly what the ingest path produces.
-        const placeholder = await seedFact({
-          workspaceId: ws,
-          episodeId: ep,
-          subject: "alice",
-          object: "-",
-        });
+        // Same slot as the incumbent — subject and predicate keyed normally —
+        // and a placeholder at the OBJECT only, which is what a legacy row
+        // reading `alice manager -` becomes under 0194.
+        const { rows } = await pool.query<{ id: string }>(
+          `INSERT INTO brain_facts
+             (workspace_id, subject, predicate, object, source_episode_id,
+              provenance, status, visible_to,
+              subject_key, predicate_key, object_key, invalidated_at)
+           VALUES ($1, 'alice', 'manager', '-', $2, '{"actor":"test"}'::jsonb, 'draft',
+                   ARRAY['org'], 'alice', 'manager', '-unkeyable:slot-1', now())
+           RETURNING id`,
+          [ws, ep],
+        );
+        const placeholder = rows[0]!.id;
 
         const reader = await resolvePrincipalContext(pool, {
           workspaceId: ws,
@@ -2097,7 +2128,6 @@ describeIfPg("brain fact review gate (real Postgres)", () => {
         });
 
         const report = await publish(ws);
-        expect(report.promoted).toBe(1);
         expect(report.superseded).toEqual([]);
         expect((await factState(published)).valid_to).toBeNull();
         expect((await factState(placeholder)).valid_to).toBeNull();

--- a/packages/api/src/lib/brain/__tests__/promotion-pg.test.ts
+++ b/packages/api/src/lib/brain/__tests__/promotion-pg.test.ts
@@ -2067,6 +2067,15 @@ describeIfPg("brain fact review gate (real Postgres)", () => {
         });
 
         const report = await publish(ws);
+        // The positive control, and its VALUE is the interesting part. Two
+        // drafts were seeded; exactly ONE is promoted, because
+        // `draftPlaceholder` is tombstoned and `DRAFT_FACTS_SQL` requires
+        // `invalidated_at IS NULL`. So this single number pins both halves: the
+        // keyed draft really did traverse the collision join (against a
+        // tombstoned incumbent, matching nothing — arm (a)), and the placeholder
+        // draft never entered the candidate set at all (arm (b)). Without it,
+        // `superseded: []` is equally satisfied by publish selecting nothing.
+        expect(report.promoted).toBe(1);
         expect(report.superseded).toEqual([]);
         for (const id of [oldPlaceholder, draftKeyed, oldKeyed, draftPlaceholder]) {
           expect((await factState(id)).valid_to).toBeNull();
@@ -2128,6 +2137,17 @@ describeIfPg("brain fact review gate (real Postgres)", () => {
         });
 
         const report = await publish(ws);
+        // ⚠️ THE POSITIVE CONTROL, and without it this test passes vacuously.
+        // A tombstoned draft is excluded by `DRAFT_FACTS_SQL`'s
+        // `invalidated_at IS NULL`, so publish never selects it and `superseded:
+        // []` plus two null `valid_to`s are satisfied by a run that did NOTHING.
+        // Measured: `promoted` is 0 here, and asserting it is what distinguishes
+        // "the placeholder was excluded" from "publish is broken".
+        expect(report.promoted).toBe(0);
+        expect(
+          (await factState(placeholder)).status,
+          "the tombstoned placeholder was promoted — it must stay a draft, out of the publish candidate set entirely",
+        ).toBe("draft");
         expect(report.superseded).toEqual([]);
         expect((await factState(published)).valid_to).toBeNull();
         expect((await factState(placeholder)).valid_to).toBeNull();

--- a/packages/api/src/lib/brain/__tests__/reconcile.test.ts
+++ b/packages/api/src/lib/brain/__tests__/reconcile.test.ts
@@ -1934,7 +1934,11 @@ describe("the draft candidate", () => {
       {
         kind: "blocked",
         reason: RECONCILE_BLOCK_REASONS.malformedClaim,
-        unkeyed: ["object"],
+        // The CAUSE travels with the position, and asserting it is what stops
+        // the 400-vs-500 split in `correction.ts` from regressing: gating on the
+        // position alone blames the caller for a vocabulary defect they cannot
+        // fix, which is exactly what the first cut of that gate did.
+        unkeyed: [{ role: "object", cause: "degenerate-surface" }],
       },
     ]);
     // NOTHING was stored, and no statement ran for it. Asserted on the fact set
@@ -1971,7 +1975,7 @@ describe("the draft candidate", () => {
     expect(report.outcomes[0]).toEqual({
       kind: "blocked",
       reason: RECONCILE_BLOCK_REASONS.malformedClaim,
-      unkeyed: ["object"],
+      unkeyed: [{ role: "object", cause: "degenerate-surface" }],
     });
     expect(report.outcomes[1]).toMatchObject({ kind: "created" });
     // The surviving claim is stored with its surface VERBATIM and its key

--- a/packages/api/src/lib/brain/__tests__/reconcile.test.ts
+++ b/packages/api/src/lib/brain/__tests__/reconcile.test.ts
@@ -57,7 +57,7 @@ import {
   type ReconcileExecutor,
   type ReconcileTransactionRunner,
 } from "@atlas/api/lib/brain/reconcile";
-import { identityVocabulary } from "@atlas/api/lib/brain/identity";
+import { identityVocabulary, inheritSlotFromFactRow } from "@atlas/api/lib/brain/identity";
 import { COMPARABLE_TAGS } from "@atlas/api/lib/brain/object-cmp";
 import { WAREHOUSE_SOURCE } from "@atlas/api/lib/brain/sources";
 import { isWarehouseDerived } from "@atlas/api/lib/brain/correction";
@@ -1908,26 +1908,83 @@ describe("the draft candidate", () => {
     expect(store.facts[0]).toMatchObject({ subject: "deploy window", object: "Thursdays" });
   });
 
-  test("a surface that norms away is bound as NULL, never as an empty string", async () => {
-    // `-` survives the MALFORMED_CLAIM guard (`trim()` strips whitespace, not
-    // `_` or `-`), so it is a storable claim whose key is permanently NULL.
-    // A bound `""` would file every placeholder in the corpus under ONE slot:
-    // two unrelated claims corroborate as one and, at `single` cardinality,
-    // publishing either stamps `valid_to` on the other. `null` joins nothing,
-    // which is the honest answer for a surface that asserts nothing.
+  test("a surface that norms away is REFUSED, not stored with a null key (#5047)", async () => {
+    // `-` clears the blank-trim guard — `String#trim` strips whitespace but not
+    // `_` or `-` — and used to be a storable claim whose key was permanently
+    // NULL. Since #5047 the second half of `MALFORMED_CLAIM` refuses it
+    // post-resolution, which is migration 0187's third prerequisite and what
+    // let 0194 flip the three key columns to `NOT NULL`.
     //
-    // The bind is what this file can see. That two such rows then fail to
-    // corroborate each other is `extract-reconcile-pg.test.ts`'s.
+    // The claim is refused rather than sentinel-keyed, which is the arm the
+    // corpus depends on: a shared `""` key would file every placeholder under
+    // ONE slot, so two unrelated claims corroborate as one and, at `single`
+    // cardinality, publishing either stamps `valid_to` on the other.
     const store = new FakeBrainStore();
-    await run(store, { candidates: [candidate({ object: "-" })] });
+    const report = await run(store, { candidates: [candidate({ object: "-" })] });
 
-    expect(store.keyBindsFor("insertFact")[0]?.object).toBeNull();
-    expect(store.keyBindsFor("corroboration")[0]?.object).toBeNull();
-    // …and the degenerate surface is still stored VERBATIM, so the reviewer can
-    // see what the producer emitted and repair it. Asserted on `object` — the
-    // column that actually carries one; the subject is the shared default and
-    // would prove nothing.
-    expect(store.facts[0]?.object).toBe("-");
+    expect(report.blocked.MALFORMED_CLAIM).toBe(1);
+    expect(report.outcomes).toEqual([
+      { kind: "blocked", reason: RECONCILE_BLOCK_REASONS.malformedClaim },
+    ]);
+    // NOTHING was stored, and no statement ran for it. Asserted on the fact set
+    // AND on the statement log, because a guard placed one line too late would
+    // still have issued the corroboration lookup for a claim it then refused —
+    // work spent on a row that will never exist, and the reason the guard sits
+    // in the preparation loop.
+    expect(store.facts).toHaveLength(0);
+    expect(store.keyBindsFor("insertFact")).toHaveLength(0);
+    expect(report.created).toBe(0);
+  });
+
+  test("the refusal is on the KEY, not on the surface — `_` and `-` are separators, not text", async () => {
+    // The falsifier for the guard testing the wrong thing. A guard written as
+    // `object.trim() === ""` (the blank-trim guard, one loop up) passes `___`
+    // through, and one written on the raw surface would refuse `a-b` — a
+    // perfectly good claim whose key is `a b`.
+    //
+    // Both directions in one test on purpose: a guard that refuses everything
+    // containing a separator makes the first assertion pass, and only the
+    // second one fails.
+    const store = new FakeBrainStore();
+    const report = await run(store, {
+      candidates: [candidate({ object: "___" }), candidate({ object: "ships-on Thursdays" })],
+    });
+
+    expect(report.blocked.MALFORMED_CLAIM).toBe(1);
+    expect(report.outcomes[0]).toEqual({
+      kind: "blocked",
+      reason: RECONCILE_BLOCK_REASONS.malformedClaim,
+    });
+    expect(report.outcomes[1]).toMatchObject({ kind: "created" });
+    // The surviving claim is stored with its surface VERBATIM and its key
+    // normalized — the retention half, which is what makes an alias reversible.
+    expect(store.facts).toHaveLength(1);
+    expect(store.facts[0]?.object).toBe("ships-on Thursdays");
+    expect(store.keyBindsFor("insertFact")[0]?.object).toBe("ships on thursdays");
+  });
+
+  test("an INHERITED null slot is refused too, at the position that was copied", async () => {
+    // The row-copy channel (#5037) reaches `keys` without going through any
+    // surface in this candidate, so a guard written over the trimmed surfaces
+    // would miss it entirely. Post-0194 an inherited null cannot come off the
+    // database — the columns are `NOT NULL` — so this pins the guard against a
+    // hand-built slot and against the deploy overlap, where an N-1 instance's
+    // rows are still unkeyed.
+    const store = new FakeBrainStore();
+    const report = await run(store, {
+      candidates: [
+        candidate({
+          inheritedSlot: inheritSlotFromFactRow({
+            id: "00000000-0000-4000-8000-000000000042",
+            subject_key: null,
+            predicate_key: null,
+          }),
+        }),
+      ],
+    });
+
+    expect(report.blocked.MALFORMED_CLAIM).toBe(1);
+    expect(store.facts).toHaveLength(0);
   });
 
   test("no candidates is a no-op, not an empty transaction", async () => {

--- a/packages/api/src/lib/brain/__tests__/reconcile.test.ts
+++ b/packages/api/src/lib/brain/__tests__/reconcile.test.ts
@@ -1923,8 +1923,19 @@ describe("the draft candidate", () => {
     const report = await run(store, { candidates: [candidate({ object: "-" })] });
 
     expect(report.blocked.MALFORMED_CLAIM).toBe(1);
+    // The POSITIONS travel with the block, and asserting them here is what keeps
+    // `correction.ts`'s supersede arm honest: it reads `unkeyed` to decide
+    // whether the human's replacement text is at fault (a 400) or the target's
+    // inherited slot is (a 500). Dropped anywhere between the preparation loop
+    // and this outcome, that arm silently blames the wrong party — which is
+    // exactly what happened when the detail was rebuilt field-by-field in the
+    // transaction loop instead of spread.
     expect(report.outcomes).toEqual([
-      { kind: "blocked", reason: RECONCILE_BLOCK_REASONS.malformedClaim },
+      {
+        kind: "blocked",
+        reason: RECONCILE_BLOCK_REASONS.malformedClaim,
+        unkeyed: ["object"],
+      },
     ]);
     // NOTHING was stored, and no statement ran for it. Asserted on the fact set
     // AND on the statement log, because a guard placed one line too late would
@@ -1933,6 +1944,12 @@ describe("the draft candidate", () => {
     // in the preparation loop.
     expect(store.facts).toHaveLength(0);
     expect(store.keyBindsFor("insertFact")).toHaveLength(0);
+    // The statement the comment above is actually about: `writeCandidate` issues
+    // `CORROBORATION_LOOKUP_SQL` before the insert, so a guard placed one line
+    // too late shows up HERE and nowhere else — the insert assertion alone
+    // cannot tell "refused in the preparation loop" from "refused in the
+    // transaction after a lookup was already spent on it".
+    expect(store.keyBindsFor("corroboration")).toHaveLength(0);
     expect(report.created).toBe(0);
   });
 
@@ -1954,6 +1971,7 @@ describe("the draft candidate", () => {
     expect(report.outcomes[0]).toEqual({
       kind: "blocked",
       reason: RECONCILE_BLOCK_REASONS.malformedClaim,
+      unkeyed: ["object"],
     });
     expect(report.outcomes[1]).toMatchObject({ kind: "created" });
     // The surviving claim is stored with its surface VERBATIM and its key

--- a/packages/api/src/lib/brain/__tests__/search-pg.test.ts
+++ b/packages/api/src/lib/brain/__tests__/search-pg.test.ts
@@ -51,6 +51,7 @@ import { MANAGED_AUTH_MIGRATIONS } from "@atlas/api/lib/db/internal";
 import { searchBrainCore } from "@atlas/api/lib/brain/search";
 import type { BrainPrincipalContext } from "@atlas/api/lib/brain/acl";
 import type { BrainFactResult, BrainSearchResult } from "@useatlas/types";
+import { identityAlias, slotKey } from "@atlas/api/lib/brain/identity";
 
 const TEST_DB_URL = process.env.TEST_DATABASE_URL;
 const describeIfPg = TEST_DB_URL ? describe : describe.skip;
@@ -148,8 +149,9 @@ describeIfPg("searchBrain against the live schema", () => {
     const { rows } = await pool.query<{ id: string }>(
       `INSERT INTO brain_facts
          (workspace_id, subject, predicate, object, source_episode_id, provenance,
-          status, visible_to, invalidated_at, valid_from, valid_to)
-       VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7, $8::text[], $9, $10, $11)
+          status, visible_to, invalidated_at, valid_from, valid_to,
+          subject_key, predicate_key, object_key)
+       VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7, $8::text[], $9, $10, $11, $12, $13, $14)
        RETURNING id`,
       [
         WS,
@@ -163,6 +165,13 @@ describeIfPg("searchBrain against the live schema", () => {
         opts.invalidated ? new Date() : null,
         opts.validFrom ?? null,
         opts.validTo ?? null,
+        // The slot keys, `NOT NULL` since migration 0194 (#5047). Computed with
+        // the same function the ingest path uses — this suite's surfaces include
+        // `owned_by`, which `lexicalNorm` unifies to `owned by` and a hand-
+        // written literal would get wrong.
+        slotKey(opts.subject, identityAlias),
+        slotKey(opts.predicate ?? "owned_by", identityAlias),
+        slotKey(opts.object ?? "platform team", identityAlias),
       ],
     );
     return rows[0]!.id;

--- a/packages/api/src/lib/brain/__tests__/vocabulary-rekey-pg.test.ts
+++ b/packages/api/src/lib/brain/__tests__/vocabulary-rekey-pg.test.ts
@@ -34,9 +34,17 @@
  *
  * ## Mutation table
  *
- * Twenty-five mutations, all twenty-five caught. Regenerated in ONE pass against
- * the final tree rather than edited row by row — #5022's review found numbers
- * carried forward under a header claiming they had been re-measured, twice. The
+ * Twenty-six mutations, all twenty-six caught. Rows 1-25 were regenerated in ONE
+ * pass against the tree that shipped them, rather than edited row by row —
+ * #5022's review found numbers carried forward under a header claiming they had
+ * been re-measured, twice.
+ *
+ * ⚠️ ROW 26 IS THE EXCEPTION AND IS SAID OUT LOUD, because a header whose whole
+ * point is that carried-forward numbers are worthless cannot quietly carry one.
+ * It was added by hand for #5047 and measured INDIVIDUALLY — drop the
+ * `IS NOT NULL` arm, watch the two named tests fail with a `23502` — not by a
+ * table-wide regeneration. Its "first test to die" cell is that measurement.
+ * The
  * harness applies each mutation, runs all three suites, records the first
  * failing test, and reverts; the "first test to die" column is that recorded
  * name, not an author's guess about which test ought to have caught it.

--- a/packages/api/src/lib/brain/__tests__/vocabulary-rekey-pg.test.ts
+++ b/packages/api/src/lib/brain/__tests__/vocabulary-rekey-pg.test.ts
@@ -80,7 +80,8 @@
  * | 22 | decide's lock_timeout RESET deleted (bound leaks past 5024) | decide locks first |
  * | 23 | `lexicalNormSql`'s `translate()` -> `lower()` | `lexicalNormSql` agrees with `lexicalNorm` on every corpus row |
  * | 24 | `chr(11)` dropped from the separator class | `lexicalNormSql` agrees with `lexicalNorm` on every corpus row |
- * | 25 | `identityKeySql`'s `NULLIF(..., '')` dropped | a re-keyed POSITION whose surface norms away reaches NULL, never the empty string |
+ * | 25 | `identityKeySql`'s `NULLIF(..., '')` dropped | SKIPS a row whose surface norms away, leaving 0194's placeholder untouched |
+ * | 26 | the `IS NOT NULL` arm on the recomputed key dropped (#5047) | SKIPS a row whose surface norms away, leaving 0194's placeholder untouched |
  *
  * ## Three rounds, and what each one caught that the previous missed
  *
@@ -581,29 +582,52 @@ describeIfPg("the drift re-key and the identity-mutation lock (#5024)", () => {
     ).toBe("ships on");
   });
 
-  it("a re-keyed POSITION whose surface norms away reaches NULL, never the empty string", async () => {
-    // `identityKeySql`'s `NULLIF(…, '')`. A stored `''` is the ONE key value that
-    // joins every other degenerate row, so two unrelated placeholder claims would
-    // occupy one slot and publishing either would stamp `valid_to` on the other.
+  it("SKIPS a row whose surface norms away, leaving 0194's placeholder untouched", async () => {
+    // Two guards in one fixture, both of which the constraint made load-bearing.
     //
-    // The approval is at the OBJECT position, and that is the point rather than
-    // an arbitrary choice: an earlier cut approved at `predicate` and asserted on
-    // `object_key`, so the object statement never ran and the NULL it checked was
-    // the one `identityKey` wrote at ingest — a no-op with respect to the re-key.
-    // The degenerate surface has to be at the position being re-keyed.
-    const id = await land(WS, { subject: "widget", predicate: "ships on", object: "-" });
-    expect((await readFact(id)).object_key).toBeNull();
-
-    // A real object alias in the same workspace, so the object statement has
-    // something to do and cannot pass by moving nothing.
+    // `identityKeySql`'s `NULLIF(…, '')` — a stored `''` is the ONE key value
+    // that joins every other degenerate row, so two unrelated placeholder claims
+    // would occupy one slot and publishing either would stamp `valid_to` on the
+    // other. Dropping it makes this expression yield `''`, which now sails past
+    // the `IS NOT NULL` arm and is WRITTEN.
+    //
+    // …and that `IS NOT NULL` arm itself (#5047). The expression is still NULL
+    // for a surface that normalizes away, and `brain_facts`' key columns are
+    // `NOT NULL` since migration 0194 — so without the arm this statement raises
+    // `23502` and aborts a human-gated alias approval that has nothing to do
+    // with the row.
+    //
+    // The fixture is the population 0194 leaves behind, built the way 0194
+    // builds it, because `reconcileFacts` will not land such a claim any more:
+    // TOMBSTONED, with a per-row placeholder in the degenerate column. It is
+    // exactly the row this statement meets and must leave alone.
     const other = await land(WS, { subject: "widget", predicate: "ships on", object: "friday" });
+    const episode = await seedEpisode(WS);
+    const { rows } = await pool.query<{ id: string }>(
+      `INSERT INTO brain_facts
+         (workspace_id, subject, predicate, object,
+          subject_key, predicate_key, object_key,
+          source_episode_id, provenance, visible_to, invalidated_at)
+       VALUES ($1, 'widget', 'ships on', '-', 'widget', 'ships on', '-unkeyable:seed', $2,
+               '{"actor":"u1"}'::jsonb, ARRAY['org'], now())
+       RETURNING id::text AS id`,
+      [WS, episode.id],
+    );
+    const degenerate = rows[0]!.id;
+
+    // The approval is at the OBJECT position, and that is the point rather than
+    // an arbitrary choice: an earlier cut approved at `predicate` and asserted
+    // on `object_key`, so the object statement never ran. The degenerate surface
+    // has to be at the position being re-keyed. The real alias beside it is what
+    // stops the test passing by moving nothing.
     await approve("friday", "fri", "object");
 
     expect((await readFact(other)).object_key).toBe("fri");
     expect(
-      (await readFact(id)).object_key,
-      "a surface that norms away was keyed to the empty string by the re-key",
-    ).toBeNull();
+      (await readFact(degenerate)).object_key,
+      "the re-key rewrote a row whose surface normalizes away — either to the empty string (which " +
+        "joins every other degenerate row) or to a recomputed key it has no basis for",
+    ).toBe("-unkeyable:seed");
   });
 
   it("re-norms the vocabulary's answer rather than trusting it", async () => {
@@ -650,9 +674,10 @@ describeIfPg("the drift re-key and the identity-mutation lock (#5024)", () => {
     ).toBe("priced at");
     expect(
       (await readFact(degenerate)).predicate_key,
-      "a vocabulary answer that norms AWAY must reach NULL, not the empty string — a stored `''` is " +
-        "the one key value that joins every other degenerate row",
-    ).toBeNull();
+      "a vocabulary answer that norms AWAY must leave the stored key alone. It must NOT become the " +
+        "empty string — the one key value that joins every other degenerate row — and it can no " +
+        "longer become NULL either, which since #5047 would be a `23502` aborting the approval",
+    ).toBe("ships on");
   });
 
   // ── 2. the undo, on removal ─────────────────────────────────────────────

--- a/packages/api/src/lib/brain/__tests__/wedge-loop-pg.test.ts
+++ b/packages/api/src/lib/brain/__tests__/wedge-loop-pg.test.ts
@@ -1250,8 +1250,11 @@ describeIfPg("brain M1 wedge loop (real Postgres)", () => {
     const episode = await episodeBySourceId(publicSourceId(0));
 
     await pool.query(
-      `INSERT INTO brain_facts (workspace_id, subject, predicate, object, predicate_cardinality, visible_to, provenance, source_episode_id)
-       VALUES ($1, 'ungranted claim', 'is', 'unreachable', 'single', ARRAY['everyone'],
+      `INSERT INTO brain_facts (workspace_id, subject, predicate, object,
+                                subject_key, predicate_key, object_key,
+                                predicate_cardinality, visible_to, provenance, source_episode_id)
+       VALUES ($1, 'ungranted claim', 'is', 'unreachable',
+               'ungranted claim', 'is', 'unreachable', 'single', ARRAY['everyone'],
                '{"source":"slack","producer":"import"}'::jsonb, $2)`,
       [WORKSPACE, episode.id],
     );

--- a/packages/api/src/lib/brain/correction.ts
+++ b/packages/api/src/lib/brain/correction.ts
@@ -155,7 +155,6 @@ import {
   type BrainPrincipalContext,
 } from "@atlas/api/lib/brain/acl";
 import {
-  identityKey,
   inheritSlotFromFactRow,
   slotKey,
   type ClaimVocabulary,
@@ -168,6 +167,7 @@ import { proposeFromCorrectionEvents } from "@atlas/api/lib/brain/cardinality";
 import { BrainReaderUnresolvedError } from "@atlas/api/lib/brain/reader-context";
 import {
   INSERT_PROVENANCE_EDGE_SQL,
+  RECONCILE_BLOCK_REASONS,
   reconcileFacts,
   withBrainTransaction,
   type ReconcileExecutor,
@@ -280,6 +280,25 @@ export const CORRECTION_REFUSAL_REASONS = {
   replacementMissing: "REPLACEMENT_MISSING",
   /** The replacement restates the target's own object — nothing to supersede. */
   replacementIdentical: "REPLACEMENT_IDENTICAL",
+  /**
+   * The replacement has no IDENTITY — its object normalizes away (`-`, `___`,
+   * `  `), so the successor would occupy no slot (#5047).
+   *
+   * ⚠️ NOT a second spelling of the ingest guard, and the distinction is what
+   * keeps it legitimate. `reconcile.ts`'s `MALFORMED_CLAIM` is the one place
+   * that DECIDES this — the check is not repeated here and this module never
+   * calls `slotKey` to ask. What this member does is TRANSLATE that seam's
+   * verdict into the module's own error type, so a human who typed `-` gets a
+   * 400 naming what is wrong with their text instead of the 500 a raw throw
+   * produced. `applySupersede`'s block arm is the only site that raises it.
+   *
+   * Reachable only through `supersede`: the other three verbs supply no claim.
+   * Before #5047 the same input passed every gate and installed a successor
+   * nothing could ever corroborate, contradict, or supersede — the case
+   * {@link replacementIdentical}'s docstring records as deliberately uncovered
+   * there, on the argument that the ingest seam would close it.
+   */
+  replacementMalformed: "REPLACEMENT_MALFORMED",
   /** The replacement could not become a published fact (structural refusal). */
   replacementUnpublishable: "REPLACEMENT_UNPUBLISHABLE",
 } as const;
@@ -781,77 +800,27 @@ async function proposeUnderDeadline(
   }
 }
 
-/**
- * Report a `supersede` whose predicate has no canonical form — the one case the
- * proposer's call-site guard would otherwise swallow.
+/*
+ * (`logDegeneratePredicate` and `DegeneratePredicateCause` lived here until
+ * #5047 and are gone because the state they reported cannot occur.
  *
- * Separate from the proposer's own degenerate-key arm because the two know
- * different things: `proposeFromCorrectionEvents` knows a key is unusable but
- * not which verb sent it, while the post-commit site receives the same `null`
- * for "not a supersede".
+ * They existed for a `supersede` that committed while closing no canonical
+ * predicate slot — reachable in two ways, a predicate SURFACE that normalizes
+ * away and an unkeyed TARGET row, which #5037 taught them to tell apart. Both
+ * are now unrepresentable at a COMMITTED supersede: the replacement inherits the
+ * target's slot, and `reconcile.ts`'s `MALFORMED_CLAIM` guard refuses a
+ * candidate whose slot key is null — so the verb is REFUSED
+ * (`REPLACEMENT_MALFORMED`) and the transaction rolls back instead of reaching
+ * the post-commit reporter. The target row itself cannot carry a null key at
+ * all: `brain_facts`' three key columns are `NOT NULL` as of migration 0194, and
+ * the legacy rows that could are tombstoned, which puts them outside what
+ * `readTargetRow` will correct.
  *
- * Called POST-COMMIT, not from the dispatch. The first cut called it inside the
- * transaction, where `applySupersede` can still raise a
- * `CorrectionRefusedError` — so the line asserting "the correction is
- * committed" was emitted BEFORE the commit and was false on every rollback. The
- * dispatch is not the only place that knows the verb: `verb` is in scope
- * post-commit too, which is where this can say what it says and be true.
+ * So `supersededPredicate` is non-null on every committed `supersede`, and the
+ * only `null` left is the honest one the other three verbs send: *this verb is
+ * not evidence about cardinality*. Kept as a note rather than dead code with a
+ * comment explaining why nothing reaches it.)
  */
-/**
- * Why a `supersede` produced no canonical predicate key (#5037).
- *
- * Two states, deliberately not collapsed. Before the key was READ off the target
- * there was only one — a predicate surface that norms away — and the reporter's
- * message says exactly that. Reading the key added a second cause with an
- * entirely different meaning and remedy, and a shared message would state the
- * first one's diagnosis about the second one's event.
- */
-type DegeneratePredicateCause = "degenerate-surface" | "unkeyed-target";
-
-function logDegeneratePredicate(meta: {
-  readonly workspaceId: string;
-  readonly factId: string;
-  readonly requestId: string | undefined;
-  /**
-   * WHY there is no key (#5037). Two states reach here and they are not the same
-   * event, so they are not the same line — collapsing them is how the second one
-   * hid.
-   */
-  readonly cause: "degenerate-surface" | "unkeyed-target";
-}): void {
-  if (meta.cause === "unkeyed-target") {
-    // ⚠️ `warn`, not `debug`, and the severity is the point. This is not one odd
-    // claim — it says the TARGET row carries no identity while its predicate
-    // surface reads perfectly well, which is a corpus-level gap (a region import
-    // that landed unkeyed is the documented cause). Every correction against such
-    // a corpus silently stops feeding the ADR-0037 §3(d)2 cardinality proposer,
-    // so the subsystem goes quiet with no other signal — and `debug` is off in
-    // production, which would make "quiet" and "healthy" indistinguishable.
-    log.warn(
-      meta,
-      // ⚠️ NAMES BOTH CAUSES AND ASSERTS NEITHER. An earlier cut of this line
-      // claimed the row "was written before the keys existed or imported from
-      // another region unkeyed" and told the operator to re-key the workspace.
-      // Neither is established here: a stored NULL beside a keyable surface also
-      // arises when the VOCABULARY maps that norm to nothing, and on that cause
-      // the prescribed remedy provably cannot work — `REKEY_DRIFTED_FACTS_SQL`
-      // recomputes `identityKey(alias(norm))`, the same composition, and gets the
-      // same NULL. A remedy that cannot work is the false promise this module
-      // refuses by name at `malformedSourceKind`.
-      //
-      // Distinguishing the two would mean re-deriving the target's key here,
-      // which is the operation this whole slice removes. Naming both is the
-      // honest answer available, and it is what the sibling warn in
-      // `reconcile.ts` already does for the identical ambiguity.
-      "brain correction: superseded a claim whose TARGET ROW has no stored predicate key, so there is no canonical predicate to propose a cardinality against — the predicate surface itself normalizes fine. Either the row was never keyed (written before the keys existed, or imported from another region unkeyed), or this workspace's vocabulary maps that predicate to something that normalizes away. Check the vocabulary entry for this predicate first: if it is clean, a re-key restores cardinality proposals; if it is not, no re-key will. The correction is committed and nothing else is affected",
-    );
-    return;
-  }
-  log.debug(
-    meta,
-    "brain correction: superseded a claim whose predicate normalizes away, so there is no canonical predicate to propose a cardinality against — the correction is committed and nothing else is affected",
-  );
-}
 
 /**
  * Tag a verb's response with the canonical predicate it closed, or with nothing.
@@ -873,23 +842,19 @@ function logDegeneratePredicate(meta: {
  * worth doing when a fifth verb arrives, not before.
  */
 async function withSupersededPredicate(
-  supersededPredicate: string | null,
   /**
-   * WHY the key is absent, when it is (#5037). A `null` key has two causes now
-   * that it is READ rather than derived — a predicate surface that norms away,
-   * and a target row that carries no stored key — and the post-commit reporter
-   * cannot tell them apart from the key alone. Decided here, where the surface,
-   * the vocabulary and the stored key are all still in hand; irrelevant and
-   * ignored when the key is non-null.
+   * The canonical predicate the verb closed. NON-NULL on every path that
+   * commits (#5047) — the type stays `string | null` only because it shares a
+   * shape with {@link noSupersededPredicate}, whose `null` means something
+   * different and is the one a reader must not confuse it with.
    */
-  cause: DegeneratePredicateCause,
+  supersededPredicate: string | null,
   response: Promise<BrainFactCorrectionResponse>,
 ): Promise<{
   response: BrainFactCorrectionResponse;
   supersededPredicate: string | null;
-  supersededPredicateCause: DegeneratePredicateCause;
 }> {
-  return { response: await response, supersededPredicate, supersededPredicateCause: cause };
+  return { response: await response, supersededPredicate };
 }
 
 async function noSupersededPredicate(
@@ -897,15 +862,10 @@ async function noSupersededPredicate(
 ): Promise<{
   response: BrainFactCorrectionResponse;
   supersededPredicate: null;
-  supersededPredicateCause: DegeneratePredicateCause;
 }> {
-  // The three non-supersede verbs never reach the proposer at all, so the cause
-  // is never read; `degenerate-surface` is the inert value rather than a claim.
-  return {
-    response: await response,
-    supersededPredicate: null,
-    supersededPredicateCause: "degenerate-surface",
-  };
+  // `null` here is a caller SAYING this verb is not evidence about cardinality
+  // — the only meaning the value still carries since #5047 removed the other.
+  return { response: await response, supersededPredicate: null };
 }
 
 interface TargetRow {
@@ -1056,7 +1016,6 @@ export async function correctFact(
   let outcome: {
     readonly response: BrainFactCorrectionResponse;
     readonly supersededPredicate: string | null;
-    readonly supersededPredicateCause: DegeneratePredicateCause;
   } | null;
   try {
     outcome = await withTransaction(async (tx) => {
@@ -1175,13 +1134,20 @@ export async function correctFact(
         //
         // ONE case it deliberately does NOT cover: a degenerate replacement
         // against a REAL target (`-` superseding `bob`) is `null !== "bob"`, so
-        // it passes here and installs a successor with no identity — a row that
-        // can never corroborate, contradict, or be superseded. It needs no
-        // refusal of its own: the `MALFORMED_CLAIM` tightening that 0187's
-        // header item 3 requires for `SET NOT NULL` blocks exactly this
-        // candidate at the ingest seam, and the replacement below goes through
-        // that seam, so the block rolls this verb's stamp back with it. Adding
-        // a second refusal here would be a second spelling of that guard.
+        // it passes here. ✅ CLOSED BY #5047, and closed where this comment said
+        // it would be rather than by a second test added here: the
+        // `MALFORMED_CLAIM` guard — 0187's header item 3, and the last
+        // prerequisite of `SET NOT NULL` — now refuses a candidate whose
+        // `slotKey` is null at the INGEST seam, and `applySupersede`'s
+        // replacement goes through that seam, so the block rolls this verb's
+        // `valid_to` stamp back with it. What `applySupersede` adds is a
+        // TRANSLATION of that verdict into {@link replacementMalformed}, not a
+        // second decision: the check still happens once, at reconcile.
+        //
+        // So this guard is still not the place to test for a degenerate
+        // replacement, and adding one here would be the second spelling of that
+        // guard the earlier note warned about. `correction.test.ts` pins the
+        // rollback rather than assuming it.
         //
         // The keys are RE-DERIVED from the surfaces rather than read: the
         // target read cannot project a key (`keys-not-on-the-wire.test.ts`), so
@@ -1425,31 +1391,22 @@ export async function correctFact(
           // the proposal accretes evidence against a slot no correction ever
           // touched, and the slot that WAS corrected accretes none.
           //
-          // A NULL answer is legal and permanent (`identityKey`'s ⚠️) and is
-          // reported POST-COMMIT — see `logDegeneratePredicate`, which cannot
-          // truthfully say "the correction is committed" from in here. Under the
-          // read it is also reachable a second way — a stored NULL on an unkeyed
-          // legacy row — and both mean the same thing to the proposer: there is
-          // no slot to propose against.
-          // WHICH null this is, decided where both halves are readable (#5037).
-          // A stored key that is absent while the surface keys perfectly well is
-          // an unkeyed TARGET — a corpus-level gap — and not the degenerate
-          // surface the reporter's original message describes.
+          // ⚠️ NON-NULL on every path that reaches the proposer, since #5047.
+          // `applySupersede` below hands this same slot to `reconcileFacts`,
+          // whose `MALFORMED_CLAIM` guard refuses a candidate with a null slot
+          // key — so a null here does not travel out with a committed response,
+          // it REFUSES the verb and rolls the transaction back. The target row
+          // cannot carry one either: the key columns are `NOT NULL` as of
+          // migration 0194.
           //
-          // `identityKey`, NOT `slotKey`: the question is whether the SURFACE
-          // itself asserts anything, which is a lexical fact about the text and
-          // needs no vocabulary. Reaching for `slotKey(target.predicate, …)`
-          // here would be a re-derivation of the very key just read — the thing
-          // this slice removes, and the ratchet in `correction.test.ts` refuses
-          // it. That the honest spelling is also the permitted one is the
-          // ratchet working rather than a coincidence.
-          const supersededCause: DegeneratePredicateCause =
-            supersededKey === null && identityKey(target.predicate) !== null
-              ? "unkeyed-target"
-              : "degenerate-surface";
+          // That is why there is no longer a cause to decide here. Until #5047
+          // this site classified the null two ways — a predicate SURFACE that
+          // normalizes away versus an unkeyed TARGET row — for a post-commit
+          // reporter that could not tell them apart from the key alone. Both
+          // states are now unrepresentable at a committed supersede; see the
+          // note where that reporter used to live.
           return withSupersededPredicate(
             supersededKey,
-            supersededCause,
             applySupersede(tx, ctx.workspaceId, target, episodeId, at, base, {
               replacement,
               sourcePrincipal,
@@ -1492,7 +1449,7 @@ export async function correctFact(
     );
     return { kind: "not-found" };
   }
-  const { response: result, supersededPredicate, supersededPredicateCause } = outcome;
+  const { response: result, supersededPredicate } = outcome;
 
   log.info(
     {
@@ -1532,11 +1489,15 @@ export async function correctFact(
   // It PROPOSES. Nothing is superseded by this write, now or ever: the row
   // lands `pending`, and `cardinalitySingleSql` reads only `approved` ones.
   // Guarded, so the three verbs that are not evidence about cardinality do not
-  // pay a pool checkout for a call that returns immediately. The case the guard
-  // used to HIDE — a `supersede` whose predicate surface norms away, which
-  // arrives as the same `null` — is reported in the other arm below: `verb` is
-  // in scope here, so this site CAN tell the two apart, and only a post-commit
-  // line can truthfully say the correction is committed.
+  // pay a pool checkout for a call that returns immediately.
+  //
+  // The guard used to have a second job — a `supersede` that committed while
+  // closing no canonical slot arrived as the same `null`, and hiding it was how
+  // that case went unreported. Since #5047 the two are no longer confusable
+  // because only one of them exists: a null slot key refuses the verb at the
+  // ingest seam, so a committed `supersede` always carries a canonical
+  // predicate, and `null` here means *this verb is not evidence about
+  // cardinality* and nothing else.
   //
   // BOUNDED, because `internalQuery` bypasses the circuit breaker and the
   // internal pool sets no `statement_timeout`: a DEGRADED internal DB —
@@ -1547,21 +1508,7 @@ export async function correctFact(
   // human decision. Same deadline and same knob as the audit write above, so
   // the two post-commit writes cannot drift into having different answers to
   // one hazard.
-  if (supersededPredicate === null) {
-    // A `supersede` that closed no canonical slot — the one case the proposer
-    // guard's `null` arm would otherwise swallow. Reported here rather than at
-    // the dispatch because only a post-commit line can say the correction is
-    // committed, and only `verb` distinguishes this from the three verbs that
-    // legitimately send `null`.
-    if (verb === "supersede") {
-      logDegeneratePredicate({
-        workspaceId: ctx.workspaceId,
-        factId: result.factId,
-        requestId,
-        cause: supersededPredicateCause,
-      });
-    }
-  } else {
+  if (supersededPredicate !== null) {
     await proposeUnderDeadline(
       () => withTransaction((tx) => proposeFromCorrectionEvents(tx, ctx.workspaceId, supersededPredicate)),
       resolveAuditDeadline(deps.auditWriteTimeoutMs),
@@ -2092,10 +2039,42 @@ async function applySupersede(
     { withTransaction: (fn) => fn(tx), now: () => at },
   );
   const outcome = report.outcomes[0];
+  if (outcome?.kind === "blocked" && outcome.reason === RECONCILE_BLOCK_REASONS.malformedClaim) {
+    // ⚠️ THE ONE BLOCK REASON THAT IS REACHABLE FROM A WELL-FORMED REQUEST, and
+    // it became reachable with #5047. Every other arm of the seam's gate is
+    // about the EPISODE — provenance, grant, principal — and this function just
+    // wrote that episode from the target's own row, so those really are
+    // unreachable by construction. `MALFORMED_CLAIM` is about the CANDIDATE, and
+    // the candidate carries a human's free text: a replacement object of `-` or
+    // `___` normalizes away, keys to null at the object position, and the ingest
+    // guard refuses it.
+    //
+    // Raised as a REFUSAL rather than left to the throw below, because the two
+    // produce the same rollback and opposite diagnoses. The throw is a 500 whose
+    // message says the seam's contract changed underneath this caller — an
+    // incident report, aimed at us, about a request that is simply wrong. A
+    // refusal is a 400 that tells the human their replacement asserts nothing,
+    // which is the true and actionable version of the same event.
+    //
+    // The SAFETY property either way is the one #5047's acceptance criteria
+    // name: `SUPERSEDE_STAMP_EXPLICIT_SQL` already ran at the top of this
+    // function, and leaving here — by throw or by refusal — rolls that stamp
+    // back with the whole transaction, so the target's `valid_to` is not closed
+    // in favour of a successor that was never stored. `correction.test.ts` pins
+    // it rather than assuming it.
+    throw new CorrectionRefusedError(
+      CORRECTION_REFUSAL_REASONS.replacementMalformed,
+      `The replacement "${inputs.replacement.object}" has no identity — it normalizes away to nothing, so ` +
+        "it would occupy no slot and could never be corroborated, contradicted, or superseded in turn. " +
+        "Supersede with the value the claim should now hold; to record that it holds no value, use " +
+        "`retract` instead.",
+    );
+  }
   if (!outcome || outcome.kind === "blocked") {
     // Unreachable by construction — the episode was just written with the
     // target's own usable grant and an explicit principal — so a block here
-    // means the seam's contract changed underneath this caller.
+    // means the seam's contract changed underneath this caller. The one
+    // candidate-level reason that IS reachable is handled above.
     throw new Error(
       `brain correction: reconcile blocked the replacement claim (${outcome ? outcome.reason : "no outcome"}) — ` +
         "the correction episode should satisfy every episode-level gate by construction",

--- a/packages/api/src/lib/brain/correction.ts
+++ b/packages/api/src/lib/brain/correction.ts
@@ -1422,6 +1422,7 @@ export async function correctFact(
               correctionSourceId,
               grantTokens: target.grantTokens,
               vocabulary,
+              requestId,
             }),
           );
         case "re-authority":
@@ -1935,6 +1936,15 @@ interface SupersedeInputs {
   readonly grantTokens: readonly string[];
   /** The workspace's vocabulary, so the replacement keys the way ingest does. */
   readonly vocabulary: ClaimVocabulary;
+  /**
+   * The caller's request id, threaded for ONE consumer: the `log.error` beside
+   * the 500 this function can throw (#5047).
+   *
+   * CLAUDE.md's rule is that every 500 carries one for log correlation, and the
+   * line is otherwise the single place in this module that drops it — a user
+   * reporting "I got a 500, requestId abc" could not be matched to it.
+   */
+  readonly requestId: string | undefined;
 }
 
 async function applySupersede(
@@ -2069,20 +2079,27 @@ async function applySupersede(
   if (
     outcome?.kind === "blocked" &&
     outcome.reason === RECONCILE_BLOCK_REASONS.malformedClaim &&
-    // ⚠️ ONLY when the OBJECT is what has no identity. `MALFORMED_CLAIM` covers
-    // four states — a blank surface, a degenerate one, a vocabulary target that
-    // normalizes away, and an INHERITED null slot — and only the object position
-    // is the human's own text here: the subject and predicate are copied off the
-    // target row (#5037).
+    // ⚠️ THE OBJECT POSITION **WITH A DEGENERATE-SURFACE CAUSE**, and the second
+    // half of that is not a refinement — it is the whole correctness of this arm.
     //
-    // Telling a human their replacement "has no identity" when the target's slot
-    // or this workspace's vocabulary is the defect sends them to fix input that
-    // is already correct, and no retry they can make will succeed. That is the
-    // same wrong-subsystem blame `inheritedUnkeyed` exists to prevent in the
-    // reconcile log, arriving on the user-facing side; the other positions fall
-    // through to the throw below, which is a 500 with a requestId — the right
-    // shape for a defect that is ours or the corpus's.
-    (outcome.unkeyed ?? []).includes("object")
+    // The first cut gated on the POSITION alone, reasoning that the object is
+    // the caller's own text where the subject and predicate are copied off the
+    // target row (#5037). That reasoning is incomplete, and a review caught it
+    // reproducing the very defect it fixes one layer over: `slotKey` is
+    // `identityKey(alias(identityKey(surface)))`, so an object key is ALSO null
+    // when this workspace's object-position vocabulary maps a real norm to
+    // something that normalizes away. A human superseding with perfectly good
+    // text, in a workspace with one bad alias entry, was told their replacement
+    // "normalizes away to nothing" — fix-your-correct-input, on a request no
+    // retry could ever satisfy.
+    //
+    // So the discriminator is the CAUSE, which `reconcile.ts` already computes
+    // at the one place all three inputs are readable. Only `degenerate-surface`
+    // is the supplier's fault; `vocabulary-target` and `inherited` are the
+    // corpus's or the configuration's and fall through to the 500 below.
+    (outcome.unkeyed ?? []).some(
+      (slot) => slot.role === "object" && slot.cause === "degenerate-surface",
+    )
   ) {
     // ⚠️ THE ONE BLOCK REASON THAT IS REACHABLE FROM A WELL-FORMED REQUEST, and
     // it became reachable with #5047. Every other arm of the seam's gate is
@@ -2130,6 +2147,14 @@ async function applySupersede(
       {
         workspaceId,
         factId: target.id,
+        // The two correlation handles this line is useless without. `requestId`
+        // is CLAUDE.md's rule for every 500 — the caller is handed one and every
+        // other log line in this module carries it. `episodeId` is what the
+        // message below tells the operator to join on: the reconcile warn logs
+        // the episode and NOT the fact, so without it the two lines share only
+        // `workspaceId`.
+        requestId: inputs.requestId,
+        episodeId,
         reason: outcome?.kind === "blocked" ? outcome.reason : "no outcome",
         unkeyed: outcome?.kind === "blocked" ? (outcome.unkeyed ?? []) : [],
       },

--- a/packages/api/src/lib/brain/correction.ts
+++ b/packages/api/src/lib/brain/correction.ts
@@ -509,9 +509,17 @@ export const CORRECTION_EPISODE_INSERT_SQL = `INSERT INTO brain_episodes
  * The tombstone — the only tombstone DECISION path, now that the review
  * surface's retract routes through this module (#4915 unification of #4772's
  * negative verb). The one other statement writing the column is the region
- * import's INSERT (`admin-migrate.ts`), which restores an existing
- * `invalidated_at` verbatim — a restore, not a new arbitration, the same
- * distinction the promotion guard's allowlist draws. It never names `status`:
+ * import's INSERT (`admin-migrate.ts`).
+ *
+ * ⚠️ That statement used to only RESTORE an existing `invalidated_at` verbatim —
+ * a restore, not a new arbitration, the same distinction the promotion guard's
+ * allowlist draws. Since #5047 it can also MINT one: a fact whose surface
+ * normalizes away lands tombstoned with a placeholder key, matching what
+ * migration 0194 does to the identical state. Still not an arbitration — it
+ * retires a claim that asserts nothing at some position, which no reader could
+ * ever have acted on — but the plain "restore, never mint" reading is no longer
+ * true, and this module is not the only tombstone WRITER even though it remains
+ * the only tombstone DECISION about a claim that says something. It never names `status`:
  * withdrawal is a tombstone, not a demotion — and the tombstone hides the row
  * from every fact-serving read, `asOf` included (#4916); only the tension
  * surfaces still list it, labelled, as a withdrawn rival. The ACL already ran
@@ -1508,7 +1516,26 @@ export async function correctFact(
   // human decision. Same deadline and same knob as the audit write above, so
   // the two post-commit writes cannot drift into having different answers to
   // one hazard.
-  if (supersededPredicate !== null) {
+  if (supersededPredicate === null && verb === "supersede") {
+    // ⚠️ UNREACHABLE, and logged anyway — which is the point (#5047).
+    //
+    // A committed `supersede` cannot carry a null canonical predicate: the
+    // replacement inherits the target's slot, `reconcile.ts` refuses a null slot
+    // key, and the target row's keys are `NOT NULL` since migration 0194. That
+    // argument rests on three facts in three modules, and if any of them moves,
+    // the failure is a supersede that silently stops feeding the ADR-0037 §3(d)2
+    // cardinality proposer — the subsystem goes quiet with nothing to grep.
+    //
+    // Deleting `logDegeneratePredicate` removed the arm that used to say so. It
+    // was right to delete: it reported two CAUSES that no longer exist and its
+    // message described states that cannot occur. What was wrong was leaving no
+    // arm at all, so the one state that must never be silent became the only one
+    // that was. This says exactly what is known and claims nothing about why.
+    log.error(
+      { workspaceId: ctx.workspaceId, factId: result.factId, requestId },
+      "brain correction: a supersede COMMITTED with no canonical predicate key — this should be impossible since #5047 (the ingest guard refuses a null slot key and `brain_facts` key columns are NOT NULL), so one of those invariants has moved. The correction itself is committed and correct; what is lost is the cardinality proposal for this predicate, silently, for every correction on this slot until it is fixed",
+    );
+  } else if (supersededPredicate !== null) {
     await proposeUnderDeadline(
       () => withTransaction((tx) => proposeFromCorrectionEvents(tx, ctx.workspaceId, supersededPredicate)),
       resolveAuditDeadline(deps.auditWriteTimeoutMs),
@@ -2039,7 +2066,24 @@ async function applySupersede(
     { withTransaction: (fn) => fn(tx), now: () => at },
   );
   const outcome = report.outcomes[0];
-  if (outcome?.kind === "blocked" && outcome.reason === RECONCILE_BLOCK_REASONS.malformedClaim) {
+  if (
+    outcome?.kind === "blocked" &&
+    outcome.reason === RECONCILE_BLOCK_REASONS.malformedClaim &&
+    // ⚠️ ONLY when the OBJECT is what has no identity. `MALFORMED_CLAIM` covers
+    // four states — a blank surface, a degenerate one, a vocabulary target that
+    // normalizes away, and an INHERITED null slot — and only the object position
+    // is the human's own text here: the subject and predicate are copied off the
+    // target row (#5037).
+    //
+    // Telling a human their replacement "has no identity" when the target's slot
+    // or this workspace's vocabulary is the defect sends them to fix input that
+    // is already correct, and no retry they can make will succeed. That is the
+    // same wrong-subsystem blame `inheritedUnkeyed` exists to prevent in the
+    // reconcile log, arriving on the user-facing side; the other positions fall
+    // through to the throw below, which is a 500 with a requestId — the right
+    // shape for a defect that is ours or the corpus's.
+    (outcome.unkeyed ?? []).includes("object")
+  ) {
     // ⚠️ THE ONE BLOCK REASON THAT IS REACHABLE FROM A WELL-FORMED REQUEST, and
     // it became reachable with #5047. Every other arm of the seam's gate is
     // about the EPISODE — provenance, grant, principal — and this function just
@@ -2071,10 +2115,26 @@ async function applySupersede(
     );
   }
   if (!outcome || outcome.kind === "blocked") {
-    // Unreachable by construction — the episode was just written with the
-    // target's own usable grant and an explicit principal — so a block here
-    // means the seam's contract changed underneath this caller. The one
-    // candidate-level reason that IS reachable is handled above.
+    // Every EPISODE-level reason is unreachable by construction — the episode was
+    // just written with the target's own usable grant and an explicit principal —
+    // so those mean the seam's contract changed underneath this caller.
+    //
+    // `MALFORMED_CLAIM` at a NON-object position also lands here, and it is a
+    // different animal: it means the target's inherited slot or this workspace's
+    // vocabulary produced no identity, which is a corpus or configuration defect
+    // rather than a request defect. A 500 with a `requestId` is the honest shape
+    // — the caller can do nothing about it and must not be told to retype their
+    // replacement. Logged with the positions so the operator does not have to
+    // reconstruct which slot failed from the message.
+    log.error(
+      {
+        workspaceId,
+        factId: target.id,
+        reason: outcome?.kind === "blocked" ? outcome.reason : "no outcome",
+        unkeyed: outcome?.kind === "blocked" ? (outcome.unkeyed ?? []) : [],
+      },
+      "brain correction: reconcile blocked the replacement claim at a position the caller does not control — the correction rolled back whole, including the supersede stamp. A MALFORMED_CLAIM here names the TARGET's inherited slot or this workspace's vocabulary, not the replacement text; see the reconcile warn for the same episode, whose `cause` field says which",
+    );
     throw new Error(
       `brain correction: reconcile blocked the replacement claim (${outcome ? outcome.reason : "no outcome"}) — ` +
         "the correction episode should satisfy every episode-level gate by construction",

--- a/packages/api/src/lib/brain/correction.ts
+++ b/packages/api/src/lib/brain/correction.ts
@@ -281,8 +281,11 @@ export const CORRECTION_REFUSAL_REASONS = {
   /** The replacement restates the target's own object — nothing to supersede. */
   replacementIdentical: "REPLACEMENT_IDENTICAL",
   /**
-   * The replacement has no IDENTITY — its object normalizes away (`-`, `___`,
-   * `  `), so the successor would occupy no slot (#5047).
+   * The replacement has no IDENTITY — its object normalizes away (`-`, `___`),
+   * so the successor would occupy no slot (#5047). NOT a whitespace-only
+   * object: `normalizeReplacement` trims that to `""` and it is refused as
+   * {@link replacementMissing} at the pure-validation gate, long before
+   * reconcile.
    *
    * ⚠️ NOT a second spelling of the ingest guard, and the distinction is what
    * keeps it legitimate. `reconcile.ts`'s `MALFORMED_CLAIM` is the one place
@@ -295,8 +298,9 @@ export const CORRECTION_REFUSAL_REASONS = {
    * Reachable only through `supersede`: the other three verbs supply no claim.
    * Before #5047 the same input passed every gate and installed a successor
    * nothing could ever corroborate, contradict, or supersede — the case
-   * {@link replacementIdentical}'s docstring records as deliberately uncovered
-   * there, on the argument that the ingest seam would close it.
+   * the identical-guard's own comment (in `correctFact`'s supersede arm)
+   * records as deliberately uncovered, on the argument that the ingest seam
+   * would close it — which is what #5047 did.
    */
   replacementMalformed: "REPLACEMENT_MALFORMED",
   /** The replacement could not become a published fact (structural refusal). */

--- a/packages/api/src/lib/brain/identity.ts
+++ b/packages/api/src/lib/brain/identity.ts
@@ -157,14 +157,16 @@ export function lexicalNorm(surface: string): string {
  * reached from the one input class the lexical layer cannot distinguish. `null`
  * joins nothing, which is the honest answer for a surface that asserts nothing.
  *
- * ⚠️ It does OVERLOAD the column, though, and the overload has a consequence
- * worth carrying forward: a NULL key now means either "no writer has keyed this
- * row yet" (transient) or "this surface norms away" (permanent, and legal). So
- * `SET NOT NULL` cannot land on the keys until `reconcile.ts`'s
- * `MALFORMED_CLAIM` guard also refuses a candidate whose `identityKey` is null
- * — otherwise the constraint turns a claim that is storable today into a
- * transaction-killing not-null violation. Migration 0187's header records this
- * as the third prerequisite; no issue owns it yet.
+ * ⚠️ NULL used to OVERLOAD the column — "no writer has keyed this row yet"
+ * (transient) and "this surface norms away" (permanent, and legal) — and
+ * `SET NOT NULL` could not land while the second was a storable state. #5047
+ * closed it at the ingest guard: `reconcile.ts`'s `MALFORMED_CLAIM` now refuses
+ * a candidate whose `slotKey` is null, and migration 0194 flipped all three
+ * columns to `NOT NULL`.
+ *
+ * So this function's `null` is a REFUSAL signal now, never a stored value. 0194's
+ * header carries the argument, including what became of the legacy rows that
+ * held the second meaning.
  *
  * Migration 0187 mirrors this with `NULLIF(…, '')`; the two are pinned against
  * each other row by row in `identity-pg.test.ts`.

--- a/packages/api/src/lib/brain/identity.ts
+++ b/packages/api/src/lib/brain/identity.ts
@@ -181,6 +181,47 @@ export function identityKey(surface: string): string | null {
 }
 
 /**
+ * The namespace for a key that stands in for NO IDENTITY (#5047, migration 0194).
+ *
+ * `brain_facts`' three key columns are `NOT NULL`, and two writers meet rows that
+ * have no key to write: migration 0194, sweeping the legacy population whose
+ * SURFACES normalize away, and the region importer, landing a fact whose surface
+ * does the same. Both write `` `${UNKEYABLE_KEY_PREFIX}${factId}` `` and TOMBSTONE
+ * the row.
+ *
+ * ## Why a per-row value, and not the sentinel 0187 rejects
+ *
+ * Migration 0187's header rejects a sentinel key as *"the one-slot-for-every-
+ * placeholder hazard"* — a SHARED value under which every degenerate row joins
+ * every other one, so two unrelated placeholder claims occupy one slot and
+ * publishing either stamps `valid_to` on the other. Interpolating the row's own
+ * id removes exactly that: the value equals itself and nothing else.
+ *
+ * ## Why it can never collide with a real key
+ *
+ * {@link lexicalNorm} collapses every run of `[ \t\n\v\f\r_-]` to a single space
+ * and then trims, so its output can neither START with `-` nor CONTAIN one. Every
+ * key in the corpus is that function's output — including a key carried verbatim
+ * from another region (#5035), which is the SOURCE region's `lexicalNorm` output.
+ * So no computed key can equal a placeholder, at any position, in any region.
+ *
+ * ⚠️ That is a property of `lexicalNorm`, not a convention, and it is what the
+ * whole scheme rests on — so it is pinned by a falsifier in `identity.test.ts`
+ * rather than argued here. **A change to {@link SEPARATOR_RUN} that stops
+ * treating `-` as a separator silently makes placeholders forgeable**, and the
+ * test is what says so.
+ *
+ * ## The migration cannot import this
+ *
+ * A `.sql` migration is frozen the moment it ships, so 0194 spells the same
+ * prefix as a literal. That duplication is deliberate and bounded — 0194 is
+ * history and will never move — but it is why this constant exists at all rather
+ * than the string being inlined at its one TypeScript call site: the importer and
+ * the migration have to agree, and a named constant is what a reader greps.
+ */
+export const UNKEYABLE_KEY_PREFIX = "-unkeyable:";
+
+/**
  * The OUTER layer of `key = alias(lexicalNorm(surface))` — the curated
  * workspace vocabulary at ONE claim slot, as a seam.
  *

--- a/packages/api/src/lib/brain/reconcile.ts
+++ b/packages/api/src/lib/brain/reconcile.ts
@@ -238,7 +238,12 @@ import { isUsableGrant } from "@atlas/api/lib/brain/ingest/grant";
 // ONE place `alias(lexicalNorm(surface))` is assembled, and a second assembly
 // site is how the write side and a future re-key start disagreeing about what a
 // claim's slot IS.
-import { slotKey, type ClaimVocabulary, type InheritedSlot } from "@atlas/api/lib/brain/identity";
+import {
+  identityKey,
+  slotKey,
+  type ClaimVocabulary,
+  type InheritedSlot,
+} from "@atlas/api/lib/brain/identity";
 // The comparable value, on the same terms: `comparableValue` is the ONE place a
 // surface becomes a typed canonical form, and `comparableSameSql` the ONE place
 // *provably same* is spelled — the two statements below negate each other and
@@ -635,7 +640,16 @@ export type ReconcileOutcome =
       /** False when this episode had already been recorded as evidence. */
       readonly evidenceAdded: boolean;
     }
-  | { readonly kind: "blocked"; readonly reason: ReconcileBlockReason };
+  | {
+      readonly kind: "blocked";
+      readonly reason: ReconcileBlockReason;
+      /**
+       * For `MALFORMED_CLAIM` only: which slots had no identity (#5047). See
+       * {@link BlockedEntry.unkeyed} — this is the same detail, on the wire the
+       * caller actually reads.
+       */
+      readonly unkeyed?: readonly SlotRole[];
+    };
 
 export interface ReconcileReport {
   /**
@@ -1232,14 +1246,51 @@ export async function reconcileFacts(
     // this guard was the fix. The signal it carried is preserved verbatim
     // below — including #5037's `inheritedUnkeyed` discriminator — because
     // blocking makes this line the only one such a claim ever produces.
-    const unkeyed = SLOT_ROLES.filter((role) => keys[role] === null);
-    if (unkeyed.length > 0) {
+    // Named for the ROLE and not `subjectKey`/`predicateKey`/`objectKey`:
+    // `keys-not-on-the-wire.test.ts` bans those three identifiers outright in any
+    // file that speaks about `brain_facts`, because it cannot tell a local from a
+    // fact-shaped type growing a key field — which is the leak it exists to
+    // catch. `SlotKeys` takes role names for the same reason.
+    const { subject: subjectSlot, predicate: predicateSlot, object: objectSlot } = keys;
+    if (subjectSlot === null || predicateSlot === null || objectSlot === null) {
+      const unkeyed = SLOT_ROLES.filter((role) => keys[role] === null);
+      const surfaces = { subject, predicate, object } as const;
+      // WHICH subsystem to fix, per position — decided here, where the surface,
+      // the vocabulary and the inherited slot are all still in hand.
+      //
+      // ⚠️ An earlier cut of this line said the first two causes "cannot be
+      // distinguished once the vocabulary is real". THAT WAS FALSE, and it is
+      // the kind of false that sends an operator to the wrong subsystem: a null
+      // `identityKey` is a fact about the TEXT alone, so a surface that norms
+      // away and a vocabulary entry that maps a real norm to nothing are one
+      // call apart. `correction.ts` made exactly this distinction for exactly
+      // this reason until #5047 made its version unreachable; the distinction
+      // is not unreachable here.
+      const cause = Object.fromEntries(
+        unkeyed.map((role) => [
+          role,
+          candidate.inheritedSlot !== undefined && role !== "object"
+            ? "inherited"
+            : identityKey(surfaces[role]) === null
+              ? "degenerate-surface"
+              : "vocabulary-target",
+        ]),
+      );
       log.warn(
         {
           workspaceId: episode.workspaceId,
           episodeId: episode.id,
           producer,
           unkeyed,
+          cause,
+          // Logged ONLY where the cause is `degenerate-surface`, and that
+          // restriction is the point: by construction such a surface is
+          // separators and whitespace and carries no claim content. A
+          // `vocabulary-target` surface is real text and stays out, matching the
+          // blank-trim guard above, which logs booleans rather than surfaces.
+          degenerateSurfaces: unkeyed
+            .filter((role) => cause[role] === "degenerate-surface")
+            .map((role) => ({ role, surface: surfaces[role] })),
           // ⚠️ `inheritedFrom` alone is NOT the discriminator, and reporting it
           // as one blames the wrong party. It is set for EVERY
           // correction-produced candidate, but only the SUBJECT and PREDICATE
@@ -1265,12 +1316,36 @@ export async function reconcileFacts(
         // norms away (`-`, `___`), or an alias entry maps a real slot to
         // something that does. Naming only the producer would send an operator
         // after the wrong subsystem.
-        "brain reconcile: blocked a candidate with no identity for one or more slots — such a claim could never corroborate, earn a tension edge, or be superseded at publish, and the slot keys are NOT NULL since #5047. Three causes: the producer emitted a surface that normalizes away (`-`, `___`, `  ` — fix the producer); a vocabulary entry maps that slot to something that normalizes away; or — for the positions listed in `inheritedUnkeyed` — a row-copy path copied a null slot off the fact named by `inheritedFrom`, in which case those positions' surfaces are fine here and the TARGET row is what has no identity. Any position NOT in `inheritedUnkeyed` was derived from this claim's own text (the object always is), so the first two causes are the ones to follow for it",
+        "brain reconcile: blocked a candidate with no identity for one or more slots — such a claim could never corroborate, earn a tension edge, or be superseded at publish, and the slot keys are NOT NULL since #5047. `cause` names the subsystem to fix, per position: `degenerate-surface` = the producer emitted separators only, and the offending text is in `degenerateSurfaces` (fix the producer); `vocabulary-target` = this workspace's vocabulary maps that slot to something that normalizes away, so the surface is fine and the ENTRY is the defect (no re-key repairs it); `inherited` = a row-copy path copied a null slot off the fact named by `inheritedFrom`, so this claim's own text is fine at that position and the TARGET row is what has no identity. The object is never inherited — it is always derived from this claim's own text",
       );
       blocked.MALFORMED_CLAIM++;
-      prepared.push({ kind: "blocked", reason: RECONCILE_BLOCK_REASONS.malformedClaim });
+      // The POSITIONS travel with the block (#5047). `MALFORMED_CLAIM` covers a
+      // blank surface, a degenerate one, a vocabulary target that norms away and
+      // an inherited null, and one caller — `correction.ts`'s supersede — turns
+      // this verdict into a message for a human. Without the positions it can
+      // only guess which slot failed, and guessing "the object" blames the
+      // replacement text for a defect in the target's slot or in the vocabulary.
+      // The REASON stays single, which is what keeps one producer bug on one
+      // counter; this is the detail beside it.
+      prepared.push({
+        kind: "blocked",
+        reason: RECONCILE_BLOCK_REASONS.malformedClaim,
+        unkeyed,
+      });
       continue;
     }
+    // Narrowed ONCE, here, so everything downstream of the guard carries three
+    // non-null keys in its TYPE rather than by position in this loop. The
+    // database stopped admitting a null key at migration 0194; this is the same
+    // statement made where the compiler can check it, and it is what stops a
+    // future edit that adds a second `prepared.push` above the guard from
+    // reaching `INSERT_FACT_SQL` with a null — which is a `23502` that fails the
+    // whole reconcile transaction, retried every cycle until quarantine.
+    const resolvedKeys: ResolvedSlotKeys = {
+      subject: subjectSlot,
+      predicate: predicateSlot,
+      object: objectSlot,
+    };
 
     // The comparable value, materialized beside the keys and for the same
     // reason: computing it per statement is how the corroboration lookup and
@@ -1400,7 +1475,7 @@ export async function reconcileFacts(
       subject,
       predicate,
       object,
-      keys,
+      keys: resolvedKeys,
       comparableAtRest,
       comparableForLookups,
       resolutionFailed: resolution.kind === "failed",
@@ -1441,7 +1516,14 @@ export async function reconcileFacts(
     const results: ReconcileOutcome[] = [];
     for (const item of prepared) {
       if (item.kind === "blocked") {
-        results.push({ kind: "blocked", reason: item.reason });
+        // SPREAD, not rebuilt field by field. `BlockedEntry` and the blocked
+        // `ReconcileOutcome` are the same shape by design, and re-listing the
+        // fields here is how `unkeyed` was silently dropped on its first cut —
+        // the detail was attached in the preparation loop, discarded at this
+        // line, and `correction.ts` then saw `undefined` and 500'd on a request
+        // that should have been a 400. A spread cannot lose a field a future
+        // edit adds.
+        results.push({ ...item });
         continue;
       }
       results.push(
@@ -1538,6 +1620,30 @@ interface SlotKeys {
  */
 const SLOT_ROLES = ["subject", "predicate", "object"] as const satisfies readonly (keyof SlotKeys)[];
 
+/** One of the three claim slots, for the block detail and the log payload. */
+type SlotRole = (typeof SLOT_ROLES)[number];
+
+/**
+ * {@link SlotKeys} AFTER the `MALFORMED_CLAIM` guard — three keys, none null.
+ *
+ * The two types are deliberately both here rather than one nullable shape with a
+ * runtime check. `SlotKeys` is what the composition PRODUCES: `slotKey` returns
+ * null for a surface that norms away, and an {@link InheritedSlot} copies a
+ * stored row whose columns the type still describes as nullable. This is what
+ * survives the guard, and it is what every consumer downstream of the guard
+ * takes — so "no null key reaches `INSERT_FACT_SQL`" is a property of the types
+ * rather than of the order of statements in a 200-line loop body.
+ *
+ * That matters because `brain_facts`' three key columns are `NOT NULL` as of
+ * migration 0194: the failure mode a lost guard produces is no longer a row that
+ * joins nothing, it is a `23502` that rolls back the whole episode.
+ */
+interface ResolvedSlotKeys {
+  readonly subject: string;
+  readonly predicate: string;
+  readonly object: string;
+}
+
 /**
  * The five agreement values, in the order all three statements bind them: the
  * three slot keys, the OBJECT's comparable value (#5030), then the SUBJECT's
@@ -1609,16 +1715,13 @@ const SLOT_ROLES = ["subject", "predicate", "object"] as const satisfies readonl
  * the two positionally.
  */
 function agreementBinds(
-  keys: SlotKeys,
+  // {@link ResolvedSlotKeys}, so the three key binds are `string` and the
+  // compiler's view of `INSERT_FACT_SQL` matches the column's `NOT NULL` (#5047).
+  // Every caller is downstream of the `MALFORMED_CLAIM` guard.
+  keys: ResolvedSlotKeys,
   objectComparable: ComparableValue,
   subjectComparable: SubjectComparable,
-): readonly [
-  string | null,
-  string | null,
-  string | null,
-  ComparableValue,
-  SubjectComparable,
-] {
+): readonly [string, string, string, ComparableValue, SubjectComparable] {
   return [keys.subject, keys.predicate, keys.object, objectComparable, subjectComparable];
 }
 
@@ -1627,8 +1730,13 @@ interface PreparedCandidate {
   readonly subject: string;
   readonly predicate: string;
   readonly object: string;
-  /** The identity of the claim above — what the two lookups below match on. */
-  readonly keys: SlotKeys;
+  /**
+   * The identity of the claim above — what the two lookups below match on.
+   *
+   * {@link ResolvedSlotKeys} and not {@link SlotKeys}: this shape only exists
+   * past the `MALFORMED_CLAIM` guard, which refuses a null at any position.
+   */
+  readonly keys: ResolvedSlotKeys;
   /**
    * The object's typed canonical value, or `null` for *unknown* (#5030). Not
    * folded into {@link SlotKeys}: a key proves sameness and is a JOIN arm, this
@@ -1711,6 +1819,16 @@ interface TrimmedCandidate {
 interface BlockedEntry {
   readonly kind: "blocked";
   readonly reason: ReconcileBlockReason;
+  /**
+   * For `MALFORMED_CLAIM` only: WHICH slots had no identity (#5047).
+   *
+   * Optional because the other three reasons refuse the whole EPISODE and the
+   * blank-trim guard refuses before any key exists. Present, it is what lets a
+   * caller translating this verdict for a human name the right slot — see
+   * `correction.ts`'s supersede arm, which must not blame a replacement's text
+   * for an inherited or vocabulary-caused failure.
+   */
+  readonly unkeyed?: readonly SlotRole[];
 }
 
 type TrimmedEntry = TrimmedCandidate | BlockedEntry;

--- a/packages/api/src/lib/brain/reconcile.ts
+++ b/packages/api/src/lib/brain/reconcile.ts
@@ -161,34 +161,43 @@
  * — those pairs corroborate instead. For rows already in the corpus it is a
  * visible number moving the opposite way from the paragraph above.
  *
- * ## What the NULLABLE keys cost
+ * ## The keys are TOTAL as of #5047, and what that changed
  *
- * The acceptance criteria for #5020 also asked for `SET NOT NULL` on all three
- * columns. It is deliberately NOT in this cut: migration 0187's header
- * enumerates three prerequisites, and the third — tightening `MALFORMED_CLAIM`
- * to refuse a candidate whose key is null — is unowned, so the constraint would
- * turn a claim that is storable TODAY into a transaction-killing violation. Read
- * that header before flipping it.
+ * `SET NOT NULL` on all three columns landed in migration 0194, so a NULL key
+ * no longer means two things — it cannot occur. Migration 0187's header
+ * enumerated three prerequisites; #5020 supplied the first (`INSERT_FACT_SQL`
+ * keys new rows), #5035 the second (a v3 bundle carries keys verbatim), and
+ * #5047 the third: the `MALFORMED_CLAIM` guard in the preparation loop below now
+ * REFUSES a candidate whose `slotKey` is null, so an ingest that used to store an
+ * identity-less row is a block instead of a not-null violation that would fail
+ * the whole reconcile transaction.
  *
- *   - A surface that norms away (`-`, `___`) has a NULL key, so it corroborates
- *     nothing and earns no tension edge — where byte-exactness would have
- *     matched another `-`. `null = null` is unknown in SQL, and that is the
- *     point: the alternative, a stored `''`, is the one key value that joins
- *     every other degenerate row (migration 0187's header). Never write these
- *     comparisons NULL-safe. This one is PERMANENT and legal; no backfill
- *     repairs it, which is why it is logged at the prepare loop below.
- *   - A row written between 0187 deploying and this code deploying is unkeyed,
- *     and drops out of all three slot consumers. Migration 0188 repeats 0187's
- *     re-runnable backfill in THIS deploy to close exactly that window — the
- *     correctness need arrives here, not at the constraint flip, because here is
- *     where the consumers start depending on the column.
- *   - A region import used to land every row unkeyed, and 0188 could not help:
- *     it runs at boot, an import runs whenever an admin triggers one. **Closed
- *     by #5035** — a v3 bundle carries the keys verbatim and a v1/v2 bundle's
- *     facts are keyed once at import. What survives is narrower: a carried key
- *     can name a norm THIS region's vocabulary cannot produce, so it collides
- *     with nothing until a human curates. Under-match, and the recoverable
- *     direction ADR-0037 §8 chose deliberately.
+ *   - A surface that norms away (`-`, `___`) is no longer a storable claim. It
+ *     used to be — `String#trim` strips whitespace but not `_` or `-`, so the
+ *     blank-trim guard let it through — and the row it produced corroborated
+ *     nothing and earned no tension edge for as long as it existed. The refusal
+ *     is what the constraint needed and is the honest verdict besides: a claim
+ *     whose subject norms away asserts nothing.
+ *   - The comparisons stay NULL-hostile even though no key is NULL now. `= NULL`
+ *     being unknown is what keeps the abstain band honest at the two `_cmp`
+ *     columns, which ARE permanently nullable; and never write the KEY
+ *     comparisons NULL-safe, because the alternative a NULL-safe arm invites is
+ *     a stored `''`, the one key value that joins every other degenerate row
+ *     (migration 0187's header).
+ *   - Rows written between 0187 deploying and #5020's deploy were unkeyed and
+ *     dropped out of all three slot consumers. Migration 0188 repeated 0187's
+ *     re-runnable backfill to close that window; 0194 repeats it once more,
+ *     vocabulary-aware and per-column, immediately before the constraint, to
+ *     sweep the residue a rolling deploy's own overlap leaves behind.
+ *   - Legacy rows whose surfaces norm away could not be keyed by any backfill.
+ *     0194 tombstones them and gives the affected columns a per-row placeholder
+ *     (the row's own id, which `lexicalNorm` can never emit — it collapses `-`
+ *     and `_` away). The tombstone is what keeps them out of all three slot
+ *     consumers, which every one of them already required; the placeholder is
+ *     only there to satisfy the constraint. See 0194's header.
+ *   - A carried key can still name a norm THIS region's vocabulary cannot
+ *     produce, so it collides with nothing until a human curates. Under-match,
+ *     and the recoverable direction ADR-0037 §8 chose deliberately.
  *   - Dedupe is still only as good as the producer's determinism, just at a
  *     coarser grain. Two passes that phrase one claim differently ("is" vs "is
  *     on") remain two claims — that pair is a vocabulary ENTRY, not a
@@ -905,23 +914,24 @@ export const INSERT_PROVENANCE_EDGE_SQL = `INSERT INTO brain_edges
  * reached here), while `Ships On`/`ships_on` as PREDICATES now put their
  * differing objects in tension instead of sorting into two silent slots.
  *
- * A NULL key on either side matches nothing — `object_key <> NULL` is unknown,
- * so a degenerate or unkeyed row abstains OUT of tension. That is the weaker
- * direction (#5000's shape, and the reason the acceptance criteria want these
- * columns `NOT NULL` eventually), and it is still strictly better than the
- * over-match a NULL-safe comparison would buy: an edge here is advisory and a
- * missing one costs a reviewer a hint, where a wrong SLOT costs a `valid_to`
- * stamp at the publish gate.
+ * The arms stay NULL-hostile even though no key is NULL any more (#5047 /
+ * migration 0194): `object_key <> NULL` is unknown, so a row with no identity
+ * abstains OUT of tension rather than joining everything. Keeping that shape is
+ * what makes the statement correct standalone — it does not rely on the
+ * constraint to avoid the over-match a NULL-safe comparison would buy, and an
+ * N-1 instance during the deploy that adds the constraint runs this exact text
+ * against a corpus that still holds NULLs.
  *
- * The object arm's falsifying case is a DEGENERATE rival, and it is reachable
- * without a region import, a concurrent writer, or `correct_fact`. A live row
- * in this slot whose object is `-` has `object_key IS NULL`, so
- * {@link CORROBORATION_LOOKUP_SQL} does not return it either — `object_key = $4`
- * is unknown, and so is the cmp arm beside it, because a surface of only
- * separators parses to no comparable value — and it survives to this scan. There `object_key <> $4` is
- * unknown — not a rival — while `object <> $4` would be TRUE, wiring a
- * permanent advisory edge from a real claim to a placeholder that asserts
- * nothing. Pinned by `extract-reconcile-pg.test.ts`.
+ * The object arm's falsifying case USED to be a DEGENERATE rival — a live row in
+ * this slot whose object is `-`, which keyed to NULL and therefore matched
+ * neither {@link CORROBORATION_LOOKUP_SQL} nor this scan, where `object <> $4`
+ * would have been TRUE and would have wired a permanent advisory edge from a
+ * real claim to a placeholder that asserts nothing. Since #5047 such a row
+ * cannot be created: the `MALFORMED_CLAIM` guard refuses the candidate at
+ * ingest, and migration 0194 tombstoned the legacy population — so the
+ * `invalidated_at IS NULL` arm below excludes what survives of it. The rule the
+ * case established is unchanged and is why the comparison is still on the KEY
+ * and not on the surface. Pinned by `extract-reconcile-pg.test.ts`.
  *
  * ## Tension is *not provably same*, which is where the abstain band LANDS
  *
@@ -1188,6 +1198,80 @@ export async function reconcileFacts(
             predicate: slotKey(predicate, vocabulary.predicate),
             object: slotKey(object, vocabulary.object),
           };
+    // ── The identity half of MALFORMED_CLAIM (#5047) ──────────────────
+    //
+    // POST-RESOLUTION, and after `keys` rather than beside the blank-trim pass
+    // above, because the two guards test different things. `trim() === ""` asks
+    // whether the producer sent a surface at all; this asks whether the
+    // surface, put through the composition that decides the row's IDENTITY,
+    // names a slot. `String#trim` strips whitespace but not `_` or `-`, so `-`
+    // and `___` pass the first test and reach here with a null key — which is
+    // migration 0187's header item 3, the third prerequisite of `SET NOT NULL`
+    // and the reason the constraint could not land with #5020.
+    //
+    // It has to be HERE and not one loop earlier: `slotKey` composes the
+    // workspace's vocabulary over the norm, so a real surface whose alias entry
+    // maps it to something that norms away is also a null key — and an
+    // INHERITED slot (#5037) is copied off the target row rather than derived
+    // from any surface in this candidate at all. Neither is visible from the
+    // raw text.
+    //
+    // ⚠️ REFUSED, not sentinel-keyed. 0187's header rejects the other repair by
+    // name: a shared placeholder key is the one value that joins every other
+    // degenerate row, so two unrelated placeholder claims would occupy one slot
+    // and publishing either would stamp `valid_to` on the other.
+    //
+    // The BLOCK REASON is reused rather than widened. A claim whose subject
+    // norms away asserts nothing, which is the argument `MALFORMED_CLAIM`
+    // already makes for a blank one — the same verdict about the same kind of
+    // defect, reached one layer deeper. A second reason code would split one
+    // producer bug across two counters.
+    //
+    // This REPLACES the post-insert `log.warn` #5020 added at `writeCandidate`,
+    // which described a row that had already been stored and told the operator
+    // this guard was the fix. The signal it carried is preserved verbatim
+    // below — including #5037's `inheritedUnkeyed` discriminator — because
+    // blocking makes this line the only one such a claim ever produces.
+    const unkeyed = SLOT_ROLES.filter((role) => keys[role] === null);
+    if (unkeyed.length > 0) {
+      log.warn(
+        {
+          workspaceId: episode.workspaceId,
+          episodeId: episode.id,
+          producer,
+          unkeyed,
+          // ⚠️ `inheritedFrom` alone is NOT the discriminator, and reporting it
+          // as one blames the wrong party. It is set for EVERY
+          // correction-produced candidate, but only the SUBJECT and PREDICATE
+          // are inherited — the object is always derived from the replacement's
+          // own text. So a human superseding with `"-"` lands here with
+          // `unkeyed: ["object"]` and a non-null `inheritedFrom`, and a message
+          // keyed on that field alone would send the operator to inspect a
+          // target row that is perfectly healthy.
+          inheritedFrom: candidate.inheritedSlot?.fromFactId ?? null,
+          // The intersection: unkeyed positions that were actually COPIED. Empty
+          // means the target explains none of this, whatever `inheritedFrom`
+          // says. Post-#5047 the slot keys are `NOT NULL`, so an inherited null
+          // is unreachable through the database — it survives as a diagnostic
+          // for a hand-built slot and for the deploy overlap, not as an expected
+          // state.
+          inheritedUnkeyed:
+            candidate.inheritedSlot === undefined
+              ? []
+              : unkeyed.filter((role) => role !== "object"),
+        },
+        // THREE causes, and the message names all three because it cannot
+        // distinguish the first two once the vocabulary is real: the SURFACE
+        // norms away (`-`, `___`), or an alias entry maps a real slot to
+        // something that does. Naming only the producer would send an operator
+        // after the wrong subsystem.
+        "brain reconcile: blocked a candidate with no identity for one or more slots — such a claim could never corroborate, earn a tension edge, or be superseded at publish, and the slot keys are NOT NULL since #5047. Three causes: the producer emitted a surface that normalizes away (`-`, `___`, `  ` — fix the producer); a vocabulary entry maps that slot to something that normalizes away; or — for the positions listed in `inheritedUnkeyed` — a row-copy path copied a null slot off the fact named by `inheritedFrom`, in which case those positions' surfaces are fine here and the TARGET row is what has no identity. Any position NOT in `inheritedUnkeyed` was derived from this claim's own text (the object always is), so the first two causes are the ones to follow for it",
+      );
+      blocked.MALFORMED_CLAIM++;
+      prepared.push({ kind: "blocked", reason: RECONCILE_BLOCK_REASONS.malformedClaim });
+      continue;
+    }
+
     // The comparable value, materialized beside the keys and for the same
     // reason: computing it per statement is how the corroboration lookup and
     // the INSERT would start disagreeing about what a claim's value IS.
@@ -2147,70 +2231,13 @@ async function writeCandidate(
 
   await tx.query(INSERT_PROVENANCE_EDGE_SQL, [episode.workspaceId, factId, episode.id]);
 
-  // A null key is legal, permanent, and invisible everywhere else: the row is
-  // stored and then joins nothing — no corroboration, no tension edge, and no
-  // supersession at the publish gate — for as long as it exists. No backfill
-  // repairs it (0187/0188 write the same NULL), so this line is the only signal
-  // such a claim ever produces.
-  //
-  // Emitted HERE rather than in the preparation loop so it describes a row that
-  // exists: everything after this point can still roll the episode back, and on
-  // the extraction path a failing episode is retried every cycle until
-  // quarantine — which would have re-emitted the identical line for a fact that
-  // was never written. `factId` is what makes it actionable.
-  //
-  // Warned rather than blocked because blocking is a GUARD change: 0187's header
-  // item 3 wants `MALFORMED_CLAIM` widened from `trim() === ""` to this
-  // predicate, and that is the `SET NOT NULL` prerequisite nobody owns yet.
-  // Refusing here unilaterally would drop claims a reviewer can currently see
-  // and repair.
-  const unkeyed = SLOT_ROLES.filter((role) => item.keys[role] === null);
-  if (unkeyed.length > 0) {
-    log.warn(
-      {
-        workspaceId: episode.workspaceId,
-        episodeId: episode.id,
-        producer: ctx.producer,
-        factId,
-        unkeyed,
-        // The row-copy provenance (#5037), and the positions it actually
-        // explains.
-        //
-        // ⚠️ `inheritedFrom` alone is NOT the discriminator, and reporting it as
-        // one blames the wrong party. It is set for EVERY correction-produced
-        // candidate, but only the SUBJECT and PREDICATE are inherited — the
-        // object is always derived from the replacement's own text. So a human
-        // superseding with `"-"` lands here with `unkeyed: ["object"]` and a
-        // non-null `inheritedFrom`, and a message keyed on that field alone
-        // would send the operator to inspect a target row that is perfectly
-        // healthy while the replacement text is what asserts nothing.
-        inheritedFrom: item.candidate.inheritedSlot?.fromFactId ?? null,
-        // The intersection: unkeyed positions that were actually COPIED. Empty
-        // means the target explains none of this, whatever `inheritedFrom` says.
-        inheritedUnkeyed:
-          item.candidate.inheritedSlot === undefined
-            ? []
-            : unkeyed.filter((role) => role !== "object"),
-      },
-      // THREE causes now, and the message names all three because it cannot
-      // distinguish the first two once the vocabulary is real: the SURFACE norms
-      // away (`-`, `___`), or an alias entry maps a real slot to something that
-      // does. Naming only the producer would send an operator after the wrong
-      // subsystem the day #5016 lands.
-      //
-      // ⚠️ The third arrived with #5037's row-copy path and inverts the advice.
-      // An inherited slot is copied off the TARGET row, so a correction whose
-      // target is unkeyed lands here with surfaces that are perfectly fine —
-      // and an operator following the first two causes would inspect
-      // `Billing / is owned by`, find nothing wrong, and conclude the log is
-      // lying.
-      //
-      // The discriminator is `inheritedUnkeyed`, NOT `inheritedFrom`: only the
-      // copied positions are the target's to answer for, and the object is never
-      // one of them.
-      "brain reconcile: stored a claim with no identity for one or more slots — it will never corroborate, earn a tension edge, or be superseded at publish. Three causes: the producer emitted a surface that norms away (fix the producer, or tighten the MALFORMED_CLAIM guard — migration 0187's header, item 3); a vocabulary entry maps that slot to nothing; or — for the positions listed in `inheritedUnkeyed` — a row-copy path copied a null slot off the fact named by `inheritedFrom`, in which case those positions' surfaces are fine here and the TARGET row is what has no identity. Any position NOT in `inheritedUnkeyed` was derived from this claim's own text (the object always is), so the first two causes are the ones to follow for it",
-    );
-  }
+  // (The post-insert unkeyed-claim warn #5020 emitted here is gone. #5047 moved
+  // the signal to the PREPARATION loop and turned it into a refusal: the
+  // `MALFORMED_CLAIM` guard now blocks a candidate whose `slotKey` is null, so
+  // no such row reaches this function and a line describing a stored one would
+  // describe a row that cannot exist. `brain_facts`' three key columns are
+  // `NOT NULL` as of migration 0194, which is the same statement made by the
+  // database.)
 
   let tensionEdges = 0;
   // The producer's hint, and since #5027 the ONLY thing it still gates. It no

--- a/packages/api/src/lib/brain/reconcile.ts
+++ b/packages/api/src/lib/brain/reconcile.ts
@@ -611,12 +611,18 @@ export const RECONCILE_BLOCK_REASONS = {
   /** Neither the caller nor the episode yields a principal to attribute to. */
   sourcePrincipalUnresolved: "SOURCE_PRINCIPAL_UNRESOLVED",
   /**
-   * The candidate itself is not a claim — a blank subject, predicate, or
-   * object. Not in the issue's list because it is not a resolution failure: it
-   * is a malformed proposal, and unlike an unresolved entity there is nothing
-   * for a reviewer to repair (`brain_facts` would happily store `''`, and a
-   * three-column claim with an empty column says nothing). The producer's bug
-   * is logged with the reason.
+   * The candidate itself is not a claim. TWO halves under one reason: a BLANK
+   * subject, predicate or object (`trim() === ""`), and — since #5047 — a
+   * surface with no IDENTITY, i.e. any slot whose `slotKey` is null (a
+   * degenerate surface, a vocabulary target that normalizes away, or an
+   * inherited null).
+   *
+   * Both say the same thing: the proposal asserts nothing and there is nothing
+   * for a reviewer to repair, which is what separates it from an unresolved
+   * entity. The REASON stays single so one producer bug lands on one counter;
+   * the positions and their causes travel beside it on
+   * {@link BlockedEntry.unkeyed}, because one caller renders this for a human
+   * and must not blame the wrong party. The producer's bug is logged with it.
    */
   malformedClaim: "MALFORMED_CLAIM",
 } as const;
@@ -840,8 +846,11 @@ export const CORROBORATION_LOOKUP_SQL = `SELECT id
  * Derived at ingest exactly as the grant is — which is why
  * `check-brain-fact-promotion.sh` gates the key columns on UPDATE only, and says
  * in as many words that OMITTING them is not a fix. They travel as three more
- * JSON scalars, `null` included: a surface that norms away has no key, and a
- * sentinel would file every such claim under one slot.
+ * JSON scalars, and since #5047 NEVER as `null`: the `MALFORMED_CLAIM` guard
+ * refuses a candidate whose `slotKey` is null, `ResolvedSlotKeys` carries that
+ * in the type, and the columns are `NOT NULL` as of migration 0194. A surface
+ * that norms away has no key and no longer becomes a row; a sentinel was the
+ * other repair and would file every such claim under one slot.
  *
  * `object_cmp` (#5030) is derived here on the same terms, and this is the only
  * path that DERIVES one — migration 0191 deliberately does not backfill, so a
@@ -1498,9 +1507,12 @@ export async function reconcileFacts(
       // entity-valued object would be a line per claim forever under the shipped
       // default resolver.
       //
-      // Emitted BEFORE the transaction, unlike the `unkeyed` warn below, and the
-      // prose is written to survive that: it claims a property of the BATCH,
-      // which is settled here, rather than of rows that may still roll back.
+      // Emitted BEFORE the transaction, and the prose is written to survive
+      // that: it claims a property of the BATCH, which is settled here, rather
+      // than of rows that may still roll back. (This used to contrast itself
+      // with the `unkeyed` warn "below" — #5047 deleted that one and its
+      // replacement sits ABOVE, also pre-transaction, so the contrast was dead
+      // twice over.)
       "brain reconcile: the entity store did not answer this episode's batch, so these candidates were reconciled with no object comparison (`object_cmp`) — worth recomputing once it does. Their identity keys are unaffected under the same vocabulary: no resolver reaches a slot key. The ones that CREATED a row carry `provenance.provisional`; the ones that corroborated get no provenance payload FROM THIS EPISODE — the existing row is untouched, keeping its own — so this count is the only place they are counted, and their `provenance` edges to this episode are how they are found",
     );
   }

--- a/packages/api/src/lib/brain/reconcile.ts
+++ b/packages/api/src/lib/brain/reconcile.ts
@@ -644,11 +644,11 @@ export type ReconcileOutcome =
       readonly kind: "blocked";
       readonly reason: ReconcileBlockReason;
       /**
-       * For `MALFORMED_CLAIM` only: which slots had no identity (#5047). See
-       * {@link BlockedEntry.unkeyed} — this is the same detail, on the wire the
-       * caller actually reads.
+       * For `MALFORMED_CLAIM` only: which slots had no identity, and WHY (#5047).
+       * See {@link BlockedEntry.unkeyed} — this is the same detail, on the wire
+       * the caller actually reads.
        */
-      readonly unkeyed?: readonly SlotRole[];
+      readonly unkeyed?: readonly UnkeyedSlot[];
     };
 
 export interface ReconcileReport {
@@ -1253,7 +1253,6 @@ export async function reconcileFacts(
     // catch. `SlotKeys` takes role names for the same reason.
     const { subject: subjectSlot, predicate: predicateSlot, object: objectSlot } = keys;
     if (subjectSlot === null || predicateSlot === null || objectSlot === null) {
-      const unkeyed = SLOT_ROLES.filter((role) => keys[role] === null);
       const surfaces = { subject, predicate, object } as const;
       // WHICH subsystem to fix, per position — decided here, where the surface,
       // the vocabulary and the inherited slot are all still in hand.
@@ -1266,31 +1265,31 @@ export async function reconcileFacts(
       // call apart. `correction.ts` made exactly this distinction for exactly
       // this reason until #5047 made its version unreachable; the distinction
       // is not unreachable here.
-      const cause = Object.fromEntries(
-        unkeyed.map((role) => [
-          role,
+      const unkeyed: readonly UnkeyedSlot[] = SLOT_ROLES.filter(
+        (role) => keys[role] === null,
+      ).map((role) => ({
+        role,
+        cause:
           candidate.inheritedSlot !== undefined && role !== "object"
             ? "inherited"
             : identityKey(surfaces[role]) === null
               ? "degenerate-surface"
               : "vocabulary-target",
-        ]),
-      );
+      }));
       log.warn(
         {
           workspaceId: episode.workspaceId,
           episodeId: episode.id,
           producer,
           unkeyed,
-          cause,
           // Logged ONLY where the cause is `degenerate-surface`, and that
           // restriction is the point: by construction such a surface is
           // separators and whitespace and carries no claim content. A
           // `vocabulary-target` surface is real text and stays out, matching the
           // blank-trim guard above, which logs booleans rather than surfaces.
           degenerateSurfaces: unkeyed
-            .filter((role) => cause[role] === "degenerate-surface")
-            .map((role) => ({ role, surface: surfaces[role] })),
+            .filter((slot) => slot.cause === "degenerate-surface")
+            .map((slot) => ({ role: slot.role, surface: surfaces[slot.role] })),
           // ⚠️ `inheritedFrom` alone is NOT the discriminator, and reporting it
           // as one blames the wrong party. It is set for EVERY
           // correction-produced candidate, but only the SUBJECT and PREDICATE
@@ -1306,16 +1305,13 @@ export async function reconcileFacts(
           // is unreachable through the database — it survives as a diagnostic
           // for a hand-built slot and for the deploy overlap, not as an expected
           // state.
-          inheritedUnkeyed:
-            candidate.inheritedSlot === undefined
-              ? []
-              : unkeyed.filter((role) => role !== "object"),
+          inheritedUnkeyed: unkeyed
+            .filter((slot) => slot.cause === "inherited")
+            .map((slot) => slot.role),
         },
-        // THREE causes, and the message names all three because it cannot
-        // distinguish the first two once the vocabulary is real: the SURFACE
-        // norms away (`-`, `___`), or an alias entry maps a real slot to
-        // something that does. Naming only the producer would send an operator
-        // after the wrong subsystem.
+        // The message renders `cause` rather than listing possibilities — see
+        // the ⚠️ above, which records why the claim that these are
+        // indistinguishable was false.
         "brain reconcile: blocked a candidate with no identity for one or more slots — such a claim could never corroborate, earn a tension edge, or be superseded at publish, and the slot keys are NOT NULL since #5047. `cause` names the subsystem to fix, per position: `degenerate-surface` = the producer emitted separators only, and the offending text is in `degenerateSurfaces` (fix the producer); `vocabulary-target` = this workspace's vocabulary maps that slot to something that normalizes away, so the surface is fine and the ENTRY is the defect (no re-key repairs it); `inherited` = a row-copy path copied a null slot off the fact named by `inheritedFrom`, so this claim's own text is fine at that position and the TARGET row is what has no identity. The object is never inherited — it is always derived from this claim's own text",
       );
       blocked.MALFORMED_CLAIM++;
@@ -1624,6 +1620,34 @@ const SLOT_ROLES = ["subject", "predicate", "object"] as const satisfies readonl
 type SlotRole = (typeof SLOT_ROLES)[number];
 
 /**
+ * WHY a slot has no key — the discriminator a consumer needs to blame the right
+ * party (#5047).
+ *
+ * ⚠️ The POSITION is not the cause, and conflating them is a defect this type
+ * exists to have already made once. `applySupersede` first gated its user-facing
+ * 400 on "the object position failed", reasoning that the object is the
+ * caller's own text. It is not always: `slotKey` is
+ * `identityKey(alias(identityKey(surface)))`, so an object key is ALSO null when
+ * the workspace's object-position vocabulary maps a real norm to something that
+ * normalizes away — and the human is then told to retype text that is already
+ * correct, on a request no retry can fix.
+ *
+ *   - `degenerate-surface` — the producer's own text asserts nothing (`-`,
+ *     `___`). The one cause the SUPPLIER of the claim can fix.
+ *   - `vocabulary-target` — the surface keys fine and this workspace's alias
+ *     entry for it maps to nothing. A configuration defect; no re-key repairs it.
+ *   - `inherited` — a row-copy path copied a null slot off the target row, so
+ *     this claim's own text is fine at that position.
+ */
+export type SlotKeyFailureCause = "degenerate-surface" | "vocabulary-target" | "inherited";
+
+/** One slot that had no key, and why. */
+export interface UnkeyedSlot {
+  readonly role: SlotRole;
+  readonly cause: SlotKeyFailureCause;
+}
+
+/**
  * {@link SlotKeys} AFTER the `MALFORMED_CLAIM` guard — three keys, none null.
  *
  * The two types are deliberately both here rather than one nullable shape with a
@@ -1828,7 +1852,7 @@ interface BlockedEntry {
    * `correction.ts`'s supersede arm, which must not blame a replacement's text
    * for an inherited or vocabulary-caused failure.
    */
-  readonly unkeyed?: readonly SlotRole[];
+  readonly unkeyed?: readonly UnkeyedSlot[];
 }
 
 type TrimmedEntry = TrimmedCandidate | BlockedEntry;

--- a/packages/api/src/lib/brain/vocabulary-decide.ts
+++ b/packages/api/src/lib/brain/vocabulary-decide.ts
@@ -2031,9 +2031,40 @@ function rekeyDriftedFactsSql(position: SlotPosition): string {
                               WHERE t.workspace_id = f.workspace_id
                                 AND t.slot_position = '${position}'
                                 AND t.norm = ${norm}), ${norm})`;
+  // ⚠️ THE RECOMPUTED KEY IS REFUSED WHEN IT IS NULL (#5047), and this arm is
+  // load-bearing rather than defensive.
+  //
+  // `brain_facts`' three key columns are `NOT NULL` as of migration 0194, and
+  // this expression can still evaluate to NULL for a row whose SURFACE norms
+  // away — the inner `identityKeySql` yields NULL, the closure lookup matches
+  // nothing, and the COALESCE stays NULL. Without this arm such a row is
+  // `IS DISTINCT FROM` its stored key, the UPDATE tries to write NULL, and
+  // Postgres raises `23502` — aborting the whole decide transaction, which is a
+  // human-gated alias approval that has nothing to do with that row.
+  //
+  // Those rows exist: 0194 could not key the legacy degenerate population, so it
+  // TOMBSTONED them and left a per-row placeholder in the key columns. They are
+  // out of every slot consumer by `invalidated_at`, and this statement is
+  // deliberately unscoped by it (the tombstoned and superseded rows must be
+  // re-keyed too, or the re-derive-from-surface undo silently stops working), so
+  // it is this statement that meets them.
+  //
+  // Skipping them loses nothing. Their surface asserts nothing, so there is no
+  // key to re-derive at any vocabulary — the value this arm declines to write is
+  // NULL, not a better key — and the placeholder they keep joins nothing, which
+  // is what the NULL it replaced did. The ingest guard refuses to make more of
+  // them, so the population is closed and shrinks only.
+  //
+  // ⚠️ It is `${expr} IS NOT NULL`, NOT `f.${surface}` — the vocabulary is part
+  // of the composition. An entry whose target normalizes away would reach the
+  // same NULL from a perfectly keyable surface; `vocabulary-decide.ts` refuses
+  // `degenerate-norm` targets at authoring, so that path is closed today, and
+  // testing the composed expression is what keeps this arm correct if it ever
+  // reopens rather than relying on the other guard staying put.
   return `UPDATE brain_facts f
             SET ${key} = ${identityKeySql(aliased)}
           WHERE f.workspace_id = $1
+            AND ${identityKeySql(aliased)} IS NOT NULL
             AND f.${key} IS DISTINCT FROM ${identityKeySql(aliased)}
       RETURNING f.id::text AS id`;
 }

--- a/packages/api/src/lib/db/__tests__/internal.test.ts
+++ b/packages/api/src/lib/db/__tests__/internal.test.ts
@@ -91,6 +91,12 @@ function createMockPool() {
           calls.releaseCount++;
           calls.lastReleaseArg = err;
         },
+        // `runMigrations` attaches a `notice` listener to hear a migration's
+        // `RAISE NOTICE`, and `migrateInternalDB` REFUSES a client that cannot
+        // carry one rather than migrating deaf (#5047). A double on that path
+        // has to model the surface the real `pg.PoolClient` has.
+        on() {},
+        off() {},
       };
     },
     on(event: "error", listener: (err: Error) => void) {
@@ -1157,6 +1163,8 @@ describe("hardDeleteWorkspace()", () => {
         return { rows: [] };
       },
       release() {},
+        on() {},
+        off() {},
     };
     const pool = {
       ...basePool,

--- a/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
@@ -3696,3 +3696,199 @@ describe("integration stores: ISO timestamp SQL", () => {
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// 0194 — the slot-key constraint's own data transform (#5047)
+// ---------------------------------------------------------------------------
+
+describeIfPg("migrate-pg: 0194 replayed against a pre-0194 corpus (#5047)", () => {
+  let pool: Pool;
+  const schemaName = `pre_0194_${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
+  const migrationsDir = join(import.meta.dir, "..", "migrations");
+  const WS = "ws-0194";
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: TEST_DB_URL });
+    pool.on("connect", (client) => {
+      void client.query(`SET search_path TO "${schemaName}"`).catch((err) => {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(`migrate-pg 0194: SET search_path failed on new connection: ${message}`);
+      });
+    });
+    await pool.query(`CREATE SCHEMA IF NOT EXISTS "${schemaName}"`);
+  });
+
+  afterAll(async () => {
+    if (!pool) return;
+    await pool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+    await pool.end();
+  });
+
+  it("keys through the VOCABULARY, scopes PER COLUMN, and tombstones what it cannot key", async () => {
+    // ⚠️ `migrate-pg.test.ts`'s ordinary run applies 0194 against an EMPTY
+    // `brain_facts`, so all four of its data statements touch zero rows and it
+    // sees nothing about what they do. This replays it against a seeded
+    // pre-state, using the partition technique the 0096 suite above established.
+    //
+    // Four fixtures, each the falsifier for one decision 0194's header argues:
+    //
+    //   (a) the backfill must write `alias(lexicalNorm(surface))`, not the raw
+    //       norm — reverting to 0188's pre-vocabulary statement writes `priced
+    //       at` where the vocabulary says `unit price`, an under-match nothing
+    //       surfaces;
+    //   (b) it must be PER COLUMN — 0187/0188's single `UPDATE` rewrites all
+    //       three keys on a row unkeyed at one position, silently reverting a
+    //       curated key at another;
+    //   (c) a degenerate position takes a per-row placeholder and a tombstone,
+    //       and its OTHER positions keep their real keys;
+    //   (d) an already-tombstoned row keeps its ORIGINAL timestamp — the
+    //       `COALESCE` — because when it stopped being a belief is a fact about
+    //       the corpus, not about this migration.
+    const allFiles = readdirSync(migrationsDir)
+      .filter((f) => f.endsWith(".sql"))
+      .sort();
+    const post0194 = allFiles.filter((f) => f.localeCompare("0194_") >= 0);
+    // Non-vacuity: an empty partition means 0194 already ran and this proves
+    // nothing.
+    expect(post0194).toContain("0194_brain_fact_slot_keys_not_null.sql");
+
+    const applied = await runMigrations(pool, {
+      skip: [...MANAGED_AUTH_MIGRATIONS, ...post0194],
+    });
+    expect(applied).toBeGreaterThan(0);
+
+    const { rows: epRows } = await pool.query<{ id: string }>(
+      `INSERT INTO brain_episodes
+         (workspace_id, source, source_id, source_actor, body, occurred_at, visible_to)
+       VALUES ($1, 'slack', '0194-ep', 'U1', 'evidence', now(), ARRAY['org'])
+       RETURNING id`,
+      [WS],
+    );
+    const episodeId = epRows[0]!.id;
+
+    // The vocabulary the backfill must consult. Written directly to both
+    // relations: the closure table has an FK onto the edge, and going through
+    // the authoring seam here would need the whole approval path for one row.
+    await pool.query(
+      `INSERT INTO brain_vocabulary_edge
+         (workspace_id, slot_position, from_norm, to_norm, approved_by)
+       VALUES ($1, 'predicate', 'priced at', 'unit price', '0194-test')`,
+      [WS],
+    );
+    await pool.query(
+      `INSERT INTO brain_vocabulary_target (workspace_id, slot_position, norm, effective_target)
+       VALUES ($1, 'predicate', 'priced at', 'unit price')`,
+      [WS],
+    );
+
+    const seed = async (
+      subject: string,
+      predicate: string,
+      object: string,
+      keys: { s: string | null; p: string | null; o: string | null },
+      invalidatedAt: Date | null = null,
+    ): Promise<string> => {
+      const { rows } = await pool.query<{ id: string }>(
+        `INSERT INTO brain_facts
+           (workspace_id, subject, predicate, object, subject_key, predicate_key, object_key,
+            source_episode_id, provenance, visible_to, invalidated_at)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, '{"actor":"u1"}'::jsonb, ARRAY['org'], $9)
+         RETURNING id::text AS id`,
+        [WS, subject, predicate, object, keys.s, keys.p, keys.o, episodeId, invalidatedAt],
+      );
+      return rows[0]!.id;
+    };
+
+    const aliased = await seed("Widget", "Priced At", "nine", { s: null, p: null, o: null });
+    const curated = await seed("gadget", "priced at", "ten", {
+      s: "gadget",
+      p: "curated predicate",
+      o: null,
+    });
+    const degenerate = await seed("billing", "is owned by", "-", {
+      s: "billing",
+      p: "is owned by",
+      o: null,
+    });
+    const alreadyDead = new Date("2026-01-02T03:04:05.000Z");
+    const tombstoned = await seed("legacy", "is", "___", { s: null, p: null, o: null }, alreadyDead);
+
+    const before = await pool.query<{ id: string; updated_at: Date }>(
+      `SELECT id::text AS id, updated_at FROM brain_facts WHERE workspace_id = $1`,
+      [WS],
+    );
+
+    // Apply 0194 (and anything after it).
+    await runMigrations(pool, { skip: MANAGED_AUTH_MIGRATIONS });
+
+    const read = async (id: string) => {
+      const { rows } = await pool.query<{
+        subject_key: string;
+        predicate_key: string;
+        object_key: string;
+        invalidated_at: Date | null;
+        updated_at: Date;
+      }>(
+        `SELECT subject_key, predicate_key, object_key, invalidated_at, updated_at
+           FROM brain_facts WHERE id = $1`,
+        [id],
+      );
+      return rows[0]!;
+    };
+
+    // (a) the backfill is VOCABULARY-AWARE. `Priced At` norms to `priced at`,
+    // which the closure maps to `unit price`. 0188's statement writes
+    // `priced at` and this assertion is what says so.
+    const a = await read(aliased);
+    expect(
+      a.predicate_key,
+      "the backfill wrote the raw norm — it must compose the vocabulary, or the row sits in a different slot from every sibling the vocabulary unified",
+    ).toBe("unit price");
+    expect(a.subject_key).toBe("widget");
+    expect(a.object_key).toBe("nine");
+    expect(a.invalidated_at).toBeNull();
+
+    // (b) PER COLUMN. `curated` is unkeyed only at the object, and its stored
+    // predicate key disagrees with what the vocabulary would compute — so a
+    // single blanket `UPDATE` rewrites it to `unit price` and this catches it.
+    const b = await read(curated);
+    expect(
+      b.predicate_key,
+      "a column that already had a key was rewritten — 0194 must scope each statement to its own column, or it silently reverts curated keys at positions it was not asked about",
+    ).toBe("curated predicate");
+    expect(b.object_key).toBe("ten");
+    expect(b.invalidated_at).toBeNull();
+
+    // (c) the degenerate position takes a per-row placeholder AND a tombstone,
+    // while the two keyable positions keep their real keys.
+    const c = await read(degenerate);
+    expect(c.object_key).toBe(`-unkeyable:${degenerate}`);
+    expect(
+      [c.subject_key, c.predicate_key],
+      "a placeholder overwrote a position that keys perfectly well — a row merely valueless at one slot became unreachable at all three",
+    ).toEqual(["billing", "is owned by"]);
+    expect(c.invalidated_at).not.toBeNull();
+
+    // The placeholders are PER ROW: two degenerate rows must not share a slot,
+    // which is the entire difference from the sentinel 0187's header rejects.
+    const d = await read(tombstoned);
+    expect(d.object_key).toBe(`-unkeyable:${tombstoned}`);
+    expect(d.object_key).not.toBe(c.object_key);
+
+    // (d) an already-tombstoned row keeps its ORIGINAL timestamp.
+    expect(
+      d.invalidated_at?.toISOString(),
+      "0194 restamped a row that was already tombstoned — when it stopped being a belief is a fact about the corpus, not about this migration",
+    ).toBe(alreadyDead.toISOString());
+
+    // `updated_at` is untouched on every row: it sorts the publish preview, and
+    // a workspace-wide stamp reshuffles every reviewer's draft queue into
+    // backfill order.
+    for (const row of before.rows) {
+      const after = await read(row.id);
+      expect(after.updated_at.toISOString(), `updated_at moved on ${row.id}`).toBe(
+        row.updated_at.toISOString(),
+      );
+    }
+  }, PG_TEST_TIMEOUT_MS);
+});

--- a/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
@@ -3308,8 +3308,8 @@ describeIfPg("migrate-pg: 0115 organization dormancy gate (#2377)", () => {
     await expectRejected(
       "chk_brain_facts_grant_nonempty",
       `INSERT INTO brain_facts
-         (workspace_id, subject, predicate, object, source_episode_id, provenance, visible_to)
-       VALUES ($1, 's', 'p', 'o', $2, '{"actor":"u1"}'::jsonb, ARRAY[NULL, '']::text[])`,
+         (workspace_id, subject, predicate, object, subject_key, predicate_key, object_key, source_episode_id, provenance, visible_to)
+       VALUES ($1, 's', 'p', 'o', 's', 'p', 'o', $2, '{"actor":"u1"}'::jsonb, ARRAY[NULL, '']::text[])`,
       [ws, episodeId],
     );
   }, PG_TEST_TIMEOUT_MS);
@@ -3321,8 +3321,8 @@ describeIfPg("migrate-pg: 0115 organization dormancy gate (#2377)", () => {
 
     const { rows } = await pool.query<{ status: string; predicate_cardinality: string }>(
       `INSERT INTO brain_facts
-         (workspace_id, subject, predicate, object, source_episode_id, provenance, visible_to)
-       VALUES ($1, 'acme', 'uses', 'postgres', $2, '{"actor":"u1"}'::jsonb, ARRAY['org'])
+         (workspace_id, subject, predicate, object, subject_key, predicate_key, object_key, source_episode_id, provenance, visible_to)
+       VALUES ($1, 'acme', 'uses', 'postgres', 'acme', 'uses', 'postgres', $2, '{"actor":"u1"}'::jsonb, ARRAY['org'])
        RETURNING status, predicate_cardinality`,
       [ws, episodeId],
     );
@@ -3334,8 +3334,8 @@ describeIfPg("migrate-pg: 0115 organization dormancy gate (#2377)", () => {
     await expectRejected(
       "chk_brain_facts_status",
       `INSERT INTO brain_facts
-         (workspace_id, subject, predicate, object, source_episode_id, provenance, visible_to, status)
-       VALUES ($1, 'acme', 'uses', 'mysql', $2, '{"actor":"u1"}'::jsonb, ARRAY['org'], 'live')`,
+         (workspace_id, subject, predicate, object, subject_key, predicate_key, object_key, source_episode_id, provenance, visible_to, status)
+       VALUES ($1, 'acme', 'uses', 'mysql', 'acme', 'uses', 'mysql', $2, '{"actor":"u1"}'::jsonb, ARRAY['org'], 'live')`,
       [ws, episodeId],
     );
   }, PG_TEST_TIMEOUT_MS);
@@ -3346,13 +3346,13 @@ describeIfPg("migrate-pg: 0115 organization dormancy gate (#2377)", () => {
     const episodeId = await insertEpisode(ws, `ep-${stamp}`);
 
     const base = `INSERT INTO brain_facts
-        (workspace_id, subject, predicate, object, source_episode_id, provenance, visible_to)`;
+        (workspace_id, subject, predicate, object, subject_key, predicate_key, object_key, source_episode_id, provenance, visible_to)`;
 
     // An EMPTY grant is the dangerous case, and the one NOT NULL alone misses:
     // it denies everyone, which reads as "hidden" but behaves as "unreviewed".
     await expectRejected(
       "chk_brain_facts_grant_nonempty",
-      `${base} VALUES ($1, 's', 'p', 'o', $2, '{"actor":"u1"}'::jsonb, ARRAY[]::text[])`,
+      `${base} VALUES ($1, 's', 'p', 'o', 's', 'p', 'o', $2, '{"actor":"u1"}'::jsonb, ARRAY[]::text[])`,
       [ws, episodeId],
     );
 
@@ -3360,7 +3360,7 @@ describeIfPg("migrate-pg: 0115 organization dormancy gate (#2377)", () => {
     // shape of a real one.
     await expectRejected(
       "chk_brain_facts_provenance_nonempty",
-      `${base} VALUES ($1, 's', 'p', 'o', $2, '{}'::jsonb, ARRAY['org'])`,
+      `${base} VALUES ($1, 's', 'p', 'o', 's', 'p', 'o', $2, '{}'::jsonb, ARRAY['org'])`,
       [ws, episodeId],
     );
 
@@ -3368,7 +3368,7 @@ describeIfPg("migrate-pg: 0115 organization dormancy gate (#2377)", () => {
     // has no constraint name, so this one matches on the message.
     let nullErr: (Error & { column?: string }) | null = null;
     try {
-      await pool.query(`${base} VALUES ($1, 's', 'p', 'o', NULL, '{"actor":"u1"}'::jsonb, ARRAY['org'])`, [ws]);
+      await pool.query(`${base} VALUES ($1, 's', 'p', 'o', 's', 'p', 'o', NULL, '{"actor":"u1"}'::jsonb, ARRAY['org'])`, [ws]);
     } catch (e) {
       nullErr = e instanceof Error ? e : new Error(String(e));
     }
@@ -3398,8 +3398,8 @@ describeIfPg("migrate-pg: 0115 organization dormancy gate (#2377)", () => {
     await expectRejected(
       "fk_brain_facts_episode",
       `INSERT INTO brain_facts
-         (workspace_id, subject, predicate, object, source_episode_id, provenance, visible_to)
-       VALUES ($1, 's', 'p', 'o', $2, '{"actor":"u1"}'::jsonb, ARRAY['org'])`,
+         (workspace_id, subject, predicate, object, subject_key, predicate_key, object_key, source_episode_id, provenance, visible_to)
+       VALUES ($1, 's', 'p', 'o', 's', 'p', 'o', $2, '{"actor":"u1"}'::jsonb, ARRAY['org'])`,
       [wsA, episodeB],
     );
   }, PG_TEST_TIMEOUT_MS);
@@ -3413,18 +3413,18 @@ describeIfPg("migrate-pg: 0115 organization dormancy gate (#2377)", () => {
     // a human promotion stamps one.
     await pool.query(
       `INSERT INTO brain_facts
-         (workspace_id, subject, predicate, object, source_episode_id, provenance, visible_to,
+         (workspace_id, subject, predicate, object, subject_key, predicate_key, object_key, source_episode_id, provenance, visible_to,
           valid_from)
-       VALUES ($1, 's', 'p', 'o', $2, '{"actor":"u1"}'::jsonb, ARRAY['org'], now())`,
+       VALUES ($1, 's', 'p', 'o', 's', 'p', 'o', $2, '{"actor":"u1"}'::jsonb, ARRAY['org'], now())`,
       [ws, episodeId],
     );
 
     await expectRejected(
       "chk_brain_facts_valid_interval",
       `INSERT INTO brain_facts
-         (workspace_id, subject, predicate, object, source_episode_id, provenance, visible_to,
+         (workspace_id, subject, predicate, object, subject_key, predicate_key, object_key, source_episode_id, provenance, visible_to,
           valid_from, valid_to)
-       VALUES ($1, 's', 'p', 'o', $2, '{"actor":"u1"}'::jsonb, ARRAY['org'],
+       VALUES ($1, 's', 'p', 'o', 's', 'p', 'o', $2, '{"actor":"u1"}'::jsonb, ARRAY['org'],
                now(), now() - interval '1 day')`,
       [ws, episodeId],
     );
@@ -3436,9 +3436,9 @@ describeIfPg("migrate-pg: 0115 organization dormancy gate (#2377)", () => {
     const episodeId = await insertEpisode(ws, `ep-${stamp}`);
     const { rows: factRows } = await pool.query<{ id: string }>(
       `INSERT INTO brain_facts
-         (workspace_id, subject, predicate, object, source_episode_id, provenance, visible_to)
-       VALUES ($1, 's', 'p', 'o', $2, '{"actor":"u1"}'::jsonb, ARRAY['org']),
-              ($1, 's', 'p', 'o2', $2, '{"actor":"u1"}'::jsonb, ARRAY['org'])
+         (workspace_id, subject, predicate, object, subject_key, predicate_key, object_key, source_episode_id, provenance, visible_to)
+       VALUES ($1, 's', 'p', 'o', 's', 'p', 'o', $2, '{"actor":"u1"}'::jsonb, ARRAY['org']),
+              ($1, 's', 'p', 'o2', 's', 'p', 'o2', $2, '{"actor":"u1"}'::jsonb, ARRAY['org'])
        RETURNING id`,
       [ws, episodeId],
     );
@@ -3480,8 +3480,8 @@ describeIfPg("migrate-pg: 0115 organization dormancy gate (#2377)", () => {
     const episodeId = await insertEpisode(ws, `ep-${stamp}`);
     const { rows: factRows } = await pool.query<{ id: string }>(
       `INSERT INTO brain_facts
-         (workspace_id, subject, predicate, object, source_episode_id, provenance, visible_to)
-       VALUES ($1, 's', 'p', 'o', $2, '{"actor":"u1"}'::jsonb, ARRAY['org'])
+         (workspace_id, subject, predicate, object, subject_key, predicate_key, object_key, source_episode_id, provenance, visible_to)
+       VALUES ($1, 's', 'p', 'o', 's', 'p', 'o', $2, '{"actor":"u1"}'::jsonb, ARRAY['org'])
        RETURNING id`,
       [ws, episodeId],
     );
@@ -3525,8 +3525,8 @@ describeIfPg("migrate-pg: 0115 organization dormancy gate (#2377)", () => {
     const episodeId = await insertEpisode(ws, `ep-${stamp}`);
     const { rows: factRows } = await pool.query<{ id: string }>(
       `INSERT INTO brain_facts
-         (workspace_id, subject, predicate, object, source_episode_id, provenance, visible_to)
-       VALUES ($1, 's', 'p', 'o', $2, '{"actor":"u1"}'::jsonb, ARRAY['org'])
+         (workspace_id, subject, predicate, object, subject_key, predicate_key, object_key, source_episode_id, provenance, visible_to)
+       VALUES ($1, 's', 'p', 'o', 's', 'p', 'o', $2, '{"actor":"u1"}'::jsonb, ARRAY['org'])
        RETURNING id`,
       [ws, episodeId],
     );
@@ -3570,8 +3570,8 @@ describeIfPg("migrate-pg: 0115 organization dormancy gate (#2377)", () => {
     const episodeA = await insertEpisode(wsA, `ep-a-${stamp}`);
     const { rows } = await pool.query<{ id: string }>(
       `INSERT INTO brain_facts
-         (workspace_id, subject, predicate, object, source_episode_id, provenance, visible_to)
-       VALUES ($1, 's', 'p', 'o', $2, '{"actor":"u1"}'::jsonb, ARRAY['org'])
+         (workspace_id, subject, predicate, object, subject_key, predicate_key, object_key, source_episode_id, provenance, visible_to)
+       VALUES ($1, 's', 'p', 'o', 's', 'p', 'o', $2, '{"actor":"u1"}'::jsonb, ARRAY['org'])
        RETURNING id`,
       [wsA, episodeA],
     );
@@ -3592,8 +3592,8 @@ describeIfPg("migrate-pg: 0115 organization dormancy gate (#2377)", () => {
     const episodeId = await insertEpisode(ws, `ep-${stamp}`);
     await pool.query(
       `INSERT INTO brain_facts
-         (workspace_id, subject, predicate, object, source_episode_id, provenance, visible_to)
-       VALUES ($1, 's', 'p', 'o', $2, '{"actor":"u1"}'::jsonb, ARRAY['org'])`,
+         (workspace_id, subject, predicate, object, subject_key, predicate_key, object_key, source_episode_id, provenance, visible_to)
+       VALUES ($1, 's', 'p', 'o', 's', 'p', 'o', $2, '{"actor":"u1"}'::jsonb, ARRAY['org'])`,
       [ws, episodeId],
     );
 
@@ -3612,8 +3612,8 @@ describeIfPg("migrate-pg: 0115 organization dormancy gate (#2377)", () => {
     const episodeId = await insertEpisode(ws, `ep-${stamp}`);
     const { rows } = await pool.query<{ id: string }>(
       `INSERT INTO brain_facts
-         (workspace_id, subject, predicate, object, source_episode_id, provenance, visible_to)
-       VALUES ($1, 's', 'p', 'o', $2, '{"actor":"u1"}'::jsonb, ARRAY['org'])
+         (workspace_id, subject, predicate, object, subject_key, predicate_key, object_key, source_episode_id, provenance, visible_to)
+       VALUES ($1, 's', 'p', 'o', 's', 'p', 'o', $2, '{"actor":"u1"}'::jsonb, ARRAY['org'])
        RETURNING id`,
       [ws, episodeId],
     );

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -306,7 +306,15 @@ describe("runMigrations", () => {
     //   overwrites `visible_to` with the union of evidence grants, so the
     //   private claim's body reaches the public audience. Only a
     //   warehouse-backed subject can ever supply one, #5032 / ADR-0037 §5) = 194.
-    expect(count).toBe(194);
+    //   Plus 0194 (brain_fact_slot_keys_not_null — the third and last step of
+    //   ADR-0037 §1's identity key: the backfill re-run, vocabulary-aware and
+    //   per-column this time, the tombstone-plus-placeholder for the legacy rows
+    //   whose surfaces normalize away, and `SET NOT NULL` on all three slot key
+    //   columns. What it buys is that a NULL key stops meaning two things —
+    //   "no writer has keyed this row yet" and "this surface asserts nothing" —
+    //   by making the first unrepresentable and the second refused at ingest,
+    //   #5047) = 195.
+    expect(count).toBe(195);
 
     // Advisory lock acquired before anything else
     expect(queries[0]).toContain("pg_advisory_lock");
@@ -529,6 +537,7 @@ describe("runMigrations", () => {
         "0191_brain_fact_object_cmp.sql",
         "0192_brain_predicate_cardinality.sql",
         "0193_brain_fact_subject_cmp.sql",
+        "0194_brain_fact_slot_keys_not_null.sql",
       ],
     });
 

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -62,6 +62,14 @@ function createMockPool(
           release.called = true;
           release.arg = err;
         },
+        // The `notice` listener surface (#5047). No-ops: a mock pool raises no
+        // server notices, and what this fake is here to prove is the statement
+        // sequence. `migrate-pg.test.ts` is where a real `RAISE NOTICE` is
+        // observed. Declared because `MigrationClient` requires them — a double
+        // that silently lacked `on` would drop every migration breadcrumb, which
+        // is exactly the gap the listener was added to close.
+        on() {},
+        off() {},
       };
     },
   };

--- a/packages/api/src/lib/db/internal.ts
+++ b/packages/api/src/lib/db/internal.ts
@@ -295,6 +295,17 @@ export interface InternalPoolClient {
     params?: unknown[],
   ): Promise<{ rows: Record<string, unknown>[]; rowCount?: number | null }>;
   release(err?: Error): void;
+  /**
+   * `node-postgres`' `EventEmitter` surface for server notices (#5047).
+   *
+   * OPTIONAL so the lightweight mocks that satisfy this interface elsewhere keep
+   * doing so — the same reason `rowCount` is. `runMigrations` is the one consumer
+   * and requires them on its own client type, so a caller passing a pool whose
+   * client lacks them is a compile error THERE, where the notices would be lost,
+   * rather than everywhere a `{ query, release }` double is built.
+   */
+  on?(event: "notice", listener: (notice: { readonly message?: string }) => void): unknown;
+  off?(event: "notice", listener: (notice: { readonly message?: string }) => void): unknown;
 }
 
 export interface InternalPool {

--- a/packages/api/src/lib/db/internal.ts
+++ b/packages/api/src/lib/db/internal.ts
@@ -298,14 +298,31 @@ export interface InternalPoolClient {
   /**
    * `node-postgres`' `EventEmitter` surface for server notices (#5047).
    *
-   * OPTIONAL so the lightweight mocks that satisfy this interface elsewhere keep
-   * doing so — the same reason `rowCount` is. `runMigrations` is the one consumer
-   * and requires them on its own client type, so a caller passing a pool whose
-   * client lacks them is a compile error THERE, where the notices would be lost,
-   * rather than everywhere a `{ query, release }` double is built.
+   * OPTIONAL HERE, and REQUIRED on `MigrationClient` — the asymmetry is
+   * deliberate and was measured. Requiring them on this interface cascades into
+   * 105 hand-built `{ query, release }` doubles across the tree, none of which
+   * raises a notice; requiring them only where they are USED costs nothing and
+   * puts the compile error at the seam that would lose the notices.
+   *
+   * The seam is `runMigrations`' one production caller below, which asserts them
+   * at runtime rather than degrading quietly — see `migrationPool`.
    */
   on?(event: "notice", listener: (notice: { readonly message?: string }) => void): unknown;
   off?(event: "notice", listener: (notice: { readonly message?: string }) => void): unknown;
+}
+
+/**
+ * The internal pool's client cannot carry a migration's server notices (#5047).
+ *
+ * Named rather than a bare `Error` for one reason: `migrateInternalDB` retries
+ * migration failures with backoff for cold-starting serverless Postgres, and
+ * this is not that — it is a contract defect that will hold on every attempt.
+ */
+export class MigrationClientContractError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "MigrationClientContractError";
+  }
 }
 
 export interface InternalPool {
@@ -1072,14 +1089,56 @@ export async function migrateInternalDB(): Promise<void> {
   const { detectAuthMode } = await import("@atlas/api/lib/auth/detect");
   const skip = detectAuthMode() === "managed" ? [] : MANAGED_AUTH_MIGRATIONS;
 
+  // The `notice`-listener seam (#5047). `MigrationClient` REQUIRES `on`/`off`
+  // because `runMigrations` attaches a listener to hear a migration's
+  // `RAISE NOTICE` — five migrations' operator breadcrumbs were being discarded
+  // before it existed. `InternalPoolClient` leaves them optional so the tree's
+  // hand-built doubles still satisfy it, so this is where the two meet.
+  //
+  // ⚠️ ASSERTED, not defaulted. The alternative — a guard in `runMigrations`
+  // that logs and carries on — is what the first cut did, and it silently
+  // reinstates the whole bug for any future pool wrapper or driver swap, below
+  // the production log level. The real `pg.PoolClient` is an `EventEmitter` and
+  // has always had both, so this throws only if that stops being true, and a
+  // boot that cannot hear its migrations should fail loudly rather than run
+  // deaf.
+  const migrationPool = {
+    query: (sql: string, params?: unknown[]) => pool.query(sql, params),
+    connect: async () => {
+      const client = await pool.connect();
+      if (typeof client.on !== "function" || typeof client.off !== "function") {
+        client.release();
+        throw new MigrationClientContractError(
+          "Internal DB client exposes no `notice` event surface, so every RAISE NOTICE " +
+            "raised by a migration would be discarded — including the row counts 0032, 0034, " +
+            "0055, 0072, 0085 and 0194 emit as post-mortem breadcrumbs. Refusing to migrate " +
+            "deaf; the driver or pool wrapper changed.",
+        );
+      }
+      // Narrowed by the check above, which TypeScript cannot carry across the
+      // optional-method boundary — the two interfaces differ only in whether
+      // these are optional, and the `typeof` guards are what make the assertion
+      // true rather than hopeful.
+      return client as InternalPoolClient & {
+        on: NonNullable<InternalPoolClient["on"]>;
+        off: NonNullable<InternalPoolClient["off"]>;
+      };
+    },
+  };
+
   // Retry with backoff for serverless Postgres cold starts (Railway).
   // Set ATLAS_MIGRATION_RETRIES=0 to disable retries (e.g. in tests).
   const maxRetries = parseInt(process.env.ATLAS_MIGRATION_RETRIES ?? "5", 10);
   for (let attempt = 1; attempt <= maxRetries; attempt++) {
     try {
-      await runMigrations(pool, { skip });
+      await runMigrations(migrationPool, { skip });
       break;
     } catch (err) {
+      // NOT retryable. The retry loop exists for a serverless DB cold-starting;
+      // a client that structurally cannot deliver notices will be exactly as
+      // unable on the fifth attempt, and retrying it burns 31s of boot backoff
+      // before reporting a defect that was decided at compile time.
+      if (err instanceof MigrationClientContractError) throw err;
       if (attempt === maxRetries) throw err;
       const delayMs = 1000 * 2 ** (attempt - 1); // 1s, 2s, 4s, 8s, 16s
       log.warn(

--- a/packages/api/src/lib/db/migrate.ts
+++ b/packages/api/src/lib/db/migrate.ts
@@ -47,11 +47,13 @@ interface MigrationClient extends Queryable {
    * A future pool wrapper or driver swap would have silently discarded every
    * migration breadcrumb again.
    *
-   * Requiring them costs nothing now: every in-repo double was updated when the
-   * listener landed. `InternalPoolClient` keeps them optional so the dozen
-   * lightweight `{ query, release }` doubles elsewhere still satisfy it — which
-   * means a pool whose client lacks them fails to compile HERE, at the one
-   * consumer, which is where the notices would be lost.
+   * `InternalPoolClient` keeps them OPTIONAL so the tree's hand-built
+   * `{ query, release }` doubles still satisfy it (the count and the reason live
+   * there, in the file that pays it). Passing such a pool straight to
+   * `runMigrations` therefore fails to compile — which is why `migrateInternalDB`
+   * builds a wrapper, and why that wrapper's `typeof` check plus
+   * `MigrationClientContractError` is what turns a future driver swap into a loud
+   * boot failure rather than a silently deaf migration.
    */
   on(event: "notice", listener: (notice: { readonly message?: string }) => void): unknown;
   off(event: "notice", listener: (notice: { readonly message?: string }) => void): unknown;

--- a/packages/api/src/lib/db/migrate.ts
+++ b/packages/api/src/lib/db/migrate.ts
@@ -41,18 +41,20 @@ interface MigrationClient extends Queryable {
    * `node-postgres`' `EventEmitter` surface, narrowed to the one event this
    * module listens for (#5047).
    *
-   * OPTIONAL, and the absence is REPORTED rather than ignored — see where it is
-   * attached. Requiring it would be the stronger design and it is not available:
-   * the real client reaches here through `InternalPoolClient`, which a dozen
-   * lightweight `{ query, release }` doubles satisfy across the tree, and making
-   * this mandatory cascades into every one of them for a signal none of them
-   * raises. So the type stays permissive and the CALL SITE says out loud when
-   * notices cannot be heard, which is the property that actually matters: the
-   * gap this listener closes was five migrations' breadcrumbs going nowhere with
-   * nothing anywhere saying so.
+   * REQUIRED, and the first cut of this had them optional with a `debug` line
+   * when absent — which reinstated the exact gap the listener closes, below the
+   * production log level, under two docstrings claiming it could not happen.
+   * A future pool wrapper or driver swap would have silently discarded every
+   * migration breadcrumb again.
+   *
+   * Requiring them costs nothing now: every in-repo double was updated when the
+   * listener landed. `InternalPoolClient` keeps them optional so the dozen
+   * lightweight `{ query, release }` doubles elsewhere still satisfy it — which
+   * means a pool whose client lacks them fails to compile HERE, at the one
+   * consumer, which is where the notices would be lost.
    */
-  on?(event: "notice", listener: (notice: { readonly message?: string }) => void): unknown;
-  off?(event: "notice", listener: (notice: { readonly message?: string }) => void): unknown;
+  on(event: "notice", listener: (notice: { readonly message?: string }) => void): unknown;
+  off(event: "notice", listener: (notice: { readonly message?: string }) => void): unknown;
 }
 
 /**
@@ -156,18 +158,7 @@ export async function runMigrations(pool: MigrationPool, options: RunMigrationsO
       "Migration notice",
     );
   };
-  if (typeof client.on === "function") {
-    client.on("notice", onNotice);
-  } else {
-    // Not silent: a client with no notice surface means every `RAISE NOTICE` in
-    // every migration this run applies is discarded, which is precisely the
-    // condition that went unnoticed for five migrations. `debug` rather than
-    // `warn` because every in-repo mock pool legitimately lands here.
-    log.debug(
-      {},
-      "Migration client exposes no `notice` event — RAISE NOTICE breadcrumbs from migrations will be discarded for this run",
-    );
-  }
+  client.on("notice", onNotice);
 
   // A failed per-migration ROLLBACK propagates here via the callback so
   // the client gets destroyed on release instead of pooled dirty.
@@ -213,10 +204,18 @@ export async function runMigrations(pool: MigrationPool, options: RunMigrationsO
       });
     }
   } finally {
+    // Anything raised after the loop — `ADVISORY_UNLOCK_SQL` — is not the last
+    // migration's doing, and attributing it there would be a small lie in the
+    // one field this line exists to get right.
+    noticeFrom.migration = "(after the last migration)";
     // Same reference, so the client goes back to the pool with no more listeners
     // than it arrived with. `off` and not `removeAllListeners`: the pool's own
     // internals may have their own.
-    client.off?.("notice", onNotice);
+    //
+    // ⚠️ `runSeeds` runs on a DIFFERENT connection, after this returns, so seed
+    // notices are still discarded. Out of scope here and stated so the next
+    // reader does not assume coverage.
+    client.off("notice", onNotice);
     client.release(rollbackErr ?? undefined);
   }
 }

--- a/packages/api/src/lib/db/migrate.ts
+++ b/packages/api/src/lib/db/migrate.ts
@@ -37,6 +37,34 @@ interface MigrationPool extends Queryable {
  */
 interface MigrationClient extends Queryable {
   release(err?: Error): void;
+  /**
+   * `node-postgres`' `EventEmitter` surface, narrowed to the one event this
+   * module listens for (#5047).
+   *
+   * OPTIONAL, and the absence is REPORTED rather than ignored — see where it is
+   * attached. Requiring it would be the stronger design and it is not available:
+   * the real client reaches here through `InternalPoolClient`, which a dozen
+   * lightweight `{ query, release }` doubles satisfy across the tree, and making
+   * this mandatory cascades into every one of them for a signal none of them
+   * raises. So the type stays permissive and the CALL SITE says out loud when
+   * notices cannot be heard, which is the property that actually matters: the
+   * gap this listener closes was five migrations' breadcrumbs going nowhere with
+   * nothing anywhere saying so.
+   */
+  on?(event: "notice", listener: (notice: { readonly message?: string }) => void): unknown;
+  off?(event: "notice", listener: (notice: { readonly message?: string }) => void): unknown;
+}
+
+/**
+ * Which migration a server notice should be attributed to.
+ *
+ * A box rather than a closure variable because the listener is attached in
+ * {@link runMigrations} while the per-file loop runs one function down, and the
+ * alternative — attributing every notice to whatever ran last — is worse than no
+ * attribution at all.
+ */
+interface NoticeAttribution {
+  migration: string;
 }
 
 const MIGRATIONS_DIR = path.join(import.meta.dir, "migrations");
@@ -87,6 +115,60 @@ export async function runMigrations(pool: MigrationPool, options: RunMigrationsO
   // transaction semantics.
   const client = await pool.connect();
 
+  // ⚠️ WITHOUT THIS, EVERY `RAISE NOTICE` IN EVERY MIGRATION IS DISCARDED (#5047).
+  //
+  // Migrations 0032, 0034, 0055, 0072 and 0085 all emit one as a deliberate
+  // operator breadcrumb — 0032's header even names the mistake it was written to
+  // stop: *"so operators have a post-mortem breadcrumb instead of silent
+  // rewrites (0031 shipped without this — don't repeat that gap)"*. `node-postgres`
+  // delivers server notices on a `notice` event and drops them when nothing is
+  // listening, and nothing was, so five files' worth of breadcrumbs had been
+  // going nowhere. 0194 adds a sixth (its tombstone count) and is what surfaced
+  // it.
+  //
+  // Attached to the DEDICATED client rather than the pool, matching every other
+  // statement here: the notice arrives on the session that raised it, and this is
+  // the only session migrations run on. Detached in `finally` with the same
+  // reference, so a pooled client cannot accumulate a listener per call — the
+  // shape that turns a long-lived pool into a `MaxListenersExceededWarning` and
+  // then a leak.
+  //
+  // `migration` is bound per statement below rather than captured here, so a
+  // notice names the file that raised it instead of whatever ran last.
+  //
+  // ⚠️ ROUTINE notices come through too — `CREATE TABLE IF NOT EXISTS` and
+  // `DROP … IF EXISTS` both raise one — and they are NOT filtered, because
+  // Postgres does not offer a discriminator that works. Measured on this repo's
+  // PG 16: a deliberate `RAISE NOTICE` reports SQLSTATE `00000`, and so does
+  // *"table … does not exist, skipping"*; only `CREATE TABLE IF NOT EXISTS`
+  // differs (`42P07`). A code filter would therefore drop nothing useful and
+  // keep half the noise.
+  //
+  // The volume is bounded by what already exists: this function logs "Applying
+  // migration" once per file at `info`, so a fresh install's few dozen extra
+  // lines sit beside ~195 of those, and an incremental deploy only runs the new
+  // files. Noise was the wrong thing to optimize against here — the failure this
+  // closes is a deliberate breadcrumb reaching nobody.
+  const noticeFrom: NoticeAttribution = { migration: "(before any migration)" };
+  const onNotice = (notice: { readonly message?: string }): void => {
+    log.info(
+      { migration: noticeFrom.migration, notice: notice.message ?? "(no message)" },
+      "Migration notice",
+    );
+  };
+  if (typeof client.on === "function") {
+    client.on("notice", onNotice);
+  } else {
+    // Not silent: a client with no notice surface means every `RAISE NOTICE` in
+    // every migration this run applies is discarded, which is precisely the
+    // condition that went unnoticed for five migrations. `debug` rather than
+    // `warn` because every in-repo mock pool legitimately lands here.
+    log.debug(
+      {},
+      "Migration client exposes no `notice` event — RAISE NOTICE breadcrumbs from migrations will be discarded for this run",
+    );
+  }
+
   // A failed per-migration ROLLBACK propagates here via the callback so
   // the client gets destroyed on release instead of pooled dirty.
   let rollbackErr: Error | null = null;
@@ -111,9 +193,14 @@ export async function runMigrations(pool: MigrationPool, options: RunMigrationsO
     await client.query(ADVISORY_LOCK_SQL);
 
     try {
-      return await _runMigrationsLocked(client, options.skip ?? [], (err) => {
-        rollbackErr = err;
-      });
+      return await _runMigrationsLocked(
+        client,
+        options.skip ?? [],
+        (err) => {
+          rollbackErr = err;
+        },
+        noticeFrom,
+      );
     } finally {
       await client.query(ADVISORY_UNLOCK_SQL).catch((err: unknown) => {
         // Unlock may legitimately fail if the connection is broken (in
@@ -126,6 +213,10 @@ export async function runMigrations(pool: MigrationPool, options: RunMigrationsO
       });
     }
   } finally {
+    // Same reference, so the client goes back to the pool with no more listeners
+    // than it arrived with. `off` and not `removeAllListeners`: the pool's own
+    // internals may have their own.
+    client.off?.("notice", onNotice);
     client.release(rollbackErr ?? undefined);
   }
 }
@@ -134,6 +225,7 @@ async function _runMigrationsLocked(
   client: MigrationClient,
   skip: string[],
   onRollbackFailure: (err: Error) => void,
+  noticeFrom: NoticeAttribution,
 ): Promise<number> {
   const skipSet = new Set(skip);
   // Ensure tracking table exists
@@ -187,6 +279,8 @@ async function _runMigrationsLocked(
     const sql = fs.readFileSync(filePath, "utf-8");
 
     log.info({ migration: file }, "Applying migration");
+    // So a `RAISE NOTICE` raised below is attributed to THIS file.
+    noticeFrom.migration = file;
 
     // Run inside a transaction — PostgreSQL DDL is transactional.
     // All queries use the same dedicated client (not the pool) so

--- a/packages/api/src/lib/db/migrations/0194_brain_fact_slot_keys_not_null.sql
+++ b/packages/api/src/lib/db/migrations/0194_brain_fact_slot_keys_not_null.sql
@@ -1,0 +1,254 @@
+-- 0194 — Claim identity, step three and last: the slot keys become TOTAL
+-- (#5047, ADR-0037 §1 "The identity key" / §7 "Migration").
+--
+-- 0187 added `subject_key` / `predicate_key` / `object_key` nullable and keyed
+-- every row that existed. 0188 repeated that backfill for the rows written in
+-- the window before #5020 keyed `INSERT_FACT_SQL`. This file makes a NULL key
+-- impossible, which is what makes a NULL key mean ONE thing again — or rather,
+-- nothing at all.
+--
+-- ⚠️ READ 0187's header before this one. It enumerates the three prerequisites
+-- of `SET NOT NULL` and it is deliberately more careful than any summary of it.
+-- All three are in place as of this migration's own PR:
+--
+--   1. **Both writers key their rows.** #5020 keyed `INSERT_FACT_SQL`; #5035
+--      carries keys verbatim on a v3 region bundle and keys a legacy v1/v2
+--      bundle once at import.
+--   2. **The backfill is re-run immediately before the constraint** — below,
+--      and see "Why the re-run is not 0188's statement" for the two caveats
+--      0187 attached to that repeat, both of which have gone live since.
+--   3. **The ingest guard is tightened.** `reconcile.ts`'s `MALFORMED_CLAIM`
+--      now refuses a candidate whose `slotKey` is null, post-resolution. Without
+--      it this constraint would not merely fail on legacy rows: `String#trim`
+--      strips whitespace but not `_` or `-`, so `-` and `___` are STORABLE
+--      claims today, and an ordinary ingest would start raising `23502` and
+--      failing the whole reconcile transaction.
+--
+-- ## The three populations, and why only one of them needed a decision
+--
+-- After 0188, a NULL key has exactly three causes, and they are not one problem:
+--
+--   * **Written in a gap.** A rolling deploy's own overlap re-opens the window
+--     each backfill closes: the migration commits on the new instance while the
+--     N-1 instance's extraction fiber is still writing through the old
+--     `INSERT_FACT_SQL`. 0188's header names this and says the constraint flip's
+--     own backfill re-run is what sweeps the residue. That is the `UPDATE`s
+--     below.
+--   * **Landed by a region import.** #5035 closed the systematic case. What can
+--     still arrive is a null on the wire, which `admin-migrate.ts` now handles on
+--     this file's terms rather than writing it.
+--   * **A surface that normalizes away.** `-`, `___`, `  ` key to NULL
+--     permanently and LEGALLY (`identityKey`'s ⚠️, and 0188's "What this does
+--     NOT fix"). No backfill has ever been able to repair these — 0187 and 0188
+--     both re-visit them on every run and both write the same NULL — because
+--     there is no key to compute. They are the only population that needed a
+--     policy, and the section below is it.
+--
+-- ## Why the re-run is not 0188's statement, character for character
+--
+-- 0188 IS 0187's statement character for character, and `migrate.test.ts`
+-- asserts that byte-identity. This file breaks that lineage deliberately, on
+-- both of the caveats 0187 attached to the repeat — each of which was inert when
+-- 0188 shipped and is live now.
+--
+--   1. **It is no longer a PRE-VOCABULARY operation.** 0187's caveat: *"This
+--      statement writes the raw `identityKey(surface)`, so once `alias` is a real
+--      table, re-running it OVERWRITES aliased keys on every row it matches."*
+--      `alias` became a real table with #5022 (migration 0189,
+--      `brain_vocabulary_target`). Two consequences, and the fix for each is
+--      below:
+--        * The value written must be `alias(lexicalNorm(surface))`, not
+--          `lexicalNorm(surface)`. A row keyed with the raw norm sits in a
+--          DIFFERENT slot from every sibling the vocabulary unified, which is an
+--          under-match nothing surfaces. So the statements below join
+--          `brain_vocabulary_target` and are transcriptions of
+--          `REKEY_DRIFTED_FACTS_SQL` (`lib/brain/vocabulary-decide.ts`, #5024),
+--          which is itself the SQL transcription of `slotKey`.
+--        * The statement must touch ONE column per statement. 0187 and 0188 are
+--          a single `UPDATE` setting all three keys `WHERE (subject_key IS NULL
+--          OR predicate_key IS NULL OR object_key IS NULL)`, so a row unkeyed at
+--          ONE position has its other two keys rewritten as well. Pre-vocabulary
+--          that is a no-op; post-vocabulary it silently reverts two aliased keys
+--          to raw norms. Hence three statements, each scoped to its own column.
+--      This is a KEYING operation and not a re-keying one, and the per-column
+--      `IS NULL` scope is what keeps that true — which matters because ADR-0037
+--      §7 puts re-keying in the decide transaction, in TypeScript, and
+--      `check-brain-fact-promotion.sh`'s identity remedy block says so by name.
+--      A row that already has a key is not touched here at any position.
+--   2. **`subject_key IS NULL` already means two things.** So the count of rows
+--      this migration must repair is NOT `WHERE subject_key IS NULL` — that set
+--      includes the permanently-degenerate rows, which no `UPDATE` repairs.
+--      Wherever this file needs to distinguish them it compares against the
+--      EXPRESSION, never against the column: a row is repairable exactly when
+--      the expression is NOT NULL and the column is, and permanently unkeyable
+--      exactly when the expression is NULL. The two statements below are written
+--      in those terms rather than in the column's.
+--
+-- ## The degenerate population: TOMBSTONED, with a per-row placeholder key
+--
+-- A claim whose surface normalizes away asserts nothing. That is the argument
+-- the tightened `MALFORMED_CLAIM` guard now makes at ingest, and it is as true
+-- of a row written last year as of a candidate arriving now. The rows already in
+-- the corpus cannot be refused retroactively, so this migration does the nearest
+-- honest thing: it marks them as not-beliefs and leaves everything else intact.
+--
+--   * **`invalidated_at` — the tombstone, and the load-bearing half.** 0180 calls
+--     it exactly that, and `schema.ts` states the corpus invariant as
+--     *"invalidate-never-delete. Nothing DELETEs."* — so deleting these rows was
+--     never on the table, whatever their content. The tombstone is also what
+--     makes the placeholder below SAFE rather than merely legal: all three slot
+--     consumers (`CORROBORATION_LOOKUP_SQL`, `TENSION_CANDIDATES_SQL`,
+--     `supersessionCollisionJoin`) require `invalidated_at IS NULL AND valid_to
+--     IS NULL`, so a tombstoned row is outside every join by the tombstone and
+--     not by its key. Its behaviour is therefore what it was — it joined nothing
+--     before, it joins nothing now.
+--   * **The placeholder is PER-ROW, and that is the whole difference from the
+--     sentinel 0187 rejects.** That header rejects a sentinel key as *"the
+--     one-slot-for-every-placeholder hazard"* — a SHARED value under which every
+--     degenerate row joins every other one, so publishing either stamps
+--     `valid_to` on the other. `'-unkeyable:' || id` is unique per row, so the
+--     hazard it names cannot arise: the value equals itself and nothing else.
+--   * **No computed key can ever collide with it**, for two independent reasons,
+--     stated twice on purpose because this is the property the placeholder rests
+--     on. `lexicalNorm` collapses every run of `[ \t\n\v\f\r_-]` to one space and
+--     then trims, so (a) its output can never START with `-`, and (b) its output
+--     can never CONTAIN a `-` at all, which the id's own hyphens would also
+--     defeat. Both hold for a carried foreign key too (#5035), since that is the
+--     source region's `lexicalNorm` output.
+--   * **`updated_at` is NOT stamped**, matching 0187 and 0188 and for their
+--     reason: it sorts the publish preview and is projected on the wire by the
+--     candidates read, so a workspace-wide stamp reshuffles every reviewer's
+--     draft queue. A tombstone removes the row from that queue outright
+--     (`brainFactCurrentClause`), so there is nothing for a sort key to order.
+--
+-- What this costs, stated plainly rather than left for a reader to find: these
+-- rows leave `searchBrain` and the review queue, where they were previously
+-- visible. They were unreviewable — nothing about `Billing / is owned by / -` can
+-- be corroborated, contradicted, arbitrated, or corrected — and the system now
+-- refuses to create more of them. The surfaces are retained verbatim, the
+-- provenance edges are untouched, and `invalidated_at` can be cleared by hand if
+-- an operator disagrees.
+--
+-- One consumer had to learn about this population: `REKEY_DRIFTED_FACTS_SQL`
+-- re-derives every key in a workspace at the next alias decision, INCLUDING
+-- tombstoned rows (deliberately — the re-derive-from-surface undo needs them),
+-- and for these rows it re-derives NULL. Left alone it would write that NULL
+-- into a `NOT NULL` column and abort a human-gated alias approval with a `23502`
+-- that has nothing to do with the approval. #5047 adds an `IS NOT NULL` arm
+-- there; see that statement's comment.
+--
+-- ## Scale
+--
+-- Four passes over `brain_facts` under the migration runner's advisory lock (the
+-- three keying `UPDATE`s and the tombstone), plus three `SET NOT NULL`, each of
+-- which is a full validating scan on PG 16 — `ALTER TABLE … SET NOT NULL` can
+-- skip the scan only when a matching `CHECK … NOT NULL` constraint already
+-- proves it, and there is none here. 0187 measured a four-figure corpus at the
+-- largest deployment the team could observe as of 2026-08-03, so this is a
+-- sub-second hold; it grows linearly, and that estimate carries 0187's own
+-- caveat about self-hosted installs nobody can see. The three keying `UPDATE`s
+-- touch zero rows on any corpus that deployed 0187, 0188 and #5020 together,
+-- which is every fresh install and every CI run, and pay only the scan.
+
+-- ── 1. The backfill re-run: vocabulary-aware, one statement per column ──────
+--
+-- Each statement is `REKEY_DRIFTED_FACTS_SQL[position]` with two changes: it is
+-- unscoped by workspace (a migration has no request to scope to), and its
+-- predicate is `IS NULL` rather than `IS DISTINCT FROM`, which is what makes it
+-- a keying operation rather than a re-key. The inner expression is 0187's,
+-- character for character, and every reason 0187's header gives for its shape
+-- holds here unchanged — `chr()` instead of a backslash class (escape processing
+-- is a GUC, and `\v` silently degrades to a literal `v`, shredding every key
+-- containing one), `translate()` instead of `lower()` (`lower()` disagrees with
+-- `String#toLowerCase()` on U+0130 and on word-final sigma, and moves with the
+-- database collation), and `NULLIF(…, '')` instead of a stored empty string
+-- (which would make every degenerate row join every other one).
+--
+-- The COALESCE is `alias`: a norm with no vocabulary entry maps to itself. The
+-- OUTER `NULLIF(btrim(regexp_replace(translate(…` is `slotKey`'s re-norm of the
+-- vocabulary's answer, and it is not optional — an entry authored as
+-- `is priced at → "Priced At"` would otherwise write a key that joins nothing.
+-- A surface that normalizes away yields NULL from the inner expression, so the
+-- closure lookup matches no row (`norm = NULL` is never true), the COALESCE
+-- stays NULL and the key stays NULL. That is `slotKey`'s "the alias is never
+-- consulted for a claim that asserts nothing", reached by the same road — and it
+-- is precisely the population statement 2 then tombstones.
+
+UPDATE brain_facts f
+   SET subject_key = NULLIF(btrim(regexp_replace(translate(COALESCE((SELECT t.effective_target
+                                                                       FROM brain_vocabulary_target t
+                                                                      WHERE t.workspace_id = f.workspace_id
+                                                                        AND t.slot_position = 'subject'
+                                                                        AND t.norm = NULLIF(btrim(regexp_replace(translate(f.subject, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz'), '[ ' || chr(9) || chr(10) || chr(11) || chr(12) || chr(13) || '_-]+', ' ', 'g'), ' '), '')),
+                                                                    NULLIF(btrim(regexp_replace(translate(f.subject, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz'), '[ ' || chr(9) || chr(10) || chr(11) || chr(12) || chr(13) || '_-]+', ' ', 'g'), ' '), '')),
+                                                          'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz'), '[ ' || chr(9) || chr(10) || chr(11) || chr(12) || chr(13) || '_-]+', ' ', 'g'), ' '), '')
+ WHERE f.subject_key IS NULL;
+
+UPDATE brain_facts f
+   SET predicate_key = NULLIF(btrim(regexp_replace(translate(COALESCE((SELECT t.effective_target
+                                                                         FROM brain_vocabulary_target t
+                                                                        WHERE t.workspace_id = f.workspace_id
+                                                                          AND t.slot_position = 'predicate'
+                                                                          AND t.norm = NULLIF(btrim(regexp_replace(translate(f.predicate, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz'), '[ ' || chr(9) || chr(10) || chr(11) || chr(12) || chr(13) || '_-]+', ' ', 'g'), ' '), '')),
+                                                                      NULLIF(btrim(regexp_replace(translate(f.predicate, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz'), '[ ' || chr(9) || chr(10) || chr(11) || chr(12) || chr(13) || '_-]+', ' ', 'g'), ' '), '')),
+                                                            'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz'), '[ ' || chr(9) || chr(10) || chr(11) || chr(12) || chr(13) || '_-]+', ' ', 'g'), ' '), '')
+ WHERE f.predicate_key IS NULL;
+
+UPDATE brain_facts f
+   SET object_key = NULLIF(btrim(regexp_replace(translate(COALESCE((SELECT t.effective_target
+                                                                      FROM brain_vocabulary_target t
+                                                                     WHERE t.workspace_id = f.workspace_id
+                                                                       AND t.slot_position = 'object'
+                                                                       AND t.norm = NULLIF(btrim(regexp_replace(translate(f.object, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz'), '[ ' || chr(9) || chr(10) || chr(11) || chr(12) || chr(13) || '_-]+', ' ', 'g'), ' '), '')),
+                                                                   NULLIF(btrim(regexp_replace(translate(f.object, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz'), '[ ' || chr(9) || chr(10) || chr(11) || chr(12) || chr(13) || '_-]+', ' ', 'g'), ' '), '')),
+                                                         'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz'), '[ ' || chr(9) || chr(10) || chr(11) || chr(12) || chr(13) || '_-]+', ' ', 'g'), ' '), '')
+ WHERE f.object_key IS NULL;
+
+-- ── 2. The permanently-unkeyable remainder: tombstone, then placeholder ─────
+--
+-- Everything statement 1 could key is keyed, so what still tests NULL here is
+-- exactly the population whose EXPRESSION is NULL — which is the distinction
+-- 0187's second caveat demands, arrived at by construction rather than by
+-- restating the expression a fourth time. Testing the column is correct HERE and
+-- only here, and only because the statements above ran first in the same
+-- transaction.
+--
+-- `COALESCE` per column rather than one blanket assignment: a row can be
+-- degenerate at one position and perfectly keyed at the other two (`Billing /
+-- is owned by / -` is the shape that reaches this in practice), and overwriting
+-- the good keys with placeholders would take a row that is merely valueless at
+-- one slot and make it unreachable at all three.
+--
+-- `invalidated_at` is likewise `COALESCE`d: a row already tombstoned keeps its
+-- original timestamp, because when it stopped being a belief is a fact about the
+-- corpus and not about this migration.
+--
+-- The parenthesized `OR` group is 0187's and 0188's, kept for their reason: the
+-- arms are all `OR`, so the group is redundant TODAY and `AND` binds tighter, so
+-- a fourth arm that scopes the statement reads as unscoped and is not.
+UPDATE brain_facts f
+   SET subject_key    = COALESCE(f.subject_key,   '-unkeyable:' || f.id::text),
+       predicate_key  = COALESCE(f.predicate_key, '-unkeyable:' || f.id::text),
+       object_key     = COALESCE(f.object_key,    '-unkeyable:' || f.id::text),
+       invalidated_at = COALESCE(f.invalidated_at, now())
+ WHERE (f.subject_key IS NULL
+     OR f.predicate_key IS NULL
+     OR f.object_key IS NULL);
+
+-- ── 3. The constraint ───────────────────────────────────────────────────────
+--
+-- ADR-0037 §1: *"`subject_key`, `predicate_key`, `object_key` are `NOT NULL`."*
+-- Three separate statements because that is what `ALTER TABLE … ALTER COLUMN`
+-- takes; they are one transaction either way, since the runner wraps the file.
+--
+-- What this buys is not tidiness. Until now `= NULL` being unknown made an
+-- unkeyed row silently INVISIBLE to all three slot consumers: a re-observation
+-- forked a duplicate draft instead of strengthening the fact, no advisory
+-- tension edge was minted, and the publish gate's will-supersede disclosure
+-- reported "nothing to supersede" for a draft whose check could not run — a
+-- positive verdict where the check was skipped. Fail-closed, recoverable, and
+-- undetectable. The constraint is what makes that state unrepresentable instead
+-- of merely rare.
+ALTER TABLE brain_facts ALTER COLUMN subject_key SET NOT NULL;
+ALTER TABLE brain_facts ALTER COLUMN predicate_key SET NOT NULL;
+ALTER TABLE brain_facts ALTER COLUMN object_key SET NOT NULL;

--- a/packages/api/src/lib/db/migrations/0194_brain_fact_slot_keys_not_null.sql
+++ b/packages/api/src/lib/db/migrations/0194_brain_fact_slot_keys_not_null.sql
@@ -35,14 +35,32 @@
 --     own backfill re-run is what sweeps the residue. That is the `UPDATE`s
 --     below.
 --   * **Landed by a region import.** #5035 closed the systematic case. What can
---     still arrive is a null on the wire, which `admin-migrate.ts` now handles on
---     this file's terms rather than writing it.
+--     still arrive is a null on the wire, and `admin-migrate.ts` now splits it by
+--     the SURFACE: a fact whose surface also normalizes away is tombstoned on this
+--     file's terms, while one whose surface keys perfectly well REFUSES the import
+--     — that row is repairable by the next drift re-key, and both ways of landing
+--     it (tombstoning a healthy belief, or re-deriving its key under this region's
+--     vocabulary) are irreversible.
 --   * **A surface that normalizes away.** `-`, `___`, `  ` key to NULL
 --     permanently and LEGALLY (`identityKey`'s ⚠️, and 0188's "What this does
 --     NOT fix"). No backfill has ever been able to repair these — 0187 and 0188
 --     both re-visit them on every run and both write the same NULL — because
 --     there is no key to compute. They are the only population that needed a
 --     policy, and the section below is it.
+--
+-- ## The reverse deploy-overlap window, which this migration OPENS
+--
+-- The first bullet above covers an N-1 instance writing UNKEYED rows BEFORE the
+-- constraint. The reverse is worth stating because it is the one an operator
+-- sees: once this file commits on the new instance, an N-1 instance — which has
+-- #5020's keyed `INSERT_FACT_SQL` but NOT #5047's tightened guard — that ingests
+-- `-` or `___` binds NULL and takes a `23502`, failing the WHOLE reconcile
+-- transaction, i.e. every candidate in that episode rather than the one offender.
+-- On the `correct_fact` path it surfaces as a 500.
+--
+-- Bounded and self-healing: the episode stays on the queue and is retried, and
+-- the window closes when the rollout completes. Recorded so `23502` spikes during
+-- a deploy read as expected rather than as a new defect.
 --
 -- ## Why the re-run is not 0188's statement, character for character
 --
@@ -226,14 +244,36 @@ UPDATE brain_facts f
 -- The parenthesized `OR` group is 0187's and 0188's, kept for their reason: the
 -- arms are all `OR`, so the group is redundant TODAY and `AND` binds tighter, so
 -- a fourth arm that scopes the statement reads as unscoped and is not.
-UPDATE brain_facts f
-   SET subject_key    = COALESCE(f.subject_key,   '-unkeyable:' || f.id::text),
-       predicate_key  = COALESCE(f.predicate_key, '-unkeyable:' || f.id::text),
-       object_key     = COALESCE(f.object_key,    '-unkeyable:' || f.id::text),
-       invalidated_at = COALESCE(f.invalidated_at, now())
- WHERE (f.subject_key IS NULL
-     OR f.predicate_key IS NULL
-     OR f.object_key IS NULL);
+--
+-- Wrapped in a `DO` block for the ROW COUNT, which is this statement's one
+-- operator breadcrumb. It retires beliefs — they leave `searchBrain` and the
+-- review queue at boot — and an operator who notices a smaller review queue
+-- afterwards has no other way to correlate it with this deploy. 0032's header
+-- names the mistake this repeats otherwise: *"Emit a RAISE NOTICE with the
+-- coerced row count so operators have a post-mortem breadcrumb instead of silent
+-- rewrites (0031 shipped without this — don't repeat that gap)."* 0034, 0055,
+-- 0072 and 0085 all follow it.
+--
+-- ⚠️ Those five breadcrumbs were being DISCARDED until #5047: `migrate.ts` ran
+-- each file with no `notice` listener on the client, and `node-postgres` drops a
+-- server notice when nothing is listening. The listener was added in this same
+-- PR, which is the only reason this block is a signal rather than a decoration.
+DO $$
+DECLARE tombstoned_count INTEGER;
+BEGIN
+  UPDATE brain_facts f
+     SET subject_key    = COALESCE(f.subject_key,   '-unkeyable:' || f.id::text),
+         predicate_key  = COALESCE(f.predicate_key, '-unkeyable:' || f.id::text),
+         object_key     = COALESCE(f.object_key,    '-unkeyable:' || f.id::text),
+         invalidated_at = COALESCE(f.invalidated_at, now())
+   WHERE (f.subject_key IS NULL
+       OR f.predicate_key IS NULL
+       OR f.object_key IS NULL);
+  GET DIAGNOSTICS tombstoned_count = ROW_COUNT;
+  IF tombstoned_count > 0 THEN
+    RAISE NOTICE '[0194] tombstoned % brain_facts row(s) whose surface normalizes away, each with a per-row placeholder key. They leave searchBrain and the review queue; their surfaces are retained verbatim and only clearing invalidated_at by hand restores them', tombstoned_count;
+  END IF;
+END $$;
 
 -- ── 3. The constraint ───────────────────────────────────────────────────────
 --

--- a/packages/api/src/lib/db/migrations/0194_brain_fact_slot_keys_not_null.sql
+++ b/packages/api/src/lib/db/migrations/0194_brain_fact_slot_keys_not_null.sql
@@ -269,9 +269,25 @@ BEGIN
    WHERE (f.subject_key IS NULL
        OR f.predicate_key IS NULL
        OR f.object_key IS NULL);
+  -- ⚠️ THIS SELECTS ON THE COMPOSED EXPRESSION'S RESULT, WHICH IS TWO
+  -- POPULATIONS, NOT ONE. Statement 1 wrote `alias(lexicalNorm(surface))`, so a
+  -- key is still NULL here when the SURFACE normalizes away (permanent, and the
+  -- case this section's argument is written for) OR when this workspace's
+  -- vocabulary maps a real norm to something that does (repairable — remove the
+  -- alias entry and the drift re-key restores the key).
+  --
+  -- The second is closed today by the authoring guards (`vocabulary-decide.ts`
+  -- refuses a `degenerate-norm` target, `validateBundle` refuses a non-norm
+  -- edge), so it should reach this statement only through a hand-written or
+  -- restored `brain_vocabulary_target` row. It is named anyway, for the reason
+  -- `REKEY_DRIFTED_FACTS_SQL` gives for not leaning on those guards either — and
+  -- because the cost is asymmetric: a repairable row tombstoned here comes back
+  -- keyed but permanently invisible, since nothing in the product clears
+  -- `invalidated_at`. The notice below says both causes rather than asserting
+  -- the one this file would prefer.
   GET DIAGNOSTICS tombstoned_count = ROW_COUNT;
   IF tombstoned_count > 0 THEN
-    RAISE NOTICE '[0194] tombstoned % brain_facts row(s) whose surface normalizes away, each with a per-row placeholder key. They leave searchBrain and the review queue; their surfaces are retained verbatim and only clearing invalidated_at by hand restores them', tombstoned_count;
+    RAISE NOTICE '[0194] tombstoned % brain_facts row(s) that could not be keyed, each with a per-row placeholder key. TWO causes reach this: the surface normalizes away (permanent — no vocabulary can ever key it), or this workspace''s vocabulary maps that norm to something that does (repairable — fix the alias entry, though the tombstone stays until cleared by hand). They leave searchBrain and the review queue; their surfaces are retained verbatim and only clearing invalidated_at restores them', tombstoned_count;
   END IF;
 END $$;
 

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -3297,30 +3297,30 @@ export const brainFacts = pgTable(
     // reading the surface, so a vocabulary edit cannot silently re-rank
     // `searchBrain`.
     //
-    // NULLABLE, and for longer than one slice. `alias` is the identity function
-    // until the vocabulary lands, so 0187 fills every existing row with
-    // `identityKey(surface)`. `INSERT_FACT_SQL` names all three since #5020;
-    // the region import names all three since #5035 — carried verbatim on a v3
-    // bundle, computed once against the destination's post-merge vocabulary
-    // below it. BOTH writers are now in place; what still blocks `SET NOT NULL`
-    // is the third prerequisite, the ingest guard (#5047).
+    // NOT NULL since migration 0194 (#5047), which took three slices to reach.
+    // They landed nullable in 0187 because neither INSERT site named them; #5020
+    // keyed `INSERT_FACT_SQL`, #5035 made the region import carry them verbatim
+    // on a v3 bundle (computed once against the destination's post-merge
+    // vocabulary for a legacy one), and #5047 supplied the third prerequisite
+    // 0187's header enumerates: `reconcile.ts`'s `MALFORMED_CLAIM` guard now
+    // refuses a candidate whose `slotKey` is null.
     //
-    // NULL carries TWO meanings, and conflating them is how the constraint
-    // plan goes wrong: "no writer has keyed this row yet" (transient, what
-    // `SET NOT NULL` exists to eliminate) and "this surface norms away to
-    // nothing" (permanent, and a legal state of a storable claim — see
-    // `identityKey`). Either way it joins nothing, which is why one column can
-    // carry both; but the second means `SET NOT NULL` needs an ingest-guard
-    // change as well as a writer. 0187's header enumerates all three
-    // prerequisites — read it there rather than trusting a one-line summary
-    // here, which is what an earlier version of this comment was.
+    // NULL used to carry TWO meanings, and eliminating the first is what the
+    // constraint is FOR: "no writer has keyed this row yet" (transient) and
+    // "this surface normalizes away to nothing" (permanent, and a legal state of
+    // a claim that was storable until #5047 — see `identityKey`). Either way it
+    // joined nothing, which is why one column could carry both, and why the
+    // constraint needed a guard change and not just a writer. The legacy rows
+    // holding the second meaning are tombstoned and carry a per-row placeholder;
+    // 0194's header is the argument, and it is the one to read rather than this
+    // summary.
     //
     // Never projected to the wire. No read surface selects a key column —
     // `keys-not-on-the-wire.test.ts` makes that a prohibition rather than an
     // accident of what has been written so far.
-    subjectKey: text("subject_key"),
-    predicateKey: text("predicate_key"),
-    objectKey: text("object_key"),
+    subjectKey: text("subject_key").notNull(),
+    predicateKey: text("predicate_key").notNull(),
+    objectKey: text("object_key").notNull(),
     // The comparable value — the column that can prove DIFFERENCE, where the
     // three keys above prove only SAMENESS (#5030, ADR-0037 §2, migration
     // 0191). A typed canonical value, tagged (`money:USD:499`, `number:499`,

--- a/packages/api/src/lib/residency/__tests__/migrate-identity-logging.test.ts
+++ b/packages/api/src/lib/residency/__tests__/migrate-identity-logging.test.ts
@@ -79,10 +79,18 @@ void mock.module("@atlas/api/lib/logger", () => {
 });
 
 type ImportBundle = typeof import("@atlas/api/api/routes/admin-migrate")["importBundle"];
+type UnkeyableError =
+  typeof import("@atlas/api/api/routes/admin-migrate")["RegionImportUnkeyableError"];
 let importBundle: ImportBundle;
+// Loaded through the same dynamic import as `importBundle`, not a static one:
+// this file mocks the logger module, so a static import would bind the real one
+// before the mock is installed.
+let RegionImportUnkeyableError: UnkeyableError;
 
 beforeAll(async () => {
-  ({ importBundle } = await import("@atlas/api/api/routes/admin-migrate"));
+  ({ importBundle, RegionImportUnkeyableError } = await import(
+    "@atlas/api/api/routes/admin-migrate"
+  ));
 });
 
 afterEach(() => {
@@ -220,21 +228,49 @@ describe("the identity-loss line (#5035)", () => {
     expect(warn!.message).toContain("DRIFT");
   });
 
-  it("reports a v3 fact that ARRIVED unkeyed — the exporter's own drift shape", async () => {
-    // The destination-side half of `textOrNull`'s failure. Region A's projection
-    // drops `f.subject_key`; every fact exports `null`; this region accepts it
-    // (null is legitimate at all five positions) and lands the whole corpus
-    // unkeyed. Without this counter the only signal lives in the OTHER region's
-    // log stream, and nobody watching the cutover reads it.
+  it("REFUSES a v3 fact that arrived unkeyed while its surface keys — the drift shape", async () => {
+    // The destination-side half of `textOrNull`'s failure, and #5047 changed the
+    // answer rather than the question. Region A's projection drops
+    // `f.subject_key`; every fact exports `null`; this region used to accept it
+    // and land the whole corpus unkeyed, with a counter as the only local
+    // signal.
+    //
+    // It now REFUSES, because the row is REPAIRABLE — `acme` keys perfectly well,
+    // so the next drift re-key would restore it — and the two ways of landing it
+    // are not. Tombstoning retires a healthy belief that no verb restores;
+    // re-deriving the key under THIS region's vocabulary is the over-match
+    // ADR-0037 §8 forbids. Refusing is the only outcome that writes nothing, and
+    // it is a louder signal than any counter.
+    const { client } = captureClient();
+    await expect(
+      importBundle(
+        client,
+        bundleWith([fact("f-1", { subjectKey: null }), fact("f-2", {})]),
+        "org-log",
+      ),
+    ).rejects.toBeInstanceOf(RegionImportUnkeyableError);
+  });
+
+  it("COUNTS a v3 fact that arrived unkeyed because its surface asserts nothing", async () => {
+    // The other cause, and the one that still lands. `-` has no identity in any
+    // region under any vocabulary, so there is nothing for the source to have
+    // carried and nothing to repair. It lands tombstoned with a placeholder key
+    // (migration 0194's treatment of the same state), and the counters are what
+    // an operator reads — `tombstonedFacts` being the one to act on, since those
+    // rows are invisible to searchBrain and the review queue.
     const { client } = captureClient();
     await importBundle(
       client,
-      bundleWith([fact("f-1", { subjectKey: null }), fact("f-2", {})]),
-      "org-log",
+      bundleWith([fact("f-1", { object: "-", objectKey: null }), fact("f-2", {})]),
+      "org-log-degenerate",
     );
     const warn = identityWarn();
     expect(warn, "a v3 fact arriving with no key is silent").toBeDefined();
-    expect(warn!.payload).toMatchObject({ nullKeyFacts: 1, unkeyableFacts: 0 });
+    expect(warn!.payload).toMatchObject({
+      nullKeyFacts: 1,
+      unkeyableFacts: 0,
+      tombstonedFacts: 1,
+    });
   });
 
   it("says nothing when nothing was lost", async () => {

--- a/packages/api/src/lib/residency/__tests__/migrate-identity-logging.test.ts
+++ b/packages/api/src/lib/residency/__tests__/migrate-identity-logging.test.ts
@@ -14,9 +14,12 @@
  *     releases produce exactly this, and nothing else in the system would ever
  *     mention it.
  *   - **`unkeyable`** — a legacy surface that normalizes away, so no key exists.
- *     Legal and permanent; the ingest path warns about it and calls that "the
- *     only signal such a claim ever produces", and this is the second key
- *     writer.
+ *     Permanent, and since #5047 this importer is the ONLY writer that still
+ *     lands such a row: the ingest path refuses the claim outright
+ *     (`MALFORMED_CLAIM`), and a region migration cannot refuse a row the source
+ *     region already holds. It lands tombstoned behind a per-row placeholder
+ *     key, so nothing else in the product will ever mention it again — this
+ *     count is the whole record that it happened.
  *
  * A `200` with healthy `imported` counts is the same response in all three
  * cases. The line is the difference, and a line nothing checks is deletable
@@ -288,10 +291,11 @@ describe("the identity-loss line (#5035)", () => {
   });
 
   it("counts a legacy surface that normalizes away as `unkeyable`", async () => {
-    // The second key writer's parity with the ingest path, which warns about
-    // exactly this and calls it "the only signal such a claim ever produces".
-    // `___` and `-` normalize to the empty string, and `identityKey` returns
-    // null rather than storing a key every other unkeyed row would join.
+    // The second key writer's counterpart to the ingest path, which since #5047
+    // refuses this claim shape outright (`MALFORMED_CLAIM`) — so the count here
+    // is the only record that one arrived. `___` and `-` normalize to the empty
+    // string, and `identityKey` returns null rather than storing a key every
+    // other unkeyed row would join.
     const { client } = captureClient();
     const legacy = bundleWith(
       [

--- a/packages/api/src/lib/residency/__tests__/migrate-roundtrip-pg.test.ts
+++ b/packages/api/src/lib/residency/__tests__/migrate-roundtrip-pg.test.ts
@@ -1545,8 +1545,9 @@ describeIfPg("region-migration bundle round-trip (real Postgres, #4460)", () => 
       );
       await pool.query(
         `INSERT INTO brain_facts (id, workspace_id, subject, predicate, object,
+                                  subject_key, predicate_key, object_key,
                                   source_episode_id, provenance, visible_to)
-         VALUES ($1, $2, 's', 'p', 'o', $3, '{"actor":"u"}'::jsonb, ARRAY['org'])`,
+         VALUES ($1, $2, 's', 'p', 'o', 's', 'p', 'o', $3, '{"actor":"u"}'::jsonb, ARRAY['org'])`,
         [cleanFact, CLEAN_ORG, cleanEpisode],
       );
       await pool.query(
@@ -1633,8 +1634,9 @@ describeIfPg("region-migration bundle round-trip (real Postgres, #4460)", () => 
         );
         await pool.query(
           `INSERT INTO brain_facts (id, workspace_id, subject, predicate, object, ingested_at,
+                                    subject_key, predicate_key, object_key,
                                     source_episode_id, provenance, status, visible_to)
-           VALUES ($1, $2, 's', 'p', 'o', now(), $3, '{"actor":"u"}'::jsonb, 'draft', ARRAY['org'])`,
+           VALUES ($1, $2, 's', 'p', 'o', now(), 's', 'p', 'o', $3, '{"actor":"u"}'::jsonb, 'draft', ARRAY['org'])`,
           [SPARED_FACT, SPARED_ORG, SPARED_EPISODE],
         );
 

--- a/packages/api/src/lib/residency/__tests__/migrate-roundtrip-pg.test.ts
+++ b/packages/api/src/lib/residency/__tests__/migrate-roundtrip-pg.test.ts
@@ -28,7 +28,11 @@ import { exportWorkspaceBundle } from "../export";
 import { approveAliasEdge, recomputeEffectiveTargets } from "@atlas/api/lib/brain/vocabulary";
 import { identityVocabulary } from "@atlas/api/lib/brain/identity";
 import { reconcileFacts } from "@atlas/api/lib/brain/reconcile";
-import { importBundle, validateBundle } from "../../../api/routes/admin-migrate";
+import {
+  RegionImportUnkeyableError,
+  importBundle,
+  validateBundle,
+} from "../../../api/routes/admin-migrate";
 import { PROVISIONAL_PREDICATE } from "@atlas/api/lib/brain/candidates";
 import { buildCleanupStatements, runSourceCleanupSweep } from "../cleanup";
 import type { ImportResult } from "@useatlas/types";
@@ -1731,6 +1735,250 @@ describeIfPg("region-migration bundle round-trip (real Postgres, #4460)", () => 
         if (savedRegion === undefined) delete process.env.ATLAS_API_REGION;
         else process.env.ATLAS_API_REGION = savedRegion;
       }
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// The import's answer to a fact with no identity (#5047)
+// ---------------------------------------------------------------------------
+
+describeIfPg("region import: a fact whose key cannot be supplied (#5047)", () => {
+  let pool: Pool;
+  const schemaName = `import_unkeyed_${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
+  const ORG = "org-unkeyed-import";
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: TEST_DB_URL });
+    pool.on("connect", (client) => {
+      void client.query(`SET search_path TO "${schemaName}"`).catch((err) => {
+        console.error(
+          `import-unkeyed: SET search_path failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      });
+    });
+    await pool.query(`CREATE SCHEMA IF NOT EXISTS "${schemaName}"`);
+    await runMigrations(pool, { skip: MANAGED_AUTH_MIGRATIONS });
+  }, PG_TEST_TIMEOUT_MS);
+
+  afterAll(async () => {
+    if (!pool) return;
+    await pool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+    await pool.end();
+  });
+
+  /**
+   * A minimal v3 bundle carrying one episode and one fact.
+   *
+   * `episodeId` is a parameter because `brain_episodes_pkey` is on `id` alone
+   * rather than `(workspace_id, id)`, so two cases reusing one id collide even
+   * in different orgs.
+   */
+  function bundleWith(
+    fact: Record<string, unknown>,
+    episodeId = "aaaaaaaa-0000-4000-8000-0000000000e1",
+  ): Record<string, unknown> {
+    return {
+      manifest: {
+        version: 3,
+        exportedAt: new Date().toISOString(),
+        source: { label: "region-a" },
+        counts: {
+          conversations: 0,
+          messages: 0,
+          semanticEntities: 0,
+          learnedPatterns: 0,
+          settings: 0,
+          brainEpisodes: 1,
+          brainFacts: 1,
+        },
+      },
+      conversations: [],
+      semanticEntities: [],
+      learnedPatterns: [],
+      settings: [],
+      // Required from v2 on: a producer that claims the version and drops a
+      // section is exporter drift, and `validateBundle` refuses it rather than
+      // stranding a pillar silently.
+      dashboards: [],
+      knowledgeDocuments: [],
+      scheduledTasks: [],
+      agentSessionMemory: [],
+      // Facts travel NESTED under their episode — the bundle has no top-level
+      // `brainFacts` section, and the episode is the evidence the fact hangs off.
+      brainEpisodes: [
+        {
+          id: episodeId,
+          source: "slack",
+          sourceId: `unkeyed-import-${episodeId}`,
+          sourceActor: "U1",
+          body: "evidence",
+          locator: null,
+          occurredAt: new Date().toISOString(),
+          ingestedAt: new Date().toISOString(),
+          extractedAt: null,
+          visibleTo: ["org"],
+          createdAt: new Date().toISOString(),
+          facts: [fact],
+        },
+      ],
+      brainEdges: [],
+      factAudienceMembers: [],
+    };
+  }
+
+  const baseFact = {
+    id: "aaaaaaaa-0000-4000-8000-0000000000f1",
+    // Overwritten per case below, alongside the episode id.
+    subject: "billing",
+    predicate: "is owned by",
+    object: "-",
+    subjectKey: "billing",
+    predicateKey: "is owned by",
+    objectKey: null,
+    subjectCmp: null,
+    objectCmp: null,
+    validFrom: null,
+    validTo: null,
+    ingestedAt: new Date().toISOString(),
+    invalidatedAt: null,
+    extractedAt: null,
+    sourceEpisodeId: "aaaaaaaa-0000-4000-8000-0000000000e1",
+    provenance: { source: "slack", actor: "U1" },
+    status: "draft",
+    visibleTo: ["org"],
+    preWideningVisibleTo: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+
+  async function runImport(body: Record<string, unknown>, org: string) {
+    const validation = validateBundle(body);
+    if (!validation.ok) throw new Error(`fixture bundle is invalid: ${validation.error}`);
+    const client = await pool.connect();
+    try {
+      await client.query("BEGIN");
+      const result = await importBundle(client, validation.bundle, org);
+      await client.query("COMMIT");
+      return result;
+    } catch (err) {
+      await client.query("ROLLBACK");
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
+
+  it(
+    "TOMBSTONES a fact whose surface normalizes away, with a per-row placeholder",
+    async () => {
+      // The one state where a null key is honest: `-` has no identity in any
+      // region under any vocabulary, so there is nothing to carry and nothing to
+      // compute. Migration 0194 does exactly this to the same state, and this is
+      // the second key writer agreeing with it.
+      const result = await runImport(bundleWith(baseFact), ORG);
+      expect(result.brainFacts.imported).toBe(1);
+
+      const { rows } = await pool.query<{
+        subject_key: string;
+        predicate_key: string;
+        object_key: string;
+        invalidated_at: Date | null;
+      }>(
+        `SELECT subject_key, predicate_key, object_key, invalidated_at
+           FROM brain_facts WHERE workspace_id = $1`,
+        [ORG],
+      );
+      expect(rows).toHaveLength(1);
+      // Per-row, so two such facts can never share a slot — the difference from
+      // the shared sentinel 0187's header rejects.
+      expect(rows[0]!.object_key).toBe(`-unkeyable:${baseFact.id}`);
+      // The keyable positions keep their CARRIED keys: a row valueless at one
+      // slot must not become unreachable at all three.
+      expect([rows[0]!.subject_key, rows[0]!.predicate_key]).toEqual(["billing", "is owned by"]);
+      // The tombstone is the load-bearing half — all three slot consumers
+      // require `invalidated_at IS NULL`, so this is what keeps the placeholder
+      // out of every join rather than the key's shape.
+      expect(
+        rows[0]!.invalidated_at,
+        "the placeholder landed LIVE — it is non-null and unequal to every real key, so the `<>` arm now reads it as a rival",
+      ).not.toBeNull();
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "REFUSES the import when the key is absent but the surface has one",
+    async () => {
+      // ⚠️ The falsifier for treating both null-key causes alike, which is what
+      // the first cut of #5047 did. This row's surface keys perfectly well, so
+      // it is REPAIRABLE — the next drift re-key computes a real key and it
+      // rejoins every consumer. Tombstoning it retires a healthy belief that no
+      // verb in the product can restore, and re-deriving its key here is what
+      // ADR-0037 §8 forbids. Refusing is the only outcome that writes nothing.
+      //
+      // This is the exporter-drift shape: a projection that stops returning the
+      // key columns exports null for every fact, and the destination would
+      // otherwise accept the whole corpus with a green 200.
+      const REFUSE_ORG = "org-unkeyed-refuse";
+      await expect(
+        runImport(
+          bundleWith(
+            {
+              ...baseFact,
+              id: "aaaaaaaa-0000-4000-8000-0000000000f3",
+              object: "platform team",
+              objectKey: null,
+              sourceEpisodeId: "aaaaaaaa-0000-4000-8000-0000000000e2",
+            },
+            "aaaaaaaa-0000-4000-8000-0000000000e2",
+          ),
+          REFUSE_ORG,
+        ),
+      ).rejects.toBeInstanceOf(RegionImportUnkeyableError);
+
+      // Nothing landed — the refusal rolled the whole transaction back, so the
+      // episode is gone too rather than left orphaned.
+      const { rows: facts } = await pool.query(
+        `SELECT 1 FROM brain_facts WHERE workspace_id = $1`,
+        [REFUSE_ORG],
+      );
+      expect(facts).toHaveLength(0);
+      const { rows: episodes } = await pool.query(
+        `SELECT 1 FROM brain_episodes WHERE workspace_id = $1`,
+        [REFUSE_ORG],
+      );
+      expect(episodes).toHaveLength(0);
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "preserves a SOURCE tombstone rather than restamping it",
+    async () => {
+      // The `COALESCE` on `invalidated_at`. When a claim stopped being a belief
+      // is a fact about the corpus, not about the import that moved it.
+      const KEEP_ORG = "org-unkeyed-keep";
+      const original = "2026-01-02T03:04:05.000Z";
+      await runImport(
+        bundleWith(
+          {
+            ...baseFact,
+            id: "aaaaaaaa-0000-4000-8000-0000000000f2",
+            invalidatedAt: original,
+            sourceEpisodeId: "aaaaaaaa-0000-4000-8000-0000000000e3",
+          },
+          "aaaaaaaa-0000-4000-8000-0000000000e3",
+        ),
+        KEEP_ORG,
+      );
+
+      const { rows } = await pool.query<{ invalidated_at: Date }>(
+        `SELECT invalidated_at FROM brain_facts WHERE workspace_id = $1`,
+        [KEEP_ORG],
+      );
+      expect(rows[0]!.invalidated_at.toISOString()).toBe(original);
     },
     PG_TEST_TIMEOUT_MS,
   );

--- a/packages/api/src/lib/tools/__tests__/correct-fact-tool.test.ts
+++ b/packages/api/src/lib/tools/__tests__/correct-fact-tool.test.ts
@@ -106,6 +106,7 @@ void mock.module("@atlas/api/lib/brain/correction", () => ({
     targetNotCurrent: "TARGET_NOT_CURRENT",
     replacementMissing: "REPLACEMENT_MISSING",
     replacementIdentical: "REPLACEMENT_IDENTICAL",
+    replacementMalformed: "REPLACEMENT_MALFORMED",
     replacementUnpublishable: "REPLACEMENT_UNPUBLISHABLE",
   } satisfies typeof import("@atlas/api/lib/brain/correction").CORRECTION_REFUSAL_REASONS,
   CorrectionRefusedError: class CorrectionRefusedError extends Error {},

--- a/scripts/check-brain-fact-promotion.sh
+++ b/scripts/check-brain-fact-promotion.sh
@@ -226,6 +226,25 @@
 # `db/migrations/scripts/*.ts` (where CLAUDE.md says they live) write this
 # column with no gate at all.
 #
+# ⚠️ THAT `.sql` EXEMPTION IS A REAL HOLE, and #5047 is the first migration to
+# walk through it, so it is recorded here rather than only in the migration:
+# `0194_brain_fact_slot_keys_not_null.sql` writes `invalidated_at` on rows whose
+# surfaces normalize away — a second, non-`promoteBrainFacts` retirement of
+# beliefs, including published ones. It passes this gate by EXCLUSION, not by
+# review, because `--include` cannot see it.
+#
+# The carve-out, per CLAUDE.md § Content Mode: those rows assert nothing at some
+# position. No reader could ever have acted on them, no vocabulary or re-key can
+# produce a key for them, and the ingest guard now refuses to create more. The
+# tombstone is what lets the slot keys be `NOT NULL` without inventing identity
+# for a row that has none. 0194's header carries the full argument.
+#
+# A future `.sql` migration writing `status`, `visible_to`, `valid_to` or
+# `invalidated_at` on `brain_facts` gets the same treatment: it is unguarded, so
+# it needs a reviewer who knows that. Widening `--include` to `.sql` is the real
+# fix and is not free — every historical migration would have to be allowlisted —
+# so this note is the interim, and the fact that it is an interim is the point.
+#
 # A regression here means a new promotion path appeared. Route it through
 # `promoteBrainFacts` (or, if it is genuinely a restore-not-a-decision like the
 # region import, add it to ALLOWLIST below WITH the rationale).

--- a/scripts/check-brain-fact-promotion.sh
+++ b/scripts/check-brain-fact-promotion.sh
@@ -119,6 +119,17 @@
 #     would re-queue a human's completed review work at every region cutover.
 #     It is a restore of a prior gate decision, not a new one; the import's own
 #     `grantProblem` validation is paired with the 0180 CHECK.
+#     ⚠️ THAT "RESTORE, NEVER MINT" READING NO LONGER COVERS THE WHOLE FILE
+#     (#5047). `tombstonePlaceholder` now MINTS an `invalidated_at` for a fact
+#     whose surface normalizes away, matching what migration 0194 does to the
+#     same population — the row has no identity at some position, cannot be
+#     keyed by any vocabulary or re-key, and the slot keys are NOT NULL. It is
+#     still not an ARBITRATION (nothing decided that a meaningful claim is
+#     false; the claim asserts nothing), which is the distinction this allowlist
+#     draws — but the plain reading above would tell a reader the file never
+#     writes a tombstone of its own, and it does. A fact whose key merely failed
+#     to ARRIVE while its surface keys fine is refused outright rather than
+#     tombstoned, because that row is repairable and retiring it would not be.
 #     It also restores `pre_widening_visible_to` (#4836) — necessarily, since
 #     the column cannot be re-derived in the target region (the import writes
 #     `status` verbatim, so the fact never re-publishes and the widening UPDATE


### PR DESCRIPTION
## Summary

Closes #5047. The third and last step of ADR-0037 §1's identity key: `brain_facts.subject_key` / `predicate_key` / `object_key` become `NOT NULL` (migration 0194). #5019 added the columns nullable, #5020 keyed `INSERT_FACT_SQL` and pivoted the three slot consumers, #5035 made the region bundle carry keys verbatim. This supplies the prerequisite migration 0187's header said nobody owned, and flips the constraint.

**The guard.** `reconcile.ts`'s `MALFORMED_CLAIM` now refuses a candidate whose `slotKey` is null, applied **post-resolution** so it sees the vocabulary's answer and an inherited slot — neither of which is visible from the raw surface. It reuses the existing block reason: a claim whose subject norms away asserts nothing, which is the argument the guard already makes for a blank one. The post-insert warn #5020 added is gone; it described a row that can no longer exist.

**`correct_fact` inherits the fix** through `reconcileFacts`, so the block rolls the `valid_to` stamp back with it — pinned against a live transaction in `candidates-pg.test.ts` rather than assumed.

**Migration 0194** re-runs 0187's backfill immediately before the constraint, respecting both caveats its header attached to the repeat — each inert when 0188 shipped and live now. The statement is **vocabulary-aware** (`alias` is a real table since #5022, so the raw norm would key a row into a different slot from every sibling the vocabulary unified) and **per-column** (0187's single `UPDATE` rewrites all three keys on a row unkeyed at one position, silently reverting curated keys elsewhere).

### Two decisions the issue did not specify

1. **Legacy rows whose surfaces normalize away** key to NULL permanently, so `SET NOT NULL` would have failed at boot on any install holding one. They are **tombstoned with a per-row placeholder**. The tombstone is the load-bearing half — all three slot consumers require `invalidated_at IS NULL`, so the row is outside every join by the tombstone rather than by its key, which is where a NULL left it. The placeholder is per-row, so it is not the shared sentinel 0187's header rejects. Cost, stated plainly: those rows leave `searchBrain` and the review queue. They were unreviewable, and the surfaces are retained.
2. **A region import now refuses** rather than landing a fact whose key did not arrive while its surface keys fine. That row is repairable by the next drift re-key; tombstoning it retires a healthy belief nothing restores, and re-deriving its key locally is the over-match §8 forbids. A single such row blocks a whole tenant migration — deliberate, since at that position it is evidence the bundle's identity is untrustworthy, not one odd claim.

### Adjacent fix, found on the way

`migrate.ts` had no `notice` listener, so **every `RAISE NOTICE` in every migration was being discarded** — including the operator breadcrumbs 0032, 0034, 0055, 0072 and 0085 emit deliberately, one of which names the gap it was written to close. 0194 adds a sixth and is what surfaced it.

## Test Plan

Docker is unavailable in this environment, so a local Postgres 16 was started rather than ship the migration untested. **Full suite: 1052/1052 files pass** against a real database, including every `-pg` suite. This surfaced 10 files of keyless fixtures the `--affected` graph does not reach.

Falsifiers were **run**, not reasoned about — each mutant applied, observed red, reverted:

- drop the vocabulary join from 0194 → the aliased-key fixture fails
- collapse 0194's per-column scoping → the curated-key fixture fails
- revert the importer to "always tombstone" → the refusal case fails
- drop `-` from `SEPARATOR_RUN` → the placeholder-collision falsifier fails
- gate the correction 400 on position instead of cause → the vocabulary-caused case fails

- [x] Manual testing — migration replayed against a seeded pre-0194 corpus
- [x] Unit tests added/updated
- [ ] E2E tests added/updated — not applicable

## Checklist

- [x] Types pass (`bun run type`)
- [x] Tests pass (`bun run test`) — 1052/1052
- [x] Lint passes (`bun run lint`)
- [ ] Deps consistent — no dependency changes
- [x] Labels added (type + area) — inherited from #5047
- [ ] CHANGELOG.md updated — `/release` owns the per-tag changelog

## Review

Two rounds of the internal panel. Round 1 returned ~21 findings, all new surface; round 2 returned ~17, of which ~13 were defects inside round 1's own fixes. That ratio is the loop's stop condition, so the loop was closed there rather than buying a third round. Everything confirmed is fixed.

The sharpest round-2 finding is worth naming because a fresh-context check caught it: round 1's fix for *"don't blame the wrong party"* blamed the wrong party one layer over. `applySupersede` gated its user-facing 400 on the failing **position**, reasoning the object is the caller's own text. But `slotKey` is `identityKey(alias(identityKey(surface)))`, so an object key is also null when the workspace's vocabulary maps a real norm to nothing — and a human superseding with good text was told their replacement "normalizes away to nothing", on a request no retry could satisfy. The block now carries the **cause**, not just the position.

### Known follow-ups, not in this PR

Deliberately deferred under the same stop rule, since each adds machinery a third round would then have to review:

- the reconcile warn's `cause` / `degenerateSurfaces` / `inheritedUnkeyed` payloads have no test — the repo has a `*-logging.test.ts` pattern for exactly this
- 0194's per-column scoping is pinned at one of three positions; the subject and object statements' `slot_position` literals are not independently falsified
- the `RegionImportUnkeyableError` → 409 route mapping is untested, and the importer's *computed* (v1/v2) tombstone arm has no case
- `scripts/check-brain-fact-promotion.sh` cannot see `.sql`, so 0194's `invalidated_at` write passes by exclusion. Recorded as a known hole in that script rather than left silent

---
_Generated by [Claude Code](https://claude.ai/code/session_014ctgWpuG7pXR4zauszr6X3)_