### PR TITLE
fix(eval): the MCP eval auth fixture depended on the runner's NODE_ENV

### DIFF
--- a/packages/mcp/src/eval/auth.ts
+++ b/packages/mcp/src/eval/auth.ts
@@ -297,6 +297,33 @@ function buildEvalAuth(opts: BuildEvalAuthOptions): EvalAuth {
   return betterAuth({
     secret: "atlas-eval-test-secret-not-for-production-use-32+chars",
     baseURL: opts.baseUrl,
+    // ⚠️ STATED, because the default is `isTest()` and that made this fixture
+    // behave differently depending on WHO RAN IT.
+    //
+    //   better-auth/dist/context/create-context.mjs:210
+    //     skipOriginCheck: options.advanced?.disableOriginCheck !== undefined
+    //       ? options.advanced.disableOriginCheck
+    //       : isTest() ? true : false
+    //
+    // Under `bun test` — the deterministic MCP job, and every local run of
+    // `canonical-mcp-auth.test.ts` — `isTest()` is true, so the origin check
+    // was skipped and the loopback DCR call (which sends a cookie and no
+    // `Origin`, as any non-browser client does) sailed through. Under the CLI
+    // binary, which is how the `eval-mcp-llm` job invokes this same fixture,
+    // `isTest()` is false and the identical request is refused with
+    // `403 MISSING_OR_NULL_ORIGIN` before a single LLM call is made.
+    //
+    // That job has never executed (#5039: its secret was never wired, and
+    // until #5040 a skipped step counted as a pass), so the break has been
+    // latent since the fixture was written and would have surfaced as a 403
+    // on the first real run — a failure that looks nothing like the eval
+    // regression the job exists to report.
+    //
+    // Setting it explicitly costs NO coverage: the check has never been
+    // exercised by either eval path, because the path that runs is always in
+    // test mode. What changes is that both paths now agree, and neither
+    // depends on the runner's NODE_ENV.
+    advanced: { disableOriginCheck: true },
     // Memory adapter requires every table the plugin set will touch to
     // be pre-allocated as an empty array, otherwise the first findOne
     // throws "Model X not found". The plugin set below exercises:


### PR DESCRIPTION
Refs #5039. Found by actually running the thing.

## The eval lane was broken, and could not have been noticed

`eval-mcp-llm` would have failed on its **first ever execution**, at Dynamic Client Registration, before making a single LLM call:

```
HostedFlowError: Dynamic Client Registration returned 403:
{"message":"Missing or null Origin","code":"MISSING_OR_NULL_ORIGIN"}
```

Root cause — `better-auth/dist/context/create-context.mjs:210`:

```js
skipOriginCheck: options.advanced?.disableOriginCheck !== undefined
  ? options.advanced.disableOriginCheck
  : isTest() ? true : false
```

The fixture sets neither option, so the origin check is skipped **only under `isTest()`**:

| Job | How it invokes the fixture | `isTest()` | Result |
|---|---|---|---|
| `canonical-mcp-eval (deterministic)` | `bun test` | **true** | check skipped → green, forever |
| `eval-mcp-llm` | the CLI binary | **false** | check enforced → **403** |

The loopback DCR call sends a cookie and no `Origin` header — which is what any non-browser client does — so the enforced path refuses it.

**Nobody could have known.** The job's secret was never wired (#5039) and until #5040 a `skipped` step counted as a pass, so it has never run. This is ADR-0037 §9's thesis landing on the exact job that motivated it: *a fully built, thoroughly commented gate that was broken the entire time it was green.* The sequence #5040 → #5039 would have produced a red 403 that looks nothing like an eval regression.

## The fix costs no coverage

Setting `advanced.disableOriginCheck` explicitly is not a loosening. **The origin check has never been exercised by either eval path**, because the path that actually runs is always in test mode. What changes is that the two paths now agree, and neither depends on the runner's `NODE_ENV`.

## Verified by running it

CLI path, `NODE_ENV` unset, against the gateway — the configuration CI will use:

- auth completes, all **20 questions dispatch**
- **124 tool calls**, 6.2 per question
- **429s** of model wall-clock

Deterministic suites unchanged: `canonical-mcp-auth` 5 pass. The evalspec's local failures are an unrelated internal-DB env issue — **identical on `main` with this change stashed**, and green in CI.

## ⚠️ The first run scored 1/20 against an 18/20 floor

Not addressed here, and it should not be quietly folded into a fix PR. Nineteen questions fail across the categories the job grades:

| Category | Failing |
|---|---|
| `recovery` | 12 |
| `tool_selection` | 4 |
| `protocol` | 3 |

Three are MCP **input-validation** errors — e.g. `describeEntity` called with `names: ['Order Items', …]` returning `MCP error -32602`. Only `cq-017` passes.

This is the acceptance work #2119 Part B never got, because the job never ran. It needs its own issue and its own investigation — the eval's grader and the tool surface are both suspects, and telling them apart is the work.

https://claude.ai/code/session_01Nw48fTVDX125V9AfDaquY3