### PR TITLE
fix(eval): a successful `explore` call no longer fails its question — apply the tool's output contract at the recording seam

### DIFF
--- a/packages/cli/bin/canonical-eval-mcp-llm.test.ts
+++ b/packages/cli/bin/canonical-eval-mcp-llm.test.ts
@@ -109,13 +109,21 @@ const METRIC_EXPECTATIONS = {
   total_gmv: { kind: "scalar", value: 1 },
 } as const;
 
+/**
+ * Build a recorded call. `contract` defaults to `"json"` — the strict
+ * contract every typed tool carries — so a fixture only opts into `"text"`
+ * where the tool's declared output really is free-form (#5131). Defaulting
+ * the OTHER way would make every existing grader fixture silently exempt
+ * from the protocol check.
+ */
 function call(
   name: string,
   args: Record<string, unknown>,
   result: RecordedToolCall["result"],
   latencyMs = 5,
+  contract: RecordedToolCall["contract"] = "json",
 ): RecordedToolCall {
-  return { name, args, latencyMs, result };
+  return { name, args, contract, latencyMs, result };
 }
 
 // ── Metric mode ──────────────────────────────────────────────────────
@@ -813,6 +821,124 @@ describe("grade", () => {
     }
   });
 
+  // ── Text-contract tools are exempt from the JSON/protocol check (#5131) ──
+  //
+  // Five of the eight failures on the eval's first real CI run were one
+  // `explore` call each: a successful `ls -la` graded as
+  // "MCP tool explore returned non-JSON content". `explore` is a sandboxed
+  // shell — text IS its output contract.
+  //
+  // The pair below is deliberately DISCRIMINATING rather than agreeing by
+  // construction: both sequences carry a text-contract call, and the second
+  // still fails. A fix that exempted the run whenever any text-contract call
+  // appeared, or that dropped the check outright, passes the first test and
+  // fails the second.
+
+  it("does NOT fail a question for a text-contract tool that answered with text", () => {
+    const q = metricQuestion("cq-001", "total_gmv");
+    const calls = [
+      call(
+        "explore",
+        { command: "ls -la" },
+        {
+          kind: "unparseable",
+          raw: "total 4\ndrwxr-xr-x 1 user user 0 Jan 1 00:00 .\nentities/\nmetrics/\n",
+        },
+        5,
+        "text",
+      ),
+      call(
+        "runMetric",
+        { id: "total_gmv" },
+        { kind: "ok", data: { id: "total_gmv", sql: "...", columns: ["v"], rows: [{ v: 1 }] } },
+      ),
+    ];
+    const out = __forTesting__.grade({
+      question: q,
+      toolCalls: calls,
+      finalText: "$1",
+      latencyMs: 10,
+      baseline: undefined,
+      metricExpectations: METRIC_EXPECTATIONS,
+      answerExpectations: undefined,
+    });
+    expect(out.status).toBe("pass");
+  });
+
+  it("STILL fails a JSON-contract tool that answered with non-JSON, even alongside a text-contract call", () => {
+    const q = metricQuestion("cq-001", "total_gmv");
+    const calls = [
+      // Same successful shell call as the test above — present so the
+      // exemption cannot be "this run touched a text tool, skip the check".
+      call(
+        "explore",
+        { command: "ls -la" },
+        { kind: "unparseable", raw: "entities/\nmetrics/\n" },
+        5,
+        "text",
+      ),
+      call(
+        "runMetric",
+        { id: "total_gmv" },
+        { kind: "unparseable", raw: "<<malformed>>" },
+      ),
+    ];
+    const out = __forTesting__.grade({
+      question: q,
+      toolCalls: calls,
+      finalText: "",
+      latencyMs: 10,
+      baseline: undefined,
+      metricExpectations: METRIC_EXPECTATIONS,
+      answerExpectations: undefined,
+    });
+    expect(out.status).toBe("fail");
+    if (out.status === "fail") {
+      expect(out.artifact.category).toBe("protocol");
+      // The tool NAMED must be the JSON one — a fix that reported `explore`
+      // here would be blaming the shell for the typed tool's regression.
+      expect(out.artifact.tool).toBe("runMetric");
+    }
+  });
+
+  it("STILL fails a text-contract tool whose TRANSPORT hung up", () => {
+    // The exemption is scoped to "non-JSON body", not to the tool. A socket
+    // hang-up on `explore` is a protocol regression exactly as it is on
+    // `runMetric` — a fix that exempted the tool wholesale would pass this
+    // question and lose a real signal.
+    const q = metricQuestion("cq-001", "total_gmv");
+    const calls: RecordedToolCall[] = [
+      {
+        name: "explore",
+        args: { command: "ls -la" },
+        contract: "text",
+        latencyMs: 3,
+        result: {
+          kind: "error",
+          envelope: {
+            __transport: true,
+            error: "socket hang up",
+            errorName: "AbortError",
+          },
+        },
+      },
+    ];
+    const out = __forTesting__.grade({
+      question: q,
+      toolCalls: calls,
+      finalText: "",
+      latencyMs: 3,
+      baseline: undefined,
+      metricExpectations: METRIC_EXPECTATIONS,
+      answerExpectations: undefined,
+    });
+    expect(out.status).toBe("fail");
+    if (out.status === "fail") {
+      expect(out.artifact.category).toBe("protocol");
+      expect(out.artifact.tool).toBe("explore");
+    }
+  });
+
   it("emits a latency artifact when dispatch exceeds baseline by >25% (after a successful answer)", () => {
     const q = metricQuestion("cq-001", "total_gmv");
     const calls = [
@@ -940,6 +1066,7 @@ describe("grade", () => {
       {
         name: "runMetric",
         args: { id: "total_gmv" },
+        contract: "json",
         latencyMs: 3,
         result: {
           kind: "error",
@@ -1168,6 +1295,93 @@ describe("bindMcpToolsForLlm", () => {
       expect(env.errorName).toBe("AbortError");
       expect(typeof env.stack).toBe("string");
     }
+  });
+
+  // ── Contract classification happens HERE, not in the grader (#5131) ──
+  //
+  // These drive the real binder rather than hand-stamping `contract` on a
+  // fixture, so they falsify `classifyToolContract` itself: point it at the
+  // wrong name, or drop the stamp, and they go red.
+
+  it("stamps the output contract per tool and hands text-contract output back verbatim", async () => {
+    const recorded: RecordedToolCall[] = [];
+    const listing = "total 4\ndrwxr-xr-x 1 user user 0 Jan 1 00:00 .\nentities/\nmetrics/\n";
+    const fakeClient = {
+      callTool: async (name: string) =>
+        // Both tools answer the SAME non-JSON body. The only thing that
+        // differs is which tool answered it — which is the whole claim.
+        fakeCallToolResult(name === "explore" ? listing : "<<malformed>>"),
+    };
+    const tools = __forTesting__.bindMcpToolsForLlm(
+      fakeClient,
+      [
+        { name: "explore", description: "Shell over the semantic layer." },
+        { name: "describeEntity", description: "Describe an entity." },
+      ],
+      recorded,
+    );
+
+    const exploreResult = await getRunner(tools, "explore")(
+      { command: "ls -la" },
+      { toolCallId: "t1", messages: [] },
+    );
+    // The model gets the listing it asked for — NOT a fabricated
+    // `{ error: "unparseable" }` for a call that succeeded.
+    expect(exploreResult).toBe(listing);
+
+    const describeResult = (await getRunner(tools, "describeEntity")(
+      { name: "orders" },
+      { toolCallId: "t2", messages: [] },
+    )) as { error?: string };
+    expect(describeResult.error).toBe("unparseable");
+
+    expect(recorded).toHaveLength(2);
+    expect(recorded[0]!.contract).toBe("text");
+    expect(recorded[1]!.contract).toBe("json");
+  });
+
+  it("classifies every typed semantic tool as json", () => {
+    // `describeEntity`, `searchGlossary` and `listEntities` declare no MCP
+    // `outputSchema` (only `runMetric` / `executeSQL` / `query` do), so any
+    // exemption keyed on `outputSchema` would have silently let these three
+    // out of the protocol check. Pinned so that shortcut cannot be taken later.
+    for (const name of [
+      "runMetric",
+      "executeSQL",
+      "query",
+      "describeEntity",
+      "searchGlossary",
+      "listEntities",
+    ]) {
+      expect(__forTesting__.classifyToolContract(name)).toBe("json");
+    }
+  });
+});
+
+// ── Text-contract anchoring ───────────────────────────────────────────
+
+describe("assertTextContractToolsPresent", () => {
+  // The exemption is spelled as a NAME. Rename `explore` and the name stops
+  // matching, the exemption becomes a no-op, and every successful shell call
+  // is graded as a protocol regression again — silently. This anchor is what
+  // turns that into a loud stop at boot.
+
+  it("passes when every text-contract tool is on the discovered surface", () => {
+    expect(() =>
+      __forTesting__.assertTextContractToolsPresent([
+        { name: "explore" },
+        { name: "runMetric" },
+      ]),
+    ).not.toThrow();
+  });
+
+  it("throws, naming the missing tool and the surface, when one was renamed away", () => {
+    expect(() =>
+      __forTesting__.assertTextContractToolsPresent([
+        { name: "shell" },
+        { name: "runMetric" },
+      ]),
+    ).toThrow(/text-contract tool\(s\) not on the MCP surface: explore.*Discovered:.*shell/s);
   });
 });
 

--- a/packages/cli/bin/canonical-eval-mcp-llm.test.ts
+++ b/packages/cli/bin/canonical-eval-mcp-llm.test.ts
@@ -21,6 +21,7 @@ import * as path from "path";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import {
   __forTesting__,
+  classifyToolContract,
   readBaseline,
   writeBaseline,
   type McpLlmOutcome,
@@ -821,29 +822,100 @@ describe("grade", () => {
     }
   });
 
-  // ── Text-contract tools are exempt from the JSON/protocol check (#5131) ──
+  // ── Text-contract tools and the protocol check (#5131) ───────────────
   //
   // Five of the eight failures on the eval's first real CI run were one
   // `explore` call each: a successful `ls -la` graded as
   // "MCP tool explore returned non-JSON content". `explore` is a sandboxed
   // shell — text IS its output contract.
   //
-  // The pair below is deliberately DISCRIMINATING rather than agreeing by
-  // construction: both sequences carry a text-contract call, and the second
-  // still fails. A fix that exempted the run whenever any text-contract call
-  // appeared, or that dropped the check outright, passes the first test and
-  // fails the second.
+  // ⚠️ THE FIX IS AT THE RECORDING SEAM, NOT HERE. `interpretResult` records a
+  // successful text-contract call as `ok`, so `grade()` never needs to know
+  // about contracts and these tests pin the grader's side of that: a recorded
+  // `unparseable` is a regression for EVERY tool, text-contract or not. The
+  // classifier's own falsifiers live in the `bindMcpToolsForLlm` block below.
 
-  it("does NOT fail a question for a text-contract tool that answered with text", () => {
+  it("passes a question whose text-contract call was recorded as ok, keeping it in the sequence", () => {
+    const q = metricQuestion("cq-001", "total_gmv");
+    const listing = "total 4\ndrwxr-xr-x 1 user user 0 Jan 1 00:00 .\nentities/\nmetrics/\n";
+    const calls = [
+      call("explore", { command: "ls -la" }, { kind: "ok", data: listing }, 5, "text"),
+      call(
+        "runMetric",
+        { id: "total_gmv" },
+        { kind: "ok", data: { id: "total_gmv", sql: "...", columns: ["v"], rows: [{ v: 1 }] } },
+      ),
+    ];
+    const out = __forTesting__.grade({
+      question: q,
+      toolCalls: calls,
+      finalText: "$1",
+      latencyMs: 10,
+      baseline: undefined,
+      metricExpectations: METRIC_EXPECTATIONS,
+      answerExpectations: undefined,
+    });
+    expect(out.status).toBe("pass");
+    // The exemption must mean "not GRADED as a regression", never "dropped
+    // from the record" — a fix that passed by deleting the call would lose the
+    // forensic trail every failure artifact is built from.
+    expect(out.toolCalls.map((c) => c.name)).toContain("explore");
+  });
+
+  it("STILL fails a JSON-contract tool recorded unparseable — same body as an exempt call, and a good answer present", () => {
+    // ⚠️ THIS FIXTURE IS BUILT TO DISCRIMINATE. All three levers a sloppier
+    // fix could key on are held constant or present:
+    //   - the exempt call and the failing call carry the IDENTICAL body, so a
+    //     content heuristic ("looks like shell output") cannot pass this;
+    //   - a successful answering call IS present, so "only report unparseable
+    //     when the run produced no answer" cannot pass this;
+    //   - a text-contract call IS present, so "skip the check when the run
+    //     touched a text tool" cannot pass this.
+    // The only thing that differs between the exempt and failing calls is the
+    // recorded `contract`.
+    const q = metricQuestion("cq-001", "total_gmv");
+    const listing = "entities/\nmetrics/\n";
+    const calls = [
+      call("explore", { command: "ls -la" }, { kind: "ok", data: listing }, 5, "text"),
+      call("describeEntity", { name: "orders" }, { kind: "unparseable", raw: listing }),
+      call(
+        "runMetric",
+        { id: "total_gmv" },
+        { kind: "ok", data: { id: "total_gmv", sql: "...", columns: ["v"], rows: [{ v: 1 }] } },
+      ),
+    ];
+    const out = __forTesting__.grade({
+      question: q,
+      toolCalls: calls,
+      finalText: "$1",
+      latencyMs: 10,
+      baseline: undefined,
+      metricExpectations: METRIC_EXPECTATIONS,
+      answerExpectations: undefined,
+    });
+    expect(out.status).toBe("fail");
+    if (out.status === "fail") {
+      expect(out.artifact.category).toBe("protocol");
+      // The tool NAMED must be the JSON one — a fix that reported `explore`
+      // here would be blaming the shell for the typed tool's regression.
+      expect(out.artifact.tool).toBe("describeEntity");
+    }
+  });
+
+  it("STILL fails a TEXT-contract tool recorded unparseable — the grader must stay contract-blind", () => {
+    // ⚠️ THIS IS THE COMPOSITION TEST, and it exists because a mutation
+    // survived without it. `interpretResult` only ever records a text-contract
+    // call as `unparseable` for the two cases that are NOT shell output: a
+    // server-flagged error, and empty content. So re-adding a
+    // `contract === "json"` clause to `isUnparseable` would reopen both holes
+    // — and every other test here would stay green, because none of them
+    // presents the grader with a text-contract `unparseable`.
     const q = metricQuestion("cq-001", "total_gmv");
     const calls = [
       call(
         "explore",
         { command: "ls -la" },
-        {
-          kind: "unparseable",
-          raw: "total 4\ndrwxr-xr-x 1 user user 0 Jan 1 00:00 .\nentities/\nmetrics/\n",
-        },
+        { kind: "unparseable", raw: "Error: sandbox failed to start" },
         5,
         "text",
       ),
@@ -862,43 +934,44 @@ describe("grade", () => {
       metricExpectations: METRIC_EXPECTATIONS,
       answerExpectations: undefined,
     });
-    expect(out.status).toBe("pass");
-  });
-
-  it("STILL fails a JSON-contract tool that answered with non-JSON, even alongside a text-contract call", () => {
-    const q = metricQuestion("cq-001", "total_gmv");
-    const calls = [
-      // Same successful shell call as the test above — present so the
-      // exemption cannot be "this run touched a text tool, skip the check".
-      call(
-        "explore",
-        { command: "ls -la" },
-        { kind: "unparseable", raw: "entities/\nmetrics/\n" },
-        5,
-        "text",
-      ),
-      call(
-        "runMetric",
-        { id: "total_gmv" },
-        { kind: "unparseable", raw: "<<malformed>>" },
-      ),
-    ];
-    const out = __forTesting__.grade({
-      question: q,
-      toolCalls: calls,
-      finalText: "",
-      latencyMs: 10,
-      baseline: undefined,
-      metricExpectations: METRIC_EXPECTATIONS,
-      answerExpectations: undefined,
-    });
     expect(out.status).toBe("fail");
     if (out.status === "fail") {
       expect(out.artifact.category).toBe("protocol");
-      // The tool NAMED must be the JSON one — a fix that reported `explore`
-      // here would be blaming the shell for the typed tool's regression.
-      expect(out.artifact.tool).toBe("runMetric");
+      expect(out.artifact.tool).toBe("explore");
     }
+  });
+
+  it("points a throttled TEXT-contract tool at the sandbox limiter, not the eval client quota", () => {
+    // `explore` can return `rate_limited` from the SANDBOX backend via
+    // `classifyExploreError`, which is a different knob from the eval client's
+    // hosted-MCP quota. Aborting is right either way — a throttled run must not
+    // produce a score — but sending an operator to
+    // EVAL_CLIENT_REQUESTS_PER_MINUTE for a sandbox limit is pointing at a knob
+    // that cannot help.
+    const q = metricQuestion("cq-001", "total_gmv");
+    const throttle = { kind: "error" as const, envelope: { code: "rate_limited", message: "pool capacity reached" } };
+    const gradeWith = (c: RecordedToolCall) =>
+      __forTesting__.grade({
+        question: q,
+        toolCalls: [c],
+        finalText: "",
+        latencyMs: 5,
+        baseline: undefined,
+        metricExpectations: METRIC_EXPECTATIONS,
+        answerExpectations: undefined,
+      });
+
+    expect(() => gradeWith(call("explore", { command: "ls" }, throttle, 5, "text"))).toThrow(
+      /sandboxed shell.*will not help/s,
+    );
+    // The JSON-contract arm keeps the original remedy — if both said the same
+    // thing the branch would be decoration.
+    expect(() => gradeWith(call("runMetric", { id: "total_gmv" }, throttle))).toThrow(
+      /EVAL_CLIENT_REQUESTS_PER_MINUTE/,
+    );
+    expect(() => gradeWith(call("runMetric", { id: "total_gmv" }, throttle))).not.toThrow(
+      /sandboxed shell/,
+    );
   });
 
   it("STILL fails a text-contract tool whose TRANSPORT hung up", () => {
@@ -1300,18 +1373,20 @@ describe("bindMcpToolsForLlm", () => {
   // ── Contract classification happens HERE, not in the grader (#5131) ──
   //
   // These drive the real binder rather than hand-stamping `contract` on a
-  // fixture, so they falsify `classifyToolContract` itself: point it at the
-  // wrong name, or drop the stamp, and they go red.
+  // fixture, so they falsify `classifyToolContract` and `interpretResult`
+  // themselves: point the name list at the wrong tool, drop the stamp, or
+  // remove the text branch, and they go red. The grader tests above cannot
+  // reach any of that.
 
-  it("stamps the output contract per tool and hands text-contract output back verbatim", async () => {
+  /** The identical body every tool in these fixtures answers with. */
+  const LISTING = "total 4\ndrwxr-xr-x 1 user user 0 Jan 1 00:00 .\nentities/\nmetrics/\n";
+
+  it("records a text tool's output as ok and hands it back verbatim; the SAME body from a json tool is unparseable", async () => {
     const recorded: RecordedToolCall[] = [];
-    const listing = "total 4\ndrwxr-xr-x 1 user user 0 Jan 1 00:00 .\nentities/\nmetrics/\n";
-    const fakeClient = {
-      callTool: async (name: string) =>
-        // Both tools answer the SAME non-JSON body. The only thing that
-        // differs is which tool answered it — which is the whole claim.
-        fakeCallToolResult(name === "explore" ? listing : "<<malformed>>"),
-    };
+    // ⚠️ Both tools answer the IDENTICAL body, so the tool NAME is the only
+    // differentiator. A binder that keyed on what the body looks like rather
+    // than on which tool produced it cannot pass this.
+    const fakeClient = { callTool: async () => fakeCallToolResult(LISTING) };
     const tools = __forTesting__.bindMcpToolsForLlm(
       fakeClient,
       [
@@ -1321,30 +1396,122 @@ describe("bindMcpToolsForLlm", () => {
       recorded,
     );
 
-    const exploreResult = await getRunner(tools, "explore")(
-      { command: "ls -la" },
-      { toolCallId: "t1", messages: [] },
-    );
     // The model gets the listing it asked for — NOT a fabricated
     // `{ error: "unparseable" }` for a call that succeeded.
-    expect(exploreResult).toBe(listing);
+    expect(
+      await getRunner(tools, "explore")({ command: "ls -la" }, { toolCallId: "t1", messages: [] }),
+    ).toBe(LISTING);
 
     const describeResult = (await getRunner(tools, "describeEntity")(
       { name: "orders" },
       { toolCallId: "t2", messages: [] },
-    )) as { error?: string };
+    )) as { error?: string; raw?: string };
     expect(describeResult.error).toBe("unparseable");
+    expect(describeResult.raw).toBe(LISTING);
 
     expect(recorded).toHaveLength(2);
     expect(recorded[0]!.contract).toBe("text");
+    expect(recorded[0]!.result).toEqual({ kind: "ok", data: LISTING });
     expect(recorded[1]!.contract).toBe("json");
+    expect(recorded[1]!.result.kind).toBe("unparseable");
   });
 
-  it("classifies every typed semantic tool as json", () => {
-    // `describeEntity`, `searchGlossary` and `listEntities` declare no MCP
-    // `outputSchema` (only `runMetric` / `executeSQL` / `query` do), so any
-    // exemption keyed on `outputSchema` would have silently let these three
-    // out of the protocol check. Pinned so that shortcut cannot be taken later.
+  it("keeps a server-FLAGGED error on a text tool in the protocol lane", async () => {
+    // `extractToolJson` reaches its `unparseable` arm from the JSON.parse
+    // catch, BEFORE it consults `isError` — so a flagged error with a prose
+    // body is shaped exactly like shell output. Exempting it would turn
+    // #5131's loud false FAIL into a silent false PASS, with the model reading
+    // an internal error message as directory contents.
+    const recorded: RecordedToolCall[] = [];
+    const fakeClient = {
+      callTool: async () => fakeCallToolResult("Error: sandbox failed to start", true),
+    };
+    const tools = __forTesting__.bindMcpToolsForLlm(
+      fakeClient,
+      [{ name: "explore", description: "Shell." }],
+      recorded,
+    );
+    const result = (await getRunner(tools, "explore")(
+      { command: "ls" },
+      { toolCallId: "t1", messages: [] },
+    )) as { error?: string };
+    expect(result.error).toBe("unparseable");
+    expect(recorded[0]!.contract).toBe("text");
+    expect(recorded[0]!.result.kind).toBe("unparseable");
+  });
+
+  it("keeps an EMPTY result on a text tool in the protocol lane", async () => {
+    // `explore` cannot return "": it normalises a silent command to
+    // "(no output)" and every failure path returns an `Error:`-prefixed
+    // string. An empty `content` array is a protocol anomaly for every tool.
+    const recorded: RecordedToolCall[] = [];
+    const fakeClient = { callTool: async () => ({ content: [] }) as CallToolResult };
+    const tools = __forTesting__.bindMcpToolsForLlm(
+      fakeClient,
+      [{ name: "explore", description: "Shell." }],
+      recorded,
+    );
+    const result = (await getRunner(tools, "explore")(
+      { command: "ls" },
+      { toolCallId: "t1", messages: [] },
+    )) as { error?: string };
+    expect(result.error).toBe("unparseable");
+    expect(recorded[0]!.result.kind).toBe("unparseable");
+  });
+
+  it("hands back a text tool's output verbatim even when it happens to parse as JSON", async () => {
+    // `grep -c revenue entities/` prints `3`. Parsing it would make the SAME
+    // tool record under two different arms depending on what the directory
+    // contained — the accidental-shape dependence #5131 was.
+    const recorded: RecordedToolCall[] = [];
+    const fakeClient = { callTool: async () => fakeCallToolResult("3\n") };
+    const tools = __forTesting__.bindMcpToolsForLlm(
+      fakeClient,
+      [{ name: "explore", description: "Shell." }],
+      recorded,
+    );
+    expect(
+      await getRunner(tools, "explore")(
+        { command: "grep -c revenue entities/" },
+        { toolCallId: "t1", messages: [] },
+      ),
+    ).toBe("3\n");
+    expect(recorded[0]!.result).toEqual({ kind: "ok", data: "3\n" });
+  });
+
+  it("stamps the contract on the TRANSPORT-failure record too", async () => {
+    // Otherwise the field is write-only on this path and free to drift into a
+    // lie in the failure artifact the operator actually reads.
+    const recorded: RecordedToolCall[] = [];
+    const fakeClient = {
+      callTool: async () => {
+        throw new Error("socket hang up");
+      },
+    };
+    const tools = __forTesting__.bindMcpToolsForLlm(
+      fakeClient,
+      [
+        { name: "explore", description: "Shell." },
+        { name: "runMetric", description: "Run a metric." },
+      ],
+      recorded,
+    );
+    await expect(
+      getRunner(tools, "explore")({ command: "ls" }, { toolCallId: "t1", messages: [] }),
+    ).rejects.toThrow(/socket hang up/);
+    await expect(
+      getRunner(tools, "runMetric")({ id: "x" }, { toolCallId: "t2", messages: [] }),
+    ).rejects.toThrow(/socket hang up/);
+    expect(recorded.map((c) => c.contract)).toEqual(["text", "json"]);
+  });
+
+  it("classifies explore as text and every typed semantic tool as json", () => {
+    // Both arms live here so the describe block, not the binder test, carries
+    // the classifier's positive case. `listEntities`, `describeEntity` and
+    // `searchGlossary` declare no MCP `outputSchema` (only `runMetric` /
+    // `executeSQL` / `query` do), so an exemption keyed on `outputSchema`
+    // would have silently let these three out of the protocol check.
+    expect(classifyToolContract("explore")).toBe("text");
     for (const name of [
       "runMetric",
       "executeSQL",
@@ -1352,36 +1519,60 @@ describe("bindMcpToolsForLlm", () => {
       "describeEntity",
       "searchGlossary",
       "listEntities",
+      "searchBrain",
     ]) {
-      expect(__forTesting__.classifyToolContract(name)).toBe("json");
+      expect(classifyToolContract(name)).toBe("json");
     }
   });
 });
 
 // ── Text-contract anchoring ───────────────────────────────────────────
 
-describe("assertTextContractToolsPresent", () => {
+describe("bindEvalToolSurface / assertTextContractToolsPresent", () => {
   // The exemption is spelled as a NAME. Rename `explore` and the name stops
   // matching, the exemption becomes a no-op, and every successful shell call
   // is graded as a protocol regression again — silently. This anchor is what
-  // turns that into a loud stop at boot.
+  // turns that into a loud stop at boot, BEFORE any paid LLM token is spent.
+
+  const fakeClient = { callTool: async () => ({ content: [] }) as CallToolResult };
 
   it("passes when every text-contract tool is on the discovered surface", () => {
     expect(() =>
-      __forTesting__.assertTextContractToolsPresent([
-        { name: "explore" },
-        { name: "runMetric" },
-      ]),
+      __forTesting__.assertTextContractToolsPresent([{ name: "explore" }, { name: "runMetric" }]),
     ).not.toThrow();
   });
 
   it("throws, naming the missing tool and the surface, when one was renamed away", () => {
     expect(() =>
-      __forTesting__.assertTextContractToolsPresent([
-        { name: "shell" },
-        { name: "runMetric" },
-      ]),
+      __forTesting__.assertTextContractToolsPresent([{ name: "shell" }, { name: "runMetric" }]),
     ).toThrow(/text-contract tool\(s\) not on the MCP surface: explore.*Discovered:.*shell/s);
+  });
+
+  it("says so explicitly when tools/list returned nothing", () => {
+    expect(() => __forTesting__.assertTextContractToolsPresent([])).toThrow(
+      /Discovered: \(empty — tools\/list returned no tools\)/,
+    );
+  });
+
+  // ⚠️ THE ANCHOR IS ONLY WORTH ITS LINES IF IT IS WIRED IN. Mutating the
+  // assert's BODY is caught by the two tests above; deleting its CALL SITE was
+  // not caught by anything, which is the same unwired-guard shape the anchor
+  // exists to prevent. `bindEvalToolSurface` is the seam `runMcpLlmEval` calls,
+  // so these two pin the wiring rather than the logic.
+
+  it("refuses to bind a surface missing a text-contract tool", () => {
+    expect(() =>
+      __forTesting__.bindEvalToolSurface(fakeClient, [{ name: "runMetric" }], []),
+    ).toThrow(/text-contract tool\(s\) not on the MCP surface: explore/);
+  });
+
+  it("binds every discovered tool when the anchor holds", () => {
+    const bound = __forTesting__.bindEvalToolSurface(
+      fakeClient,
+      [{ name: "explore" }, { name: "runMetric" }],
+      [],
+    );
+    expect(Object.keys(bound).sort()).toEqual(["explore", "runMetric"]);
   });
 });
 

--- a/packages/cli/bin/canonical-eval-mcp-llm.test.ts
+++ b/packages/cli/bin/canonical-eval-mcp-llm.test.ts
@@ -938,19 +938,63 @@ describe("grade", () => {
     if (out.status === "fail") {
       expect(out.artifact.category).toBe("protocol");
       expect(out.artifact.tool).toBe("explore");
+      // ⚠️ THE REMEDY MUST NOT BE THE JSON ONE. "Add it to TEXT_CONTRACT_TOOLS"
+      // is provably a no-op here — the anchor guarantees `explore` is already
+      // in the list or the run would not have booted — so printing it would be
+      // instructing an operator to do nothing.
+      expect(out.artifact.summary).toContain("already there");
+      expect(out.artifact.summary).not.toMatch(/add it to TEXT_CONTRACT_TOOLS/i);
     }
   });
 
-  it("points a throttled TEXT-contract tool at the sandbox limiter, not the eval client quota", () => {
-    // `explore` can return `rate_limited` from the SANDBOX backend via
-    // `classifyExploreError`, which is a different knob from the eval client's
-    // hosted-MCP quota. Aborting is right either way — a throttled run must not
-    // produce a score — but sending an operator to
-    // EVAL_CLIENT_REQUESTS_PER_MINUTE for a sandbox limit is pointing at a knob
-    // that cannot help.
+  it("DOES tell a json-contract tool to declare itself — the case the anchor cannot detect", () => {
+    // The mirror of the test above, and the reason the branch exists rather
+    // than one message serving both. The anchor proves declared ⊆ discovered,
+    // never the reverse, so a newly-added prose-returning tool lands here and
+    // "add it to TEXT_CONTRACT_TOOLS" is exactly the right advice.
+    const out = __forTesting__.grade({
+      question: metricQuestion("cq-001", "total_gmv"),
+      toolCalls: [call("someNewTool", {}, { kind: "unparseable", raw: "plain prose" })],
+      finalText: "",
+      latencyMs: 5,
+      baseline: undefined,
+      metricExpectations: METRIC_EXPECTATIONS,
+      answerExpectations: undefined,
+    });
+    expect(out.status).toBe("fail");
+    if (out.status === "fail") {
+      expect(out.artifact.summary).toMatch(/add it to TEXT_CONTRACT_TOOLS/i);
+      expect(out.artifact.summary).not.toContain("already there");
+    }
+  });
+
+  describe("throttle remedy", () => {
+    // ⚠️ THE DISCRIMINATOR IS THE ENVELOPE, NOT THE TOOL'S CONTRACT, and an
+    // earlier cut got this exactly backwards — it told anyone whose `explore`
+    // dispatch was throttled that raising EVAL_CLIENT_REQUESTS_PER_MINUTE
+    // "will not help". The hosted per-OAuth-client quota runs ahead of EVERY
+    // tool body and charges `explore` weight 5, so that is the DOMINANT case
+    // and the advice was confidently wrong on it.
+    //
+    // The four cases below cross the two levers — contract × limiter — so
+    // neither can be mistaken for the other. A remedy keyed on contract fails
+    // the two off-diagonal cases; one keyed on nothing fails two of the four.
     const q = metricQuestion("cq-001", "total_gmv");
-    const throttle = { kind: "error" as const, envelope: { code: "rate_limited", message: "pool capacity reached" } };
-    const gradeWith = (c: RecordedToolCall) =>
+    // The hosted limiter always sets `retry_after` (rate-limit/middleware.ts).
+    const hostedQuota = {
+      kind: "error" as const,
+      envelope: {
+        code: "rate_limited",
+        message: 'OAuth client "eval" exceeded its hosted-MCP quota (250 weighted requests/min).',
+        retry_after: 30,
+      },
+    };
+    // The sandbox/datasource paths build their envelope with no extras.
+    const downstream = {
+      kind: "error" as const,
+      envelope: { code: "rate_limited", message: "pool capacity reached" },
+    };
+    const gradeWith = (c: RecordedToolCall) => () =>
       __forTesting__.grade({
         question: q,
         toolCalls: [c],
@@ -961,17 +1005,33 @@ describe("grade", () => {
         answerExpectations: undefined,
       });
 
-    expect(() => gradeWith(call("explore", { command: "ls" }, throttle, 5, "text"))).toThrow(
-      /sandboxed shell.*will not help/s,
-    );
-    // The JSON-contract arm keeps the original remedy — if both said the same
-    // thing the branch would be decoration.
-    expect(() => gradeWith(call("runMetric", { id: "total_gmv" }, throttle))).toThrow(
-      /EVAL_CLIENT_REQUESTS_PER_MINUTE/,
-    );
-    expect(() => gradeWith(call("runMetric", { id: "total_gmv" }, throttle))).not.toThrow(
-      /sandboxed shell/,
-    );
+    // ⚠️ ASSERT ON ARM-UNIQUE PHRASES, NOT ON THE KNOB'S NAME. Both arms
+    // mention EVAL_CLIENT_REQUESTS_PER_MINUTE — one says to raise it, the other
+    // says raising it will not help — so matching the identifier matches BOTH
+    // and cannot tell the arms apart. A mutation pinning the remedy to the
+    // downstream message survived a battery on exactly that substring double.
+    const RAISE_IT = /Raise it via liftEvalClientRateLimit/;
+    const WONT_HELP = /will not help/;
+
+    it("names the eval client's quota for a hosted-quota envelope — on a TEXT tool too", () => {
+      for (const c of [
+        call("explore", { command: "ls" }, hostedQuota, 5, "text"),
+        call("runMetric", { id: "total_gmv" }, hostedQuota),
+      ]) {
+        expect(gradeWith(c)).toThrow(RAISE_IT);
+        expect(gradeWith(c)).not.toThrow(WONT_HELP);
+      }
+    });
+
+    it("points AWAY from the eval client's quota for a downstream envelope — on a JSON tool too", () => {
+      for (const c of [
+        call("explore", { command: "ls" }, downstream, 5, "text"),
+        call("runMetric", { id: "total_gmv" }, downstream),
+      ]) {
+        expect(gradeWith(c)).toThrow(WONT_HELP);
+        expect(gradeWith(c)).not.toThrow(RAISE_IT);
+      }
+    });
   });
 
   it("STILL fails a text-contract tool whose TRANSPORT hung up", () => {
@@ -1303,7 +1363,7 @@ describe("bindMcpToolsForLlm", () => {
     };
     const tools = __forTesting__.bindMcpToolsForLlm(
       fakeClient,
-      [{ name: "runMetric", description: "Run a metric." }],
+      [{ name: "explore", description: "Shell." }, { name: "runMetric", description: "Run a metric." }],
       recorded,
     );
     const runner = getRunner(tools, "runMetric");
@@ -1326,7 +1386,7 @@ describe("bindMcpToolsForLlm", () => {
     };
     const tools = __forTesting__.bindMcpToolsForLlm(
       fakeClient,
-      [{ name: "runMetric", description: "Run a metric." }],
+      [{ name: "explore", description: "Shell." }, { name: "runMetric", description: "Run a metric." }],
       recorded,
     );
     const runner = getRunner(tools, "runMetric");
@@ -1349,7 +1409,7 @@ describe("bindMcpToolsForLlm", () => {
     };
     const tools = __forTesting__.bindMcpToolsForLlm(
       fakeClient,
-      [{ name: "runMetric", description: "Run a metric." }],
+      [{ name: "explore", description: "Shell." }, { name: "runMetric", description: "Run a metric." }],
       recorded,
     );
     const runner = getRunner(tools, "runMetric");
@@ -1428,7 +1488,7 @@ describe("bindMcpToolsForLlm", () => {
     };
     const tools = __forTesting__.bindMcpToolsForLlm(
       fakeClient,
-      [{ name: "explore", description: "Shell." }],
+      [{ name: "explore", description: "Shell." }, { name: "runMetric", description: "Run a metric." }],
       recorded,
     );
     const result = (await getRunner(tools, "explore")(
@@ -1440,6 +1500,52 @@ describe("bindMcpToolsForLlm", () => {
     expect(recorded[0]!.result.kind).toBe("unparseable");
   });
 
+  it("records a text tool's TYPED envelope as an error, and that record still aborts the run", async () => {
+    // ⚠️ THIS IS THE PRODUCTION-DOMINANT `explore` FAILURE SHAPE, and it was
+    // the untested one: the prose-body case above comes from the SDK's generic
+    // `createToolError`, but Atlas's own registration lifts every `Error:`
+    // line into a typed envelope first (tools.ts → toEnvelopeResult), so a real
+    // sandbox failure arrives as isError + JSON. Collapsing the fallback to a
+    // flat `unparseable` would pass every other test here while silently
+    // turning a throttle abort into a `protocol` grade — the #5122 class.
+    //
+    // The second half is a COMPOSITION check: the record fed to `grade()` is
+    // the one the binder actually produced, not a hand-built fixture. That is
+    // what proves the throttle branch is reachable rather than merely correct.
+    const recorded: RecordedToolCall[] = [];
+    const fakeClient = {
+      callTool: async () =>
+        fakeCallToolResult(
+          JSON.stringify({ code: "rate_limited", message: "pool capacity reached" }),
+          true,
+        ),
+    };
+    const tools = __forTesting__.bindMcpToolsForLlm(
+      fakeClient,
+      [{ name: "explore", description: "Shell." }, { name: "runMetric", description: "Run a metric." }],
+      recorded,
+    );
+    const result = (await getRunner(tools, "explore")(
+      { command: "ls" },
+      { toolCallId: "t1", messages: [] },
+    )) as { code?: string };
+    expect(result.code).toBe("rate_limited");
+    expect(recorded[0]!.result.kind).toBe("error");
+    expect(recorded[0]!.contract).toBe("text");
+
+    expect(() =>
+      __forTesting__.grade({
+        question: metricQuestion("cq-001", "total_gmv"),
+        toolCalls: recorded,
+        finalText: "",
+        latencyMs: 5,
+        baseline: undefined,
+        metricExpectations: METRIC_EXPECTATIONS,
+        answerExpectations: undefined,
+      }),
+    ).toThrow(/rate limited on explore.*will not help/s);
+  });
+
   it("keeps an EMPTY result on a text tool in the protocol lane", async () => {
     // `explore` cannot return "": it normalises a silent command to
     // "(no output)" and every failure path returns an `Error:`-prefixed
@@ -1448,7 +1554,7 @@ describe("bindMcpToolsForLlm", () => {
     const fakeClient = { callTool: async () => ({ content: [] }) as CallToolResult };
     const tools = __forTesting__.bindMcpToolsForLlm(
       fakeClient,
-      [{ name: "explore", description: "Shell." }],
+      [{ name: "explore", description: "Shell." }, { name: "runMetric", description: "Run a metric." }],
       recorded,
     );
     const result = (await getRunner(tools, "explore")(
@@ -1467,7 +1573,7 @@ describe("bindMcpToolsForLlm", () => {
     const fakeClient = { callTool: async () => fakeCallToolResult("3\n") };
     const tools = __forTesting__.bindMcpToolsForLlm(
       fakeClient,
-      [{ name: "explore", description: "Shell." }],
+      [{ name: "explore", description: "Shell." }, { name: "runMetric", description: "Run a metric." }],
       recorded,
     );
     expect(
@@ -1508,9 +1614,9 @@ describe("bindMcpToolsForLlm", () => {
   it("classifies explore as text and every typed semantic tool as json", () => {
     // Both arms live here so the describe block, not the binder test, carries
     // the classifier's positive case. `listEntities`, `describeEntity` and
-    // `searchGlossary` declare no MCP `outputSchema` (only `runMetric` /
-    // `executeSQL` / `query` do), so an exemption keyed on `outputSchema`
-    // would have silently let these three out of the protocol check.
+    // `searchGlossary` declare no MCP `outputSchema` — within `semantic-tools.ts`
+    // only `runMetric` does — so an exemption keyed on `outputSchema` would have
+    // silently let these three out of the protocol check.
     expect(classifyToolContract("explore")).toBe("text");
     for (const name of [
       "runMetric",
@@ -1528,51 +1634,41 @@ describe("bindMcpToolsForLlm", () => {
 
 // ── Text-contract anchoring ───────────────────────────────────────────
 
-describe("bindEvalToolSurface / assertTextContractToolsPresent", () => {
+describe("text-contract anchoring", () => {
   // The exemption is spelled as a NAME. Rename `explore` and the name stops
   // matching, the exemption becomes a no-op, and every successful shell call
   // is graded as a protocol regression again — silently. This anchor is what
   // turns that into a loud stop at boot, BEFORE any paid LLM token is spent.
+  //
+  // ⚠️ EVERY CASE BELOW GOES THROUGH `bindMcpToolsForLlm`, NOT THE ASSERT
+  // DIRECTLY — testing the assert alone leaves its WIRING untested, and
+  // `runMcpLlmEval` has no test to catch an unanchored bind.
 
   const fakeClient = { callTool: async () => ({ content: [] }) as CallToolResult };
 
-  it("passes when every text-contract tool is on the discovered surface", () => {
-    expect(() =>
-      __forTesting__.assertTextContractToolsPresent([{ name: "explore" }, { name: "runMetric" }]),
-    ).not.toThrow();
-  });
-
-  it("throws, naming the missing tool and the surface, when one was renamed away", () => {
-    expect(() =>
-      __forTesting__.assertTextContractToolsPresent([{ name: "shell" }, { name: "runMetric" }]),
-    ).toThrow(/text-contract tool\(s\) not on the MCP surface: explore.*Discovered:.*shell/s);
-  });
-
-  it("says so explicitly when tools/list returned nothing", () => {
-    expect(() => __forTesting__.assertTextContractToolsPresent([])).toThrow(
-      /Discovered: \(empty — tools\/list returned no tools\)/,
-    );
-  });
-
-  // ⚠️ THE ANCHOR IS ONLY WORTH ITS LINES IF IT IS WIRED IN. Mutating the
-  // assert's BODY is caught by the two tests above; deleting its CALL SITE was
-  // not caught by anything, which is the same unwired-guard shape the anchor
-  // exists to prevent. `bindEvalToolSurface` is the seam `runMcpLlmEval` calls,
-  // so these two pin the wiring rather than the logic.
-
-  it("refuses to bind a surface missing a text-contract tool", () => {
-    expect(() =>
-      __forTesting__.bindEvalToolSurface(fakeClient, [{ name: "runMetric" }], []),
-    ).toThrow(/text-contract tool\(s\) not on the MCP surface: explore/);
-  });
-
   it("binds every discovered tool when the anchor holds", () => {
-    const bound = __forTesting__.bindEvalToolSurface(
+    const bound = __forTesting__.bindMcpToolsForLlm(
       fakeClient,
       [{ name: "explore" }, { name: "runMetric" }],
       [],
     );
     expect(Object.keys(bound).sort()).toEqual(["explore", "runMetric"]);
+  });
+
+  it("refuses to bind, naming the missing tool and the surface, when one was renamed away", () => {
+    expect(() =>
+      __forTesting__.bindMcpToolsForLlm(fakeClient, [{ name: "shell" }, { name: "runMetric" }], []),
+    ).toThrow(/text-contract tool\(s\) not on the MCP surface: explore.*Discovered:.*shell/s);
+  });
+
+  it("refuses to bind an EMPTY surface, and says tools/list returned nothing", () => {
+    // Driven through the binder rather than the assert on purpose: guarding
+    // the call as `if (tools.length > 0) assert(...)` is a plausible edit, and
+    // an empty surface would then bind cleanly and grade every question as
+    // `tool_selection` instead of stopping.
+    expect(() => __forTesting__.bindMcpToolsForLlm(fakeClient, [], [])).toThrow(
+      /Discovered: \(empty — tools\/list returned no tools\)/,
+    );
   });
 });
 
@@ -1658,5 +1754,13 @@ describe("readBaseline / writeBaseline", () => {
 // job wires a real LLM against the real route and is the integration
 // surface. The `bindMcpToolsForLlm` contract tests above pin the
 // recorder thread `runMcpLlmEval` builds on; the per-mode grader tests
-// pin the dispatch evaluation. Together these cover every regression
-// class the per-question dispatch loop can introduce.
+// pin the dispatch evaluation.
+//
+// ⚠️ WHAT IS NOT COVERED, stated rather than implied. This note used to
+// claim the two together "cover every regression class the per-question
+// dispatch loop can introduce", and that was false in the way that
+// matters: `runMcpLlmEval`'s own body — the ORDER it composes those
+// pieces in — has no test at all. That is why the text-contract anchor
+// lives inside `bindMcpToolsForLlm` rather than in a wrapper around it:
+// anything the loop must not be able to skip has to be unskippable by
+// construction, because nothing here would notice the skip.

--- a/packages/cli/bin/canonical-eval-mcp-llm.ts
+++ b/packages/cli/bin/canonical-eval-mcp-llm.ts
@@ -83,6 +83,22 @@ import {
 // ── Public types ──────────────────────────────────────────────────────
 
 /**
+ * What a tool's result is CONTRACTED to look like.
+ *
+ * - `"json"` — the tool answers with a JSON body (success) or an
+ *   `AtlasMcpToolError` envelope (failure). Non-JSON from one of these is an
+ *   MCP protocol regression and the grader fails the question for it.
+ * - `"text"` — the tool's declared output is free-form text. `explore` is a
+ *   sandboxed **shell**: `ls -la` answering with a directory listing is the
+ *   contract being honoured, not broken.
+ *
+ * Stamped onto every {@link RecordedToolCall} by {@link bindMcpToolsForLlm}
+ * (see {@link classifyToolContract}) so the grader branches on the recorded
+ * contract rather than re-deriving it from a tool name at the point of use.
+ */
+export type ToolContract = "json" | "text";
+
+/**
  * Captured shape of one tool dispatch the LLM fired through MCP. The
  * grading code below walks the recorded sequence to decide pass / fail
  * categories — keep this shape stable; the unit tests assert on it.
@@ -91,6 +107,15 @@ export interface RecordedToolCall {
   readonly name: string;
   readonly args: Readonly<Record<string, unknown>>;
   readonly latencyMs: number;
+  /**
+   * The dispatched tool's output contract, resolved once at bind time.
+   *
+   * ⚠️ REQUIRED ON PURPOSE. Optional-with-a-default would let a recorder that
+   * forgot to classify fall through to `"json"` silently, which is the exact
+   * shape of the defect this field exists to close (#5131) — a text-output
+   * tool graded against the JSON contract.
+   */
+  readonly contract: ToolContract;
   /**
    * Either the parsed MCP tool result (via {@link extractToolJson}) or
    * a synthesized error envelope when the dispatch itself threw before
@@ -306,6 +331,9 @@ export async function runMcpLlmEval(
 
     try {
       const tools = await client.listTools();
+      // Anchor the text-contract exemption against the surface actually
+      // discovered, before a single question runs. See the function's note.
+      assertTextContractToolsPresent(tools);
       const recorded: RecordedToolCall[] = [];
       const aiTools = bindMcpToolsForLlm(client, tools, recorded);
 
@@ -351,6 +379,84 @@ async function bootDefaultFixture(): Promise<EvalAuthFixture> {
   return startEvalAuthServer({ mcpRouter });
 }
 
+// ── Tool output contracts ────────────────────────────────────────────
+
+/**
+ * MCP tools whose declared output is free-form TEXT rather than JSON.
+ *
+ * ⚠️ THIS IS A NAME LIST, DELIBERATELY, AND THE ALTERNATIVES WERE MEASURED
+ * RATHER THAN ASSUMED (#5131).
+ *
+ * 1. There is nothing on the wire to derive it from. `bindMcpToolsForLlm`
+ *    classifies from `ToolListEntry`, which is `{ name, description?,
+ *    inputSchema? }` — the `tools/list` response carries no statement about
+ *    the shape of a tool's OUTPUT. Any "marker set at bind time" is therefore
+ *    still computed from the name; a marker relocates this list, it cannot
+ *    replace it.
+ * 2. The one machine-readable candidate — MCP `outputSchema` — is provably
+ *    unfaithful here. `describeEntity`, `searchGlossary`, and `listEntities`
+ *    all answer JSON and declare NO `outputSchema`
+ *    (`packages/mcp/src/semantic-tools.ts:287/327/453`; only `runMetric` at
+ *    :523 declares one). Exempting "no outputSchema" would exempt three of the
+ *    four typed tools the protocol check exists to protect — it would disable
+ *    the detector rather than sharpen it.
+ *
+ * What a name list genuinely gets wrong is ROT: rename or drop `explore` and
+ * the exemption silently stops matching, restoring the bug with no signal.
+ * That is closed by {@link assertTextContractToolsPresent}, which anchors every
+ * name here against the live discovered surface — not by a type, since both
+ * spellings of the type carry the same string.
+ *
+ * ── What this does and does NOT make backend-independent ─────────────
+ *
+ * `explore` resolves to a different sandbox backend locally than on the CI
+ * runner (`packages/api/src/lib/tools/backends/selection.ts`), which is how
+ * #5131 stayed invisible across four local runs. With the exemption in place
+ * the SHAPE of its output no longer moves the verdict: `explore` is not in
+ * {@link ANSWERING_TOOLS} and no per-mode grader inspects it, so the only
+ * branches it can still reach are `assertNotRateLimited` (a throttle is a
+ * harness fault whatever the tool) and `isTransportFail` (a hang-up is a real
+ * protocol regression whatever the tool). Both are backend-agnostic.
+ *
+ * The residual, recorded rather than papered over: the CONTENT differs. One
+ * backend lists the semantic-layer directory and another fails to start, and
+ * the model may answer differently on the strength of what it read. No grader
+ * change can remove that — it is a property of running a shell in two
+ * environments, and the honest fix is pinning the eval's backend, not widening
+ * the rubric.
+ */
+const TEXT_CONTRACT_TOOLS: ReadonlySet<string> = new Set(["explore"]);
+
+/** Resolve a discovered tool's output contract. See {@link TEXT_CONTRACT_TOOLS}. */
+function classifyToolContract(name: string): ToolContract {
+  return TEXT_CONTRACT_TOOLS.has(name) ? "text" : "json";
+}
+
+/**
+ * Fail the run when a declared text-contract tool is absent from the surface
+ * the eval actually discovered.
+ *
+ * This is the anchor that makes {@link TEXT_CONTRACT_TOOLS} safe to spell as
+ * names. Without it, renaming `explore` (or dropping it from the hosted
+ * registration) turns the exemption into a no-op and every successful shell
+ * call starts failing its question as `protocol` again — the #5131 defect,
+ * back, with no diagnostic. Called against the real `tools/list` result, so a
+ * rename is a loud stop at boot rather than five silent mis-graded questions.
+ */
+function assertTextContractToolsPresent(tools: readonly ToolListEntry[]): void {
+  const discovered = new Set(tools.map((t) => t.name));
+  const missing = [...TEXT_CONTRACT_TOOLS].filter((n) => !discovered.has(n));
+  if (missing.length === 0) return;
+  throw new Error(
+    `[harness] text-contract tool(s) not on the MCP surface: ${missing.join(", ")}. ` +
+      `TEXT_CONTRACT_TOOLS exempts these from the JSON/protocol check because their ` +
+      `declared output is free-form text; a name that no longer resolves means the ` +
+      `exemption is dead and successful text output would be graded as a protocol ` +
+      `regression. Update TEXT_CONTRACT_TOOLS to match the renamed tool. ` +
+      `Discovered: ${[...discovered].sort().join(", ")}`,
+  );
+}
+
 /**
  * Translate the MCP tool surface to a Vercel AI SDK `ToolSet`. Every
  * tool's `execute` dispatches back through the MCP transport so the
@@ -383,6 +489,7 @@ function bindMcpToolsForLlm(
         properties: {},
         additionalProperties: true,
       };
+    const contract = classifyToolContract(t.name);
     set[t.name] = dynamicTool({
       description: t.description ?? `MCP tool ${t.name}`,
       inputSchema: jsonSchema(schema),
@@ -396,11 +503,19 @@ function bindMcpToolsForLlm(
           recorder.push({
             name: t.name,
             args,
+            contract,
             latencyMs,
             result: parsed,
           });
           if (parsed.kind === "error") return parsed.envelope;
           if (parsed.kind === "unparseable") {
+            // A text-contract tool answering with text is a SUCCESS. Handing
+            // the model `{ error: "unparseable" }` for a successful `ls` is a
+            // harness-fabricated error: it hides the listing the model asked
+            // for behind a failure word, and the model then "recovers" from
+            // something that never went wrong. Return the raw text — the
+            // tool's actual product (#5131).
+            if (contract === "text") return parsed.raw;
             return { error: "unparseable", raw: parsed.raw };
           }
           return parsed.data;
@@ -420,6 +535,7 @@ function bindMcpToolsForLlm(
           recorder.push({
             name: t.name,
             args,
+            contract,
             latencyMs,
             result: { kind: "error", envelope: transportEnvelope },
           });
@@ -1355,11 +1471,21 @@ function findSqlMatch(
   });
 }
 
+/**
+ * A JSON-contract tool that answered with something that is not JSON — the
+ * MCP protocol regression `grade()`'s first branch exists to catch. The
+ * `contract: "json"` member is part of the type, not just the guard body, so
+ * a caller that narrows through {@link isUnparseable} carries the proof that
+ * the tool was contracted to answer JSON in the first place.
+ */
 type UnparseableCall = RecordedToolCall & {
+  readonly contract: "json";
   readonly result: { readonly kind: "unparseable"; readonly raw: string };
 };
 function isUnparseable(c: RecordedToolCall): c is UnparseableCall {
-  return c.result.kind === "unparseable";
+  // Text-contract tools are exempt: non-JSON from a shell is its output, not
+  // a protocol regression (#5131). The check stays strict for every JSON tool.
+  return c.contract === "json" && c.result.kind === "unparseable";
 }
 
 type ErrorCall = RecordedToolCall & {
@@ -1393,6 +1519,8 @@ export const __forTesting__ = {
   gradePattern,
   gradeVirtual,
   bindMcpToolsForLlm,
+  classifyToolContract,
+  assertTextContractToolsPresent,
 } as const;
 
 // ── Baseline I/O ────────────────────────────────────────────────────

--- a/packages/cli/bin/canonical-eval-mcp-llm.ts
+++ b/packages/cli/bin/canonical-eval-mcp-llm.ts
@@ -62,9 +62,11 @@ import {
   startEvalAuthServer,
   type EvalAuthFixture,
 } from "@atlas/mcp/eval/auth";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import {
   EvalMcpClient,
   extractToolJson,
+  joinTextContent,
   type ExtractedToolJson,
   type ToolErrorEnvelope,
   type ToolListEntry,
@@ -320,8 +322,10 @@ export async function runMcpLlmEval(
       try {
         await client.close();
       } catch (closeErr) {
-        // intentionally ignored: surfacing the close error would mask
-        // the original connect failure, which is the actionable signal.
+        // Logged rather than re-thrown: the original connect failure is the
+        // actionable signal and must be the error that propagates. NOT
+        // `// intentionally ignored:` — that marker means the catch emits
+        // nothing at all, and this one writes to stderr.
         process.stderr.write(
           `[mcp-llm-eval] client.close after failed connect threw: ${closeErr instanceof Error ? closeErr.message : String(closeErr)}\n`,
         );
@@ -331,11 +335,8 @@ export async function runMcpLlmEval(
 
     try {
       const tools = await client.listTools();
-      // Anchor the text-contract exemption against the surface actually
-      // discovered, before a single question runs. See the function's note.
-      assertTextContractToolsPresent(tools);
       const recorded: RecordedToolCall[] = [];
-      const aiTools = bindMcpToolsForLlm(client, tools, recorded);
+      const aiTools = bindEvalToolSurface(client, tools, recorded);
 
       const questions = loadQuestions(
         opts.questionsPath ?? DEFAULT_QUESTIONS_PATH,
@@ -394,12 +395,13 @@ async function bootDefaultFixture(): Promise<EvalAuthFixture> {
  *    still computed from the name; a marker relocates this list, it cannot
  *    replace it.
  * 2. The one machine-readable candidate — MCP `outputSchema` — is provably
- *    unfaithful here. `describeEntity`, `searchGlossary`, and `listEntities`
+ *    unfaithful here. `listEntities`, `describeEntity` and `searchGlossary`
  *    all answer JSON and declare NO `outputSchema`
- *    (`packages/mcp/src/semantic-tools.ts:287/327/453`; only `runMetric` at
- *    :523 declares one). Exempting "no outputSchema" would exempt three of the
- *    four typed tools the protocol check exists to protect — it would disable
- *    the detector rather than sharpen it.
+ *    (`packages/mcp/src/semantic-tools.ts:287/327/453`, in that order; only
+ *    `runMetric` at :523 declares one). Exempting "no outputSchema" would
+ *    exempt three of the four typed tools the protocol check exists to protect
+ *    — it would disable the detector rather than sharpen it. `explore` declares
+ *    none either, so the signal does not discriminate in EITHER direction.
  *
  * What a name list genuinely gets wrong is ROT: rename or drop `explore` and
  * the exemption silently stops matching, restoring the bug with no signal.
@@ -411,25 +413,80 @@ async function bootDefaultFixture(): Promise<EvalAuthFixture> {
  *
  * `explore` resolves to a different sandbox backend locally than on the CI
  * runner (`packages/api/src/lib/tools/backends/selection.ts`), which is how
- * #5131 stayed invisible across four local runs. With the exemption in place
- * the SHAPE of its output no longer moves the verdict: `explore` is not in
- * {@link ANSWERING_TOOLS} and no per-mode grader inspects it, so the only
- * branches it can still reach are `assertNotRateLimited` (a throttle is a
- * harness fault whatever the tool) and `isTransportFail` (a hang-up is a real
- * protocol regression whatever the tool). Both are backend-agnostic.
+ * #5131 stayed invisible across four local runs. What the fix removes is the
+ * dependence on output SHAPE: a successful call is recorded as `ok` whether the
+ * backend printed a listing or something that happens to parse as JSON, and
+ * `explore` is not in {@link ANSWERING_TOOLS}, so no per-mode grader inspects
+ * it.
  *
- * The residual, recorded rather than papered over: the CONTENT differs. One
- * backend lists the semantic-layer directory and another fails to start, and
- * the model may answer differently on the strength of what it read. No grader
- * change can remove that — it is a property of running a shell in two
- * environments, and the honest fix is pinning the eval's backend, not widening
- * the rubric.
+ * THREE backend-sensitive paths remain, named rather than papered over — the
+ * claim is that each reaches the RIGHT verdict, not that the backend stopped
+ * mattering:
+ *
+ *   - **Latency.** `latencyMs` is whole-question wall clock, so every `explore`
+ *     dispatch sits inside it and a slow cold start can trip the
+ *     `baseline * 1.25` ceiling. This is the most backend-sensitive branch in
+ *     the file and the fix does not touch it.
+ *   - **Throttling.** `explore` can return `rate_limited` from the SANDBOX
+ *     backend, not the eval client's quota (`classifyExploreError`), and
+ *     {@link assertNotRateLimited} aborts on it. Aborting is right either way —
+ *     a throttled run must not produce a score — but the remedy differs, which
+ *     is why that message branches on the tool's contract.
+ *   - **Content.** One backend lists the semantic layer and another fails to
+ *     start, and the model may answer differently on the strength of what it
+ *     read. No grader change can remove this; the honest fix is pinning the
+ *     eval's backend, not widening the rubric.
  */
 const TEXT_CONTRACT_TOOLS: ReadonlySet<string> = new Set(["explore"]);
 
 /** Resolve a discovered tool's output contract. See {@link TEXT_CONTRACT_TOOLS}. */
-function classifyToolContract(name: string): ToolContract {
+export function classifyToolContract(name: string): ToolContract {
   return TEXT_CONTRACT_TOOLS.has(name) ? "text" : "json";
+}
+
+/**
+ * Read one `tools/call` result according to the calling tool's contract.
+ *
+ * ⚠️ THE CONTRACT IS APPLIED HERE, AT THE RECORDING SEAM — NOT IN THE GRADER.
+ * `grade()`'s protocol branch stays a plain `result.kind === "unparseable"`
+ * test, so a future branch that reads `kind` directly cannot reopen #5131, and
+ * a successful `ls` never wears the word "unparseable" in a failure artifact.
+ *
+ * For a `"json"` contract this is exactly {@link extractToolJson}. For a
+ * `"text"` contract the tool's product IS its text, so a successful call is
+ * recorded as `ok` carrying that text verbatim — including when the text
+ * happens to parse as JSON (`wc -l` printing `3`), which otherwise makes the
+ * SAME tool record under two different arms depending on what the directory
+ * contained.
+ *
+ * Two cases stay in the `unparseable` (→ `protocol`) lane, and both are
+ * regressions rather than shell output:
+ *
+ *   - **`isError` was flagged.** `extractToolJson` reaches its `unparseable`
+ *     arm from the `JSON.parse` catch, BEFORE it consults `isError`, so a
+ *     server-flagged error with a prose body — what the MCP SDK's own
+ *     `createToolError` emits for an uncaught throw — is indistinguishable
+ *     from shell output by shape alone. Exempting it would turn #5131's loud
+ *     false FAIL into a silent false PASS, with the model reading an internal
+ *     error message as directory contents.
+ *   - **No text content at all.** `explore` cannot produce this: it normalises
+ *     a silent command to `"(no output)"`
+ *     (`packages/api/src/lib/tools/explore.ts`), and every failure path returns
+ *     an `Error:`-prefixed string. An empty `content` array is a protocol
+ *     anomaly for every tool, whatever its output contract.
+ */
+function interpretResult(
+  result: CallToolResult,
+  contract: ToolContract,
+): ExtractedToolJson {
+  if (contract !== "text") return extractToolJson(result);
+  const text = joinTextContent(result);
+  if (result.isError === true || text === "") {
+    // Not shell output — fall back to the JSON reading so a typed envelope is
+    // still recorded as `error`, and anything else stays `unparseable`.
+    return extractToolJson(result);
+  }
+  return { kind: "ok", data: text };
 }
 
 /**
@@ -452,9 +509,31 @@ function assertTextContractToolsPresent(tools: readonly ToolListEntry[]): void {
       `TEXT_CONTRACT_TOOLS exempts these from the JSON/protocol check because their ` +
       `declared output is free-form text; a name that no longer resolves means the ` +
       `exemption is dead and successful text output would be graded as a protocol ` +
-      `regression. Update TEXT_CONTRACT_TOOLS to match the renamed tool. ` +
-      `Discovered: ${[...discovered].sort().join(", ")}`,
+      `regression (#5131). If the tool was RENAMED, point TEXT_CONTRACT_TOOLS at the ` +
+      `new name. If it was deliberately REMOVED from this surface, delete the name — ` +
+      `re-adding a dead one is the wrong repair. ` +
+      `Discovered: ${
+        discovered.size === 0
+          ? "(empty — tools/list returned no tools)"
+          : [...discovered].sort().join(", ")
+      }`,
   );
+}
+
+/**
+ * Anchor the text-contract exemption against the surface actually discovered,
+ * then bind it for the LLM. The two steps are one seam on purpose: binding
+ * without the anchor is the state #5131 shipped in, and a wrapper is what
+ * makes the wiring testable — a guard whose call site nothing exercises can be
+ * deleted with the whole suite still green.
+ */
+function bindEvalToolSurface(
+  client: { callTool: EvalMcpClient["callTool"] },
+  tools: readonly ToolListEntry[],
+  recorder: RecordedToolCall[],
+): ToolSet {
+  assertTextContractToolsPresent(tools);
+  return bindMcpToolsForLlm(client, tools, recorder);
 }
 
 /**
@@ -498,7 +577,7 @@ function bindMcpToolsForLlm(
         const start = Date.now();
         try {
           const result = await client.callTool(t.name, args);
-          const parsed = extractToolJson(result);
+          const parsed = interpretResult(result, contract);
           const latencyMs = Date.now() - start;
           recorder.push({
             name: t.name,
@@ -509,13 +588,6 @@ function bindMcpToolsForLlm(
           });
           if (parsed.kind === "error") return parsed.envelope;
           if (parsed.kind === "unparseable") {
-            // A text-contract tool answering with text is a SUCCESS. Handing
-            // the model `{ error: "unparseable" }` for a successful `ls` is a
-            // harness-fabricated error: it hides the listing the model asked
-            // for behind a failure word, and the model then "recovers" from
-            // something that never went wrong. Return the raw text — the
-            // tool's actual product (#5131).
-            if (contract === "text") return parsed.raw;
             return { error: "unparseable", raw: parsed.raw };
           }
           return parsed.data;
@@ -671,13 +743,24 @@ function assertNotRateLimited(
   if (!throttled) return;
   const envelope =
     throttled.result.kind === "error" ? throttled.result.envelope : null;
+  // The remedy depends on WHICH limiter fired, and the two are different knobs.
+  // A text-contract tool is a sandboxed shell: its `rate_limited` comes from the
+  // sandbox backend via `classifyExploreError`, not from the eval client's
+  // hosted-MCP quota, so sending an operator to EVAL_CLIENT_REQUESTS_PER_MINUTE
+  // would be pointing at a knob that cannot help (#5131).
+  const remedy =
+    throttled.contract === "text"
+      ? `${throttled.name} is a sandboxed shell, so this is the SANDBOX backend's limiter, ` +
+        `not the eval client's hosted-MCP quota — raising EVAL_CLIENT_REQUESTS_PER_MINUTE ` +
+        `will not help. Check the backend the eval resolved (see backends/selection.ts).`
+      : `This is the eval throttling ITSELF, not a model failure: the run's own ` +
+        `dispatch volume exceeded the eval client's hosted-MCP quota. Raise it via ` +
+        `liftEvalClientRateLimit (EVAL_CLIENT_REQUESTS_PER_MINUTE).`;
   throw new Error(
     `[harness] ${q.id}: MCP dispatch was rate limited on ${throttled.name} — ` +
-      `${envelope?.message ?? "no message"} ` +
-      `This is the eval throttling ITSELF, not a model failure: the run's own ` +
-      `dispatch volume exceeded the eval client's hosted-MCP quota. Raise it via ` +
-      `liftEvalClientRateLimit (EVAL_CLIENT_REQUESTS_PER_MINUTE) rather than ` +
-      `letting the throttle be graded as a recovery regression.`,
+      `${envelope?.message ?? "no message"} ${remedy} ` +
+      `Either way the run stops rather than letting the throttle be graded as a ` +
+      `recovery regression.`,
   );
 }
 
@@ -703,7 +786,15 @@ function grade(input: GradeInput): McpLlmOutcome {
       args: unparseable.args,
       response: { raw: unparseable.result.raw },
       expected: "JSON envelope from MCP tool",
-      summary: `MCP tool ${unparseable.name} returned non-JSON content`,
+      // The anchor proves every DECLARED text tool is on the surface; nothing
+      // proves the reverse, so a newly-added prose-returning tool reproduces
+      // #5131 verbatim and lands here. Say what to do about it rather than
+      // making the next reader re-derive it.
+      summary:
+        `MCP tool ${unparseable.name} returned content that could not be read as JSON. ` +
+        `If this tool's DECLARED output is free-form text (as \`explore\`'s is), add it ` +
+        `to TEXT_CONTRACT_TOOLS; otherwise this is a genuine MCP protocol regression — ` +
+        `note that a server-flagged error carrying a prose body also lands here.`,
     });
   }
 
@@ -1472,20 +1563,21 @@ function findSqlMatch(
 }
 
 /**
- * A JSON-contract tool that answered with something that is not JSON — the
- * MCP protocol regression `grade()`'s first branch exists to catch. The
- * `contract: "json"` member is part of the type, not just the guard body, so
- * a caller that narrows through {@link isUnparseable} carries the proof that
- * the tool was contracted to answer JSON in the first place.
+ * A call whose result could not be read as the protocol requires.
+ *
+ * ⚠️ DELIBERATELY CONTRACT-BLIND. #5131 was a text-output tool graded against
+ * the JSON contract, and the tempting fix was a `contract === "json"` clause
+ * right here — which would have put the exemption in a guard body, leaving
+ * every other reader of `result.kind` free to reopen the bug. The contract is
+ * applied by {@link interpretResult} at the recording seam instead, so by the
+ * time a call reaches this predicate `unparseable` already means the same
+ * thing for every tool: nobody could read it, and that is a regression.
  */
 type UnparseableCall = RecordedToolCall & {
-  readonly contract: "json";
   readonly result: { readonly kind: "unparseable"; readonly raw: string };
 };
 function isUnparseable(c: RecordedToolCall): c is UnparseableCall {
-  // Text-contract tools are exempt: non-JSON from a shell is its output, not
-  // a protocol regression (#5131). The check stays strict for every JSON tool.
-  return c.contract === "json" && c.result.kind === "unparseable";
+  return c.result.kind === "unparseable";
 }
 
 type ErrorCall = RecordedToolCall & {
@@ -1519,7 +1611,7 @@ export const __forTesting__ = {
   gradePattern,
   gradeVirtual,
   bindMcpToolsForLlm,
-  classifyToolContract,
+  bindEvalToolSurface,
   assertTextContractToolsPresent,
 } as const;
 

--- a/packages/cli/bin/canonical-eval-mcp-llm.ts
+++ b/packages/cli/bin/canonical-eval-mcp-llm.ts
@@ -29,7 +29,9 @@
  * against synthetic tool-call sequences (no real LLM tokens, no real
  * MCP connection). The end-to-end `runMcpLlmEval` integration path is
  * exercised in CI by the `eval-mcp-llm` job, which wires a real LLM
- * gated on `ANTHROPIC_API_KEY`.
+ * through the AI gateway, gated on `AI_GATEWAY_API_KEY` — NOT on
+ * `ANTHROPIC_API_KEY`, which would exercise the wrong credential path
+ * (`.github/workflows/eval-llm.yml`).
  *
  * ── Real-DB SQL execution ────────────────────────────────────────────
  *
@@ -94,9 +96,12 @@ import {
  *   sandboxed **shell**: `ls -la` answering with a directory listing is the
  *   contract being honoured, not broken.
  *
- * Stamped onto every {@link RecordedToolCall} by {@link bindMcpToolsForLlm}
- * (see {@link classifyToolContract}) so the grader branches on the recorded
- * contract rather than re-deriving it from a tool name at the point of use.
+ * Resolved once per tool at bind time by {@link classifyToolContract} and
+ * applied by {@link interpretResult}, which is where #5131 is actually closed.
+ * The stamp on {@link RecordedToolCall} is the RECORD of that decision, not the
+ * mechanism: `grade()`'s VERDICT is contract-blind ({@link isUnparseable} never
+ * sees the field), and it reads `contract` only to choose which remedy an
+ * artifact prints.
  */
 export type ToolContract = "json" | "text";
 
@@ -112,15 +117,24 @@ export interface RecordedToolCall {
   /**
    * The dispatched tool's output contract, resolved once at bind time.
    *
-   * ⚠️ REQUIRED ON PURPOSE. Optional-with-a-default would let a recorder that
-   * forgot to classify fall through to `"json"` silently, which is the exact
-   * shape of the defect this field exists to close (#5131) — a text-output
-   * tool graded against the JSON contract.
+   * ⚠️ NOT WHAT CLOSES #5131 — {@link interpretResult} is, from the same value
+   * passed as an argument. This field is the forensic record of that decision,
+   * read only to shape two diagnostics: the throttle abort message, and the
+   * `protocol` artifact, where `explore / contract: text` tells an operator
+   * immediately that they are in the flagged-error-or-empty lane rather than
+   * the shell-output one. It is NOT a discriminator — {@link assertNotRateLimited}
+   * branches on the envelope, not on this.
+   *
+   * REQUIRED rather than optional-with-a-default: it costs nothing, it keeps
+   * the recorder total (no `undefined` arm to narrow at every read), and every
+   * construction site is forced to state the answer rather than inherit one.
    */
   readonly contract: ToolContract;
   /**
-   * Either the parsed MCP tool result (via {@link extractToolJson}) or
-   * a synthesized error envelope when the dispatch itself threw before
+   * The MCP tool result read according to its contract (via
+   * {@link interpretResult} — parsed JSON for a `json` contract, the RAW TEXT
+   * BODY for a `text` one, so `ok.data` is a string there), or a synthesized
+   * error envelope when the dispatch itself threw before
    * MCP returned a frame. Synthesized envelopes carry `__transport: true`
    * + an `error`/`errorName`/`stack` triple so artifact bundles can
    * distinguish a transport hang-up from a typed `AtlasMcpToolError`.
@@ -322,10 +336,8 @@ export async function runMcpLlmEval(
       try {
         await client.close();
       } catch (closeErr) {
-        // Logged rather than re-thrown: the original connect failure is the
-        // actionable signal and must be the error that propagates. NOT
-        // `// intentionally ignored:` — that marker means the catch emits
-        // nothing at all, and this one writes to stderr.
+        // Logged, not re-thrown: the connect failure is the actionable signal
+        // and must be the error that propagates.
         process.stderr.write(
           `[mcp-llm-eval] client.close after failed connect threw: ${closeErr instanceof Error ? closeErr.message : String(closeErr)}\n`,
         );
@@ -336,7 +348,7 @@ export async function runMcpLlmEval(
     try {
       const tools = await client.listTools();
       const recorded: RecordedToolCall[] = [];
-      const aiTools = bindEvalToolSurface(client, tools, recorded);
+      const aiTools = bindMcpToolsForLlm(client, tools, recorded);
 
       const questions = loadQuestions(
         opts.questionsPath ?? DEFAULT_QUESTIONS_PATH,
@@ -395,13 +407,15 @@ async function bootDefaultFixture(): Promise<EvalAuthFixture> {
  *    still computed from the name; a marker relocates this list, it cannot
  *    replace it.
  * 2. The one machine-readable candidate — MCP `outputSchema` — is provably
- *    unfaithful here. `listEntities`, `describeEntity` and `searchGlossary`
- *    all answer JSON and declare NO `outputSchema`
- *    (`packages/mcp/src/semantic-tools.ts:287/327/453`, in that order; only
- *    `runMetric` at :523 declares one). Exempting "no outputSchema" would
- *    exempt three of the four typed tools the protocol check exists to protect
- *    — it would disable the detector rather than sharpen it. `explore` declares
- *    none either, so the signal does not discriminate in EITHER direction.
+ *    unfaithful here. In `packages/mcp/src/semantic-tools.ts`, `listEntities`,
+ *    `describeEntity` and `searchGlossary` all answer JSON and declare NO
+ *    `outputSchema`; `runMetric` is the only one in that file that does.
+ *    Exempting "no outputSchema" would exempt three of the four typed tools the
+ *    protocol check exists to protect — it would disable the detector rather
+ *    than sharpen it. `explore` declares none either, so the signal does not
+ *    discriminate in EITHER direction. (Grep the registrations rather than
+ *    trusting line numbers; an earlier draft of this note cited four and every
+ *    one had drifted before the PR merged.)
  *
  * What a name list genuinely gets wrong is ROT: rename or drop `explore` and
  * the exemption silently stops matching, restoring the bug with no signal.
@@ -409,35 +423,53 @@ async function bootDefaultFixture(): Promise<EvalAuthFixture> {
  * name here against the live discovered surface — not by a type, since both
  * spellings of the type carry the same string.
  *
- * ── What this does and does NOT make backend-independent ─────────────
+ * ── Backend dependence: what the fix removes, and what it does not ───
  *
  * `explore` resolves to a different sandbox backend locally than on the CI
  * runner (`packages/api/src/lib/tools/backends/selection.ts`), which is how
- * #5131 stayed invisible across four local runs. What the fix removes is the
- * dependence on output SHAPE: a successful call is recorded as `ok` whether the
- * backend printed a listing or something that happens to parse as JSON, and
- * `explore` is not in {@link ANSWERING_TOOLS}, so no per-mode grader inspects
- * it.
+ * #5131 stayed invisible across four local runs. The fix removes the dependence
+ * on output SHAPE only. Three backend-sensitive paths remain, recorded rather
+ * than papered over — each reaches the right verdict, but the backend has not
+ * stopped mattering:
  *
- * THREE backend-sensitive paths remain, named rather than papered over — the
- * claim is that each reaches the RIGHT verdict, not that the backend stopped
- * mattering:
- *
- *   - **Latency.** `latencyMs` is whole-question wall clock, so every `explore`
- *     dispatch sits inside it and a slow cold start can trip the
- *     `baseline * 1.25` ceiling. This is the most backend-sensitive branch in
- *     the file and the fix does not touch it.
- *   - **Throttling.** `explore` can return `rate_limited` from the SANDBOX
- *     backend, not the eval client's quota (`classifyExploreError`), and
- *     {@link assertNotRateLimited} aborts on it. Aborting is right either way —
- *     a throttled run must not produce a score — but the remedy differs, which
- *     is why that message branches on the tool's contract.
- *   - **Content.** One backend lists the semantic layer and another fails to
- *     start, and the model may answer differently on the strength of what it
- *     read. No grader change can remove this; the honest fix is pinning the
- *     eval's backend, not widening the rubric.
+ *   - **Latency.** The GRADER's `latencyMs` (`GradeInput`, not the per-dispatch
+ *     {@link RecordedToolCall} field) is whole-question wall clock, so a slow
+ *     sandbox cold start can trip the `baseline * 1.25` ceiling.
+ *   - **Throttling.** `rate_limited` on `explore` can come from the sandbox
+ *     backend OR the hosted quota; see {@link assertNotRateLimited}.
+ *   - **Content.** A backend that lists the semantic layer and one that fails
+ *     to start give the model different information to answer from. No grader
+ *     change can remove this — the honest fix is pinning the eval's backend.
  */
-const TEXT_CONTRACT_TOOLS: ReadonlySet<string> = new Set(["explore"]);
+const TEXT_CONTRACT_TOOL_NAMES = ["explore"] as const;
+const TEXT_CONTRACT_TOOLS: ReadonlySet<string> = new Set(TEXT_CONTRACT_TOOL_NAMES);
+
+/**
+ * Tools whose successful `data` is read as parsed JSON somewhere in grading:
+ * {@link resultMatchesExpectation} via {@link isAnsweringCall}, and the
+ * `entity.query_patterns` cast in {@link gradePattern}.
+ *
+ * A text contract puts RAW PROSE in `data` ({@link interpretResult}), so a tool
+ * in both lists would have a directory listing compared against a metric's
+ * authoritative value, or `data?.entity` read off a string: no crash, no
+ * artifact, just `false`. A silent false negative rather than a loud stop —
+ * hence a COMPILE-time check rather than a comment.
+ */
+type DataReadingToolName = (typeof ANSWERING_TOOLS)[number] | "describeEntity";
+
+type _AssertContractsDisjoint =
+  Extract<
+    DataReadingToolName,
+    (typeof TEXT_CONTRACT_TOOL_NAMES)[number]
+  > extends never
+    ? true
+    : never;
+/**
+ * The assignment IS the assertion — it stops compiling if the lists overlap.
+ * Type-only on purpose: a runtime `[...ANSWERING_TOOLS, …]` here would be a TDZ
+ * reference, since `ANSWERING_TOOLS` is declared further down the file.
+ */
+const _contractsAreDisjoint: _AssertContractsDisjoint = true;
 
 /** Resolve a discovered tool's output contract. See {@link TEXT_CONTRACT_TOOLS}. */
 export function classifyToolContract(name: string): ToolContract {
@@ -475,7 +507,7 @@ export function classifyToolContract(name: string): ToolContract {
  *     an `Error:`-prefixed string. An empty `content` array is a protocol
  *     anomaly for every tool, whatever its output contract.
  */
-function interpretResult(
+export function interpretResult(
   result: CallToolResult,
   contract: ToolContract,
 ): ExtractedToolJson {
@@ -500,7 +532,7 @@ function interpretResult(
  * back, with no diagnostic. Called against the real `tools/list` result, so a
  * rename is a loud stop at boot rather than five silent mis-graded questions.
  */
-function assertTextContractToolsPresent(tools: readonly ToolListEntry[]): void {
+export function assertTextContractToolsPresent(tools: readonly ToolListEntry[]): void {
   const discovered = new Set(tools.map((t) => t.name));
   const missing = [...TEXT_CONTRACT_TOOLS].filter((n) => !discovered.has(n));
   if (missing.length === 0) return;
@@ -521,22 +553,6 @@ function assertTextContractToolsPresent(tools: readonly ToolListEntry[]): void {
 }
 
 /**
- * Anchor the text-contract exemption against the surface actually discovered,
- * then bind it for the LLM. The two steps are one seam on purpose: binding
- * without the anchor is the state #5131 shipped in, and a wrapper is what
- * makes the wiring testable — a guard whose call site nothing exercises can be
- * deleted with the whole suite still green.
- */
-function bindEvalToolSurface(
-  client: { callTool: EvalMcpClient["callTool"] },
-  tools: readonly ToolListEntry[],
-  recorder: RecordedToolCall[],
-): ToolSet {
-  assertTextContractToolsPresent(tools);
-  return bindMcpToolsForLlm(client, tools, recorder);
-}
-
-/**
  * Translate the MCP tool surface to a Vercel AI SDK `ToolSet`. Every
  * tool's `execute` dispatches back through the MCP transport so the
  * round-trip the LLM sees is identical to what an external client
@@ -553,6 +569,13 @@ function bindMcpToolsForLlm(
   tools: readonly ToolListEntry[],
   recorder: RecordedToolCall[],
 ): ToolSet {
+  // ⚠️ THE ANCHOR LIVES INSIDE THE BINDER, NOT IN A WRAPPER AROUND IT.
+  // A wrapper leaves an unanchored binder callable beside it, so swapping the
+  // wrapper back out at the one production call site is invisible — `runMcpLlmEval`
+  // has no test, so nothing would go red. Binding a surface and vouching for it
+  // are one operation here; the sibling binder in `canonical-eval-tool-selection.ts`
+  // calls the anchor the same way, from inside itself.
+  assertTextContractToolsPresent(tools);
   // `dynamicTool` (rather than `tool`) is the right shape here: the
   // input schema comes from the MCP server at runtime, so we cannot
   // statically infer the input type. The production agent loop binds
@@ -714,14 +737,6 @@ interface GradeInput {
 }
 
 /**
- * Per-mode grader. Pass criteria are intentionally lenient on **how**
- * the LLM arrived at the answer (multiple tool sequences are valid for
- * most questions) and strict on **whether** the answer matches the
- * question's contract. This mirrors the deterministic eval's posture —
- * `--mcp-llm` is a regression gate on tool-selection quality, not a
- * style guide for the model.
- */
-/**
  * Abort the run when any dispatch came back `rate_limited`.
  *
  * ⚠️ A THROTTLE IS A HARNESS FAULT, NOT A MODEL FAULT, AND MUST NOT BE GRADED
@@ -743,22 +758,37 @@ function assertNotRateLimited(
   if (!throttled) return;
   const envelope =
     throttled.result.kind === "error" ? throttled.result.envelope : null;
-  // The remedy depends on WHICH limiter fired, and the two are different knobs.
-  // A text-contract tool is a sandboxed shell: its `rate_limited` comes from the
-  // sandbox backend via `classifyExploreError`, not from the eval client's
-  // hosted-MCP quota, so sending an operator to EVAL_CLIENT_REQUESTS_PER_MINUTE
-  // would be pointing at a knob that cannot help (#5131).
-  const remedy =
-    throttled.contract === "text"
-      ? `${throttled.name} is a sandboxed shell, so this is the SANDBOX backend's limiter, ` +
-        `not the eval client's hosted-MCP quota — raising EVAL_CLIENT_REQUESTS_PER_MINUTE ` +
-        `will not help. Check the backend the eval resolved (see backends/selection.ts).`
-      : `This is the eval throttling ITSELF, not a model failure: the run's own ` +
-        `dispatch volume exceeded the eval client's hosted-MCP quota. Raise it via ` +
-        `liftEvalClientRateLimit (EVAL_CLIENT_REQUESTS_PER_MINUTE).`;
+  // ⚠️ THE REMEDY BRANCHES ON THE ENVELOPE, NOT ON THE TOOL'S CONTRACT — an
+  // earlier cut keyed it on `contract === "text"` and asserted that a throttled
+  // `explore` could only be the sandbox's limiter. That is false, and false in
+  // the dominant direction: the hosted per-OAuth-client quota runs ahead of
+  // EVERY tool body (`rateLimitOrNull` in mcp-dispatch), and `explore` is
+  // charged weight 5 there — tied with `executeSQL` for the second-priciest
+  // tool, so it is one of the largest contributors to the exhaustion
+  // `liftEvalClientRateLimit` exists to prevent. Output shape simply does not
+  // encode which limiter fired.
+  //
+  // The envelope does. The hosted limiter always sets `retry_after` + `hint`
+  // (rate-limit/middleware.ts); the sandbox path builds its envelope with no
+  // extras for `rate_limited` (tools.ts → classifyExploreError), so the field
+  // is absent there.
+  const retryAfter = (envelope as { retry_after?: unknown } | null)?.retry_after;
+  const message = typeof envelope?.message === "string" ? envelope.message : "";
+  const isHostedQuota =
+    typeof retryAfter === "number" || /hosted-MCP quota/.test(message);
+  const remedy = isHostedQuota
+    ? `This is the eval throttling ITSELF, not a model failure: the run's own dispatch ` +
+      `volume exceeded the eval client's hosted-MCP quota (${throttled.name} is just the ` +
+      `dispatch that happened to hit it). Raise it via liftEvalClientRateLimit ` +
+      `(EVAL_CLIENT_REQUESTS_PER_MINUTE).`
+    : `The envelope carries no hosted-quota markers, so a limiter DOWNSTREAM of the eval ` +
+      `client fired — for a text-contract tool that is the sandbox backend ` +
+      `(classifyExploreError); for a JSON one, the datasource QPM/pool or the billing ` +
+      `throttle. Raising EVAL_CLIENT_REQUESTS_PER_MINUTE will not help; read the message ` +
+      `above and check that limiter.`;
   throw new Error(
-    `[harness] ${q.id}: MCP dispatch was rate limited on ${throttled.name} — ` +
-      `${envelope?.message ?? "no message"} ${remedy} ` +
+    `[harness] ${q.id}: MCP dispatch was rate limited on ${throttled.name} ` +
+      `(contract: ${throttled.contract}) — ${message || "no message"} ${remedy} ` +
       `Either way the run stops rather than letting the throttle be graded as a ` +
       `recovery regression.`,
   );
@@ -784,17 +814,33 @@ function grade(input: GradeInput): McpLlmOutcome {
       category: "protocol",
       tool: unparseable.name,
       args: unparseable.args,
-      response: { raw: unparseable.result.raw },
-      expected: "JSON envelope from MCP tool",
-      // The anchor proves every DECLARED text tool is on the surface; nothing
-      // proves the reverse, so a newly-added prose-returning tool reproduces
-      // #5131 verbatim and lands here. Say what to do about it rather than
-      // making the next reader re-derive it.
+      response: { raw: unparseable.result.raw, contract: unparseable.contract },
+      // ⚠️ THE REMEDY DIFFERS BY CONTRACT, AND THE WRONG ONE IS A NO-OP.
+      // A text-contract tool only reaches this branch through
+      // `interpretResult`'s two carve-outs, and in both the tool is ALREADY in
+      // TEXT_CONTRACT_TOOLS — the anchor guarantees it or the run would not
+      // have booted. Telling that operator to add it would be an instruction
+      // that provably changes nothing. The json arm is the newly-added-text-
+      // tool case, which the anchor cannot detect (it proves declared ⊆
+      // discovered, never the reverse).
+      expected:
+        unparseable.contract === "text"
+          ? "text body from a declared text-contract tool"
+          : "JSON envelope from MCP tool",
       summary:
-        `MCP tool ${unparseable.name} returned content that could not be read as JSON. ` +
-        `If this tool's DECLARED output is free-form text (as \`explore\`'s is), add it ` +
-        `to TEXT_CONTRACT_TOOLS; otherwise this is a genuine MCP protocol regression — ` +
-        `note that a server-flagged error carrying a prose body also lands here.`,
+        unparseable.contract === "text"
+          ? `MCP tool ${unparseable.name} is a DECLARED text-contract tool, so this is ` +
+            `NOT shell output: it ${
+              unparseable.result.raw === ""
+                ? "returned no text content at all"
+                : "carried a server-flagged error with a prose body"
+            }. Adding it to TEXT_CONTRACT_TOOLS will not help — it is already there. ` +
+            `Check the sandbox backend the eval resolved (backends/selection.ts).`
+          : `MCP tool ${unparseable.name} returned content that could not be read as ` +
+            `JSON. If this tool's DECLARED output is free-form text (as \`explore\`'s ` +
+            `is), add it to TEXT_CONTRACT_TOOLS; otherwise this is a genuine MCP ` +
+            `protocol regression — note that a server-flagged error carrying a prose ` +
+            `body also lands here.`,
     });
   }
 
@@ -854,6 +900,14 @@ function grade(input: GradeInput): McpLlmOutcome {
   return modeOutcome;
 }
 
+/**
+ * Per-mode grader. Pass criteria are intentionally lenient on **how**
+ * the LLM arrived at the answer (multiple tool sequences are valid for
+ * most questions) and strict on **whether** the answer matches the
+ * question's contract. This mirrors the deterministic eval's posture —
+ * `--mcp-llm` is a regression gate on tool-selection quality, not a
+ * style guide for the model.
+ */
 function gradeByMode(
   q: Question,
   toolCalls: readonly RecordedToolCall[],
@@ -1603,6 +1657,11 @@ function isTransportFail(c: RecordedToolCall): c is ErrorCall {
  * dependency on the per-mode graders' shape and lock the grader
  * implementation. The unit tests in `canonical-eval-mcp-llm.test.ts`
  * are the only intended consumers.
+ *
+ * `classifyToolContract`, `interpretResult` and `assertTextContractToolsPresent`
+ * are deliberately NOT here: `canonical-eval-tool-selection.ts` consumes them as
+ * real dependencies, so they are ordinary top-level exports. Listing them here
+ * as well would imply a test-only surface they do not have.
  */
 export const __forTesting__ = {
   grade: (input: GradeInput) => grade(input),
@@ -1611,8 +1670,6 @@ export const __forTesting__ = {
   gradePattern,
   gradeVirtual,
   bindMcpToolsForLlm,
-  bindEvalToolSurface,
-  assertTextContractToolsPresent,
 } as const;
 
 // ── Baseline I/O ────────────────────────────────────────────────────

--- a/packages/cli/bin/canonical-eval-tool-selection.test.ts
+++ b/packages/cli/bin/canonical-eval-tool-selection.test.ts
@@ -227,7 +227,34 @@ describe("bindToolsForRecording", () => {
     expect(recorder).toEqual(["runMetric"]);
   });
 
-  it("returns an unparseable shape when MCP content isn't JSON", async () => {
+  it("returns an unparseable shape when a JSON-contract tool's content isn't JSON", async () => {
+    const recorder: string[] = [];
+    const fakeClient = {
+      callTool: async () => fakeResult("not-json", false),
+    };
+    const tools = __forTesting__.bindToolsForRecording(
+      fakeClient,
+      [{ name: "describeEntity", description: "Describe." }],
+      recorder,
+    );
+    const runner = getRunner(tools as Record<string, Tool>, "describeEntity");
+    const result = (await runner(
+      { name: "orders" },
+      { toolCallId: "t1", messages: [] },
+    )) as { error?: string; raw?: string };
+    expect(result.error).toBe("unparseable");
+    expect(result.raw).toBe("not-json");
+    expect(recorder).toEqual(["describeEntity"]);
+  });
+
+  it("hands a TEXT-contract tool's output back verbatim rather than fabricating an error (#5131)", async () => {
+    // ⚠️ THIS TEST PREVIOUSLY ASSERTED THE OPPOSITE, on this exact tool. It
+    // pinned `{ error: "unparseable" }` for a successful `explore` — which is
+    // the model-facing half of #5131, and it matters MORE in this mode than in
+    // the grading one: telling a model its `ls` errored is exactly what makes
+    // it retry or switch tools, and tool SEQUENCE is what this eval scores.
+    // Same body as the JSON case above, so the tool name is the only
+    // differentiator.
     const recorder: string[] = [];
     const fakeClient = {
       callTool: async () => fakeResult("not-json", false),
@@ -238,13 +265,27 @@ describe("bindToolsForRecording", () => {
       recorder,
     );
     const runner = getRunner(tools as Record<string, Tool>, "explore");
+    const result = await runner({ command: "ls" }, { toolCallId: "t1", messages: [] });
+    expect(result).toBe("not-json");
+    expect(recorder).toEqual(["explore"]);
+  });
+
+  it("keeps a server-FLAGGED error on a text-contract tool as an error, not shell output", async () => {
+    const recorder: string[] = [];
+    const fakeClient = {
+      callTool: async () => fakeResult("Error: sandbox failed to start", true),
+    };
+    const tools = __forTesting__.bindToolsForRecording(
+      fakeClient,
+      [{ name: "explore", description: "Explore." }],
+      recorder,
+    );
+    const runner = getRunner(tools as Record<string, Tool>, "explore");
     const result = (await runner(
       { command: "ls" },
       { toolCallId: "t1", messages: [] },
-    )) as { error?: string; raw?: string };
+    )) as { error?: string };
     expect(result.error).toBe("unparseable");
-    expect(result.raw).toBe("not-json");
-    expect(recorder).toEqual(["explore"]);
   });
 
   it("records the tool name BEFORE awaiting dispatch (transport throw still leaves name visible)", async () => {

--- a/packages/cli/bin/canonical-eval-tool-selection.test.ts
+++ b/packages/cli/bin/canonical-eval-tool-selection.test.ts
@@ -194,7 +194,7 @@ describe("bindToolsForRecording", () => {
     };
     const tools = __forTesting__.bindToolsForRecording(
       fakeClient,
-      [{ name: "listEntities", description: "List entities." }],
+      [{ name: "explore", description: "Explore." }, { name: "listEntities", description: "List entities." }],
       recorder,
     );
     const runner = getRunner(tools as Record<string, Tool>, "listEntities");
@@ -216,7 +216,7 @@ describe("bindToolsForRecording", () => {
     };
     const tools = __forTesting__.bindToolsForRecording(
       fakeClient,
-      [{ name: "runMetric", description: "Run a metric." }],
+      [{ name: "explore", description: "Explore." }, { name: "runMetric", description: "Run a metric." }],
       recorder,
     );
     const runner = getRunner(tools as Record<string, Tool>, "runMetric");
@@ -234,7 +234,7 @@ describe("bindToolsForRecording", () => {
     };
     const tools = __forTesting__.bindToolsForRecording(
       fakeClient,
-      [{ name: "describeEntity", description: "Describe." }],
+      [{ name: "explore", description: "Explore." }, { name: "describeEntity", description: "Describe." }],
       recorder,
     );
     const runner = getRunner(tools as Record<string, Tool>, "describeEntity");
@@ -249,12 +249,9 @@ describe("bindToolsForRecording", () => {
 
   it("hands a TEXT-contract tool's output back verbatim rather than fabricating an error (#5131)", async () => {
     // ⚠️ THIS TEST PREVIOUSLY ASSERTED THE OPPOSITE, on this exact tool. It
-    // pinned `{ error: "unparseable" }` for a successful `explore` — which is
-    // the model-facing half of #5131, and it matters MORE in this mode than in
-    // the grading one: telling a model its `ls` errored is exactly what makes
-    // it retry or switch tools, and tool SEQUENCE is what this eval scores.
-    // Same body as the JSON case above, so the tool name is the only
-    // differentiator.
+    // pinned `{ error: "unparseable" }` for a successful `explore` — the
+    // model-facing half of #5131. Same body as the JSON case above, so the tool
+    // name is the only differentiator.
     const recorder: string[] = [];
     const fakeClient = {
       callTool: async () => fakeResult("not-json", false),
@@ -286,6 +283,37 @@ describe("bindToolsForRecording", () => {
       { toolCallId: "t1", messages: [] },
     )) as { error?: string };
     expect(result.error).toBe("unparseable");
+    expect(recorder).toEqual(["explore"]);
+  });
+
+  it("keeps an EMPTY result on a text-contract tool as an error, not shell output", async () => {
+    const recorder: string[] = [];
+    const fakeClient = { callTool: async () => ({ content: [] }) };
+    const tools = __forTesting__.bindToolsForRecording(
+      fakeClient,
+      [{ name: "explore", description: "Explore." }],
+      recorder,
+    );
+    const runner = getRunner(tools as Record<string, Tool>, "explore");
+    const result = (await runner(
+      { command: "ls" },
+      { toolCallId: "t1", messages: [] },
+    )) as { error?: string };
+    expect(result.error).toBe("unparseable");
+  });
+
+  // The anchor is wired here too: a renamed `explore` would silently go back to
+  // handing the model `{ error: "unparseable" }` for a successful `ls`. It is
+  // inside `bindToolsForRecording` rather than around it for the same reason as
+  // in the mcp-llm binder — an unanchored binder beside it would be callable.
+  it("refuses to bind a surface missing a text-contract tool", () => {
+    expect(() =>
+      __forTesting__.bindToolsForRecording(
+        { callTool: async () => ({ content: [] }) },
+        [{ name: "runMetric", description: "Run a metric." }],
+        [],
+      ),
+    ).toThrow(/text-contract tool\(s\) not on the MCP surface: explore/);
   });
 
   it("records the tool name BEFORE awaiting dispatch (transport throw still leaves name visible)", async () => {
@@ -302,7 +330,7 @@ describe("bindToolsForRecording", () => {
     };
     const tools = __forTesting__.bindToolsForRecording(
       fakeClient,
-      [{ name: "describeEntity", description: "Describe." }],
+      [{ name: "explore", description: "Explore." }, { name: "describeEntity", description: "Describe." }],
       recorder,
     );
     const runner = getRunner(tools as Record<string, Tool>, "describeEntity");

--- a/packages/cli/bin/canonical-eval-tool-selection.ts
+++ b/packages/cli/bin/canonical-eval-tool-selection.ts
@@ -37,14 +37,13 @@ import {
   startEvalAuthServer,
   type EvalAuthFixture,
 } from "@atlas/mcp/eval/auth";
-import {
-  EvalMcpClient,
-  extractToolJson,
-  joinTextContent,
-  type ToolListEntry,
-} from "@atlas/mcp/eval/client";
+import { EvalMcpClient, type ToolListEntry } from "@atlas/mcp/eval/client";
 import { createHostedMcpRouter } from "@atlas/mcp/hosted";
-import { classifyToolContract } from "./canonical-eval-mcp-llm";
+import {
+  assertTextContractToolsPresent,
+  classifyToolContract,
+  interpretResult,
+} from "./canonical-eval-mcp-llm";
 
 // ── Public types ──────────────────────────────────────────────────────
 
@@ -231,8 +230,8 @@ export async function runToolSelectionEval(
       try {
         await client.close();
       } catch (closeErr) {
-        // intentionally ignored: surfacing the close error would mask
-        // the original connect failure, which is the actionable signal.
+        // Logged, not re-thrown: the connect failure is the actionable signal
+        // and must be the error that propagates.
         process.stderr.write(
           `[tool-selection-eval] client.close after failed connect threw: ${closeErr instanceof Error ? closeErr.message : String(closeErr)}\n`,
         );
@@ -298,11 +297,23 @@ async function bootDefaultFixture(): Promise<EvalAuthFixture> {
 // Bind every MCP-discovered tool to a `dynamicTool` that records its
 // `name` in dispatch order. We don't need the result envelope here —
 // the grader only inspects the call sequence.
+//
+// ⚠️ ANCHORED, for the same reason the mcp-llm binder is: the imported
+// text-contract list is spelled as a NAME, so renaming `explore` would silently
+// turn the exemption back into a fabricated `{ error: "unparseable" }` for a
+// successful `ls`.
+//
+// That cannot move THIS eval's score — `gradeToolSelection` reads
+// `toolSequence[0]` only, and the name is recorded before the dispatch resolves,
+// so no result can change the verdict. The reason to fix it here anyway is
+// fidelity: the model must see the surface production shows it, or the tool
+// choice being audited is made against a lie.
 function bindToolsForRecording(
   client: { callTool: EvalMcpClient["callTool"] },
   tools: readonly ToolListEntry[],
   recorder: string[],
 ): ToolSet {
+  assertTextContractToolsPresent(tools);
   const set: Record<string, Tool> = {};
   for (const t of tools) {
     const schema =
@@ -324,17 +335,14 @@ function bindToolsForRecording(
         const result = await client.callTool(t.name, args);
         // A text-contract tool's product IS its text (#5131). This eval does
         // not grade `protocol`, so the mis-grading half of that bug never
-        // applied here — but the model-facing half matters MORE in this mode:
-        // telling a model its successful `ls` errored is exactly what makes it
-        // retry or switch tools, and tool SEQUENCE is what this eval scores.
-        // The flagged-error / empty-content carve-outs are the same ones
-        // `interpretResult` makes; see its note for why they are not shell
-        // output.
-        if (classifyToolContract(t.name) === "text" && result.isError !== true) {
-          const text = joinTextContent(result);
-          if (text !== "") return text;
-        }
-        const parsed = extractToolJson(result);
+        // applied here; the model-facing half does, and fidelity is the reason
+        // to close it (see the binder's note above).
+        //
+        // ⚠️ CALLS the shared `interpretResult` rather than restating its rule.
+        // An earlier cut spelled the same three-way decision out inline here,
+        // with a comment promising it matched — an invariant enforced by prose,
+        // which a third carve-out added on the other side would silently break.
+        const parsed = interpretResult(result, classifyToolContract(t.name));
         if (parsed.kind === "error") return parsed.envelope;
         if (parsed.kind === "unparseable") {
           return { error: "unparseable", raw: parsed.raw };

--- a/packages/cli/bin/canonical-eval-tool-selection.ts
+++ b/packages/cli/bin/canonical-eval-tool-selection.ts
@@ -40,9 +40,11 @@ import {
 import {
   EvalMcpClient,
   extractToolJson,
+  joinTextContent,
   type ToolListEntry,
 } from "@atlas/mcp/eval/client";
 import { createHostedMcpRouter } from "@atlas/mcp/hosted";
+import { classifyToolContract } from "./canonical-eval-mcp-llm";
 
 // ── Public types ──────────────────────────────────────────────────────
 
@@ -320,6 +322,18 @@ function bindToolsForRecording(
         // call fails.
         recorder.push(t.name);
         const result = await client.callTool(t.name, args);
+        // A text-contract tool's product IS its text (#5131). This eval does
+        // not grade `protocol`, so the mis-grading half of that bug never
+        // applied here — but the model-facing half matters MORE in this mode:
+        // telling a model its successful `ls` errored is exactly what makes it
+        // retry or switch tools, and tool SEQUENCE is what this eval scores.
+        // The flagged-error / empty-content carve-outs are the same ones
+        // `interpretResult` makes; see its note for why they are not shell
+        // output.
+        if (classifyToolContract(t.name) === "text" && result.isError !== true) {
+          const text = joinTextContent(result);
+          if (text !== "") return text;
+        }
         const parsed = extractToolJson(result);
         if (parsed.kind === "error") return parsed.envelope;
         if (parsed.kind === "unparseable") {

--- a/packages/mcp/src/eval/client.test.ts
+++ b/packages/mcp/src/eval/client.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Unit tests for the eval client's content readers.
+ *
+ * `joinTextContent` became a SHARED seam in #5131 — the `--mcp-llm` and
+ * `--tool-selection` binders both read a text-contract tool's output through
+ * it, and `extractToolJson` parses whatever it returns. Until then it was an
+ * expression inlined in one function and its behaviour was only ever exercised
+ * through fixtures carrying exactly one text item, so an ordering, filtering or
+ * separator regression was invisible: mutating the join to `"\n"`, reversing it,
+ * or widening the `type === "text"` filter left every suite in the repo green.
+ */
+
+import { describe, expect, it } from "bun:test";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { extractToolJson, joinTextContent } from "./client.js";
+
+function result(content: CallToolResult["content"], isError?: boolean): CallToolResult {
+  return isError === undefined ? { content } : { content, isError };
+}
+
+describe("joinTextContent", () => {
+  it("concatenates multiple text items in order with NO separator", () => {
+    // Both halves matter: a `"\n"` separator would corrupt JSON split across
+    // items, and reversing would corrupt a shell listing. `{"a":` + `1}` is
+    // chosen so a separator is not merely different but breaks the parse.
+    expect(joinTextContent(result([textItem('{"a":'), textItem("1}")]))).toBe('{"a":1}');
+    expect(extractToolJson(result([textItem('{"a":'), textItem("1}")]))).toEqual({
+      kind: "ok",
+      data: { a: 1 },
+    });
+  });
+
+  it("keeps ordering — the reverse of a listing is a different listing", () => {
+    expect(joinTextContent(result([textItem("entities/\n"), textItem("metrics/\n")]))).toBe(
+      "entities/\nmetrics/\n",
+    );
+  });
+
+  it("returns ONLY the text items when non-text content is interleaved", () => {
+    const mixed = result([
+      { type: "image" as const, data: "aGk=", mimeType: "image/png" },
+      textItem("entities/"),
+      { type: "image" as const, data: "aGk=", mimeType: "image/png" },
+      textItem("metrics/"),
+    ]);
+    expect(joinTextContent(mixed)).toBe("entities/metrics/");
+  });
+
+  it("ignores a NON-text item that carries its own `text` field", () => {
+    // ⚠️ THIS IS THE ONLY SHAPE WHERE THE `type === "text"` FILTER IS
+    // LOAD-BEARING, and without this case a mutation deleting the filter is
+    // EQUIVALENT rather than caught: `Array#join` already coalesces `undefined`
+    // to "", so dropping the filter changes nothing for an image item, which
+    // has no `text` property at all. A decoy `text` on a non-text item is what
+    // makes the filter falsifiable — and it is a real shape, because MCP keeps
+    // adding content types and a future one carrying `text` would silently
+    // splice itself into what the model reads and the grader records.
+    const decoy = result([
+      { type: "resource_link", uri: "file:///x", text: "SHOULD NOT APPEAR" },
+      textItem("entities/"),
+    ] as unknown as CallToolResult["content"]);
+    expect(joinTextContent(decoy)).toBe("entities/");
+  });
+
+  it("returns the empty string when there is no text content at all", () => {
+    expect(joinTextContent(result([]))).toBe("");
+    expect(
+      joinTextContent(result([{ type: "image" as const, data: "aGk=", mimeType: "image/png" }])),
+    ).toBe("");
+  });
+
+  it("also returns the empty string for a text item that carried nothing", () => {
+    // Distinct situation, same value — which is exactly why the binders route
+    // BOTH to the protocol lane rather than treating "" as shell output.
+    expect(joinTextContent(result([textItem("")]))).toBe("");
+  });
+});
+
+describe("extractToolJson", () => {
+  it("reaches the unparseable arm BEFORE consulting isError", () => {
+    // The ordering the #5131 carve-outs depend on: a server-flagged error with
+    // a prose body is indistinguishable from shell output by shape alone, so a
+    // caller that exempts a tool must read `isError` itself.
+    expect(extractToolJson(result([textItem("Error: sandbox failed")], true))).toEqual({
+      kind: "unparseable",
+      raw: "Error: sandbox failed",
+    });
+  });
+
+  it("returns the typed envelope when a flagged error's body IS JSON", () => {
+    expect(
+      extractToolJson(result([textItem(JSON.stringify({ code: "rate_limited" }))], true)),
+    ).toEqual({ kind: "error", envelope: { code: "rate_limited" } });
+  });
+});
+
+function textItem(text: string) {
+  return { type: "text" as const, text };
+}

--- a/packages/mcp/src/eval/client.ts
+++ b/packages/mcp/src/eval/client.ts
@@ -222,17 +222,42 @@ export type ExtractedToolJson =
   | { readonly kind: "unparseable"; readonly raw: string };
 
 /**
+ * Concatenate a `tools/call` result's text content items, in order.
+ *
+ * Exported so a caller that needs the tool's TEXT rather than its parsed JSON
+ * — the `--mcp-llm` eval binder, for a tool whose declared output is free-form
+ * prose — reads exactly the bytes {@link extractToolJson} would have parsed,
+ * from the same implementation. Re-deriving the join at the call site is how
+ * the two drift.
+ *
+ * An empty string means the result carried NO text content at all (an
+ * image-only or empty `content` array), which is distinct from a tool that
+ * legitimately printed nothing — Atlas tools normalise that to a placeholder.
+ */
+export function joinTextContent(result: CallToolResult): string {
+  return result.content
+    .filter((c): c is { type: "text"; text: string } => c.type === "text")
+    .map((c) => c.text)
+    .join("");
+}
+
+/**
  * MCP `tools/call` returns content as an array of items (text / image /
  * resource). The semantic-layer tools always return a single text item
  * containing JSON (success path) or the `AtlasMcpToolError` envelope
  * (failure path). Extract that JSON so callers compare structured data
  * instead of pattern-matching on prose.
+ *
+ * ⚠️ THE `unparseable` ARM IS REACHED BEFORE `result.isError` IS CONSULTED, and
+ * a caller that treats `unparseable` as benign must read `isError` itself. A
+ * server-flagged error whose body is prose rather than JSON — what the MCP
+ * SDK's own `createToolError` emits — lands in the `JSON.parse` catch below
+ * and never reaches the `isError` branch, so the flag is dropped. That is
+ * harmless while every caller fails the question on `unparseable`; it is not
+ * harmless for a caller that exempts a tool (#5131).
  */
 export function extractToolJson(result: CallToolResult): ExtractedToolJson {
-  const text = result.content
-    .filter((c): c is { type: "text"; text: string } => c.type === "text")
-    .map((c) => c.text)
-    .join("");
+  const text = joinTextContent(result);
   if (!text) return { kind: "unparseable", raw: "" };
   let parsed: unknown;
   try {


### PR DESCRIPTION
Closes #5131

A successful `explore` call failed its question. `grade()`'s first branch walks every recorded MCP call for a non-JSON result and fails the question as `protocol` — but `explore` is a sandboxed **shell**, so `ls -la` answering with a directory listing is its contract being honoured, not broken. Five of the eight failures on the eval's first real CI run ([run 31453800369](https://github.com/AtlasDevHQ/atlas/actions/runs/31453800369)) were exactly this, one call each.

Reproduced before any test was written — the artifact matches the issue's payload shape exactly.

## The design question, decided

The issue asked explicitly: distinguish the two contracts **by name**, or **by a marker set at bind time** so they are distinguishable at the type level?

**By name — but anchored, and applied at the recording seam rather than in the grader.** The reasoning, because "a name-list is defensible" deserves better than an assertion:

1. **A bind-time marker cannot escape being a name list; it can only move it.** `bindMcpToolsForLlm` classifies from `ToolListEntry` = `{ name, description?, inputSchema? }`. The `tools/list` response says *nothing* about the shape of a tool's **output**. So any marker set at bind time is still computed from the name.
2. **The one machine-readable candidate is unfaithful, and this was measured rather than assumed.** MCP `outputSchema` looks like the principled discriminator. It is not: in `semantic-tools.ts`, `listEntities`, `describeEntity` and `searchGlossary` all answer JSON and declare **no** `outputSchema` — only `runMetric` does. Keying the exemption on "no outputSchema" would exempt **three of the four typed tools the check exists to protect**, i.e. disable the detector rather than sharpen it. `explore` declares none either, so the signal does not discriminate in *either* direction.
3. **What a name list actually gets wrong is ROT**, and no type fixes that — both spellings carry the same string. Rename `explore` and the exemption silently stops matching, restoring the bug with no signal. That is closed by `assertTextContractToolsPresent`, which anchors the list against the **live discovered surface**. A rename is now a loud stop at boot, before a single paid LLM token is spent, instead of five silently mis-graded questions.
4. **Where the contract is APPLIED turned out to matter more than how it is derived.** The first cut put it in `grade()`'s predicate. Review killed that (below). It now lives in `interpretResult` at the recording seam, so `grade()` is contract-blind and no future reader of `result.kind` can reopen #5131.

The `contract` field on `RecordedToolCall` stays — required, so no construction site can inherit an answer instead of stating one — but it is honestly documented as the **record** of the decision plus a diagnostic dimension, not the mechanism.

## Behaviour delta — text-contract tool (json-contract is unchanged in every row)

| input | before | after |
|---|---|---|
| clean text body | **FAIL** `protocol` | pass (recorded `ok`) |
| body that happens to parse as JSON | ok, *parsed* | pass (recorded `ok`, **raw text**) |
| `isError` + prose body | FAIL `protocol` | FAIL `protocol` |
| `isError` + JSON envelope | error envelope | error envelope |
| empty content | FAIL `protocol` | FAIL `protocol` |
| transport hang-up | FAIL `protocol` | FAIL `protocol` |

Exactly one row moves in the permitting direction, and it is the defect. The exemption is scoped to the **body shape**, never to the tool — a hang-up or a flagged error on `explore` still fails as `protocol`.

The binder also stops handing the model `{ error: "unparseable" }` for a text tool that succeeded. That envelope was a harness-fabricated error: it hid the listing behind a failure word and invited the model to "recover" from something that never went wrong.

## Acceptance criteria

- [x] **A successful `explore` call does not fail its question.**
- [x] **A typed tool returning non-JSON STILL fails as `protocol`, with a test that goes red against the fix.** The fixture is deliberately discriminating: the exempt call and the failing call carry the **identical body**, a successful answering call **is** present, and a text-contract call **is** present — so a content heuristic, a "no answer was produced" heuristic, and a "this run touched a text tool" heuristic all fail it. The only difference is the recorded contract.
- [x] **Same verdict regardless of sandbox backend — or the dependence recorded deliberately.** Both. Output **shape** no longer moves the verdict. Three residual backend-sensitive paths are named in the source rather than papered over: latency (whole-question wall clock), throttling (either limiter can fire), and content (the model may answer differently on what it read). The honest fix for the last is pinning the eval's backend, not widening the rubric.
- [ ] **Re-measured on a real CI run, not only locally.** ⚠️ **NOT MET — see below.**

### The CI-measurement criterion, honestly

I could not satisfy this. The eval is a `workflow_dispatch` job on the **paid** real-model lane and it runs against a branch's code, so a genuine re-measurement needs a dispatch a maintainer authorises. Everything below it is local: 113 unit tests plus 19 mutations. **Treat the "17/20 without these five" arithmetic in the issue as still unverified end to end.**

The dispatch to run after merge:
```
gh workflow run eval-llm.yml -R AtlasDevHQ/atlas --ref main
```
Worth noting the defect is *invisible* locally by construction — that is the whole "Why only in CI" section of the issue — so this criterion is the one that closes the loop, and it remains open.

## Review

`/review-panel`, **2 rounds**. Stopped on the **ratio rule**, not the cap.

| round | findings | new surface | defect-in-prior-fix |
|---|---|---|---|
| 1 | ~18 | 18 | 0 |
| 2 | ~18 | ~5 | **~13** |

Round 2's majority was defects inside round 1's own fixes, so another round would have added work faster than it removed it. Every confirmed must-fix is closed; the rounds are what stopped, not the work. The two that most deserve calling out, because both were **my fix reproducing the defect it fixed, one layer over**:

- **Round 1's exemption turned a loud false FAIL into a silent false PASS.** `extractToolJson` reaches its `unparseable` arm from the `JSON.parse` catch *before* it consults `isError`, so a server-flagged error with a prose body — what the MCP SDK's own `createToolError` emits — is shaped identically to shell output. The grader-side exemption swallowed it, and the model would have read an internal error message as directory contents.
- **Round 1's fix for "the anchor's call site is untested" was a wrapper, which moved the hole up one frame.** `bindMcpToolsForLlm` stayed callable unanchored, so swapping the wrapper back out at the one production call site left the entire suite green. The assert now lives *inside* the binder; there is no unanchored bind to forget.

Round 2 also caught a **false claim I had written while fixing a false claim**: the throttle remedy asserted that a throttled `explore` "is the SANDBOX backend's limiter, not the eval client's quota". The hosted per-OAuth-client quota runs ahead of every tool body and charges `explore` weight 5, so that is the *dominant* case — and the advice was printed directly beneath an envelope message saying "exceeded its hosted-MCP quota". It now branches on the envelope (`retry_after`), which is the field that actually encodes which limiter fired.

The closing round's comment sweep found **seven** more false claims, including one repeated four times ("tool SEQUENCE is what this eval scores" — `gradeToolSelection` reads `toolSequence[0]` only) and four line citations that had all drifted before the PR merged.

## Falsifiers — 19 mutations, built and RUN

Every fix has one, and two survived a pass rather than being reasoned about:

- **M20 survived** because both remedy arms contain the string `EVAL_CLIENT_REQUESTS_PER_MINUTE` — one says raise it, the other says raising it will not help — so the assertion matched either. A **substring double**. Now keyed on arm-unique phrases plus negative assertions.
- **M17 was an EQUIVALENT mutant, not a survivor**: `Array#join` coalesces `undefined` to `""`, so dropping `joinTextContent`'s type filter changes nothing for an image item. Rather than record it as equivalent and move on, the filter was made load-bearing — a non-text item carrying a decoy `text` is the only shape that distinguishes them, and the faithful mutation now dies.
- **M11 survived the round-1 battery** — re-adding a `contract === "json"` clause to `isUnparseable` was undetectable, because no test presented the grader with a text-contract `unparseable`. That is precisely the reopened hole, so the composition test was added.

## Scope

Deliberately narrow, for the Wave-2 siblings. Untouched: `canonical-eval-run.ts` (#5130), `resultMatchesExpectation` (#5128), and the `McpLlmOutcome` / `MetricExpectation` shapes (#5123). One additive field on `RecordedToolCall`; no reshape of the types those PRs need.

The sibling binder in `canonical-eval-tool-selection.ts` **is** in scope — it fabricated the same error and had no anchor. Its mis-grading half never applied (that eval scores the *first* tool and records the name before dispatch), but the model-facing half did, and fixing one instance of a two-instance class is how the class survives.

## Deferred, with reasons

- **Pin `TEXT_CONTRACT_TOOLS` against the real registered MCP surface in the required suite.** Today the anchor catches rot at *boot*, which is loud but only on the weekly paid run. The smallest correct fix moves the constant into `packages/mcp/src/eval/` so `tools.test.ts` can assert `TEXT_CONTRACT_TOOLS ⊆ listTools()` — new shared machinery, which defaults to a follow-up. `TEXT_CONTRACT_TOOLS` was independently verified complete against all 17 registered tools during review.
- **`runToolSelectionEval` has no `assertNotRateLimited` equivalent** — a throttled dispatch there is scored as a tool-selection miss. Same class as #5122, different eval, out of this diff.
- **`withTrialFooter` can make every JSON tool unparseable on a trial workspace** — it appends prose to billing-gated results and `extractToolJson` joins all text blocks. Not reachable in the CI fixture, but the same "the grader assumes a wire contract the server does not guarantee" defect one layer over.
