### PR TITLE
docs(agents): open the PR as a draft first, so remote CI runs alongside the panel

### DIFF
--- a/.claude/commands/ship-batch.md
+++ b/.claude/commands/ship-batch.md
@@ -47,7 +47,11 @@ Agent(
   run_in_background: true,
   description: "ship #<N>",
   prompt: "Run /ship-issue <N>. Follow it exactly — worktree isolation, craft loop,
-           /review-panel until clean (max 3 rounds), /ci, /pr, then drive to merge per
+           cheap pre-flight (--affected/lint/type), push, /pr as a DRAFT, then
+           /review-panel until clean (max 3 rounds) while remote CI runs against the
+           same SHA. Do NOT run a full local /ci — remote CI on the PR is the gate
+           (see /ship-issue Step 4). Mark the PR ready only once the panel closes,
+           then drive to merge per
            Step 5: wait for the first full CI to complete (gh pr checks --watch), then run
            `bash scripts/pr-review-status.sh <N>` ONCE. If it reports no third-party
            reviewer, converge on CI green + clean panel — do NOT wait for bots that don't

--- a/.claude/commands/ship-issue.md
+++ b/.claude/commands/ship-issue.md
@@ -110,7 +110,28 @@ Note the type label, acceptance criteria, and any `Depends on #M`. If a dependen
 
 Use `cd packages/api && bun run scripts/test-isolated.ts --affected` for the fast red→green loop.
 
-**Step 3 — Internal review BEFORE the PR**
+**Step 3 — Push, open a DRAFT PR, then run the panel against it**
+
+Run the cheap pre-flight (Step 4), push, and open the PR **as a draft** — then start
+the panel. Remote CI and the panel run **concurrently**, against the same head SHA:
+
+```bash
+cd packages/api && bun run scripts/test-isolated.ts --affected   # + bun run lint, bun run type
+git push -u origin <branch>
+# then /pr, adding --draft to its `gh pr create` invocation
+```
+
+⚠️ **The draft is what makes the concurrency safe, and it is not optional.** A draft
+PR cannot be merged — GitHub refuses, and `mergeStateStatus` reports `DRAFT` — so
+"the panel has not closed yet" becomes a **structural** fact about the PR rather
+than a rule someone has to remember. Opening it non-draft and promising to wait is
+the exact posture Step 5's evidence below says fails.
+
+CI runs on drafts (no workflow in `.github/workflows/` guards on
+`github.event.pull_request.draft`, verified 2026-08-11), so the ~4 minutes of remote
+CI overlaps the panel instead of queueing behind it. Panel fixes are `git commit -o
+<files>` + push, which updates the PR in place and re-runs CI — so by the time the
+panel closes, CI has usually already answered on the final SHA.
 
 ```
 /review-panel
@@ -126,16 +147,24 @@ round 1 describes code that round 1's own fixes are about to change.
 
 Measured on #5110: the run picked `comment-analyzer` and `fix-vs-finding` first —
 comment-analyzer in what was effectively round 1, the inversion that file names
-outright — and ran the three code reviewers **after the PR was already open and
-CI green**. That is Step 3 executed at Step 5. `silent-failure-hunter` then
-returned a CRITICAL finding (a poisoned pooled client returned via
-`client.release()` with no argument, under a 500 body asserting *"nothing was
-written … re-sending is safe"*) on code the PR had been declared ready to merge
-with. Nothing was lost because the merge had not happened — but the gate had been
-reported as passed, which is the failure.
+outright — and ran the three code reviewers **after the PR had been declared
+ready to merge**. `silent-failure-hunter` then returned a CRITICAL finding (a
+poisoned pooled client returned via `client.release()` with no argument, under a
+500 body asserting *"nothing was written … re-sending is safe"*) on code the PR
+had been declared ready to merge with. Nothing was lost because the merge had not
+happened — but the gate had been reported as passed, which is the failure.
 
-**Step 3 is BEFORE Step 5. If you are reading review findings after a PR URL
-exists, you are recovering, not reviewing.**
+⚠️ **Read that failure precisely, because the draft-PR flow above deliberately
+does one half of it.** #5110's defect was **not** that a PR URL existed while
+reviewers were still running — that is now the intended flow, and it is how CI
+and the panel overlap. The defect was that the run **reported the gate passed**
+and treated the PR as merge-ready with the code reviewers not yet run. Those are
+different acts, and only the second one is forbidden.
+
+**The panel closes BEFORE the PR leaves draft.** A PR URL existing means nothing;
+a PR marked *ready* is a claim that Step 3 finished. If you are marking a PR ready
+— or reading `mergeStateStatus` as anything but `DRAFT` — with panel rounds still
+outstanding, you are recovering, not reviewing.
 - Verdict **CHANGES REQUESTED** → **triage the must-fix findings first** (`/review-panel` Step 5: local defect → fix inline; new machinery → follow-up by default, from round one), then **Step 5b before writing each fix** — for a guard/branch/comparison, the BEHAVIOUR DELTA table (input classes × old vs new, in the commit); for everything else, the sibling grep. Then fix, build the falsifier in the same commit, then re-run `/review-panel` on the new diff.
 
   ⚠️ **Fixing the reported instance and not the class is THE reason rounds multiply, and the class has members in two directions.** The grep finds siblings in space; the delta table finds siblings in the input domain at one site. #5037 swept diligently for the first and lost three rounds to the second — one guard, edited three times, each edit closing the symptom a reviewer named and opening the input class beside it.
@@ -144,7 +173,7 @@ exists, you are recovering, not reviewing.**
 ⚠️ **"STOP" IN THIS STEP ENDS THE ROUNDS, NOT THE RUN. Read this before any stop rule below.**
 
 Every stop in Step 3 means *this diff gets no more review rounds* — fix what is
-confirmed, pay the closing round's costs, and **continue to Step 4's pre-flight and Step 5's PR.**
+confirmed, pay the closing round's costs, and **continue to Step 5 — mark the draft PR ready and drive it to merge.**
 It does **not** mean park the issue and wait for a human. `/ship-issue` is the
 autonomous loop; the human boundaries are Step 5's HARD HALTS (a fork PR, a
 structurally missing required check) and a genuine blocker — a spec ambiguity you
@@ -189,11 +218,14 @@ and names the boundary.
 
 **Step 4 — CI gate: PUSH FIRST, and let REMOTE CI be the gate**
 
+This is the pre-flight Step 3 opens with — it is documented here, but it **runs
+before the push**, at the top of Step 3:
+
 ```bash
 cd packages/api && bun run scripts/test-isolated.ts --affected   # + bun run lint, bun run type
 ```
 
-Then open the PR (Step 5) and let remote CI run. **Do NOT run `/ci` locally before every PR.**
+Then push, open the draft PR, and let remote CI run **while the panel runs**. **Do NOT run `/ci` locally before every PR.**
 
 ⚠️ **This is a change, and the arithmetic is the whole argument.** `scripts/ci-local.sh` is ~25 minutes, largely serial, and the mutation gate inside it rewrites source files in place — so nothing else can touch the tree while it runs. Remote CI on the PR covers the same gates in **~4 minutes**, in parallel, on hardware that is not yours, while you do something else. Running both means paying the slow one first for a result the fast one is about to produce anyway. Measured across `/ship-issue` runs, local `/ci` was one of the largest single blocks of wall clock in the loop and caught nothing remote CI did not.
 
@@ -323,12 +355,18 @@ disagree with, which is worse than the stale table you started with.
 
 `/ci` uses a **launch-and-watch protocol** (see `ci.md`): the wrapper runs in the background and YOU poll `.ci-local/RESULT` on a loop — never end the turn "waiting for the CI report". A lost subagent hand-off here used to stall the whole ship loop until a human poked it; `.ci-local/RESULT` on disk is the completion signal, not any agent's reply.
 
-**Step 5 — Open the PR, then drive it to merge**
+**Step 5 — Mark the PR ready, then drive it to merge**
 
+The PR already exists — Step 3 opened it as a draft and `/pr` gave it its title,
+body and `Closes #<N>`. The panel has now closed, so take it out of draft:
+
+```bash
+gh pr ready <N> -R AtlasDevHQ/atlas
 ```
-/pr
-```
-`/pr` branches/commits/pushes and opens the PR with `Closes #<N>`.
+
+⚠️ **Marking it ready IS the claim that Step 3 finished.** Do not run this with
+rounds outstanding — see Step 3's #5110 note. If the panel stopped early, the body
+owes the curve *before* this command, not after.
 
 ⚠️ **If the Step-3 panel stopped early, the PR body owes the CURVE and the residue** — rounds with both numbers per round (`round 2: 17 — 4 new surface, 13 defect-in-prior-fix`), why the loop closed, and what was consciously left as a follow-up. That disclosure is what makes an early stop legitimate rather than a shortcut: the reviewer opening the PR is the human the stop rule wanted told, and the PR body is where they are standing.
 
@@ -482,4 +520,4 @@ PR URL · issue closed · CI/merge status · panel rounds it took, with the CURV
 
 ---
 
-**Rules:** Always `-R AtlasDevHQ/atlas`. Worktree-isolated commits only. The panel + `/ci` are mandatory gates, not optional. Respect every merge-discipline halt in CLAUDE.md.
+**Rules:** Always `-R AtlasDevHQ/atlas`. Worktree-isolated commits only. The panel and **remote** CI are the mandatory gates; a full local `/ci` is NOT one — run it only under Step 4's stated exceptions. The PR stays in draft until the panel closes. Respect every merge-discipline halt in CLAUDE.md.

--- a/.claude/commands/ship-milestone.md
+++ b/.claude/commands/ship-milestone.md
@@ -33,7 +33,11 @@ Agent(
   run_in_background: true,
   description: "ship #<N>",
   prompt: "Run /ship-issue <N>. Follow it exactly — worktree isolation, craft loop,
-           /review-panel until clean (max 3 rounds), /ci, /pr, then drive to merge per
+           cheap pre-flight (--affected/lint/type), push, /pr as a DRAFT, then
+           /review-panel until clean (max 3 rounds) while remote CI runs against the
+           same SHA. Do NOT run a full local /ci — remote CI on the PR is the gate
+           (see /ship-issue Step 4). Mark the PR ready only once the panel closes,
+           then drive to merge per
            Step 5: wait for the first full CI to complete (gh pr checks --watch), then run
            `bash scripts/pr-review-status.sh <N>` ONCE. If it reports no third-party
            reviewer, converge on CI green + clean panel — do NOT wait for bots that don't

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ These hold everywhere. The rest of this file is orientation, not rules.
 
 ### Tests
 - **`bun run test`, never bare `bun test`** — isolated per-file runner. Single file OK: `bun test path/to/file.test.ts`
-- **`/ci` before every PR** — `scripts/ci-local.sh`, 32 gates. Iterate with `cd packages/api && bun run scripts/test-isolated.ts --affected`
+- **Remote CI on the PR is the gate, not a local `/ci`** — push, open the PR as a **draft**, and let `ci.yml` run (~4 min, parallel) while you review. The local pre-flight is the cheap subset: `cd packages/api && bun run scripts/test-isolated.ts --affected`, plus `bun run lint` and `bun run type`. Run the full `scripts/ci-local.sh` (32 gates, ~25 min, serial, rewrites source in place for the mutation gate) only when remote CI is broken, when you reshaped something `mutation-tables` anchors on, or before `/release`. Exceptions and the arithmetic: `/ship-issue` Step 4
 
 ### Merge discipline
 Rationale + override rules: [docs/development/branch-protection.md](docs/development/branch-protection.md). These are workflow rules — no file-read triggers them, so they stay here:

--- a/docs/agents/workflow.md
+++ b/docs/agents/workflow.md
@@ -78,8 +78,9 @@ When Atlas opens to a community, `/triage` runs first (move new issues through t
 
 | Situation | Use |
 | --- | --- |
-| Pre-PR gate — lint, type, test, syncpack, template drift, railway-watch | `/ci` (Atlas) — all five must pass |
-| Open a PR | `/pr` (Atlas) — branch, commit, push, create PR |
+| Pre-PR gate | Remote CI on a **draft** PR — push first, review while it runs. Local pre-flight is only `--affected` + `lint` + `type` |
+| Full local battery — 32 gates, ~25 min | `/ci` (Atlas) — only when remote CI is broken, a mutation anchor moved, or before `/release`. See `/ship-issue` Step 4 |
+| Open a PR | `/pr` (Atlas) — branch, commit, push, create PR (add `--draft` when the panel hasn't run yet) |
 | Milestone is fully shipped | `/closeout` (Atlas) — docs audit, changelog, close GH milestone |
 | Handing the in-flight session to another agent / clone / day | `/handoff` (Matt Pocock — compacts the session into a handoff doc) |
 | Need a recurring run of any of the above | `/loop` or `/schedule` (Claude Code) |


### PR DESCRIPTION
Docs/commands only — no source, no tests.

## What changed

**The ordering.** `/ship-issue` ran the full review panel, and only then opened a PR for remote CI to start on. Those two have no dependency on each other, so the loop paid for them serially. The PR now opens as a **draft** immediately after the cheap pre-flight, and the panel runs against it while CI burns down on the same SHA. Panel fixes are `git commit -o <files>` + push, which update the PR in place and re-run CI.

**Why a draft specifically.** A draft PR cannot be merged — GitHub refuses and `mergeStateStatus` reports `DRAFT` — so "the panel has not closed yet" is a structural fact about the PR instead of a rule an agent has to remember. `gh pr ready` becomes the single act that claims Step 3 finished.

Verified before writing it: no workflow in `.github/workflows/` guards on `github.event.pull_request.draft`, so CI genuinely runs on drafts. `ci.yml`'s `pull_request` trigger is branch-filtered only.

## This narrows #5110's rule, it does not reverse it

Step 3 carried a strongly-argued invariant — *"If you are reading review findings after a PR URL exists, you are recovering, not reviewing."* Read precisely, #5110's defect was that the run **reported the gate passed** and treated the PR as merge-ready with the three code reviewers not yet run. The PR URL's existence was incidental; the premature *claim* was the failure.

So the invariant is restated on the act that actually matters: **the panel closes before the PR leaves draft.** The roster/ordering half of #5110's lesson (comment-analyzer must not run in round 1) is untouched.

## The `/ci` drift this surfaced

`ship-issue.md` Step 4 has argued "push first, let remote CI be the gate" — with the arithmetic (~25 min serial local vs ~4 min parallel remote, and "caught nothing remote CI did not") — while **five** other places still said to run the full local battery before every PR:

| file | what it said |
|---|---|
| `ship-batch.md` dispatch template | `"/review-panel …, /ci, /pr"` |
| `ship-milestone.md` dispatch template | identical |
| `ship-issue.md:485` trailer | "The panel + `/ci` are mandatory gates" — contradicting its own Step 4 |
| `CLAUDE.md` | "**`/ci` before every PR**" — the highest-authority statement of it |
| `docs/agents/workflow.md` | pre-PR gate row |

The two dispatch templates are the ones with teeth: every worker `/ship-batch` and `/ship-milestone` spawn got the stale instruction injected into their prompt. That is how this was found — a live batch dispatched three minutes before I read Step 4.

## Risk

Docs-only, so the failure mode is behavioural, not a broken build. The one to watch is an agent marking a PR ready before the panel closes — previously prevented by there being no PR at all, now prevented by the draft state plus an explicit rule. The draft is the stronger of the two mechanisms, which is why it is the one carrying the invariant.