### PR TITLE
ci: take the two heavy gates off every PR's critical path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -521,6 +521,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          # Full history: `--affected` diffs against the PR base SHA, which is
+          # not reachable from a shallow clone. The script widens to `--all` if
+          # the diff fails, so a shallow clone would silently cost 14 minutes
+          # rather than break — which is exactly the failure nobody notices.
+          fetch-depth: 0
 
       - uses: ./.github/actions/setup-bun-cached
         with:
@@ -529,14 +535,36 @@ jobs:
       - name: Build @useatlas/types + @useatlas/plugin-sdk
         run: bun run --filter '@useatlas/types' build && bun run --filter '@useatlas/plugin-sdk' build
 
-      - name: Verify every generated mutation table
+      - name: Verify the generated mutation tables
         env:
           # Required, not optional: several specs target *-pg.test.ts, which
           # self-skip without it. The runner refuses a baseline that skipped
           # anything, so an absent URL fails this job loudly rather than
           # regenerating zeros over real measurements.
           TEST_DATABASE_URL: postgresql://atlas:atlas@localhost:5432/atlas
-        run: bash scripts/check-mutation-tables.sh --all
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          # ⚠️ The SWEEP still happens — it MOVED, it was not deleted. #5077's
+          # finding was that four of eight tables were stale on `main` because
+          # `--check` existed and nothing ran it; `push: main` below is what
+          # keeps that closed. What changed is only WHEN a full sweep blocks:
+          # not on a PR whose diff cannot have touched a table.
+          #
+          # The `--all` justification this job shipped with was "14 minutes is
+          # FREE, jobs run in parallel and `Built image (docs)` already takes
+          # ~25". That premise is conditional on a job that is itself
+          # path-gated — when the image scan skips, this job IS the critical
+          # path, and it gated every docs-only and ROADMAP-only PR on a
+          # 14-minute Postgres sweep. `--affected` widens to `--all` on any
+          # unresolvable diff, so the narrow path can never silently verify
+          # nothing.
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            bash scripts/check-mutation-tables.sh --affected "$BASE_SHA"
+          else
+            bash scripts/check-mutation-tables.sh --all
+          fi
     services:
       postgres:
         image: postgres:16-alpine

--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -188,11 +188,39 @@ jobs:
             exit 0
           fi
 
-          # Deliberately broad. A false positive costs ~10 min of parallel CI; a
-          # false negative ships an unscanned image. bun.lock and package.json
-          # are included because the resolved production dependency tree is part
-          # of the image, and Trivy scans it.
-          if echo "$CHANGED" | grep -qE '^(deploy/|packages/|plugins/|ee/|apps/docs/|create-atlas/templates/docker/|examples/docker/|bun\.lock$|package\.json$|\.trivyignore$|scripts/(scan-image|list-runtime-base-images)\.sh$|\.github/workflows/image-scan\.yml$)'; then
+          # Broad, but no longer "everything". ⚠️ This filter opened with
+          # `^packages/`, which matches essentially every code PR in the repo —
+          # so the ~10-min build+scan of three images ran on a one-line edit to
+          # a test file under packages/api/src. That is not a broad filter, it
+          # is an absent one, and it is what put this job on every PR's critical
+          # path.
+          #
+          # What this gate detects is a vulnerable OS package in a runtime
+          # layer, plus library findings in the image's resolved node_modules.
+          # A TypeScript edit under packages/ changes NEITHER: it is compiled
+          # into a layer above the base, and the dependency closure Trivy reads
+          # is decided by the lockfile and the manifests. So the trigger set is
+          # the things that can actually move those two surfaces —
+          #
+          #   any Dockerfile        base image pin, layer contents, apt/apk installs
+          #   any package.json      a manifest anywhere in the workspace graph
+          #   bun.lock              the resolved closure that ships
+          #   deploy/               the three images that are actually built here
+          #   the scanner itself    scripts + baseline + this file
+          #
+          # ⚠️ `(^|/)` on the file-name patterns, not `^`: the old `package\.json$`
+          # was anchored to the ROOT manifest alone, so a workspace package
+          # gaining a dependency was matched only by the `^packages/` blanket
+          # this narrowing removes. Dropping the blanket without widening these
+          # would have opened a real hole.
+          #
+          # The residual is bounded by design, and by two backstops already in
+          # this file: `push: main` scans unconditionally (the early return
+          # above) — the last chance before an artifact reaches Railway — and
+          # the Monday cron scans an unchanged tree, which is the only thing
+          # that ever catches a CVE disclosed against a digest-pinned base.
+          # PR-time scanning is early warning, not the gate of record.
+          if echo "$CHANGED" | grep -qE '^(deploy/|create-atlas/templates/docker/|examples/docker/|\.trivyignore$|scripts/(scan-image|list-runtime-base-images)\.sh$|\.github/workflows/image-scan\.yml$)|(^|/)Dockerfile|(^|/)package\.json$|(^|/)bun\.lock$'; then
             echo "built-images=true" >> "$GITHUB_OUTPUT"
             echo "Image-relevant paths changed — scanning built images"
           else

--- a/scripts/check-mutation-tables.sh
+++ b/scripts/check-mutation-tables.sh
@@ -165,7 +165,7 @@ $UNTRACKED"
       done
       if [ ${#SELECTED[@]} -eq 0 ]; then
         echo "check-mutation-tables: no spec's targets or sources changed vs $BASE — nothing to verify."
-        echo "  (CI runs --all regardless, so a table that drifted for another reason is still caught.)"
+        echo "  (push: main runs --all, so a table that drifted for another reason is still caught there.)"
         exit 0
       fi
       echo "check-mutation-tables: ${#SELECTED[@]} of ${#SPECS[@]} spec(s) affected by this branch."


### PR DESCRIPTION
Both sweeps **move**, neither is deleted. `push: main` still runs the full mutation sweep and an unconditional image scan; image-scan keeps its Monday cron. What changes is only when a heavy job **blocks a PR**.

## `mutation-tables` — `--affected` on PR, `--all` on push

The job had **no `if:`, no `needs:`, no path filter**. ~14 min of Postgres-backed sweep on every PR, including docs-only ones — and the required `ci` umbrella has it in `needs:`, so every merge button waited on it.

Its own comment justified that:

> ~14 minutes measured for the full sweep, which is **FREE here**: jobs run in parallel and `Built image (docs)` already takes ~25, so this lands well inside the existing critical path.

That premise is conditional on a job which is **itself path-gated** (`built-images` has `if: needs.changes.outputs.built-images == 'true'`). When the image scan skips, `mutation-tables` *is* the critical path. The premise was never wrong — it was never re-checked against the other job's guard.

`--affected` is what `ci-local.sh` already runs. It widens to `--all` on any unresolvable diff, so the narrow path cannot silently verify nothing; that widen needs `fetch-depth: 0`.

**#5077's guarantee is intact.** Its finding was that `--check` existed and nothing ran it — four of eight tables stale on `main`. `push: main` is what keeps that closed.

## `image-scan` — narrow a filter that matched every code PR

The filter opened with `^packages/` — essentially every code change in this repo. Three images built and scanned for a one-line test edit. Its comment calls this "deliberately broad", but **a pattern matching everything is an absent filter, not a broad one**.

The gate detects a vulnerable OS package in a runtime layer, plus library findings in the image's resolved `node_modules`. A TypeScript edit moves neither — it compiles into a layer *above* the base, and the closure Trivy reads is decided by the lockfile and manifests. New trigger set: any `Dockerfile`, any `package.json`, `bun.lock`, `deploy/`, and the scanner's own files.

⚠️ **`(^|/)package\.json$`, not `^package\.json$`.** The old anchor caught the **root** manifest only; workspace manifests rode in on the `^packages/` blanket this removes. Dropping the blanket without widening that would have opened a real hole.

Two backstops already in the file and unchanged: `push: main` scans unconditionally (last chance before Railway) and the Monday cron scans an unchanged tree — the only thing that catches a CVE disclosed against a digest-pinned base.

## Verification

- Regex checked against **12 must-match** paths (all 11 Dockerfiles' dirs, root + workspace manifests, `bun.lock`, `.trivyignore`, scanner scripts) and **7 must-not-match** (source under `packages/`, `ee/`, `plugins/`, `apps/docs` content, `.claude/`, `README.md`). All pass.
- Both workflows parse as YAML; `bash -n` clean on the script.
- ⚠️ **This PR is the test.** `--affected` only runs on a `pull_request` event — pushing straight to `main` would exercise only the `--all` branch and prove nothing. Watch `mutation-tables` here: it should select the affected specs (or report none) instead of sweeping all eight, and `built-images` should **skip**, since this diff touches no Dockerfile, manifest or lockfile.

Test Plan
- [x] Unit tests added/updated — n/a, CI config
- [x] Manual testing — regex validated against 19 paths; YAML + shell syntax
- [ ] E2E tests added/updated