### PR TITLE
fix(brain): close the five #5047 follow-ups — the leak falsifier, the import 500, 0194's per-column scoping, the computed arm, the re-key's lost distinction

### DIFF
--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -56632,7 +56632,7 @@
             }
           },
           "500": {
-            "description": "Internal server error",
+            "description": "Import failed and the transaction rolled back — nothing was written. The `message` is deliberately GENERIC and the `requestId` is the handle: the underlying driver error is recorded server-side against that id and is not echoed here, because a `pg` message routinely embeds row content, constraint and column names, and — on a connection failure — the internal host and port (#5106).",
             "content": {
               "application/json": {
                 "schema": {

--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -56607,7 +56607,7 @@
             }
           },
           "409": {
-            "description": "Bundle refused — a fact has no identity key at a position whose surface normalizes to a real one, so landing it would either retire a healthy belief or re-derive its key under this region's vocabulary, and neither is reversible (#5047). NOTHING WAS WRITTEN. Two causes with two different remedies, and the `message` says which: on a v3 bundle the key was supposed to travel and did not — re-export from the source region, checking it for identity drift and that it has applied migration 0194 — while on a v1/v2 bundle the key is computed at import, so a refusal means THIS region's vocabulary maps that norm away and the fix is a local `brain_vocabulary_target` entry, which re-exporting cannot change.",
+            "description": "Bundle refused — a fact has no identity key at a position whose surface normalizes to a real one, so landing it would either retire a healthy belief or re-derive its key under this region's vocabulary, and neither is reversible (#5047). NOTHING WAS WRITTEN. Two causes with two different remedies, and the `message` says which: on a v3 bundle the key was supposed to travel and did not — re-export from the source region, checking it for identity drift and that it has applied migration 0194 — while on a v1/v2 bundle the key is computed at import, so a refusal means THIS region's vocabulary maps that norm away and the fix is a local `brain_vocabulary_target` entry, which re-exporting cannot change. NOTHING WAS WRITTEN is a claim about the ROLLBACK, so a refusal whose rollback ALSO failed is reported as `import_rollback_uncertain` (500) instead of this status — this 409 is only returned when the rollback is known to have completed.",
             "content": {
               "application/json": {
                 "schema": {
@@ -56632,7 +56632,7 @@
             }
           },
           "500": {
-            "description": "Import failed and the transaction rolled back — nothing was written. The `message` is deliberately GENERIC and the `requestId` is the handle: the underlying driver error is recorded server-side against that id and is not echoed here, because a `pg` message routinely embeds row content, constraint and column names, and — on a connection failure — the internal host and port (#5106).",
+            "description": "Import failed. TWO codes, and they mean opposite things for a retry. `import_failed`: the transaction rolled back, nothing was written, and re-sending the same bundle is safe once the cause is resolved. `import_rollback_uncertain`: the ROLLBACK itself did not complete, so whether any of it committed is UNKNOWN — do NOT re-send; inspect the destination workspace first, because a retry over a partially-committed import can duplicate or interleave rows (the connection is discarded rather than pooled). In both cases the `message` is deliberately GENERIC and the `requestId` is the handle: the underlying driver error is recorded server-side against that id and is not echoed here, because a `pg` message routinely embeds row content, constraint and column names, and — on a connection failure — the internal host and port (#5106).",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/api/scripts/mutations/bundle-identity.md
+++ b/packages/api/scripts/mutations/bundle-identity.md
@@ -39,15 +39,15 @@ Every number is the count of tests that FAIL in that suite under that mutation, 
 |---|---|---|---|---|---|---|
 | the importer RE-DERIVES a v3 fact's keys instead of carrying them | 2 | 0 | 0 | 0 | 0 | 1 |
 | a store-local `entity:` id travels verbatim | 1 | 0 | 0 | 2 | 0 | 1 |
-| a LEGACY bundle's facts are left unkeyed | 2 | 3 | 0 | 0 | 0 | 3 |
-| the legacy arm keys against an EMPTY vocabulary (the load deleted) | 1 | 0 | 0 | 0 | 0 | 2 |
+| a LEGACY bundle's facts are left unkeyed | 4 | 3 | 0 | 0 | 0 | 4 |
+| the legacy arm keys against an EMPTY vocabulary (the load deleted) | 2 | 0 | 0 | 0 | 0 | 2 |
 | `provisional` is never written for a nulled row | 1 | 0 | 0 | 0 | 0 | 0 |
 | `provisional` is written for EVERY imported row | 1 | 0 | 0 | 0 | 0 | 0 |
 | `readStoredComparable` skips the PAYLOAD fixpoint check | 0 | 0 | 0 | 2 | 0 | 1 |
 | the importer binds the ARRIVING `_cmp` straight through (the ComparableValue narrowing widened) | 1 | 0 | 0 | 0 | 0 | 0 |
 | the SUBJECT position is hardcoded to null instead of following the tag rule | 1 | 0 | 0 | 0 | 0 | 0 |
 | `textOrNull` stops counting drift (goes silent again) | 0 | 0 | 1 | 0 | 0 | 0 |
-| the identity-loss line is deleted | 0 | 0 | 0 | 0 | 0 | 3 |
+| the identity-loss line is deleted | 0 | 0 | 0 | 0 | 0 | 4 |
 | the `unreadable` split collapses into `storeLocal` | 0 | 0 | 0 | 0 | 0 | 1 |
 | the legacy READ runs without the workspace vocabulary lock | 0 | 0 | 0 | 0 | 0 | 1 |
 | a v3 import loads a vocabulary it never uses | 0 | 0 | 0 | 0 | 0 | 1 |
@@ -63,9 +63,9 @@ Every number is the count of tests that FAIL in that suite under that mutation, 
 | the required-sections gate reads `=== CURRENT` again | 0 | 1 | 0 | 0 | 0 | 0 |
 | the exporter stops projecting the identity columns | 1 | 0 | 0 | 0 | 1 | 0 |
 | the exporter feeds identity values through a cast instead of `textOrNull` | 0 | 0 | 2 | 0 | 0 | 0 |
-| the importer writes `predicate_cardinality` again (from the legacy field) | 6 | 0 | 0 | 0 | 1 | 0 |
+| the importer writes `predicate_cardinality` again (from the legacy field) | 8 | 0 | 0 | 0 | 1 | 0 |
 
-Suite sizes: **roundtrip-pg** 11 tests (`src/lib/residency/__tests__/migrate-roundtrip-pg.test.ts`) · **admin-migrate** 96 tests (`src/api/__tests__/admin-migrate.test.ts`) · **export** 24 tests (`src/lib/residency/__tests__/export.test.ts`) · **object-cmp** 64 tests (`src/lib/brain/__tests__/object-cmp.test.ts`) · **v3 pin** 6 tests (`src/lib/residency/__tests__/bundle-identity-v3.test.ts`) · **logging** 8 tests (`src/lib/residency/__tests__/migrate-identity-logging.test.ts`).
+Suite sizes: **roundtrip-pg** 14 tests (`src/lib/residency/__tests__/migrate-roundtrip-pg.test.ts`) · **admin-migrate** 96 tests (`src/api/__tests__/admin-migrate.test.ts`) · **export** 24 tests (`src/lib/residency/__tests__/export.test.ts`) · **object-cmp** 64 tests (`src/lib/brain/__tests__/object-cmp.test.ts`) · **v3 pin** 6 tests (`src/lib/residency/__tests__/bundle-identity-v3.test.ts`) · **logging** 9 tests (`src/lib/residency/__tests__/migrate-identity-logging.test.ts`).
 
 ## Notes
 

--- a/packages/api/src/api/routes/__tests__/admin-migrate-import-errors.test.ts
+++ b/packages/api/src/api/routes/__tests__/admin-migrate-import-errors.test.ts
@@ -57,16 +57,27 @@ let queryFailure: Error | null = null;
 /** Statements the fake client saw — `ROLLBACK` is asserted from here. */
 let statements: string[] = [];
 
+/**
+ * When set, `ROLLBACK` itself throws this — the path where the handler cannot
+ * know whether anything committed (#5106 round 2).
+ */
+let rollbackFailure: Error | null = null;
+/** What `release()` was called WITH. `undefined` = pooled; an Error = destroyed. */
+let releasedWith: unknown[] = [];
+
 const FAKE_CLIENT = {
   query: async (sql: string) => {
     statements.push(typeof sql === "string" ? sql : String(sql));
-    // BEGIN and ROLLBACK must both succeed: a ROLLBACK that throws sends the
-    // handler down its own `.catch` and would mask the arm under test.
+    if (sql === "ROLLBACK" && rollbackFailure !== null) throw rollbackFailure;
+    // BEGIN and COMMIT always succeed: a failure there is a different test, and
+    // one here would mask the arm under test.
     if (sql === "BEGIN" || sql === "ROLLBACK" || sql === "COMMIT") return { rows: [], rowCount: 0 };
     if (queryFailure !== null) throw queryFailure;
     return { rows: [], rowCount: 0 };
   },
-  release: () => {},
+  release: (err?: unknown) => {
+    releasedWith.push(err);
+  },
 };
 
 void mock.module("@atlas/api/lib/db/internal", () => ({
@@ -134,6 +145,13 @@ const { adminMigrate, internalMigrate, RegionImportUnkeyableError, RegionImportV
  * `BEGIN`/`COMMIT` and nothing between them, so the injected failure never
  * fires and every assertion here passes against a 200 — the first cut of this
  * file did exactly that, and read as fifteen green tests of nothing.
+ *
+ * ⚠️ NO CAST. The return annotation is this fixture's ONLY compile-time check:
+ * `validateBundle` is a hand-rolled shallow validator that tests top-level
+ * array-ness and nothing else, so `as unknown as ExportBundle` (which the first
+ * cut carried) would let the fixture go stale in silence the day `ExportBundle`
+ * gains a required section — the suite would keep passing against a bundle the
+ * importer rejects.
  */
 function minimalBundle(): ExportBundle {
   return {
@@ -147,7 +165,7 @@ function minimalBundle(): ExportBundle {
     semanticEntities: [],
     learnedPatterns: [],
     settings: [{ key: "theme", value: "dark" }],
-  } as unknown as ExportBundle;
+  };
 }
 
 interface ErrorBody {
@@ -194,6 +212,8 @@ const HANDLERS: Handler[] = [
 describe("the import's error responses — both handlers", () => {
   beforeEach(() => {
     queryFailure = null;
+    rollbackFailure = null;
+    releasedWith = [];
     statements = [];
     logged.length = 0;
     process.env.ATLAS_INTERNAL_SECRET = INTERNAL_SECRET;
@@ -331,6 +351,97 @@ describe("the import's error responses — both handlers", () => {
           "subsystems with different remedies, and the message is the only thing that says which",
       ).toBe(refusal.message);
       expect(body.requestId).toBeTruthy();
+    });
+
+    it("⭐ a FAILED rollback gets its own body — it never claims nothing was written", async () => {
+      // ⚠️ THE assertion this round added. `IMPORT_FAILED_MESSAGE` promises
+      // "nothing was written … re-sending the same bundle is safe". On this path
+      // the handler issued a ROLLBACK and the request FAILED, so whether the
+      // transaction aborted, is still open, or committed is unknown to it.
+      //
+      // Returning the confident sentence here is the same defect #5106 fixed one
+      // layer up — a body asserting a state nobody established — and the
+      // consequence is worse than the leak was: the leak exposed detail, this
+      // would tell an operator to retry over a possibly-committed import.
+      queryFailure = new Error("duplicate key value violates unique constraint");
+      rollbackFailure = new Error("Connection terminated unexpectedly");
+
+      const res = await post(minimalBundle());
+      expect(res.status).toBe(500);
+      const body = (await res.json()) as ErrorBody;
+
+      // A DISTINCT code, because callers branch on it and these two answers are
+      // the furthest apart this endpoint gives.
+      expect(
+        body.error,
+        "a failed rollback returned the ordinary `import_failed` code — a caller cannot tell " +
+          "'retry is safe' from 'a human must inspect the destination'",
+      ).toBe("import_rollback_uncertain");
+      expect(body.message).toContain("UNKNOWN");
+      expect(body.message).toContain("Do NOT re-send");
+      expect(body.message).not.toContain("re-sending the same bundle is safe");
+      // …and still no driver text, at either status.
+      expect(body.message).not.toContain("duplicate key");
+      expect(body.message).not.toContain("Connection terminated");
+      expect(body.requestId).toBeTruthy();
+    });
+
+    it("⭐ DESTROYS the client when the rollback failed, instead of pooling it", async () => {
+      // The corruption path, and why this is a defect rather than a wording nit.
+      // `pg` destroys the socket when `release(err)` is called with a truthy
+      // arg. Released bare, a client still inside an open transaction goes back
+      // to the pool — and Postgres answers a second `BEGIN` on an open
+      // transaction with a WARNING, not an error, so the next borrower's work
+      // silently joins this failed import's transaction and ITS commit commits
+      // the partial import, under a different requestId, minutes later.
+      queryFailure = new Error("duplicate key value violates unique constraint");
+      rollbackFailure = new Error("Connection terminated unexpectedly");
+
+      await post(minimalBundle());
+
+      expect(releasedWith).toHaveLength(1);
+      expect(
+        releasedWith[0],
+        "the client was released bare after a FAILED rollback — it may still hold an open " +
+          "transaction, and pooling it lets an unrelated later request commit this import",
+      ).toBeInstanceOf(Error);
+    });
+
+    it("…and POOLS the client normally when the rollback succeeded", async () => {
+      // The control, and it is not decoration: `release(err)` closes the socket,
+      // so a handler that passed a truthy arg unconditionally would throw away a
+      // healthy connection on every ordinary import failure — a fix that turns a
+      // recoverable error into pool churn. Both directions, one pair.
+      queryFailure = new Error("duplicate key value violates unique constraint");
+
+      await post(minimalBundle());
+
+      expect(releasedWith).toHaveLength(1);
+      expect(
+        releasedWith[0],
+        "a healthy client was destroyed after a SUCCESSFUL rollback — release(err) closes the " +
+          "socket, so this churns the pool on every ordinary import failure",
+      ).toBeUndefined();
+    });
+
+    it("records the rollback failure server-side, with the workspace it may have corrupted", async () => {
+      // The other half: the response says "inspect the destination", and this
+      // line is what tells the operator WHICH destination. It is the one log
+      // line naming a possibly-corrupted workspace, so `orgId` is not optional.
+      queryFailure = new Error("duplicate key value violates unique constraint");
+      rollbackFailure = new Error("Connection terminated unexpectedly");
+
+      await post(minimalBundle());
+
+      const rollbackLine = logged.find((entry) => entry.message.includes("ROLLBACK failed"));
+      expect(rollbackLine, "a failed rollback left no log line").toBeDefined();
+      const payload = rollbackLine?.payload as { err?: Error; orgId?: string; requestId?: string };
+      expect(payload.err).toBeInstanceOf(Error);
+      expect(payload.err?.message).toBe("Connection terminated unexpectedly");
+      expect(payload.orgId, "the line that names a possibly-corrupted workspace omits it").toBe(
+        CURRENT_ORG,
+      );
+      expect(payload.requestId).toBeTruthy();
     });
 
     it("a refusal and a driver error do not converge on one body", async () => {

--- a/packages/api/src/api/routes/__tests__/admin-migrate-import-errors.test.ts
+++ b/packages/api/src/api/routes/__tests__/admin-migrate-import-errors.test.ts
@@ -1,0 +1,364 @@
+/**
+ * The import seam's ERROR RESPONSES — both handlers (#5106, #5108).
+ *
+ * `admin-migrate.ts` ships the import twice: the admin route behind
+ * `requireOrgContext`, and the internal service-to-service route behind
+ * `ATLAS_INTERNAL_SECRET`. The two catch blocks are copies of each other, and
+ * that duplication is the whole reason this file exists — every assertion below
+ * runs against BOTH, because the realistic defect at this seam is a fix applied
+ * to one handler and not the other.
+ *
+ * Two properties, neither of which had any coverage before:
+ *
+ *   - **A driver error's TEXT never reaches the response body** (#5106). A `pg`
+ *     message is a fragment of the database, not a description of a failure: it
+ *     embeds row content (`Key (id)=(…)`), internal constraint and column
+ *     spellings, and on a connection failure the internal host and port. The
+ *     500 carries a fixed generic message and the `requestId` as the handle.
+ *   - **A REFUSAL is a 409, and its self-authored message IS echoed** (#5108).
+ *     `RegionImportUnkeyableError` and `RegionImportVocabularyTargetError` name
+ *     two different subsystems with two different remedies, and the `message` is
+ *     the only thing that says which. A revert to the generic 500 — which is
+ *     what #5047's commit message says was wrong — would be invisible without
+ *     these.
+ *
+ * The two are asserted TOGETHER rather than in separate files on purpose: they
+ * are the two arms of one `catch`, and the property that matters is the SPLIT.
+ * A scrub applied to both arms closes the leak and destroys the refusal's
+ * actionable text; a scrub applied to neither is today's bug. Only a test that
+ * holds both ends sees that.
+ *
+ * ## How the error is injected, and why that is honest
+ *
+ * The fake client throws from `query`, so the error surfaces out of
+ * `importBundle` exactly as a real one would. For the refusal cases that means
+ * the error is RAISED somewhere other than `tombstonePlaceholder` — but what is
+ * under test here is the catch's `instanceof` branch and the status it picks,
+ * not where the throw originated. That `tombstonePlaceholder` raises these two
+ * types on the right arms is pinned against real Postgres in
+ * `lib/residency/__tests__/migrate-roundtrip-pg.test.ts`.
+ */
+
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import { OpenAPIHono } from "@hono/zod-openapi";
+import { buildInternalDbMockDefaults } from "@atlas/api/testing/api-test-mocks";
+import type { ExportBundle } from "@useatlas/types";
+
+const CURRENT_ORG = "org-1";
+const INTERNAL_SECRET = "internal-secret-for-tests";
+
+/**
+ * What the next `client.query` throws, or `null` to let it succeed.
+ *
+ * Set per test. `importBundle` issues its first statement immediately, so this
+ * is what a failure anywhere inside the import looks like from the handler.
+ */
+let queryFailure: Error | null = null;
+/** Statements the fake client saw — `ROLLBACK` is asserted from here. */
+let statements: string[] = [];
+
+const FAKE_CLIENT = {
+  query: async (sql: string) => {
+    statements.push(typeof sql === "string" ? sql : String(sql));
+    // BEGIN and ROLLBACK must both succeed: a ROLLBACK that throws sends the
+    // handler down its own `.catch` and would mask the arm under test.
+    if (sql === "BEGIN" || sql === "ROLLBACK" || sql === "COMMIT") return { rows: [], rowCount: 0 };
+    if (queryFailure !== null) throw queryFailure;
+    return { rows: [], rowCount: 0 };
+  },
+  release: () => {},
+};
+
+void mock.module("@atlas/api/lib/db/internal", () => ({
+  ...buildInternalDbMockDefaults({ internalQuery: async () => [] }),
+  getInternalDB: () => ({ connect: async () => FAKE_CLIENT }),
+}));
+
+// Mock-ALL-exports (10 of them). A partial factory leaves the missing exports
+// `undefined`, and the failure lands as `undefined is not a function` in an
+// unrelated module one import away — the trap `alias-proposal-logging.test.ts`
+// records at length.
+const logged: { payload: unknown; message: string }[] = [];
+void mock.module("@atlas/api/lib/logger", () => {
+  const record = (payload: unknown, message?: unknown) =>
+    logged.push({ payload, message: typeof message === "string" ? message : String(payload) });
+  const logger = {
+    info: () => {},
+    warn: record,
+    error: record,
+    debug: () => {},
+    level: "info",
+    child: () => logger,
+  };
+  return {
+    createLogger: () => logger,
+    getLogger: () => logger,
+    setLogLevel: () => true,
+    getRequestContext: () => ({ requestId: "test-req" }),
+    withRequestContext: <T,>(_ctx: unknown, fn: () => T): T => fn(),
+    redactPaths: [] as string[],
+    scrubErrSerializer: (err: unknown) => err,
+    scrubLogFormatter: (obj: unknown) => obj,
+    hashShareToken: (token: string) => token,
+    ACTOR_KINDS: ["human", "agent", "mcp", "scheduler", "api_key"] as const,
+  };
+});
+
+void mock.module("../admin-router", () => ({
+  createAdminRouter: () => new OpenAPIHono(),
+  NO_ACTIVE_ORG_MESSAGE: "No active organization. Set an active org first.",
+  noActiveOrgBody: (requestId: string) => ({
+    error: "no_active_org",
+    message: "No active organization. Set an active org first.",
+    requestId,
+  }),
+  requireOrgContext:
+    () =>
+    async (
+      c: { set: (k: string, v: unknown) => void },
+      next: () => Promise<void>,
+    ): Promise<void> => {
+      c.set("orgContext", { requestId: "test-req", orgId: CURRENT_ORG });
+      c.set("requestId", "test-req");
+      await next();
+    },
+}));
+
+const { adminMigrate, internalMigrate, RegionImportUnkeyableError, RegionImportVocabularyTargetError } =
+  await import("../admin-migrate");
+
+/**
+ * A bundle `validateBundle` accepts that makes the importer ISSUE A STATEMENT.
+ *
+ * ⚠️ The one setting is load-bearing, not decoration. An all-empty bundle runs
+ * `BEGIN`/`COMMIT` and nothing between them, so the injected failure never
+ * fires and every assertion here passes against a 200 — the first cut of this
+ * file did exactly that, and read as fifteen green tests of nothing.
+ */
+function minimalBundle(): ExportBundle {
+  return {
+    manifest: {
+      version: 1,
+      exportedAt: "2026-08-10T00:00:00.000Z",
+      source: { label: "self-hosted" },
+      counts: { conversations: 0, messages: 0, semanticEntities: 0, learnedPatterns: 0, settings: 1 },
+    },
+    conversations: [],
+    semanticEntities: [],
+    learnedPatterns: [],
+    settings: [{ key: "theme", value: "dark" }],
+  } as unknown as ExportBundle;
+}
+
+interface ErrorBody {
+  readonly error: string;
+  readonly message: string;
+  readonly requestId: string;
+}
+
+/**
+ * The two handlers, behind one calling convention.
+ *
+ * Every assertion runs over this list — which is what makes "both handlers" a
+ * property of the suite rather than a discipline someone has to remember.
+ */
+const HANDLERS = [
+  {
+    name: "admin",
+    post: (body: unknown) =>
+      adminMigrate.request("/import", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body),
+      }),
+  },
+  {
+    name: "internal (service-to-service)",
+    post: (body: unknown) =>
+      internalMigrate.request("/import", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "X-Atlas-Internal-Token": INTERNAL_SECRET,
+        },
+        body: JSON.stringify({ orgId: CURRENT_ORG, ...(body as Record<string, unknown>) }),
+      }),
+  },
+] as const;
+
+describe("the import's error responses — both handlers", () => {
+  beforeEach(() => {
+    queryFailure = null;
+    statements = [];
+    logged.length = 0;
+    process.env.ATLAS_INTERNAL_SECRET = INTERNAL_SECRET;
+  });
+
+  describe.each(HANDLERS)("$name handler", ({ post }) => {
+    it("does NOT echo a driver error's text in the 500 body (#5106)", async () => {
+      // The shape a real `pg` unique-violation takes, carrying the three things
+      // that must never leave the process: ROW CONTENT, the internal constraint
+      // spelling, and the column name.
+      const leak =
+        'duplicate key value violates unique constraint "brain_facts_pkey" ' +
+        "Key (id)=(0f8c4a2e-1111-4000-8000-00000000dead) already exists.";
+      queryFailure = new Error(leak);
+
+      const res = await post(minimalBundle());
+      expect(res.status).toBe(500);
+      const body = (await res.json()) as ErrorBody;
+
+      expect(body.error).toBe("import_failed");
+      // The whole message, and every distinctive fragment of it. Asserting the
+      // full string alone would pass a body that appended the detail; asserting
+      // the fragments alone would pass one that echoed a DIFFERENT driver
+      // error. Both directions, because the leak is a substring problem.
+      expect(body.message).not.toContain(leak);
+      for (const fragment of [
+        "duplicate key",
+        "brain_facts_pkey",
+        "Key (id)=",
+        "0f8c4a2e-1111-4000-8000-00000000dead",
+      ]) {
+        expect(
+          body.message.includes(fragment),
+          `the 500 body echoed \`${fragment}\` from the driver's message — a pg error carries row ` +
+            "content, internal constraint and column names, and on a connection failure the host " +
+            "and port. CLAUDE.md § Product invariants: no secrets in responses.",
+        ).toBe(false);
+      }
+      // …and it is not merely scrubbed to nothing: the caller still gets an
+      // actionable message and the handle that reaches the detail.
+      expect(body.message).toContain("rolled back");
+      expect(body.message).toContain("requestId");
+      expect(body.requestId).toBeTruthy();
+    });
+
+    it("a connection failure's host and port do not reach the body either (#5106)", async () => {
+      // The second shape, and the one a scrub written against `Key (id)=` alone
+      // would sail past: `pg` puts the internal host and port in the message
+      // when the connection itself fails.
+      queryFailure = new Error("connect ECONNREFUSED 10.4.19.221:5432");
+
+      const res = await post(minimalBundle());
+      expect(res.status).toBe(500);
+      const body = (await res.json()) as ErrorBody;
+
+      expect(body.message).not.toContain("10.4.19.221");
+      expect(body.message).not.toContain("5432");
+      expect(body.message).not.toContain("ECONNREFUSED");
+    });
+
+    it("still records the driver error server-side, against the same requestId (#5106)", async () => {
+      // ⚠️ THE OTHER HALF, and the half a fix for the leak most easily breaks:
+      // scrubbing the response is only correct because the detail is MOVED, not
+      // dropped. Without this assertion, "return a generic message" and "delete
+      // the error handling" are the same green.
+      const leak = 'null value in column "subject_key" violates not-null constraint';
+      queryFailure = new Error(leak);
+
+      const res = await post(minimalBundle());
+      const body = (await res.json()) as ErrorBody;
+
+      const recorded = logged.find(
+        (entry) =>
+          entry.message.includes("import failed") || entry.message.includes("Import failed"),
+      );
+      expect(recorded, "no log line recorded the failed import").toBeDefined();
+      const payload = recorded?.payload as { err?: Error; requestId?: string };
+      // The real Error instance, so pino's `err` serializer keeps the message
+      // AND the stack — not a pre-stringified message that loses the stack.
+      expect(payload.err).toBeInstanceOf(Error);
+      expect(payload.err?.message).toBe(leak);
+      // Same handle on both sides. This is what makes the requestId in the body
+      // worth quoting: without it the operator holds a detail they cannot join
+      // to the caller's complaint.
+      expect(payload.requestId).toBe(body.requestId);
+    });
+
+    it("rolls back before responding, so the 500's promise is true", async () => {
+      queryFailure = new Error("simulated 57014: statement cancelled");
+
+      const res = await post(minimalBundle());
+      expect(res.status).toBe(500);
+      // The body says "all changes rolled back". Asserted rather than trusted,
+      // because that sentence is the caller's basis for re-sending the bundle.
+      expect(statements).toContain("ROLLBACK");
+    });
+
+    it.each([
+      {
+        label: "RegionImportUnkeyableError (a v3 bundle's key failed to arrive)",
+        make: () =>
+          new RegionImportUnkeyableError("0f8c4a2e-2222-4000-8000-000000000001", ["object"]),
+      },
+      {
+        label: "RegionImportVocabularyTargetError (this region's vocabulary maps the norm away)",
+        make: () =>
+          new RegionImportVocabularyTargetError("0f8c4a2e-3333-4000-8000-000000000002", [
+            "predicate",
+          ]),
+      },
+    ])("maps $label to 409, echoing its self-authored message (#5108)", async ({ make }) => {
+      const refusal = make();
+      queryFailure = refusal;
+
+      const res = await post(minimalBundle());
+
+      // 409 rather than 400 (the request is well-formed — `validateBundle`
+      // passed) and rather than 500 (nothing is broken, and retrying THIS body
+      // can never succeed).
+      expect(
+        res.status,
+        "a refusal fell back to the generic 500 — the status is what tells a caller that " +
+          "re-sending cannot help, and #5047's whole point was that 500 was the wrong answer here",
+      ).toBe(409);
+      const body = (await res.json()) as ErrorBody;
+      expect(body.error).toBe("import_refused");
+      // VERBATIM, and this is the arm that must NOT be scrubbed. These two
+      // errors author their own messages out of a fact UUID and position names
+      // — no surfaces, no row content, no connection detail — and the message
+      // is the only thing that names WHICH subsystem to fix. #5106's scrub
+      // stops at the 500.
+      expect(
+        body.message,
+        "the refusal's own message was replaced — the two refusal types name different " +
+          "subsystems with different remedies, and the message is the only thing that says which",
+      ).toBe(refusal.message);
+      expect(body.requestId).toBeTruthy();
+    });
+
+    it("a refusal and a driver error do not converge on one body", async () => {
+      // The falsifier for the split itself. A fix that scrubbed BOTH arms — the
+      // obvious over-correction for #5106 — passes every leak assertion above
+      // and every status assertion beside it, and is caught only by comparing
+      // the two bodies.
+      queryFailure = new RegionImportUnkeyableError("0f8c4a2e-4444-4000-8000-000000000003", [
+        "subject",
+      ]);
+      const refused = (await (await post(minimalBundle())).json()) as ErrorBody;
+
+      queryFailure = new Error("duplicate key value violates unique constraint");
+      const failed = (await (await post(minimalBundle())).json()) as ErrorBody;
+
+      expect(refused.message).not.toBe(failed.message);
+      // The refusal names the row it refused on; the generic never names
+      // anything the caller did not already send.
+      expect(refused.message).toContain("0f8c4a2e-4444-4000-8000-000000000003");
+      expect(failed.message).not.toContain("0f8c4a2e-4444-4000-8000-000000000003");
+    });
+  });
+
+  it("both handlers return the SAME generic 500 message", async () => {
+    // The duplication assertion, and the reason #5106 names it: the two catch
+    // blocks are copies, so the realistic defect is a fix that lands in one.
+    // Sharing one constant is what makes that structurally impossible — this
+    // test is what says the sharing is still in force.
+    queryFailure = new Error("duplicate key value violates unique constraint");
+    const [admin, internal] = await Promise.all(
+      HANDLERS.map(async ({ post }) => ((await (await post(minimalBundle())).json()) as ErrorBody).message),
+    );
+
+    expect(admin).toBe(internal);
+  });
+});

--- a/packages/api/src/api/routes/__tests__/admin-migrate-import-errors.test.ts
+++ b/packages/api/src/api/routes/__tests__/admin-migrate-import-errors.test.ts
@@ -162,10 +162,15 @@ interface ErrorBody {
  * Every assertion runs over this list — which is what makes "both handlers" a
  * property of the suite rather than a discipline someone has to remember.
  */
-const HANDLERS = [
+interface Handler {
+  readonly name: string;
+  readonly post: (body: unknown) => Promise<Response>;
+}
+
+const HANDLERS: Handler[] = [
   {
     name: "admin",
-    post: (body: unknown) =>
+    post: async (body: unknown) =>
       adminMigrate.request("/import", {
         method: "POST",
         headers: { "content-type": "application/json" },
@@ -174,7 +179,7 @@ const HANDLERS = [
   },
   {
     name: "internal (service-to-service)",
-    post: (body: unknown) =>
+    post: async (body: unknown) =>
       internalMigrate.request("/import", {
         method: "POST",
         headers: {
@@ -184,7 +189,7 @@ const HANDLERS = [
         body: JSON.stringify({ orgId: CURRENT_ORG, ...(body as Record<string, unknown>) }),
       }),
   },
-] as const;
+];
 
 describe("the import's error responses — both handlers", () => {
   beforeEach(() => {

--- a/packages/api/src/api/routes/__tests__/admin-migrate-import-errors.test.ts
+++ b/packages/api/src/api/routes/__tests__/admin-migrate-import-errors.test.ts
@@ -62,6 +62,8 @@ let statements: string[] = [];
  * know whether anything committed (#5106 round 2).
  */
 let rollbackFailure: Error | null = null;
+/** When set, `BEGIN` throws this — a socket that was dead before anything ran. */
+let beginFailure: Error | null = null;
 /** What `release()` was called WITH. `undefined` = pooled; an Error = destroyed. */
 let releasedWith: unknown[] = [];
 /** Saved so the suite leaves the environment as it found it. */
@@ -70,6 +72,7 @@ let priorInternalSecret: string | undefined;
 const FAKE_CLIENT = {
   query: async (sql: string) => {
     statements.push(typeof sql === "string" ? sql : String(sql));
+    if (sql === "BEGIN" && beginFailure !== null) throw beginFailure;
     if (sql === "ROLLBACK" && rollbackFailure !== null) throw rollbackFailure;
     // BEGIN and COMMIT always succeed: a failure there is a different test, and
     // one here would mask the arm under test.
@@ -235,6 +238,7 @@ describe("the import's error responses — both handlers", () => {
   beforeEach(() => {
     queryFailure = null;
     rollbackFailure = null;
+    beginFailure = null;
     releasedWith = [];
     statements = [];
     logged.length = 0;
@@ -490,6 +494,39 @@ describe("the import's error responses — both handlers", () => {
         "the rollback failure was logged below `error` — it reports a possibly-poisoned pooled " +
           "connection and an unknown transaction outcome",
       ).toBe("error");
+    });
+
+    it("⭐ a BEGIN that never succeeded is NOT uncertain — nothing could have been written", async () => {
+      // ⚠️ `begun` is what makes the uncertain body honest in BOTH directions.
+      // `pool.connect()` can hand back a dead socket: BEGIN throws, the catch's
+      // ROLLBACK throws on the same socket, and `rollbackErr` is set — but
+      // `importBundle` never ran, so nothing could have been written. Reporting
+      // "inspect the destination workspace first" here sends a human to audit a
+      // workspace on the one path where the answer is knowable.
+      //
+      // The log must agree with the body: round 3 keyed the message on
+      // `rollbackErr` alone while the body used `rollbackErr && begun`, so this
+      // case produced a log saying "the transaction's fate is unknown" beside a
+      // body saying "all changes rolled back". Both now read one derived answer.
+      beginFailure = new Error("Connection terminated unexpectedly");
+      rollbackFailure = new Error("Connection terminated unexpectedly");
+
+      const res = await post(minimalBundle());
+      expect(res.status).toBe(500);
+      const body = (await res.json()) as ErrorBody;
+      expect(
+        body.error,
+        "a BEGIN that never resolved was reported as an uncertain outcome — nothing ran, so " +
+          "`nothing was written` is established rather than assumed",
+      ).toBe("import_failed");
+
+      const failureLine = logged.find((e) => e.message.includes("import failed"));
+      expect(
+        (failureLine?.payload as { rolledBack?: boolean }).rolledBack,
+        "the log and the body disagreed about the same transaction",
+      ).toBe(true);
+      // The client is still destroyed — the socket is untrustworthy either way.
+      expect(releasedWith[0]).toBeInstanceOf(Error);
     });
 
     it("⭐ a REFUSAL whose rollback also failed is uncertain, NOT a confident 409", async () => {

--- a/packages/api/src/api/routes/__tests__/admin-migrate-import-errors.test.ts
+++ b/packages/api/src/api/routes/__tests__/admin-migrate-import-errors.test.ts
@@ -39,7 +39,7 @@
  * `lib/residency/__tests__/migrate-roundtrip-pg.test.ts`.
  */
 
-import { beforeEach, describe, expect, it, mock } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 import { OpenAPIHono } from "@hono/zod-openapi";
 import { buildInternalDbMockDefaults } from "@atlas/api/testing/api-test-mocks";
 import type { ExportBundle } from "@useatlas/types";
@@ -64,6 +64,8 @@ let statements: string[] = [];
 let rollbackFailure: Error | null = null;
 /** What `release()` was called WITH. `undefined` = pooled; an Error = destroyed. */
 let releasedWith: unknown[] = [];
+/** Saved so the suite leaves the environment as it found it. */
+let priorInternalSecret: string | undefined;
 
 const FAKE_CLIENT = {
   query: async (sql: string) => {
@@ -89,14 +91,18 @@ void mock.module("@atlas/api/lib/db/internal", () => ({
 // `undefined`, and the failure lands as `undefined is not a function` in an
 // unrelated module one import away — the trap `alias-proposal-logging.test.ts`
 // records at length.
-const logged: { payload: unknown; message: string }[] = [];
+const logged: { payload: unknown; message: string; level: "warn" | "error" }[] = [];
 void mock.module("@atlas/api/lib/logger", () => {
-  const record = (payload: unknown, message?: unknown) =>
-    logged.push({ payload, message: typeof message === "string" ? message : String(payload) });
+  // ⚠️ THE LEVEL IS RECORDED, not merged. Two sinks bound to one array that
+  // dropped the level is the same defect this branch fixed twice already
+  // (`vocabulary-rekey-logging.test.ts`): the ROLLBACK line was deliberately
+  // promoted warn -> error, and reverting it killed ZERO tests until this.
+  const record = (level: "warn" | "error") => (payload: unknown, message?: unknown) =>
+    logged.push({ payload, message: typeof message === "string" ? message : String(payload), level });
   const logger = {
     info: () => {},
-    warn: record,
-    error: record,
+    warn: record("warn"),
+    error: record("error"),
     debug: () => {},
     level: "info",
     child: () => logger,
@@ -115,9 +121,20 @@ void mock.module("@atlas/api/lib/logger", () => {
   };
 });
 
+// Mock-ALL-exports again, and this file had been supplying 4 of the 8 — the
+// same partial-factory trap its logger mock above is emphatic about. Harmless
+// today only because `admin-migrate.ts` imports two of them; the day it reaches
+// for `requirePermission`, the failure is `undefined is not a function` in a
+// file with nothing to do with this one.
 void mock.module("../admin-router", () => ({
   createAdminRouter: () => new OpenAPIHono(),
+  createPlatformRouter: () => new OpenAPIHono(),
   NO_ACTIVE_ORG_MESSAGE: "No active organization. Set an active org first.",
+  NO_INTERNAL_DB_MESSAGE: "No internal database configured.",
+  requirePermission: () => async (_c: unknown, next: () => Promise<void>) => {
+    await next();
+  },
+  enforcePermission: async () => {},
   noActiveOrgBody: (requestId: string) => ({
     error: "no_active_org",
     message: "No active organization. Set an active org first.",
@@ -135,8 +152,13 @@ void mock.module("../admin-router", () => ({
     },
 }));
 
-const { adminMigrate, internalMigrate, RegionImportUnkeyableError, RegionImportVocabularyTargetError } =
-  await import("../admin-migrate");
+const {
+  adminMigrate,
+  internalMigrate,
+  RegionImportUnkeyableError,
+  RegionImportVocabularyTargetError,
+  IMPORT_FAILED_MESSAGE,
+} = await import("../admin-migrate");
 
 /**
  * A bundle `validateBundle` accepts that makes the importer ISSUE A STATEMENT.
@@ -216,7 +238,16 @@ describe("the import's error responses — both handlers", () => {
     releasedWith = [];
     statements = [];
     logged.length = 0;
+    priorInternalSecret = process.env.ATLAS_INTERNAL_SECRET;
     process.env.ATLAS_INTERNAL_SECRET = INTERNAL_SECRET;
+  });
+
+  // Restored rather than left set: the isolated runner contains the blast
+  // radius, but every `-pg` sibling save/restores and a leaked secret env var
+  // is the kind of cross-file coupling that is only ever debugged once.
+  afterEach(() => {
+    if (priorInternalSecret === undefined) delete process.env.ATLAS_INTERNAL_SECRET;
+    else process.env.ATLAS_INTERNAL_SECRET = priorInternalSecret;
   });
 
   describe.each(HANDLERS)("$name handler", ({ post }) => {
@@ -283,6 +314,9 @@ describe("the import's error responses — both handlers", () => {
       queryFailure = new Error(leak);
 
       const res = await post(minimalBundle());
+      // Pinned, for the reason this file's own header records: the first cut
+      // passed every body assertion against a 200.
+      expect(res.status).toBe(500);
       const body = (await res.json()) as ErrorBody;
 
       const recorded = logged.find(
@@ -379,7 +413,13 @@ describe("the import's error responses — both handlers", () => {
       ).toBe("import_rollback_uncertain");
       expect(body.message).toContain("UNKNOWN");
       expect(body.message).toContain("Do NOT re-send");
-      expect(body.message).not.toContain("re-sending the same bundle is safe");
+      // ⚠️ Compared against the CONSTANT, not a lowercase substring. The first
+      // cut asserted `.not.toContain("re-sending the same bundle is safe")`
+      // while the real text reads "Re-sending …" at a sentence start — so the
+      // one assertion guarding "never promise retry-safety here" was inert
+      // against the exact message it forbids.
+      expect(body.message).not.toBe(IMPORT_FAILED_MESSAGE);
+      expect(body.message.toLowerCase()).not.toContain("re-sending the same bundle is safe");
       // …and still no driver text, at either status.
       expect(body.message).not.toContain("duplicate key");
       expect(body.message).not.toContain("Connection terminated");
@@ -442,6 +482,61 @@ describe("the import's error responses — both handlers", () => {
         CURRENT_ORG,
       );
       expect(payload.requestId).toBeTruthy();
+      // ⚠️ `error`, not `warn`. This line says a pooled connection may be
+      // poisoned and a transaction's fate is unknown; at `warn` it sits beside
+      // routine noise. Unasserted, reverting the promotion killed no test.
+      expect(
+        rollbackLine?.level,
+        "the rollback failure was logged below `error` — it reports a possibly-poisoned pooled " +
+          "connection and an unknown transaction outcome",
+      ).toBe("error");
+    });
+
+    it("⭐ a REFUSAL whose rollback also failed is uncertain, NOT a confident 409", async () => {
+      // ⚠️ The arm all three round-3 reviewers found, and the fifth appearance
+      // of this branch's recurring shape. The refusal's own message ends
+      // "re-export and re-run" and its OpenAPI description says NOTHING WAS
+      // WRITTEN — both claims about the ROLLBACK, not about the error that
+      // triggered it. And these refusals are raised in the brain-facts section,
+      // AFTER conversations, entities, settings, dashboards, knowledge, tasks
+      // and episodes have already inserted into the open transaction.
+      //
+      // So a refusal whose rollback failed is the uncertain state exactly, and
+      // a confident 409 tells the operator to re-send over a possibly-committed
+      // partial import. The uncertainty check therefore sits ABOVE the 409 arm.
+      queryFailure = new RegionImportUnkeyableError("0f8c4a2e-5555-4000-8000-000000000005", [
+        "object",
+      ]);
+      rollbackFailure = new Error("Connection terminated unexpectedly");
+
+      const res = await post(minimalBundle());
+      const body = (await res.json()) as ErrorBody;
+
+      expect(
+        res.status,
+        "a refusal whose ROLLBACK failed was answered 409 — that status's contract says nothing " +
+          "was written, which is a claim about the rollback the process just failed to make",
+      ).toBe(500);
+      expect(body.error).toBe("import_rollback_uncertain");
+      expect(body.message).toContain("Do NOT re-send");
+      // The client is destroyed here too — the session is untrustworthy
+      // regardless of which error diagnosed the failure.
+      expect(releasedWith[0]).toBeInstanceOf(Error);
+    });
+
+    it("…and a refusal whose rollback SUCCEEDED is still a clean 409", async () => {
+      // The control for the hoist. Checking `rollbackErr` first is correct only
+      // if it does not swallow the ordinary refusal — the whole point of #5047's
+      // 409 is that a well-diagnosed refusal keeps its actionable message.
+      queryFailure = new RegionImportUnkeyableError("0f8c4a2e-6666-4000-8000-000000000006", [
+        "object",
+      ]);
+
+      const res = await post(minimalBundle());
+      expect(res.status).toBe(409);
+      const body = (await res.json()) as ErrorBody;
+      expect(body.error).toBe("import_refused");
+      expect(body.message).toContain("0f8c4a2e-6666-4000-8000-000000000006");
     });
 
     it("a refusal and a driver error do not converge on one body", async () => {
@@ -472,7 +567,11 @@ describe("the import's error responses — both handlers", () => {
     // test is what says the sharing is still in force.
     queryFailure = new Error("duplicate key value violates unique constraint");
     const [admin, internal] = await Promise.all(
-      HANDLERS.map(async ({ post }) => ((await (await post(minimalBundle())).json()) as ErrorBody).message),
+      HANDLERS.map(async ({ post }) => {
+        const res = await post(minimalBundle());
+        expect(res.status).toBe(500);
+        return ((await res.json()) as ErrorBody).message;
+      }),
     );
 
     expect(admin).toBe(internal);

--- a/packages/api/src/api/routes/admin-migrate.ts
+++ b/packages/api/src/api/routes/admin-migrate.ts
@@ -921,6 +921,36 @@ const IMPORT_FAILED_MESSAGE =
   "unchanged. The failure detail is recorded server-side against this response's `requestId`; " +
   "quote it when reporting this. Re-sending the same bundle is safe once the cause is resolved.";
 
+/**
+ * The 500 body when the ROLLBACK ITSELF failed — a state the handler cannot
+ * describe with {@link IMPORT_FAILED_MESSAGE} (#5106 round 2).
+ *
+ * That message promises *"nothing was written … re-sending the same bundle is
+ * safe"*. On this path the process has established neither. It issued a
+ * `ROLLBACK` and the request failed, so whether the transaction aborted, is
+ * still open, or committed is unknown to it. Returning the confident sentence
+ * here would be a claim about a state nobody observed — the same defect #5106
+ * fixed one layer up, where the 500 asserted things it had read off a driver
+ * error rather than established.
+ *
+ * ⚠️ A DISTINCT `error` CODE, not just distinct prose. A caller — including
+ * `lib/residency/migrate.ts`, which drives region migrations — branches on the
+ * code, and "retry is safe" versus "a human must inspect the destination before
+ * anything else happens" are the two most different answers this endpoint gives.
+ * Same 500 status, because the request was well-formed and the fault is ours.
+ *
+ * The remedy is deliberately concrete: the destination workspace has to be
+ * inspected, because the honest answer to *did anything land?* is that nobody
+ * knows. The connection is destroyed rather than pooled at the same time, which
+ * is what stops the uncertainty spreading to the next borrower.
+ */
+const IMPORT_ROLLBACK_UNCERTAIN_MESSAGE =
+  "Import failed AND the rollback did not complete — whether any of it committed is UNKNOWN. Do " +
+  "NOT re-send this bundle: inspect the destination workspace first, because a retry over a " +
+  "partially-committed import can duplicate or interleave rows. The connection has been " +
+  "discarded rather than returned to the pool. Both failures are recorded server-side against " +
+  "this response's `requestId`; quote it when reporting this.";
+
 // ---------------------------------------------------------------------------
 // Import logic (runs inside a transaction)
 // ---------------------------------------------------------------------------
@@ -2316,6 +2346,9 @@ adminMigrate.openapi(importRoute, async (c) => {
   // Run entire import inside a transaction for atomicity
   const pool = getInternalDB();
   const client = await pool.connect();
+  // Set ONLY when the ROLLBACK itself failed. Two things read it: the client
+  // release below, and the response arm — see {@link IMPORT_ROLLBACK_UNCERTAIN_MESSAGE}.
+  let rollbackErr: Error | undefined;
   try {
     await client.query("BEGIN");
     const result = await importBundle(client, bundle, orgId);
@@ -2324,17 +2357,24 @@ adminMigrate.openapi(importRoute, async (c) => {
     log.info({ requestId, orgId, result }, "Migration import complete");
     return c.json(result, 200);
   } catch (err) {
-    await client.query("ROLLBACK").catch((rollbackErr) => {
-      log.warn({ err: rollbackErr instanceof Error ? rollbackErr : new Error(String(rollbackErr)), requestId }, "Rollback failed");
+    // ROLLBACK can itself fail (a TCP reset between BEGIN and ROLLBACK, `57P01`
+    // admin shutdown, a statement timeout on the rollback, a pgbouncer-side
+    // kill). `pg` destroys the socket when `release(err)` is called with a
+    // truthy arg, so a poisoned client does not return to the pool to corrupt
+    // the next borrower's transaction — `admin-revoke.ts`, `admin-mfa-reset.ts`,
+    // `me-trusted-devices.ts` and `oauth-workspace-grants.ts` all do this and
+    // this handler was the outlier.
+    //
+    // ⚠️ `log.error`, not `warn`: this line says a pooled connection may be
+    // poisoned AND that a partial import's fate is unknown. It carries `orgId`
+    // because it is the one line that names a possibly-corrupted workspace.
+    await client.query("ROLLBACK").catch((rbErr: unknown) => {
+      rollbackErr = rbErr instanceof Error ? rbErr : new Error(String(rbErr));
+      log.error(
+        { err: rollbackErr, requestId, orgId },
+        "ROLLBACK failed after import error — the client will be DESTROYED rather than pooled, and whether the transaction committed is UNKNOWN",
+      );
     });
-    // ⚠️ FOR THE 409 ARM ONLY (#5106). `RegionImportUnkeyableError` and
-    // `RegionImportVocabularyTargetError` AUTHOR their own messages, and those
-    // carry a fact UUID and position names and nothing else — no surfaces, no
-    // row content, no connection detail — so echoing one verbatim is safe and
-    // is what makes the refusal actionable. Everything else arriving here is a
-    // driver error, and its text is not echoed at any status; see
-    // {@link IMPORT_FAILED_MESSAGE}.
-    const detail = err instanceof Error ? err.message : String(err);
     log.error({ err: err instanceof Error ? err : new Error(String(err)), requestId, orgId }, "Migration import failed, rolled back");
     // A refused bundle is not a server fault (#5047). TWO causes with two
     // different remedies, and the `message` carries the right one: a v3 bundle
@@ -2351,11 +2391,29 @@ adminMigrate.openapi(importRoute, async (c) => {
       err instanceof RegionImportUnkeyableError ||
       err instanceof RegionImportVocabularyTargetError
     ) {
-      return c.json({ error: "import_refused", message: detail, requestId }, 409);
+      // ⚠️ `err.message` is read HERE, inside the narrowed branch, and nowhere
+      // else (#5106 round 2). An outer `const detail = …` in the catch's scope
+      // was visible to the 500 return one line below — the exact leak #5106
+      // closed, sitting in scope and guarded only by a comment. Narrowing the
+      // read to the arm makes it unreachable rather than merely un-taken.
+      //
+      // Safe because BOTH constructors interpolate only a fact UUID and
+      // position names — no surfaces, no row content, no connection detail.
+      // That is a property of those constructors, not of this line: if either
+      // ever interpolates a `cause`, the leak returns here silently.
+      return c.json({ error: "import_refused", message: err.message, requestId }, 409);
     }
-    return c.json({ error: "import_failed", message: IMPORT_FAILED_MESSAGE, requestId }, 500);
+    // ⚠️ A FAILED ROLLBACK GETS ITS OWN BODY. `IMPORT_FAILED_MESSAGE` promises
+    // "nothing was written … re-sending is safe", and on this path the process
+    // has established neither — it knows only that it ASKED for a rollback and
+    // the request failed. Returning the same sentence would be a claim about a
+    // state nobody observed, which is the defect #5106 fixed one layer up.
+    return rollbackErr
+      ? c.json({ error: "import_rollback_uncertain", message: IMPORT_ROLLBACK_UNCERTAIN_MESSAGE, requestId }, 500)
+      : c.json({ error: "import_failed", message: IMPORT_FAILED_MESSAGE, requestId }, 500);
   } finally {
-    client.release();
+    // Truthy arg ⇒ `pg` destroys the socket instead of pooling it.
+    client.release(rollbackErr ?? undefined);
   }
 });
 
@@ -2419,6 +2477,9 @@ internalMigrate.post("/import", async (c) => {
 
   const pool = getInternalDB();
   const client = await pool.connect();
+  // Set ONLY when the ROLLBACK itself failed. Two things read it: the client
+  // release below, and the response arm — see {@link IMPORT_ROLLBACK_UNCERTAIN_MESSAGE}.
+  let rollbackErr: Error | undefined;
   try {
     await client.query("BEGIN");
     const result = await importBundle(client, bundle, orgId);
@@ -2427,17 +2488,24 @@ internalMigrate.post("/import", async (c) => {
     log.info({ requestId, orgId, result }, "Internal cross-region import complete");
     return c.json(result, 200);
   } catch (err) {
-    await client.query("ROLLBACK").catch((rollbackErr) => {
-      log.warn({ err: rollbackErr instanceof Error ? rollbackErr : new Error(String(rollbackErr)), requestId }, "Rollback failed");
+    // ROLLBACK can itself fail (a TCP reset between BEGIN and ROLLBACK, `57P01`
+    // admin shutdown, a statement timeout on the rollback, a pgbouncer-side
+    // kill). `pg` destroys the socket when `release(err)` is called with a
+    // truthy arg, so a poisoned client does not return to the pool to corrupt
+    // the next borrower's transaction — `admin-revoke.ts`, `admin-mfa-reset.ts`,
+    // `me-trusted-devices.ts` and `oauth-workspace-grants.ts` all do this and
+    // this handler was the outlier.
+    //
+    // ⚠️ `log.error`, not `warn`: this line says a pooled connection may be
+    // poisoned AND that a partial import's fate is unknown. It carries `orgId`
+    // because it is the one line that names a possibly-corrupted workspace.
+    await client.query("ROLLBACK").catch((rbErr: unknown) => {
+      rollbackErr = rbErr instanceof Error ? rbErr : new Error(String(rbErr));
+      log.error(
+        { err: rollbackErr, requestId, orgId },
+        "ROLLBACK failed after import error — the client will be DESTROYED rather than pooled, and whether the transaction committed is UNKNOWN",
+      );
     });
-    // ⚠️ FOR THE 409 ARM ONLY (#5106). `RegionImportUnkeyableError` and
-    // `RegionImportVocabularyTargetError` AUTHOR their own messages, and those
-    // carry a fact UUID and position names and nothing else — no surfaces, no
-    // row content, no connection detail — so echoing one verbatim is safe and
-    // is what makes the refusal actionable. Everything else arriving here is a
-    // driver error, and its text is not echoed at any status; see
-    // {@link IMPORT_FAILED_MESSAGE}.
-    const detail = err instanceof Error ? err.message : String(err);
     log.error({ err: err instanceof Error ? err : new Error(String(err)), requestId, orgId }, "Internal import failed, rolled back");
     // A refused bundle is not a server fault (#5047). TWO causes with two
     // different remedies, and the `message` carries the right one: a v3 bundle
@@ -2454,10 +2522,28 @@ internalMigrate.post("/import", async (c) => {
       err instanceof RegionImportUnkeyableError ||
       err instanceof RegionImportVocabularyTargetError
     ) {
-      return c.json({ error: "import_refused", message: detail, requestId }, 409);
+      // ⚠️ `err.message` is read HERE, inside the narrowed branch, and nowhere
+      // else (#5106 round 2). An outer `const detail = …` in the catch's scope
+      // was visible to the 500 return one line below — the exact leak #5106
+      // closed, sitting in scope and guarded only by a comment. Narrowing the
+      // read to the arm makes it unreachable rather than merely un-taken.
+      //
+      // Safe because BOTH constructors interpolate only a fact UUID and
+      // position names — no surfaces, no row content, no connection detail.
+      // That is a property of those constructors, not of this line: if either
+      // ever interpolates a `cause`, the leak returns here silently.
+      return c.json({ error: "import_refused", message: err.message, requestId }, 409);
     }
-    return c.json({ error: "import_failed", message: IMPORT_FAILED_MESSAGE, requestId }, 500);
+    // ⚠️ A FAILED ROLLBACK GETS ITS OWN BODY. `IMPORT_FAILED_MESSAGE` promises
+    // "nothing was written … re-sending is safe", and on this path the process
+    // has established neither — it knows only that it ASKED for a rollback and
+    // the request failed. Returning the same sentence would be a claim about a
+    // state nobody observed, which is the defect #5106 fixed one layer up.
+    return rollbackErr
+      ? c.json({ error: "import_rollback_uncertain", message: IMPORT_ROLLBACK_UNCERTAIN_MESSAGE, requestId }, 500)
+      : c.json({ error: "import_failed", message: IMPORT_FAILED_MESSAGE, requestId }, 500);
   } finally {
-    client.release();
+    // Truthy arg ⇒ `pg` destroys the socket instead of pooling it.
+    client.release(rollbackErr ?? undefined);
   }
 });

--- a/packages/api/src/api/routes/admin-migrate.ts
+++ b/packages/api/src/api/routes/admin-migrate.ts
@@ -871,16 +871,24 @@ const importRoute = createRoute({
         "was supposed to travel and did not — re-export from the source region, checking it for " +
         "identity drift and that it has applied migration 0194 — while on a v1/v2 bundle the key " +
         "is computed at import, so a refusal means THIS region's vocabulary maps that norm away " +
-        "and the fix is a local `brain_vocabulary_target` entry, which re-exporting cannot change.",
+        "and the fix is a local `brain_vocabulary_target` entry, which re-exporting cannot change. " +
+        "NOTHING WAS WRITTEN is a claim about the ROLLBACK, so a refusal whose rollback ALSO " +
+        "failed is reported as `import_rollback_uncertain` (500) instead of this status — this " +
+        "409 is only returned when the rollback is known to have completed.",
       content: { "application/json": { schema: ErrorSchema } },
     },
     500: {
       description:
-        "Import failed and the transaction rolled back — nothing was written. The `message` is " +
-        "deliberately GENERIC and the `requestId` is the handle: the underlying driver error is " +
-        "recorded server-side against that id and is not echoed here, because a `pg` message " +
-        "routinely embeds row content, constraint and column names, and — on a connection " +
-        "failure — the internal host and port (#5106).",
+        "Import failed. TWO codes, and they mean opposite things for a retry. `import_failed`: the " +
+        "transaction rolled back, nothing was written, and re-sending the same bundle is safe once " +
+        "the cause is resolved. `import_rollback_uncertain`: the ROLLBACK itself did not complete, " +
+        "so whether any of it committed is UNKNOWN — do NOT re-send; inspect the destination " +
+        "workspace first, because a retry over a partially-committed import can duplicate or " +
+        "interleave rows (the connection is discarded rather than pooled). In both cases the " +
+        "`message` is deliberately GENERIC and the `requestId` is the handle: the underlying " +
+        "driver error is recorded server-side against that id and is not echoed here, because a " +
+        "`pg` message routinely embeds row content, constraint and column names, and — on a " +
+        "connection failure — the internal host and port (#5106).",
       content: { "application/json": { schema: ErrorSchema } },
     },
   },
@@ -916,7 +924,7 @@ const importRoute = createRoute({
  * leak lived in both; a second string literal is how the next fix reaches one and
  * misses the other.
  */
-const IMPORT_FAILED_MESSAGE =
+export const IMPORT_FAILED_MESSAGE =
   "Import failed — all changes rolled back, so nothing was written and the source region is " +
   "unchanged. The failure detail is recorded server-side against this response's `requestId`; " +
   "quote it when reporting this. Re-sending the same bundle is safe once the cause is resolved.";
@@ -933,10 +941,21 @@ const IMPORT_FAILED_MESSAGE =
  * fixed one layer up, where the 500 asserted things it had read off a driver
  * error rather than established.
  *
- * ⚠️ A DISTINCT `error` CODE, not just distinct prose. A caller — including
- * `lib/residency/migrate.ts`, which drives region migrations — branches on the
- * code, and "retry is safe" versus "a human must inspect the destination before
- * anything else happens" are the two most different answers this endpoint gives.
+ * ⚠️ A DISTINCT `error` CODE, not just distinct prose — so that a caller CAN
+ * branch, which is not the same as saying one does. Stated precisely because an
+ * earlier cut of this line claimed `lib/residency/migrate.ts` branches on it and
+ * that is false: `transferBundleToTarget` flattens the body to
+ * `body.message ?? body.error` and returns one opaque string, so today the
+ * warning reaches a human as PROSE and the code has no machine reader. A
+ * comment asserting a consumer that does not exist is how the next maintainer
+ * concludes the hazard is already handled.
+ *
+ * The gap is real and is left as a follow-up rather than widened here:
+ * `resetMigrationForRetry` gates on `status`/`region_updated` alone, so the
+ * retry affordance will happily re-send the identical bundle — which is what
+ * this message forbids. Making it refuse an uncertain migration is new
+ * machinery across a second module.
+ *
  * Same 500 status, because the request was well-formed and the fault is ours.
  *
  * The remedy is deliberately concrete: the destination workspace has to be
@@ -2349,8 +2368,16 @@ adminMigrate.openapi(importRoute, async (c) => {
   // Set ONLY when the ROLLBACK itself failed. Two things read it: the client
   // release below, and the response arm — see {@link IMPORT_ROLLBACK_UNCERTAIN_MESSAGE}.
   let rollbackErr: Error | undefined;
+  // ⚠️ Set only once BEGIN has RESOLVED. Without it, a `pool.connect()` that
+  // handed back a dead socket fails at BEGIN, the catch's ROLLBACK fails on the
+  // same dead socket, `rollbackErr` is set — and the caller is told to
+  // hand-inspect a workspace for an import that provably never started. The
+  // uncertain body is expensive advice; it should only be given where the
+  // uncertainty is real.
+  let begun = false;
   try {
     await client.query("BEGIN");
+    begun = true;
     const result = await importBundle(client, bundle, orgId);
     await client.query("COMMIT");
 
@@ -2375,7 +2402,33 @@ adminMigrate.openapi(importRoute, async (c) => {
         "ROLLBACK failed after import error — the client will be DESTROYED rather than pooled, and whether the transaction committed is UNKNOWN",
       );
     });
-    log.error({ err: err instanceof Error ? err : new Error(String(err)), requestId, orgId }, "Migration import failed, rolled back");
+    log.error(
+      { err: err instanceof Error ? err : new Error(String(err)), requestId, orgId, rolledBack: !rollbackErr },
+      // ⚠️ CONDITIONAL, because the unconditional wording contradicted the line
+      // seven lines above it. An operator grepping one `requestId` would get two
+      // `error` lines making opposite claims about the same transaction, and the
+      // one that named the actual cause was the one that lied.
+      rollbackErr
+        ? "Migration import failed AND the ROLLBACK did not complete — see the line above; the transaction's fate is unknown"
+        : "Migration import failed, rolled back",
+    );
+    // ⚠️ A FAILED ROLLBACK OUTRANKS THE DIAGNOSIS, and this check sits ABOVE the
+    // 409 arm for that reason (round 3). The refusal's message ends "re-export
+    // and re-run" and its OpenAPI description says NOTHING WAS WRITTEN — both
+    // claims about the ROLLBACK, not about the error that triggered it. And the
+    // refusals are raised in `importBundle`'s brain-facts section, AFTER
+    // conversations, entities, settings, dashboards, knowledge, tasks and
+    // episodes have already inserted into the open transaction. So a refusal
+    // whose rollback failed is the uncertain state exactly, and answering it
+    // with a confident 409 tells the operator to re-send over a possibly
+    // committed partial import — the defect this arm exists to prevent, left
+    // standing on the arm #5047 exists to serve.
+    if (rollbackErr && begun) {
+      return c.json(
+        { error: "import_rollback_uncertain", message: IMPORT_ROLLBACK_UNCERTAIN_MESSAGE, requestId },
+        500,
+      );
+    }
     // A refused bundle is not a server fault (#5047). TWO causes with two
     // different remedies, and the `message` carries the right one: a v3 bundle
     // that supplied no identity for a keyable surface (source-side — re-export),
@@ -2403,17 +2456,15 @@ adminMigrate.openapi(importRoute, async (c) => {
       // ever interpolates a `cause`, the leak returns here silently.
       return c.json({ error: "import_refused", message: err.message, requestId }, 409);
     }
-    // ⚠️ A FAILED ROLLBACK GETS ITS OWN BODY. `IMPORT_FAILED_MESSAGE` promises
-    // "nothing was written … re-sending is safe", and on this path the process
-    // has established neither — it knows only that it ASKED for a rollback and
-    // the request failed. Returning the same sentence would be a claim about a
-    // state nobody observed, which is the defect #5106 fixed one layer up.
-    return rollbackErr
-      ? c.json({ error: "import_rollback_uncertain", message: IMPORT_ROLLBACK_UNCERTAIN_MESSAGE, requestId }, 500)
-      : c.json({ error: "import_failed", message: IMPORT_FAILED_MESSAGE, requestId }, 500);
+    // The rollback SUCCEEDED, so this body's "nothing was written" is a state
+    // the process established rather than assumed — the uncertain arm above
+    // took every case where it did not.
+    return c.json({ error: "import_failed", message: IMPORT_FAILED_MESSAGE, requestId }, 500);
   } finally {
-    // Truthy arg ⇒ `pg` destroys the socket instead of pooling it.
-    client.release(rollbackErr ?? undefined);
+    // Truthy arg ⇒ `pg` destroys the socket instead of pooling it. No
+    // `?? undefined`: the variable is already `Error | undefined`, and a no-op
+    // coalesce reads as a meaningful guard.
+    client.release(rollbackErr);
   }
 });
 
@@ -2480,8 +2531,16 @@ internalMigrate.post("/import", async (c) => {
   // Set ONLY when the ROLLBACK itself failed. Two things read it: the client
   // release below, and the response arm — see {@link IMPORT_ROLLBACK_UNCERTAIN_MESSAGE}.
   let rollbackErr: Error | undefined;
+  // ⚠️ Set only once BEGIN has RESOLVED. Without it, a `pool.connect()` that
+  // handed back a dead socket fails at BEGIN, the catch's ROLLBACK fails on the
+  // same dead socket, `rollbackErr` is set — and the caller is told to
+  // hand-inspect a workspace for an import that provably never started. The
+  // uncertain body is expensive advice; it should only be given where the
+  // uncertainty is real.
+  let begun = false;
   try {
     await client.query("BEGIN");
+    begun = true;
     const result = await importBundle(client, bundle, orgId);
     await client.query("COMMIT");
 
@@ -2506,7 +2565,33 @@ internalMigrate.post("/import", async (c) => {
         "ROLLBACK failed after import error — the client will be DESTROYED rather than pooled, and whether the transaction committed is UNKNOWN",
       );
     });
-    log.error({ err: err instanceof Error ? err : new Error(String(err)), requestId, orgId }, "Internal import failed, rolled back");
+    log.error(
+      { err: err instanceof Error ? err : new Error(String(err)), requestId, orgId, rolledBack: !rollbackErr },
+      // ⚠️ CONDITIONAL, because the unconditional wording contradicted the line
+      // seven lines above it. An operator grepping one `requestId` would get two
+      // `error` lines making opposite claims about the same transaction, and the
+      // one that named the actual cause was the one that lied.
+      rollbackErr
+        ? "Internal import failed AND the ROLLBACK did not complete — see the line above; the transaction's fate is unknown"
+        : "Internal import failed, rolled back",
+    );
+    // ⚠️ A FAILED ROLLBACK OUTRANKS THE DIAGNOSIS, and this check sits ABOVE the
+    // 409 arm for that reason (round 3). The refusal's message ends "re-export
+    // and re-run" and its OpenAPI description says NOTHING WAS WRITTEN — both
+    // claims about the ROLLBACK, not about the error that triggered it. And the
+    // refusals are raised in `importBundle`'s brain-facts section, AFTER
+    // conversations, entities, settings, dashboards, knowledge, tasks and
+    // episodes have already inserted into the open transaction. So a refusal
+    // whose rollback failed is the uncertain state exactly, and answering it
+    // with a confident 409 tells the operator to re-send over a possibly
+    // committed partial import — the defect this arm exists to prevent, left
+    // standing on the arm #5047 exists to serve.
+    if (rollbackErr && begun) {
+      return c.json(
+        { error: "import_rollback_uncertain", message: IMPORT_ROLLBACK_UNCERTAIN_MESSAGE, requestId },
+        500,
+      );
+    }
     // A refused bundle is not a server fault (#5047). TWO causes with two
     // different remedies, and the `message` carries the right one: a v3 bundle
     // that supplied no identity for a keyable surface (source-side — re-export),
@@ -2534,16 +2619,14 @@ internalMigrate.post("/import", async (c) => {
       // ever interpolates a `cause`, the leak returns here silently.
       return c.json({ error: "import_refused", message: err.message, requestId }, 409);
     }
-    // ⚠️ A FAILED ROLLBACK GETS ITS OWN BODY. `IMPORT_FAILED_MESSAGE` promises
-    // "nothing was written … re-sending is safe", and on this path the process
-    // has established neither — it knows only that it ASKED for a rollback and
-    // the request failed. Returning the same sentence would be a claim about a
-    // state nobody observed, which is the defect #5106 fixed one layer up.
-    return rollbackErr
-      ? c.json({ error: "import_rollback_uncertain", message: IMPORT_ROLLBACK_UNCERTAIN_MESSAGE, requestId }, 500)
-      : c.json({ error: "import_failed", message: IMPORT_FAILED_MESSAGE, requestId }, 500);
+    // The rollback SUCCEEDED, so this body's "nothing was written" is a state
+    // the process established rather than assumed — the uncertain arm above
+    // took every case where it did not.
+    return c.json({ error: "import_failed", message: IMPORT_FAILED_MESSAGE, requestId }, 500);
   } finally {
-    // Truthy arg ⇒ `pg` destroys the socket instead of pooling it.
-    client.release(rollbackErr ?? undefined);
+    // Truthy arg ⇒ `pg` destroys the socket instead of pooling it. No
+    // `?? undefined`: the variable is already `Error | undefined`, and a no-op
+    // coalesce reads as a meaningful guard.
+    client.release(rollbackErr);
   }
 });

--- a/packages/api/src/api/routes/admin-migrate.ts
+++ b/packages/api/src/api/routes/admin-migrate.ts
@@ -875,11 +875,51 @@ const importRoute = createRoute({
       content: { "application/json": { schema: ErrorSchema } },
     },
     500: {
-      description: "Internal server error",
+      description:
+        "Import failed and the transaction rolled back — nothing was written. The `message` is " +
+        "deliberately GENERIC and the `requestId` is the handle: the underlying driver error is " +
+        "recorded server-side against that id and is not echoed here, because a `pg` message " +
+        "routinely embeds row content, constraint and column names, and — on a connection " +
+        "failure — the internal host and port (#5106).",
       content: { "application/json": { schema: ErrorSchema } },
     },
   },
 });
+
+/**
+ * The 500 body's entire `message` — the driver's own text NEVER reaches it (#5106).
+ *
+ * A `pg` error message is not a description of what went wrong, it is a fragment
+ * of the database: `duplicate key value violates unique constraint "…" Key
+ * (id)=(…)` carries ROW CONTENT, every constraint violation names internal
+ * constraint and column spellings, and a connection failure carries the internal
+ * host and port. CLAUDE.md § Product invariants: *never expose connection
+ * strings, API keys, or stack traces to the user or agent.*
+ *
+ * ⚠️ THE DETAIL IS NOT DROPPED, it is MOVED. The `log.error` at each call site
+ * records the real error — as an `Error` instance, so pino's `err` serializer
+ * keeps the message AND the stack — beside the same `requestId` this body
+ * carries. That pairing is the whole design: the operator loses nothing and the
+ * caller learns nothing they should not. A fix that scrubbed the response and
+ * also stopped logging would close the leak by destroying the evidence, which is
+ * the failure this note exists to prevent.
+ *
+ * ⚠️ NOT routed through `audit/error-scrub.ts`'s `errorMessage`. That helper is
+ * for `admin_action_log.metadata` — a JSONB column compliance reviewers read —
+ * and its own docstring rules itself out for a pino `err` field, which the
+ * serializer handles with full stack preservation. Scrubbing userinfo out of a
+ * message that is not going to a caller at all would only cost the operator
+ * detail.
+ *
+ * ONE constant, read by BOTH handlers. The admin route and the internal
+ * service-to-service route are copies of each other, and #5106 exists because a
+ * leak lived in both; a second string literal is how the next fix reaches one and
+ * misses the other.
+ */
+const IMPORT_FAILED_MESSAGE =
+  "Import failed — all changes rolled back, so nothing was written and the source region is " +
+  "unchanged. The failure detail is recorded server-side against this response's `requestId`; " +
+  "quote it when reporting this. Re-sending the same bundle is safe once the cause is resolved.";
 
 // ---------------------------------------------------------------------------
 // Import logic (runs inside a transaction)
@@ -2287,6 +2327,13 @@ adminMigrate.openapi(importRoute, async (c) => {
     await client.query("ROLLBACK").catch((rollbackErr) => {
       log.warn({ err: rollbackErr instanceof Error ? rollbackErr : new Error(String(rollbackErr)), requestId }, "Rollback failed");
     });
+    // ⚠️ FOR THE 409 ARM ONLY (#5106). `RegionImportUnkeyableError` and
+    // `RegionImportVocabularyTargetError` AUTHOR their own messages, and those
+    // carry a fact UUID and position names and nothing else — no surfaces, no
+    // row content, no connection detail — so echoing one verbatim is safe and
+    // is what makes the refusal actionable. Everything else arriving here is a
+    // driver error, and its text is not echoed at any status; see
+    // {@link IMPORT_FAILED_MESSAGE}.
     const detail = err instanceof Error ? err.message : String(err);
     log.error({ err: err instanceof Error ? err : new Error(String(err)), requestId, orgId }, "Migration import failed, rolled back");
     // A refused bundle is not a server fault (#5047). TWO causes with two
@@ -2306,7 +2353,7 @@ adminMigrate.openapi(importRoute, async (c) => {
     ) {
       return c.json({ error: "import_refused", message: detail, requestId }, 409);
     }
-    return c.json({ error: "import_failed", message: `Import failed — all changes rolled back. ${detail}`, requestId }, 500);
+    return c.json({ error: "import_failed", message: IMPORT_FAILED_MESSAGE, requestId }, 500);
   } finally {
     client.release();
   }
@@ -2383,6 +2430,13 @@ internalMigrate.post("/import", async (c) => {
     await client.query("ROLLBACK").catch((rollbackErr) => {
       log.warn({ err: rollbackErr instanceof Error ? rollbackErr : new Error(String(rollbackErr)), requestId }, "Rollback failed");
     });
+    // ⚠️ FOR THE 409 ARM ONLY (#5106). `RegionImportUnkeyableError` and
+    // `RegionImportVocabularyTargetError` AUTHOR their own messages, and those
+    // carry a fact UUID and position names and nothing else — no surfaces, no
+    // row content, no connection detail — so echoing one verbatim is safe and
+    // is what makes the refusal actionable. Everything else arriving here is a
+    // driver error, and its text is not echoed at any status; see
+    // {@link IMPORT_FAILED_MESSAGE}.
     const detail = err instanceof Error ? err.message : String(err);
     log.error({ err: err instanceof Error ? err : new Error(String(err)), requestId, orgId }, "Internal import failed, rolled back");
     // A refused bundle is not a server fault (#5047). TWO causes with two
@@ -2402,7 +2456,7 @@ internalMigrate.post("/import", async (c) => {
     ) {
       return c.json({ error: "import_refused", message: detail, requestId }, 409);
     }
-    return c.json({ error: "import_failed", message: `Import failed — all changes rolled back. ${detail}`, requestId }, 500);
+    return c.json({ error: "import_failed", message: IMPORT_FAILED_MESSAGE, requestId }, 500);
   } finally {
     client.release();
   }

--- a/packages/api/src/api/routes/admin-migrate.ts
+++ b/packages/api/src/api/routes/admin-migrate.ts
@@ -922,7 +922,9 @@ const importRoute = createRoute({
  * ONE constant, read by BOTH handlers. The admin route and the internal
  * service-to-service route are copies of each other, and #5106 exists because a
  * leak lived in both; a second string literal is how the next fix reaches one and
- * misses the other.
+ * misses the other. EXPORTED for a third reader: the route test anchors
+ * `expect(body.message).not.toBe(IMPORT_FAILED_MESSAGE)` on it, after a
+ * hand-typed lowercase substring made that assertion silently inert.
  */
 export const IMPORT_FAILED_MESSAGE =
   "Import failed — all changes rolled back, so nothing was written and the source region is " +
@@ -930,8 +932,10 @@ export const IMPORT_FAILED_MESSAGE =
   "quote it when reporting this. Re-sending the same bundle is safe once the cause is resolved.";
 
 /**
- * The 500 body when the ROLLBACK ITSELF failed — a state the handler cannot
- * describe with {@link IMPORT_FAILED_MESSAGE} (#5106 round 2).
+ * The 500 body when the ROLLBACK ITSELF failed AND a transaction was open — a
+ * state the handler cannot describe with {@link IMPORT_FAILED_MESSAGE} (#5106
+ * round 2). The `begun` half of that gate is load-bearing, not redundant: a
+ * BEGIN that never resolved leaves nothing to be uncertain about.
  *
  * That message promises *"nothing was written … re-sending the same bundle is
  * safe"*. On this path the process has established neither. It issued a
@@ -2365,8 +2369,11 @@ adminMigrate.openapi(importRoute, async (c) => {
   // Run entire import inside a transaction for atomicity
   const pool = getInternalDB();
   const client = await pool.connect();
-  // Set ONLY when the ROLLBACK itself failed. Two things read it: the client
-  // release below, and the response arm — see {@link IMPORT_ROLLBACK_UNCERTAIN_MESSAGE}.
+  // Set ONLY when the ROLLBACK itself failed. FOUR readers: the client release,
+  // the `uncertain` derivation below (which the response arm and the log message
+  // both consume) and the log payload's `rolledBack`. See
+  // {@link IMPORT_ROLLBACK_UNCERTAIN_MESSAGE} for why the release's question is
+  // narrower than the body's.
   let rollbackErr: Error | undefined;
   // ⚠️ Set only once BEGIN has RESOLVED. Without it, a `pool.connect()` that
   // handed back a dead socket fails at BEGIN, the catch's ROLLBACK fails on the
@@ -2402,13 +2409,25 @@ adminMigrate.openapi(importRoute, async (c) => {
         "ROLLBACK failed after import error — the client will be DESTROYED rather than pooled, and whether the transaction committed is UNKNOWN",
       );
     });
+    // ⚠️ ONE derived answer, read by the log AND the body. Round 3 keyed the log
+    // on `rollbackErr` alone while the body used `rollbackErr && begun`, so a
+    // BEGIN that never resolved produced a log saying "the transaction's fate is
+    // unknown" beside a body saying "all changes rolled back, nothing was
+    // written" — the very contradiction the conditional message was added to
+    // remove, reproduced between the two surfaces instead of between two lines.
+    const uncertain = rollbackErr !== undefined && begun;
     log.error(
-      { err: err instanceof Error ? err : new Error(String(err)), requestId, orgId, rolledBack: !rollbackErr },
+      {
+        err: err instanceof Error ? err : new Error(String(err)),
+        requestId,
+        orgId,
+        rolledBack: !uncertain,
+      },
       // ⚠️ CONDITIONAL, because the unconditional wording contradicted the line
       // seven lines above it. An operator grepping one `requestId` would get two
       // `error` lines making opposite claims about the same transaction, and the
       // one that named the actual cause was the one that lied.
-      rollbackErr
+      uncertain
         ? "Migration import failed AND the ROLLBACK did not complete — see the line above; the transaction's fate is unknown"
         : "Migration import failed, rolled back",
     );
@@ -2417,13 +2436,12 @@ adminMigrate.openapi(importRoute, async (c) => {
     // and re-run" and its OpenAPI description says NOTHING WAS WRITTEN — both
     // claims about the ROLLBACK, not about the error that triggered it. And the
     // refusals are raised in `importBundle`'s brain-facts section, AFTER
-    // conversations, entities, settings, dashboards, knowledge, tasks and
-    // episodes have already inserted into the open transaction. So a refusal
+    // EVERY earlier section has already inserted into the open transaction. So a refusal
     // whose rollback failed is the uncertain state exactly, and answering it
     // with a confident 409 tells the operator to re-send over a possibly
     // committed partial import — the defect this arm exists to prevent, left
     // standing on the arm #5047 exists to serve.
-    if (rollbackErr && begun) {
+    if (uncertain) {
       return c.json(
         { error: "import_rollback_uncertain", message: IMPORT_ROLLBACK_UNCERTAIN_MESSAGE, requestId },
         500,
@@ -2456,14 +2474,17 @@ adminMigrate.openapi(importRoute, async (c) => {
       // ever interpolates a `cause`, the leak returns here silently.
       return c.json({ error: "import_refused", message: err.message, requestId }, 409);
     }
-    // The rollback SUCCEEDED, so this body's "nothing was written" is a state
-    // the process established rather than assumed — the uncertain arm above
-    // took every case where it did not.
+    // Reached TWO ways, and "nothing was written" is established on both: the
+    // ROLLBACK completed, or it failed before BEGIN ever resolved — in which
+    // case no statement ran at all and `begun === false` is the evidence, not
+    // the rollback. An earlier cut of this line said simply "the rollback
+    // SUCCEEDED", which is false on exactly the path `begun` was added to
+    // create.
     return c.json({ error: "import_failed", message: IMPORT_FAILED_MESSAGE, requestId }, 500);
   } finally {
     // Truthy arg ⇒ `pg` destroys the socket instead of pooling it. No
-    // `?? undefined`: the variable is already `Error | undefined`, and a no-op
-    // coalesce reads as a meaningful guard.
+    // `?? undefined`: this variable is already `Error | undefined`. (Contrast
+    // `admin-archive.ts`, whose own is `Error | null` and genuinely needs it.)
     client.release(rollbackErr);
   }
 });
@@ -2528,8 +2549,11 @@ internalMigrate.post("/import", async (c) => {
 
   const pool = getInternalDB();
   const client = await pool.connect();
-  // Set ONLY when the ROLLBACK itself failed. Two things read it: the client
-  // release below, and the response arm — see {@link IMPORT_ROLLBACK_UNCERTAIN_MESSAGE}.
+  // Set ONLY when the ROLLBACK itself failed. FOUR readers: the client release,
+  // the `uncertain` derivation below (which the response arm and the log message
+  // both consume) and the log payload's `rolledBack`. See
+  // {@link IMPORT_ROLLBACK_UNCERTAIN_MESSAGE} for why the release's question is
+  // narrower than the body's.
   let rollbackErr: Error | undefined;
   // ⚠️ Set only once BEGIN has RESOLVED. Without it, a `pool.connect()` that
   // handed back a dead socket fails at BEGIN, the catch's ROLLBACK fails on the
@@ -2565,13 +2589,25 @@ internalMigrate.post("/import", async (c) => {
         "ROLLBACK failed after import error — the client will be DESTROYED rather than pooled, and whether the transaction committed is UNKNOWN",
       );
     });
+    // ⚠️ ONE derived answer, read by the log AND the body. Round 3 keyed the log
+    // on `rollbackErr` alone while the body used `rollbackErr && begun`, so a
+    // BEGIN that never resolved produced a log saying "the transaction's fate is
+    // unknown" beside a body saying "all changes rolled back, nothing was
+    // written" — the very contradiction the conditional message was added to
+    // remove, reproduced between the two surfaces instead of between two lines.
+    const uncertain = rollbackErr !== undefined && begun;
     log.error(
-      { err: err instanceof Error ? err : new Error(String(err)), requestId, orgId, rolledBack: !rollbackErr },
+      {
+        err: err instanceof Error ? err : new Error(String(err)),
+        requestId,
+        orgId,
+        rolledBack: !uncertain,
+      },
       // ⚠️ CONDITIONAL, because the unconditional wording contradicted the line
       // seven lines above it. An operator grepping one `requestId` would get two
       // `error` lines making opposite claims about the same transaction, and the
       // one that named the actual cause was the one that lied.
-      rollbackErr
+      uncertain
         ? "Internal import failed AND the ROLLBACK did not complete — see the line above; the transaction's fate is unknown"
         : "Internal import failed, rolled back",
     );
@@ -2580,13 +2616,12 @@ internalMigrate.post("/import", async (c) => {
     // and re-run" and its OpenAPI description says NOTHING WAS WRITTEN — both
     // claims about the ROLLBACK, not about the error that triggered it. And the
     // refusals are raised in `importBundle`'s brain-facts section, AFTER
-    // conversations, entities, settings, dashboards, knowledge, tasks and
-    // episodes have already inserted into the open transaction. So a refusal
+    // EVERY earlier section has already inserted into the open transaction. So a refusal
     // whose rollback failed is the uncertain state exactly, and answering it
     // with a confident 409 tells the operator to re-send over a possibly
     // committed partial import — the defect this arm exists to prevent, left
     // standing on the arm #5047 exists to serve.
-    if (rollbackErr && begun) {
+    if (uncertain) {
       return c.json(
         { error: "import_rollback_uncertain", message: IMPORT_ROLLBACK_UNCERTAIN_MESSAGE, requestId },
         500,
@@ -2619,14 +2654,17 @@ internalMigrate.post("/import", async (c) => {
       // ever interpolates a `cause`, the leak returns here silently.
       return c.json({ error: "import_refused", message: err.message, requestId }, 409);
     }
-    // The rollback SUCCEEDED, so this body's "nothing was written" is a state
-    // the process established rather than assumed — the uncertain arm above
-    // took every case where it did not.
+    // Reached TWO ways, and "nothing was written" is established on both: the
+    // ROLLBACK completed, or it failed before BEGIN ever resolved — in which
+    // case no statement ran at all and `begun === false` is the evidence, not
+    // the rollback. An earlier cut of this line said simply "the rollback
+    // SUCCEEDED", which is false on exactly the path `begun` was added to
+    // create.
     return c.json({ error: "import_failed", message: IMPORT_FAILED_MESSAGE, requestId }, 500);
   } finally {
     // Truthy arg ⇒ `pg` destroys the socket instead of pooling it. No
-    // `?? undefined`: the variable is already `Error | undefined`, and a no-op
-    // coalesce reads as a meaningful guard.
+    // `?? undefined`: this variable is already `Error | undefined`. (Contrast
+    // `admin-archive.ts`, whose own is `Error | null` and genuinely needs it.)
     client.release(rollbackErr);
   }
 });

--- a/packages/api/src/api/routes/admin-migrate.ts
+++ b/packages/api/src/api/routes/admin-migrate.ts
@@ -906,8 +906,8 @@ const importRoute = createRoute({
  *
  * ⚠️ NOT routed through `audit/error-scrub.ts`'s `errorMessage`. That helper is
  * for `admin_action_log.metadata` — a JSONB column compliance reviewers read —
- * and its own docstring rules itself out for a pino `err` field, which the
- * serializer handles with full stack preservation. Scrubbing userinfo out of a
+ * and its own docstring carves out an `Error` instance handed to pino, whose
+ * `err` serializer preserves the message and the stack. Scrubbing userinfo out of a
  * message that is not going to a caller at all would only cost the operator
  * detail.
  *

--- a/packages/api/src/lib/brain/__tests__/reconcile-logging.test.ts
+++ b/packages/api/src/lib/brain/__tests__/reconcile-logging.test.ts
@@ -406,8 +406,16 @@ describe("the MALFORMED_CLAIM warn payload (#5105)", () => {
     // The control. Every assertion above is about the CONTENT of a line, so a
     // guard that fired on everything would satisfy all of them — this is the
     // only test that says the line is conditional.
-    await run([{}]);
+    const report = await run([{}]);
 
+    // ⚠️ THE CLAIM IS CREATED, asserted before the absence. Measured: forcing
+    // the grant screen — which sits ABOVE the identity guard — to refuse every
+    // candidate kills 7 of this file's 8 tests, and this control was the
+    // survivor. An absence assertion alone cannot tell "the warn is
+    // conditional" from "the pipeline never reached the guard", so any future
+    // change that blocks the healthy claim earlier would leave this green while
+    // deleting the file's premise.
+    expect(report.outcomes[0]).toMatchObject({ kind: "created" });
     expect(warns.filter((w) => w.message.includes("no identity for one or more slots"))).toHaveLength(0);
   });
 });

--- a/packages/api/src/lib/brain/__tests__/reconcile-logging.test.ts
+++ b/packages/api/src/lib/brain/__tests__/reconcile-logging.test.ts
@@ -1,0 +1,406 @@
+/**
+ * `MALFORMED_CLAIM`'s OPERATOR-FACING warn payload (#5105, ADR-0037 §8).
+ *
+ * The line this file pins had no coverage anywhere — a repo-wide grep for the
+ * message returned nothing, and `inheritedUnkeyed` appeared only in
+ * `reconcile.ts` itself, before #5047 and after it.
+ *
+ * ## The one field with a data-exposure edge
+ *
+ * **`degenerateSurfaces` logs RAW CLAIM TEXT.** It is safe only while the
+ * `cause === "degenerate-surface"` filter is correct: by construction such a
+ * surface is separators and whitespace and carries no claim content, which is
+ * exactly the argument the blank-trim guard one loop up makes when it logs
+ * booleans instead of surfaces. Misclassify a `vocabulary-target` failure as
+ * `degenerate-surface` and real subject or object text — a customer's claim,
+ * verbatim — enters the log stream, where it is retained, shipped to whatever
+ * aggregator the deployment uses, and not recallable.
+ *
+ * So the assertion that carries this file is not that `degenerateSurfaces`
+ * contains the right thing. It is that on a `vocabulary-target` failure over a
+ * REAL surface it is **empty** — the leak falsifier, and the reason #5105
+ * exists. Everything else here is the classification that assertion depends on.
+ *
+ * ## Why the three-way `cause` needs pinning and not just reading
+ *
+ * `cause` decides which SUBSYSTEM an operator goes and fixes, and the three
+ * answers name three different teams' problems: the producer, this workspace's
+ * vocabulary table, and the target row of a row-copy. #5047's review found the
+ * sibling gate in `correction.ts` branching on the failing POSITION instead of
+ * its CAUSE — which told a human superseding with perfectly good text that
+ * their replacement "normalizes away to nothing", on a request no retry could
+ * satisfy. Same class of defect, one layer over; here it is a warn nobody was
+ * reading rather than a 400 somebody was.
+ *
+ * The `inherited` arm's correctness also rests on a property of ANOTHER module:
+ * `InheritedSlotValue` always supplies both subject and predicate, so
+ * `inheritedSlot !== undefined && role !== "object"` cannot mislabel a
+ * vocabulary failure as `inherited`. Nothing detects that property moving, so
+ * the last case below asserts the shape it depends on rather than assuming it.
+ *
+ * ## Mutations, measured
+ *
+ * Each applied one at a time against an otherwise clean tree, all eight tests
+ * run, then reverted. Every number below is a count of FAILING tests, not an
+ * author's guess about which test ought to have caught it.
+ *
+ * | Mutation | Kills | Note |
+ * |---|---|---|
+ * | `degenerateSurfaces`' `.filter(cause === "degenerate-surface")` deleted | 4 | ⭐ THE leak. Every unkeyed position's surface is logged, including a real one |
+ * | the two non-inherited causes SWAPPED (a `vocabulary-target` labelled `degenerate-surface`) | 5 | the leak reached the other way — the ⭐ falsifier is one of the five |
+ * | `cause` gates on the POSITION instead of the CAUSE (`role === "object" ? "degenerate-surface" : …`) | 1 | #5047's own defect, one layer over. ONLY the two-causes-in-one-claim case sees it, which is why that case is not redundant with the single-cause ones |
+ *
+ * The third row is the argument for the multi-position case existing at all:
+ * every single-cause test above agrees with a position-based classifier by
+ * coincidence, because in each of them the position and the cause happen to
+ * line up.
+ *
+ * ## Why a separate file
+ *
+ * `acl-logging.test.ts`'s pattern, and its constraint: mocking the logger means
+ * `mock.module`ing **every** value export of `@atlas/api/lib/logger` and then
+ * importing the module under test DYNAMICALLY, so the mock is installed before
+ * the import binds. That is process-wide, so it cannot share a file with suites
+ * that want real logging. `reconcile.test.ts` deliberately uses no
+ * `mock.module()` at all (see its header), which is why this is a sibling and
+ * not a `describe` block over there.
+ *
+ * No database: every case blocks in the PREPARATION LOOP, above the
+ * transaction, so the executor below never answers an identity question.
+ */
+
+import { afterEach, beforeAll, describe, expect, it, mock } from "bun:test";
+
+interface Captured {
+  readonly payload: Record<string, unknown>;
+  readonly message: string;
+}
+
+const warns: Captured[] = [];
+const errors: Captured[] = [];
+
+/**
+ * Every value export of `lib/logger`, replaced.
+ *
+ * ⚠️ A PARTIAL mock is the trap this repo has recorded: `mock.module` replaces
+ * the whole module, so any export left out becomes `undefined` and the module
+ * under test throws on first use — which reads as a broken test rather than a
+ * missing mock. The factory is SYNCHRONOUS, because an async one deadlocks
+ * `bun:test`.
+ */
+void mock.module("@atlas/api/lib/logger", () => {
+  const record = (sink: Captured[]) => (payload: unknown, message?: unknown) =>
+    sink.push({
+      payload: (payload ?? {}) as Record<string, unknown>,
+      message: typeof message === "string" ? message : String(payload),
+    });
+  const capture = {
+    error: record(errors),
+    warn: record(warns),
+    info: () => {},
+    debug: () => {},
+    level: "info",
+  };
+  return {
+    createLogger: () => capture,
+    getLogger: () => capture,
+    setLogLevel: () => true,
+    getRequestContext: () => undefined,
+    withRequestContext: <T,>(_ctx: unknown, fn: () => T): T => fn(),
+    redactPaths: [] as string[],
+    scrubErrSerializer: (err: unknown) => err,
+    scrubLogFormatter: (obj: unknown) => obj,
+    hashShareToken: (token: string) => token,
+    ACTOR_KINDS: ["human", "agent", "mcp", "scheduler", "api_key"] as const,
+  };
+});
+
+type ReconcileModule = typeof import("@atlas/api/lib/brain/reconcile");
+type IdentityModule = typeof import("@atlas/api/lib/brain/identity");
+
+let reconcileFacts: ReconcileModule["reconcileFacts"];
+let identityVocabulary: IdentityModule["identityVocabulary"];
+let inheritSlotFromFactRow: IdentityModule["inheritSlotFromFactRow"];
+
+beforeAll(async () => {
+  // DYNAMIC, after the mock above is installed. A static import binds the real
+  // logger before the factory runs and every assertion here reads an empty sink.
+  ({ reconcileFacts } = await import("@atlas/api/lib/brain/reconcile"));
+  ({ identityVocabulary, inheritSlotFromFactRow } = await import(
+    "@atlas/api/lib/brain/identity"
+  ));
+});
+
+afterEach(() => {
+  warns.length = 0;
+  errors.length = 0;
+});
+
+const WORKSPACE = "ws-5105";
+const EPISODE = "ep-5105";
+const PRODUCER = "extraction:v1";
+
+/**
+ * The transaction seam, answering as little as it can.
+ *
+ * Every REFUSED candidate is decided in the preparation loop, above the
+ * transaction, so no statement here classifies anything — but a batch whose
+ * candidates are all malformed still opens the transaction, so the runner has
+ * to exist.
+ *
+ * The one answer it gives is an id for the fact insert, and only the control
+ * case reaches it: `writeCandidate` throws on an insert that returns no id
+ * (correctly — a silent `return` would report a fact that does not exist), so a
+ * blanket `{ rows: [] }` turns "the healthy claim was NOT refused" into a
+ * failure that reads like a defect in the guard. Every other statement still
+ * answers nothing, which keeps the corroboration and tension lookups from
+ * inventing a collision this file is in no position to assert about.
+ */
+const noopRunner = async <T,>(
+  fn: (tx: { query: (sql: string) => Promise<{ rows: { id: string }[] }> }) => Promise<T>,
+) =>
+  fn({
+    query: async (sql: string) => ({
+      rows: sql.includes("INSERT INTO brain_facts")
+        ? [{ id: "00000000-0000-4000-8000-0000000000ff" }]
+        : [],
+    }),
+  });
+
+function run(
+  candidates: readonly { subject?: string; predicate?: string; object?: string; inheritedSlot?: unknown }[],
+  vocabulary = identityVocabulary,
+) {
+  return reconcileFacts(
+    {
+      episode: {
+        id: EPISODE,
+        workspaceId: WORKSPACE,
+        source: "slack",
+        sourceId: "C01:1719000000.000100",
+        sourceActor: "U123",
+        occurredAt: new Date("2026-06-21T09:00:00.000Z"),
+        visibleTo: ["org"],
+      },
+      candidates: candidates.map((c) => ({
+        subject: "deploy window",
+        predicate: "is",
+        object: "Thursdays",
+        ...c,
+      })) as Parameters<typeof reconcileFacts>[0]["candidates"],
+      producer: PRODUCER,
+      extractedAt: new Date("2026-06-21T10:00:00.000Z"),
+      vocabulary,
+    },
+    {
+      withTransaction: noopRunner as Parameters<typeof reconcileFacts>[1]["withTransaction"],
+      now: () => new Date("2026-06-21T10:00:01.000Z"),
+    },
+  );
+}
+
+/** The one `MALFORMED_CLAIM` warn, refused if there is not exactly one. */
+function theWarn(): Captured {
+  const malformed = warns.filter((w) => w.message.includes("no identity for one or more slots"));
+  expect(
+    malformed,
+    "expected exactly one MALFORMED_CLAIM warn — zero means the line was deleted or the " +
+      "candidate was not refused at all, and more than one means the assertions below are " +
+      "reading an arbitrary member of a set",
+  ).toHaveLength(1);
+  return malformed[0]!;
+}
+
+describe("the MALFORMED_CLAIM warn payload (#5105)", () => {
+  it("a degenerate OBJECT surface: cause `degenerate-surface`, and the surface IS logged", async () => {
+    // `-` clears the blank-trim guard — `String#trim` strips whitespace but not
+    // `_` or `-` — and reaches the identity guard with a null key. This is the
+    // one cause whose surface is safe to log, and the payload is what sends the
+    // operator to the PRODUCER rather than to the vocabulary table.
+    await run([{ object: "-" }]);
+
+    const { payload } = theWarn();
+    expect(payload.unkeyed).toEqual([{ role: "object", cause: "degenerate-surface" }]);
+    expect(payload.degenerateSurfaces).toEqual([{ role: "object", surface: "-" }]);
+    // Not the target's fault, and not a copy: an ordinary extracted candidate
+    // carries no inherited slot at all.
+    expect(payload.inheritedUnkeyed).toEqual([]);
+    expect(payload.inheritedFrom).toBeNull();
+    // The correlation fields, without which the line names no episode to go and
+    // look at.
+    expect(payload).toMatchObject({
+      workspaceId: WORKSPACE,
+      episodeId: EPISODE,
+      producer: PRODUCER,
+    });
+  });
+
+  it("⭐ a VOCABULARY-TARGET failure over a real surface logs NO surface — the leak falsifier", async () => {
+    // ⚠️ THE ASSERTION THIS FILE EXISTS FOR.
+    //
+    // `slotKey` is `identityKey(alias(identityKey(surface)))`, so a null key
+    // has a second cause that has nothing to do with the text: this workspace's
+    // vocabulary maps a real norm to something that normalizes away. The
+    // surface here — `"ships on"` — is a perfectly good claim slot. It is
+    // customer text.
+    //
+    // If the `cause === "degenerate-surface"` filter on `degenerateSurfaces`
+    // ever widens (dropped, inverted, or written over the POSITION instead of
+    // the CAUSE), that text lands in the log stream, gets shipped to whatever
+    // aggregator the deployment uses, and is not recallable. Nothing else in
+    // the repo would notice.
+    //
+    // Both halves are asserted deliberately: `cause` proves the classification
+    // reached `vocabulary-target` (so the case is really exercising this arm
+    // and not silently degenerating), and the empty `degenerateSurfaces` is the
+    // leak assertion itself. Either alone can be satisfied by a defect.
+    const mapsAway = (norm: string) => (norm === "ships on" ? "-" : norm);
+    await run([{ predicate: "ships on" }], { ...identityVocabulary, predicate: mapsAway });
+
+    const { payload } = theWarn();
+    expect(payload.unkeyed).toEqual([{ role: "predicate", cause: "vocabulary-target" }]);
+    expect(
+      payload.degenerateSurfaces,
+      "a claim's REAL text reached the log stream. `degenerateSurfaces` is safe only while it " +
+        "is filtered to `degenerate-surface`, whose surfaces are separators and whitespace by " +
+        "construction; a vocabulary-target surface is customer content and must stay out.",
+    ).toEqual([]);
+    expect(payload.inheritedUnkeyed).toEqual([]);
+  });
+
+  it("…and the surface is not smuggled in through any other field of that payload", async () => {
+    // The wider version of the same question, and the one that survives a
+    // future field being added beside `degenerateSurfaces`. `unkeyed` carries
+    // roles and causes, `inheritedUnkeyed` carries roles, `inheritedFrom`
+    // carries a fact id — none of them is a channel for claim text, and the
+    // cheapest way to keep that true is to search the whole serialized payload.
+    const secret = "acme corp quarterly revenue";
+    const mapsAway = (norm: string) => (norm === secret ? "-" : norm);
+    await run([{ subject: secret }], { ...identityVocabulary, subject: mapsAway });
+
+    const { payload } = theWarn();
+    expect(payload.unkeyed).toEqual([{ role: "subject", cause: "vocabulary-target" }]);
+    expect(
+      JSON.stringify(payload),
+      `the claim's subject text reached the warn payload through a field other than ` +
+        "`degenerateSurfaces`",
+    ).not.toContain(secret);
+  });
+
+  it("an INHERITED null slot: cause `inherited`, at BOTH copied positions", async () => {
+    // The row-copy channel (#5037). The slot is copied off the target row
+    // rather than derived from any surface in this candidate, so an operator
+    // sent to inspect this claim's text would find nothing wrong with it — the
+    // TARGET row is what has no identity, and `inheritedFrom` names it.
+    //
+    // Post-0194 the key columns are `NOT NULL`, so this cannot come off the
+    // database any more; it survives as a diagnostic for a hand-built slot and
+    // for the deploy overlap, where an N-1 instance's rows are still unkeyed.
+    const target = "00000000-0000-4000-8000-000000000042";
+    await run([
+      {
+        inheritedSlot: inheritSlotFromFactRow({
+          id: target,
+          subject_key: null,
+          predicate_key: null,
+        }),
+      },
+    ]);
+
+    const { payload } = theWarn();
+    // BOTH positions, and the order is the slot order. This is the assertion
+    // that pins the property `InheritedSlotValue` supplies and this arm depends
+    // on: it always carries subject AND predicate, which is what makes
+    // `inheritedSlot !== undefined && role !== "object"` unable to mislabel a
+    // vocabulary failure as `inherited`. If that ever narrows to one position,
+    // this is what says so.
+    expect(payload.unkeyed).toEqual([
+      { role: "subject", cause: "inherited" },
+      { role: "predicate", cause: "inherited" },
+    ]);
+    expect(payload.inheritedUnkeyed).toEqual(["subject", "predicate"]);
+    expect(payload.inheritedFrom).toBe(target);
+    // Nothing about this claim's own text is at fault, so nothing is logged
+    // from it.
+    expect(payload.degenerateSurfaces).toEqual([]);
+  });
+
+  it("the OBJECT of an inherited candidate is never `inherited` — it is derived from its own text", async () => {
+    // ⚠️ The discriminator #5047's comment is emphatic about, and the one a
+    // reader is most likely to get wrong. `inheritedFrom` is set for EVERY
+    // correction-produced candidate, but only the SUBJECT and PREDICATE are
+    // copied — the object is always derived from the replacement's own text.
+    //
+    // So a human superseding with `"-"` lands here with a healthy inherited
+    // slot and a degenerate object, and a payload keyed on `inheritedFrom`
+    // alone would send the operator to inspect a target row that is perfectly
+    // fine. The cause must say `degenerate-surface` and `inheritedUnkeyed`
+    // must be EMPTY even though `inheritedFrom` is not null.
+    await run([
+      {
+        object: "-",
+        inheritedSlot: inheritSlotFromFactRow({
+          id: "00000000-0000-4000-8000-000000000043",
+          subject_key: "deploy window",
+          predicate_key: "is",
+        }),
+      },
+    ]);
+
+    const { payload } = theWarn();
+    expect(payload.unkeyed).toEqual([{ role: "object", cause: "degenerate-surface" }]);
+    expect(
+      payload.inheritedUnkeyed,
+      "the object was reported as inherited — it never is, and a message keyed on that would " +
+        "blame a target row with nothing wrong with it",
+    ).toEqual([]);
+    // Non-null, and that is the point: `inheritedFrom` alone is NOT the
+    // discriminator, and this pairing is what proves the payload distinguishes
+    // the two.
+    expect(payload.inheritedFrom).toBe("00000000-0000-4000-8000-000000000043");
+    expect(payload.degenerateSurfaces).toEqual([{ role: "object", surface: "-" }]);
+  });
+
+  it("classifies each position independently when two fail for different reasons", async () => {
+    // One claim, two causes: a degenerate subject and a vocabulary-mapped-away
+    // predicate. A classifier that decided per ROW rather than per POSITION
+    // passes every single-cause case above and fails only here — and it would
+    // put the real predicate text into `degenerateSurfaces` if it collapsed the
+    // other way, which is the leak again, reached from a direction the
+    // dedicated falsifier does not cover.
+    const mapsAway = (norm: string) => (norm === "ships on" ? "___" : norm);
+    await run([{ subject: "___", predicate: "ships on" }], {
+      ...identityVocabulary,
+      predicate: mapsAway,
+    });
+
+    const { payload } = theWarn();
+    expect(payload.unkeyed).toEqual([
+      { role: "subject", cause: "degenerate-surface" },
+      { role: "predicate", cause: "vocabulary-target" },
+    ]);
+    // ONLY the degenerate one. The predicate's real text stays out.
+    expect(payload.degenerateSurfaces).toEqual([{ role: "subject", surface: "___" }]);
+  });
+
+  it("the message names all three causes, so the payload is readable without the source", async () => {
+    // The line is what an operator holds at 3am. `cause` is a bare enum, and a
+    // message that rendered it without saying what each value means would send
+    // them to the source of `reconcile.ts` to decode their own alert.
+    await run([{ object: "-" }]);
+
+    const { message } = theWarn();
+    for (const cause of ["degenerate-surface", "vocabulary-target", "inherited"]) {
+      expect(message, `the warn message stopped naming the \`${cause}\` cause`).toContain(cause);
+    }
+  });
+
+  it("a healthy claim produces no MALFORMED_CLAIM warn at all", async () => {
+    // The control. Every assertion above is about the CONTENT of a line, so a
+    // guard that fired on everything would satisfy all of them — this is the
+    // only test that says the line is conditional.
+    await run([{}]);
+
+    expect(warns.filter((w) => w.message.includes("no identity for one or more slots"))).toHaveLength(0);
+  });
+});

--- a/packages/api/src/lib/brain/__tests__/reconcile-logging.test.ts
+++ b/packages/api/src/lib/brain/__tests__/reconcile-logging.test.ts
@@ -193,7 +193,9 @@ function run(
       vocabulary,
     },
     {
-      withTransaction: noopRunner as Parameters<typeof reconcileFacts>[1]["withTransaction"],
+      withTransaction: noopRunner as NonNullable<
+        Parameters<typeof reconcileFacts>[1]
+      >["withTransaction"],
       now: () => new Date("2026-06-21T10:00:01.000Z"),
     },
   );

--- a/packages/api/src/lib/brain/__tests__/reconcile-logging.test.ts
+++ b/packages/api/src/lib/brain/__tests__/reconcile-logging.test.ts
@@ -187,15 +187,20 @@ function run(
         predicate: "is",
         object: "Thursdays",
         ...c,
+        // This cast IS load-bearing, unlike the one below it used to be: the
+        // local `inheritedSlot?: unknown` is deliberately WIDER than
+        // `InheritedSlot`, so the cases here can drive the runtime narrowing.
       })) as Parameters<typeof reconcileFacts>[0]["candidates"],
       producer: PRODUCER,
       extractedAt: new Date("2026-06-21T10:00:00.000Z"),
       vocabulary,
     },
+    // No cast on `withTransaction`: `noopRunner` is assignable to
+    // `ReconcileTransactionRunner` as written, and a cast that is not
+    // load-bearing is worse than none — it would absorb a genuine future
+    // incompatibility in that type silently.
     {
-      withTransaction: noopRunner as NonNullable<
-        Parameters<typeof reconcileFacts>[1]
-      >["withTransaction"],
+      withTransaction: noopRunner,
       now: () => new Date("2026-06-21T10:00:01.000Z"),
     },
   );

--- a/packages/api/src/lib/brain/__tests__/vocabulary-authoring-pg.test.ts
+++ b/packages/api/src/lib/brain/__tests__/vocabulary-authoring-pg.test.ts
@@ -445,6 +445,58 @@ describeIfPg("direct authoring and the In-force pane (#5087)", () => {
       expect(rows.map((r) => r.predicate_key).toSorted()).toEqual(["is priced at", "priced at"]);
     });
 
+    it("⭐ REFUSES a re-key count that is not a whole number — the alarm must not fail open", async () => {
+      // ⚠️ `typeof v === "number"` admits `NaN`, and `NaN > 0` is FALSE — so a
+      // `NaN` in `skipped_vocabulary_target` would sail past a `typeof` guard and
+      // then select the message *"existing facts now carry the keys this
+      // vocabulary decides"*: a clean-run sentence about the exact population the
+      // count exists to surface. The guard meant to prevent that would be the
+      // thing delivering it.
+      //
+      // Reachable without a Postgres bug: `VocabularyExecutor` is deliberately
+      // satisfiable by any `{ query }`, and `pg`'s int4 parser is `parseInt`,
+      // which yields `NaN` on any non-numeric text. Simulated exactly that way.
+      await seedBothSides();
+
+      const nanRunner: ReconcileTransactionRunner = async (fn) =>
+        runner(async (tx) => {
+          const guarded = {
+            query: async (sql: string, params?: unknown[]) => {
+              if (sql === REKEY_DRIFTED_FACTS_SQL.predicate) {
+                return {
+                  rows: [
+                    {
+                      rekeyed: 1,
+                      skipped_degenerate_surface: 0,
+                      // What `parseInt("not a number")` hands back.
+                      skipped_vocabulary_target: Number.NaN,
+                    },
+                  ],
+                };
+              }
+              return tx.query(sql, params);
+            },
+          };
+          return fn(guarded as unknown as PoolClient);
+        });
+
+      await expect(
+        authorAliasEdge(
+          WS,
+          { position: "predicate", fromNorm: "is priced at", toNorm: "priced at" },
+          owner(),
+          { withTransaction: nanRunner },
+        ),
+        "an unreadable count was accepted — the approval committed and the operator was told the " +
+          "corpus is consistent, on the one value that decides whether it is",
+      ).rejects.toThrow(/without the three counts/);
+
+      // Refused means refused: the decision rolls back whole, exactly as the
+      // failing-statement case above.
+      expect(await proposals()).toEqual([]);
+      expect(await storedEdges()).toEqual([]);
+    });
+
     it("converges on a producer's pending proposal rather than inserting a second row", async () => {
       await seedBothSides();
       const queued = await proposeAliasEdge(

--- a/packages/api/src/lib/brain/__tests__/vocabulary-authoring-pg.test.ts
+++ b/packages/api/src/lib/brain/__tests__/vocabulary-authoring-pg.test.ts
@@ -445,6 +445,61 @@ describeIfPg("direct authoring and the In-force pane (#5087)", () => {
       expect(rows.map((r) => r.predicate_key).toSorted()).toEqual(["is priced at", "priced at"]);
     });
 
+    it.each([
+      {
+        label: "no usable `rows` array at all (an executor that is not a pg client)",
+        answer: { rowCount: 1 } as unknown,
+        expected: /no usable `rows`/,
+      },
+      {
+        label: "an EMPTY rows array (the statement's one-row SELECT answered nothing)",
+        answer: { rows: [] },
+        expected: /without the three counts/,
+      },
+      {
+        label: "counts as pg TEXT rather than numbers",
+        answer: { rows: [{ rekeyed: "2", skipped_degenerate_surface: "0", skipped_vocabulary_target: "0" }] },
+        expected: /without the three counts/,
+      },
+    ])("⭐ REFUSES rather than defaults when the re-key answers with $label", async ({ answer, expected }) => {
+      // ⚠️ THE GUARDS' OWN COVERAGE, and it was measured at ZERO. Replacing both
+      // throws with `?? 0` defaults left 225 tests green across six suites —
+      // which restores exactly the `?? []` behaviour `rekeyDriftedFacts`'
+      // docstring calls "the exact shape this slice exists to eliminate": an
+      // executor that is not answering as a Postgres client commits a
+      // human-gated approval and logs "Drift re-key complete" with `rekeyed: 0`.
+      //
+      // `VocabularyExecutor` is deliberately satisfiable by any `{ query }`, so
+      // these three shapes are what a pool, a partial mock and a driver whose
+      // int parser handed back text actually look like from here.
+      await seedBothSides();
+
+      const answeringRunner: ReconcileTransactionRunner = async (fn) =>
+        runner(async (tx) => {
+          const guarded = {
+            query: async (sql: string, params?: unknown[]) => {
+              if (sql === REKEY_DRIFTED_FACTS_SQL.predicate) return answer;
+              return tx.query(sql, params);
+            },
+          };
+          return fn(guarded as unknown as PoolClient);
+        });
+
+      await expect(
+        authorAliasEdge(
+          WS,
+          { position: "predicate", fromNorm: "is priced at", toNorm: "priced at" },
+          owner(),
+          { withTransaction: answeringRunner },
+        ),
+        "the re-key's result was never observed and the approval committed anyway",
+      ).rejects.toThrow(expected);
+
+      // The refusal names WHERE, so an operator holding the error can find it.
+      expect(await proposals()).toEqual([]);
+      expect(await storedEdges()).toEqual([]);
+    });
+
     it("⭐ REFUSES a re-key count that is not a whole number — the alarm must not fail open", async () => {
       // ⚠️ `typeof v === "number"` admits `NaN`, and `NaN > 0` is FALSE — so a
       // `NaN` in `skipped_vocabulary_target` would sail past a `typeof` guard and

--- a/packages/api/src/lib/brain/__tests__/vocabulary-decide-pg.test.ts
+++ b/packages/api/src/lib/brain/__tests__/vocabulary-decide-pg.test.ts
@@ -360,20 +360,25 @@ describe("the decide seam's allowlist carve-out is column-scoped (#5024)", () =>
     // for them would pass while writing anything at all.
     for (const position of SLOT_POSITIONS) {
       const statement = REKEY_DRIFTED_FACTS_SQL[position];
-      // Everything between `SET` and the statement's OWN `WHERE`, and neither
-      // boundary can be found positionally. The assignment embeds a closure
-      // subquery, so `indexOf("WHERE ")` lands inside it (clause cut short — the
-      // forbidden check would then pass by truncation rather than by absence)
-      // and `lastIndexOf("WHERE ")` lands inside the second copy in the
-      // `IS DISTINCT FROM` guard (clause overruns into the WHERE — the scoping
-      // is gone). The statement's own `WHERE` is the only one on the `f` alias;
-      // the subqueries are all on `t`.
+      // Everything between `SET` and the `UPDATE`'s OWN `WHERE`, and neither
+      // boundary can be found positionally — the statement carries four
+      // `WHERE`s since #5109 lifted its scan into a CTE. `indexOf("WHERE ")`
+      // lands in the CTE's projection, BEFORE `SET ` entirely (clause cut short
+      // — the forbidden check would then pass by truncation rather than by
+      // absence), and `lastIndexOf("WHERE ")` lands in the final counting
+      // `SELECT`, past the end of the UPDATE (clause overruns — the scoping is
+      // gone). `WHERE f.` is the discriminator: the CTE's own scope is written
+      // UNQUALIFIED and the closure subqueries are all on `t`, so the only
+      // `WHERE` on the updated alias is the `UPDATE`'s.
       const setAt = statement.indexOf("SET ");
       const whereAt = statement.indexOf("WHERE f.");
       expect(setAt).toBeGreaterThanOrEqual(0);
       expect(whereAt).toBeGreaterThan(setAt);
-      // Unambiguous: exactly one `WHERE` on the updated alias, so the slice above
-      // is the whole SET clause and nothing else.
+      // Unambiguous: exactly one `WHERE` on the updated alias, so the slice
+      // above is the whole SET clause plus the `FROM recomputed r` that feeds
+      // it — and nothing beyond the UPDATE. This length assertion is also what
+      // makes a future qualified `WHERE f.` in the CTE fail loudly here rather
+      // than quietly move the boundary.
       expect([...statement.matchAll(/WHERE f\./g)]).toHaveLength(1);
       const written = statement.slice(setAt, whereAt);
 

--- a/packages/api/src/lib/brain/__tests__/vocabulary-rekey-logging.test.ts
+++ b/packages/api/src/lib/brain/__tests__/vocabulary-rekey-logging.test.ts
@@ -4,21 +4,36 @@
  * `rekeyDriftedFacts`' own docstring calls this line *"the operator's only
  * signal that the re-key ran and how wide it reached"*, and since #5047 added
  * the `IS NOT NULL` arm the single number it carried stopped being able to say
- * that. `rekeyed: 0` covers two states an operator would act on differently:
+ * that. `rekeyed: 0` covers THREE states an operator would act on differently:
  *
  *   - **nothing drifted** — ordinary, healthy, and what a workspace reports on
- *     every approval once its corpus is a fixpoint of its vocabulary; and
- *   - **N rows hold `-unkeyable:` placeholders and were declined** — a corpus
- *     still carrying the legacy degenerate population migration 0194
- *     tombstoned. That population is closed and shrinks only, so a number that
- *     stays flat across approvals is the signal.
+ *     every approval once its corpus is a fixpoint of its vocabulary;
+ *   - **N rows hold `-unkeyable:` placeholders and were declined**
+ *     (`skippedDegenerateSurface`) — a corpus still carrying the legacy
+ *     degenerate population migration 0194 tombstoned. Nothing to do: the set
+ *     is closed and shrinks only, so a flat number is health; and
+ *   - **N rows were declined because this workspace's vocabulary maps their
+ *     norm to something that normalizes away** (`skippedVocabularyTarget`) —
+ *     ⚠️ the one to act on. Their surfaces key fine and they keep the key the
+ *     PREVIOUS vocabulary decided, so the closure and the corpus disagree. No
+ *     re-key repairs it; the `brain_vocabulary_target` entry is the defect.
+ *     (The count is not scoped by `invalidated_at` — this statement
+ *     deliberately is not — so it reads as "rows the vocabulary now disagrees
+ *     with" rather than strictly "live rows".)
  *
- * `skipped_unkeyable` is computed in SQL and pinned against real Postgres in
- * `vocabulary-rekey-pg.test.ts`. What is pinned HERE is the last hop: that the
- * number reaches the LINE. Nothing else in the repo reads it — the value is
- * never returned, never stored and never branched on — so a `log.info` that
- * quietly stopped carrying it would leave four green SQL tests measuring a
- * number no human is shown.
+ * ⚠️ The third state is why there are two skip counts and not one. The first
+ * cut of #5109 merged them, which re-collapsed the exact distinction the slice
+ * was filed to undo — one layer above the arm that draws it, and against the
+ * same three-way `cause` that `reconcile.ts`'s `MALFORMED_CLAIM` and the region
+ * import's two refusal types both draw over this identical NULL.
+ *
+ * The counts are computed in SQL and pinned against real Postgres in
+ * `vocabulary-rekey-pg.test.ts`. What is pinned HERE is the last hop: that they
+ * reach the LINE, and that the line's MESSAGE changes when the actionable one
+ * is non-zero. Nothing else in the repo reads them — the values are never
+ * returned, never stored, never branched on except for that message — so a
+ * `log.info` that quietly stopped carrying one would leave every SQL test green
+ * while measuring a number no human is shown.
  *
  * That gap is precisely #5105's, one module over, and this file exists so this
  * slice does not reopen it while closing it.
@@ -45,7 +60,15 @@ interface Captured {
 
 const infos: Captured[] = [];
 
-/** Every value export of `lib/logger`, replaced — a partial mock link-fails. */
+/**
+ * Every value export of `lib/logger`, replaced.
+ *
+ * ⚠️ A PARTIAL mock is the trap this repo has recorded: `mock.module` replaces
+ * the whole module, so any export left out becomes `undefined` and the module
+ * under test throws on first use — which reads as a broken test rather than a
+ * missing mock. The factory is SYNCHRONOUS, because an async one deadlocks
+ * `bun:test`.
+ */
 void mock.module("@atlas/api/lib/logger", () => {
   const capture = {
     info: (payload: unknown, message?: unknown) =>
@@ -238,9 +261,9 @@ describeIfPg("the drift re-key's info line (#5109)", () => {
     expect(
       payload,
       "the info line stopped distinguishing `nothing drifted` from `N rows were declined` — " +
-        "`skippedUnkeyable` is not read anywhere else in the product, so dropping it from this " +
+        "the skip counts are not read anywhere else in the product, so dropping one from this " +
         "line deletes the signal outright while every SQL-level test stays green",
-    ).toMatchObject({ rekeyed: 2, skippedUnkeyable: 1 });
+    ).toMatchObject({ rekeyed: 2, skippedDegenerateSurface: 1, skippedVocabularyTarget: 0 });
     // The correlation fields, without which the counts name no decision.
     expect(payload).toMatchObject({ workspaceId: WS, position: "object" });
     expect(payload.proposalId).toBeTruthy();
@@ -248,7 +271,7 @@ describeIfPg("the drift re-key's info line (#5109)", () => {
 
   it("reports zero declined on a corpus with no degenerate rows", async () => {
     // The control, and the half that makes the number readable: on a healthy
-    // corpus `skippedUnkeyable` is 0, so a non-zero reading is the exception an
+    // corpus both skip counts are 0, so a non-zero reading is the exception an
     // operator can act on rather than background noise. A line that hardcoded
     // the count, or wired it to the same expression as `rekeyed`, passes the
     // case above and fails here.
@@ -256,7 +279,11 @@ describeIfPg("the drift re-key's info line (#5109)", () => {
 
     await approveObjectAlias("friday", "fri");
 
-    expect(theLine().payload).toMatchObject({ rekeyed: 1, skippedUnkeyable: 0 });
+    expect(theLine().payload).toMatchObject({
+      rekeyed: 1,
+      skippedDegenerateSurface: 0,
+      skippedVocabularyTarget: 0,
+    });
   });
 
   it("distinguishes `nothing drifted` from `everything was declined`", async () => {
@@ -271,6 +298,51 @@ describeIfPg("the drift re-key's info line (#5109)", () => {
     expect(
       theLine().payload,
       "`rekeyed: 0` with two declined rows read identically to `rekeyed: 0` on a clean corpus",
-    ).toMatchObject({ rekeyed: 0, skippedUnkeyable: 2 });
+    ).toMatchObject({ rekeyed: 0, skippedDegenerateSurface: 2, skippedVocabularyTarget: 0 });
+    // …and the message stays the ordinary one: a tombstoned population needs no
+    // human, so an alarming line here would be the alert fatigue that makes the
+    // real one unreadable.
+    expect(theLine().message).toContain("existing facts now carry the keys this vocabulary decides");
+  });
+
+  it("⭐ says so IN THE MESSAGE when a live row was declined by a vocabulary target", async () => {
+    // ⚠️ The line's MESSAGE is the assertion, not just its payload. *"existing
+    // facts now carry the keys this vocabulary decides"* is FALSE of exactly
+    // these rows — they carry the keys the PREVIOUS vocabulary decided — so
+    // emitting it here would be a success sentence about the one population
+    // that needs a human, and an operator scanning messages rather than fields
+    // would never look.
+    //
+    // The closure is written DIRECTLY because `vocabulary-decide.ts` refuses a
+    // `degenerate-norm` target at authoring; that guard is what keeps this
+    // population empty in practice and exactly what makes the seam unable to
+    // build the fixture. Neither this line nor the `IS NOT NULL` arm rests on
+    // the guard staying put.
+    await land("billing", "is", "platform team");
+    await pool.query(
+      `INSERT INTO brain_vocabulary_edge
+         (workspace_id, slot_position, from_norm, to_norm, approved_by)
+       VALUES ($1, 'object', 'platform team', ' - ', '5109-test')`,
+      [WS],
+    );
+    await pool.query(
+      `INSERT INTO brain_vocabulary_target (workspace_id, slot_position, norm, effective_target)
+       VALUES ($1, 'object', 'platform team', ' - ')`,
+      [WS],
+    );
+
+    // An unrelated real approval, so the re-key runs at the object position.
+    await approveObjectAlias("friday", "fri");
+
+    const line = theLine();
+    expect(line.payload).toMatchObject({ skippedVocabularyTarget: 1, skippedDegenerateSurface: 0 });
+    expect(
+      line.message,
+      "the line reported a clean completion over a live row whose key the vocabulary now " +
+        "disagrees with — the count alone is not the signal if the sentence beside it says the " +
+        "opposite",
+    ).not.toContain("existing facts now carry the keys this vocabulary decides");
+    // It names the remedy: the entry, not another re-key.
+    expect(line.message).toContain("brain_vocabulary_target");
   });
 });

--- a/packages/api/src/lib/brain/__tests__/vocabulary-rekey-logging.test.ts
+++ b/packages/api/src/lib/brain/__tests__/vocabulary-rekey-logging.test.ts
@@ -59,6 +59,8 @@ interface Captured {
 }
 
 const infos: Captured[] = [];
+/** Separate sink: the LEVEL is part of what this file pins, not just the payload. */
+const warns: Captured[] = [];
 
 /**
  * Every value export of `lib/logger`, replaced.
@@ -70,13 +72,14 @@ const infos: Captured[] = [];
  * `bun:test`.
  */
 void mock.module("@atlas/api/lib/logger", () => {
+  const record = (sink: Captured[]) => (payload: unknown, message?: unknown) =>
+    sink.push({
+      payload: (payload ?? {}) as Record<string, unknown>,
+      message: typeof message === "string" ? message : String(payload),
+    });
   const capture = {
-    info: (payload: unknown, message?: unknown) =>
-      infos.push({
-        payload: (payload ?? {}) as Record<string, unknown>,
-        message: typeof message === "string" ? message : String(payload),
-      }),
-    warn: () => {},
+    info: record(infos),
+    warn: record(warns),
     error: () => {},
     debug: () => {},
     level: "info",
@@ -151,6 +154,7 @@ describeIfPg("the drift re-key's info line (#5109)", () => {
     await pool.query("DELETE FROM brain_facts");
     await pool.query("DELETE FROM brain_episodes");
     infos.length = 0;
+    warns.length = 0;
   });
 
   const owner = (): BrainPrincipalContext => ({
@@ -236,15 +240,32 @@ describeIfPg("the drift re-key's info line (#5109)", () => {
   }
 
   /** The one re-key completion line, refused if there is not exactly one. */
-  function theLine(): Captured {
-    const lines = infos.filter((entry) => entry.message.includes("Drift re-key complete"));
+  /**
+   * The completion line and THE SINK IT LANDED IN.
+   *
+   * ⚠️ Returning the payload alone is not enough, and the first cut of this file
+   * did exactly that: dropping the actionable arm from `warn` back to `info`
+   * SURVIVED every assertion here, because a helper that merges the sinks cannot
+   * see the level. The level is half of what makes this line discoverable — a
+   * deployment filtering `info`, which is the ordinary posture for a path this
+   * chatty, loses it entirely — so the sink travels with the line.
+   */
+  function theLineAt(): { line: Captured; level: "info" | "warn" } {
+    const hit = (sink: Captured[]) =>
+      sink.filter((entry) => entry.message.includes("Drift re-key complete"));
+    const atInfo = hit(infos);
+    const atWarn = hit(warns);
+    const lines = [...atInfo, ...atWarn];
     expect(
       lines,
       "expected exactly one re-key completion line — the approval runs the statement for ONE " +
         "position, and more than one means these assertions are reading an arbitrary member",
     ).toHaveLength(1);
-    return lines[0]!;
+    return { line: lines[0]!, level: atWarn.length === 1 ? "warn" : "info" };
   }
+
+  /** The payload alone, where the level is not what the case is about. */
+  const theLine = (): Captured => theLineAt().line;
 
   it("carries BOTH counts — the declined rows beside the moved ones", async () => {
     // ⭐ The assertion this file exists for. Two healthy rows drift onto the
@@ -279,11 +300,16 @@ describeIfPg("the drift re-key's info line (#5109)", () => {
 
     await approveObjectAlias("friday", "fri");
 
-    expect(theLine().payload).toMatchObject({
+    const clean = theLineAt();
+    expect(clean.line.payload).toMatchObject({
       rekeyed: 1,
       skippedDegenerateSurface: 0,
       skippedVocabularyTarget: 0,
     });
+    // INFO on the happy path. The other direction of the level split: a line
+    // that warned on every ordinary approval is alert fatigue, which makes the
+    // real warning unreadable — the failure mode the conditional exists to avoid.
+    expect(clean.level).toBe("info");
   });
 
   it("distinguishes `nothing drifted` from `everything was declined`", async () => {
@@ -302,7 +328,11 @@ describeIfPg("the drift re-key's info line (#5109)", () => {
     // …and the message stays the ordinary one: a tombstoned population needs no
     // human, so an alarming line here would be the alert fatigue that makes the
     // real one unreadable.
-    expect(theLine().message).toContain("existing facts now carry the keys this vocabulary decides");
+    const degenerateOnly = theLineAt();
+    expect(degenerateOnly.line.message).toContain(
+      "existing facts now carry the keys this vocabulary decides",
+    );
+    expect(degenerateOnly.level).toBe("info");
   });
 
   it("⭐ says so IN THE MESSAGE when a live row was declined by a vocabulary target", async () => {
@@ -334,8 +364,18 @@ describeIfPg("the drift re-key's info line (#5109)", () => {
     // An unrelated real approval, so the re-key runs at the object position.
     await approveObjectAlias("friday", "fri");
 
-    const line = theLine();
+    const { line, level } = theLineAt();
     expect(line.payload).toMatchObject({ skippedVocabularyTarget: 1, skippedDegenerateSurface: 0 });
+    // ⚠️ WARN, not INFO. The payload being right is worth nothing if the record
+    // is filtered out before anyone reads it: this is an operator-actionable
+    // data-integrity divergence, emitted at the same severity as the routine
+    // success line until #5106's review round caught it.
+    expect(
+      level,
+      "the actionable arm went out at `info` — a deployment filtering info-level logs, which is " +
+        "the ordinary posture for a path this chatty, loses the only record that live rows were " +
+        "left on keys the previous vocabulary decided",
+    ).toBe("warn");
     expect(
       line.message,
       "the line reported a clean completion over a live row whose key the vocabulary now " +

--- a/packages/api/src/lib/brain/__tests__/vocabulary-rekey-logging.test.ts
+++ b/packages/api/src/lib/brain/__tests__/vocabulary-rekey-logging.test.ts
@@ -1,0 +1,276 @@
+/**
+ * The drift re-key's OPERATOR-FACING info line (#5109).
+ *
+ * `rekeyDriftedFacts`' own docstring calls this line *"the operator's only
+ * signal that the re-key ran and how wide it reached"*, and since #5047 added
+ * the `IS NOT NULL` arm the single number it carried stopped being able to say
+ * that. `rekeyed: 0` covers two states an operator would act on differently:
+ *
+ *   - **nothing drifted** — ordinary, healthy, and what a workspace reports on
+ *     every approval once its corpus is a fixpoint of its vocabulary; and
+ *   - **N rows hold `-unkeyable:` placeholders and were declined** — a corpus
+ *     still carrying the legacy degenerate population migration 0194
+ *     tombstoned. That population is closed and shrinks only, so a number that
+ *     stays flat across approvals is the signal.
+ *
+ * `skipped_unkeyable` is computed in SQL and pinned against real Postgres in
+ * `vocabulary-rekey-pg.test.ts`. What is pinned HERE is the last hop: that the
+ * number reaches the LINE. Nothing else in the repo reads it — the value is
+ * never returned, never stored and never branched on — so a `log.info` that
+ * quietly stopped carrying it would leave four green SQL tests measuring a
+ * number no human is shown.
+ *
+ * That gap is precisely #5105's, one module over, and this file exists so this
+ * slice does not reopen it while closing it.
+ *
+ * ## Why a separate file
+ *
+ * `acl-logging.test.ts`'s pattern: mocking the logger means `mock.module`ing
+ * **every** value export of `@atlas/api/lib/logger` and importing the module
+ * under test DYNAMICALLY, so the mock binds first. That is process-wide, so it
+ * cannot share a file with `vocabulary-rekey-pg.test.ts`, which wants real
+ * logging.
+ *
+ * Real Postgres, not a scripted executor: the counts come out of the statement,
+ * so a fake that answered them would be asserting this file's own arithmetic.
+ */
+
+import { afterAll, afterEach, beforeAll, describe, expect, it, mock } from "bun:test";
+import { Pool } from "pg";
+
+interface Captured {
+  readonly payload: Record<string, unknown>;
+  readonly message: string;
+}
+
+const infos: Captured[] = [];
+
+/** Every value export of `lib/logger`, replaced — a partial mock link-fails. */
+void mock.module("@atlas/api/lib/logger", () => {
+  const capture = {
+    info: (payload: unknown, message?: unknown) =>
+      infos.push({
+        payload: (payload ?? {}) as Record<string, unknown>,
+        message: typeof message === "string" ? message : String(payload),
+      }),
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+    level: "info",
+  };
+  return {
+    createLogger: () => capture,
+    getLogger: () => capture,
+    setLogLevel: () => true,
+    getRequestContext: () => undefined,
+    withRequestContext: <T,>(_ctx: unknown, fn: () => T): T => fn(),
+    redactPaths: [] as string[],
+    scrubErrSerializer: (err: unknown) => err,
+    scrubLogFormatter: (obj: unknown) => obj,
+    hashShareToken: (token: string) => token,
+    ACTOR_KINDS: ["human", "agent", "mcp", "scheduler", "api_key"] as const,
+  };
+});
+
+const TEST_DB_URL = process.env.TEST_DATABASE_URL;
+const describeIfPg = TEST_DB_URL ? describe : describe.skip;
+const PG_TEST_TIMEOUT_MS = 60_000;
+const WS = "ws-rekey-log-5109";
+
+// DYNAMIC, after the mock above is installed.
+const { runMigrations } = await import("@atlas/api/lib/db/migrate");
+const { MANAGED_AUTH_MIGRATIONS, _resetPool } = await import("@atlas/api/lib/db/internal");
+const { decideAliasProposal, proposeAliasEdge } = await import(
+  "@atlas/api/lib/brain/vocabulary-decide"
+);
+const { reconcileFacts } = await import("@atlas/api/lib/brain/reconcile");
+const { identityVocabulary } = await import("@atlas/api/lib/brain/identity");
+type BrainPrincipalContext = import("@atlas/api/lib/brain/acl").BrainPrincipalContext;
+
+describeIfPg("the drift re-key's info line (#5109)", () => {
+  let pool: Pool;
+  const schemaName = `brain_5109log_${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
+  let priorDatabaseUrl: string | undefined;
+
+  beforeAll(async () => {
+    priorDatabaseUrl = process.env.DATABASE_URL;
+    process.env.DATABASE_URL = TEST_DB_URL;
+    pool = new Pool({
+      connectionString: TEST_DB_URL,
+      options: `-c search_path="${schemaName}",public`,
+    });
+    const bootstrap = new Pool({ connectionString: TEST_DB_URL });
+    try {
+      await bootstrap.query(`CREATE SCHEMA IF NOT EXISTS "${schemaName}"`);
+    } finally {
+      await bootstrap.end();
+    }
+    await runMigrations(pool, { skip: MANAGED_AUTH_MIGRATIONS });
+    _resetPool(pool);
+  }, PG_TEST_TIMEOUT_MS);
+
+  afterAll(async () => {
+    _resetPool(null);
+    if (priorDatabaseUrl === undefined) delete process.env.DATABASE_URL;
+    else process.env.DATABASE_URL = priorDatabaseUrl;
+    if (pool) {
+      await pool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+      await pool.end();
+    }
+  }, PG_TEST_TIMEOUT_MS);
+
+  afterEach(async () => {
+    // Targets BEFORE edges — `fk_brain_vocabulary_target_edge` is RESTRICT.
+    await pool.query("DELETE FROM brain_vocabulary_target");
+    await pool.query("DELETE FROM brain_vocabulary_edge");
+    await pool.query("DELETE FROM brain_vocabulary_proposal");
+    await pool.query("DELETE FROM brain_edges");
+    await pool.query("DELETE FROM brain_facts");
+    await pool.query("DELETE FROM brain_episodes");
+    infos.length = 0;
+  });
+
+  const owner = (): BrainPrincipalContext => ({
+    origin: "authenticated",
+    workspaceId: WS,
+    userId: "user-owner",
+    role: "owner",
+    audienceIds: ["org"],
+  });
+
+  let episodeSeq = 0;
+  async function seedEpisode(): Promise<string> {
+    const { rows } = await pool.query<{ id: string }>(
+      `INSERT INTO brain_episodes
+         (workspace_id, source, source_id, source_actor, body, occurred_at, visible_to)
+       VALUES ($1, 'slack', $2, 'U123', 'evidence', '2026-06-21T09:00:00.000Z'::timestamptz,
+               ARRAY['org'])
+       RETURNING id`,
+      [WS, `C01:5109.${episodeSeq++}`],
+    );
+    return rows[0]!.id;
+  }
+
+  /** Land one claim through the REAL ingest stage, under the EMPTY vocabulary. */
+  async function land(subject: string, predicate: string, object: string): Promise<void> {
+    const id = await seedEpisode();
+    const report = await reconcileFacts({
+      vocabulary: identityVocabulary,
+      episode: {
+        id,
+        workspaceId: WS,
+        source: "slack",
+        sourceId: `C01:5109.land.${episodeSeq}`,
+        sourceActor: "U123",
+        occurredAt: new Date("2026-06-21T09:00:00.000Z"),
+        visibleTo: ["org"],
+      },
+      candidates: [{ subject, predicate, object }],
+      producer: "rekey-5109",
+      extractedAt: new Date("2026-06-21T10:00:00.000Z"),
+    });
+    // `reconcileFacts` reports a domain refusal as a counted outcome and never
+    // throws, so without this a refused candidate would leave an empty corpus
+    // and the counts below would be zero for the wrong reason.
+    expect(report.outcomes[0], `"${subject} ${predicate} ${object}" was refused`).not.toMatchObject({
+      kind: "blocked",
+    });
+  }
+
+  /** One TOMBSTONED placeholder row, built the way migration 0194 builds them. */
+  async function landDegenerate(objectSurface: string, placeholder: string): Promise<void> {
+    const episodeId = await seedEpisode();
+    await pool.query(
+      `INSERT INTO brain_facts
+         (workspace_id, subject, predicate, object,
+          subject_key, predicate_key, object_key,
+          source_episode_id, provenance, visible_to, invalidated_at)
+       VALUES ($1, 'widget', 'is', $2, 'widget', 'is', $3, $4,
+               '{"actor":"u1"}'::jsonb, ARRAY['org'], now())`,
+      [WS, objectSurface, placeholder, episodeId],
+    );
+  }
+
+  async function approveObjectAlias(fromNorm: string, toNorm: string): Promise<void> {
+    const queued = await proposeAliasEdge(WS, {
+      position: "object",
+      fromNorm,
+      toNorm,
+      directed: true,
+      sourceClass: "human",
+      confidence: 1,
+      proposedBy: "user-owner",
+    });
+    expect(queued.kind).toBe("queued");
+    if (queued.kind !== "queued") throw new Error("unreachable");
+    const decided = await decideAliasProposal({
+      id: queued.id,
+      workspaceId: WS,
+      decision: "approved",
+      approver: { kind: "human", ctx: owner() },
+    });
+    expect(decided.kind, `approving ${fromNorm} → ${toNorm} did not land`).toBe("approved");
+  }
+
+  /** The one re-key completion line, refused if there is not exactly one. */
+  function theLine(): Captured {
+    const lines = infos.filter((entry) => entry.message.includes("Drift re-key complete"));
+    expect(
+      lines,
+      "expected exactly one re-key completion line — the approval runs the statement for ONE " +
+        "position, and more than one means these assertions are reading an arbitrary member",
+    ).toHaveLength(1);
+    return lines[0]!;
+  }
+
+  it("carries BOTH counts — the declined rows beside the moved ones", async () => {
+    // ⭐ The assertion this file exists for. Two healthy rows drift onto the
+    // approved target; two degenerate rows hold 0194's placeholders and are
+    // declined. Distinct values (2 and 2 would pass a line that logged the same
+    // number twice — so the fixture uses 2 and 1).
+    await land("widget", "is", "friday");
+    await land("gadget", "is", "friday");
+    await landDegenerate("-", "-unkeyable:seed-a");
+
+    await approveObjectAlias("friday", "fri");
+
+    const { payload } = theLine();
+    expect(
+      payload,
+      "the info line stopped distinguishing `nothing drifted` from `N rows were declined` — " +
+        "`skippedUnkeyable` is not read anywhere else in the product, so dropping it from this " +
+        "line deletes the signal outright while every SQL-level test stays green",
+    ).toMatchObject({ rekeyed: 2, skippedUnkeyable: 1 });
+    // The correlation fields, without which the counts name no decision.
+    expect(payload).toMatchObject({ workspaceId: WS, position: "object" });
+    expect(payload.proposalId).toBeTruthy();
+  });
+
+  it("reports zero declined on a corpus with no degenerate rows", async () => {
+    // The control, and the half that makes the number readable: on a healthy
+    // corpus `skippedUnkeyable` is 0, so a non-zero reading is the exception an
+    // operator can act on rather than background noise. A line that hardcoded
+    // the count, or wired it to the same expression as `rekeyed`, passes the
+    // case above and fails here.
+    await land("widget", "is", "friday");
+
+    await approveObjectAlias("friday", "fri");
+
+    expect(theLine().payload).toMatchObject({ rekeyed: 1, skippedUnkeyable: 0 });
+  });
+
+  it("distinguishes `nothing drifted` from `everything was declined`", async () => {
+    // ⚠️ THE two states #5109 is about, side by side in one assertion. Both
+    // report `rekeyed: 0`, and before this slice they were the same line.
+    await landDegenerate("-", "-unkeyable:seed-a");
+    await landDegenerate("___", "-unkeyable:seed-b");
+    // A real alias that moves nothing: no fact carries `friday` at the object,
+    // so the approval is a no-op for the healthy population.
+    await approveObjectAlias("friday", "fri");
+
+    expect(
+      theLine().payload,
+      "`rekeyed: 0` with two declined rows read identically to `rekeyed: 0` on a clean corpus",
+    ).toMatchObject({ rekeyed: 0, skippedUnkeyable: 2 });
+  });
+});

--- a/packages/api/src/lib/brain/__tests__/vocabulary-rekey-logging.test.ts
+++ b/packages/api/src/lib/brain/__tests__/vocabulary-rekey-logging.test.ts
@@ -106,12 +106,47 @@ const WS = "ws-rekey-log-5109";
 // DYNAMIC, after the mock above is installed.
 const { runMigrations } = await import("@atlas/api/lib/db/migrate");
 const { MANAGED_AUTH_MIGRATIONS, _resetPool } = await import("@atlas/api/lib/db/internal");
-const { decideAliasProposal, proposeAliasEdge } = await import(
+const { decideAliasProposal, proposeAliasEdge, isCount } = await import(
   "@atlas/api/lib/brain/vocabulary-decide"
 );
 const { reconcileFacts } = await import("@atlas/api/lib/brain/reconcile");
 const { identityVocabulary } = await import("@atlas/api/lib/brain/identity");
 type BrainPrincipalContext = import("@atlas/api/lib/brain/acl").BrainPrincipalContext;
+
+/**
+ * `isCount`, exhaustively and WITHOUT Postgres.
+ *
+ * ⚠️ Deliberately outside `describeIfPg`. The predicate is the guard that stops
+ * an unreadable count selecting the clean-run message, and its only other
+ * coverage is one `NaN` case on one field inside a `-pg` suite — so on a local
+ * gate run with no `TEST_DATABASE_URL`, the whole of it silently skipped.
+ * A pure function deserves a pure test, and this one runs everywhere.
+ */
+describe("isCount — the deny polarity, per shape (#5109)", () => {
+  it.each([
+    { label: "NaN (what `parseInt` returns on non-numeric text)", value: Number.NaN },
+    { label: "a numeric STRING (an int8 or ::text column)", value: "3" },
+    { label: "negative", value: -1 },
+    { label: "fractional", value: 1.5 },
+    { label: "Infinity", value: Number.POSITIVE_INFINITY },
+    { label: "undefined (the column absent)", value: undefined },
+    { label: "null", value: null },
+    { label: "a boxed number", value: new Number(3) },
+  ])("REFUSES $label", ({ value }) => {
+    expect(isCount(value)).toBe(false);
+  });
+
+  it.each([
+    { label: "zero — the ordinary healthy reading", value: 0 },
+    { label: "a positive whole number", value: 7 },
+    { label: "a large count", value: 4_000_000 },
+  ])("ACCEPTS $label", ({ value }) => {
+    // The other direction, and it is not decoration: a guard tightened to
+    // `value > 0` would refuse every healthy approval on a workspace whose
+    // corpus is already a fixpoint — the commonest outcome there is.
+    expect(isCount(value)).toBe(true);
+  });
+});
 
 describeIfPg("the drift re-key's info line (#5109)", () => {
   let pool: Pool;

--- a/packages/api/src/lib/brain/__tests__/vocabulary-rekey-pg.test.ts
+++ b/packages/api/src/lib/brain/__tests__/vocabulary-rekey-pg.test.ts
@@ -34,16 +34,23 @@
  *
  * ## Mutation table
  *
- * Twenty-seven mutations, all twenty-seven caught. Rows 1-25 were regenerated in
+ * Twenty-nine mutations, all twenty-nine caught. Rows 1-25 were regenerated in
  * ONE pass against the tree that shipped them, rather than edited row by row —
  * #5022's review found numbers carried forward under a header claiming they had
  * been re-measured, twice.
  *
- * ⚠️ ROWS 26 AND 27 ARE THE EXCEPTIONS AND ARE SAID OUT LOUD, because a header
+ * ⚠️ ROWS 26-29 ARE THE EXCEPTIONS AND ARE SAID OUT LOUD, because a header
  * whose whole point is that carried-forward numbers are worthless cannot quietly
- * carry one. Both were added by hand and measured INDIVIDUALLY rather than by a
- * table-wide regeneration; their "first test to die" cells are those
+ * carry one. All four were added by hand and measured INDIVIDUALLY rather than by
+ * a table-wide regeneration; their "first test to die" cells are those
  * measurements.
+ *
+ * ⚠️ ROW 28 IS #5109'S OWN FIRST CUT, kept as a row rather than quietly fixed.
+ * That cut reported the declined rows as ONE number, which re-collapsed the very
+ * distinction #5109 was filed to draw: a tombstoned row needing nothing and a
+ * LIVE row whose vocabulary entry is the defect have different remedies. The
+ * review that caught it asked one question — *does this fix exhibit the defect it
+ * fixes, one layer over?* — and the answer was yes.
  *
  * ⚠️ ROWS 6 AND 26 WERE RE-MEASURED FOR #5109, not carried. That slice lifted
  * this statement's scan into a `MATERIALIZED` CTE so the declined rows could be
@@ -101,7 +108,9 @@
  * | 24 | `chr(11)` dropped from the separator class | `lexicalNormSql` agrees with `lexicalNorm` on every corpus row |
  * | 25 | `identityKeySql`'s `NULLIF(..., '')` dropped | SKIPS a row whose surface norms away, leaving 0194's placeholder untouched |
  * | 26 | the `IS NOT NULL` arm on the recomputed key dropped (#5047) | SKIPS a row whose surface norms away, leaving 0194's placeholder untouched |
- * | 27 | `skippedUnkeyable` dropped from the completion line (#5109) | carries BOTH counts — the declined rows beside the moved ones (`vocabulary-rekey-logging.test.ts`) |
+ * | 27 | a skip count dropped from the completion line (#5109) | carries BOTH counts — the declined rows beside the moved ones (`vocabulary-rekey-logging.test.ts`) |
+ * | 28 | the two skip causes MERGED into one count (#5109 round 1's own defect) | splits the declined rows BY CAUSE — a vocabulary target that norms away is not a tombstone |
+ * | 29 | the completion message stops being conditional on `skippedVocabularyTarget` | says so IN THE MESSAGE when a live row was declined by a vocabulary target (`vocabulary-rekey-logging.test.ts`) |
  *
  * ## Three rounds, and what each one caught that the previous missed
  *
@@ -704,7 +713,8 @@ describeIfPg("the drift re-key and the identity-mutation lock (#5024)", () => {
 
   interface RekeyCounts {
     readonly rekeyed: number;
-    readonly skipped_unkeyable: number;
+    readonly skipped_degenerate_surface: number;
+    readonly skipped_vocabulary_target: number;
   }
 
   /** Run one position's statement directly and read the counts it reports. */
@@ -727,9 +737,9 @@ describeIfPg("the drift re-key and the identity-mutation lock (#5024)", () => {
     // which, and the second is the one worth acting on.
     //
     // The fixture holds BOTH populations at once, which is the only shape that
-    // falsifies a count wired to the wrong one: a `skipped_unkeyable` reading
-    // the moved rows, or a `rekeyed` reading the scan, both agree with a
-    // fixture that has only one kind of row.
+    // falsifies a count wired to the wrong one: a skip count reading the moved
+    // rows, or a `rekeyed` reading the scan, both agree with a fixture that has
+    // only one kind of row.
     const healthy = await land(WS, { subject: "widget", predicate: "is", object: "friday" });
     const alsoHealthy = await land(WS, { subject: "gadget", predicate: "is", object: "friday" });
     const episode = await seedEpisode(WS);
@@ -763,10 +773,11 @@ describeIfPg("the drift re-key and the identity-mutation lock (#5024)", () => {
 
     expect(
       counts,
-      "the two numbers disagree with the corpus — `rekeyed` counts rows whose key MOVED and " +
-        "`skipped_unkeyable` counts rows the `IS NOT NULL` arm declined, and a fixture holding " +
-        "two of each is what stops one being wired to the other's population",
-    ).toEqual({ rekeyed: 2, skipped_unkeyable: 2 });
+      "the counts disagree with the corpus — `rekeyed` counts rows whose key MOVED and " +
+        "`skipped_degenerate_surface` counts rows the `IS NOT NULL` arm declined because their " +
+        "SURFACE asserts nothing, and a fixture holding two of each is what stops one being " +
+        "wired to the other's population",
+    ).toEqual({ rekeyed: 2, skipped_degenerate_surface: 2, skipped_vocabulary_target: 0 });
     // The moved rows really moved, and the declined rows really did not — the
     // counts are a report ABOUT the corpus, so a test that only read them back
     // would pass against a statement that wrote nothing at all.
@@ -786,10 +797,10 @@ describeIfPg("the drift re-key and the identity-mutation lock (#5024)", () => {
   it("a second run reports nothing moved and the SAME rows still declined", async () => {
     // The distinction, exercised. On the second pass `rekeyed` falls to zero
     // because nothing drifts any more — the ordinary, healthy reading — while
-    // `skipped_unkeyable` holds, because that population is closed and shrinks
-    // only. Two runs is the only way to show the numbers are independent: in a
-    // single run a `skipped_unkeyable` that secretly counted "rows I did not
-    // update" would give the same answer.
+    // the skip count holds, because that population is closed and shrinks only.
+    // Two runs is the only way to show the numbers are independent: in a single
+    // run a skip count that secretly counted "rows I did not update" would give
+    // the same answer.
     await land(WS, { subject: "widget", predicate: "is", object: "friday" });
     const episode = await seedEpisode(WS);
     await pool.query(
@@ -813,12 +824,20 @@ describeIfPg("the drift re-key and the identity-mutation lock (#5024)", () => {
       [WS],
     );
 
-    expect(await rekeyCounts("object")).toEqual({ rekeyed: 1, skipped_unkeyable: 1 });
-    // ⚠️ `rekeyed` drops, `skipped_unkeyable` does not. A count wired to "rows
+    expect(await rekeyCounts("object")).toEqual({
+      rekeyed: 1,
+      skipped_degenerate_surface: 1,
+      skipped_vocabulary_target: 0,
+    });
+    // ⚠️ `rekeyed` drops, the skip count does not. A count wired to "rows
     // this statement did not touch" would report 2 here (the placeholder AND
     // the now-fixpoint healthy row), which is the reading that would send an
     // operator hunting a degenerate population twice its real size.
-    expect(await rekeyCounts("object")).toEqual({ rekeyed: 0, skipped_unkeyable: 1 });
+    expect(await rekeyCounts("object")).toEqual({
+      rekeyed: 0,
+      skipped_degenerate_surface: 1,
+      skipped_vocabulary_target: 0,
+    });
   });
 
   it("counts against the EXPRESSION, not against the placeholder in the column", async () => {
@@ -845,7 +864,7 @@ describeIfPg("the drift re-key and the identity-mutation lock (#5024)", () => {
       "a row still HOLDING a placeholder but whose surface keys fine was counted as skipped — " +
         "the column is what the last writer put there, the expression is what this vocabulary " +
         "decides now, and only the second is the question being asked",
-    ).toEqual({ rekeyed: 1, skipped_unkeyable: 0 });
+    ).toEqual({ rekeyed: 1, skipped_degenerate_surface: 0, skipped_vocabulary_target: 0 });
     const { rows } = await pool.query<{ object_key: string }>(
       `SELECT object_key FROM brain_facts WHERE workspace_id = $1`,
       [WS],
@@ -853,13 +872,80 @@ describeIfPg("the drift re-key and the identity-mutation lock (#5024)", () => {
     expect(rows[0]?.object_key).toBe("friday");
   });
 
-  it("an empty workspace reports two zeroes rather than no row", async () => {
-    // The statement's final `SELECT` is two scalar subqueries with no `FROM`,
-    // so it yields one row even against a workspace with no facts. That is what
+  it("⭐ splits the declined rows BY CAUSE — a vocabulary target that norms away is not a tombstone", async () => {
+    // ⚠️ THE assertion the split exists for, and the defect the first cut of
+    // #5109 shipped: ONE `skipped` count merged two states with two different
+    // remedies, which is the exact collapse #5109 was filed to undo, one layer
+    // up from the arm that draws it.
+    //
+    //   - the DEGENERATE row: surface `-`, tombstoned by 0194, holding a
+    //     placeholder. Nothing to do, ever — there is no key to compute at any
+    //     vocabulary, and the population shrinks only.
+    //   - the VOCABULARY-TARGET row: surface `platform team`, which keys
+    //     perfectly well. LIVE, un-tombstoned, and declined only because this
+    //     workspace's closure maps its norm to ` - `. It keeps the key the
+    //     PREVIOUS vocabulary decided, so the closure and the corpus now
+    //     disagree — and the fix is the `brain_vocabulary_target` entry, not
+    //     another re-key.
+    //
+    // Both rows are declined by the same `IS NOT NULL` arm and are
+    // indistinguishable in `rekeyed`. Merged into one skip count they are
+    // indistinguishable there too, and the operator is told a closed
+    // self-healing population and a live disagreement are the same number.
+    //
+    // The closure is written DIRECTLY: `vocabulary-decide.ts` refuses a
+    // `degenerate-norm` target at authoring, which is what keeps this
+    // population empty in practice and exactly what makes the seam unable to
+    // build the fixture. The refusal arm deliberately does not rest on that
+    // guard holding, and neither does this count.
+    const live = await land(WS, { subject: "billing", predicate: "is", object: "platform team" });
+    const episode = await seedEpisode(WS);
+    await pool.query(
+      `INSERT INTO brain_facts
+         (workspace_id, subject, predicate, object,
+          subject_key, predicate_key, object_key,
+          source_episode_id, provenance, visible_to, invalidated_at)
+       VALUES ($1, 'widget', 'is', '-', 'widget', 'is', '-unkeyable:seed-a', $2,
+               '{"actor":"u1"}'::jsonb, ARRAY['org'], now())`,
+      [WS, episode.id],
+    );
+    await pool.query(
+      `INSERT INTO brain_vocabulary_edge
+         (workspace_id, slot_position, from_norm, to_norm, approved_by)
+       VALUES ($1, 'object', 'platform team', ' - ', 'hand-written')`,
+      [WS],
+    );
+    await pool.query(
+      `INSERT INTO brain_vocabulary_target (workspace_id, slot_position, norm, effective_target)
+       VALUES ($1, 'object', 'platform team', ' - ')`,
+      [WS],
+    );
+
+    expect(
+      await rekeyCounts("object"),
+      "the two declined rows were reported as one population — a tombstoned row needing nothing " +
+        "and a live row whose vocabulary entry is the defect have different remedies, which is " +
+        "the same split `MALFORMED_CLAIM`'s `cause` and the region import's two refusal types " +
+        "both make over this identical NULL",
+    ).toEqual({ rekeyed: 0, skipped_degenerate_surface: 1, skipped_vocabulary_target: 1 });
+
+    // The live row really did keep its old key — the count is a report ABOUT
+    // the corpus, and this is the disagreement it is reporting.
+    expect((await readFact(live)).object_key).toBe("platform team");
+    expect((await readFact(live)).invalidated_at).toBeNull();
+  });
+
+  it("an empty workspace reports zeroes rather than no row", async () => {
+    // The statement's final `SELECT` is three scalar subqueries with no
+    // `FROM`, so it yields one row even against a workspace with no facts. That is what
     // lets `rekeyDriftedFacts` treat an EMPTY result as "the executor is not
     // answering as a Postgres client" and refuse — the guard it already applies
     // to a missing `rows` array, extended to the shape.
-    expect(await rekeyCounts("predicate")).toEqual({ rekeyed: 0, skipped_unkeyable: 0 });
+    expect(await rekeyCounts("predicate")).toEqual({
+      rekeyed: 0,
+      skipped_degenerate_surface: 0,
+      skipped_vocabulary_target: 0,
+    });
   });
 
   // ── 2. the undo, on removal ─────────────────────────────────────────────

--- a/packages/api/src/lib/brain/__tests__/vocabulary-rekey-pg.test.ts
+++ b/packages/api/src/lib/brain/__tests__/vocabulary-rekey-pg.test.ts
@@ -898,6 +898,13 @@ describeIfPg("the drift re-key and the identity-mutation lock (#5024)", () => {
     // population empty in practice and exactly what makes the seam unable to
     // build the fixture. The refusal arm deliberately does not rest on that
     // guard holding, and neither does this count.
+    // ⚠️ TWO degenerate rows and ONE vocabulary-target row, so the counts are
+    // {0, 2, 1} and not {0, 1, 1}. Measured: with both at 1, swapping the two
+    // SQL predicates — or pointing `skipped_vocabulary_target` at
+    // `surface_norm IS NULL` so it silently duplicates the other count — passed
+    // this test, the one test whose entire subject is telling them apart. The
+    // sibling in `vocabulary-rekey-logging.test.ts` records the same lesson and
+    // this case had not applied it.
     const live = await land(WS, { subject: "billing", predicate: "is", object: "platform team" });
     const episode = await seedEpisode(WS);
     await pool.query(
@@ -906,6 +913,8 @@ describeIfPg("the drift re-key and the identity-mutation lock (#5024)", () => {
           subject_key, predicate_key, object_key,
           source_episode_id, provenance, visible_to, invalidated_at)
        VALUES ($1, 'widget', 'is', '-', 'widget', 'is', '-unkeyable:seed-a', $2,
+               '{"actor":"u1"}'::jsonb, ARRAY['org'], now()),
+              ($1, 'gadget', 'is', '___', 'gadget', 'is', '-unkeyable:seed-b', $2,
                '{"actor":"u1"}'::jsonb, ARRAY['org'], now())`,
       [WS, episode.id],
     );
@@ -927,7 +936,7 @@ describeIfPg("the drift re-key and the identity-mutation lock (#5024)", () => {
         "and a live row whose vocabulary entry is the defect have different remedies, which is " +
         "the same split `MALFORMED_CLAIM`'s `cause` and the region import's two refusal types " +
         "both make over this identical NULL",
-    ).toEqual({ rekeyed: 0, skipped_degenerate_surface: 1, skipped_vocabulary_target: 1 });
+    ).toEqual({ rekeyed: 0, skipped_degenerate_surface: 2, skipped_vocabulary_target: 1 });
 
     // The live row really did keep its old key — the count is a report ABOUT
     // the corpus, and this is the disagreement it is reporting.

--- a/packages/api/src/lib/brain/__tests__/vocabulary-rekey-pg.test.ts
+++ b/packages/api/src/lib/brain/__tests__/vocabulary-rekey-pg.test.ts
@@ -34,16 +34,27 @@
  *
  * ## Mutation table
  *
- * Twenty-six mutations, all twenty-six caught. Rows 1-25 were regenerated in ONE
- * pass against the tree that shipped them, rather than edited row by row —
+ * Twenty-seven mutations, all twenty-seven caught. Rows 1-25 were regenerated in
+ * ONE pass against the tree that shipped them, rather than edited row by row —
  * #5022's review found numbers carried forward under a header claiming they had
  * been re-measured, twice.
  *
- * ⚠️ ROW 26 IS THE EXCEPTION AND IS SAID OUT LOUD, because a header whose whole
- * point is that carried-forward numbers are worthless cannot quietly carry one.
- * It was added by hand for #5047 and measured INDIVIDUALLY — drop the
- * `IS NOT NULL` arm, watch the two named tests fail with a `23502` — not by a
- * table-wide regeneration. Its "first test to die" cell is that measurement.
+ * ⚠️ ROWS 26 AND 27 ARE THE EXCEPTIONS AND ARE SAID OUT LOUD, because a header
+ * whose whole point is that carried-forward numbers are worthless cannot quietly
+ * carry one. Both were added by hand and measured INDIVIDUALLY rather than by a
+ * table-wide regeneration; their "first test to die" cells are those
+ * measurements.
+ *
+ * ⚠️ ROWS 6 AND 26 WERE RE-MEASURED FOR #5109, not carried. That slice lifted
+ * this statement's scan into a `MATERIALIZED` CTE so the declined rows could be
+ * counted without a second workspace-wide pass, which moved the workspace scope
+ * onto the CTE and respelled the refusal arm as `r.new_key IS NOT NULL` over the
+ * same expression. A restructure is exactly the change under which a carried
+ * number is worthless, so both were re-applied against the new shape: row 26
+ * still dies on the same test with the same `23502`, and row 6 still dies on the
+ * foreign-row test. Row 27 is the one the restructure ADDED — the counts are
+ * computed in SQL and pinned there, but nothing read the number, so dropping it
+ * from the line left all 26 rows above green.
  * The
  * harness applies each mutation, runs all three suites, records the first
  * failing test, and reverts; the "first test to die" column is that recorded
@@ -90,6 +101,7 @@
  * | 24 | `chr(11)` dropped from the separator class | `lexicalNormSql` agrees with `lexicalNorm` on every corpus row |
  * | 25 | `identityKeySql`'s `NULLIF(..., '')` dropped | SKIPS a row whose surface norms away, leaving 0194's placeholder untouched |
  * | 26 | the `IS NOT NULL` arm on the recomputed key dropped (#5047) | SKIPS a row whose surface norms away, leaving 0194's placeholder untouched |
+ * | 27 | `skippedUnkeyable` dropped from the completion line (#5109) | carries BOTH counts — the declined rows beside the moved ones (`vocabulary-rekey-logging.test.ts`) |
  *
  * ## Three rounds, and what each one caught that the previous missed
  *
@@ -686,6 +698,168 @@ describeIfPg("the drift re-key and the identity-mutation lock (#5024)", () => {
         "empty string — the one key value that joins every other degenerate row — and it can no " +
         "longer become NULL either, which since #5047 would be a `23502` aborting the approval",
     ).toBe("ships on");
+  });
+
+  // ── 1b. the two counts the statement reports (#5109) ────────────────────
+
+  interface RekeyCounts {
+    readonly rekeyed: number;
+    readonly skipped_unkeyable: number;
+  }
+
+  /** Run one position's statement directly and read the counts it reports. */
+  async function rekeyCounts(position: SlotPosition, workspaceId = WS): Promise<RekeyCounts> {
+    const { rows } = await pool.query<RekeyCounts>(REKEY_DRIFTED_FACTS_SQL[position], [
+      workspaceId,
+    ]);
+    expect(rows, "the re-key statement stopped reporting its counts").toHaveLength(1);
+    return rows[0]!;
+  }
+
+  it("counts the rows it DECLINED beside the rows it moved (#5109)", async () => {
+    // ⭐ The distinction #5047's `IS NOT NULL` arm cost, restored.
+    //
+    // `rekeyed: 0` used to mean one thing and now means two: *nothing drifted*
+    // — ordinary, healthy, and what a workspace with no aliases at that slot
+    // reports forever — or *N rows hold `-unkeyable:` placeholders and were
+    // declined*, which says the corpus still carries the legacy degenerate
+    // population 0194 tombstoned. An operator reading a low number cannot tell
+    // which, and the second is the one worth acting on.
+    //
+    // The fixture holds BOTH populations at once, which is the only shape that
+    // falsifies a count wired to the wrong one: a `skipped_unkeyable` reading
+    // the moved rows, or a `rekeyed` reading the scan, both agree with a
+    // fixture that has only one kind of row.
+    const healthy = await land(WS, { subject: "widget", predicate: "is", object: "friday" });
+    const alsoHealthy = await land(WS, { subject: "gadget", predicate: "is", object: "friday" });
+    const episode = await seedEpisode(WS);
+    // Two degenerate rows, built the way 0194 builds them: TOMBSTONED, with a
+    // per-row placeholder in the column whose surface norms away. TWO, not one,
+    // so a count hardcoded to 1 — or one reporting a boolean — fails.
+    await pool.query(
+      `INSERT INTO brain_facts
+         (workspace_id, subject, predicate, object,
+          subject_key, predicate_key, object_key,
+          source_episode_id, provenance, visible_to, invalidated_at)
+       VALUES ($1, 'widget', 'is', '-', 'widget', 'is', '-unkeyable:seed-a', $2,
+               '{"actor":"u1"}'::jsonb, ARRAY['org'], now()),
+              ($1, 'gadget', 'is', '___', 'gadget', 'is', '-unkeyable:seed-b', $2,
+               '{"actor":"u1"}'::jsonb, ARRAY['org'], now())`,
+      [WS, episode.id],
+    );
+    await pool.query(
+      `INSERT INTO brain_vocabulary_edge
+         (workspace_id, slot_position, from_norm, to_norm, approved_by)
+       VALUES ($1, 'object', 'friday', 'fri', 'hand-written')`,
+      [WS],
+    );
+    await pool.query(
+      `INSERT INTO brain_vocabulary_target (workspace_id, slot_position, norm, effective_target)
+       VALUES ($1, 'object', 'friday', 'fri')`,
+      [WS],
+    );
+
+    const counts = await rekeyCounts("object");
+
+    expect(
+      counts,
+      "the two numbers disagree with the corpus — `rekeyed` counts rows whose key MOVED and " +
+        "`skipped_unkeyable` counts rows the `IS NOT NULL` arm declined, and a fixture holding " +
+        "two of each is what stops one being wired to the other's population",
+    ).toEqual({ rekeyed: 2, skipped_unkeyable: 2 });
+    // The moved rows really moved, and the declined rows really did not — the
+    // counts are a report ABOUT the corpus, so a test that only read them back
+    // would pass against a statement that wrote nothing at all.
+    expect((await readFact(healthy)).object_key).toBe("fri");
+    expect((await readFact(alsoHealthy)).object_key).toBe("fri");
+    const placeholders = await pool.query<{ object_key: string }>(
+      `SELECT object_key FROM brain_facts WHERE workspace_id = $1 AND object IN ('-', '___')
+        ORDER BY object_key`,
+      [WS],
+    );
+    expect(placeholders.rows.map((r) => r.object_key)).toEqual([
+      "-unkeyable:seed-a",
+      "-unkeyable:seed-b",
+    ]);
+  });
+
+  it("a second run reports nothing moved and the SAME rows still declined", async () => {
+    // The distinction, exercised. On the second pass `rekeyed` falls to zero
+    // because nothing drifts any more — the ordinary, healthy reading — while
+    // `skipped_unkeyable` holds, because that population is closed and shrinks
+    // only. Two runs is the only way to show the numbers are independent: in a
+    // single run a `skipped_unkeyable` that secretly counted "rows I did not
+    // update" would give the same answer.
+    await land(WS, { subject: "widget", predicate: "is", object: "friday" });
+    const episode = await seedEpisode(WS);
+    await pool.query(
+      `INSERT INTO brain_facts
+         (workspace_id, subject, predicate, object,
+          subject_key, predicate_key, object_key,
+          source_episode_id, provenance, visible_to, invalidated_at)
+       VALUES ($1, 'widget', 'is', '-', 'widget', 'is', '-unkeyable:seed-a', $2,
+               '{"actor":"u1"}'::jsonb, ARRAY['org'], now())`,
+      [WS, episode.id],
+    );
+    await pool.query(
+      `INSERT INTO brain_vocabulary_edge
+         (workspace_id, slot_position, from_norm, to_norm, approved_by)
+       VALUES ($1, 'object', 'friday', 'fri', 'hand-written')`,
+      [WS],
+    );
+    await pool.query(
+      `INSERT INTO brain_vocabulary_target (workspace_id, slot_position, norm, effective_target)
+       VALUES ($1, 'object', 'friday', 'fri')`,
+      [WS],
+    );
+
+    expect(await rekeyCounts("object")).toEqual({ rekeyed: 1, skipped_unkeyable: 1 });
+    // ⚠️ `rekeyed` drops, `skipped_unkeyable` does not. A count wired to "rows
+    // this statement did not touch" would report 2 here (the placeholder AND
+    // the now-fixpoint healthy row), which is the reading that would send an
+    // operator hunting a degenerate population twice its real size.
+    expect(await rekeyCounts("object")).toEqual({ rekeyed: 0, skipped_unkeyable: 1 });
+  });
+
+  it("counts against the EXPRESSION, not against the placeholder in the column", async () => {
+    // ⚠️ 0187's header sets this rule for counting unkeyed rows, and the two
+    // readings diverge on exactly one population: a row whose placeholder 0194
+    // wrote and whose SURFACE has since been corrected. It is keyable again —
+    // the statement re-keys it and reports it under `rekeyed` — while a count
+    // that tested the column for `-unkeyable:` would report the same row as
+    // skipped, in the same run, and the two numbers would sum to more rows than
+    // the workspace holds.
+    const episode = await seedEpisode(WS);
+    await pool.query(
+      `INSERT INTO brain_facts
+         (workspace_id, subject, predicate, object,
+          subject_key, predicate_key, object_key,
+          source_episode_id, provenance, visible_to, invalidated_at)
+       VALUES ($1, 'widget', 'is', 'friday', 'widget', 'is', '-unkeyable:repaired', $2,
+               '{"actor":"u1"}'::jsonb, ARRAY['org'], now())`,
+      [WS, episode.id],
+    );
+
+    expect(
+      await rekeyCounts("object"),
+      "a row still HOLDING a placeholder but whose surface keys fine was counted as skipped — " +
+        "the column is what the last writer put there, the expression is what this vocabulary " +
+        "decides now, and only the second is the question being asked",
+    ).toEqual({ rekeyed: 1, skipped_unkeyable: 0 });
+    const { rows } = await pool.query<{ object_key: string }>(
+      `SELECT object_key FROM brain_facts WHERE workspace_id = $1`,
+      [WS],
+    );
+    expect(rows[0]?.object_key).toBe("friday");
+  });
+
+  it("an empty workspace reports two zeroes rather than no row", async () => {
+    // The statement's final `SELECT` is two scalar subqueries with no `FROM`,
+    // so it yields one row even against a workspace with no facts. That is what
+    // lets `rekeyDriftedFacts` treat an EMPTY result as "the executor is not
+    // answering as a Postgres client" and refuse — the guard it already applies
+    // to a missing `rows` array, extended to the shape.
+    expect(await rekeyCounts("predicate")).toEqual({ rekeyed: 0, skipped_unkeyable: 0 });
   });
 
   // ── 2. the undo, on removal ─────────────────────────────────────────────

--- a/packages/api/src/lib/brain/identity.ts
+++ b/packages/api/src/lib/brain/identity.ts
@@ -657,13 +657,22 @@ export type InheritedSlot = InheritedSlotValue;
  * conservative direction (#5035's null-at-import rule makes the same call for the
  * same reason).
  *
- * ⚠️ That preservation is not PERMANENT, and saying so matters because the
- * conservative argument above reads as if it were. `REKEY_DRIFTED_FACTS_SQL`
- * (`vocabulary-decide.ts`, #5024) rewrites every key in the workspace that is not
- * a fixpoint of the local vocabulary at the next alias decision — inherited nulls
- * included. Nothing breaks: the target is rewritten by the same statement, so the
- * pair moves together and stays in one slot. What expires is the *unkeyedness*,
- * not the inheritance.
+ * ⚠️ That preservation is not PERMANENT — but since #5047 it is not
+ * unconditional either, and the difference matters because the conservative
+ * argument above reads as if the repair were guaranteed.
+ * `REKEY_DRIFTED_FACTS_SQL` (`vocabulary-decide.ts`, #5024) rewrites every key in
+ * the workspace that is not a fixpoint of the local vocabulary at the next alias
+ * decision. Nothing breaks: the target is rewritten by the same statement, so the
+ * pair moves together and stays in one slot.
+ *
+ * What that statement can no longer do is repair a row whose RECOMPUTED key is
+ * null. #5047 added an `IS NOT NULL` arm — the key columns are `NOT NULL` since
+ * migration 0194, so writing one would raise `23502` and abort a human-gated
+ * approval — and #5109 counts the declined rows precisely because their
+ * unkeyedness does NOT expire. So: an inherited null over a surface that KEYS
+ * loses its unkeyedness at the next decision; an inherited null over a surface
+ * that norms away keeps it forever, and the re-key reports it rather than fixing
+ * it. In both cases what survives is the inheritance, not the unkeyedness.
  */
 export function inheritSlotFromFactRow(row: {
   readonly id: string;

--- a/packages/api/src/lib/brain/vocabulary-decide.ts
+++ b/packages/api/src/lib/brain/vocabulary-decide.ts
@@ -2253,7 +2253,7 @@ export const REKEY_DRIFTED_FACTS_SQL: Readonly<Record<SlotPosition, string>> = O
  * polarity is how the fix becomes the defect."* `Number.isInteger` also encodes
  * what `count(*)` can return and the type cannot: a non-negative whole number.
  */
-function isCount(value: unknown): value is number {
+export function isCount(value: unknown): value is number {
   return typeof value === "number" && Number.isInteger(value) && value >= 0;
 }
 
@@ -2394,7 +2394,17 @@ async function rekeyDriftedFacts(
   // the number.
   //
   // ⚠️ THE LEVEL SPLITS WITH THE MESSAGE, and a conditional message at a flat
-  // `info` would have been the same defect one layer out. The comment above
+  // `info` would have been the same defect one layer out.
+  //
+  // ⚠️ The alert-fatigue cost is REAL and accepted rather than overlooked: this
+  // count is not temporally scoped, so a workspace holding one old tombstoned
+  // row in that population warns on every approval at that position until
+  // someone fixes the entry. Kept at `warn` because the alternative — scoping
+  // the count for the level decision alone — would make the number the line
+  // reports disagree with the number the statement computed, and a count that
+  // means one thing in the payload and another in the severity is worse than a
+  // repeated warning. The MESSAGE says the population may include retired rows,
+  // so the line is actionable rather than merely loud. The comment above
   // calls `skippedVocabularyTarget` "THE ONE TO ACT ON" — a data-integrity
   // divergence a human must repair by hand — and a deployment filtering `info`,
   // which is the ordinary posture for a path this chatty, would drop the only
@@ -2415,7 +2425,9 @@ async function rekeyDriftedFacts(
       "Drift re-key complete, but NOT total — some facts keep the keys the previous vocabulary " +
         "decided because this workspace's vocabulary maps their norm to something that normalizes " +
         "away. Their surfaces key fine and no re-key repairs them: fix the " +
-        "`brain_vocabulary_target` entry at this position",
+        "`brain_vocabulary_target` entry at this position. NOTE this count is not scoped by " +
+        "`invalidated_at`/`valid_to` (the statement deliberately is not), so it may include " +
+        "tombstoned or superseded rows — check before treating the number as live claims",
     );
   } else {
     log.info(payload, "Drift re-key complete — existing facts now carry the keys this vocabulary decides");

--- a/packages/api/src/lib/brain/vocabulary-decide.ts
+++ b/packages/api/src/lib/brain/vocabulary-decide.ts
@@ -2130,7 +2130,7 @@ function rekeyDriftedFactsSql(position: SlotPosition): string {
   // ⚠️ THE DECLINED ROWS ARE SPLIT BY CAUSE, NOT COUNTED AS ONE (#5109 round 2).
   //
   // `new_key` is NULL for two reasons, and they are not one problem — which is
-  // the distinction the ⚠️ two blocks up is already emphatic about, and which a
+  // the distinction the `IS NOT NULL` block above is already emphatic about, and which a
   // single `skipped` count re-collapses one layer above the arm that draws it:
   //
   //   * `surface_norm IS NULL` — the SURFACE asserts nothing (`-`, `___`).
@@ -2209,6 +2209,30 @@ export const REKEY_DRIFTED_FACTS_SQL: Readonly<Record<SlotPosition, string>> = O
   object: rekeyDriftedFactsSql("object"),
 });
 /**
+ * A `count(*)::int` {@link rekeyDriftedFacts} is willing to act on.
+ *
+ * ⚠️ `typeof v === "number"` IS NOT ENOUGH, and the gap fails OPEN on the one
+ * value that decides the alarm. `NaN` is a number, and `NaN > 0` is **false** —
+ * so a `NaN` in `skipped_vocabulary_target` would sail past a `typeof` guard and
+ * then silently select *"existing facts now carry the keys this vocabulary
+ * decides"*: a success sentence about the exact population the split exists to
+ * make visible. The guard meant to prevent that would be the thing delivering it.
+ *
+ * `NaN` is reachable without a bug in Postgres. `VocabularyExecutor` is
+ * deliberately satisfiable by any `{ query }`, and `pg`'s int4 parser is
+ * `parseInt`, which yields `NaN` on any non-numeric text.
+ *
+ * Written in the DENY polarity for `vocabulary.ts`'s stated reason — its lock
+ * probe guards the identical "read an int off a one-row probe" with
+ * `Number.isFinite` and argues that *"a deny point written in the permissive
+ * polarity is how the fix becomes the defect."* `Number.isInteger` also encodes
+ * what `count(*)` can return and the type cannot: a non-negative whole number.
+ */
+export function isCount(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0;
+}
+
+/**
  * Run the drift re-key for one position, INSIDE the decide transaction.
  *
  * ## Why it stays in this transaction, stated rather than discovered
@@ -2233,29 +2257,6 @@ export const REKEY_DRIFTED_FACTS_SQL: Readonly<Record<SlotPosition, string>> = O
  * per-workspace, and the alternative trades a bounded latency for an unbounded
  * correctness window.
  */
-/**
- * A `count(*)::int` this function is willing to act on.
- *
- * ⚠️ `typeof v === "number"` IS NOT ENOUGH, and the gap fails OPEN on the one
- * value that decides the alarm. `NaN` is a number, and `NaN > 0` is **false** —
- * so a `NaN` in `skipped_vocabulary_target` would sail past a `typeof` guard and
- * then silently select *"existing facts now carry the keys this vocabulary
- * decides"*: a success sentence about the exact population the split exists to
- * make visible. The guard meant to prevent that would be the thing delivering it.
- *
- * `NaN` is reachable without a bug in Postgres. `VocabularyExecutor` is
- * deliberately satisfiable by any `{ query }`, and `pg`'s int4 parser is
- * `parseInt`, which yields `NaN` on any non-numeric text.
- *
- * Written in the DENY polarity for `vocabulary.ts`'s stated reason — its lock
- * probe guards the identical "read an int off a one-row probe" with
- * `Number.isFinite` and argues that *"a deny point written in the permissive
- * polarity is how the fix becomes the defect."* `Number.isInteger` also encodes
- * what `count(*)` can return and the type cannot: a non-negative whole number.
- */
-export function isCount(value: unknown): value is number {
-  return typeof value === "number" && Number.isInteger(value) && value >= 0;
-}
 
 async function rekeyDriftedFacts(
   tx: VocabularyExecutor,
@@ -2365,11 +2366,14 @@ async function rekeyDriftedFacts(
   //
   //   `skippedDegenerateSurface` — 0194's tombstoned population. Nothing to do;
   //     the set is closed and shrinks only, so a flat number is health.
-  //   `skippedVocabularyTarget` — ⚠️ THE ONE TO ACT ON. Live, un-tombstoned
-  //     rows whose surface keys fine, left on their old key because this
-  //     workspace's `brain_vocabulary_target` maps their norm to something that
-  //     normalizes away. The closure and the corpus now disagree, and no
-  //     re-key repairs it — the entry does.
+  //   `skippedVocabularyTarget` — ⚠️ THE ONE TO ACT ON. Rows whose surface keys
+  //     fine, left on their old key because this workspace's
+  //     `brain_vocabulary_target` maps their norm to something that normalizes
+  //     away. The closure and the corpus now disagree, and no re-key repairs it
+  //     — the entry does. TYPICALLY live, but NOT scoped by `invalidated_at` or
+  //     `valid_to` (see the ⚠️ below) — an earlier cut of this line asserted
+  //     "live, un-tombstoned" as a premise and the retraction landed only on
+  //     the consequence, leaving a reader the wrong answer first.
   //
   // Counted against the EXPRESSION being NULL rather than by testing the key
   // column for the placeholder prefix, which is the rule migration 0187's

--- a/packages/api/src/lib/brain/vocabulary-decide.ts
+++ b/packages/api/src/lib/brain/vocabulary-decide.ts
@@ -2061,12 +2061,61 @@ function rekeyDriftedFactsSql(position: SlotPosition): string {
   // `degenerate-norm` targets at authoring, so that path is closed today, and
   // testing the composed expression is what keeps this arm correct if it ever
   // reopens rather than relying on the other guard staying put.
-  return `UPDATE brain_facts f
-            SET ${key} = ${identityKeySql(aliased)}
-          WHERE f.workspace_id = $1
-            AND ${identityKeySql(aliased)} IS NOT NULL
-            AND f.${key} IS DISTINCT FROM ${identityKeySql(aliased)}
-      RETURNING f.id::text AS id`;
+  // ── ONE SCAN, TWO NUMBERS (#5109) ─────────────────────────────────────
+  //
+  // The `IS NOT NULL` arm above made `rekeyed` ambiguous: it can no longer
+  // distinguish *nothing drifted* — the ordinary case, and healthy — from
+  // *N rows hold `-unkeyable:` placeholders and were declined*, which is a
+  // corpus carrying legacy degenerate rows and is worth knowing about. Both
+  // read as a low or zero count, and an `UPDATE` cannot report the rows it
+  // did not touch.
+  //
+  // So the scan is LIFTED into a CTE and both numbers come off it. The
+  // alternative — a second `SELECT count(*) … WHERE <expr> IS NULL` — is a
+  // second workspace-wide sequential scan on a statement whose cost is
+  // already argued paragraph by paragraph above, for a diagnostic. `AS
+  // MATERIALIZED` is what makes that a promise rather than a hope: without it
+  // PG 12+ may inline the CTE and re-plan the scan per reference.
+  //
+  // It is also cheaper than what it replaces. The old shape spelled
+  // `identityKeySql(aliased)` THREE times — once in `SET`, once in each of two
+  // `WHERE` arms — so the closure subquery was evaluated three times per row.
+  // Here it is computed once per row and read by name.
+  //
+  // ⚠️ THE REFUSAL ARM IS THE SAME ARM. It reads `r.new_key IS NOT NULL`
+  // rather than repeating the expression, and `r.new_key` IS that expression —
+  // the projection above is `${identityKeySql(aliased)} AS new_key`, unchanged
+  // character for character. Dropping this arm still writes NULL into a
+  // `NOT NULL` column and still raises `23502`, which is what row 26 of this
+  // module's mutation table measures.
+  //
+  // ⚠️ The workspace scope MOVED to the CTE and did not weaken. `f.id = r.id`
+  // joins on the primary key against a set already scoped to `$1`, so no
+  // foreign row is reachable; the mutation that weakens the scope is caught in
+  // the CTE exactly as it was on the `UPDATE` (row 6).
+  //
+  // ⚠️ The CTE's own `WHERE` is deliberately UNQUALIFIED (`workspace_id`, not
+  // `f.workspace_id`). `vocabulary-decide-pg.test.ts` finds this statement's
+  // SET clause by slicing to the single `WHERE f.` — the one on the updated
+  // alias — and a second qualified `WHERE f.` would break that parse rather
+  // than fail an assertion, which is the worse failure. Unqualified resolves
+  // to the same column.
+  return `WITH recomputed AS MATERIALIZED (
+            SELECT f.id AS id, ${identityKeySql(aliased)} AS new_key
+              FROM brain_facts f
+             WHERE workspace_id = $1
+          ),
+          moved AS (
+            UPDATE brain_facts f
+               SET ${key} = r.new_key
+              FROM recomputed r
+             WHERE f.id = r.id
+               AND r.new_key IS NOT NULL
+               AND f.${key} IS DISTINCT FROM r.new_key
+         RETURNING f.id::text AS id
+          )
+          SELECT (SELECT count(*) FROM moved)::int AS rekeyed,
+                 (SELECT count(*) FROM recomputed WHERE new_key IS NULL)::int AS skipped_unkeyable`;
 }
 
 export const REKEY_DRIFTED_FACTS_SQL: Readonly<Record<SlotPosition, string>> = Object.freeze({
@@ -2113,7 +2162,7 @@ async function rekeyDriftedFacts(
   position: SlotPosition,
   proposalId: string,
 ): Promise<void> {
-  let rows: readonly unknown[];
+  let counts: { readonly rekeyed: number; readonly skippedUnkeyable: number };
   try {
     // REFUSED, not defaulted. `VocabularyExecutor` is deliberately satisfiable
     // by any `{ query }`, and the earlier `?? []` turned an executor that is not
@@ -2132,7 +2181,24 @@ async function rekeyDriftedFacts(
           "committing an approval that may not have moved a single key.",
       );
     }
-    rows = result.rows;
+    // ONE row, always — the statement's final `SELECT` is two scalar
+    // subqueries over the CTEs and has no `FROM`, so it produces exactly one
+    // row even when the workspace holds no facts at all. An EMPTY array here
+    // therefore means the same thing the guard above catches: an executor that
+    // is not answering as a Postgres client. Refused for the same reason, and
+    // not defaulted to zeroes — `rekeyed: 0, skippedUnkeyable: 0` is a
+    // perfectly ordinary reading, so a default would be indistinguishable from
+    // the healthy case rather than obviously wrong.
+    const row = result.rows[0] as { rekeyed?: unknown; skipped_unkeyable?: unknown } | undefined;
+    if (typeof row?.rekeyed !== "number" || typeof row.skipped_unkeyable !== "number") {
+      throw new Error(
+        `rekeyDriftedFacts: the executor answered the ${position} re-key without the two counts ` +
+          `(workspace ${workspaceId}, proposal ${proposalId}). The statement's result was never ` +
+          "observed, so whether the corpus was re-keyed is unknown — refusing rather than " +
+          "committing an approval that may not have moved a single key.",
+      );
+    }
+    counts = { rekeyed: row.rekeyed, skippedUnkeyable: row.skipped_unkeyable };
   } catch (err) {
     // LOGGED before it propagates. `decideAliasProposal`'s outer catch narrows
     // on `AliasApplyRefusedError` and re-throws everything else WITHOUT a log
@@ -2152,19 +2218,41 @@ async function rekeyDriftedFacts(
     );
     throw err;
   }
-  // COUNTED from `RETURNING`, not from `pg`'s `rowCount`. `VocabularyExecutor`
-  // and `ReconcileExecutor` both declare `{ rows }` and `withBrainTransaction`'s
+  // COUNTED IN SQL, not from `pg`'s `rowCount`. `VocabularyExecutor` and
+  // `ReconcileExecutor` both declare `{ rows }` and `withBrainTransaction`'s
   // wrapper projects exactly that, so `rowCount` does not survive the seam at
   // all — reading it yields `undefined` and logs a re-key that moved thousands
-  // of rows as having moved none. `RETURNING` is only as expensive as the rows
-  // that actually changed, which the `IS DISTINCT FROM` guard already narrows.
+  // of rows as having moved none.
   //
-  // Nothing branches on the number. An approval whose re-key moved zero rows is
-  // the ordinary case — the workspace may have no facts at that slot yet — and
-  // treating it as a failure would refuse the first alias a workspace approves.
-  // It is the operator's only signal that the re-key ran and how wide it reached.
+  // Nothing branches on either number. An approval whose re-key moved zero rows
+  // is the ordinary case — the workspace may have no facts at that slot yet —
+  // and treating it as a failure would refuse the first alias a workspace
+  // approves. They are the operator's only signal that the re-key ran and how
+  // wide it reached.
+  //
+  // ⚠️ `skippedUnkeyable` EXISTS BECAUSE `rekeyed` ALONE LOST A DISTINCTION
+  // (#5109). Since #5047's `IS NOT NULL` arm, a low `rekeyed` covers two very
+  // different states: *nothing drifted*, which is ordinary and healthy, and
+  // *N rows hold `-unkeyable:` placeholders and were declined*, which says the
+  // corpus still carries the legacy degenerate population migration 0194
+  // tombstoned. The second is worth knowing about — that population is closed
+  // and shrinks only, so a number that stays flat across approvals is the
+  // signal — and it was indistinguishable from the first.
+  //
+  // Counted against the EXPRESSION being NULL rather than by testing the key
+  // column for the placeholder prefix, which is the rule migration 0187's
+  // header sets for counting unkeyed rows: the column is what the last writer
+  // put there, while the expression is what this vocabulary decides now. A row
+  // whose placeholder was written by 0194 and whose surface has since been
+  // corrected is keyable again, and the column would still call it unkeyable.
   log.info(
-    { workspaceId, proposalId, position, rekeyed: rows.length },
+    {
+      workspaceId,
+      proposalId,
+      position,
+      rekeyed: counts.rekeyed,
+      skippedUnkeyable: counts.skippedUnkeyable,
+    },
     "Drift re-key complete — existing facts now carry the keys this vocabulary decides",
   );
 }

--- a/packages/api/src/lib/brain/vocabulary-decide.ts
+++ b/packages/api/src/lib/brain/vocabulary-decide.ts
@@ -2021,14 +2021,19 @@ async function lockIdentityMutation(tx: VocabularyExecutor, workspaceId: string)
  * NULL-safe on both sides, unlike `<>`. Every row is still EVALUATED, which is
  * what the paragraph above requires; what this avoids is a dead tuple per row
  * per approval on a table the review queue reads constantly. It also makes
- * `moved` mean "rows re-keyed" exactly, which is one of the two numbers the
+ * `moved` mean "rows re-keyed" exactly, which is one of the three numbers the
  * statement reports.
  *
- * ⚠️ TWO numbers, since #5109 — see the block inside the builder. `rekeyed`
- * counts the rows whose key moved; `skipped_unkeyable` counts the rows the
- * `IS NOT NULL` arm declined. An earlier cut of this paragraph said the
- * `UPDATE`'s ROW COUNT was "the number worth logging", singular, and that
- * stopped being true the moment #5047 gave a low count two meanings.
+ * ⚠️ THREE numbers, since #5109 — see the two blocks inside the builder.
+ * `rekeyed` counts the rows whose key moved; `skipped_degenerate_surface` and
+ * `skipped_vocabulary_target` split the rows the `IS NOT NULL` arm declined, by
+ * WHY it declined them. Two earlier cuts of this paragraph are worth recording
+ * because each was true when written and stopped being true one slice later:
+ * the first called the `UPDATE`'s ROW COUNT "the number worth logging",
+ * singular, which #5047 ended by giving a low count two meanings; the second
+ * said TWO numbers, which round 2 of #5109 ended by splitting the declined
+ * rows — a single `skipped` re-collapsed the very distinction the slice was
+ * filed to draw.
  */
 function rekeyDriftedFactsSql(position: SlotPosition): string {
   const { surface, key } = SLOT_COLUMNS[position];
@@ -2068,26 +2073,37 @@ function rekeyDriftedFactsSql(position: SlotPosition): string {
   // `degenerate-norm` targets at authoring, so that path is closed today, and
   // testing the composed expression is what keeps this arm correct if it ever
   // reopens rather than relying on the other guard staying put.
-  // ── ONE SCAN, TWO NUMBERS (#5109) ─────────────────────────────────────
+  // ── ONE SCAN, THREE NUMBERS (#5109) ───────────────────────────────────
   //
   // The `IS NOT NULL` arm above made `rekeyed` ambiguous: it can no longer
   // distinguish *nothing drifted* — the ordinary case, and healthy — from
-  // *N rows hold `-unkeyable:` placeholders and were declined*, which is a
-  // corpus carrying legacy degenerate rows and is worth knowing about. Both
-  // read as a low or zero count, and an `UPDATE` cannot report the rows it
-  // did not touch.
+  // *N rows were declined*, which is worth knowing about. Both read as a low
+  // or zero count, and an `UPDATE` cannot report the rows it did not touch.
+  // The declined rows are then split again by CAUSE — see the ⚠️ below, which
+  // is the argument for why this is three numbers and not two.
   //
-  // So the scan is LIFTED into a CTE and both numbers come off it. The
+  // So the scan is LIFTED into a CTE and every number comes off it. The
   // alternative — a second `SELECT count(*) … WHERE <expr> IS NULL` — is a
   // second workspace-wide sequential scan on a statement whose cost is
-  // already argued paragraph by paragraph above, for a diagnostic. `AS
-  // MATERIALIZED` is what makes that a promise rather than a hope: without it
-  // PG 12+ may inline the CTE and re-plan the scan per reference.
+  // already argued paragraph by paragraph above, for a diagnostic.
   //
-  // It is also cheaper than what it replaces. The old shape spelled
-  // `identityKeySql(aliased)` THREE times — once in `SET`, once in each of two
-  // `WHERE` arms — so the closure subquery was evaluated three times per row.
-  // Here it is computed once per row and read by name.
+  // `AS MATERIALIZED` is BELT-AND-BRACES, not the thing that makes the single
+  // scan true, and an earlier cut of this line claimed otherwise. PG folds a
+  // non-recursive, side-effect-free CTE into the parent only when the parent
+  // references it EXACTLY ONCE; `recomputed` is referenced twice (`moved`'s
+  // `FROM`, and the count subqueries), so PG 12+ materializes it by default
+  // and the hazard that cut described cannot arise. What the keyword actually
+  // buys is a future edit that drops one of those references — which would
+  // silently restore per-reference re-planning with nothing objecting.
+  //
+  // On cost against the old shape: the closure subquery is now evaluated once
+  // per row rather than up to three times (`SET` plus two `WHERE` arms —
+  // though the `SET` occurrence only ever ran for rows that passed, i.e. the
+  // rows actually moving). That is not a pure win and should not be read as
+  // one: the CTE materializes one `(id, surface_norm, new_key)` tuple per
+  // workspace fact where the old shape streamed. A workspace-scoped scan on a
+  // rare, human-gated act is the same budget §7 already argued for; the
+  // memory is the new line item.
   //
   // ⚠️ THE REFUSAL ARM IS THE SAME ARM. It reads `r.new_key IS NOT NULL`
   // rather than repeating the expression, and `r.new_key` IS that expression —
@@ -2104,11 +2120,62 @@ function rekeyDriftedFactsSql(position: SlotPosition): string {
   // ⚠️ The CTE's own `WHERE` is deliberately UNQUALIFIED (`workspace_id`, not
   // `f.workspace_id`). `vocabulary-decide-pg.test.ts` finds this statement's
   // SET clause by slicing to the single `WHERE f.` — the one on the updated
-  // alias — and a second qualified `WHERE f.` would break that parse rather
-  // than fail an assertion, which is the worse failure. Unqualified resolves
-  // to the same column.
+  // alias — so a second qualified `WHERE f.` would move that boundary and make
+  // the slice read a clause it was not measuring. It FAILS LOUDLY rather than
+  // silently: that test asserts `matchAll(/WHERE f\./g)` has length exactly 1,
+  // and the `WHERE f.` would also precede `SET `, tripping its ordering
+  // assertion too. (An earlier cut of this note claimed the parse would break
+  // silently, which undersold the guard the test already has.) Unqualified
+  // resolves to the same column, so the convention costs nothing.
+  // ⚠️ THE DECLINED ROWS ARE SPLIT BY CAUSE, NOT COUNTED AS ONE (#5109 round 2).
+  //
+  // `new_key` is NULL for two reasons, and they are not one problem — which is
+  // the distinction the ⚠️ two blocks up is already emphatic about, and which a
+  // single `skipped` count re-collapses one layer above the arm that draws it:
+  //
+  //   * `surface_norm IS NULL` — the SURFACE asserts nothing (`-`, `___`).
+  //     0194's tombstoned population: `invalidated_at` is set, the row is
+  //     outside every slot consumer, the placeholder it keeps joins nothing,
+  //     and there is no key to compute at any vocabulary. NOTHING TO DO. The
+  //     population is closed and shrinks only, so a flat number is health.
+  //   * `surface_norm IS NOT NULL` — the surface keys perfectly well and THIS
+  //     WORKSPACE'S VOCABULARY maps its norm to something that normalizes away.
+  //     Such a row was silently left on its OLD key while the vocabulary says
+  //     something else — a committed disagreement between the closure and the
+  //     corpus, and typically a live one, since the entry is authored against
+  //     text somebody is using. ACT ON IT: the defect is the
+  //     `brain_vocabulary_target` entry, and no re-key repairs it.
+  //
+  // Two counts and two remedies, which is exactly the split `admin-migrate.ts`
+  // makes between `RegionImportUnkeyableError` and
+  // `RegionImportVocabularyTargetError` over this same NULL, and exactly the
+  // split `reconcile.ts`'s `MALFORMED_CLAIM` `cause` makes over it a third
+  // time — `degenerate-surface` vs `vocabulary-target`, whose spellings these
+  // column names deliberately reuse. A count that merged them would send an
+  // operator to inspect a tombstoned population that needs nothing, or say
+  // nothing at all about a live row that needs an edit.
+  //
+  // `vocabulary-decide.ts` refuses `degenerate-norm` targets at AUTHORING, so
+  // the second population is empty today. That is the same argument the
+  // refusal arm above declines to rest on, for the same reason: the arm tests
+  // the composed expression rather than trusting the other guard to stay put,
+  // and a count that assumed the guard holds would be the one thing that does
+  // not say so when it stops holding.
+  //
+  // ⚠️ NEITHER COUNT IS SCOPED BY `invalidated_at` OR `valid_to`, because this
+  // statement deliberately is not (see "Scope: EVERY row, and no index"). So
+  // `skipped_vocabulary_target` counts a tombstoned or superseded row too, if
+  // its surface keys fine and the vocabulary maps its norm away. That is rare —
+  // the population is created by an entry authored against live text — but it
+  // means the number is "rows the vocabulary now disagrees with", not "live
+  // rows". Adding a temporal arm to this ONE count would make it disagree with
+  // the statement it is a report about, which is the worse trade.
+  //
+  // It reuses `norm` — the same expression the closure lookup already keys on,
+  // bound once at the top of this function. A second binding for the same
+  // expression is the shape #5000 was.
   return `WITH recomputed AS MATERIALIZED (
-            SELECT f.id AS id, ${identityKeySql(aliased)} AS new_key
+            SELECT f.id AS id, ${norm} AS surface_norm, ${identityKeySql(aliased)} AS new_key
               FROM brain_facts f
              WHERE workspace_id = $1
           ),
@@ -2122,7 +2189,10 @@ function rekeyDriftedFactsSql(position: SlotPosition): string {
          RETURNING f.id::text AS id
           )
           SELECT (SELECT count(*) FROM moved)::int AS rekeyed,
-                 (SELECT count(*) FROM recomputed WHERE new_key IS NULL)::int AS skipped_unkeyable`;
+                 (SELECT count(*) FROM recomputed
+                   WHERE new_key IS NULL AND surface_norm IS NULL)::int AS skipped_degenerate_surface,
+                 (SELECT count(*) FROM recomputed
+                   WHERE new_key IS NULL AND surface_norm IS NOT NULL)::int AS skipped_vocabulary_target`;
 }
 
 export const REKEY_DRIFTED_FACTS_SQL: Readonly<Record<SlotPosition, string>> = Object.freeze({
@@ -2169,7 +2239,11 @@ async function rekeyDriftedFacts(
   position: SlotPosition,
   proposalId: string,
 ): Promise<void> {
-  let counts: { readonly rekeyed: number; readonly skippedUnkeyable: number };
+  let counts: {
+    readonly rekeyed: number;
+    readonly skippedDegenerateSurface: number;
+    readonly skippedVocabularyTarget: number;
+  };
   try {
     // REFUSED, not defaulted. `VocabularyExecutor` is deliberately satisfiable
     // by any `{ query }`, and the earlier `?? []` turned an executor that is not
@@ -2188,24 +2262,38 @@ async function rekeyDriftedFacts(
           "committing an approval that may not have moved a single key.",
       );
     }
-    // ONE row, always — the statement's final `SELECT` is two scalar
+    // ONE row, always — the statement's final `SELECT` is three scalar
     // subqueries over the CTEs and has no `FROM`, so it produces exactly one
     // row even when the workspace holds no facts at all. An EMPTY array here
     // therefore means the same thing the guard above catches: an executor that
     // is not answering as a Postgres client. Refused for the same reason, and
-    // not defaulted to zeroes — `rekeyed: 0, skippedUnkeyable: 0` is a
-    // perfectly ordinary reading, so a default would be indistinguishable from
-    // the healthy case rather than obviously wrong.
-    const row = result.rows[0] as { rekeyed?: unknown; skipped_unkeyable?: unknown } | undefined;
-    if (typeof row?.rekeyed !== "number" || typeof row.skipped_unkeyable !== "number") {
+    // not defaulted to zeroes — all-zero is a perfectly ordinary reading, so a
+    // default would be indistinguishable from the healthy case rather than
+    // obviously wrong.
+    const row = result.rows[0] as
+      | {
+          rekeyed?: unknown;
+          skipped_degenerate_surface?: unknown;
+          skipped_vocabulary_target?: unknown;
+        }
+      | undefined;
+    if (
+      typeof row?.rekeyed !== "number" ||
+      typeof row.skipped_degenerate_surface !== "number" ||
+      typeof row.skipped_vocabulary_target !== "number"
+    ) {
       throw new Error(
-        `rekeyDriftedFacts: the executor answered the ${position} re-key without the two counts ` +
+        `rekeyDriftedFacts: the executor answered the ${position} re-key without the three counts ` +
           `(workspace ${workspaceId}, proposal ${proposalId}). The statement's result was never ` +
           "observed, so whether the corpus was re-keyed is unknown — refusing rather than " +
           "committing an approval that may not have moved a single key.",
       );
     }
-    counts = { rekeyed: row.rekeyed, skippedUnkeyable: row.skipped_unkeyable };
+    counts = {
+      rekeyed: row.rekeyed,
+      skippedDegenerateSurface: row.skipped_degenerate_surface,
+      skippedVocabularyTarget: row.skipped_vocabulary_target,
+    };
   } catch (err) {
     // LOGGED before it propagates. `decideAliasProposal`'s outer catch narrows
     // on `AliasApplyRefusedError` and re-throws everything else WITHOUT a log
@@ -2237,14 +2325,20 @@ async function rekeyDriftedFacts(
   // approves. They are the operator's only signal that the re-key ran and how
   // wide it reached.
   //
-  // ⚠️ `skippedUnkeyable` EXISTS BECAUSE `rekeyed` ALONE LOST A DISTINCTION
-  // (#5109). Since #5047's `IS NOT NULL` arm, a low `rekeyed` covers two very
+  // ⚠️ THE TWO SKIP COUNTS EXIST BECAUSE `rekeyed` ALONE LOST A DISTINCTION
+  // (#5109). Since #5047's `IS NOT NULL` arm, a low `rekeyed` covered two very
   // different states: *nothing drifted*, which is ordinary and healthy, and
-  // *N rows hold `-unkeyable:` placeholders and were declined*, which says the
-  // corpus still carries the legacy degenerate population migration 0194
-  // tombstoned. The second is worth knowing about — that population is closed
-  // and shrinks only, so a number that stays flat across approvals is the
-  // signal — and it was indistinguishable from the first.
+  // *N rows were declined*, which is not. They are reported separately, and the
+  // declined rows are split again by CAUSE — see the builder's ⚠️ for why one
+  // merged `skipped` re-collapsed the distinction this line exists to draw.
+  //
+  //   `skippedDegenerateSurface` — 0194's tombstoned population. Nothing to do;
+  //     the set is closed and shrinks only, so a flat number is health.
+  //   `skippedVocabularyTarget` — ⚠️ THE ONE TO ACT ON. Live, un-tombstoned
+  //     rows whose surface keys fine, left on their old key because this
+  //     workspace's `brain_vocabulary_target` maps their norm to something that
+  //     normalizes away. The closure and the corpus now disagree, and no
+  //     re-key repairs it — the entry does.
   //
   // Counted against the EXPRESSION being NULL rather than by testing the key
   // column for the placeholder prefix, which is the rule migration 0187's
@@ -2252,15 +2346,36 @@ async function rekeyDriftedFacts(
   // put there, while the expression is what this vocabulary decides now. A row
   // whose placeholder was written by 0194 and whose surface has since been
   // corrected is keyable again, and the column would still call it unkeyable.
+  //
+  // ⚠️ THE MESSAGE IS CONDITIONAL, and that is not cosmetic. *"existing facts
+  // now carry the keys this vocabulary decides"* is false of the
+  // `skippedVocabularyTarget` rows — they carry the keys the PREVIOUS
+  // vocabulary decided — so emitting it unconditionally would be a success
+  // sentence about the one population that needs a human. That is the same
+  // defect the `?? []` removal above describes, reached by a different road.
+  //
+  // It is strictly speaking false of the `skippedDegenerateSurface` rows too:
+  // they carry `-unkeyable:<id>`, which no vocabulary decided. The message
+  // does not branch on them ON PURPOSE — there is no key to decide for a
+  // surface that asserts nothing, nothing for a human to do, and a line that
+  // sounded an alarm on a closed self-healing population is the alert fatigue
+  // that makes the real one unreadable. The count is there for whoever wants
+  // the number.
   log.info(
     {
       workspaceId,
       proposalId,
       position,
       rekeyed: counts.rekeyed,
-      skippedUnkeyable: counts.skippedUnkeyable,
+      skippedDegenerateSurface: counts.skippedDegenerateSurface,
+      skippedVocabularyTarget: counts.skippedVocabularyTarget,
     },
-    "Drift re-key complete — existing facts now carry the keys this vocabulary decides",
+    counts.skippedVocabularyTarget > 0
+      ? "Drift re-key complete, but NOT total — some facts keep the keys the previous vocabulary " +
+        "decided because this workspace's vocabulary maps their norm to something that normalizes " +
+        "away. Their surfaces key fine, they are live, and no re-key repairs them: fix the " +
+        "`brain_vocabulary_target` entry at this position"
+      : "Drift re-key complete — existing facts now carry the keys this vocabulary decides",
   );
 }
 

--- a/packages/api/src/lib/brain/vocabulary-decide.ts
+++ b/packages/api/src/lib/brain/vocabulary-decide.ts
@@ -2020,8 +2020,15 @@ async function lockIdentityMutation(tx: VocabularyExecutor, workspaceId: string)
  * `IS DISTINCT FROM` restricts the WRITE to rows whose key actually moves —
  * NULL-safe on both sides, unlike `<>`. Every row is still EVALUATED, which is
  * what the paragraph above requires; what this avoids is a dead tuple per row
- * per approval on a table the review queue reads constantly. It also makes the
- * `UPDATE`'s row count mean "rows re-keyed", which is the number worth logging.
+ * per approval on a table the review queue reads constantly. It also makes
+ * `moved` mean "rows re-keyed" exactly, which is one of the two numbers the
+ * statement reports.
+ *
+ * ⚠️ TWO numbers, since #5109 — see the block inside the builder. `rekeyed`
+ * counts the rows whose key moved; `skipped_unkeyable` counts the rows the
+ * `IS NOT NULL` arm declined. An earlier cut of this paragraph said the
+ * `UPDATE`'s ROW COUNT was "the number worth logging", singular, and that
+ * stopped being true the moment #5047 gave a low count two meanings.
  */
 function rekeyDriftedFactsSql(position: SlotPosition): string {
   const { surface, key } = SLOT_COLUMNS[position];

--- a/packages/api/src/lib/brain/vocabulary-decide.ts
+++ b/packages/api/src/lib/brain/vocabulary-decide.ts
@@ -2233,6 +2233,30 @@ export const REKEY_DRIFTED_FACTS_SQL: Readonly<Record<SlotPosition, string>> = O
  * per-workspace, and the alternative trades a bounded latency for an unbounded
  * correctness window.
  */
+/**
+ * A `count(*)::int` this function is willing to act on.
+ *
+ * ⚠️ `typeof v === "number"` IS NOT ENOUGH, and the gap fails OPEN on the one
+ * value that decides the alarm. `NaN` is a number, and `NaN > 0` is **false** —
+ * so a `NaN` in `skipped_vocabulary_target` would sail past a `typeof` guard and
+ * then silently select *"existing facts now carry the keys this vocabulary
+ * decides"*: a success sentence about the exact population the split exists to
+ * make visible. The guard meant to prevent that would be the thing delivering it.
+ *
+ * `NaN` is reachable without a bug in Postgres. `VocabularyExecutor` is
+ * deliberately satisfiable by any `{ query }`, and `pg`'s int4 parser is
+ * `parseInt`, which yields `NaN` on any non-numeric text.
+ *
+ * Written in the DENY polarity for `vocabulary.ts`'s stated reason — its lock
+ * probe guards the identical "read an int off a one-row probe" with
+ * `Number.isFinite` and argues that *"a deny point written in the permissive
+ * polarity is how the fix becomes the defect."* `Number.isInteger` also encodes
+ * what `count(*)` can return and the type cannot: a non-negative whole number.
+ */
+function isCount(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0;
+}
+
 async function rekeyDriftedFacts(
   tx: VocabularyExecutor,
   workspaceId: string,
@@ -2278,9 +2302,9 @@ async function rekeyDriftedFacts(
         }
       | undefined;
     if (
-      typeof row?.rekeyed !== "number" ||
-      typeof row.skipped_degenerate_surface !== "number" ||
-      typeof row.skipped_vocabulary_target !== "number"
+      !isCount(row?.rekeyed) ||
+      !isCount(row.skipped_degenerate_surface) ||
+      !isCount(row.skipped_vocabulary_target)
     ) {
       throw new Error(
         `rekeyDriftedFacts: the executor answered the ${position} re-key without the three counts ` +
@@ -2302,12 +2326,19 @@ async function rekeyDriftedFacts(
     // that arrive here are all operationally distinct and all look identical
     // from the route: `40P01` deadlock, `55P03` lock timeout, `57014` statement
     // cancellation on the scan, `42P01` on a partially-migrated region.
+    // ⚠️ THE `Error` INSTANCE, NOT ITS `.message`. The comment above enumerates
+    // `40P01`, `55P03`, `57014` and `42P01` and says they "all look identical
+    // from the route" — and the ONE field that tells them apart is `pg`'s `code`,
+    // which lives on the error object. Binding `.message` satisfies the
+    // type-narrow rule and then throws away the discriminator the line exists to
+    // carry, along with the stack: pino's `err` serializer needs an `Error` to
+    // serialize. `admin-migrate.ts` passes the instance for the same reason.
     log.error(
       {
         workspaceId,
         proposalId,
         position,
-        err: err instanceof Error ? err.message : String(err),
+        err: err instanceof Error ? err : new Error(String(err)),
       },
       "Drift re-key failed — the alias decision is rolling back whole, so no key moved and no edge was applied",
     );
@@ -2361,22 +2392,34 @@ async function rekeyDriftedFacts(
   // sounded an alarm on a closed self-healing population is the alert fatigue
   // that makes the real one unreadable. The count is there for whoever wants
   // the number.
-  log.info(
-    {
-      workspaceId,
-      proposalId,
-      position,
-      rekeyed: counts.rekeyed,
-      skippedDegenerateSurface: counts.skippedDegenerateSurface,
-      skippedVocabularyTarget: counts.skippedVocabularyTarget,
-    },
-    counts.skippedVocabularyTarget > 0
-      ? "Drift re-key complete, but NOT total — some facts keep the keys the previous vocabulary " +
+  //
+  // ⚠️ THE LEVEL SPLITS WITH THE MESSAGE, and a conditional message at a flat
+  // `info` would have been the same defect one layer out. The comment above
+  // calls `skippedVocabularyTarget` "THE ONE TO ACT ON" — a data-integrity
+  // divergence a human must repair by hand — and a deployment filtering `info`,
+  // which is the ordinary posture for a path this chatty, would drop the only
+  // record that it happened. Emitting an actionable state at the same severity
+  // as the routine success line is how a signal becomes undiscoverable without
+  // ever being deleted.
+  const payload = {
+    workspaceId,
+    proposalId,
+    position,
+    rekeyed: counts.rekeyed,
+    skippedDegenerateSurface: counts.skippedDegenerateSurface,
+    skippedVocabularyTarget: counts.skippedVocabularyTarget,
+  };
+  if (counts.skippedVocabularyTarget > 0) {
+    log.warn(
+      payload,
+      "Drift re-key complete, but NOT total — some facts keep the keys the previous vocabulary " +
         "decided because this workspace's vocabulary maps their norm to something that normalizes " +
-        "away. Their surfaces key fine, they are live, and no re-key repairs them: fix the " +
-        "`brain_vocabulary_target` entry at this position"
-      : "Drift re-key complete — existing facts now carry the keys this vocabulary decides",
-  );
+        "away. Their surfaces key fine and no re-key repairs them: fix the " +
+        "`brain_vocabulary_target` entry at this position",
+    );
+  } else {
+    log.info(payload, "Drift re-key complete — existing facts now carry the keys this vocabulary decides");
+  }
 }
 
 /**

--- a/packages/api/src/lib/brain/vocabulary-visibility.ts
+++ b/packages/api/src/lib/brain/vocabulary-visibility.ts
@@ -134,9 +134,11 @@ const SAFE_ALIAS = /^[A-Za-z_][A-Za-z0-9_]*$/;
  *
  * ⚠️ Deliberately NARROWER than the drift re-key's scope, and the asymmetry is
  * load-bearing rather than an inconsistency. `REKEY_DRIFTED_FACTS_SQL` applies
- * no TEMPORAL arm at all (it scopes by workspace and by key disagreement, and
- * nothing else), because a tombstoned row left on a stale key is a row whose
- * surface and key disagree forever. This clause answers a different question —
+ * no TEMPORAL arm at all, because a tombstoned row left on a stale key is a row
+ * whose surface and key disagree forever. (It does apply other arms — a
+ * workspace scope, the key disagreement, and since #5047 a refusal on a null
+ * recomputed key. An earlier cut of this line said "and nothing else", which
+ * was true when written and went stale twice over.) This clause answers a different question —
  * *is there a live claim a human could be looking at?* — and counting retracted
  * claims toward a population would let an alias be authored for a spelling the
  * corpus has already withdrawn, which is the "unfalsifiable and rots silently"

--- a/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
@@ -3743,7 +3743,33 @@ describeIfPg("migrate-pg: 0194 replayed against a pre-0194 corpus (#5047)", () =
     //       and its OTHER positions keep their real keys;
     //   (d) an already-tombstoned row keeps its ORIGINAL timestamp — the
     //       `COALESCE` — because when it stopped being a belief is a fact about
-    //       the corpus, not about this migration.
+    //       the corpus, not about this migration;
+    //   (e)+(f) the SUBJECT and OBJECT statements are pinned INDEPENDENTLY
+    //       (#5107). Fixtures (a)-(d) covered the predicate position only —
+    //       `curated` was the sole row whose stored key disagreed with the
+    //       expression, and it disagreed at the predicate — so the other two
+    //       statements' `slot_position` literals and `IS NULL` scopes were held
+    //       by nothing.
+    //
+    // ## Measured, not reasoned (#5107)
+    //
+    // Six mutations, applied to `0194_brain_fact_slot_keys_not_null.sql` one at
+    // a time and reverted, each re-running this suite. ALL SIX now fail it; on
+    // the tree before (e)+(f) the four subject/object rows all SURVIVED.
+    //
+    // | Mutation | Before | After |
+    // |---|---|---|
+    // | `WHERE f.subject_key IS NULL` dropped | SURVIVED | fails |
+    // | `WHERE f.predicate_key IS NULL` dropped | fails | fails |
+    // | `WHERE f.object_key IS NULL` dropped | SURVIVED | fails |
+    // | subject statement's literal → `'predicate'` | SURVIVED | fails |
+    // | predicate statement's literal → `'subject'` | fails | fails |
+    // | object statement's literal → `'predicate'` | SURVIVED | fails |
+    //
+    // The two `IS NULL` rows are the ones with teeth: dropping a scope turns
+    // 0194's KEYING operation into a RE-KEY, which is the distinction its own
+    // header calls load-bearing and which ADR-0037 §7 reserves for the decide
+    // transaction.
     const allFiles = readdirSync(migrationsDir)
       .filter((f) => f.endsWith(".sql"))
       .sort();
@@ -3769,15 +3795,28 @@ describeIfPg("migrate-pg: 0194 replayed against a pre-0194 corpus (#5047)", () =
     // The vocabulary the backfill must consult. Written directly to both
     // relations: the closure table has an FK onto the edge, and going through
     // the authoring seam here would need the whole approval path for one row.
+    //
+    // ⚠️ ONE ENTRY PER POSITION, AND THE THREE `from_norm`s ARE DISTINCT (#5107).
+    // Statement 1 is three near-identical six-line copy-pastes differing in two
+    // column names and a `slot_position` literal, and **a wrong literal is the
+    // single most likely edit defect there**. It is detectable only if the norm
+    // each statement looks up is absent from the OTHER positions' closures — a
+    // norm entered at two positions makes a flipped literal find an entry anyway
+    // and the mutation survives. `acme co`, `priced at` and `monday` share
+    // nothing.
     await pool.query(
       `INSERT INTO brain_vocabulary_edge
          (workspace_id, slot_position, from_norm, to_norm, approved_by)
-       VALUES ($1, 'predicate', 'priced at', 'unit price', '0194-test')`,
+       VALUES ($1, 'predicate', 'priced at', 'unit price', '0194-test'),
+              ($1, 'subject', 'acme co', 'acme corp', '0194-test'),
+              ($1, 'object', 'monday', 'mon', '0194-test')`,
       [WS],
     );
     await pool.query(
       `INSERT INTO brain_vocabulary_target (workspace_id, slot_position, norm, effective_target)
-       VALUES ($1, 'predicate', 'priced at', 'unit price')`,
+       VALUES ($1, 'predicate', 'priced at', 'unit price'),
+              ($1, 'subject', 'acme co', 'acme corp'),
+              ($1, 'object', 'monday', 'mon')`,
       [WS],
     );
 
@@ -3812,6 +3851,42 @@ describeIfPg("migrate-pg: 0194 replayed against a pre-0194 corpus (#5047)", () =
     });
     const alreadyDead = new Date("2026-01-02T03:04:05.000Z");
     const tombstoned = await seed("legacy", "is", "___", { s: null, p: null, o: null }, alreadyDead);
+
+    // ── (e)+(f) the SUBJECT and OBJECT statements, independently (#5107) ────
+    //
+    // Before these, only `curated` held a stored key that disagreed with what
+    // the expression would compute, and it held it at the PREDICATE. So the
+    // subject and object statements were pinned by nothing of their own: their
+    // `slot_position` literals could be flipped and their `IS NULL` scopes
+    // dropped with every assertion above still green.
+    //
+    // Each position needs TWO rows, and both are load-bearing:
+    //
+    //   - an ALIASED row (keys null) whose norm has an entry at THIS position
+    //     and at no other, so a flipped literal reads the wrong closure, finds
+    //     nothing, and the COALESCE falls back to the raw norm;
+    //   - a CURATED row whose stored key at this position is non-null and
+    //     DISAGREES with the vocabulary's answer, so dropping the `IS NULL`
+    //     scope turns the KEYING operation into a RE-KEY and overwrites it.
+    //
+    // ⚠️ The disagreement is the whole point. A fixture whose stale key happened
+    // to EQUAL the vocabulary's answer passes either way and falsifies nothing.
+    const subjectAliased = await seed("Acme Co", "delivers", "goods", {
+      s: null,
+      p: null,
+      o: null,
+    });
+    const subjectCurated = await seed("acme co", "ships", "friday", {
+      s: "curated subject",
+      p: null,
+      o: null,
+    });
+    const objectAliased = await seed("release", "lands", "Monday", { s: null, p: null, o: null });
+    const objectCurated = await seed("standup", "happens", "monday", {
+      s: null,
+      p: null,
+      o: "curated object",
+    });
 
     const before = await pool.query<{ id: string; updated_at: Date }>(
       `SELECT id::text AS id, updated_at FROM brain_facts WHERE workspace_id = $1`,
@@ -3880,6 +3955,46 @@ describeIfPg("migrate-pg: 0194 replayed against a pre-0194 corpus (#5047)", () =
       d.invalidated_at?.toISOString(),
       "0194 restamped a row that was already tombstoned — when it stopped being a belief is a fact about the corpus, not about this migration",
     ).toBe(alreadyDead.toISOString());
+
+    // (e) the SUBJECT statement reads the SUBJECT closure, and only it.
+    const e1 = await read(subjectAliased);
+    expect(
+      e1.subject_key,
+      "the subject backfill did not compose the SUBJECT vocabulary — either its `slot_position` " +
+        "literal names another position (so it read a closure `acme co` is not in and fell back " +
+        "to the raw norm) or it stopped consulting the closure at all",
+    ).toBe("acme corp");
+    // Its other two positions take the plain norm: no entry exists for them,
+    // which is also what keeps this row from being tombstoned.
+    expect([e1.predicate_key, e1.object_key]).toEqual(["delivers", "goods"]);
+    expect(e1.invalidated_at).toBeNull();
+
+    const e2 = await read(subjectCurated);
+    expect(
+      e2.subject_key,
+      "a curated `subject_key` was overwritten — dropping `WHERE f.subject_key IS NULL` turns " +
+        "0194's KEYING operation into a RE-KEY, which is the distinction its header calls " +
+        "load-bearing and which ADR-0037 §7 reserves for the decide transaction",
+    ).toBe("curated subject");
+    expect([e2.predicate_key, e2.object_key]).toEqual(["ships", "friday"]);
+
+    // (f) the OBJECT statement, the same two ways.
+    const f1 = await read(objectAliased);
+    expect(
+      f1.object_key,
+      "the object backfill did not compose the OBJECT vocabulary — `Monday` norms to `monday`, " +
+        "which the object closure maps to `mon`",
+    ).toBe("mon");
+    expect([f1.subject_key, f1.predicate_key]).toEqual(["release", "lands"]);
+    expect(f1.invalidated_at).toBeNull();
+
+    const f2 = await read(objectCurated);
+    expect(
+      f2.object_key,
+      "a curated `object_key` was overwritten — the object statement's `IS NULL` scope is what " +
+        "keeps it a keying operation",
+    ).toBe("curated object");
+    expect([f2.subject_key, f2.predicate_key]).toEqual(["standup", "happens"]);
 
     // `updated_at` is untouched on every row: it sorts the publish preview, and
     // a workspace-wide stamp reshuffles every reviewer's draft queue into

--- a/packages/api/src/lib/residency/__tests__/migrate-identity-logging.test.ts
+++ b/packages/api/src/lib/residency/__tests__/migrate-identity-logging.test.ts
@@ -322,6 +322,49 @@ describe("the identity-loss line (#5035)", () => {
     });
   });
 
+  it("splits the two counters on the COMPUTED arm — `unkeyable`, never `nullKey` (#5108)", async () => {
+    // ⚠️ The pairing, which the case above asserts only half of. The two
+    // counters answer different questions and a v1/v2 bundle can only ever
+    // reach one of them: `unkeyableFacts` says the key was COMPUTED here and
+    // came out null, `nullKeyFacts` says one ARRIVED null on a v3 wire. A
+    // legacy bundle carries no key columns at all, so `nullKeyFacts: 0` is a
+    // structural property of the arm rather than a property of this fixture —
+    // and asserting `unkeyableFacts` alone leaves a counter wired to the wrong
+    // arm completely invisible.
+    //
+    // `tombstonedFacts` beside them because it is the number the aggregate
+    // warn tells an operator to act on FIRST: those rows are invisible to
+    // searchBrain and to the review queue, and no verb in the product restores
+    // them.
+    const { client } = captureClient();
+    const legacy = bundleWith(
+      [
+        {
+          ...fact("f-1", {}),
+          subject: "billing",
+          predicate: "is owned by",
+          object: "-",
+          subjectKey: undefined,
+          predicateKey: undefined,
+          objectKey: undefined,
+          subjectCmp: undefined,
+          objectCmp: undefined,
+        },
+      ],
+      2,
+    );
+    await importBundle(client, legacy, "org-log");
+
+    const warn = identityWarn();
+    expect(warn, "a legacy fact that tombstoned is now silent").toBeDefined();
+    expect(warn!.payload).toMatchObject({
+      unkeyableFacts: 1,
+      // ⚠️ Zero, and load-bearing: this arm has nothing to arrive null.
+      nullKeyFacts: 0,
+      tombstonedFacts: 1,
+    });
+  });
+
   it("merges the vocabulary BEFORE it reads one to key legacy facts", async () => {
     // The section reorder, pinned as an ORDER rather than as an outcome. The
     // `-pg` test proves the effect (a fact keys through an edge that arrived in

--- a/packages/api/src/lib/residency/__tests__/migrate-identity-logging.test.ts
+++ b/packages/api/src/lib/residency/__tests__/migrate-identity-logging.test.ts
@@ -336,6 +336,11 @@ describe("the identity-loss line (#5035)", () => {
     // warn tells an operator to act on FIRST: those rows are invisible to
     // searchBrain and to the review queue, and no verb in the product restores
     // them.
+    // ⚠️ TWO facts, only ONE degenerate, so `unkeyableFacts` and
+    // `tombstonedFacts` cannot be equal by accident. Measured: with a
+    // single-fact fixture both were 1, and rewiring `tombstonedFacts++` to
+    // `identity.unkeyable` — which also deletes the NEWLY-tombstoned-only arm —
+    // left this test green.
     const { client } = captureClient();
     const legacy = bundleWith(
       [
@@ -344,6 +349,17 @@ describe("the identity-loss line (#5035)", () => {
           subject: "billing",
           predicate: "is owned by",
           object: "-",
+          subjectKey: undefined,
+          predicateKey: undefined,
+          objectKey: undefined,
+          subjectCmp: undefined,
+          objectCmp: undefined,
+        },
+        {
+          ...fact("f-2", {}),
+          subject: "billing",
+          predicate: "is owned by",
+          object: "platform team",
           subjectKey: undefined,
           predicateKey: undefined,
           objectKey: undefined,

--- a/packages/api/src/lib/residency/__tests__/migrate-roundtrip-pg.test.ts
+++ b/packages/api/src/lib/residency/__tests__/migrate-roundtrip-pg.test.ts
@@ -2073,7 +2073,7 @@ describeIfPg("region import: a fact whose key cannot be supplied (#5047)", () =>
       // LANDED, not refused — which is the arm's whole behaviour and the thing
       // `ImportResult` can see. The COUNTERS (`unkeyableFacts` / `nullKeyFacts`)
       // are not on `ImportResult`; they travel on the aggregate identity warn,
-      // and are asserted on this exact fixture in `migrate-identity-logging.ts`
+      // and are asserted on this exact fixture in `migrate-identity-logging.test.ts`
       // where the log is observable.
       expect(result.brainFacts.imported).toBe(1);
 

--- a/packages/api/src/lib/residency/__tests__/migrate-roundtrip-pg.test.ts
+++ b/packages/api/src/lib/residency/__tests__/migrate-roundtrip-pg.test.ts
@@ -30,6 +30,7 @@ import { identityVocabulary } from "@atlas/api/lib/brain/identity";
 import { reconcileFacts } from "@atlas/api/lib/brain/reconcile";
 import {
   RegionImportUnkeyableError,
+  RegionImportVocabularyTargetError,
   importBundle,
   validateBundle,
 } from "../../../api/routes/admin-migrate";
@@ -1938,6 +1939,63 @@ describeIfPg("region import: a fact whose key cannot be supplied (#5047)", () =>
         ),
       ).rejects.toBeInstanceOf(RegionImportUnkeyableError);
 
+      // ⚠️ THE POSITION AND THE ROW, not just the type (#5108). `positions` is
+      // how an operator finds the offending slot in a bundle of thousands, and
+      // without asserting it a mutant that refuses on the WRONG position — the
+      // subject, say, which here is `billing` and keys perfectly well —
+      // survives every other assertion in this test. `factId` is the same
+      // argument for the row.
+      await expect(
+        runImport(
+          bundleWith(
+            {
+              ...baseFact,
+              id: "aaaaaaaa-0000-4000-8000-0000000000f8",
+              object: "platform team",
+              objectKey: null,
+              sourceEpisodeId: "aaaaaaaa-0000-4000-8000-0000000000e8",
+            },
+            "aaaaaaaa-0000-4000-8000-0000000000e8",
+          ),
+          "org-unkeyed-refuse-positions",
+        ),
+      ).rejects.toMatchObject({
+        factId: "aaaaaaaa-0000-4000-8000-0000000000f8",
+        positions: ["object"],
+      });
+
+      // ⚠️ `positions` names the REPAIRABLE positions, not every null one, and
+      // this fixture is the only shape that can tell the two apart: the
+      // predicate is null AND degenerate (`-` has no key in any region, so
+      // nothing to fix), while the object is null and KEYABLE (`platform team`
+      // is real text the source region should have carried). `absent` is both;
+      // `repairable` is the object alone.
+      //
+      // Reporting `absent` sends the operator to hunt a predicate key that
+      // cannot exist — and the earlier one-null fixture cannot see it, because
+      // there the two sets are equal. Measured: that mutation SURVIVED until
+      // this case existed.
+      await expect(
+        runImport(
+          bundleWith(
+            {
+              ...baseFact,
+              id: "aaaaaaaa-0000-4000-8000-0000000000fa",
+              predicate: "-",
+              predicateKey: null,
+              object: "platform team",
+              objectKey: null,
+              sourceEpisodeId: "aaaaaaaa-0000-4000-8000-0000000000ea",
+            },
+            "aaaaaaaa-0000-4000-8000-0000000000ea",
+          ),
+          "org-unkeyed-refuse-mixed",
+        ),
+      ).rejects.toMatchObject({
+        factId: "aaaaaaaa-0000-4000-8000-0000000000fa",
+        positions: ["object"],
+      });
+
       // Nothing landed — the refusal rolled the whole transaction back, so the
       // episode is gone too rather than left orphaned.
       const { rows: facts } = await pool.query(
@@ -1950,6 +2008,216 @@ describeIfPg("region import: a fact whose key cannot be supplied (#5047)", () =>
         [REFUSE_ORG],
       );
       expect(episodes).toHaveLength(0);
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+
+  // ── The COMPUTED (v1/v2) arm (#5108) ───────────────────────────────────
+  //
+  // Everything above drives the CARRIED (v3) arm. The legacy arm computes its
+  // keys here via `slotKey(surface, vocabulary[position])` and sets
+  // `unkeyable: true` — a distinct path, with its own counter and its own
+  // refusal type, that nothing exercised.
+
+  /** The same bundle at version 2: no identity fields on the wire at all. */
+  function legacyBundleWith(
+    fact: Record<string, unknown>,
+    episodeId: string,
+  ): Record<string, unknown> {
+    const v3 = bundleWith(fact, episodeId) as Record<string, unknown>;
+    const manifest = { ...(v3.manifest as Record<string, unknown>), version: 2 };
+    const episodes = (v3.brainEpisodes as Record<string, unknown>[]).map((episode) => ({
+      ...episode,
+      facts: (episode.facts as Record<string, unknown>[]).map((f) => {
+        // The five identity fields do not exist before v3 — stripped rather
+        // than nulled, because a v2 fact that CARRIED them would be a shape no
+        // exporter produces and would not exercise the computed arm.
+        const {
+          subjectKey: _s,
+          predicateKey: _p,
+          objectKey: _o,
+          subjectCmp: _sc,
+          objectCmp: _oc,
+          ...rest
+        } = f;
+        return rest;
+      }),
+    }));
+    return { ...v3, manifest, brainEpisodes: episodes };
+  }
+
+  it(
+    "COMPUTED arm: a degenerate object is tombstoned with a placeholder, and counted as unkeyable",
+    async () => {
+      // The legacy arm's tombstone, which had no case at all. The distinction
+      // from the carried arm is the COUNTER: `unkeyableFacts` says the key was
+      // computed HERE and came out null, while `nullKeyFacts` says one arrived
+      // null on the wire. A v1/v2 bundle carries no key columns, so the second
+      // must be zero — and a counter wired to the wrong arm is invisible
+      // without both numbers asserted together.
+      const LEGACY_ORG = "org-legacy-tombstone";
+      const result = await runImport(
+        legacyBundleWith(
+          {
+            ...baseFact,
+            id: "aaaaaaaa-0000-4000-8000-0000000000f5",
+            subject: "billing",
+            predicate: "is owned by",
+            object: "-",
+            sourceEpisodeId: "aaaaaaaa-0000-4000-8000-0000000000e5",
+          },
+          "aaaaaaaa-0000-4000-8000-0000000000e5",
+        ),
+        LEGACY_ORG,
+      );
+      // LANDED, not refused — which is the arm's whole behaviour and the thing
+      // `ImportResult` can see. The COUNTERS (`unkeyableFacts` / `nullKeyFacts`)
+      // are not on `ImportResult`; they travel on the aggregate identity warn,
+      // and are asserted on this exact fixture in `migrate-identity-logging.ts`
+      // where the log is observable.
+      expect(result.brainFacts.imported).toBe(1);
+
+      const { rows } = await pool.query<{
+        subject_key: string;
+        predicate_key: string;
+        object_key: string;
+        invalidated_at: Date | null;
+      }>(
+        `SELECT subject_key, predicate_key, object_key, invalidated_at
+           FROM brain_facts WHERE workspace_id = $1`,
+        [LEGACY_ORG],
+      );
+      expect(rows).toHaveLength(1);
+      expect(rows[0]!.object_key).toBe("-unkeyable:aaaaaaaa-0000-4000-8000-0000000000f5");
+      // The other two were COMPUTED, not carried — the surfaces key fine, so
+      // they hold real keys and the row is not unreachable at all three slots.
+      expect([rows[0]!.subject_key, rows[0]!.predicate_key]).toEqual(["billing", "is owned by"]);
+      expect(rows[0]!.invalidated_at).not.toBeNull();
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "COMPUTED arm: under an EMPTY vocabulary a null key always implies a degenerate surface, so it cannot refuse",
+    async () => {
+      // The asymmetry #5108 asks to assert rather than assume. With no
+      // vocabulary entry at the position, `slotKey` reduces to
+      // `identityKey(surface)` — so a computed null and a degenerate surface
+      // are the same condition, `repairable` is empty, and the arm tombstones
+      // instead of throwing.
+      //
+      // Two surfaces that reach null by different spellings, because the guard
+      // tests the KEY and not the text: `String#trim` strips whitespace but
+      // neither `_` nor `-`.
+      const NO_REFUSE_ORG = "org-legacy-no-refuse";
+      const result = await runImport(
+        legacyBundleWith(
+          {
+            ...baseFact,
+            id: "aaaaaaaa-0000-4000-8000-0000000000f6",
+            subject: "___",
+            predicate: "is owned by",
+            object: "-",
+            sourceEpisodeId: "aaaaaaaa-0000-4000-8000-0000000000e6",
+          },
+          "aaaaaaaa-0000-4000-8000-0000000000e6",
+        ),
+        NO_REFUSE_ORG,
+      );
+      // Landed, not refused — the assertion this case exists for.
+      expect(result.brainFacts.imported).toBe(1);
+      const { rows } = await pool.query<{ subject_key: string; object_key: string }>(
+        `SELECT subject_key, object_key FROM brain_facts WHERE workspace_id = $1`,
+        [NO_REFUSE_ORG],
+      );
+      const placeholder = "-unkeyable:aaaaaaaa-0000-4000-8000-0000000000f6";
+      // ONE placeholder value across both degenerate positions of the SAME row,
+      // which is what makes it per-row rather than per-slot.
+      expect([rows[0]!.subject_key, rows[0]!.object_key]).toEqual([placeholder, placeholder]);
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "COMPUTED arm: a VOCABULARY whose target normalizes away DOES refuse, as RegionImportVocabularyTargetError",
+    async () => {
+      // ⚠️ #5108's parenthetical says the computed arm "can never REFUSE:
+      // a computed null implies a degenerate surface". That holds only under an
+      // EMPTY vocabulary (the case above). `slotKey` is
+      // `identityKey(alias(identityKey(surface)))`, so it reaches null a SECOND
+      // way — this region's own closure maps a real norm to something that
+      // normalizes away — and on that road the surface keys perfectly well, so
+      // `repairable` is non-empty and the arm throws.
+      //
+      // Far from being unreachable, this is the ONLY arm that can raise
+      // `RegionImportVocabularyTargetError`: `tombstonePlaceholder` picks the
+      // type off `source.carried`, and `carried: false` IS the legacy arm. The
+      // type would be dead code if the claim were true.
+      //
+      // Written directly to both relations rather than through the authoring
+      // seam, because `vocabulary-decide.ts` refuses a `degenerate-norm` target
+      // at authoring — which is what keeps this path closed in practice, and
+      // exactly what makes the seam unable to build the fixture.
+      const VOCAB_ORG = "org-legacy-vocab-refuse";
+      await pool.query(
+        `INSERT INTO brain_vocabulary_edge
+           (workspace_id, slot_position, from_norm, to_norm, approved_by)
+         VALUES ($1, 'object', 'platform team', ' - ', '5108-test')`,
+        [VOCAB_ORG],
+      );
+      await pool.query(
+        `INSERT INTO brain_vocabulary_target (workspace_id, slot_position, norm, effective_target)
+         VALUES ($1, 'object', 'platform team', ' - ')`,
+        [VOCAB_ORG],
+      );
+
+      await expect(
+        runImport(
+          legacyBundleWith(
+            {
+              ...baseFact,
+              id: "aaaaaaaa-0000-4000-8000-0000000000f7",
+              subject: "billing",
+              predicate: "is owned by",
+              object: "platform team",
+              sourceEpisodeId: "aaaaaaaa-0000-4000-8000-0000000000e7",
+            },
+            "aaaaaaaa-0000-4000-8000-0000000000e7",
+          ),
+          VOCAB_ORG,
+        ),
+      ).rejects.toBeInstanceOf(RegionImportVocabularyTargetError);
+
+      // ⚠️ The TYPE is the whole point, and it is not interchangeable with the
+      // carried arm's. `RegionImportUnkeyableError` tells the operator to
+      // re-export from the source region and check it has applied 0194 — advice
+      // nobody can follow here, because a v1/v2 bundle carries no key columns
+      // and re-exporting changes nothing. The defect is a local
+      // `brain_vocabulary_target` row. #5047's first cut raised the source-side
+      // error from both arms and wedged the migration behind that instruction.
+      await expect(
+        runImport(
+          legacyBundleWith(
+            {
+              ...baseFact,
+              id: "aaaaaaaa-0000-4000-8000-0000000000f9",
+              subject: "billing",
+              predicate: "is owned by",
+              object: "platform team",
+              sourceEpisodeId: "aaaaaaaa-0000-4000-8000-0000000000e9",
+            },
+            "aaaaaaaa-0000-4000-8000-0000000000e9",
+          ),
+          VOCAB_ORG,
+        ),
+      ).rejects.not.toBeInstanceOf(RegionImportUnkeyableError);
+
+      // Nothing landed — the refusal writes nothing, which is the only outcome
+      // that is reversible.
+      const { rows } = await pool.query(`SELECT 1 FROM brain_facts WHERE workspace_id = $1`, [
+        VOCAB_ORG,
+      ]);
+      expect(rows).toHaveLength(0);
     },
     PG_TEST_TIMEOUT_MS,
   );


### PR DESCRIPTION
## Summary

Closes the five follow-ups deferred from #5047 (PR #5104, merged as c35222b). All five are independent and land in `lib/brain/` plus `admin-migrate.ts`.

Closes #5105 · Closes #5106 · Closes #5107 · Closes #5108 · Closes #5109

| # | What | Where |
|---|---|---|
| #5105 | `MALFORMED_CLAIM`'s warn payload had no test anywhere. `degenerateSurfaces` logs **raw claim text**, safe only while the `cause === "degenerate-surface"` filter holds | new `reconcile-logging.test.ts` |
| #5106 | The region-import 500 echoed the raw `pg` error to the caller — row content, constraint/column names, and on connection failure the internal host and port | `admin-migrate.ts`, both handlers |
| #5107 | 0194's per-column scoping was pinned at **one** slot position of three | `migrate-pg.test.ts` |
| #5108 | The 409 refusal mapping and the importer's COMPUTED (v1/v2) tombstone arm were untested | `migrate-roundtrip-pg`, `migrate-identity-logging`, new route test |
| #5109 | `rekeyed: N` could no longer distinguish "nothing drifted" from "N rows were declined" | `vocabulary-decide.ts` |

### The one that carries the PR

**#5105's leak falsifier.** `slotKey` is `identityKey(alias(identityKey(surface)))`, so a null key has a cause that has nothing to do with the text: this workspace's vocabulary maps a real norm to something degenerate. If the `degenerate-surface` filter ever widens, a customer's claim text enters the log stream — shipped to whatever aggregator the deployment uses, and not recallable. The assertion that carries the file is that on a `vocabulary-target` failure over a real surface `degenerateSurfaces` is **empty**; a second case searches the whole serialized payload, so a future field added beside it cannot become a new channel.

## Two issue premises were wrong

Flagged rather than silently worked around.

**#5108** states the computed arm "can never REFUSE: a computed null always implies a degenerate surface." That holds only under an *empty* vocabulary. On the second road to null the surface keys perfectly well, `repairable` is non-empty, and the arm throws — and it is in fact the **only** arm that can raise `RegionImportVocabularyTargetError`, since `tombstonePlaceholder` picks the type off `source.carried` and `carried: false` **is** the legacy arm. That type would be dead code if the claim held. Both properties are now pinned.

**#5109** asks for "no second workspace-wide scan" *and* "the `IS NOT NULL` arm itself unchanged." Not simultaneously satisfiable — an `UPDATE` cannot report rows it did not touch. The scan is lifted into a `MATERIALIZED` CTE and the arm reads `r.new_key IS NOT NULL` over the byte-identical expression. Rows 6 and 26 of the mutation table were **re-measured** against the new shape rather than carried.

## Review panel — three rounds, closed on the ratio rule

| Round | Findings | New surface | Defect-in-prior-fix |
|---|---|---|---|
| 1 (hand-picked — see below) | 17 | 16 | 1 |
| 2 (three code reviewers) | ~23 | ~21 | ~2 |
| 3 (re-run on the fix commit) | ~19 | ~7 | **~12** |

⚠️ **Round 1 was run wrong, and that is part of the record.** It picked `comment-analyzer` and `fix-vs-finding` by hand — `comment-analyzer` in what was effectively round 1, the inversion `/review-panel` argues against by name — and the three code reviewers ran only *after* this PR was open and CI green. That is Step 3 executed at Step 5. `silent-failure-hunter` then returned a CRITICAL on code already declared merge-ready.

**Stopped at round 3 on the defect-in-prior-fix ratio**, not the round cap: ~12 of 19 findings were defects the previous round's fixes introduced, which exceeds new surface. More review cannot help when the fixes are the defect source. Everything confirmed is fixed, and the closing round paid its costs — comment sweep run, every named falsifier built and measured.

### What each round caught

**Round 2 — a poisoned connection returned to the pool.** Both handlers called `client.release()` bare after a failed `ROLLBACK`. `pg` destroys the socket only on `release(err)`, so a client still inside an open transaction was pooled — and Postgres answers a second `BEGIN` on an open transaction with a *warning*, not an error. The next borrower's work joins the failed import's transaction and its commit commits the partial import, under a different `requestId`, minutes later. `admin-revoke.ts`, `admin-mfa-reset.ts`, `me-trusted-devices.ts` and `oauth-workspace-grants.ts` all do this correctly with the reasoning written out; `admin-migrate.ts` was the outlier.

Plus two fail-open defects in this PR's own code: `typeof v === "number"` admits `NaN`, and `NaN > 0` is false, so a `NaN` in `skippedVocabularyTarget` selected the clean-run message from the guard meant to prevent exactly that; and the actionable line went out at `log.info`, which any deployment filtering info drops.

**Round 3 — all three reviewers independently found the same arm.** Round 2's `import_rollback_uncertain` check sat *after* the 409 refusal arm, so a refusal whose rollback also failed returned the confident 409 — whose message ends "re-export and re-run" and whose OpenAPI description says NOTHING WAS WRITTEN. Both are claims about the rollback, not about the error that triggered it, and the refusals are raised after every earlier import section has already inserted into the open transaction.

**Closing sweep — a code defect, not just rot.** The failure log keyed on `rollbackErr` alone while the body used `rollbackErr && begun`, so a BEGIN that never resolved logged "the transaction's fate is unknown" beside a body saying "all changes rolled back, nothing was written".

### The recurring shape

Five times on this branch a fix reproduced its own defect one layer over: the position-vs-cause split in #5105, the merged skip counts in #5109 round 1, the confident 409 in round 2, the log/body disagreement in round 3, and merged log sinks in three separate test files. It is why `fix-vs-finding` earned its keep and why the mutation measurements are in every commit message.

Four times a fixture made the two states it was distinguishing **accidentally equal** — most sharply the split test whose counts were both `1`, so swapping the two SQL predicates passed the one test whose entire subject is telling them apart.

## Mutations, measured

Each applied one at a time against an otherwise clean tree, suites re-run, then reverted.

**#5105** — filter deleted → 4 fail · the two non-inherited causes swapped → 5 · `cause` gates on POSITION not CAUSE → 1 (only the two-causes-in-one-claim case sees it).

**#5106 / #5108 (409)** — leak restored in the 500 → 4 · 409 arm deleted → 6 · **both** arms scrubbed, the obvious over-correction → 6 · `release()` bare again → 2 · the two 500 bodies collapsed → 2 · the uncertainty check moved back below the 409 arm → 2 · the ROLLBACK line demoted to warn → 2 · the `begun` gate dropped → 2.

**#5107** — six mutations; the "before" column is a measurement against the pre-change suite, not a reading of the code:

| Mutation | Before | After |
|---|---|---|
| `WHERE f.subject_key IS NULL` dropped | **SURVIVED** | fails |
| `WHERE f.predicate_key IS NULL` dropped | fails | fails |
| `WHERE f.object_key IS NULL` dropped | **SURVIVED** | fails |
| subject literal → `'predicate'` | **SURVIVED** | fails |
| predicate literal → `'subject'` | fails | fails |
| object literal → `'predicate'` | **SURVIVED** | fails |

**#5108** — both arms raise the source-side error (#5047's first cut) → 1 · computed arm stops counting `unkeyable` → 2 · refusal reports `absent` instead of `repairable` → 1. That last one survived this PR's first cut: with a single null position the two sets are equal, so it needed a fact null at two positions where only one is repairable.

**#5109** — the two causes merged (round 1's own defect) → 1 pg + 1 log · the message stops being conditional → 1 · row 26 dropped → 5 pg + 3 log · both refusal guards replaced by `?? 0` defaults → 4 · the vocab-target count duplicates the degenerate one → 3 · the two skip predicates swapped → 3.

`bundle-identity.md` was regenerated (not hand-edited); four rows got stronger on the COMPUTED arm and none weakened.

## Comment rot

#5047 deleted one warn and left three files quoting it. This PR's own restructures did the same twice, and the sweeps caught both — including a **factually wrong claim about Postgres** (the `AS MATERIALIZED` rationale said the CTE would otherwise be inlined and re-planned per reference; PG inlines only a CTE referenced *exactly once*, and this one is referenced twice), a `skippedVocabularyTarget` premise still reading "Live, un-tombstoned rows" thirty lines above its own retraction, and an `isCount` docstring inserted **between** `rekeyDriftedFacts`' docstring and its function, orphaning it.

Two pre-existing sites the restructure made worse: `identity.ts` promised the next re-key repairs inherited nulls (it has declined exactly those since #5047), and `vocabulary-visibility.ts`'s "and nothing else" about the re-key's arms.

## Deferred as follow-ups (new machinery)

Extract the duplicated import catch into one `importFailureResponse`; export a shared `RekeyCounts` reader so the SQL, the production narrowing and the test stop re-declaring the row; make `ErrorSchema.error` a literal union; and make `resetMigrationForRetry` refuse an uncertain migration — today it gates on `status`/`region_updated` alone and would re-send the bundle the new body forbids.

## Test Plan

- [x] Unit tests added/updated — 7 new/extended suites
- [ ] Manual testing
- [ ] E2E tests added/updated

Real Postgres 16 locally (Docker unavailable in this environment); every `-pg` suite ran rather than self-skipping.

## Checklist

- [x] Types pass (`bun run type`)
- [x] Tests pass (`bun run test`) — full suite, plus `test-isolated.ts --affected` (49 files)
- [x] Lint passes (`bun run lint`)
- [x] Deps consistent (`bun run deps:lint`) — no dependency changes
- [x] `/ci` — 34/34 gates green
- [x] Labels added (type + area)
- [ ] CHANGELOG.md updated — not user-facing; the 500's contract change is carried by the OpenAPI description, regenerated in `apps/docs/openapi.json`