### PR TITLE
feat(residency): merge two vocabularies on import — union approved edges, refuse cycles (#5036)

### DIFF
--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -56532,11 +56532,15 @@
                         },
                         "skipped": {
                           "type": "number"
+                        },
+                        "refused": {
+                          "type": "number"
                         }
                       },
                       "required": [
                         "imported",
-                        "skipped"
+                        "skipped",
+                        "refused"
                       ]
                     }
                   },

--- a/packages/api/src/api/__tests__/admin-migrate.test.ts
+++ b/packages/api/src/api/__tests__/admin-migrate.test.ts
@@ -260,7 +260,9 @@ describe("bundle round-trip shape", () => {
       brainFacts: { imported: 9, skipped: 3 },
       brainEdges: { imported: 4, skipped: 0 },
       factAudienceMembers: { imported: 2, skipped: 5 },
-      brainVocabularyEdges: { imported: 1, skipped: 4 },
+      // Three counters here alone (#5036), and three DISTINCT values so the
+      // accounting assertion below cannot pass on two of them being confused.
+      brainVocabularyEdges: { imported: 1, skipped: 4, refused: 6 },
     };
 
     const total = (r: { imported: number; skipped: number }) => r.imported + r.skipped;
@@ -276,6 +278,14 @@ describe("bundle round-trip shape", () => {
     expect(total(result.brainFacts)).toBe(12);
     expect(total(result.brainEdges)).toBe(4);
     expect(total(result.factAudienceMembers)).toBe(7);
+    // The vocabulary's own total is a THREE-way sum, and `migrate.ts` reconciles
+    // it against the manifest count before cutover — an arriving edge that fell
+    // through all three counters would abort a whole migration.
+    expect(
+      result.brainVocabularyEdges.imported +
+        result.brainVocabularyEdges.skipped +
+        result.brainVocabularyEdges.refused,
+    ).toBe(11);
   });
 });
 

--- a/packages/api/src/api/__tests__/admin-migrate.test.ts
+++ b/packages/api/src/api/__tests__/admin-migrate.test.ts
@@ -260,8 +260,7 @@ describe("bundle round-trip shape", () => {
       brainFacts: { imported: 9, skipped: 3 },
       brainEdges: { imported: 4, skipped: 0 },
       factAudienceMembers: { imported: 2, skipped: 5 },
-      // Three counters here alone (#5036), and three DISTINCT values so the
-      // accounting assertion below cannot pass on two of them being confused.
+      // Three counters here alone (#5036).
       brainVocabularyEdges: { imported: 1, skipped: 4, refused: 6 },
     };
 
@@ -279,12 +278,15 @@ describe("bundle round-trip shape", () => {
     expect(total(result.brainEdges)).toBe(4);
     expect(total(result.factAudienceMembers)).toBe(7);
     // ⚠️ THE COUNTER SET, not a sum of literals this test just wrote. Summing
-    // `1 + 4 + 6 === 11` cannot go red for any production change — it is
-    // arithmetic over its own fixture — whereas the key set goes red the day a
-    // FOURTH counter is added, which is the change that would need
-    // `migrate.ts`'s reconciliation sum revisited in the same breath. (The
-    // reconciliation behaviour itself is pinned in `migrate.test.ts`; this file
-    // pins the shape, and the real enforcement of the shape is `bun run type`.)
+    // `1 + 4 + 6 === 11` is arithmetic over its own fixture and cannot go red
+    // for any production change.
+    //
+    // What the key set adds, stated at its real strength: it catches a counter
+    // RENAMED or REMOVED, and it catches a REQUIRED fourth one (which stops the
+    // literal above type-checking, so someone has to edit it). An OPTIONAL
+    // fourth counter slips past both. The reconciliation behaviour that would
+    // need revisiting is pinned in `migrate.test.ts`; this file pins shape, and
+    // `bun run type` is what enforces it.
     expect(Object.keys(result.brainVocabularyEdges).toSorted()).toEqual([
       "imported",
       "refused",

--- a/packages/api/src/api/__tests__/admin-migrate.test.ts
+++ b/packages/api/src/api/__tests__/admin-migrate.test.ts
@@ -278,14 +278,18 @@ describe("bundle round-trip shape", () => {
     expect(total(result.brainFacts)).toBe(12);
     expect(total(result.brainEdges)).toBe(4);
     expect(total(result.factAudienceMembers)).toBe(7);
-    // The vocabulary's own total is a THREE-way sum, and `migrate.ts` reconciles
-    // it against the manifest count before cutover — an arriving edge that fell
-    // through all three counters would abort a whole migration.
-    expect(
-      result.brainVocabularyEdges.imported +
-        result.brainVocabularyEdges.skipped +
-        result.brainVocabularyEdges.refused,
-    ).toBe(11);
+    // ⚠️ THE COUNTER SET, not a sum of literals this test just wrote. Summing
+    // `1 + 4 + 6 === 11` cannot go red for any production change — it is
+    // arithmetic over its own fixture — whereas the key set goes red the day a
+    // FOURTH counter is added, which is the change that would need
+    // `migrate.ts`'s reconciliation sum revisited in the same breath. (The
+    // reconciliation behaviour itself is pinned in `migrate.test.ts`; this file
+    // pins the shape, and the real enforcement of the shape is `bun run type`.)
+    expect(Object.keys(result.brainVocabularyEdges).toSorted()).toEqual([
+      "imported",
+      "refused",
+      "skipped",
+    ]);
   });
 });
 

--- a/packages/api/src/api/routes/admin-migrate.ts
+++ b/packages/api/src/api/routes/admin-migrate.ts
@@ -21,13 +21,12 @@ import {
   lexicalNorm,
   slotKey,
   type ClaimVocabulary,
-  type SlotPosition,
 } from "@atlas/api/lib/brain/identity";
 import {
   VOCABULARY_LOCK_NAMESPACE,
   VOCABULARY_LOCK_SQL,
   loadClaimVocabulary,
-  recomputeEffectiveTargets,
+  mergeApprovedEdges,
 } from "@atlas/api/lib/brain/vocabulary";
 import {
   regionPortableComparable,
@@ -773,7 +772,16 @@ const ImportResultSchema = z.object({
   brainFacts: z.object({ imported: z.number(), skipped: z.number() }),
   brainEdges: z.object({ imported: z.number(), skipped: z.number() }),
   factAudienceMembers: z.object({ imported: z.number(), skipped: z.number() }),
-  brainVocabularyEdges: z.object({ imported: z.number(), skipped: z.number() }),
+  // Three counters, alone among the sections (#5036). `skipped` is the benign
+  // half — an edge already approved here onto the SAME target; `refused` is a
+  // source-region human decision this region dropped because it would have
+  // closed a cycle or taken a second parent. `ImportResult` carries the argument
+  // for why the two must not be one number.
+  brainVocabularyEdges: z.object({
+    imported: z.number(),
+    skipped: z.number(),
+    refused: z.number(),
+  }),
 });
 
 const importRoute = createRoute({
@@ -1402,7 +1410,7 @@ export async function importBundle(
     brainFacts: { imported: 0, skipped: 0 },
     brainEdges: { imported: 0, skipped: 0 },
     factAudienceMembers: { imported: 0, skipped: 0 },
-    brainVocabularyEdges: { imported: 0, skipped: 0 },
+    brainVocabularyEdges: { imported: 0, skipped: 0, refused: 0 },
   };
 
   // --- 1. Conversations + Messages ---
@@ -1772,7 +1780,7 @@ export async function importBundle(
     result.agentSessionMemory.imported++;
   }
 
-  // --- 9. The curated identity vocabulary (#5022, ADR-0037 §6/§8) ---
+  // --- 9. The curated identity vocabulary (#5022, ADR-0037 §6/§8; merged by #5036) ---
   // It travels because the identity keys on every imported fact are
   // `alias(lexicalNorm(surface))` and ADR-0037 §8 carries those keys verbatim —
   // a workspace that arrived without its vocabulary would hold keys nothing in
@@ -1786,107 +1794,70 @@ export async function importBundle(
   // legacy arm would compose only the destination's own pre-existing decisions
   // and discard the source's, which is the half of §4's merge that exists to be
   // composed. Nothing else moved: this block touches only the two vocabulary
-  // tables, and `recomputeEffectiveTargets` reads no fact.
+  // tables, and the closure rebuild inside the merge reads no fact.
   //
-  // `ON CONFLICT DO NOTHING` on the at-most-one-parent key, which is the
-  // deliberately CONSERVATIVE half of this block. An arriving edge whose
-  // `fromNorm` is already approved onto something else in this region is
-  // SKIPPED, never applied over the top: the destination's edge is a decision a
-  // human here made, and silently retargeting it is exactly the rewrite
-  // ADR-0037 §6 forbids at approval time. #5036 owns the real merge — union the
-  // approved edges, refuse cycle-closing ones, log every refusal — and this
-  // skip is what keeps the gap from being a corruption in the meantime.
+  // ⚠️ THE MERGE IS `mergeApprovedEdges`, NOT A STATEMENT SPELLED HERE, and that
+  // is the whole shape of #5036. Until it landed this block was an
+  // `ON CONFLICT DO NOTHING` — deliberately conservative, and wrong in a way
+  // that only shows up against a destination that ALREADY holds a vocabulary:
   //
-  // ⚠️ TWO residuals, recorded rather than papered over. Both need a
-  // destination that ALREADY holds a vocabulary, which the ordinary migration
-  // flow (a fresh region) does not produce — they are the re-import and
-  // merge-into-occupied cases #5036 owns.
+  //   1. `DO NOTHING` is destination-wins-SILENTLY. That is the right rule for
+  //      every other section here, because a conversation in both regions is the
+  //      same conversation — but a vocabulary edge is a HUMAN REVIEW DECISION,
+  //      and two regions can hold contradictory ones legitimately. Skipping
+  //      discarded the source's approved review work with no record it existed.
+  //   2. It did not look for CYCLES at all, so an arriving edge could close one
+  //      against a destination edge. Nothing corrupt committed — the closure
+  //      rebuild refuses to commit a non-converging closure — but it aborted the
+  //      ENTIRE import rather than dropping the one offending edge.
   //
-  //   1. Skipping means an imported workspace can end up with FEWER aliases
-  //      than the bundle carried, and nothing says which. Visible in the counts
-  //      (`skipped > 0`) and no further; the surfacing is #5036's refusal log.
-  //   2. `ON CONFLICT DO NOTHING` does not look for CYCLES, so an arriving edge
-  //      can close one against a destination edge. That does not corrupt
-  //      anything — the closure rebuild below refuses to commit a
-  //      non-converging closure — but it aborts the ENTIRE import transaction
-  //      rather than dropping the one offending edge. Loud and recoverable
-  //      beats silent and not; refusing the edge instead is #5036's job, and
-  //      doing it here would be implementing the merge this PR scopes out.
+  // Both are now the merge's job: it unions the approved edges, refuses the ones
+  // that would close a cycle or take a second parent, LOGS every refusal with
+  // enough of the source row to re-author it, and recomputes the closure once
+  // per position that gained an edge. It lives in `lib/brain/vocabulary.ts`
+  // beside `approveAliasEdge` so the two write paths share one copy of the four
+  // refusal rules — and because `lib/` must not import from `api/routes/`.
   //
-  // ⚠️ THE LOCK IS TAKEN BEFORE THE INSERT LOOP, AND THE ORDER IS THE POINT.
-  //
-  // `approveAliasEdge` acquires the advisory lock FIRST and then touches rows.
-  // An importer that inserts first and reaches the lock only inside
-  // `recomputeEffectiveTargets` acquires the same two resources in the opposite
-  // order, so two writers sharing a `from_norm` close a cycle: the approver
-  // holds the advisory lock and blocks on the importer's uncommitted row, while
-  // the importer blocks on the advisory lock. Postgres resolves it with `40P01
-  // deadlock detected`, and the victim — sometimes the entire region import — is
-  // whichever transaction it picks.
-  //
-  // This is recorded at length because the acquisition was REMOVED once, on the
-  // reasoning that `recomputeEffectiveTargets` takes the same lock so an earlier
-  // acquisition was redundant. That reasoning is wrong in the way lock-ordering
-  // arguments usually are: the later lock does not block in the same PLACE, and
-  // the displacement IS the bug. Measured — with the removal, an approver and an
-  // import over the same norm deadlock; with it restored, they serialize and the
-  // approver gets its typed `already-aliased` refusal.
-  //
-  // Re-taking it inside `recomputeEffectiveTargets` costs nothing:
-  // `pg_advisory_xact_lock` is re-entrant within a transaction.
-  const vocabularyEdges = bundle.brainVocabularyEdges ?? [];
-  if (vocabularyEdges.length > 0) {
-    await client.query(VOCABULARY_LOCK_SQL, [VOCABULARY_LOCK_NAMESPACE, orgId]);
-  }
+  // ⚠️ THE LOCK IS TAKEN INSIDE THE MERGE, BEFORE ITS FIRST INSERT, and the
+  // order is the point: an importer that inserts first and reaches the lock only
+  // at closure-rebuild time acquires the same two resources in the opposite
+  // order to `approveAliasEdge`, and two writers sharing a `from_norm` deadlock
+  // (`40P01`) with the whole region import as a possible victim. That
+  // acquisition was removed once on a redundancy argument and had to be
+  // restored; `mergeApprovedEdges` carries the long version of the story.
+  const vocabularyMerge = await mergeApprovedEdges(
+    client,
+    orgId,
+    (bundle.brainVocabularyEdges ?? []).map((edge) => ({
+      // No cast: `validateBundle` narrowed this through `isSlotPosition`, and
+      // `mergeApprovedEdges` asks for a `SlotPosition` — so assignability here
+      // IS the check, and drift between the wire union and `SlotPosition`
+      // surfaces as a compile error at this line. An `as SlotPosition` would
+      // suppress exactly that error. This is the call site `identity.ts`'s
+      // `_SlotPositionsCoverTheWire` pin names.
+      position: edge.slotPosition,
+      fromNorm: edge.fromNorm,
+      toNorm: edge.toNorm,
+      approvedBy: edge.approvedBy ?? null,
+      approvedAt: edge.approvedAt,
+    })),
+  );
 
-  const vocabularyPositionsTouched = new Set<SlotPosition>();
-  for (const edge of vocabularyEdges) {
-    const inserted = await client.query(
-      `INSERT INTO brain_vocabulary_edge
-         (workspace_id, slot_position, from_norm, to_norm, approved_by, approved_at)
-       VALUES ($1, $2, $3, $4, $5, $6)
-       ON CONFLICT (workspace_id, slot_position, from_norm) DO NOTHING`,
-      [orgId, edge.slotPosition, edge.fromNorm, edge.toNorm, edge.approvedBy ?? null, edge.approvedAt],
-    );
-
-    // `!== 0`, deliberately NOT `(rowCount ?? 0) !== 0`: an ABSENT `rowCount` is
-    // UNKNOWN and must rebuild, while a reported `0` is a definite conflict that
-    // needs none. Gating the rebuild on a `?? 0` would make it depend on the one
-    // value whose absence means "did this land?" is unanswerable, and an
-    // executor that omits it would then commit an edge with NO closure row —
-    // precisely the half-rebuilt state `loadClaimVocabulary` refuses to load.
-    //
-    // The COUNTER below takes the opposite default on purpose: unknown counts as
-    // skipped, because `skipped > 0` is the only signal that a curated decision
-    // was dropped and a counter should under-claim rather than over-claim.
-    // No `as SlotPosition` here: `validateBundle` narrowed it through
-    // `isSlotPosition`, and a cast would suppress exactly the compile error that
-    // drift between the wire union and `SlotPosition` should produce. That is
-    // the call site `identity.ts`'s `_SlotPositionsCoverTheWire` pin names.
-    if (inserted.rowCount !== 0) vocabularyPositionsTouched.add(edge.slotPosition);
-
-    if ((inserted.rowCount ?? 0) === 0) {
-      result.brainVocabularyEdges.skipped++;
-      continue;
-    }
-    result.brainVocabularyEdges.imported++;
-  }
-
-  // The closure is RECOMPUTED, never carried — which is why the bundle has no
-  // `brainVocabularyTargets` section and `brain_vocabulary_target` is classified
-  // 'stays'. Restoring a source closure into a destination that already holds
-  // its own vocabulary would produce a closure of neither: the source's rows
-  // know nothing about the destination's edges, and the destination's know
-  // nothing about the arrivals. Recomputing from the edges now present is the
-  // only answer that is a closure of what this region actually approves.
+  // Three counters, and the split is the point of the slice. `skipped` is the
+  // BENIGN half — an edge this region already holds with the same target, i.e.
+  // what an idempotent re-import looks like from the inside. `refused` is a
+  // source-region human decision this region dropped. Reporting them as one
+  // number would restore the exact conflation the `DO NOTHING` had: an operator
+  // reading `skipped: 2` cannot tell a clean re-import from two discarded
+  // approvals, and only one of those needs them to go and re-author something.
   //
-  // Deliberately NOT a re-derive of anything ADR-0037 §8 says must be carried.
-  // §8's rule is about identity KEYS, where re-deriving fails to OVER-match (the
-  // irreversible direction); this is a derived relation whose inputs are all
-  // present in the same transaction, so recomputation is exact.
-  for (const position of vocabularyPositionsTouched) {
-    await recomputeEffectiveTargets(client, orgId, position);
-  }
+  // ⚠️ `migrate.ts` reconciles these against the manifest count and ABORTS the
+  // migration before cutover if they do not add up, so `refused` had to be added
+  // to that sum in the same change — otherwise the first genuinely conflicting
+  // edge would fail a whole cutover instead of being logged and carried on past.
+  result.brainVocabularyEdges.imported = vocabularyMerge.applied;
+  result.brainVocabularyEdges.skipped = vocabularyMerge.duplicate;
+  result.brainVocabularyEdges.refused = vocabularyMerge.refusals.length;
 
   // --- 10. Company brain (#4767, ADR-0036) — facts ride inside their episode ---
   // Ordering is load-bearing, and it is the reason facts are NESTED rather

--- a/packages/api/src/api/routes/admin-migrate.ts
+++ b/packages/api/src/api/routes/admin-migrate.ts
@@ -799,9 +799,21 @@ const ImportResultSchema = z.object({
  * that dropped a field. `migrate.ts`'s `_everySectionReconciled` is the same
  * idiom two modules over, which is why this is a pin rather than a comment.
  */
+/**
+ * ⚠️ The assignability pair alone does NOT cover an OPTIONAL field, which is the
+ * pin's own motivating case: `{a} extends {a, b?}` is `true` in both directions,
+ * so a `refused?: number` added to one spelling and not the other would satisfy
+ * it. The key-set check is what closes that, and it is why there are two halves.
+ */
+type _MissingKeys =
+  | Exclude<keyof z.infer<typeof ImportResultSchema>, keyof ImportResult>
+  | Exclude<keyof ImportResult, keyof z.infer<typeof ImportResultSchema>>;
+
 type _SchemaMatchesWireType = z.infer<typeof ImportResultSchema> extends ImportResult
   ? ImportResult extends z.infer<typeof ImportResultSchema>
-    ? true
+    ? [_MissingKeys] extends [never]
+      ? true
+      : never
     : never
   : never;
 const _importResultSchemaMatchesWireType: _SchemaMatchesWireType = true;

--- a/packages/api/src/api/routes/admin-migrate.ts
+++ b/packages/api/src/api/routes/admin-migrate.ts
@@ -814,14 +814,17 @@ const ImportResultSchema = z.object({
  * REQUIRED is what keeps it pinned, which is the reason `refused` is required on
  * `ImportResult`.
  */
-type _MissingKeys =
-  | Exclude<keyof z.infer<typeof ImportResultSchema>, keyof ImportResult>
-  | Exclude<keyof ImportResult, keyof z.infer<typeof ImportResultSchema>>;
-
+// ⚠️ The two key-set directions are checked as SEPARATE nested conditions, not
+// unioned. While the spellings agree both `Exclude`s are `never`, and a union of
+// nevers trips `no-duplicate-type-constituents` + `no-redundant-type-constituents`
+// in `lint:type-aware` — a CI-blocking gate. Nesting keeps the pin lint-clean and
+// keeps each direction separately falsifiable.
 type _SchemaMatchesWireType = z.infer<typeof ImportResultSchema> extends ImportResult
   ? ImportResult extends z.infer<typeof ImportResultSchema>
-    ? [_MissingKeys] extends [never]
-      ? true
+    ? [Exclude<keyof z.infer<typeof ImportResultSchema>, keyof ImportResult>] extends [never]
+      ? [Exclude<keyof ImportResult, keyof z.infer<typeof ImportResultSchema>>] extends [never]
+        ? true
+        : never
       : never
     : never
   : never;

--- a/packages/api/src/api/routes/admin-migrate.ts
+++ b/packages/api/src/api/routes/admin-migrate.ts
@@ -800,10 +800,19 @@ const ImportResultSchema = z.object({
  * idiom two modules over, which is why this is a pin rather than a comment.
  */
 /**
- * ⚠️ The assignability pair alone does NOT cover an OPTIONAL field, which is the
- * pin's own motivating case: `{a} extends {a, b?}` is `true` in both directions,
- * so a `refused?: number` added to one spelling and not the other would satisfy
- * it. The key-set check is what closes that, and it is why there are two halves.
+ * ⚠️ ITS REACH, STATED EXACTLY — because the first version of this comment
+ * overclaimed in precisely the way this whole pin exists to prevent.
+ *
+ * The assignability pair catches a REQUIRED field added or dropped on either
+ * side, nested counters included. The key-set arm adds one thing the pair cannot
+ * see: an OPTIONAL top-level SECTION, since `{a} extends {a, b?}` holds in both
+ * directions.
+ *
+ * NEITHER arm sees an optional NESTED counter — a `refused?: number` added to
+ * one spelling and not the other still compiles, because the top-level key sets
+ * are unchanged and assignability tolerates the optional. Declaring a counter
+ * REQUIRED is what keeps it pinned, which is the reason `refused` is required on
+ * `ImportResult`.
  */
 type _MissingKeys =
   | Exclude<keyof z.infer<typeof ImportResultSchema>, keyof ImportResult>

--- a/packages/api/src/api/routes/admin-migrate.ts
+++ b/packages/api/src/api/routes/admin-migrate.ts
@@ -784,6 +784,29 @@ const ImportResultSchema = z.object({
   }),
 });
 
+/**
+ * Compile-time pin: the response SCHEMA and the published wire TYPE agree.
+ *
+ * All thirteen sections are spelled twice — once as Zod here, once as
+ * `ImportResult` in `@useatlas/types` — with nothing tying them together, so the
+ * OpenAPI contract this route publishes could silently stop describing what it
+ * returns. #5036 had to update both by hand and nothing would have caught
+ * missing one; a section added to the schema alone would document a field no
+ * client receives, and one added to the type alone would return a field the
+ * spec denies exists.
+ *
+ * Both directions, deliberately: assignability alone is satisfied by a schema
+ * that dropped a field. `migrate.ts`'s `_everySectionReconciled` is the same
+ * idiom two modules over, which is why this is a pin rather than a comment.
+ */
+type _SchemaMatchesWireType = z.infer<typeof ImportResultSchema> extends ImportResult
+  ? ImportResult extends z.infer<typeof ImportResultSchema>
+    ? true
+    : never
+  : never;
+const _importResultSchemaMatchesWireType: _SchemaMatchesWireType = true;
+void _importResultSchemaMatchesWireType;
+
 const importRoute = createRoute({
   method: "post",
   path: "/import",

--- a/packages/api/src/lib/brain/__tests__/vocabulary-merge-pg.test.ts
+++ b/packages/api/src/lib/brain/__tests__/vocabulary-merge-pg.test.ts
@@ -432,6 +432,8 @@ describeIfPg("merging two vocabularies (#5036)", () => {
         edge: arriving("price", "unit price"),
         refusal: "already-aliased",
         existingTarget: "cost",
+        // Deliberately self-referential: this assertion pins the SHAPE, and the
+        // message's content is pinned separately above via `payload.reason`.
         message: refusal.message,
       });
 
@@ -651,6 +653,71 @@ describeIfPg("merging two vocabularies (#5036)", () => {
       expect(await closureOf(ws, "subject")).toEqual([
         { norm: "p", effective_target: "r" },
         { norm: "q", effective_target: "r" },
+      ]);
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "writes a NON-NORM arriving edge verbatim and says so, rather than re-norming it",
+    async () => {
+      // Two claims in one, and the module's comment defends both. ADR-0037 §8
+      // makes a row-copy path carry values verbatim, so this must NOT rewrite
+      // another region's decision — but a non-norm `from` side can never match a
+      // lookup, so writing it silently is the under-match this module exists to
+      // prevent. `validateBundle` refuses these at the wire boundary; the
+      // primitive is exported, so a caller that skipped it is reachable.
+      //
+      // Untestable through `arriving("")` — `lexicalNorm("") === ""`, so the
+      // degenerate-norm arm catches that one first and this branch never runs.
+      const ws = freshWorkspace();
+
+      const merge = await inTx((tx) => mergeApprovedEdges(tx, ws, [arriving("Priced At", "cost")]));
+
+      expect(merge.applied).toBe(1);
+      // VERBATIM — the row keeps the bytes that arrived. A module that "helpfully"
+      // re-normed would pass the warn assertion below and still be wrong.
+      expect((await edgesOf(ws)).map((e) => e.from_norm)).toEqual(["Priced At"]);
+      expect(warns.map((w) => w.message)).toEqual([
+        expect.stringContaining("not in lexical-norm form"),
+      ]);
+      expect(warns[0].payload).toMatchObject({ workspaceId: ws, fromNorm: "Priced At", toNorm: "cost" });
+      // Future tense, for the same reason as the refusal warn: this runs inside
+      // an uncommitted transaction.
+      expect(warns[0].message).toContain("WILL be written");
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "does NOT claim a verbatim write for a non-norm edge that is then refused",
+    async () => {
+      // The warn used to sit at the top of the loop, so it fired for edges the
+      // merge went on to refuse — announcing a dead alias row that was never
+      // written and sending an operator hunting rows that do not exist, in the
+      // same log stream where the refusal lines are the recovery path.
+      //
+      // TWO non-norm arrivals sharing a `fromNorm`: the first is written, the
+      // second takes a second parent and is refused. A warn at the top of the
+      // loop emits the verbatim-write line TWICE; correctly placed it emits it
+      // once, for the edge that actually landed. Note a non-norm cannot be
+      // refused by a CYCLE — `"Price"` never matches the stored `price`, which
+      // is precisely the dead-alias problem the warn exists to announce — so
+      // at-most-one-parent is the only reachable refusal here.
+      const ws = freshWorkspace();
+
+      const merge = await inTx((tx) =>
+        mergeApprovedEdges(tx, ws, [arriving("Priced At", "cost"), arriving("Priced At", "other")]),
+      );
+
+      expect(merge.applied).toBe(1);
+      expect(merge.refusals).toHaveLength(1);
+      expect(merge.refusals[0].refusal).toBe("already-aliased");
+      // Exactly ONE verbatim-write claim, and it is the applied edge's.
+      expect(warns.filter((w) => w.message.includes("WILL be written"))).toHaveLength(1);
+      expect(warns.map((w) => w.message)).toEqual([
+        expect.stringContaining("WILL be written"),
+        expect.stringContaining("WILL DROP an arriving alias edge"),
       ]);
     },
     PG_TEST_TIMEOUT_MS,

--- a/packages/api/src/lib/brain/__tests__/vocabulary-merge-pg.test.ts
+++ b/packages/api/src/lib/brain/__tests__/vocabulary-merge-pg.test.ts
@@ -287,7 +287,13 @@ describeIfPg("merging two vocabularies (#5036)", () => {
         total: 1,
       });
       expect(String(warns[0].payload.reason)).toContain("would close a cycle");
-      expect(warns[0].message).toContain("REFUSED");
+      // ⚠️ FUTURE TENSE. This log is emitted INSIDE the import transaction —
+      // section 9 of ~13 — so a later section throwing rolls it all back and no
+      // edge was dropped at all. A past-tense line on a rolled-back import sends
+      // an operator to re-author decisions that are still there. Matches
+      // `admin-migrate.ts`'s identity-loss warn, which solved this one module over.
+      expect(warns[0].message).toContain("WILL DROP");
+      expect(warns[0].message).toContain("when this transaction commits");
     },
     PG_TEST_TIMEOUT_MS,
   );
@@ -418,6 +424,16 @@ describeIfPg("merging two vocabularies (#5036)", () => {
       // source's decision can be re-authored.
       expect(refusal.refusal === "already-aliased" && refusal.existingTarget).toBe("cost");
       expect(warns[0].payload).toMatchObject({ refusal: "already-aliased", existingTarget: "cost" });
+      // The STORE-decided arm's whole shape — the twin of the norm-decided
+      // assertion in the group above. No `ok`: the discriminant is stripped
+      // before the push, so both arms of `VocabularyMergeRefusal` are the same
+      // shape at runtime as well as in the type.
+      expect(refusal).toEqual({
+        edge: arriving("price", "unit price"),
+        refusal: "already-aliased",
+        existingTarget: "cost",
+        message: refusal.message,
+      });
 
       expect(await closureOf(ws)).toEqual([{ norm: "price", effective_target: "cost" }]);
     },
@@ -440,6 +456,19 @@ describeIfPg("merging two vocabularies (#5036)", () => {
       expect(merge.applied).toBe(0);
       expect(merge.refusals.map((r) => r.refusal)).toEqual(["degenerate-norm", "self-edge"]);
       expect(await edgesOf(ws)).toEqual([]);
+      // ⚠️ WHOLE-OBJECT equality, not `toMatchObject`, and it is the norm-decided
+      // arm of a union whose other arm is built by a DIFFERENT spread. The two
+      // must be structurally identical: `{ edge, ...admission }` on the
+      // store-decided side would carry a stray `ok: false` that
+      // `VocabularyMergeRefusal` does not declare, while this side never has
+      // one — so an operator dumping the recovery payload as JSON would see the
+      // key on `would-cycle` and not on `self-edge`. Object-literal SPREAD is
+      // exempt from excess-property checking, so only an assertion catches it.
+      expect(merge.refusals[1]).toEqual({
+        edge: arriving("price", "price"),
+        refusal: "self-edge",
+        message: merge.refusals[1].message,
+      });
       expect(warns.map((w) => w.payload.refusal)).toEqual(["degenerate-norm", "self-edge"]);
       // Index and total let an operator tell a truncated log from a complete one.
       expect(warns.map((w) => [w.payload.index, w.payload.total])).toEqual([
@@ -526,6 +555,11 @@ describeIfPg("merging two vocabularies (#5036)", () => {
       expect(merge.applied).toBe(0);
       expect(merge.refusals).toEqual([]);
       expect(warns).toEqual([]);
+      // Nothing was written, so nothing is rebuilt. Without this, moving
+      // `positionsTouched.add(position)` above the duplicate `continue` survives
+      // the suite — harmless in effect, since the rebuild is idempotent, but the
+      // returned value would then claim work that did not happen.
+      expect(merge.positionsRecomputed).toEqual([]);
       // Whole-row equality: the destination's approver and timestamp are its own.
       expect(await edgesOf(ws)).toEqual(before);
     },
@@ -576,7 +610,137 @@ describeIfPg("merging two vocabularies (#5036)", () => {
     PG_TEST_TIMEOUT_MS,
   );
 
-  // ── 6. The transaction contract ─────────────────────────────────────────────
+  it(
+    "rebuilds EVERY position that gained an edge, not just the first",
+    async () => {
+      // ⚠️ Until this case existed, no test in the tree ever put two positions
+      // into the recompute set — so `for (const p of [...touched].slice(0, 1))`,
+      // or a `break` at the end of that loop body, survived the entire suite.
+      //
+      // The consequence is not cosmetic. An applied edge whose position was
+      // never rebuilt leaves a norm with an approved edge and NO closure row,
+      // which is the half-rebuilt state `loadClaimVocabulary` refuses — it
+      // throws `VocabularyClosureError` for the whole workspace, permanently,
+      // and only at the next read: the extraction fiber, every `correctFact`
+      // entry point, and the legacy import-keying arm all stop working.
+      //
+      // Each position gets a destination edge the arrival composes ONTO, so a
+      // skipped rebuild is visible rather than coincidentally correct: `a` must
+      // move to `c` and `p` must move to `r`, and neither is a row the arriving
+      // edge mentions.
+      const ws = freshWorkspace();
+      await seedDestination(ws, [
+        ["b", "c", "predicate"],
+        ["q", "r", "subject"],
+      ]);
+
+      const merge = await inTx((tx) =>
+        mergeApprovedEdges(tx, ws, [
+          arriving("a", "b", { position: "predicate" }),
+          arriving("p", "q", { position: "subject" }),
+        ]),
+      );
+
+      expect(merge.applied).toBe(2);
+      expect(merge.refusals).toEqual([]);
+      expect([...merge.positionsRecomputed].toSorted()).toEqual(["predicate", "subject"]);
+      expect(await closureOf(ws, "predicate")).toEqual([
+        { norm: "a", effective_target: "c" },
+        { norm: "b", effective_target: "c" },
+      ]);
+      expect(await closureOf(ws, "subject")).toEqual([
+        { norm: "p", effective_target: "r" },
+        { norm: "q", effective_target: "r" },
+      ]);
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+
+  // ── 6. Intra-bundle conflicts — the input class nothing upstream screens ────
+
+  it.each([
+    {
+      label: "two arrivals claiming the same `fromNorm`",
+      edges: () => [arriving("a", "b"), arriving("a", "c")],
+      expected: { applied: 1, duplicate: 0, refused: ["already-aliased"] },
+      existingTarget: "b",
+    },
+    {
+      label: "two arrivals that cycle against each other",
+      edges: () => [arriving("a", "b"), arriving("b", "a")],
+      expected: { applied: 1, duplicate: 0, refused: ["would-cycle"] },
+      existingTarget: null,
+    },
+    {
+      label: "the identical edge twice",
+      edges: () => [arriving("a", "b"), arriving("a", "b")],
+      expected: { applied: 1, duplicate: 1, refused: [] },
+      existingTarget: null,
+    },
+  ])(
+    "accounts for $label against an EMPTY destination",
+    async ({ edges, expected, existingTarget }) => {
+      // `mergeApprovedEdges`' docstring asserts the arriving set is itself a
+      // valid forest, so no two arrivals can conflict. That holds for a bundle
+      // this product exported — and `validateBundle` checks each edge
+      // INDEPENDENTLY, with no duplicate-`fromNorm` and no intra-bundle cycle
+      // check, so a hand-built or corrupted bundle reaches here anyway.
+      //
+      // The destination is EMPTY on purpose: every refusal below is therefore
+      // purely intra-bundle, decided against a row the same transaction wrote
+      // and has not committed. That is the arm the accounting contract — which
+      // `migrate.ts` aborts a cutover on — depends on and nothing else covers.
+      const ws = freshWorkspace();
+      const bundle = edges();
+
+      const merge = await inTx((tx) => mergeApprovedEdges(tx, ws, bundle));
+
+      expect(merge.applied).toBe(expected.applied);
+      expect(merge.duplicate).toBe(expected.duplicate);
+      expect(merge.refusals.map((r) => r.refusal)).toEqual([...expected.refused]);
+      expect(merge.applied + merge.duplicate + merge.refusals.length).toBe(bundle.length);
+      if (existingTarget !== null) {
+        const [refusal] = merge.refusals;
+        expect(refusal.refusal === "already-aliased" && refusal.existingTarget).toBe(existingTarget);
+      }
+      // Whatever was refused, the destination is still a forest: exactly the
+      // applied edges are present.
+      expect(await edgesOf(ws)).toHaveLength(expected.applied);
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "refuses the OTHER edge when the same conflicting bundle arrives in the opposite order",
+    async () => {
+      // The docstring states the order-dependence outright — *"which of them is
+      // refused depends on which is seen first"* — and a prose claim nothing
+      // pins is the same defect class as a comment that has drifted. Both
+      // orders must leave a forest and a well-formed closure; only WHICH human
+      // decision is dropped differs, which is why the refusal is logged.
+      const ws = freshWorkspace();
+      await seedDestination(ws, [["x", "y"]]);
+
+      const merge = await inTx((tx) =>
+        // Reversed against group 1's `[y→z, z→x]`, which refuses `z→x`.
+        mergeApprovedEdges(tx, ws, [arriving("z", "x"), arriving("y", "z")]),
+      );
+
+      expect(merge.applied).toBe(1);
+      expect(merge.refusals).toHaveLength(1);
+      expect(merge.refusals[0].refusal).toBe("would-cycle");
+      // The OTHER edge, and this is the whole assertion: same bundle, same
+      // destination, different victim.
+      expect(merge.refusals[0].edge.fromNorm).toBe("y");
+      expect(await closureOf(ws)).toEqual([
+        { norm: "x", effective_target: "y" },
+        { norm: "z", effective_target: "y" },
+      ]);
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+
+  // ── 7. The transaction contract ─────────────────────────────────────────────
 
   it(
     "REFUSES to merge outside a transaction",

--- a/packages/api/src/lib/brain/__tests__/vocabulary-merge-pg.test.ts
+++ b/packages/api/src/lib/brain/__tests__/vocabulary-merge-pg.test.ts
@@ -27,8 +27,13 @@
  *   4. **The row-copy** — values are written verbatim, `approved_at` included,
  *      and an identical arriving edge does NOT rewrite the destination's row.
  *   5. **The scoping** — positions are independent forests, and only a position
- *      that gained an edge is recomputed.
- *   6. **The transaction** — the merge refuses to run outside one, and takes no
+ *      that gained an edge is recomputed. Also the verbatim non-norm write,
+ *      whose warn must fire ONLY on the edge that actually lands.
+ *   6. **Intra-bundle conflicts** — the input class nothing upstream screens.
+ *      `validateBundle` checks each edge independently, so a duplicate
+ *      `fromNorm`, a self-cycling pair, or the identical edge twice reaches the
+ *      merge and must still account three ways.
+ *   7. **The transaction** — the merge refuses to run outside one, and takes no
  *      lock when there is nothing to merge.
  *
  * ## Why the logger is mocked here
@@ -425,7 +430,7 @@ describeIfPg("merging two vocabularies (#5036)", () => {
       expect(refusal.refusal === "already-aliased" && refusal.existingTarget).toBe("cost");
       expect(warns[0].payload).toMatchObject({ refusal: "already-aliased", existingTarget: "cost" });
       // The STORE-decided arm's whole shape — the twin of the norm-decided
-      // assertion in the group above. No `ok`: the discriminant is stripped
+      // assertion in the next case of this group. No `ok`: the discriminant is stripped
       // before the push, so both arms of `VocabularyMergeRefusal` are the same
       // shape at runtime as well as in the type.
       expect(refusal).toEqual({
@@ -700,10 +705,12 @@ describeIfPg("merging two vocabularies (#5036)", () => {
       // TWO non-norm arrivals sharing a `fromNorm`: the first is written, the
       // second takes a second parent and is refused. A warn at the top of the
       // loop emits the verbatim-write line TWICE; correctly placed it emits it
-      // once, for the edge that actually landed. Note a non-norm cannot be
-      // refused by a CYCLE — `"Price"` never matches the stored `price`, which
-      // is precisely the dead-alias problem the warn exists to announce — so
-      // at-most-one-parent is the only reachable refusal here.
+      // once, for the edge that actually landed. Note a non-norm cannot cycle
+      // against this destination's NORMED edges — `"Price"` never matches the
+      // stored `price`, which is precisely the dead-alias problem the warn
+      // exists to announce — so at-most-one-parent is the only reachable refusal
+      // here. (Two non-norm edges CAN cycle against each other; that is a
+      // different fixture.)
       const ws = freshWorkspace();
 
       const merge = await inTx((tx) =>
@@ -831,7 +838,7 @@ describeIfPg("merging two vocabularies (#5036)", () => {
       // vocabulary must not serialize against every open approval in the
       // workspace — and it reaches this function on a POOL from the importer's
       // perspective only in tests, which is exactly why the check is worth
-      // making here. If the early return were removed, the line above would throw.
+      // making here. If the early return were removed, the call below would throw.
       const ws = freshWorkspace();
       const merge = await mergeApprovedEdges(pool, ws, []);
       expect(merge).toEqual({ applied: 0, duplicate: 0, refusals: [], positionsRecomputed: [] });

--- a/packages/api/src/lib/brain/__tests__/vocabulary-merge-pg.test.ts
+++ b/packages/api/src/lib/brain/__tests__/vocabulary-merge-pg.test.ts
@@ -1,0 +1,611 @@
+/**
+ * Merging two vocabularies (#5036, ADR-0037 §8 §4).
+ *
+ * > Union the approved edges; refuse any edge that would close a cycle or
+ * > violate at-most-one-parent; log every refusal; recompute the effective-target
+ * > closure at the destination.
+ *
+ * The hole this closes is CROSS-vocabulary. The forest invariant is enforced
+ * per-vocabulary and nothing enforced it across two: canonical direction is
+ * arbitrary, so a source that curated `price → priced at` and a destination that
+ * curated `priced at → price` are both valid forests whose UNION is a 2-cycle.
+ * Group 1 is that case, and it is the issue's named falsification.
+ *
+ * ## What each group falsifies
+ *
+ *   1. **The cycle** — two individually-valid forests whose union is cyclic
+ *      refuse, log, and leave the destination a forest. Run TWICE, because
+ *      "refuses" and "does not oscillate" are different claims and only the
+ *      second one is about a merge that runs again.
+ *   2. **The union** — non-conflicting decisions from BOTH regions survive, and
+ *      the closure is recomputed over the union rather than over either half.
+ *      The chain case (`a → b` destination, `b → c` arriving) is the one a
+ *      per-edge closure patch gets wrong.
+ *   3. **The refusals** — at-most-one-parent, and the two that need no store.
+ *      Every arriving edge lands in exactly one of applied / duplicate /
+ *      refused, which `migrate.ts` reconciliation depends on.
+ *   4. **The row-copy** — values are written verbatim, `approved_at` included,
+ *      and an identical arriving edge does NOT rewrite the destination's row.
+ *   5. **The scoping** — positions are independent forests, and only a position
+ *      that gained an edge is recomputed.
+ *   6. **The transaction** — the merge refuses to run outside one, and takes no
+ *      lock when there is nothing to merge.
+ *
+ * ## Why the logger is mocked here
+ *
+ * #5036 makes the log THE recovery path: a refused edge is a human's approved
+ * decision this region is dropping, and the log line is the only artifact from
+ * which it can be re-authored once the bundle is gone (`stays` cleanup, #4458).
+ * A test that asserted only the returned counts would leave a merge that
+ * computes refusals correctly and tells nobody entirely green.
+ *
+ * Separate SINKS per level, not one array with the level in the payload: the
+ * level is part of the claim, and a helper that merged the two would pass a
+ * mutation demoting `log.warn` to `log.debug`.
+ *
+ * Real Postgres throughout — the cycle walk and the closure rebuild are SQL, so
+ * a scripted executor would be asserting this file's own arithmetic.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it, mock } from "bun:test";
+import { Pool, type PoolClient } from "pg";
+
+interface Captured {
+  readonly payload: Record<string, unknown>;
+  readonly message: string;
+}
+
+const warns: Captured[] = [];
+/** Separate sinks: the LEVEL is part of what this file pins, not just the payload. */
+const infos: Captured[] = [];
+const errors: Captured[] = [];
+
+/**
+ * Every value export of `lib/logger`, replaced.
+ *
+ * ⚠️ A PARTIAL mock is the trap this repo has recorded: `mock.module` replaces
+ * the whole module, so any export left out becomes `undefined` and the module
+ * under test throws on first use — which reads as a broken test rather than a
+ * missing mock. The factory is SYNCHRONOUS, because an async one deadlocks
+ * `bun:test`.
+ */
+void mock.module("@atlas/api/lib/logger", () => {
+  const record = (sink: Captured[]) => (payload: unknown, message?: unknown) =>
+    sink.push({
+      payload: (payload ?? {}) as Record<string, unknown>,
+      message: typeof message === "string" ? message : String(payload),
+    });
+  const capture = {
+    info: record(infos),
+    warn: record(warns),
+    error: record(errors),
+    debug: () => {},
+    level: "info",
+  };
+  return {
+    createLogger: () => capture,
+    getLogger: () => capture,
+    setLogLevel: () => true,
+    getRequestContext: () => undefined,
+    withRequestContext: <T,>(_ctx: unknown, fn: () => T): T => fn(),
+    redactPaths: [] as string[],
+    scrubErrSerializer: (err: unknown) => err,
+    scrubLogFormatter: (obj: unknown) => obj,
+    hashShareToken: (token: string) => token,
+    ACTOR_KINDS: ["human", "agent", "mcp", "scheduler", "api_key"] as const,
+  };
+});
+
+const TEST_DB_URL = process.env.TEST_DATABASE_URL;
+const describeIfPg = TEST_DB_URL ? describe : describe.skip;
+const PG_TEST_TIMEOUT_MS = 60_000;
+
+// DYNAMIC, after the mock above is installed.
+const { runMigrations } = await import("@atlas/api/lib/db/migrate");
+const { MANAGED_AUTH_MIGRATIONS, _resetPool } = await import("@atlas/api/lib/db/internal");
+const { approveAliasEdge, mergeApprovedEdges } = await import("@atlas/api/lib/brain/vocabulary");
+type ArrivingAliasEdge = import("@atlas/api/lib/brain/vocabulary").ArrivingAliasEdge;
+type SlotPosition = import("@atlas/api/lib/brain/identity").SlotPosition;
+
+/** The source region's approval timestamp — never `now()`, which is the point of group 4. */
+const SOURCE_APPROVED_AT = "2026-01-02T03:04:05.000Z";
+
+const arriving = (
+  fromNorm: string,
+  toNorm: string,
+  overrides: Partial<ArrivingAliasEdge> = {},
+): ArrivingAliasEdge => ({
+  position: "predicate",
+  fromNorm,
+  toNorm,
+  approvedBy: "source-admin",
+  approvedAt: SOURCE_APPROVED_AT,
+  ...overrides,
+});
+
+describeIfPg("merging two vocabularies (#5036)", () => {
+  let pool: Pool;
+  const schemaName = `brain_5036_${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
+  let priorDatabaseUrl: string | undefined;
+  let wsCounter = 0;
+
+  beforeAll(async () => {
+    priorDatabaseUrl = process.env.DATABASE_URL;
+    process.env.DATABASE_URL = TEST_DB_URL;
+    pool = new Pool({
+      connectionString: TEST_DB_URL,
+      options: `-c search_path="${schemaName}",public`,
+    });
+    const bootstrap = new Pool({ connectionString: TEST_DB_URL });
+    try {
+      await bootstrap.query(`CREATE SCHEMA IF NOT EXISTS "${schemaName}"`);
+    } finally {
+      await bootstrap.end();
+    }
+    await runMigrations(pool, { skip: MANAGED_AUTH_MIGRATIONS });
+    _resetPool(pool);
+  }, PG_TEST_TIMEOUT_MS);
+
+  afterAll(async () => {
+    _resetPool(null);
+    if (priorDatabaseUrl === undefined) delete process.env.DATABASE_URL;
+    else process.env.DATABASE_URL = priorDatabaseUrl;
+    if (pool) {
+      await pool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+      await pool.end();
+    }
+  }, PG_TEST_TIMEOUT_MS);
+
+  // BEFORE each, not after: `runMigrations` in `beforeAll` emits ~200 info
+  // lines, so an after-only reset leaves the FIRST test measuring the migration
+  // runner's output. That is not hypothetical — the `infos` assertion in group 1
+  // caught it, which is the only reason the level sinks are worth having.
+  beforeEach(() => {
+    warns.length = 0;
+    infos.length = 0;
+    errors.length = 0;
+  });
+
+  /**
+   * A workspace nobody else in this file touches.
+   *
+   * Every group shares one schema, and the closure assertions below read whole
+   * tables by workspace — an unscoped fixture would make one group's edges show
+   * up in another's `ORDER BY` and the failure would look like a merge bug.
+   */
+  const freshWorkspace = () => `ws-merge-5036-${++wsCounter}`;
+
+  /** Run one unit of work inside a real transaction — every primitive here demands one. */
+  const inTx = async <T,>(fn: (tx: PoolClient) => Promise<T>): Promise<T> => {
+    const client = await pool.connect();
+    try {
+      await client.query("BEGIN");
+      const out = await fn(client);
+      await client.query("COMMIT");
+      return out;
+    } catch (err) {
+      await client.query("ROLLBACK").catch((rollbackErr: unknown) => {
+        // The original error below is the real outcome; a rollback failure on an
+        // already-dead connection would mask it. Logged rather than dropped.
+        console.debug(
+          "rollback after a failed test transaction:",
+          rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr),
+        );
+      });
+      throw err;
+    } finally {
+      client.release();
+    }
+  };
+
+  /** Seed the DESTINATION region's own curated decisions, through the real approval path. */
+  const seedDestination = (ws: string, edges: readonly (readonly [string, string, SlotPosition?])[]) =>
+    inTx(async (tx) => {
+      for (const [fromNorm, toNorm, position] of edges) {
+        const result = await approveAliasEdge(tx, ws, {
+          position: position ?? "predicate",
+          fromNorm,
+          toNorm,
+          approvedBy: "destination-admin",
+        });
+        // Seeding through the real path means a seed that silently refused would
+        // make the group under test measure an empty destination.
+        expect(result.ok).toBe(true);
+      }
+    });
+
+  const closureOf = async (ws: string, position: SlotPosition = "predicate") => {
+    const rows = await pool.query<{ norm: string; effective_target: string }>(
+      `SELECT norm, effective_target FROM brain_vocabulary_target
+        WHERE workspace_id = $1 AND slot_position = $2 ORDER BY norm`,
+      [ws, position],
+    );
+    return rows.rows;
+  };
+
+  const edgesOf = async (ws: string) => {
+    const rows = await pool.query<{
+      slot_position: string;
+      from_norm: string;
+      to_norm: string;
+      approved_by: string | null;
+      approved_at: Date;
+    }>(
+      `SELECT slot_position, from_norm, to_norm, approved_by, approved_at
+         FROM brain_vocabulary_edge WHERE workspace_id = $1
+        ORDER BY slot_position, from_norm`,
+      [ws],
+    );
+    return rows.rows;
+  };
+
+  // ── 1. The cycle: two valid forests whose union is not one ──────────────────
+
+  it(
+    "REFUSES an arriving edge that would close a cycle against a destination edge, and logs it",
+    async () => {
+      // Not contrived: canonical direction is arbitrary, so both regions made a
+      // defensible call and each store is individually a valid forest.
+      const ws = freshWorkspace();
+      await seedDestination(ws, [["priced at", "price"]]);
+
+      const merge = await inTx((tx) => mergeApprovedEdges(tx, ws, [arriving("price", "priced at")]));
+
+      expect(merge.applied).toBe(0);
+      expect(merge.duplicate).toBe(0);
+      expect(merge.refusals).toHaveLength(1);
+      expect(merge.refusals[0].refusal).toBe("would-cycle");
+      // The position was NOT recomputed: nothing was written, so a rebuild would
+      // be a no-op that reads as "something changed here".
+      expect(merge.positionsRecomputed).toEqual([]);
+
+      // The destination is still a forest, and still says exactly what it said.
+      expect(await edgesOf(ws)).toMatchObject([
+        { slot_position: "predicate", from_norm: "priced at", to_norm: "price" },
+      ]);
+      expect(await closureOf(ws)).toEqual([{ norm: "priced at", effective_target: "price" }]);
+
+      // ── The log IS the recovery path (#5036) ──
+      expect(warns).toHaveLength(1);
+      expect(errors).toHaveLength(0);
+      expect(infos).toHaveLength(0);
+      // The whole edge, not a norm pair: the bundle may be gone by the time an
+      // operator reads this, so everything needed to re-author the source row
+      // has to be in the line itself.
+      expect(warns[0].payload).toMatchObject({
+        workspaceId: ws,
+        position: "predicate",
+        fromNorm: "price",
+        toNorm: "priced at",
+        approvedBy: "source-admin",
+        approvedAt: SOURCE_APPROVED_AT,
+        refusal: "would-cycle",
+        // Explicitly `null` rather than absent — a missing key and "there is no
+        // conflicting edge" read identically in an aggregator, and only one is true.
+        existingTarget: null,
+        index: 0,
+        total: 1,
+      });
+      expect(String(warns[0].payload.reason)).toContain("would close a cycle");
+      expect(warns[0].message).toContain("REFUSED");
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "does not OSCILLATE — re-running the same merge repeats the refusal and moves nothing",
+    async () => {
+      // The failure this rules out is the one the issue names: a merge that
+      // resolved the cycle by flipping an edge would flip it back on the next
+      // catch-up import, and the corpus would re-key on every migration.
+      const ws = freshWorkspace();
+      await seedDestination(ws, [["priced at", "price"]]);
+      const bundle = [arriving("price", "priced at")];
+
+      const first = await inTx((tx) => mergeApprovedEdges(tx, ws, bundle));
+      const edgesAfterFirst = await edgesOf(ws);
+      const closureAfterFirst = await closureOf(ws);
+
+      const second = await inTx((tx) => mergeApprovedEdges(tx, ws, bundle));
+
+      expect(second.applied).toBe(first.applied);
+      expect(second.duplicate).toBe(first.duplicate);
+      expect(second.refusals.map((r) => r.refusal)).toEqual(first.refusals.map((r) => r.refusal));
+      expect(await edgesOf(ws)).toEqual(edgesAfterFirst);
+      expect(await closureOf(ws)).toEqual(closureAfterFirst);
+      // Logged BOTH times — an operator re-running a catch-up import must not be
+      // told a decision landed just because a previous run already refused it.
+      expect(warns).toHaveLength(2);
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "refuses a cycle closed through a LONGER chain, not only a 2-cycle",
+    async () => {
+      // `x → y` here; `y → z` and `z → x` arriving. The arriving pair is itself a
+      // valid forest (z is unaliased at the source), and only the union cycles.
+      // A cycle check that compared endpoints instead of walking the chain would
+      // apply both.
+      const ws = freshWorkspace();
+      await seedDestination(ws, [["x", "y"]]);
+
+      const merge = await inTx((tx) =>
+        mergeApprovedEdges(tx, ws, [arriving("y", "z"), arriving("z", "x")]),
+      );
+
+      expect(merge.applied).toBe(1);
+      expect(merge.refusals).toHaveLength(1);
+      expect(merge.refusals[0].refusal).toBe("would-cycle");
+      expect(merge.refusals[0].edge.fromNorm).toBe("z");
+      // The half that does not cycle still lands — refusing the whole bundle
+      // over one bad edge would discard the source's other decisions too.
+      expect(await closureOf(ws)).toEqual([
+        { norm: "x", effective_target: "z" },
+        { norm: "y", effective_target: "z" },
+      ]);
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+
+  // ── 2. The union: both regions' decisions survive, closure recomputed ───────
+
+  it(
+    "UNIONS the approved edges and recomputes the closure over the union",
+    async () => {
+      // The case a per-edge closure patch gets wrong. Destination holds `a → b`;
+      // `b → c` arrives. Writing the arrival and patching only `b` leaves `a`
+      // keyed onto `b`, which nothing approves any more — silently.
+      const ws = freshWorkspace();
+      await seedDestination(ws, [["a", "b"]]);
+
+      const merge = await inTx((tx) => mergeApprovedEdges(tx, ws, [arriving("b", "c")]));
+
+      expect(merge.applied).toBe(1);
+      expect(merge.refusals).toEqual([]);
+      expect(merge.positionsRecomputed).toEqual(["predicate"]);
+      expect(await closureOf(ws)).toEqual([
+        { norm: "a", effective_target: "c" },
+        { norm: "b", effective_target: "c" },
+      ]);
+      // Both approved edges are still there — the closure composed them, it did
+      // not COMPRESS them. Compression is what destroys reversibility (ADR-0037 §6).
+      expect((await edgesOf(ws)).map((e) => [e.from_norm, e.to_norm])).toEqual([
+        ["a", "b"],
+        ["b", "c"],
+      ]);
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "unions in the other direction too — an arriving edge UNDER a destination edge",
+    async () => {
+      // Destination `b → c`; `a → b` arrives. Same union, opposite insertion
+      // order, and it is the direction in which the arriving edge is the one
+      // whose effective target has to be composed rather than stored.
+      const ws = freshWorkspace();
+      await seedDestination(ws, [["b", "c"]]);
+
+      const merge = await inTx((tx) => mergeApprovedEdges(tx, ws, [arriving("a", "b")]));
+
+      expect(merge.applied).toBe(1);
+      expect(await closureOf(ws)).toEqual([
+        { norm: "a", effective_target: "c" },
+        { norm: "b", effective_target: "c" },
+      ]);
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+
+  // ── 3. The refusals, and the three-way accounting ───────────────────────────
+
+  it(
+    "REFUSES an arriving edge whose `fromNorm` this region already aliased elsewhere",
+    async () => {
+      const ws = freshWorkspace();
+      await seedDestination(ws, [["price", "cost"]]);
+
+      const merge = await inTx((tx) => mergeApprovedEdges(tx, ws, [arriving("price", "unit price")]));
+
+      expect(merge.applied).toBe(0);
+      expect(merge.duplicate).toBe(0);
+      expect(merge.refusals).toHaveLength(1);
+      const [refusal] = merge.refusals;
+      expect(refusal.refusal).toBe("already-aliased");
+      // The destination's target, which is the ONLY thing that makes the log
+      // line actionable: an operator has to know what to remove before the
+      // source's decision can be re-authored.
+      expect(refusal.refusal === "already-aliased" && refusal.existingTarget).toBe("cost");
+      expect(warns[0].payload).toMatchObject({ refusal: "already-aliased", existingTarget: "cost" });
+
+      expect(await closureOf(ws)).toEqual([{ norm: "price", effective_target: "cost" }]);
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "refuses the two that need no store — a degenerate norm and a self-edge",
+    async () => {
+      // Unreachable through the importer (`validateBundle` refuses both at the
+      // door) and reachable through this function's own contract, which is the
+      // surface being tested. A merge that wrote them would put a row in that
+      // can never match anything.
+      const ws = freshWorkspace();
+
+      const merge = await inTx((tx) =>
+        mergeApprovedEdges(tx, ws, [arriving("", "price"), arriving("price", "price")]),
+      );
+
+      expect(merge.applied).toBe(0);
+      expect(merge.refusals.map((r) => r.refusal)).toEqual(["degenerate-norm", "self-edge"]);
+      expect(await edgesOf(ws)).toEqual([]);
+      expect(warns.map((w) => w.payload.refusal)).toEqual(["degenerate-norm", "self-edge"]);
+      // Index and total let an operator tell a truncated log from a complete one.
+      expect(warns.map((w) => [w.payload.index, w.payload.total])).toEqual([
+        [0, 2],
+        [1, 2],
+      ]);
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "accounts for EVERY arriving edge exactly once — applied + duplicate + refused",
+    async () => {
+      // `migrate.ts` reconciles the target's counters against the manifest count
+      // and ABORTS the migration before cutover when they disagree, so an edge
+      // that fell through all three would fail a whole cutover.
+      //
+      // Deliberately three DIFFERENT numbers (2 / 1 / 3): with 1/1/1 a merge that
+      // mixed two counters up would pass every assertion here.
+      const ws = freshWorkspace();
+      await seedDestination(ws, [
+        ["price", "cost"], // conflicts with one arrival
+        ["priced at", "amount"], // cycles with one arrival
+      ]);
+
+      const bundle: readonly ArrivingAliasEdge[] = [
+        arriving("fresh one", "target one"), // applied
+        arriving("fresh two", "target two"), // applied
+        arriving("price", "cost"), // duplicate — same decision
+        arriving("price", "unit price"), // refused — already-aliased
+        arriving("amount", "priced at"), // refused — would-cycle
+        arriving("", "nothing"), // refused — degenerate-norm
+      ];
+
+      const merge = await inTx((tx) => mergeApprovedEdges(tx, ws, bundle));
+
+      expect(merge.applied).toBe(2);
+      expect(merge.duplicate).toBe(1);
+      expect(merge.refusals).toHaveLength(3);
+      expect(merge.applied + merge.duplicate + merge.refusals.length).toBe(bundle.length);
+      // Every refusal logged, and the duplicate NOT logged — a re-import that
+      // warned about decisions it already holds is how a real refusal gets skimmed past.
+      expect(warns).toHaveLength(3);
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+
+  // ── 4. The row-copy: verbatim, and never a rewrite ──────────────────────────
+
+  it(
+    "carries the source's `approved_by` and `approved_at` VERBATIM",
+    async () => {
+      // ADR-0037 §8: a row-copy path carries values verbatim. Letting
+      // `approved_at` fall to its `now()` default would date every migrated
+      // decision to the migration and erase when it was actually made.
+      const ws = freshWorkspace();
+
+      await inTx((tx) =>
+        mergeApprovedEdges(tx, ws, [arriving("price", "cost", { approvedBy: "eu-reviewer" })]),
+      );
+
+      const [edge] = await edgesOf(ws);
+      expect(edge.approved_by).toBe("eu-reviewer");
+      expect(new Date(edge.approved_at).toISOString()).toBe(SOURCE_APPROVED_AT);
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "treats an IDENTICAL arriving edge as a duplicate and leaves the destination row untouched",
+    async () => {
+      // The idempotent re-import path, and it must not be reported as a lost
+      // decision — nor overwrite the destination's own approval metadata, which
+      // is the `ON CONFLICT DO UPDATE` this table must never grow.
+      const ws = freshWorkspace();
+      await seedDestination(ws, [["price", "cost"]]);
+      const before = await edgesOf(ws);
+
+      const merge = await inTx((tx) =>
+        mergeApprovedEdges(tx, ws, [arriving("price", "cost", { approvedBy: "source-admin" })]),
+      );
+
+      expect(merge.duplicate).toBe(1);
+      expect(merge.applied).toBe(0);
+      expect(merge.refusals).toEqual([]);
+      expect(warns).toEqual([]);
+      // Whole-row equality: the destination's approver and timestamp are its own.
+      expect(await edgesOf(ws)).toEqual(before);
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+
+  // ── 5. Position scoping, and which closures get rebuilt ─────────────────────
+
+  it(
+    "keeps positions independent — the same norm pair may run opposite ways at two positions",
+    async () => {
+      // Three forests, not one (ADR-0037 §6). A cycle walk that dropped
+      // `slot_position` would see `price → cost` and `cost → price` as a 2-cycle
+      // and refuse the arrival, which is a predicate decision re-keying subjects.
+      const ws = freshWorkspace();
+      await seedDestination(ws, [["price", "cost", "subject"]]);
+
+      const merge = await inTx((tx) =>
+        mergeApprovedEdges(tx, ws, [arriving("cost", "price", { position: "predicate" })]),
+      );
+
+      expect(merge.applied).toBe(1);
+      expect(merge.refusals).toEqual([]);
+      expect(await closureOf(ws, "subject")).toEqual([{ norm: "price", effective_target: "cost" }]);
+      expect(await closureOf(ws, "predicate")).toEqual([{ norm: "cost", effective_target: "price" }]);
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "recomputes ONLY the positions that gained an edge",
+    async () => {
+      const ws = freshWorkspace();
+      await seedDestination(ws, [["price", "cost", "subject"]]);
+
+      const merge = await inTx((tx) =>
+        mergeApprovedEdges(tx, ws, [
+          arriving("a", "b", { position: "predicate" }), // applied
+          arriving("price", "elsewhere", { position: "subject" }), // refused
+        ]),
+      );
+
+      expect(merge.applied).toBe(1);
+      expect(merge.refusals).toHaveLength(1);
+      // `subject` saw an arrival but gained nothing, so it is absent.
+      expect(merge.positionsRecomputed).toEqual(["predicate"]);
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+
+  // ── 6. The transaction contract ─────────────────────────────────────────────
+
+  it(
+    "REFUSES to merge outside a transaction",
+    async () => {
+      // On an autocommit connection the advisory lock is taken and dropped
+      // inside its own statement, so the check-then-insert stops being atomic
+      // and a concurrent approval can close a cycle either side of it.
+      const ws = freshWorkspace();
+      await expect(mergeApprovedEdges(pool, ws, [arriving("price", "cost")])).rejects.toThrow(
+        /must run inside a transaction/,
+      );
+      expect(await edgesOf(ws)).toEqual([]);
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "takes no lock at all when there is nothing to merge",
+    async () => {
+      // The positive control for the early return: a bundle carrying no
+      // vocabulary must not serialize against every open approval in the
+      // workspace — and it reaches this function on a POOL from the importer's
+      // perspective only in tests, which is exactly why the check is worth
+      // making here. If the early return were removed, the line above would throw.
+      const ws = freshWorkspace();
+      const merge = await mergeApprovedEdges(pool, ws, []);
+      expect(merge).toEqual({ applied: 0, duplicate: 0, refusals: [], positionsRecomputed: [] });
+      expect(warns).toEqual([]);
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+});

--- a/packages/api/src/lib/brain/__tests__/vocabulary-merge-types.test.ts
+++ b/packages/api/src/lib/brain/__tests__/vocabulary-merge-types.test.ts
@@ -1,0 +1,72 @@
+/**
+ * The compile-time half of the vocabulary merge (#5036, ADR-0037 §8).
+ *
+ * ⚠️ SEPARATE FROM `vocabulary-merge-pg.test.ts` FOR TWO REASONS, and the second
+ * is the one that matters. The obvious one: `mock.module` there is process-wide,
+ * so a file that wants the real logger cannot share it. The load-bearing one:
+ * every behavioural falsifier for this slice lives in a `-pg` file, which is
+ * `describe.skip`ped whenever `TEST_DATABASE_URL` is unset — the local default.
+ * So a mutation to the merge produces a GREEN local `bun run test`, which is the
+ * topology that let a workspace-fatal `slice(0, 1)` survive a whole review round.
+ * The claims below need no database, so they run everywhere and put at least the
+ * type-level guarantees back inside the local loop.
+ *
+ * `@ts-expect-error` IS the assertion here, which is this repo's existing idiom
+ * (`subject-cmp.test.ts`, `sources.test.ts`): an UNUSED `@ts-expect-error` is
+ * itself a compile error, so deleting the guard the directive documents turns
+ * `bun run type` red. That is what makes a type-level barrier falsifiable at
+ * all — nothing at runtime can observe it.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { approveAliasEdge, type ArrivingAliasEdge } from "@atlas/api/lib/brain/vocabulary";
+import type { VocabularyExecutor } from "@atlas/api/lib/brain/vocabulary";
+
+/** Never called — every assertion in this file is settled by the compiler. */
+const unusedExecutor = { query: async () => ({ rows: [] }) } satisfies VocabularyExecutor;
+
+describe("approveAliasEdge refuses a row-copy edge (⚠️ the `@ts-expect-error` IS the assertion)", () => {
+  test("an ArrivingAliasEdge cannot be approved, because approval would re-date it", () => {
+    // The mistake this makes unrepresentable is silent and permanent.
+    // `ArrivingAliasEdge extends AliasEdgeInput`, so without the
+    // `approvedAt?: never` barrier on the parameter this call type-checks
+    // perfectly — and `approveAliasEdge`'s INSERT omits `approved_at`, so the
+    // column falls to its `now()` default. Every migrated human decision would
+    // be re-dated to the migration, which is exactly what ADR-0037 §8's
+    // row-copy rule exists to prevent, reached through the one door that looks
+    // like it belongs.
+    //
+    // Nothing at runtime can catch it: the write succeeds, the timestamp is
+    // plausible, and the original is deleted at the source after the grace
+    // period. The compiler is the only detector, so the guard needs the only
+    // kind of test a compiler-enforced guard can have.
+    const arriving: ArrivingAliasEdge = {
+      position: "predicate",
+      fromNorm: "price",
+      toNorm: "cost",
+      approvedBy: "source-admin",
+      approvedAt: "2026-01-02T03:04:05.000Z",
+    };
+
+    // @ts-expect-error #5036 — a row-copy edge must not go through the approval path
+    const refused = () => approveAliasEdge(unusedExecutor, "ws", arriving);
+    void refused;
+
+    // The control: the same call WITHOUT the carried timestamp is legal, so the
+    // barrier refuses the row-copy shape specifically rather than refusing
+    // everything. Without this, deleting `approvedAt` from `ArrivingAliasEdge`
+    // would satisfy the directive above for the wrong reason.
+    const allowed = () =>
+      approveAliasEdge(unusedExecutor, "ws", {
+        position: "predicate",
+        fromNorm: "price",
+        toNorm: "cost",
+        approvedBy: "an-admin",
+      });
+    void allowed;
+
+    // One runtime assertion so the case is not a no-op body — the compile-time
+    // claims above are the point, and this keeps the test honest about that.
+    expect(arriving.approvedAt).toBe("2026-01-02T03:04:05.000Z");
+  });
+});

--- a/packages/api/src/lib/brain/vocabulary.ts
+++ b/packages/api/src/lib/brain/vocabulary.ts
@@ -560,7 +560,16 @@ async function admitAliasEdge(
 export async function approveAliasEdge(
   tx: VocabularyExecutor,
   workspaceId: string,
-  input: AliasEdgeInput,
+  // ⚠️ `approvedAt?: never` is a BARRIER against {@link ArrivingAliasEdge}, not
+  // a field. That type extends this one, so without it
+  // `approveAliasEdge(tx, ws, arrivingEdge)` type-checks perfectly — and then
+  // silently does the one thing a row-copy must never do: the INSERT below omits
+  // `approved_at`, so the column falls to its `now()` default and a decision
+  // made in another region a year ago is re-dated to the migration. The subtype
+  // relation is what makes the mistake reachable, so the barrier belongs here
+  // rather than in a comment on the caller. Every existing caller passes an
+  // object literal with no `approvedAt` and is unaffected.
+  input: AliasEdgeInput & { readonly approvedAt?: never },
 ): Promise<AliasApprovalResult> {
   const { position } = input;
   // Re-normed, never trusted. `alias` composes over `lexicalNorm`, and an
@@ -603,9 +612,29 @@ export async function approveAliasEdge(
  * migration.
  */
 export interface ArrivingAliasEdge extends AliasEdgeInput {
-  /** The SOURCE region's approval timestamp, carried verbatim. */
+  /**
+   * The SOURCE region's approval timestamp, carried verbatim.
+   *
+   * ⚠️ Callers must have validated this parses — it is bound straight into a
+   * `timestamptz`, so an unparseable string is a Postgres THROW that aborts the
+   * whole import, which is the failure mode this module exists to replace with
+   * typed refusals. The one caller validates it in `validateBundle`'s
+   * `missingTimestamps` at the wire boundary.
+   */
   readonly approvedAt: string;
 }
+
+/**
+ * ⚠️ {@link ArrivingAliasEdge} is a SUBTYPE of {@link AliasEdgeInput}, which
+ * pins the field names together deliberately — but the two have OPPOSITE
+ * contracts on one axis, and the inheritance cannot express that.
+ * `AliasEdgeInput`'s norms are re-normed before they are written; an arriving
+ * edge's are written verbatim (ADR-0037 §8). The barrier on
+ * {@link approveAliasEdge}'s parameter is what stops the subtype relation from
+ * making the wrong one callable. Branding the norms so "already normed" is a
+ * type rather than a comment is the deeper fix and is deliberately not taken
+ * here: it needs a mint point in `validateBundle` and is its own slice.
+ */
 
 /**
  * One arriving edge the merge would not write, and everything needed to
@@ -754,6 +783,28 @@ export async function mergeApprovedEdges(
   for (const edge of edges) {
     const { position, fromNorm, toNorm } = edge;
 
+    // ⚠️ The verbatim-write contract is enforced TWO MODULES AWAY, and violating
+    // it is silently lossy — so make it audible here without changing it.
+    // `validateBundle` refuses a non-norm at the wire boundary, which is why the
+    // raw and normed arguments below are the same value; but `lib/` must not
+    // import from `api/routes/`, this function is exported, and
+    // `screenAliasNorms` cannot catch it — `"Priced At"` is neither empty nor
+    // self-equal, so it sails through and lands an alias that can never match
+    // anything, which is exactly the silent under-match this module exists to
+    // prevent. Not refused, because ADR-0037 §8 forbids rewriting another
+    // region's decision on a row-copy path and a refusal here would be this
+    // module second-guessing a validated wire contract; logged, because a
+    // caller that skipped the check should not find out from a lookup that
+    // quietly never fires. Costs nothing on the route path, where the predicate
+    // is false by construction.
+    if (lexicalNorm(fromNorm) !== fromNorm || lexicalNorm(toNorm) !== toNorm) {
+      log.warn(
+        { workspaceId, position, fromNorm, toNorm },
+        "Arriving alias edge is not in lexical-norm form — writing it verbatim per ADR-0037 §8, " +
+          "but it can never match a lookup. The caller skipped validateBundle's norm check.",
+      );
+    }
+
     // Raw and normed are the same value on purpose — see `screenAliasNorms`.
     const screened = screenAliasNorms(fromNorm, toNorm, fromNorm, toNorm);
     if (screened !== null) {
@@ -772,7 +823,17 @@ export async function mergeApprovedEdges(
         duplicate++;
         continue;
       }
-      refusals.push({ edge, ...admission });
+      // `ok` is stripped, NOT spread through. `{ edge, ...admission }` compiles
+      // — object-literal SPREAD is exempt from excess-property checking, unlike
+      // the equivalent inline literal — and pushes a runtime `ok: false` that
+      // `VocabularyMergeRefusal` does not declare. The twin four lines up does
+      // not, because `screenAliasNorms` returns no discriminant, so the two arms
+      // of one union would carry structurally different shapes: a `toEqual` or a
+      // `JSON.stringify` of the recovery payload sees `ok` on `would-cycle` and
+      // not on `self-edge`. Destructuring is what makes the declared type and
+      // the constructed value the same thing.
+      const { ok: _admitted, ...detail } = admission;
+      refusals.push({ edge, ...detail });
       continue;
     }
 
@@ -813,7 +874,17 @@ export async function mergeApprovedEdges(
         total: refusals.length,
         reason: refusal.message,
       },
-      "Vocabulary merge REFUSED an arriving alias edge — a source region's approved decision was not applied here",
+      // ⚠️ FUTURE TENSE, and it is not a stylistic choice. This runs inside the
+      // caller's transaction, which is section 9 of ~13 in `importBundle` — the
+      // closure rebuild below, the brain's identity refusal, or any driver error
+      // can still roll the whole thing back, and then NO edge was dropped
+      // because none was applied. Stated in the past tense, a rolled-back import
+      // tells an operator to go re-author decisions that are still there, and
+      // the retry emits an identical line set with nothing to tell the attempts
+      // apart. `admin-migrate.ts`'s identity-loss warn solved the same problem
+      // one module over with the same tense — "WILL land ... when this
+      // transaction commits" — and this matches it deliberately.
+      "Vocabulary merge WILL DROP an arriving alias edge when this transaction commits — a source region's approved decision is not being applied here",
     );
   });
 

--- a/packages/api/src/lib/brain/vocabulary.ts
+++ b/packages/api/src/lib/brain/vocabulary.ts
@@ -783,28 +783,6 @@ export async function mergeApprovedEdges(
   for (const edge of edges) {
     const { position, fromNorm, toNorm } = edge;
 
-    // ⚠️ The verbatim-write contract is enforced TWO MODULES AWAY, and violating
-    // it is silently lossy — so make it audible here without changing it.
-    // `validateBundle` refuses a non-norm at the wire boundary, which is why the
-    // raw and normed arguments below are the same value; but `lib/` must not
-    // import from `api/routes/`, this function is exported, and
-    // `screenAliasNorms` cannot catch it — `"Priced At"` is neither empty nor
-    // self-equal, so it sails through and lands an alias that can never match
-    // anything, which is exactly the silent under-match this module exists to
-    // prevent. Not refused, because ADR-0037 §8 forbids rewriting another
-    // region's decision on a row-copy path and a refusal here would be this
-    // module second-guessing a validated wire contract; logged, because a
-    // caller that skipped the check should not find out from a lookup that
-    // quietly never fires. Costs nothing on the route path, where the predicate
-    // is false by construction.
-    if (lexicalNorm(fromNorm) !== fromNorm || lexicalNorm(toNorm) !== toNorm) {
-      log.warn(
-        { workspaceId, position, fromNorm, toNorm },
-        "Arriving alias edge is not in lexical-norm form — writing it verbatim per ADR-0037 §8, " +
-          "but it can never match a lookup. The caller skipped validateBundle's norm check.",
-      );
-    }
-
     // Raw and normed are the same value on purpose — see `screenAliasNorms`.
     const screened = screenAliasNorms(fromNorm, toNorm, fromNorm, toNorm);
     if (screened !== null) {
@@ -835,6 +813,39 @@ export async function mergeApprovedEdges(
       const { ok: _admitted, ...detail } = admission;
       refusals.push({ edge, ...detail });
       continue;
+    }
+
+    // ⚠️ The verbatim-write contract is enforced TWO MODULES AWAY, and violating
+    // it is silently lossy — so make it audible here without changing it.
+    // `validateBundle` refuses a non-norm at the wire boundary, which is why the
+    // raw and normed arguments passed to `screenAliasNorms` are the same value;
+    // but `lib/` must not import from `api/routes/`, this function is exported,
+    // and `screenAliasNorms` cannot catch it — `"Priced At"` is neither empty
+    // nor self-equal, so it sails through and lands an alias that can never
+    // match anything, which is exactly the silent under-match this module exists
+    // to prevent. Not REFUSED, because ADR-0037 §8 forbids rewriting another
+    // region's decision on a row-copy path and refusing here would be this
+    // module second-guessing a validated wire contract; logged, because a caller
+    // that skipped the check should not find out from a lookup that quietly
+    // never fires. Costs nothing on the route path, where the predicate is false
+    // by construction.
+    //
+    // ⚠️ POSITIONED AFTER THE ADMISSION CHECKS AND IMMEDIATELY BEFORE THE
+    // INSERT, and phrased in the FUTURE TENSE — both for the same reason as the
+    // refusal warn below, which this originally contradicted from forty lines
+    // above it in the same commit. Emitted at the top of the loop it fired for
+    // edges that were then REFUSED or counted as duplicates, claiming a write
+    // that never happened and sending an operator hunting rows that do not
+    // exist — in the very log stream where the refusal lines are the recovery
+    // path, so both lose the same credibility. Here it fires only on the path
+    // that actually writes, and only commits to what a COMMIT would make true.
+    if (lexicalNorm(fromNorm) !== fromNorm || lexicalNorm(toNorm) !== toNorm) {
+      log.warn(
+        { workspaceId, position, fromNorm, toNorm },
+        "Arriving alias edge is not in lexical-norm form — it WILL be written verbatim per " +
+          "ADR-0037 §8 when this transaction commits, and can never match a lookup. The caller " +
+          "skipped validateBundle's norm check.",
+      );
     }
 
     await tx.query(

--- a/packages/api/src/lib/brain/vocabulary.ts
+++ b/packages/api/src/lib/brain/vocabulary.ts
@@ -393,14 +393,16 @@ export class VocabularyClosureError extends Error {
  *
  * Split out so {@link mergeApprovedEdges} enforces them from the SAME source
  * rather than from a second copy. That matters more here than the usual DRY
- * argument: the import path and the approval path disagree about almost
- * everything else (one re-norms, the other must not; one recomputes per edge,
- * the other once per position), and the rules they DO share are exactly the ones
- * a reader would assume had drifted.
+ * argument: the two paths disagree about almost everything else —
+ * `approveAliasEdge` re-norms and `mergeApprovedEdges` must not; the approval
+ * recomputes the closure per edge and the merge once per position — and the
+ * rules they DO share are exactly the ones a reader would assume had drifted.
  *
- * Called OUTSIDE the lock by both callers, which is not an optimization: a
- * caller refused here has touched no row, so there is nothing for the lock to
- * make atomic.
+ * Lock position differs between the callers, and either is safe.
+ * `approveAliasEdge` screens BEFORE taking the lock; `mergeApprovedEdges` takes
+ * it once for the whole batch before its first insert, so this runs under it.
+ * Neither ordering matters here: a caller refused at this point has touched no
+ * row, so there is nothing for the lock to make atomic.
  *
  * Takes the raw inputs beside the normed ones purely for the MESSAGE — an
  * approver who typed `Priced At` needs to see what they typed, not only what it
@@ -625,17 +627,6 @@ export interface ArrivingAliasEdge extends AliasEdgeInput {
 }
 
 /**
- * ⚠️ {@link ArrivingAliasEdge} is a SUBTYPE of {@link AliasEdgeInput}, which
- * pins the field names together deliberately — but the two have OPPOSITE
- * contracts on one axis, and the inheritance cannot express that.
- * `AliasEdgeInput`'s norms are re-normed before they are written; an arriving
- * edge's are written verbatim (ADR-0037 §8). The barrier on
- * {@link approveAliasEdge}'s parameter is what stops the subtype relation from
- * making the wrong one callable. Branding the norms so "already normed" is a
- * type rather than a comment is the deeper fix and is deliberately not taken
- * here: it needs a mint point in `validateBundle` and is its own slice.
- */
-
 /**
  * One arriving edge the merge would not write, and everything needed to
  * re-author it by hand.
@@ -724,12 +715,18 @@ export interface VocabularyMergeResult {
  *
  * Edges are applied in the order supplied, and that is deterministic in
  * practice: `export.ts` orders them `slot_position, from_norm ASC`. Order still
- * MATTERS, and the honest statement of it is narrow — the arriving set is itself
- * a valid forest, so no two arriving edges can conflict with each other, but a
- * cycle formed jointly with destination edges can be closable by more than one
- * arrival, and which of them is refused depends on which is seen first. Both
- * outcomes leave a forest, both are logged; a hand-built bundle in another order
- * may pick the other edge.
+ * MATTERS. For any bundle this product exported the arriving set is itself a
+ * valid forest, so in practice no two arrivals conflict — but NOTHING UPSTREAM
+ * ENFORCES THAT: `validateBundle` screens each edge independently, with no
+ * duplicate-`fromNorm` and no intra-bundle cycle check, so a hand-built or
+ * corrupted bundle can conflict with itself, and the merge decides those against
+ * rows this same transaction has already written. Group 6 of
+ * `vocabulary-merge-pg.test.ts` pins that arm.
+ *
+ * Separately, a cycle formed jointly with destination edges can be closable by
+ * more than one arrival, and which of them is refused depends on which is seen
+ * first. Both outcomes leave a forest, both are logged; a bundle in another
+ * order may pick the other edge.
  *
  * ## No re-norming, and no version stamp
  *
@@ -804,8 +801,9 @@ export async function mergeApprovedEdges(
       // `ok` is stripped, NOT spread through. `{ edge, ...admission }` compiles
       // — object-literal SPREAD is exempt from excess-property checking, unlike
       // the equivalent inline literal — and pushes a runtime `ok: false` that
-      // `VocabularyMergeRefusal` does not declare. The twin four lines up does
-      // not, because `screenAliasNorms` returns no discriminant, so the two arms
+      // `VocabularyMergeRefusal` does not declare. The twin in the
+      // `screenAliasNorms` branch above does not, because that helper returns no
+      // discriminant — so the two arms
       // of one union would carry structurally different shapes: a `toEqual` or a
       // `JSON.stringify` of the recovery payload sees `ok` on `would-cycle` and
       // not on `self-edge`. Destructuring is what makes the declared type and

--- a/packages/api/src/lib/brain/vocabulary.ts
+++ b/packages/api/src/lib/brain/vocabulary.ts
@@ -389,69 +389,92 @@ export class VocabularyClosureError extends Error {
 }
 
 /**
- * Approve one alias edge, and recompute the position's closure.
+ * The two refusals that need no database — the endpoint norms alone decide them.
  *
- * MUST run inside a transaction — the check-then-insert and the recompute are
- * one atomic decision, and the advisory lock below is a `_xact_` lock that is
- * released at commit. #5023 supplies that transaction from the decide seam.
+ * Split out so {@link mergeApprovedEdges} enforces them from the SAME source
+ * rather than from a second copy. That matters more here than the usual DRY
+ * argument: the import path and the approval path disagree about almost
+ * everything else (one re-norms, the other must not; one recomputes per edge,
+ * the other once per position), and the rules they DO share are exactly the ones
+ * a reader would assume had drifted.
  *
- * ## Four refusals, and none of them is a rewrite
+ * Called OUTSIDE the lock by both callers, which is not an optimization: a
+ * caller refused here has touched no row, so there is nothing for the lock to
+ * make atomic.
  *
- * An approval NEVER retargets a previously approved edge (ADR-0037 §6). There
- * is no upsert here and there must not be one: the whole reversibility argument
- * rests on approved edges being the durable record of what a human decided, and
- * an `ON CONFLICT DO UPDATE` would silently overwrite one decision with another
- * at the exact moment an operator believed they were adding.
- *
- * At-most-one-parent is enforced twice, deliberately. The primary key is what
- * holds under concurrency; the explicit read is what turns "unique violation on
- * brain_vocabulary_edge_pkey" into a typed refusal naming the existing target.
- * Deleting the explicit check does not make the write succeed — it makes it
- * THROW instead of refusing, which is a different observable outcome and is
- * what `vocabulary-pg.test.ts` asserts on.
- *
- * Cycle refusal has no structural twin: a CHECK cannot read other rows, and the
- * `not_self` CHECK covers only length 1. Longer cycles are caught here by
- * walking up from the proposed PARENT and asking whether the chain reaches the
- * proposed CHILD.
+ * Takes the raw inputs beside the normed ones purely for the MESSAGE — an
+ * approver who typed `Priced At` needs to see what they typed, not only what it
+ * normed to. On the import path the two are equal by construction, because
+ * `validateBundle` refuses a non-norm rather than rewriting another region's
+ * decision (ADR-0037 §8).
  */
-export async function approveAliasEdge(
-  tx: VocabularyExecutor,
-  workspaceId: string,
-  input: AliasEdgeInput,
-): Promise<AliasApprovalResult> {
-  const { position } = input;
-  // Re-normed, never trusted. `alias` composes over `lexicalNorm`, and an
-  // approver typing the canonical DISPLAY form (`Priced At`) is the likeliest
-  // authoring mistake once this is a reviewed data table — `slotKey` re-norms
-  // the ANSWER for the same reason, but a stored non-norm would also make the
-  // closure's joins miss, which `slotKey` cannot repair.
-  const fromNorm = lexicalNorm(input.fromNorm);
-  const toNorm = lexicalNorm(input.toNorm);
-
+function screenAliasNorms(
+  rawFrom: string,
+  rawTo: string,
+  fromNorm: string,
+  toNorm: string,
+): { readonly refusal: Exclude<AliasApprovalRefusal, AlreadyAliased>; readonly message: string } | null {
   if (fromNorm === "" || toNorm === "") {
     return {
-      ok: false,
       refusal: "degenerate-norm",
       message:
         `An alias edge needs two non-empty norms; ` +
-        `"${input.fromNorm}" → "${input.toNorm}" normalizes to "${fromNorm}" → "${toNorm}". ` +
+        `"${rawFrom}" → "${rawTo}" normalizes to "${fromNorm}" → "${toNorm}". ` +
         "A surface made only of separators asserts nothing and has no slot to alias.",
     };
   }
 
   if (fromNorm === toNorm) {
     return {
-      ok: false,
       refusal: "self-edge",
       message:
-        `"${input.fromNorm}" and "${input.toNorm}" both normalize to "${fromNorm}", so they ` +
+        `"${rawFrom}" and "${rawTo}" both normalize to "${fromNorm}", so they ` +
         "already share an identity key and there is nothing to alias.",
     };
   }
 
-  await lockWorkspaceVocabulary(tx, workspaceId, "approveAliasEdge");
+  return null;
+}
 
+/**
+ * The outcome of the two refusals that DO need the store — at-most-one-parent,
+ * and the cycle walk.
+ *
+ * `existingTarget` is required on its own arm for the reason
+ * {@link AliasApprovalResult} gives at length: as a shared optional field, every
+ * consumer that narrowed to `already-aliased` still had to reach for `!` or a
+ * `?? "unknown"`, which is the "makes the operator guess" outcome the field
+ * exists to prevent. {@link mergeApprovedEdges} is the consumer that proves the
+ * point — it reads `existingTarget` to tell an idempotent re-import from a
+ * discarded decision, and that read must not be able to compile against
+ * `undefined`.
+ */
+type AliasEdgeAdmission =
+  | { readonly ok: true }
+  | {
+      readonly ok: false;
+      readonly refusal: AlreadyAliased;
+      readonly existingTarget: string;
+      readonly message: string;
+    }
+  | { readonly ok: false; readonly refusal: "would-cycle"; readonly message: string };
+
+/**
+ * Ask the store whether one edge may be written. Writes nothing.
+ *
+ * MUST be called with the workspace vocabulary lock already held — both checks
+ * are the read half of a check-then-write, and {@link lockWorkspaceVocabulary}
+ * is what makes the pair atomic. Not re-taken here: this is a private helper
+ * with two call sites, both of which lock first, and a third acquisition would
+ * imply to a reader that it were safe to call unlocked.
+ */
+async function admitAliasEdge(
+  tx: VocabularyExecutor,
+  workspaceId: string,
+  position: SlotPosition,
+  fromNorm: string,
+  toNorm: string,
+): Promise<AliasEdgeAdmission> {
   const existing = await tx.query(
     `SELECT to_norm FROM brain_vocabulary_edge
       WHERE workspace_id = $1 AND slot_position = $2 AND from_norm = $3`,
@@ -498,6 +521,64 @@ export async function approveAliasEdge(
     };
   }
 
+  return { ok: true };
+}
+
+/**
+ * Approve one alias edge, and recompute the position's closure.
+ *
+ * MUST run inside a transaction — the check-then-insert and the recompute are
+ * one atomic decision, and the advisory lock below is a `_xact_` lock that is
+ * released at commit. #5023 supplies that transaction from the decide seam.
+ *
+ * ## Four refusals, and none of them is a rewrite
+ *
+ * An approval NEVER retargets a previously approved edge (ADR-0037 §6). There
+ * is no upsert here and there must not be one: the whole reversibility argument
+ * rests on approved edges being the durable record of what a human decided, and
+ * an `ON CONFLICT DO UPDATE` would silently overwrite one decision with another
+ * at the exact moment an operator believed they were adding.
+ *
+ * The four live in the two helpers above rather than inline, because since
+ * #5036 the import merge answers to the same four. Which one produces which is
+ * worth keeping straight: {@link screenAliasNorms} decides `degenerate-norm` and
+ * `self-edge` from the norms alone, {@link admitAliasEdge} decides
+ * `already-aliased` and `would-cycle` from the store.
+ *
+ * At-most-one-parent is enforced twice, deliberately. The primary key is what
+ * holds under concurrency; the explicit read is what turns "unique violation on
+ * brain_vocabulary_edge_pkey" into a typed refusal naming the existing target.
+ * Deleting the explicit check does not make the write succeed — it makes it
+ * THROW instead of refusing, which is a different observable outcome and is
+ * what `vocabulary-pg.test.ts` asserts on.
+ *
+ * Cycle refusal has no structural twin: a CHECK cannot read other rows, and the
+ * `not_self` CHECK covers only length 1. Longer cycles are caught by walking up
+ * from the proposed PARENT and asking whether the chain reaches the proposed
+ * CHILD.
+ */
+export async function approveAliasEdge(
+  tx: VocabularyExecutor,
+  workspaceId: string,
+  input: AliasEdgeInput,
+): Promise<AliasApprovalResult> {
+  const { position } = input;
+  // Re-normed, never trusted. `alias` composes over `lexicalNorm`, and an
+  // approver typing the canonical DISPLAY form (`Priced At`) is the likeliest
+  // authoring mistake once this is a reviewed data table — `slotKey` re-norms
+  // the ANSWER for the same reason, but a stored non-norm would also make the
+  // closure's joins miss, which `slotKey` cannot repair.
+  const fromNorm = lexicalNorm(input.fromNorm);
+  const toNorm = lexicalNorm(input.toNorm);
+
+  const screened = screenAliasNorms(input.fromNorm, input.toNorm, fromNorm, toNorm);
+  if (screened !== null) return { ok: false, ...screened };
+
+  await lockWorkspaceVocabulary(tx, workspaceId, "approveAliasEdge");
+
+  const admission = await admitAliasEdge(tx, workspaceId, position, fromNorm, toNorm);
+  if (!admission.ok) return admission;
+
   await tx.query(
     `INSERT INTO brain_vocabulary_edge
        (workspace_id, slot_position, from_norm, to_norm, approved_by)
@@ -508,6 +589,242 @@ export async function approveAliasEdge(
   await recomputeEffectiveTargets(tx, workspaceId, position);
 
   return { ok: true, position, fromNorm, toNorm };
+}
+
+/**
+ * One approved edge arriving from another region, as a row-copy path supplies
+ * it (ADR-0037 §8).
+ *
+ * Extends {@link AliasEdgeInput} rather than restating it, so the merge and the
+ * approval cannot drift about what an edge IS. The single addition is
+ * `approvedAt`: an approval MINTS one (the column defaults to `now()`), while a
+ * row-copy carries the source region's, because the timestamp is part of the
+ * decision being copied and a re-stamp would date every migrated decision to the
+ * migration.
+ */
+export interface ArrivingAliasEdge extends AliasEdgeInput {
+  /** The SOURCE region's approval timestamp, carried verbatim. */
+  readonly approvedAt: string;
+}
+
+/**
+ * One arriving edge the merge would not write, and everything needed to
+ * re-author it by hand.
+ *
+ * The refused edge is a HUMAN's approved decision that this region is dropping,
+ * and #5036 makes the log the entire recovery path — so the payload is the
+ * whole edge, not a norm pair. An operator reading one of these has to be able
+ * to reconstruct the source row without the bundle, which by then may be
+ * deleted (`stays` cleanup, #4458).
+ */
+export type VocabularyMergeRefusal =
+  | {
+      readonly edge: ArrivingAliasEdge;
+      readonly refusal: AlreadyAliased;
+      /** What this region holds for `edge.fromNorm` instead. */
+      readonly existingTarget: string;
+      readonly message: string;
+    }
+  | {
+      readonly edge: ArrivingAliasEdge;
+      readonly refusal: Exclude<AliasApprovalRefusal, AlreadyAliased>;
+      readonly message: string;
+    };
+
+/**
+ * What a merge did, counted so that `applied + duplicate + refusals.length`
+ * equals the number of edges supplied.
+ *
+ * That total is a CONTRACT, not an incidental property: `migrate.ts` reconciles
+ * the target's counters against the manifest count and ABORTS the migration
+ * before cutover when they disagree. Every arriving edge therefore lands in
+ * exactly one of the three.
+ */
+export interface VocabularyMergeResult {
+  /** Edges written — decisions this region did not previously hold. */
+  readonly applied: number;
+  /**
+   * Edges already present with the SAME target. Not a loss and not a refusal:
+   * the destination already holds the decision the source is offering, which is
+   * what an idempotent re-import looks like from the inside.
+   */
+  readonly duplicate: number;
+  readonly refusals: readonly VocabularyMergeRefusal[];
+  /** Positions whose closure was rebuilt — those, and only those, that gained an edge. */
+  readonly positionsRecomputed: readonly SlotPosition[];
+}
+
+/**
+ * Merge another region's approved edges into this one's (#5036, ADR-0037 §8 §4).
+ *
+ * > Union the approved edges; refuse any edge that would close a cycle or
+ * > violate at-most-one-parent; log every refusal; recompute the effective-target
+ * > closure at the destination.
+ *
+ * MUST run inside a transaction, for {@link approveAliasEdge}'s reasons exactly.
+ *
+ * ## Why the importer could not keep using `ON CONFLICT DO NOTHING`
+ *
+ * Every other merge rule in the importer is destination-wins-silently — fact and
+ * episode dedup is an id-skip, `fact_audience_member` is `DO NOTHING` — and for
+ * ordinary workspace data that is right, because the destination's row and the
+ * source's row are the same row. A vocabulary edge is not data; it is a HUMAN
+ * REVIEW DECISION, and two regions can hold contradictory ones legitimately.
+ * Silently keeping the destination's discards the other region's review work
+ * with no record that it existed.
+ *
+ * ## The forest invariant holds per-vocabulary and nothing enforced it across two
+ *
+ * Canonical direction is arbitrary, so a source that curated `price → priced at`
+ * and a destination that curated `priced at → price` are BOTH valid forests
+ * whose union is a 2-cycle. A cyclic store has no effective target, so the
+ * closure rebuild does not terminate meaningfully — `alias` stops being a
+ * function. Refusing the arriving edge is what keeps the destination a forest at
+ * every step; the losing decision survives as a log line rather than as
+ * corruption.
+ *
+ * ## Destination wins, and the alternative is recorded rather than lost
+ *
+ * The refusal always falls on the ARRIVING edge, which is the same asymmetry
+ * `approveAliasEdge` applies to a second approval. The counter-case — queue the
+ * conflict for human review instead — is real and was rejected for one reason:
+ * it blocks a region migration on human attention, which is the one thing a
+ * cutover cannot wait for. Logging is what makes the choice affordable.
+ *
+ * ## Order, and how far determinism goes
+ *
+ * Edges are applied in the order supplied, and that is deterministic in
+ * practice: `export.ts` orders them `slot_position, from_norm ASC`. Order still
+ * MATTERS, and the honest statement of it is narrow — the arriving set is itself
+ * a valid forest, so no two arriving edges can conflict with each other, but a
+ * cycle formed jointly with destination edges can be closable by more than one
+ * arrival, and which of them is refused depends on which is seen first. Both
+ * outcomes leave a forest, both are logged; a hand-built bundle in another order
+ * may pick the other edge.
+ *
+ * ## No re-norming, and no version stamp
+ *
+ * Both norms are written exactly as they arrive. ADR-0037 §8 makes a row-copy
+ * path carry values verbatim, and `validateBundle` refuses a non-norm at the
+ * door rather than rewriting another region's decision — so re-norming here
+ * would be a second, silent canonicalizer over data already proven canonical.
+ *
+ * Nor is anything stamped per row to record which vocabulary an edge came from.
+ * The approved-edge set IS the durable record of every decision and the keys are
+ * re-derivable from it; a per-row version would be a third representation to
+ * keep consistent, and an imported row would carry a FOREIGN version that means
+ * nothing in this region.
+ */
+export async function mergeApprovedEdges(
+  tx: VocabularyExecutor,
+  workspaceId: string,
+  edges: readonly ArrivingAliasEdge[],
+): Promise<VocabularyMergeResult> {
+  // No edges, no lock. Not an optimization — the lock is only meaningful around
+  // a write, and taking it here would make every import of a bundle that
+  // carries no vocabulary serialize against every open approval in the
+  // workspace, for nothing.
+  if (edges.length === 0) {
+    return { applied: 0, duplicate: 0, refusals: [], positionsRecomputed: [] };
+  }
+
+  // ⚠️ TAKEN BEFORE THE FIRST INSERT, AND THE ORDER IS THE POINT.
+  //
+  // `approveAliasEdge` acquires the advisory lock FIRST and then touches rows. A
+  // merge that inserted first and reached the lock only inside
+  // `recomputeEffectiveTargets` would acquire the same two resources in the
+  // opposite order, so two writers sharing a `from_norm` deadlock: the approver
+  // holds the advisory lock and blocks on the merge's uncommitted row, while the
+  // merge blocks on the advisory lock. Postgres resolves it with `40P01`, and
+  // the victim can be the entire region import.
+  //
+  // Recorded at length because the acquisition was REMOVED once, on the
+  // reasoning that `recomputeEffectiveTargets` takes the same lock anyway. That
+  // is wrong in the way lock-ordering arguments usually are: the later lock does
+  // not block in the same PLACE, and the displacement IS the bug. Re-taking it
+  // in `recomputeEffectiveTargets` costs nothing — `pg_advisory_xact_lock` is
+  // re-entrant within a transaction.
+  await lockWorkspaceVocabulary(tx, workspaceId, "mergeApprovedEdges");
+
+  let applied = 0;
+  let duplicate = 0;
+  const refusals: VocabularyMergeRefusal[] = [];
+  const positionsTouched = new Set<SlotPosition>();
+
+  for (const edge of edges) {
+    const { position, fromNorm, toNorm } = edge;
+
+    // Raw and normed are the same value on purpose — see `screenAliasNorms`.
+    const screened = screenAliasNorms(fromNorm, toNorm, fromNorm, toNorm);
+    if (screened !== null) {
+      refusals.push({ edge, ...screened });
+      continue;
+    }
+
+    const admission = await admitAliasEdge(tx, workspaceId, position, fromNorm, toNorm);
+    if (!admission.ok) {
+      // The one case that is not a loss: this region already holds the very
+      // decision the source is offering. `existingTarget` is what tells the two
+      // apart, and it is why that field is REQUIRED on its arm — read through an
+      // optional, a `undefined === toNorm` comparison would be false and every
+      // idempotent re-import would report a discarded human decision.
+      if (admission.refusal === "already-aliased" && admission.existingTarget === toNorm) {
+        duplicate++;
+        continue;
+      }
+      refusals.push({ edge, ...admission });
+      continue;
+    }
+
+    await tx.query(
+      `INSERT INTO brain_vocabulary_edge
+         (workspace_id, slot_position, from_norm, to_norm, approved_by, approved_at)
+       VALUES ($1, $2, $3, $4, $5, $6)`,
+      [workspaceId, position, fromNorm, toNorm, edge.approvedBy, edge.approvedAt],
+    );
+
+    applied++;
+    positionsTouched.add(position);
+  }
+
+  // ONE line per refusal, which is a deliberate exception to the aggregate-then-
+  // warn rule the importer applies to its per-fact identity losses. The two are
+  // different in kind: an identity loss is expected, corpus-sized, and its SIZE
+  // is the signal, so per-row lines train an operator to skim. A refusal is rare
+  // by construction and each one is a distinct human decision this region
+  // dropped — there is no aggregate that would let an operator re-author it, and
+  // re-authoring is the entire remedy. `index`/`total` are carried so a
+  // truncated log still says how much is missing.
+  refusals.forEach((refusal, index) => {
+    log.warn(
+      {
+        workspaceId,
+        position: refusal.edge.position,
+        fromNorm: refusal.edge.fromNorm,
+        toNorm: refusal.edge.toNorm,
+        approvedBy: refusal.edge.approvedBy,
+        approvedAt: refusal.edge.approvedAt,
+        refusal: refusal.refusal,
+        // `null` rather than absent for the arms that have no existing target:
+        // a missing key and a key whose value is "there is no conflicting edge"
+        // read identically in a log aggregator, and only one of them is true.
+        existingTarget: refusal.refusal === "already-aliased" ? refusal.existingTarget : null,
+        index,
+        total: refusals.length,
+        reason: refusal.message,
+      },
+      "Vocabulary merge REFUSED an arriving alias edge — a source region's approved decision was not applied here",
+    );
+  });
+
+  // Only positions that gained an edge. A position whose every arrival was
+  // refused or duplicated has a closure that is already correct, and rebuilding
+  // it would be a no-op that reads as "something changed here".
+  for (const position of positionsTouched) {
+    await recomputeEffectiveTargets(tx, workspaceId, position);
+  }
+
+  return { applied, duplicate, refusals, positionsRecomputed: [...positionsTouched] };
 }
 
 /**

--- a/packages/api/src/lib/residency/__tests__/bundle-scope.test.ts
+++ b/packages/api/src/lib/residency/__tests__/bundle-scope.test.ts
@@ -156,25 +156,49 @@ describe("bundle-scope drift tripwire (#4460)", () => {
    * shared implementation lives in `lib/brain/vocabulary.ts` and the route calls
    * `mergeApprovedEdges`.
    *
-   * The tripwire keeps its full strength either way: it still asks "is this
-   * exported table actually written back somewhere on the import path", and
-   * deleting that INSERT still fails here. What it stops asserting is the
-   * incidental part — which FILE the statement happens to sit in.
+   * ⚠️ A DELEGATED WRITER NAMES ITS FUNCTION, and the scoping is load-bearing
+   * rather than tidiness. `vocabulary.ts` contains TWO
+   * `INSERT INTO brain_vocabulary_edge` statements — `approveAliasEdge`'s and
+   * `mergeApprovedEdges`' — so a whole-file search stays true after the IMPORT
+   * path's write is deleted outright, which is precisely the drift this arm
+   * exists to catch. The single-file form never had that problem, because
+   * `admin-migrate.ts` held exactly one. Searching only the delegated function's
+   * own body restores the original strength.
    */
-  const IMPORT_WRITER_FILE: Readonly<Record<string, readonly string[]>> = {
-    brain_vocabulary_edge: ["..", "..", "brain", "vocabulary.ts"],
+  const IMPORT_WRITER: Readonly<
+    Partial<Record<string, { readonly path: readonly string[]; readonly symbol: string }>>
+  > = {
+    brain_vocabulary_edge: {
+      path: ["..", "..", "brain", "vocabulary.ts"],
+      symbol: "export async function mergeApprovedEdges",
+    },
   };
   const DEFAULT_IMPORT_WRITER = ["..", "..", "..", "api", "routes", "admin-migrate.ts"] as const;
 
+  /**
+   * The source of the declaration `symbol` opens, up to the next top-level
+   * declaration. Deliberately crude — it only has to be tight enough that a
+   * sibling function's statement cannot satisfy the search.
+   */
+  const declarationBody = (source: string, symbol: string): string => {
+    const start = source.indexOf(symbol);
+    expect(start, `delegated writer '${symbol}' no longer exists`).toBeGreaterThanOrEqual(0);
+    const rest = source.slice(start + symbol.length);
+    const end = rest.search(/\nexport (?:async function|function|const|interface|type|class) /);
+    return end === -1 ? rest : rest.slice(0, end);
+  };
+
   it("every exported table is actually written by the import implementation", () => {
     for (const table of EXPORTED_TABLES) {
-      const relative = IMPORT_WRITER_FILE[table] ?? DEFAULT_IMPORT_WRITER;
-      const writerPath = join(import.meta.dir, ...relative);
-      const importSource = readFileSync(writerPath, "utf8");
+      const delegated = IMPORT_WRITER[table];
+      const relative = delegated?.path ?? DEFAULT_IMPORT_WRITER;
+      const source = readFileSync(join(import.meta.dir, ...relative), "utf8");
       const writer = relative[relative.length - 1];
+      const haystack = delegated ? declarationBody(source, delegated.symbol) : source;
+      const where = delegated ? `${writer}'s ${delegated.symbol.split(" ").pop()}` : writer;
       expect(
-        importSource.includes(`INSERT INTO ${table}`),
-        `bundle-scope.ts says '${table}' is exported, but ${writer} has no ` +
+        haystack.includes(`INSERT INTO ${table}`),
+        `bundle-scope.ts says '${table}' is exported, but ${where} has no ` +
           `'INSERT INTO ${table}' — the bundle would be produced but never restored.`,
       ).toBe(true);
     }
@@ -189,7 +213,7 @@ describe("bundle-scope drift tripwire (#4460)", () => {
     // single-file assertion was strong against, handed back the moment the
     // indirection was allowed.
     const routeSource = readFileSync(join(import.meta.dir, ...DEFAULT_IMPORT_WRITER), "utf8");
-    expect(Object.keys(IMPORT_WRITER_FILE)).toEqual(["brain_vocabulary_edge"]);
+    expect(Object.keys(IMPORT_WRITER)).toEqual(["brain_vocabulary_edge"]);
     expect(routeSource).toContain("mergeApprovedEdges(");
   });
 

--- a/packages/api/src/lib/residency/__tests__/bundle-scope.test.ts
+++ b/packages/api/src/lib/residency/__tests__/bundle-scope.test.ts
@@ -141,18 +141,56 @@ describe("bundle-scope drift tripwire (#4460)", () => {
     }
   });
 
+  /**
+   * Where each exported table's RESTORING statement lives.
+   *
+   * `admin-migrate.ts` for everything by default — it is the import path, and
+   * for an ordinary section the INSERT is spelled there inline.
+   *
+   * ⚠️ `brain_vocabulary_edge` is the one delegation, and it is a delegation
+   * rather than a loophole (#5036). Restoring an alias edge is a MERGE, not an
+   * insert: the arriving edge has to be screened against this region's own
+   * approved edges for at-most-one-parent and for cycles, which are the exact
+   * four rules `approveAliasEdge` applies. Spelled a second time in the route
+   * they would drift, and `lib/` must not import from `api/routes/` — so the
+   * shared implementation lives in `lib/brain/vocabulary.ts` and the route calls
+   * `mergeApprovedEdges`.
+   *
+   * The tripwire keeps its full strength either way: it still asks "is this
+   * exported table actually written back somewhere on the import path", and
+   * deleting that INSERT still fails here. What it stops asserting is the
+   * incidental part — which FILE the statement happens to sit in.
+   */
+  const IMPORT_WRITER_FILE: Readonly<Record<string, readonly string[]>> = {
+    brain_vocabulary_edge: ["..", "..", "brain", "vocabulary.ts"],
+  };
+  const DEFAULT_IMPORT_WRITER = ["..", "..", "..", "api", "routes", "admin-migrate.ts"] as const;
+
   it("every exported table is actually written by the import implementation", () => {
-    const importSource = readFileSync(
-      join(import.meta.dir, "..", "..", "..", "api", "routes", "admin-migrate.ts"),
-      "utf8",
-    );
     for (const table of EXPORTED_TABLES) {
+      const relative = IMPORT_WRITER_FILE[table] ?? DEFAULT_IMPORT_WRITER;
+      const writerPath = join(import.meta.dir, ...relative);
+      const importSource = readFileSync(writerPath, "utf8");
+      const writer = relative[relative.length - 1];
       expect(
         importSource.includes(`INSERT INTO ${table}`),
-        `bundle-scope.ts says '${table}' is exported, but admin-migrate.ts has no ` +
+        `bundle-scope.ts says '${table}' is exported, but ${writer} has no ` +
           `'INSERT INTO ${table}' — the bundle would be produced but never restored.`,
       ).toBe(true);
     }
+  });
+
+  it("the import path still REACHES every delegated writer", () => {
+    // The half the lookup above cannot check on its own. Pointing the tripwire
+    // at another file proves a statement exists there; it does not prove the
+    // route still calls it. Without this, deleting the `mergeApprovedEdges` call
+    // from `admin-migrate.ts` would leave the vocabulary silently unrestored
+    // with every drift test green — which is precisely the failure the original
+    // single-file assertion was strong against, handed back the moment the
+    // indirection was allowed.
+    const routeSource = readFileSync(join(import.meta.dir, ...DEFAULT_IMPORT_WRITER), "utf8");
+    expect(Object.keys(IMPORT_WRITER_FILE)).toEqual(["brain_vocabulary_edge"]);
+    expect(routeSource).toContain("mergeApprovedEdges(");
   });
 
   it("org-scoped tables classified 'platform' stay a pinned, deliberate exemption set", () => {

--- a/packages/api/src/lib/residency/__tests__/bundle-scope.test.ts
+++ b/packages/api/src/lib/residency/__tests__/bundle-scope.test.ts
@@ -177,16 +177,66 @@ describe("bundle-scope drift tripwire (#4460)", () => {
 
   /**
    * The source of the declaration `symbol` opens, up to the next top-level
-   * declaration. Deliberately crude — it only has to be tight enough that a
-   * sibling function's statement cannot satisfy the search.
+   * declaration, with COMMENTS STRIPPED.
+   *
+   * ⚠️ Both halves are load-bearing and the first cut of this helper had neither.
+   *
+   * Comments, because the terminator matches a DECLARATION line and every
+   * declaration in this repo is preceded by a docblock — so the slice ran to the
+   * end of the NEXT function's documentation. Measured: `mergeApprovedEdges`'
+   * slice was 9,278 bytes and its tail was the whole of `removeAliasEdge`'s
+   * 40-line docblock. In a codebase whose docblocks routinely quote SQL, a
+   * tripwire that a COMMENT can satisfy is not a tripwire: deleting the real
+   * INSERT and mentioning the statement in nearby prose left this suite green.
+   *
+   * The wider terminator, because `export enum` / `export default` /
+   * `export abstract class` / `export function*` were all unmatched — and an
+   * unmatched terminator runs the slice to EOF, re-admitting `approveAliasEdge`'s
+   * INSERT and reopening the exact hole. That would be reintroduced by nothing
+   * more than reordering the file.
    */
+  const stripComments = (source: string): string =>
+    source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/^\s*\/\/.*$/gm, "");
+
   const declarationBody = (source: string, symbol: string): string => {
-    const start = source.indexOf(symbol);
+    const src = stripComments(source);
+    const start = src.indexOf(symbol);
     expect(start, `delegated writer '${symbol}' no longer exists`).toBeGreaterThanOrEqual(0);
-    const rest = source.slice(start + symbol.length);
-    const end = rest.search(/\nexport (?:async function|function|const|interface|type|class) /);
+    const rest = src.slice(start + symbol.length);
+    const end = rest.search(
+      /\nexport (?:default |declare |abstract )?(?:async function|function\*?|const|interface|type|class|enum) /,
+    );
     return end === -1 ? rest : rest.slice(0, end);
   };
+
+  it("declarationBody isolates the delegated writer — the tripwire's own falsifier", () => {
+    // ⚠️ `declarationBody` is machinery INSIDE a guard, so it needs its own
+    // guard: a slicer that quietly returned the whole file would make the arm
+    // below pass for every possible edit, which is worse than no arm at all.
+    // Both assertions were RED against this helper's first cut.
+    const vocabularySource = readFileSync(
+      join(import.meta.dir, "..", "..", "brain", "vocabulary.ts"),
+      "utf8",
+    );
+    const mergeBody = declarationBody(vocabularySource, "export async function mergeApprovedEdges");
+
+    // It stops before the neighbours in both directions — `approveAliasEdge`
+    // above it holds the OTHER `INSERT INTO brain_vocabulary_edge`, which is the
+    // statement that made a whole-file search useless.
+    expect(mergeBody).not.toContain("export async function approveAliasEdge");
+    expect(mergeBody).not.toContain("export async function removeAliasEdge");
+
+    // And a COMMENT cannot satisfy it. `removeAliasEdge`'s docblock follows the
+    // merge in the file, so an un-stripped slice swept it up — and any docblock
+    // quoting the statement would then stand in for the code.
+    const withPretendComment = declarationBody(
+      `export async function mergeApprovedEdges() { return 1; }\n` +
+        `/** INSERT INTO brain_vocabulary_edge — prose, not code */\n` +
+        `export async function next() {}\n`,
+      "export async function mergeApprovedEdges",
+    );
+    expect(withPretendComment).not.toContain("INSERT INTO brain_vocabulary_edge");
+  });
 
   it("every exported table is actually written by the import implementation", () => {
     for (const table of EXPORTED_TABLES) {

--- a/packages/api/src/lib/residency/__tests__/bundle-scope.test.ts
+++ b/packages/api/src/lib/residency/__tests__/bundle-scope.test.ts
@@ -183,17 +183,23 @@ describe("bundle-scope drift tripwire (#4460)", () => {
    *
    * Comments, because the terminator matches a DECLARATION line and every
    * declaration in this repo is preceded by a docblock — so the slice ran to the
-   * end of the NEXT function's documentation. Measured: `mergeApprovedEdges`'
-   * slice was 9,278 bytes and its tail was the whole of `removeAliasEdge`'s
-   * 40-line docblock. In a codebase whose docblocks routinely quote SQL, a
-   * tripwire that a COMMENT can satisfy is not a tripwire: deleting the real
-   * INSERT and mentioning the statement in nearby prose left this suite green.
+   * end of the NEXT function's documentation, roughly 10 KB whose tail was the
+   * whole of `removeAliasEdge`'s docblock. Nothing in that tail quotes the
+   * statement TODAY; the hazard is that in a codebase whose docblocks routinely
+   * quote SQL, a tripwire a COMMENT can satisfy is not a tripwire. Delete the
+   * real INSERT, mention it in the next function's prose, and the suite goes
+   * green. The falsifier below pins that directly rather than resting on a
+   * measurement that drifts with every comment edit in `vocabulary.ts`.
    *
    * The wider terminator, because `export enum` / `export default` /
    * `export abstract class` / `export function*` were all unmatched — and an
-   * unmatched terminator runs the slice to EOF, re-admitting `approveAliasEdge`'s
-   * INSERT and reopening the exact hole. That would be reintroduced by nothing
-   * more than reordering the file.
+   * unmatched terminator runs the slice to EOF, so everything BELOW
+   * `mergeApprovedEdges` counts as its body. No statement down there satisfies
+   * the tripwire today, which is exactly why that failure would be silent: the
+   * first `INSERT INTO brain_vocabulary_edge` added below this function would
+   * stand in for the merge's own. (`approveAliasEdge`'s INSERT sits ABOVE the
+   * start point and is structurally out of reach either way — the slice only
+   * extends forward.)
    */
   const stripComments = (source: string): string =>
     source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/^\s*\/\/.*$/gm, "");
@@ -213,18 +219,23 @@ describe("bundle-scope drift tripwire (#4460)", () => {
     // ⚠️ `declarationBody` is machinery INSIDE a guard, so it needs its own
     // guard: a slicer that quietly returned the whole file would make the arm
     // below pass for every possible edit, which is worse than no arm at all.
-    // Both assertions were RED against this helper's first cut.
+    // The `removeAliasEdge` bound and the comment-stripping case were both RED
+    // against this helper's first cut.
     const vocabularySource = readFileSync(
       join(import.meta.dir, "..", "..", "brain", "vocabulary.ts"),
       "utf8",
     );
     const mergeBody = declarationBody(vocabularySource, "export async function mergeApprovedEdges");
 
-    // It stops before the neighbours in both directions — `approveAliasEdge`
-    // above it holds the OTHER `INSERT INTO brain_vocabulary_edge`, which is the
-    // statement that made a whole-file search useless.
-    expect(mergeBody).not.toContain("export async function approveAliasEdge");
+    // It stops before the neighbour BELOW it. `removeAliasEdge` is the one whose
+    // docblock the un-stripped slice swept up, so that bound is the assertion
+    // that was actually red.
     expect(mergeBody).not.toContain("export async function removeAliasEdge");
+    // `approveAliasEdge` holds the OTHER `INSERT INTO brain_vocabulary_edge` and
+    // sits ABOVE the start point, so it can never appear in a forward-only
+    // slice. Kept as a readability marker naming the statement this arm exists
+    // to exclude — NOT a falsifier: it is vacuously true for any implementation.
+    expect(mergeBody).not.toContain("export async function approveAliasEdge");
 
     // And a COMMENT cannot satisfy it. `removeAliasEdge`'s docblock follows the
     // merge in the file, so an un-stripped slice swept it up — and any docblock

--- a/packages/api/src/lib/residency/__tests__/migrate-roundtrip-pg.test.ts
+++ b/packages/api/src/lib/residency/__tests__/migrate-roundtrip-pg.test.ts
@@ -1116,9 +1116,9 @@ describeIfPg("region-migration bundle round-trip (real Postgres, #4460)", () => 
         [FACT_ID, REFUSED_ORG],
       );
       expect(keyed.rows).toHaveLength(1);
-      // `cost`, not `priced at` and not the bare norm `price`. Each of those
-      // three is a different bug: `priced at` means the refusal did not hold,
-      // `price` means the keying ran against no vocabulary at all.
+      // `cost` — and each of the two alternatives would be a different bug:
+      // `priced at` means the refusal did not hold, `price` means the keying ran
+      // against no vocabulary at all.
       expect(keyed.rows[0].predicate_key).toBe("cost");
 
       // The destination's edge is untouched and still the only one.
@@ -1386,10 +1386,12 @@ describeIfPg("region-migration bundle round-trip (real Postgres, #4460)", () => 
       // logs enough of the source row to re-author it, and lets everything else
       // land.
       //
-      // THREE nodes, for `vocabulary-pg.test.ts`'s reason: at an even
-      // MAX_CHAIN_DEPTH a 2-cycle lands every norm back on itself and dies on
-      // `ck_..._not_self` rather than in the cycle walk, so a two-node fixture
-      // would not exercise the guard this test is named for.
+      // THREE nodes, kept from the pre-#5036 version of this test where a
+      // 2-cycle died on `ck_brain_vocabulary_target_not_self` during the closure
+      // REBUILD rather than in the cycle walk. That no longer applies — the
+      // merge refuses before it writes, so the rebuild never runs and a two-node
+      // fixture now takes the same path. Three still buy the stronger claim:
+      // that the walk COMPOSES a chain rather than comparing endpoints.
       const CYCLE_ORG = "org-migrate-vocab-cycle";
       await pool.query(
         `INSERT INTO brain_vocabulary_edge (workspace_id, slot_position, from_norm, to_norm, approved_by)

--- a/packages/api/src/lib/residency/__tests__/migrate-roundtrip-pg.test.ts
+++ b/packages/api/src/lib/residency/__tests__/migrate-roundtrip-pg.test.ts
@@ -996,6 +996,142 @@ describeIfPg("region-migration bundle round-trip (real Postgres, #4460)", () => 
   );
 
   it(
+    "keys a legacy corpus against the DESTINATION's decision when the source's edge is refused (#5036)",
+    async () => {
+      // The arm #5036 newly makes reachable, and the one place its two halves
+      // meet. Before this slice the same input either aborted the whole import
+      // (a cycle) or was a documented silent skip; now it COMMITS, and the
+      // consequence lands on facts rather than on edges.
+      //
+      // Source curated `price → priced at`; this region had already curated
+      // `price → cost`. The arriving edge takes a second parent, so it is
+      // refused — and the legacy bundle's facts are then keyed, in the same
+      // transaction, through the vocabulary that survived the merge. So the
+      // imported claim keys onto THIS region's canonical predicate, not the
+      // source's, which is exactly the accepted cost of destination-wins and is
+      // worth pinning so a future reader sees it was decided rather than missed.
+      const REFUSED_ORG = "org-migrate-legacy-refused";
+      const EPISODE_ID = "bbbbbbbb-5036-4000-8000-000000000001";
+      const FACT_ID = "bbbbbbbb-5036-4000-8000-000000000002";
+
+      const seedClient = await pool.connect();
+      try {
+        await seedClient.query("BEGIN");
+        expect(
+          (
+            await approveAliasEdge(seedClient, REFUSED_ORG, {
+              position: "predicate",
+              fromNorm: "price",
+              toNorm: "cost",
+              approvedBy: "target-admin",
+            })
+          ).ok,
+        ).toBe(true);
+        await seedClient.query("COMMIT");
+      } finally {
+        seedClient.release();
+      }
+
+      const legacy = {
+        manifest: {
+          version: 2 as const,
+          exportedAt: "2026-06-01T00:00:00Z",
+          source: { label: "legacy-refused-test" },
+          counts: {
+            conversations: 0, messages: 0, semanticEntities: 0,
+            learnedPatterns: 0, settings: 0,
+            brainEpisodes: 1, brainFacts: 1, brainVocabularyEdges: 1,
+          },
+        },
+        conversations: [],
+        semanticEntities: [],
+        learnedPatterns: [],
+        settings: [],
+        brainEpisodes: [
+          {
+            id: EPISODE_ID,
+            source: "slack",
+            sourceId: "C-refused/1700000000.1",
+            sourceActor: "U-alice",
+            body: "Price is $49/seat.",
+            locator: null,
+            occurredAt: "2026-06-01T00:00:00Z",
+            ingestedAt: "2026-06-01T00:00:00Z",
+            extractedAt: "2026-06-01T00:05:00Z",
+            visibleTo: ["org"],
+            createdAt: "2026-06-01T00:00:00Z",
+            facts: [
+              {
+                id: FACT_ID,
+                subject: "acme pro",
+                // Norms to `price` — the very norm both regions curated, in
+                // opposite directions.
+                predicate: "Price",
+                object: "49",
+                validFrom: "2026-06-01T00:00:00Z",
+                validTo: null,
+                ingestedAt: "2026-06-01T00:05:00Z",
+                invalidatedAt: null,
+                extractedAt: "2026-06-01T00:05:00Z",
+                provenance: { actor: "U-alice", episode: "C-refused/1700000000.1" },
+                status: "published" as const,
+                visibleTo: ["org"],
+                preWideningVisibleTo: null,
+                predicateCardinality: "single" as const,
+                createdAt: "2026-06-01T00:05:00Z",
+                updatedAt: "2026-06-01T00:05:00Z",
+              },
+            ],
+          },
+        ],
+        brainVocabularyEdges: [
+          {
+            slotPosition: "predicate" as const,
+            fromNorm: "price",
+            toNorm: "priced at",
+            approvedBy: "source-admin",
+            approvedAt: "2026-06-01T00:00:00Z",
+          },
+        ],
+      };
+
+      const client = await pool.connect();
+      try {
+        await client.query("BEGIN");
+        const result = await importBundle(
+          client,
+          legacy as unknown as Parameters<typeof importBundle>[1],
+          REFUSED_ORG,
+        );
+        await client.query("COMMIT");
+        // The import COMMITS — one refusal, and the fact still lands.
+        expect(result.brainVocabularyEdges).toEqual({ imported: 0, skipped: 0, refused: 1 });
+        expect(result.brainFacts).toEqual({ imported: 1, skipped: 0 });
+      } finally {
+        client.release();
+      }
+
+      const keyed = await pool.query<{ predicate_key: string | null }>(
+        `SELECT predicate_key FROM brain_facts WHERE id = $1 AND workspace_id = $2`,
+        [FACT_ID, REFUSED_ORG],
+      );
+      expect(keyed.rows).toHaveLength(1);
+      // `cost`, not `priced at` and not the bare norm `price`. Each of those
+      // three is a different bug: `priced at` means the refusal did not hold,
+      // `price` means the keying ran against no vocabulary at all.
+      expect(keyed.rows[0].predicate_key).toBe("cost");
+
+      // The destination's edge is untouched and still the only one.
+      const edges = await pool.query<{ from_norm: string; to_norm: string }>(
+        `SELECT from_norm, to_norm FROM brain_vocabulary_edge WHERE workspace_id = $1`,
+        [REFUSED_ORG],
+      );
+      expect(edges.rows).toEqual([{ from_norm: "price", to_norm: "cost" }]);
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+
+  it(
     "positive control: this region's OWN writer does fill both _cmp columns (#5035)",
     async () => {
       // Without this, every `toBeNull()` above is satisfied by a build in which

--- a/packages/api/src/lib/residency/__tests__/migrate-roundtrip-pg.test.ts
+++ b/packages/api/src/lib/residency/__tests__/migrate-roundtrip-pg.test.ts
@@ -385,7 +385,7 @@ describeIfPg("region-migration bundle round-trip (real Postgres, #4460)", () => 
       expect(result.brainFacts).toEqual({ imported: 3, skipped: 0 });
       expect(result.brainEdges).toEqual({ imported: 2, skipped: 0 });
       expect(result.factAudienceMembers).toEqual({ imported: 1, skipped: 0 });
-      expect(result.brainVocabularyEdges).toEqual({ imported: 2, skipped: 0 });
+      expect(result.brainVocabularyEdges).toEqual({ imported: 2, skipped: 0, refused: 0 });
 
       // The vocabulary's closure is REBUILT in the target, not carried. Nothing
       // in the bundle says `is priced at` resolves to `unit price` — the export
@@ -733,10 +733,15 @@ describeIfPg("region-migration bundle round-trip (real Postgres, #4460)", () => 
         brainFacts: { imported: 0, skipped: 3 },
         brainEdges: { imported: 0, skipped: 2 },
         factAudienceMembers: { imported: 0, skipped: 1 },
-        // Skipped on the at-most-one-parent key. A re-import must never apply
-        // an arriving edge over a target-region decision — that is the rewrite
-        // ADR-0037 §6 forbids, reached through the import door.
-        brainVocabularyEdges: { imported: 0, skipped: 2 },
+        // ⚠️ `skipped`, NOT `refused`, and the distinction is the whole of
+        // #5036. Both edges are already approved here onto the SAME target —
+        // they are this region's own rows, arriving back — so nothing is lost
+        // and nothing is logged. `refused: 0` is the load-bearing half of this
+        // assertion: it says an idempotent re-import reports NO discarded human
+        // decision, which is what an operator reads the counter to find out.
+        // A merge that counted every conflict as a refusal would report two
+        // dropped approvals on the most routine path there is.
+        brainVocabularyEdges: { imported: 0, skipped: 2, refused: 0 },
       });
 
       // ── Catch-up import: an episode the target already has, carrying a
@@ -939,7 +944,7 @@ describeIfPg("region-migration bundle round-trip (real Postgres, #4460)", () => 
         );
         await client.query("COMMIT");
         expect(result.brainFacts).toEqual({ imported: 1, skipped: 0 });
-        expect(result.brainVocabularyEdges).toEqual({ imported: 2, skipped: 0 });
+        expect(result.brainVocabularyEdges).toEqual({ imported: 2, skipped: 0, refused: 0 });
       } finally {
         client.release();
       }
@@ -1112,7 +1117,7 @@ describeIfPg("region-migration bundle round-trip (real Postgres, #4460)", () => 
 
         await holder.query("COMMIT");
         const result = await blocked;
-        expect(result.brainVocabularyEdges).toEqual({ imported: 1, skipped: 0 });
+        expect(result.brainVocabularyEdges).toEqual({ imported: 1, skipped: 0, refused: 0 });
         await importer.query("COMMIT");
       } catch (err) {
         // intentionally ignored: the assertion failure below is the real
@@ -1228,23 +1233,27 @@ describeIfPg("region-migration bundle round-trip (real Postgres, #4460)", () => 
   );
 
   it(
-    "aborts the import when an arriving alias edge would close a cycle with the target's own (#5022)",
+    "REFUSES only the arriving alias edge that would close a cycle, and imports the rest (#5036)",
     async () => {
-      // The importer's documented residual #2, which was documented and never
-      // tested. `ON CONFLICT DO NOTHING` deduplicates on the at-most-one-parent
-      // key and does NOT look for cycles, so an arriving edge can close one
-      // against a decision the destination region already holds.
+      // The importer's residual #2, inverted by #5036. Until this slice the
+      // block was `ON CONFLICT DO NOTHING`: it deduplicated on the
+      // at-most-one-parent key and did not look for cycles at all, so an
+      // arriving edge could close one against a decision the destination region
+      // already held — and the closure rebuild then aborted the ENTIRE import
+      // transaction. That was "loud and recoverable beats silent and not", and
+      // it was the right call while the merge did not exist.
       //
-      // The claim under test is "loud and recoverable beats silent and not":
-      // the closure rebuild refuses, and because the whole import is one
-      // transaction NOTHING lands — not the edge, and not the pillars imported
-      // before it. Refusing the single offending edge instead is #5036's merge
-      // semantics, deliberately not implemented here.
+      // It is the wrong outcome now, and the reason is the failure MODE rather
+      // than the noise: a cross-region cutover is not a retryable unit of work
+      // an operator can fix and re-run cheaply, and the edge that killed it is
+      // one alias out of a whole workspace. The merge refuses the single edge,
+      // logs enough of the source row to re-author it, and lets everything else
+      // land.
       //
       // THREE nodes, for `vocabulary-pg.test.ts`'s reason: at an even
       // MAX_CHAIN_DEPTH a 2-cycle lands every norm back on itself and dies on
-      // `ck_..._not_self` instead of the convergence check. Both abort, but only
-      // one exercises the guard this test is named for.
+      // `ck_..._not_self` rather than in the cycle walk, so a two-node fixture
+      // would not exercise the guard this test is named for.
       const CYCLE_ORG = "org-migrate-vocab-cycle";
       await pool.query(
         `INSERT INTO brain_vocabulary_edge (workspace_id, slot_position, from_norm, to_norm, approved_by)
@@ -1261,24 +1270,52 @@ describeIfPg("region-migration bundle round-trip (real Postgres, #4460)", () => 
         seedClient.release();
       }
 
+      // `c → a` closes the cycle; `d → a` beside it does not, and is what proves
+      // the refusal is scoped to the offending edge rather than to the section.
       const cyclic = vocabularyOnlyBundle("c", "a");
+      cyclic.brainVocabularyEdges.push({
+        slotPosition: "predicate" as const,
+        fromNorm: "d",
+        toNorm: "a",
+        approvedBy: "source-admin",
+        approvedAt: "2026-06-01T00:00:00Z",
+      });
 
       const client = await pool.connect();
+      let result: Awaited<ReturnType<typeof importBundle>>;
       try {
         await client.query("BEGIN");
-        await expect(importBundle(client, cyclic, CYCLE_ORG)).rejects.toThrow(/did not converge/);
-        await client.query("ROLLBACK");
+        // No longer throws. The import COMMITS.
+        result = await importBundle(client, cyclic, CYCLE_ORG);
+        await client.query("COMMIT");
+      } catch (err) {
+        await client.query("ROLLBACK").catch((rollbackErr: unknown) => {
+          // intentionally logged rather than rethrown: the original error is the
+          // real outcome, and a rollback failure on a dead connection would mask it
+          console.debug(
+            "rollback after a failed import:",
+            rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr),
+          );
+        });
+        throw err;
       } finally {
         client.release();
       }
 
-      // The target's own vocabulary is exactly as it was — the arriving edge is
-      // absent and the closure still resolves to the root it always did.
+      // One applied, one refused, nothing duplicated — three distinct values, so
+      // a merge that mixed two counters up cannot satisfy this.
+      expect(result.brainVocabularyEdges).toEqual({ imported: 1, skipped: 0, refused: 1 });
+
+      // The target keeps its own two decisions, GAINS the non-cycling arrival,
+      // and never receives `c → a`.
       const edges = await pool.query<{ from_norm: string }>(
         `SELECT from_norm FROM brain_vocabulary_edge WHERE workspace_id = $1 ORDER BY from_norm`,
         [CYCLE_ORG],
       );
-      expect(edges.rows.map((r) => r.from_norm)).toEqual(["a", "b"]);
+      expect(edges.rows.map((r) => r.from_norm)).toEqual(["a", "b", "d"]);
+
+      // The closure is recomputed over the union: `d` joins the chain and lands
+      // on the same root, and `c` is still nobody's child.
       const closure = await pool.query<{ norm: string; effective_target: string }>(
         `SELECT norm, effective_target FROM brain_vocabulary_target
           WHERE workspace_id = $1 ORDER BY norm`,
@@ -1287,6 +1324,7 @@ describeIfPg("region-migration bundle round-trip (real Postgres, #4460)", () => 
       expect(closure.rows).toEqual([
         { norm: "a", effective_target: "c" },
         { norm: "b", effective_target: "c" },
+        { norm: "d", effective_target: "c" },
       ]);
     },
     PG_TEST_TIMEOUT_MS,

--- a/packages/api/src/lib/residency/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/residency/__tests__/migrate.test.ts
@@ -33,6 +33,17 @@ void mock.module("@atlas/api/lib/db/internal", () => ({
           sql.includes("FROM settings")) {
         return Promise.resolve({ rows: [] });
       }
+      // ⚠️ THREE rows for the vocabulary, where every other section gets one.
+      // Systemic accidental equality otherwise: with every manifest count equal
+      // to 1, a section's `refused`, its `imported`, its `expected` and every
+      // OTHER section's count are all the literal 1, so an assertion pinning one
+      // of them pins all of them. Measured — rewriting the refusal disclosure's
+      // payload from `refused` to the section TOTAL passed the whole suite,
+      // which is precisely the count the disclosure exists to carry. Three makes
+      // the numbers separable: expected 3 = imported 2 + refused 1.
+      if (sql.includes("FROM brain_vocabulary_edge")) {
+        return Promise.resolve({ rows: [{ id: "e1" }, { id: "e2" }, { id: "e3" }] });
+      }
       return Promise.resolve(mockPoolQueryResult);
     },
     end: async () => {},
@@ -268,6 +279,15 @@ describe("executeRegionMigration", () => {
     // whole region — a co-tenant on this process keeps its warm entries.
     expect(mockFlushCacheByOrg).toHaveBeenCalledWith("org-1");
     expect(mockFlushCache).not.toHaveBeenCalled();
+
+    // ⚠️ THE NEGATIVE CONTROL for #5036's refusal disclosure, and it is the arm
+    // that had none: dropping `&& refused > 0` from its guard was green. Every
+    // clean migration would then announce that approved human review decisions
+    // were not applied, with `refused: 0` — alarm fatigue that destroys the
+    // value of the one line an operator has to act on within the grace period.
+    expect(
+      capturedWarns.filter((w) => w.message.includes("REFUSED curated alias edges")),
+    ).toEqual([]);
   });
 
   it("includes internal token in transfer request", async () => {
@@ -402,9 +422,13 @@ describe("executeRegionMigration", () => {
     reshapeAck = (ack) => {
       const vocabulary = ack.brainVocabularyEdges;
       vocabularyExpected = vocabulary?.imported ?? 0;
-      // Every arriving edge refused, none imported — the extreme of the case,
-      // and the shape under which an excluded `refused` reads as 0/n.
-      if (vocabulary) ack.brainVocabularyEdges = { imported: 0, skipped: 0, refused: vocabularyExpected };
+      // ⚠️ A MIXED answer, not the all-refused extreme, and the three numbers are
+      // deliberately DISTINCT: expected 3 = imported 2 + refused 1. All-refused
+      // made `refused` equal to the section total, so an implementation that
+      // reported the total instead of the refusal count satisfied every
+      // assertion here — measured, and it survived. Mixed also keeps the
+      // `imported` term live for the one section that has three counters.
+      if (vocabulary) ack.brainVocabularyEdges = { imported: 2, skipped: 0, refused: 1 };
       // ⚠️ A SECOND section answering entirely in `skipped`, because otherwise
       // the `skipped` TERM of the sum is dead in every fixture in this file —
       // the generator, the explicit body above, and this hook all set
@@ -422,7 +446,10 @@ describe("executeRegionMigration", () => {
     // ⚠️ Guards the test against becoming vacuous: reconciliation `continue`s on
     // a section whose manifest count is 0, so a fixture that stopped exporting
     // any vocabulary edge would make this pass while testing nothing.
-    expect(vocabularyExpected).toBeGreaterThan(0);
+    // Exactly 3, not merely nonzero: the split above is only meaningful if the
+    // section really carries three rows, and a fixture change that collapsed it
+    // back to 1 would silently restore the accidental equality.
+    expect(vocabularyExpected).toBe(3);
     expect(dashboardsExpected).toBeGreaterThan(0);
     expect(result.success).toBe(true);
 
@@ -442,14 +469,59 @@ describe("executeRegionMigration", () => {
     // stays green — measured, which is why the assertion exists.
     const disclosure = capturedWarns.find((w) => w.message.includes("REFUSED curated alias edges"));
     expect(disclosure).toBeDefined();
+    // `1`, which is NOT the section total (3) and NOT the imported count (2) —
+    // the whole point of the mixed fixture above.
     expect(disclosure?.payload).toMatchObject({
       migrationId: "mig-1",
       section: "brainVocabularyEdges",
-      refused: vocabularyExpected,
+      refused: 1,
     });
     // Names the delete timer, because that is what makes it urgent rather than
     // merely informational.
     expect(disclosure?.message).toContain("grace period");
+  });
+
+  it("ABORTS on a NEGATIVE counter, which would otherwise mask an over-import (#5036)", async () => {
+    // The fail-OPEN direction, and the one an arithmetic guard cannot see on its
+    // own. `acknowledged` is `as`-cast from another region's JSON and only its
+    // top level is shape-checked, so a counter can be negative — and a negative
+    // one balances the sum: `{imported: expected + 2, refused: -2}` totals
+    // exactly `expected`, reconciles CLEAN, and cuts over having imported two
+    // rows more than the bundle carried. `refused > 0` is false too, so the
+    // disclosure stays silent. Every other malformed counter (NaN, fractional)
+    // fails closed and is benign; this one does not.
+    mockQueryResults["SELECT id, workspace_id"] = [
+      { id: "mig-1", workspace_id: "org-1", source_region: "us-east", target_region: "eu-west", status: "pending" },
+    ];
+    mockQueryResults["UPDATE region_migrations"] = [];
+
+    let vocabularyExpected = -1;
+    reshapeAck = (ack) => {
+      const vocabulary = ack.brainVocabularyEdges;
+      vocabularyExpected = vocabulary?.imported ?? 0;
+      // Sums to exactly `expected`, so a guard that only checks the arithmetic
+      // passes this.
+      if (vocabulary) {
+        ack.brainVocabularyEdges = { imported: vocabularyExpected + 2, skipped: 0, refused: -2 };
+      }
+      return ack;
+    };
+
+    const result = await executeRegionMigration("mig-1");
+
+    expect(vocabularyExpected).toBe(3);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("unusable 'refused' counter");
+      expect(result.error).toContain("no source data has been deleted");
+    }
+
+    // No cutover — which is what stops the source cleanup running against a
+    // target whose own accounting is incoherent.
+    const cutover = capturedQueries.find(
+      (q) => q.sql.includes("UPDATE organization") || q.sql.includes("region_updated = TRUE"),
+    );
+    expect(cutover).toBeUndefined();
   });
 
   it("still ABORTS when a section that cannot refuse reports `refused` (#5036)", async () => {
@@ -482,7 +554,24 @@ describe("executeRegionMigration", () => {
     // Vacuity guard, as above: a 0-count section short-circuits before the sum.
     expect(dashboardsExpected).toBeGreaterThan(0);
     expect(result.success).toBe(false);
-    if (!result.success) expect(result.error).toContain("dashboards");
+    if (!result.success) {
+      expect(result.error).toContain("dashboards");
+      // ⚠️ The DIAGNOSIS has to reach the durable surface. This string lands in
+      // `region_migrations.error_message` and is what the API and CLI render;
+      // the warn below is an ephemeral log line. Without this the one channel an
+      // operator is guaranteed to read carries only the version-skew GUESS.
+      expect(result.error).toContain("refused=");
+      expect(result.error).toContain("no refusal outcome in this build");
+    }
+
+    // The warn is the other half, and it had NO falsifier — deleting the whole
+    // block was green when this test only pinned the abort.
+    const unexpected = capturedWarns.find((w) => w.message.includes("cannot refuse any"));
+    expect(unexpected).toBeDefined();
+    expect(unexpected?.payload).toMatchObject({
+      section: "dashboards",
+      refused: dashboardsExpected,
+    });
 
     // The cutover must NOT have run — that is what stops the source cleanup
     // deleting rows the target never imported.

--- a/packages/api/src/lib/residency/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/residency/__tests__/migrate.test.ts
@@ -61,10 +61,24 @@ void mock.module("@atlas/api/lib/db/internal", () => ({
   getPendingAmendmentCount: async () => 0,
 }));
 
+/**
+ * Captured `log.warn` payloads.
+ *
+ * Its own sink rather than one array with the level in the payload: the LEVEL is
+ * part of what the refusal disclosure claims, and a helper that merged the
+ * levels would pass a mutation demoting `log.warn` to `log.debug` — this repo's
+ * recorded "helper that merges what the test asserts" shape.
+ */
+const capturedWarns: Array<{ payload: Record<string, unknown>; message: string }> = [];
+
 void mock.module("@atlas/api/lib/logger", () => ({
   createLogger: () => ({
     info: () => {},
-    warn: () => {},
+    warn: (payload: unknown, message?: unknown) =>
+      capturedWarns.push({
+        payload: (payload ?? {}) as Record<string, unknown>,
+        message: typeof message === "string" ? message : String(payload),
+      }),
     error: () => {},
     debug: () => {},
   }),
@@ -185,6 +199,7 @@ function resetMocks() {
   mockFetchResponse = { ok: true, status: 200, body: undefined };
   mockFetchError = null;
   reshapeAck = null;
+  capturedWarns.length = 0;
   capturedFetchCalls = [];
   mockConfig = { ...DEFAULT_MOCK_CONFIG };
   process.env.ATLAS_INTERNAL_SECRET = "test-secret";
@@ -345,8 +360,16 @@ describe("executeRegionMigration", () => {
     if (!result.success) {
       // Actionable: names the section, the shortfall, and that nothing was
       // deleted — an operator must not have to guess whether to panic.
-      expect(result.error).toContain("older build");
+      expect(result.error).toContain("dashboards");
+      expect(result.error).toContain("0/1");
       expect(result.error).toContain("no source data");
+      // ⚠️ BOTH skew directions, since #5036. The message used to say the target
+      // "is most likely running an older build" — but a new target reporting a
+      // counter an OLD SOURCE cannot sum produces this same shortfall, and that
+      // wording sent the operator to upgrade the one build that was already
+      // current. Regions deploy independently, which is this test's own premise.
+      expect(result.error).toContain("older target");
+      expect(result.error).toContain("older SOURCE");
     }
 
     // The cutover must NOT have run. `region_updated` is what flips the
@@ -375,12 +398,22 @@ describe("executeRegionMigration", () => {
     mockQueryResults["UPDATE region_migrations"] = [];
 
     let vocabularyExpected = -1;
+    let dashboardsExpected = -1;
     reshapeAck = (ack) => {
       const vocabulary = ack.brainVocabularyEdges;
       vocabularyExpected = vocabulary?.imported ?? 0;
       // Every arriving edge refused, none imported — the extreme of the case,
       // and the shape under which an excluded `refused` reads as 0/n.
       if (vocabulary) ack.brainVocabularyEdges = { imported: 0, skipped: 0, refused: vocabularyExpected };
+      // ⚠️ A SECOND section answering entirely in `skipped`, because otherwise
+      // the `skipped` TERM of the sum is dead in every fixture in this file —
+      // the generator, the explicit body above, and this hook all set
+      // `skipped: 0`, so deleting `+ (got?.skipped ?? 0)` passes the whole
+      // suite. Three terms are only distinguishable when at least two of them
+      // are nonzero, which is this repo's recorded accidental-equality shape.
+      const dashboards = ack.dashboards;
+      dashboardsExpected = dashboards?.imported ?? 0;
+      if (dashboards) ack.dashboards = { imported: 0, skipped: dashboardsExpected };
       return ack;
     };
 
@@ -390,6 +423,7 @@ describe("executeRegionMigration", () => {
     // a section whose manifest count is 0, so a fixture that stopped exporting
     // any vocabulary edge would make this pass while testing nothing.
     expect(vocabularyExpected).toBeGreaterThan(0);
+    expect(dashboardsExpected).toBeGreaterThan(0);
     expect(result.success).toBe(true);
 
     // The positive control the assertion above cannot give on its own: the
@@ -399,6 +433,63 @@ describe("executeRegionMigration", () => {
       (q) => q.sql.includes("UPDATE organization") || q.sql.includes("region_updated = TRUE"),
     );
     expect(cutover).toBeDefined();
+
+    // ⚠️ AND THE SOURCE SIDE SAYS SO. Proceeding quietly is the defect, not the
+    // feature: THIS region schedules the cleanup that deletes the source's own
+    // `brain_vocabulary_edge` rows after the grace period, while the only other
+    // record of the dropped decisions is a warn in the TARGET region's process.
+    // Without this assertion the entire disclosure can be deleted and the suite
+    // stays green — measured, which is why the assertion exists.
+    const disclosure = capturedWarns.find((w) => w.message.includes("REFUSED curated alias edges"));
+    expect(disclosure).toBeDefined();
+    expect(disclosure?.payload).toMatchObject({
+      migrationId: "mig-1",
+      section: "brainVocabularyEdges",
+      refused: vocabularyExpected,
+    });
+    // Names the delete timer, because that is what makes it urgent rather than
+    // merely informational.
+    expect(disclosure?.message).toContain("grace period");
+  });
+
+  it("still ABORTS when a section that cannot refuse reports `refused` (#5036)", async () => {
+    // The regression the FIRST cut of #5036's reconciliation fix introduced, and
+    // the reason `refused` is section-scoped rather than added for every section.
+    //
+    // `brainVocabularyEdges` is the only section whose import can refuse
+    // anything. Summed blanketly, a target answering
+    // `brainFacts: {imported: 0, skipped: 0, refused: N}` — through a bug, a
+    // proxy, or a future section half-implemented in one region — reconciles
+    // CLEAN, the migration cuts over, and the source cleanup then DELETES N
+    // facts that were never imported. That is exactly the silently-dropped-a-
+    // section event this whole block exists to prevent, re-opened by one key.
+    mockQueryResults["SELECT id, workspace_id"] = [
+      { id: "mig-1", workspace_id: "org-1", source_region: "us-east", target_region: "eu-west", status: "pending" },
+    ];
+    mockQueryResults["UPDATE region_migrations"] = [];
+
+    let dashboardsExpected = -1;
+    reshapeAck = (ack) => {
+      const dashboards = ack.dashboards;
+      dashboardsExpected = dashboards?.imported ?? 0;
+      // A section with no refusal semantics claiming its whole count as refused.
+      if (dashboards) ack.dashboards = { imported: 0, skipped: 0, refused: dashboardsExpected };
+      return ack;
+    };
+
+    const result = await executeRegionMigration("mig-1");
+
+    // Vacuity guard, as above: a 0-count section short-circuits before the sum.
+    expect(dashboardsExpected).toBeGreaterThan(0);
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain("dashboards");
+
+    // The cutover must NOT have run — that is what stops the source cleanup
+    // deleting rows the target never imported.
+    const cutover = capturedQueries.find(
+      (q) => q.sql.includes("UPDATE organization") || q.sql.includes("region_updated = TRUE"),
+    );
+    expect(cutover).toBeUndefined();
   });
 
   it("fails when transfer HTTP call returns error", async () => {

--- a/packages/api/src/lib/residency/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/residency/__tests__/migrate.test.ts
@@ -112,15 +112,33 @@ let capturedFetchCalls: Array<{ url: string; options: RequestInit }> = [];
  * mock has to answer like a CURRENT target; a test that wants the
  * older-target behaviour sets `mockFetchResponse.body` explicitly.
  */
-function acknowledgeAll(options?: RequestInit): Record<string, { imported: number; skipped: number }> {
+interface SectionAck {
+  imported: number;
+  skipped: number;
+  /** #5036's third vocabulary counter. Absent from every other section. */
+  refused?: number;
+}
+
+function acknowledgeAll(options?: RequestInit): Record<string, SectionAck> {
   const raw = typeof options?.body === "string" ? options.body : "{}";
   const counts = (JSON.parse(raw) as { manifest?: { counts?: Record<string, number> } }).manifest?.counts ?? {};
-  const ack: Record<string, { imported: number; skipped: number }> = {};
+  const ack: Record<string, SectionAck> = {};
   for (const [section, n] of Object.entries(counts)) {
     ack[section] = { imported: n, skipped: 0 };
   }
-  return ack;
+  return reshapeAck ? reshapeAck(ack) : ack;
 }
+
+/**
+ * Rewrite the derived acknowledgement before the mock answers with it.
+ *
+ * A hook rather than a static `mockFetchResponse.body`, because what a test
+ * needs to answer depends on the bundle the exporter actually built from the
+ * mocked DB — which the test cannot know in advance. Hard-coding it would make
+ * the reconciliation pass for the wrong reason the day a fixture's row count
+ * changed, which is the failure mode this whole guard exists to catch.
+ */
+let reshapeAck: ((ack: Record<string, SectionAck>) => Record<string, SectionAck>) | null = null;
 
 const _originalFetch = globalThis.fetch;
 globalThis.fetch = ((url: string | URL | Request, options?: RequestInit) => {
@@ -166,6 +184,7 @@ function resetMocks() {
   // dropped sections sets `body` explicitly.
   mockFetchResponse = { ok: true, status: 200, body: undefined };
   mockFetchError = null;
+  reshapeAck = null;
   capturedFetchCalls = [];
   mockConfig = { ...DEFAULT_MOCK_CONFIG };
   process.env.ATLAS_INTERNAL_SECRET = "test-secret";
@@ -337,6 +356,49 @@ describe("executeRegionMigration", () => {
       (q) => q.sql.includes("UPDATE organization") || q.sql.includes("region_updated = TRUE"),
     );
     expect(cutover).toBeUndefined();
+  });
+
+  it("PROCEEDS with cutover when the target REFUSED a vocabulary edge (#5036)", async () => {
+    // The regression this pins is the one #5036 created and had to fix in the
+    // same change. The merge gained a third outcome — an arriving alias edge
+    // that would close a cycle or take a second parent is refused, logged and
+    // skipped — and this reconciliation summed only `imported + skipped`. Left
+    // that way, the FIRST genuinely conflicting alias edge in a workspace fails
+    // the whole cutover, with an error message blaming an old target build.
+    //
+    // A refusal is ACCOUNTING, not loss: the target looked at the row, decided,
+    // and logged enough to re-author it. What this guard exists to catch is a
+    // target that silently DROPPED a section, which is a different event.
+    mockQueryResults["SELECT id, workspace_id"] = [
+      { id: "mig-1", workspace_id: "org-1", source_region: "us-east", target_region: "eu-west", status: "pending" },
+    ];
+    mockQueryResults["UPDATE region_migrations"] = [];
+
+    let vocabularyExpected = -1;
+    reshapeAck = (ack) => {
+      const vocabulary = ack.brainVocabularyEdges;
+      vocabularyExpected = vocabulary?.imported ?? 0;
+      // Every arriving edge refused, none imported — the extreme of the case,
+      // and the shape under which an excluded `refused` reads as 0/n.
+      if (vocabulary) ack.brainVocabularyEdges = { imported: 0, skipped: 0, refused: vocabularyExpected };
+      return ack;
+    };
+
+    const result = await executeRegionMigration("mig-1");
+
+    // ⚠️ Guards the test against becoming vacuous: reconciliation `continue`s on
+    // a section whose manifest count is 0, so a fixture that stopped exporting
+    // any vocabulary edge would make this pass while testing nothing.
+    expect(vocabularyExpected).toBeGreaterThan(0);
+    expect(result.success).toBe(true);
+
+    // The positive control the assertion above cannot give on its own: the
+    // cutover actually RAN. `success` with no region flip would be the same
+    // symptom as the abort this test rules out.
+    const cutover = capturedQueries.find(
+      (q) => q.sql.includes("UPDATE organization") || q.sql.includes("region_updated = TRUE"),
+    );
+    expect(cutover).toBeDefined();
   });
 
   it("fails when transfer HTTP call returns error", async () => {

--- a/packages/api/src/lib/residency/migrate.ts
+++ b/packages/api/src/lib/residency/migrate.ts
@@ -77,6 +77,30 @@ const RECONCILED_SECTIONS = [
  * is forced into RECONCILED_SECTIONS, where the `satisfies` then fails until
  * the manifest count exists — so both halves of the mistake are caught.
  */
+/**
+ * The sections whose import can legitimately REFUSE a row (#5036).
+ *
+ * Derived from the wire type rather than asserted: a section is refusal-capable
+ * exactly when `ImportResult` gives it a `refused` counter. Only
+ * `brainVocabularyEdges` does — an alias edge is a human review decision and two
+ * regions can hold contradictory ones, so the destination refuses one and logs
+ * it. Everywhere else `imported + skipped` accounts for every row and a
+ * `refused` in the response is a target bug.
+ *
+ * The distinction decides whether a shortfall ABORTS a cutover, so a second
+ * section growing the counter has to be a deliberate decision rather than a
+ * discovery: the pin below turns it into a compile error.
+ */
+type RefusalCapableSection = {
+  [K in keyof ImportResult]: ImportResult[K] extends { refused: number } ? K : never;
+}[keyof ImportResult];
+
+const REFUSAL_ACCOUNTING = [
+  "brainVocabularyEdges",
+] as const satisfies readonly RefusalCapableSection[];
+
+const REFUSAL_ACCOUNTING_SECTIONS: ReadonlySet<string> = new Set(REFUSAL_ACCOUNTING);
+
 type UnreconciledSection = Exclude<keyof ImportResult, (typeof RECONCILED_SECTIONS)[number]>;
 const _everySectionReconciled: [UnreconciledSection] extends [never] ? true : never = true;
 void _everySectionReconciled;
@@ -279,6 +303,22 @@ async function transferBundleToTarget(
     };
   }
 
+  // ⚠️ DERIVED FROM THE WIRE TYPE, not spelled as a literal — this file's own
+  // idiom, and for its own reason. `RECONCILED_SECTIONS`' two-sided pin exists
+  // because "adding a section and forgetting to reconcile it is a silent
+  // no-op"; adding a REFUSAL OUTCOME to a second section is the same shape, and
+  // a hard-coded `section === "brainVocabularyEdges"` would be guarded only by a
+  // runtime warn that fires during a live migration, AFTER the target has
+  // already committed a partial import. Declared this way, a second section
+  // growing `refused` is a COMPILE error that forces the
+  // accounting-versus-loss decision to be made deliberately.
+  const _refusalSectionsReviewed: [
+    Exclude<RefusalCapableSection, (typeof REFUSAL_ACCOUNTING)[number]>,
+  ] extends [never]
+    ? true
+    : never = true;
+  void _refusalSectionsReviewed;
+
   for (const section of RECONCILED_SECTIONS) {
     // Ground truth from the payload where the section IS a top-level array;
     // the manifest is a self-report written in a different literal, so a
@@ -336,8 +376,32 @@ async function transferBundleToTarget(
     // accounting rather than loss. Both are worth a human's attention, and
     // neither is worth failing a cutover over on its own — the count still has
     // to reconcile without it, which is the conservative reading.
+    // ⚠️ EVERY COUNTER IS FOREIGN INPUT. `acknowledged` is `as`-cast from another
+    // region's JSON and only its top level is shape-checked, so a counter can be
+    // negative, fractional or NaN. Negative is the one that FAILS OPEN: a target
+    // answering `{imported: 12, skipped: 0, refused: -2}` against an expected 10
+    // sums to exactly 10, reconciles clean, and cuts over while having imported
+    // two rows more than the bundle carried — and `refused > 0` is false, so the
+    // disclosure below stays silent too. Refusing an unusable counter outright
+    // is the conservative reading, and it is the same polarity as the rest of
+    // this block: a count that cannot be trusted is not a count.
+    const counters = { imported: got?.imported, skipped: got?.skipped, refused: got?.refused };
+    for (const [name, value] of Object.entries(counters)) {
+      if (value === undefined) continue;
+      if (!Number.isInteger(value) || value < 0) {
+        return {
+          ok: false,
+          error:
+            `Target region reported an unusable '${name}' counter (${String(value)}) for section ` +
+            `'${section}' — counters must be non-negative whole numbers. Migration ${migrationId} ` +
+            "aborted BEFORE cutover; no source data has been deleted. This is a target bug: a " +
+            "counter that cannot be trusted cannot reconcile the section it describes.",
+        };
+      }
+    }
+
     const refused = got?.refused ?? 0;
-    const refusalIsAccounting = section === "brainVocabularyEdges";
+    const refusalIsAccounting = REFUSAL_ACCOUNTING_SECTIONS.has(section);
     if (refused > 0 && !refusalIsAccounting) {
       log.warn(
         { migrationId, section, refused },
@@ -348,10 +412,22 @@ async function transferBundleToTarget(
     }
     const total = (got?.imported ?? 0) + (got?.skipped ?? 0) + (refusalIsAccounting ? refused : 0);
     if (total !== expected) {
+      // ⚠️ THE EVIDENCE BELONGS IN THE ERROR, not only in the warn above. This
+      // string is the DURABLE operator-facing surface — it lands in
+      // `region_migrations.error_message` and is what the API and the CLI
+      // render — while the warn is an ephemeral line in a stream nobody may
+      // read. Without this clause the channel an operator is guaranteed to see
+      // carries only the GUESS ("version skew, check both builds") while the
+      // channel they may never open carries the actual cause.
+      const anomaly =
+        refused > 0 && !refusalIsAccounting
+          ? ` The target also reported refused=${refused} for '${section}', which has no refusal ` +
+            `outcome in this build — that is the likely cause rather than a dropped section.`
+          : "";
       return {
         ok: false,
         error:
-          `Target region accounted for ${got ? total : 0}/${expected} '${section}' rows. ` +
+          `Target region accounted for ${got ? total : 0}/${expected} '${section}' rows.${anomaly} ` +
           `The most likely cause is a version skew between this region and the target — ` +
           `EITHER an older target that does not understand this bundle section and dropped it, ` +
           `OR an older SOURCE (this region) that does not understand a counter the target ` +
@@ -379,10 +455,28 @@ async function transferBundleToTarget(
     if (refusalIsAccounting && refused > 0) {
       log.warn(
         { migrationId, section, refused },
-        "Target region REFUSED curated alias edges during import — approved human review " +
-          "decisions were NOT applied in the destination. They are logged in the TARGET region " +
-          "against this workspace, and the SOURCE copy is deleted after the cleanup grace " +
-          "period. Retrieve them from the target's logs and re-author them there before then.",
+        // ⚠️ CONDITIONAL TENSE, and it points at THIS region's own data.
+        //
+        // Two corrections, both caught by asking whether this fix reproduces the
+        // defect it fixes. First: it runs in phase 2, BEFORE cutover and before
+        // cleanup is scheduled, either of which can still fail — so stating "the
+        // source copy is deleted" as fact is the same over-report the target-side
+        // warn was just rewritten to avoid, one module over and in the same
+        // commit. Second, and worse: it used to say "retrieve them from the
+        // TARGET's logs", which makes another region's log retention the
+        // recovery path — the very artifact this disclosure exists because it is
+        // NOT sufficient.
+        //
+        // The source does not need them. It still HOLDS its own
+        // `brain_vocabulary_edge` rows, in its own database, for the whole grace
+        // period — the operator's job is to look before the window closes, not
+        // to go reading a foreign log stream.
+        "Target region REFUSED curated alias edges during import — that many approved human " +
+          "review decisions will NOT be applied in the destination. If this migration completes, " +
+          "THIS region's own brain_vocabulary_edge rows are deleted once the cleanup grace " +
+          "period expires: export or re-author them from this region's database before then. " +
+          "Which specific edges were refused is logged in the target region against this " +
+          "workspace; the full set is still here until cleanup runs.",
       );
     }
   }

--- a/packages/api/src/lib/residency/migrate.ts
+++ b/packages/api/src/lib/residency/migrate.ts
@@ -254,7 +254,18 @@ async function transferBundleToTarget(
   // Deployment reality that makes this a live hazard rather than a theoretical
   // one: regions deploy independently, so a window where US has #4767 and EU
   // does not is routine, not exceptional.
-  let acknowledged: Partial<Record<(typeof RECONCILED_SECTIONS)[number], { imported?: number; skipped?: number }>>;
+  // `refused` is #5036's third vocabulary counter, and it is declared for EVERY
+  // section rather than only the one that emits it. That is the shape this
+  // parse already takes for `imported`/`skipped` — the response is another
+  // region's JSON, so every field is optional here regardless of what the local
+  // `ImportResult` requires — and narrowing it to one key would make the sum
+  // below have to know which section it was reading.
+  let acknowledged: Partial<
+    Record<
+      (typeof RECONCILED_SECTIONS)[number],
+      { imported?: number; skipped?: number; refused?: number }
+    >
+  >;
   try {
     acknowledged = await response.json() as typeof acknowledged;
   } catch (err) {
@@ -301,7 +312,21 @@ async function transferBundleToTarget(
     }
     if (expected === 0) continue; // nothing exported ⇒ nothing to reconcile
     const got = acknowledged[section];
-    const total = (got?.imported ?? 0) + (got?.skipped ?? 0);
+    // ⚠️ `refused` IS ACCOUNTING, NOT LOSS, and leaving it out of this sum was
+    // the live regression #5036 had to fix in the same change (ADR-0037 §8 §4).
+    //
+    // This guard asks one question: did the target ACCOUNT for every row the
+    // bundle carried, or did it silently drop a section it does not understand?
+    // A refused vocabulary edge is accounted for — the target looked at it,
+    // decided applying it would close a cycle or take a second parent, logged
+    // enough to re-author it, and carried on. Excluded from the sum, the FIRST
+    // genuinely conflicting alias edge in a workspace would abort an entire
+    // cutover, which is the opposite of the graceful merge the slice exists to
+    // provide, and it would do so with an error message blaming an old build.
+    //
+    // `?? 0` on all three: a target predating #5036 sends no `refused` and
+    // refuses nothing — it skips instead — so the sum is unchanged there.
+    const total = (got?.imported ?? 0) + (got?.skipped ?? 0) + (got?.refused ?? 0);
     if (total !== expected) {
       return {
         ok: false,

--- a/packages/api/src/lib/residency/migrate.ts
+++ b/packages/api/src/lib/residency/migrate.ts
@@ -254,12 +254,9 @@ async function transferBundleToTarget(
   // Deployment reality that makes this a live hazard rather than a theoretical
   // one: regions deploy independently, so a window where US has #4767 and EU
   // does not is routine, not exceptional.
-  // `refused` is #5036's third vocabulary counter, and it is declared for EVERY
-  // section rather than only the one that emits it. That is the shape this
-  // parse already takes for `imported`/`skipped` — the response is another
-  // region's JSON, so every field is optional here regardless of what the local
-  // `ImportResult` requires — and narrowing it to one key would make the sum
-  // below have to know which section it was reading.
+  // `refused` is #5036's third vocabulary counter. Every field is optional here
+  // regardless of what the local `ImportResult` requires, because this is
+  // another region's JSON and possibly another region's BUILD.
   let acknowledged: Partial<
     Record<
       (typeof RECONCILED_SECTIONS)[number],
@@ -312,32 +309,81 @@ async function transferBundleToTarget(
     }
     if (expected === 0) continue; // nothing exported ⇒ nothing to reconcile
     const got = acknowledged[section];
-    // ⚠️ `refused` IS ACCOUNTING, NOT LOSS, and leaving it out of this sum was
-    // the live regression #5036 had to fix in the same change (ADR-0037 §8 §4).
+
+    // ⚠️ `refused` IS ACCOUNTING, NOT LOSS — but ONLY for the one section that
+    // can produce it, and the scoping is the whole point (ADR-0037 §8 §4).
     //
     // This guard asks one question: did the target ACCOUNT for every row the
     // bundle carried, or did it silently drop a section it does not understand?
     // A refused vocabulary edge is accounted for — the target looked at it,
     // decided applying it would close a cycle or take a second parent, logged
-    // enough to re-author it, and carried on. Excluded from the sum, the FIRST
-    // genuinely conflicting alias edge in a workspace would abort an entire
-    // cutover, which is the opposite of the graceful merge the slice exists to
-    // provide, and it would do so with an error message blaming an old build.
+    // enough to re-author it by hand, and carried on. Left out of the sum
+    // entirely, the FIRST genuinely conflicting alias edge in a workspace would
+    // abort an entire cutover and blame an old target build.
     //
-    // `?? 0` on all three: a target predating #5036 sends no `refused` and
-    // refuses nothing — it skips instead — so the sum is unchanged there.
-    const total = (got?.imported ?? 0) + (got?.skipped ?? 0) + (got?.refused ?? 0);
+    // ⚠️ ADDING IT FOR EVERY SECTION IS THE WRONG FIX, and it was this slice's
+    // own first cut. `brainVocabularyEdges` is the only section whose import can
+    // refuse anything. A blanket `+ (got?.refused ?? 0)` means a target that
+    // answers `brainFacts: {imported: 0, skipped: 0, refused: 40}` — through a
+    // bug, a proxy, or a future section half-implemented in one region —
+    // reconciles CLEAN, cuts over, and the source cleanup then deletes 40 facts
+    // that were never imported. That is exactly the silently-dropped-a-section
+    // event this block exists to prevent, re-opened by one key.
+    //
+    // So the term is section-scoped, and an unexpected `refused` elsewhere is
+    // surfaced rather than ignored: it is either a target bug or a section that
+    // grew a refusal without anyone revisiting whether ITS refusal is also
+    // accounting rather than loss. Both are worth a human's attention, and
+    // neither is worth failing a cutover over on its own — the count still has
+    // to reconcile without it, which is the conservative reading.
+    const refused = got?.refused ?? 0;
+    const refusalIsAccounting = section === "brainVocabularyEdges";
+    if (refused > 0 && !refusalIsAccounting) {
+      log.warn(
+        { migrationId, section, refused },
+        "Target region reported REFUSED rows for a section that cannot refuse any — not counted " +
+          "toward reconciliation. Either the target is buggy or this section grew a refusal " +
+          "outcome whose accounting nobody has reviewed.",
+      );
+    }
+    const total = (got?.imported ?? 0) + (got?.skipped ?? 0) + (refusalIsAccounting ? refused : 0);
     if (total !== expected) {
       return {
         ok: false,
         error:
           `Target region accounted for ${got ? total : 0}/${expected} '${section}' rows. ` +
-          `The target is most likely running an older build that does not understand this ` +
-          `bundle section. Migration ${migrationId} aborted BEFORE cutover — no source data ` +
-          `has been deleted and the workspace is still served from its current region. ` +
+          `The most likely cause is a version skew between this region and the target — ` +
+          `EITHER an older target that does not understand this bundle section and dropped it, ` +
+          `OR an older SOURCE (this region) that does not understand a counter the target ` +
+          `reported. Check both builds before upgrading either. Migration ${migrationId} ` +
+          `aborted BEFORE cutover — no source data has been deleted and the workspace is still ` +
+          `served from its current region. ` +
           `NOTE: the target has already COMMITTED a partial import; the import is idempotent, ` +
-          `so upgrade the target and re-run, or tear down the partial copy if abandoning.`,
+          `so align the builds and re-run, or tear down the partial copy if abandoning.`,
       };
+    }
+
+    // ⚠️ THE SOURCE SIDE HAS TO SAY THIS OUT LOUD, and until #5036's review it
+    // did not. `refused` was consumed by the sum above and discarded — the only
+    // record of a dropped human decision was a `log.warn` in the TARGET
+    // region's process, which the operator driving the cutover is not watching.
+    // Meanwhile THIS region schedules the source cleanup (`cleanupAfter`), and
+    // after the grace period the source's own `brain_vocabulary_edge` rows are
+    // DELETED. So the durable record of N approved review decisions would have
+    // been log lines in another region, outliving the data by only as long as
+    // that region's retention.
+    //
+    // Pre-#5036 the same input failed the import outright and nothing was ever
+    // scheduled for deletion. Refusing gracefully is the right call; doing it
+    // without telling the side that owns the delete timer is not.
+    if (refusalIsAccounting && refused > 0) {
+      log.warn(
+        { migrationId, section, refused },
+        "Target region REFUSED curated alias edges during import — approved human review " +
+          "decisions were NOT applied in the destination. They are logged in the TARGET region " +
+          "against this workspace, and the SOURCE copy is deleted after the cleanup grace " +
+          "period. Retrieve them from the target's logs and re-author them there before then.",
+      );
     }
   }
 

--- a/packages/api/src/lib/residency/migrate.ts
+++ b/packages/api/src/lib/residency/migrate.ts
@@ -60,6 +60,16 @@ const RECONCILED_SECTIONS = [
   "brainVocabularyEdges",
 ] as const satisfies readonly (keyof ExportManifest["counts"] & keyof ImportResult)[];
 
+type RefusalCapableSection = {
+  [K in keyof ImportResult]: ImportResult[K] extends { refused: number } ? K : never;
+}[keyof ImportResult];
+
+const REFUSAL_ACCOUNTING = [
+  "brainVocabularyEdges",
+] as const satisfies readonly RefusalCapableSection[];
+
+const REFUSAL_ACCOUNTING_SECTIONS: ReadonlySet<string> = new Set(REFUSAL_ACCOUNTING);
+
 /**
  * Completeness half of the bound above: every section that HAS both a manifest
  * count and an ImportResult counter must be listed.
@@ -81,7 +91,10 @@ const RECONCILED_SECTIONS = [
  * The sections whose import can legitimately REFUSE a row (#5036).
  *
  * Derived from the wire type rather than asserted: a section is refusal-capable
- * exactly when `ImportResult` gives it a `refused` counter. Only
+ * exactly when `ImportResult` gives it a REQUIRED `refused: number`. An OPTIONAL
+ * one falls out of the conditional below and would be missed — which is the
+ * argument for declaring the counter required on the wire type in the first
+ * place. Only
  * `brainVocabularyEdges` does — an alias edge is a human review decision and two
  * regions can hold contradictory ones, so the destination refuses one and logs
  * it. Everywhere else `imported + skipped` accounts for every row and a
@@ -89,18 +102,12 @@ const RECONCILED_SECTIONS = [
  *
  * The distinction decides whether a shortfall ABORTS a cutover, so a second
  * section growing the counter has to be a deliberate decision rather than a
- * discovery: the pin below turns it into a compile error.
+ * discovery. Two halves do that, and only the second is the completeness claim:
+ * the `satisfies` below proves every LISTED member is genuinely refusal-capable,
+ * while `_refusalSectionsReviewed` — inside `transferBundleToTarget`, where the
+ * decision is consumed — proves none is MISSING. That split mirrors
+ * `RECONCILED_SECTIONS`' own two-sided pin.
  */
-type RefusalCapableSection = {
-  [K in keyof ImportResult]: ImportResult[K] extends { refused: number } ? K : never;
-}[keyof ImportResult];
-
-const REFUSAL_ACCOUNTING = [
-  "brainVocabularyEdges",
-] as const satisfies readonly RefusalCapableSection[];
-
-const REFUSAL_ACCOUNTING_SECTIONS: ReadonlySet<string> = new Set(REFUSAL_ACCOUNTING);
-
 type UnreconciledSection = Exclude<keyof ImportResult, (typeof RECONCILED_SECTIONS)[number]>;
 const _everySectionReconciled: [UnreconciledSection] extends [never] ? true : never = true;
 void _everySectionReconciled;

--- a/packages/types/src/__tests__/migration.test.ts
+++ b/packages/types/src/__tests__/migration.test.ts
@@ -261,7 +261,15 @@ describe("migration types", () => {
     expect(result.knowledgeDocuments.skipped).toBe(1);
     expect(result.brainFacts.imported).toBe(8);
     expect(result.factAudienceMembers.skipped).toBe(1);
-    expect(result.brainVocabularyEdges.refused).toBe(4);
+    // The counter SET rather than a literal read back — reading `refused: 4` out
+    // of the object this test just wrote cannot go red for any type change,
+    // while the key set goes red if a counter is added or renamed. (The type
+    // itself is enforced by `bun run type`; this is the runtime half.)
+    expect(Object.keys(result.brainVocabularyEdges).toSorted()).toEqual([
+      "imported",
+      "refused",
+      "skipped",
+    ]);
   });
 
   it("ExportManifest includes optional apiUrl", () => {

--- a/packages/types/src/__tests__/migration.test.ts
+++ b/packages/types/src/__tests__/migration.test.ts
@@ -251,8 +251,7 @@ describe("migration types", () => {
       brainFacts: { imported: 8, skipped: 2 },
       brainEdges: { imported: 5, skipped: 0 },
       factAudienceMembers: { imported: 3, skipped: 1 },
-      // The one section with a THIRD counter (#5036). Three DISTINCT values, so
-      // a shape that mixed two of them up cannot satisfy the assertion below.
+      // The one section with a THIRD counter (#5036).
       brainVocabularyEdges: { imported: 2, skipped: 1, refused: 4 },
     };
 
@@ -261,10 +260,14 @@ describe("migration types", () => {
     expect(result.knowledgeDocuments.skipped).toBe(1);
     expect(result.brainFacts.imported).toBe(8);
     expect(result.factAudienceMembers.skipped).toBe(1);
-    // The counter SET rather than a literal read back — reading `refused: 4` out
-    // of the object this test just wrote cannot go red for any type change,
-    // while the key set goes red if a counter is added or renamed. (The type
-    // itself is enforced by `bun run type`; this is the runtime half.)
+    // The counter SET rather than a literal read back: reading `refused: 4` out
+    // of the object this test itself just wrote cannot go red for any change.
+    //
+    // ⚠️ Its reach is narrower than "catches a fourth counter", and the limit is
+    // worth stating: a REQUIRED addition stops this literal type-checking, so
+    // someone edits it and this fires — but an OPTIONAL one changes nothing
+    // here. `bun run type` is the real enforcement of the shape; this is the
+    // runtime half, and it catches a rename or a removal.
     expect(Object.keys(result.brainVocabularyEdges).toSorted()).toEqual([
       "imported",
       "refused",

--- a/packages/types/src/__tests__/migration.test.ts
+++ b/packages/types/src/__tests__/migration.test.ts
@@ -251,7 +251,9 @@ describe("migration types", () => {
       brainFacts: { imported: 8, skipped: 2 },
       brainEdges: { imported: 5, skipped: 0 },
       factAudienceMembers: { imported: 3, skipped: 1 },
-      brainVocabularyEdges: { imported: 2, skipped: 1 },
+      // The one section with a THIRD counter (#5036). Three DISTINCT values, so
+      // a shape that mixed two of them up cannot satisfy the assertion below.
+      brainVocabularyEdges: { imported: 2, skipped: 1, refused: 4 },
     };
 
     expect(result.conversations.imported + result.conversations.skipped).toBe(7);
@@ -259,6 +261,7 @@ describe("migration types", () => {
     expect(result.knowledgeDocuments.skipped).toBe(1);
     expect(result.brainFacts.imported).toBe(8);
     expect(result.factAudienceMembers.skipped).toBe(1);
+    expect(result.brainVocabularyEdges.refused).toBe(4);
   });
 
   it("ExportManifest includes optional apiUrl", () => {

--- a/packages/types/src/migration.ts
+++ b/packages/types/src/migration.ts
@@ -634,8 +634,33 @@ export interface ImportResult {
    * The curated identity vocabulary (#5022). Counted on the EDGES — the
    * decisions — because the closure is recomputed rather than imported, so a
    * count of its rows would report work the bundle did not carry.
+   *
+   * THE ONLY SECTION WITH A THIRD COUNTER, and the asymmetry is the point
+   * (#5036, ADR-0037 §8 §4). Everywhere else `skipped` means "the destination
+   * already holds this row", because a conversation present in both regions is
+   * the same conversation. An alias edge is a HUMAN REVIEW DECISION, and two
+   * regions can hold contradictory ones legitimately — so the import has two
+   * outcomes here that are not the same event at all:
+   *
+   *   - `skipped` — already approved in this region onto the SAME target.
+   *     Benign, and exactly what an idempotent re-import looks like from the
+   *     inside.
+   *   - `refused` — the arriving edge would have closed a cycle or taken a
+   *     second parent, so a source-region human's approved decision was NOT
+   *     applied. Every one is logged with enough of the source row to re-author
+   *     it by hand, and that log is the entire recovery path.
+   *
+   * Reporting them as one number would restore the conflation the slice exists
+   * to remove: `skipped: 2` cannot distinguish a clean re-import from two
+   * discarded approvals, and only one of those is something to act on.
+   *
+   * REQUIRED, like every other counter, on the established reading that this
+   * type describes what THIS region answers. A target predating #5036 omits it
+   * and refuses nothing (it skips instead); consumers that read a foreign
+   * region's response model that with their own cross-version type, as
+   * `migrate.ts` and `cli/migrate-import.ts` already do for whole sections.
    */
-  brainVocabularyEdges: { imported: number; skipped: number };
+  brainVocabularyEdges: { imported: number; skipped: number; refused: number };
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/check-brain-fact-promotion.sh
+++ b/scripts/check-brain-fact-promotion.sh
@@ -139,6 +139,34 @@
 #     the fail direction is opposite to `visible_to`'s — a bad pre-widening
 #     grant over-WITHHOLDS attribution, which is recoverable, where a bad
 #     `visible_to` would over-disclose.
+#     SINCE #5035 IT ALSO WRITES THE IDENTITY KEYS, and #5036 records it here
+#     for `correction.ts`'s reason exactly: the entry is WHOLE-FILE, so it
+#     already covers what follows whether or not anyone writes it down, which is
+#     precisely why it has to be written down rather than left to the scan.
+#     WHAT IT DOES WITH THEM: the explicit column INSERT carries `subject_key`,
+#     `predicate_key` and `object_key` verbatim off a v3 bundle, and computes
+#     them ONCE for a legacy v1/v2 one via `alias_dest(lexicalNorm(surface))`.
+#     WHY THAT IS A ROW-COPY AND NOT A SECOND CANONICALIZER: ADR-0037 §8 — *a
+#     row-copy path carries keys verbatim; a claim-supply path never supplies
+#     them*. §1 prohibits a PRODUCER computing identity; this copies rows that
+#     were already keyed in another region of the same product. The legacy arm
+#     is the one place it computes rather than copies, and it is bounded to
+#     bundles that carry no keys at all — where the alternative is not "carry"
+#     but "leave NULL", which the NOT NULL slot keys forbid.
+#     ⚠️ WHAT THE ENTRY THEREFORE COSTS, stated because it is load-bearing: a
+#     future `UPDATE brain_facts SET subject_key = …` added to THIS file would
+#     be exempt, silently — it was allowlisted for `status` long before it had
+#     any business near a key. The compensating pins are
+#     `migrate-roundtrip-pg.test.ts`'s verbatim-carry assertions (read against
+#     what the BUNDLE carried, not against literals the test also wrote) and
+#     `keys-not-on-the-wire.test.ts`.
+#     ⚠️ IT IS ALSO THE ONE IMPORT PATH THAT NOW WRITES NO VOCABULARY STATEMENT
+#     OF ITS OWN (#5036). The arriving alias edges are merged by
+#     `lib/brain/vocabulary.ts`'s `mergeApprovedEdges`, which the route calls —
+#     so a reader looking here for the vocabulary's restore will not find it,
+#     and `bundle-scope.test.ts` is what keeps that delegation honest in both
+#     directions. Nothing about the fact-key story above changes: the merge
+#     touches the two vocabulary tables only, and reads no fact.
 #
 #   packages/api/src/lib/brain/correction.ts
 #     `correct_fact` (#4915) — the SECOND gate-time decision maker this


### PR DESCRIPTION
Closes #5036 — slice E of ADR-0037.

## The hole

The forest invariant is enforced **per-vocabulary**, and nothing enforced it across two. Canonical direction is arbitrary, so a source that curated `price → priced at` and a destination that curated `priced at → price` are *both* valid forests whose **union is a 2-cycle**.

Every merge rule the importer had was wrong for this table. `ON CONFLICT DO NOTHING` is destination-wins-**silently** — right for a conversation present in both regions (it is the same conversation), wrong for an alias edge, which is a **human review decision** two regions can legitimately hold contradictory versions of. And it looked for no cycles at all, so an arriving edge could close one and abort the **entire** import at closure-rebuild time.

## What lands

`mergeApprovedEdges` in `lib/brain/vocabulary.ts`: union the approved edges, refuse any that would close a cycle or take a second parent, log every refusal with enough of the source row to re-author it, recompute the closure once per position that gained an edge.

It lives beside `approveAliasEdge` so both write paths share **one** copy of the four refusal rules — extracted as `screenAliasNorms` (the two the norms decide) and `admitAliasEdge` (the two the store decides) — and because `lib/` must not import from `api/routes/`.

**Three counters where every other section has two.** `skipped` is the benign half (already approved here onto the *same* target — an idempotent re-import); `refused` is a human decision this region dropped. One number would restore exactly the conflation the slice exists to remove.

**A cross-cutting fix that had to ride along:** `migrate.ts` reconciles the target's counters against the manifest and **aborts a migration before cutover** on a mismatch. Summing only `imported + skipped`, the first genuinely conflicting alias edge in a workspace would have failed a whole cutover — blaming an old target build. A refusal is accounting, not loss.

## Acceptance criteria

- [x] Scope is the **vocabulary only** — the entity store rides #5043
- [x] The merge unions **approved edges**, never effective targets
- [x] Cycle-closing and at-most-one-parent-violating edges are **refused and logged**
- [x] The closure is **recomputed at the destination** after the merge
- [x] **No per-row vocabulary version stamp**
- [x] `admin-migrate.ts` allowlisted in `check-brain-fact-promotion.sh` for the key columns, with the row-copy rationale (extends the existing whole-file entry)
- [x] Falsification: two individually-valid forests whose union has a cycle **refuse and log** — and do not oscillate (re-run pins it)

## Review panel — stopped on the RATIO rule at round 2

| round | total | new surface | defect-in-prior-fix |
|---|---|---|---|
| 1 | ~30 | ~30 | 0 |
| 2 | ~23 | 3 | **~20** |

Total fell (30 → 23), but **defect-in-prior-fix far exceeded new surface**, which is the hard stop: more review buys more findings rather than fewer, because the fixes are manufacturing the work. Everything confirmed is fixed; the closing round's costs were paid in full (comment sweep run, every falsifier built *and* measured).

Round 1 found two regressions the first commit introduced, both data-loss shaped:

- **`refused` was summed for every section.** Only the vocabulary can refuse. A target answering `brainFacts: {imported: 0, skipped: 0, refused: 40}` reconciled clean, cut over, and the source cleanup then deleted 40 never-imported facts — the silently-dropped-a-section event the block exists to prevent, reopened by one key.
- **The source side got no signal.** `refused` was consumed by the sum and discarded, while *this* region schedules the cleanup that deletes the originals after the grace period.

Round 2's sharpest finding was the **#5077 pattern verbatim**: round 1 rewrote the refusal warn to the future tense because it runs in an uncommitted transaction — and in the *same commit* added another warn forty lines above it in the present tense, at the top of the loop, so it claimed writes for edges the merge then refused. `fix-vs-finding` also returned **REPRODUCED** on the source-side disclosure: it spoke in the definite past while running pre-cutover, and told operators to "retrieve them from the target's logs" — making the artifact the finding had just called insufficient into the official recovery path. The source never needed them: it still *holds* its own edges for the whole grace period.

**Three mutations the reviewer ran actually survived**, all now killed — including one hidden by systemic accidental equality (every fixture count was `1`, so the disclosure's refusal count was indistinguishable from the section total; the vocabulary section now exports 3 rows and answers 2 imported / 1 refused).

## Falsifiers — measured, not reasoned about

25 mutations applied across the three rounds, every one killed. Two apparent "survivals" were my own no-op mutations, re-run with verified anchors — a mutation that does not apply is indistinguishable from one that does not kill.

Two guards were measured **unfalsified** and fixed for that reason rather than on suspicion: the source-side disclosure (deleting it was green) and the `approvedAt?: never` barrier (which cannot be observed at runtime, and loosening a parameter never fails a typecheck — pinned with the repo's `@ts-expect-error`-as-assertion idiom, in a new **non-pg** file that also puts part of this slice back inside the local test loop).

## Consciously deferred

- **#5112** — making a refused edge durable at the source. The refusal *payload* still exists only in the target region's log; the source gets a count and a pointer to its own data. Closing that means carrying details on the wire and persisting them past the cleanup — new machinery, so a follow-up by default.
- **#5113** — `brain_vocabulary_proposal` / `brain_predicate_cardinality` reclassification. Two `bundle-scope.ts` entries name #5036 as where their deferral ends, but this issue scopes itself to *merge semantics only*, and each needs its own export wiring plus a merge rule that is **not** the edge rule.
- The CLI never printed vocabulary counters at all (pre-existing); adding a third column is presentational and rides #5112.

## Note for the releaser

`@useatlas/types` gains a required `refused` on `ImportResult`. Templates pin `^0.7.0` while the workspace is at `0.8.0` and `prepare-templates.sh` copies `admin-migrate.ts` wholesale, so the types publish must land **before** template refs bump — CLAUDE.md's standing sequencing rule, not new to this change.


---
_Generated by [Claude Code](https://claude.ai/code/session_014nPtK5513hLbxVPsxCe2JA)_