### PR TITLE
fix(eval): route every canonical-eval path through one process.exit

### DIFF
--- a/packages/cli/bin/__tests__/canonical-eval-exit-code.test.ts
+++ b/packages/cli/bin/__tests__/canonical-eval-exit-code.test.ts
@@ -9,10 +9,17 @@
  * `try`/`finally` left the function before `process.exit(exitCode)`, so the
  * process ended on its natural code, 0. A 12/20 shipped as a green CI check.
  *
+ * ⚠️ THE EXIT-0 CASE IS LOAD-BEARING, not symmetry for its own sake. Without it
+ * the suite says only "some runs are non-zero", which `process.exit(exitCode || 1)`
+ * and an inverted `results.some(...)` ternary both satisfy — and a permanently
+ * red canonical-eval blocks tag pushes via `scripts/eval-informational-gate.sh`.
+ * The three exit codes this command can produce (0, 1, 2) are each asserted by
+ * at least one test, so no assertion here can pass by accidental equality.
+ *
  * The sandbox is a throwaway cwd, because `canonical-eval-run.ts` resolves both
  * `semantic/` and the seed fixture root from `process.cwd()` at module load. A
  * spawn rooted in a tmpdir therefore stages, backs up, and restores entirely
- * inside that tmpdir and cannot touch the repo's own `semantic/`.
+ * inside that tmpdir; the tests assert that directly rather than trusting it.
  */
 import { afterEach, describe, expect, test } from "bun:test";
 import * as fs from "fs";
@@ -33,12 +40,24 @@ const PRELOAD = path.join(
  */
 const DEAD_DATASOURCE_URL = "postgres://atlas:atlas@127.0.0.1:1/atlas_demo";
 
-/** Mirrors `BACKUP_DIR` in `canonical-eval-run.ts`, which is cwd-relative. */
+/**
+ * Mirrors `BACKUP_DIR` in `canonical-eval-run.ts`, which is cwd-relative.
+ * Duplicated rather than exported, and it fails safe: rename it in the source
+ * and `ATLAS_TEST_FAIL_CP_FROM` matches nothing, the restore succeeds, and the
+ * exit-2 test sees 1 instead of 2.
+ */
 const BACKUP_DIR_NAME = ".semantic-backup-canonical-eval";
 
 const sandboxes: string[] = [];
+const children: Array<{ kill: () => void }> = [];
 
 afterEach(() => {
+  // Kill first: `test-isolated.ts` awaits `proc.exited` with no per-file timer,
+  // so a child that outlives its test would hang the whole file rather than
+  // fail it.
+  while (children.length > 0) {
+    children.pop()?.kill();
+  }
   while (sandboxes.length > 0) {
     const dir = sandboxes.pop();
     if (dir) fs.rmSync(dir, { recursive: true, force: true });
@@ -52,7 +71,12 @@ afterEach(() => {
  * `restoreSemanticLayer` short-circuits to success before it can fail.
  */
 function makeSandbox(): string {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "canonical-eval-exit-"));
+  // realpath, because the child computes BACKUP_DIR through `process.cwd()`,
+  // which resolves symlinks. `os.tmpdir()` is behind `/private` on macOS, and
+  // the exact-string path comparison in the preload would never match.
+  const dir = fs.realpathSync(
+    fs.mkdtempSync(path.join(os.tmpdir(), "canonical-eval-exit-")),
+  );
   sandboxes.push(dir);
 
   const seedEntities = path.join(
@@ -81,28 +105,38 @@ function makeSandbox(): string {
   return dir;
 }
 
+/** The caller's own `semantic/entities/mine.yml`, which restore must put back. */
+function callersLayerPath(sandbox: string): string {
+  return path.join(sandbox, "semantic", "entities", "mine.yml");
+}
+
 interface RunResult {
   readonly exitCode: number;
   readonly stdout: string;
   readonly stderr: string;
 }
 
+interface RunOptions {
+  readonly args?: string[];
+  /**
+   * Explicit rather than inferred from the presence of a switch in `env` — an
+   * env switch added later would otherwise silently fail to be preloaded.
+   */
+  readonly preload?: boolean;
+  readonly env?: Record<string, string>;
+}
+
 async function runCanonicalEval(
   cwd: string,
-  args: string[],
-  extraEnv: Record<string, string> = {},
+  options: RunOptions = {},
 ): Promise<RunResult> {
-  const needsPreload =
-    extraEnv.ATLAS_TEST_STUB_SEED !== undefined ||
-    extraEnv.ATLAS_TEST_FAIL_RM_PATH !== undefined;
-
   const proc = Bun.spawn(
     [
       process.execPath,
-      ...(needsPreload ? ["--preload", PRELOAD] : []),
+      ...(options.preload === true ? ["--preload", PRELOAD] : []),
       CLI_ENTRY,
       "canonical-eval",
-      ...args,
+      ...(options.args ?? []),
     ],
     {
       cwd,
@@ -115,12 +149,13 @@ async function runCanonicalEval(
         ATLAS_DATASOURCE_URL: DEAD_DATASOURCE_URL,
         ATLAS_DEPLOY_MODE: "self-hosted",
         ATLAS_DEPLOY_ENV: "development",
-        ...extraEnv,
+        ...(options.env ?? {}),
       },
       stdout: "pipe",
       stderr: "pipe",
     },
   );
+  children.push(proc);
 
   const [stdout, stderr, exitCode] = await Promise.all([
     new Response(proc.stdout).text(),
@@ -130,17 +165,33 @@ async function runCanonicalEval(
   return { exitCode, stdout, stderr };
 }
 
+/**
+ * `bin/atlas.ts` ends `main().catch(...)` with `process.exit(1)`, so an
+ * unrelated crash also reports 1. Every exit-1 assertion below pairs with this
+ * so it cannot pass for that reason.
+ */
+function expectNoCrash(stderr: string): void {
+  expect(stderr).not.toContain("canonical eval failed");
+  expect(stderr).not.toContain("at handleCanonicalEval");
+}
+
 describe("canonical-eval process exit code", () => {
   test(
     "a demo-seed failure exits 1 in deterministic mode",
     async () => {
-      const { exitCode, stderr } = await runCanonicalEval(makeSandbox(), []);
+      const sandbox = makeSandbox();
+      const { exitCode, stderr } = await runCanonicalEval(sandbox);
 
       // The message alone was never the bug — it printed correctly throughout.
       // Assert it only to prove the run reached the seed catch rather than
       // dying somewhere else with a coincidentally non-zero code.
       expect(stderr).toContain("failed to seed demo Postgres");
+      expectNoCrash(stderr);
       expect(exitCode).toBe(1);
+      // The `finally` still restored on the early-return path, and it restored
+      // inside the sandbox rather than anywhere near the repo.
+      expect(fs.existsSync(callersLayerPath(sandbox))).toBe(true);
+      expect(fs.existsSync(path.join(sandbox, BACKUP_DIR_NAME))).toBe(false);
     },
     120_000,
   );
@@ -148,12 +199,15 @@ describe("canonical-eval process exit code", () => {
   test(
     "a demo-seed failure exits 1 in --mcp-llm mode",
     async () => {
-      const { exitCode, stderr } = await runCanonicalEval(makeSandbox(), [
-        "--mcp-llm",
-      ]);
+      const sandbox = makeSandbox();
+      const { exitCode, stderr } = await runCanonicalEval(sandbox, {
+        args: ["--mcp-llm"],
+      });
 
       expect(stderr).toContain("failed to seed demo Postgres");
+      expectNoCrash(stderr);
       expect(exitCode).toBe(1);
+      expect(fs.existsSync(callersLayerPath(sandbox))).toBe(true);
     },
     120_000,
   );
@@ -164,38 +218,141 @@ describe("canonical-eval process exit code", () => {
       // Seed stubbed so the run gets past it without a live Postgres; the
       // provider key deliberately absent so `runMcpLlmMode` returns 1 the same
       // way a below-floor score does. What is under test is that ANY non-zero
-      // it returns survives the assignment-then-return at the mcp-llm branch.
-      const { exitCode, stderr } = await runCanonicalEval(
-        makeSandbox(),
-        ["--mcp-llm"],
-        {
+      // it returns survives the `return await runMcpLlmMode(...)` branch.
+      const { exitCode, stderr } = await runCanonicalEval(makeSandbox(), {
+        args: ["--mcp-llm"],
+        preload: true,
+        env: {
           ATLAS_TEST_STUB_SEED: "1",
           ATLAS_PROVIDER: "anthropic",
           ATLAS_MODEL: "claude-sonnet-4-5",
         },
-      );
+      });
 
-      expect(stderr).toContain("--mcp-llm requires");
+      // The full string, not the shared `--mcp-llm requires` prefix: that
+      // prefix also matches the provider-resolution failure one branch up, so
+      // a model-registry change could slide the test onto a guard it was not
+      // written for and it would still pass.
+      expect(stderr).toContain(
+        '--mcp-llm requires ANTHROPIC_API_KEY for provider "anthropic"',
+      );
+      expectNoCrash(stderr);
       expect(exitCode).toBe(1);
     },
     180_000,
   );
 
   test(
+    "a clean run exits 0 — the code is derived, not a constant",
+    async () => {
+      // An empty question set is the one clean run reachable without Postgres:
+      // `runDeterministic` builds its `executeSql` closure per question, so
+      // zero questions means zero database work. The stdout assertion is what
+      // keeps this from being a vacuous pass — it proves the run reached the
+      // summary rather than exiting 0 by dying early.
+      const sandbox = makeSandbox();
+      const questionsPath = path.join(sandbox, "no-questions.yml");
+      fs.writeFileSync(questionsPath, "questions: []\n");
+
+      const { exitCode, stdout, stderr } = await runCanonicalEval(sandbox, {
+        args: ["--questions", questionsPath],
+        preload: true,
+        env: { ATLAS_TEST_STUB_SEED: "1" },
+      });
+
+      expect(stdout).toContain("0/0");
+      expectNoCrash(stderr);
+      expect(exitCode).toBe(0);
+      expect(fs.existsSync(callersLayerPath(sandbox))).toBe(true);
+    },
+    120_000,
+  );
+
+  test(
+    "a THROWN eval body still reports the restore failure as 2",
+    async () => {
+      // No seed fixture in the sandbox, so `installSchemaSemanticLayer` throws
+      // before it touches anything — the one code-less path the `Promise<number>`
+      // signature cannot reject. Without the `catch` in `runStagedCanonicalEval`
+      // the throw propagates to `main().catch`, which exits 1 unconditionally,
+      // and the restore bump computed in the `finally` is discarded: the run
+      // that destroyed the caller's semantic layer reports the same code as an
+      // ordinary eval failure.
+      const sandbox = makeSandbox();
+      fs.rmSync(path.join(sandbox, "packages"), { recursive: true });
+
+      const { exitCode, stderr } = await runCanonicalEval(sandbox, {
+        preload: true,
+        env: {
+          ATLAS_TEST_FAIL_CP_FROM: path.join(sandbox, BACKUP_DIR_NAME),
+        },
+      });
+
+      expect(stderr).toContain("Canonical semantic layer not found");
+      expect(stderr).toContain("Failed to restore semantic layer");
+      expect(exitCode).toBe(2);
+    },
+    120_000,
+  );
+
+  test(
+    "the JSON payload survives process.exit — writeStdoutSync is not buffered",
+    async () => {
+      // 2 MB against a 64 KiB pipe buffer. `process.exit` discards whatever is
+      // still buffered in `process.stdout`, silently and with no error on
+      // either side; the real `eval-mcp-llm-output.json` is 63 KB, so the
+      // margin here is ~2.5 KB in production. Both arms run so the assertion
+      // is anchored to a measured contrast rather than to one number.
+      const size = 2_000_000;
+      const driver = path.join(
+        import.meta.dir,
+        "fixtures",
+        "canonical-eval-write-stdout-driver.ts",
+      );
+
+      const read = async (mode: string): Promise<number> => {
+        const proc = Bun.spawn(
+          [process.execPath, driver, String(size), mode],
+          { stdout: "pipe", stderr: "inherit" },
+        );
+        children.push(proc);
+        const [text] = await Promise.all([
+          new Response(proc.stdout).text(),
+          proc.exited,
+        ]);
+        return text.length;
+      };
+
+      expect(await read("sync")).toBe(size);
+      // The contrast, so a future "simplification" back to the buffered stream
+      // cannot pass this test by making both arms agree.
+      expect(await read("buffered")).toBeLessThan(size);
+    },
+    120_000,
+  );
+
+  test(
     "a restore failure outranks the eval failure — exit 2, not 1",
     async () => {
       const sandbox = makeSandbox();
-      const { exitCode, stderr } = await runCanonicalEval(sandbox, [], {
-        ATLAS_TEST_FAIL_RM_PATH: path.join(sandbox, BACKUP_DIR_NAME),
+      const { exitCode, stderr } = await runCanonicalEval(sandbox, {
+        preload: true,
+        env: {
+          ATLAS_TEST_FAIL_CP_FROM: path.join(sandbox, BACKUP_DIR_NAME),
+        },
       });
 
       // Both halves must be present: the body earned 1 (seed failure) and the
       // finally bumped it to 2. Asserting 2 against a run that also earns 1
-      // keeps the three outcomes this file cares about — 0, 1, 2 — distinct, so
-      // the assertion cannot pass by accidental equality.
+      // keeps 1 and 2 distinct, so this cannot pass by accidental equality.
       expect(stderr).toContain("failed to seed demo Postgres");
       expect(stderr).toContain("Failed to restore semantic layer");
       expect(exitCode).toBe(2);
+      // Exit 2 means "your layer may be gone, it is at $BACKUP_DIR". Assert the
+      // scenario the message describes actually holds, so the test is pinned to
+      // the branch that motivates the code rather than a benign one.
+      expect(fs.existsSync(callersLayerPath(sandbox))).toBe(false);
+      expect(fs.existsSync(path.join(sandbox, BACKUP_DIR_NAME))).toBe(true);
     },
     120_000,
   );

--- a/packages/cli/bin/__tests__/canonical-eval-exit-code.test.ts
+++ b/packages/cli/bin/__tests__/canonical-eval-exit-code.test.ts
@@ -1,0 +1,202 @@
+/**
+ * The canonical-eval CLI's exit code, observed from the shell (#5130).
+ *
+ * ⚠️ EVERY TEST HERE SPAWNS THE CLI AND READS THE PROCESS EXIT CODE. That is
+ * the whole point, and it is not interchangeable with asserting a function's
+ * return value. The bug this file locks down was invisible to a return-value
+ * test: `runMcpLlmMode` returned 1 exactly as designed, the acceptance floor was
+ * computed and printed — and then an early `return` inside the staging
+ * `try`/`finally` left the function before `process.exit(exitCode)`, so the
+ * process ended on its natural code, 0. A 12/20 shipped as a green CI check.
+ *
+ * The sandbox is a throwaway cwd, because `canonical-eval-run.ts` resolves both
+ * `semantic/` and the seed fixture root from `process.cwd()` at module load. A
+ * spawn rooted in a tmpdir therefore stages, backs up, and restores entirely
+ * inside that tmpdir and cannot touch the repo's own `semantic/`.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+const REPO_ROOT = path.resolve(import.meta.dir, "..", "..", "..", "..");
+const CLI_ENTRY = path.join(REPO_ROOT, "packages", "cli", "bin", "atlas.ts");
+const PRELOAD = path.join(
+  import.meta.dir,
+  "fixtures",
+  "canonical-eval-exit-code.preload.ts",
+);
+
+/**
+ * Port 1 is reserved and never listening, so `seedDemoPostgres` fails with a
+ * fast ECONNREFUSED rather than a connect timeout.
+ */
+const DEAD_DATASOURCE_URL = "postgres://atlas:atlas@127.0.0.1:1/atlas_demo";
+
+/** Mirrors `BACKUP_DIR` in `canonical-eval-run.ts`, which is cwd-relative. */
+const BACKUP_DIR_NAME = ".semantic-backup-canonical-eval";
+
+const sandboxes: string[] = [];
+
+afterEach(() => {
+  while (sandboxes.length > 0) {
+    const dir = sandboxes.pop();
+    if (dir) fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+/**
+ * A cwd the CLI can stage into: a seed fixture for `--schema ecommerce` plus a
+ * pre-existing `semantic/`. The pre-existing layer is load-bearing for the
+ * restore tests — with no `semantic/` there is nothing to back up, and
+ * `restoreSemanticLayer` short-circuits to success before it can fail.
+ */
+function makeSandbox(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "canonical-eval-exit-"));
+  sandboxes.push(dir);
+
+  const seedEntities = path.join(
+    dir,
+    "packages",
+    "cli",
+    "data",
+    "seeds",
+    "ecommerce",
+    "semantic",
+    "entities",
+  );
+  fs.mkdirSync(seedEntities, { recursive: true });
+  fs.writeFileSync(
+    path.join(seedEntities, "orders.yml"),
+    "name: orders\ntable: orders\n",
+  );
+
+  const originalEntities = path.join(dir, "semantic", "entities");
+  fs.mkdirSync(originalEntities, { recursive: true });
+  fs.writeFileSync(
+    path.join(originalEntities, "mine.yml"),
+    "name: mine\ntable: mine\n",
+  );
+
+  return dir;
+}
+
+interface RunResult {
+  readonly exitCode: number;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+async function runCanonicalEval(
+  cwd: string,
+  args: string[],
+  extraEnv: Record<string, string> = {},
+): Promise<RunResult> {
+  const needsPreload =
+    extraEnv.ATLAS_TEST_STUB_SEED !== undefined ||
+    extraEnv.ATLAS_TEST_FAIL_RM_PATH !== undefined;
+
+  const proc = Bun.spawn(
+    [
+      process.execPath,
+      ...(needsPreload ? ["--preload", PRELOAD] : []),
+      CLI_ENTRY,
+      "canonical-eval",
+      ...args,
+    ],
+    {
+      cwd,
+      // Built from scratch rather than spread from `process.env` so an
+      // ANTHROPIC_API_KEY in the developer's shell cannot change which branch
+      // the `--mcp-llm` test lands on.
+      env: {
+        PATH: process.env.PATH ?? "",
+        HOME: process.env.HOME ?? "",
+        ATLAS_DATASOURCE_URL: DEAD_DATASOURCE_URL,
+        ATLAS_DEPLOY_MODE: "self-hosted",
+        ATLAS_DEPLOY_ENV: "development",
+        ...extraEnv,
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    },
+  );
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  return { exitCode, stdout, stderr };
+}
+
+describe("canonical-eval process exit code", () => {
+  test(
+    "a demo-seed failure exits 1 in deterministic mode",
+    async () => {
+      const { exitCode, stderr } = await runCanonicalEval(makeSandbox(), []);
+
+      // The message alone was never the bug — it printed correctly throughout.
+      // Assert it only to prove the run reached the seed catch rather than
+      // dying somewhere else with a coincidentally non-zero code.
+      expect(stderr).toContain("failed to seed demo Postgres");
+      expect(exitCode).toBe(1);
+    },
+    120_000,
+  );
+
+  test(
+    "a demo-seed failure exits 1 in --mcp-llm mode",
+    async () => {
+      const { exitCode, stderr } = await runCanonicalEval(makeSandbox(), [
+        "--mcp-llm",
+      ]);
+
+      expect(stderr).toContain("failed to seed demo Postgres");
+      expect(exitCode).toBe(1);
+    },
+    120_000,
+  );
+
+  test(
+    "--mcp-llm hands the mode's own non-zero code to the shell",
+    async () => {
+      // Seed stubbed so the run gets past it without a live Postgres; the
+      // provider key deliberately absent so `runMcpLlmMode` returns 1 the same
+      // way a below-floor score does. What is under test is that ANY non-zero
+      // it returns survives the assignment-then-return at the mcp-llm branch.
+      const { exitCode, stderr } = await runCanonicalEval(
+        makeSandbox(),
+        ["--mcp-llm"],
+        {
+          ATLAS_TEST_STUB_SEED: "1",
+          ATLAS_PROVIDER: "anthropic",
+          ATLAS_MODEL: "claude-sonnet-4-5",
+        },
+      );
+
+      expect(stderr).toContain("--mcp-llm requires");
+      expect(exitCode).toBe(1);
+    },
+    180_000,
+  );
+
+  test(
+    "a restore failure outranks the eval failure — exit 2, not 1",
+    async () => {
+      const sandbox = makeSandbox();
+      const { exitCode, stderr } = await runCanonicalEval(sandbox, [], {
+        ATLAS_TEST_FAIL_RM_PATH: path.join(sandbox, BACKUP_DIR_NAME),
+      });
+
+      // Both halves must be present: the body earned 1 (seed failure) and the
+      // finally bumped it to 2. Asserting 2 against a run that also earns 1
+      // keeps the three outcomes this file cares about — 0, 1, 2 — distinct, so
+      // the assertion cannot pass by accidental equality.
+      expect(stderr).toContain("failed to seed demo Postgres");
+      expect(stderr).toContain("Failed to restore semantic layer");
+      expect(exitCode).toBe(2);
+    },
+    120_000,
+  );
+});

--- a/packages/cli/bin/__tests__/canonical-eval-exit-code.test.ts
+++ b/packages/cli/bin/__tests__/canonical-eval-exit-code.test.ts
@@ -49,14 +49,20 @@ const DEAD_DATASOURCE_URL = "postgres://atlas:atlas@127.0.0.1:1/atlas_demo";
 const BACKUP_DIR_NAME = ".semantic-backup-canonical-eval";
 
 const sandboxes: string[] = [];
-const children: Array<{ kill: () => void }> = [];
+const children: Array<{ kill: () => void; exited: Promise<number> }> = [];
 
-afterEach(() => {
-  // Kill first: `test-isolated.ts` awaits `proc.exited` with no per-file timer,
-  // so a child that outlives its test would hang the whole file rather than
-  // fail it.
+afterEach(async () => {
+  // Kill first, and AWAIT the exit before removing the sandbox: `rmSync` on a
+  // directory a live child is still writing to races it. Unreachable on the
+  // happy path (every test awaits `proc.exited`), live only on a test-timeout —
+  // which is exactly when a clean diagnosis matters. `test-isolated.ts` awaits
+  // `proc.exited` with no per-file timer, so a child that outlives its test
+  // hangs the whole file rather than failing it.
   while (children.length > 0) {
-    children.pop()?.kill();
+    const child = children.pop();
+    if (!child) continue;
+    child.kill();
+    await child.exited;
   }
   while (sandboxes.length > 0) {
     const dir = sandboxes.pop();
@@ -110,6 +116,34 @@ function callersLayerPath(sandbox: string): string {
   return path.join(sandbox, "semantic", "entities", "mine.yml");
 }
 
+/**
+ * A corpus of questions that every grade as `fail` WITHOUT a database.
+ * `resolveQuestion` returns `fail` for an unknown `metric_id` before it ever
+ * builds SQL, so this exercises the real grading loop and the real exit-code
+ * derivation on a dead datasource.
+ *
+ * The padded id is what pushes the `--json` body past the 65_536-byte pipe
+ * buffer, which is what makes this the end-to-end proof that the payload
+ * survives `process.exit` — the 2 MB driver test pins the HELPER, this pins the
+ * WIRING at the call site the CI artifact actually comes from.
+ */
+function writeFailingCorpus(sandbox: string, count: number): string {
+  const questions = Array.from({ length: count }, (_, i) => {
+    const id = `cq-${String(i + 1).padStart(3, "0")}`;
+    return [
+      `  - id: ${id}`,
+      `    question: "what is ${id}?"`,
+      `    mode: metric`,
+      `    category: simple_metric`,
+      `    metric_id: no_such_metric_${"z".repeat(2000)}`,
+      `    expect: {}`,
+    ].join("\n");
+  });
+  const file = path.join(sandbox, "failing-questions.yml");
+  fs.writeFileSync(file, `questions:\n${questions.join("\n")}\n`);
+  return file;
+}
+
 interface RunResult {
   readonly exitCode: number;
   readonly stdout: string;
@@ -124,20 +158,53 @@ interface RunOptions {
    */
   readonly preload?: boolean;
   readonly env?: Record<string, string>;
+  /**
+   * Run the CLI through a real shell pipeline (`… | cat`) instead of reading
+   * `Bun.spawn`'s own pipe.
+   *
+   * ⚠️ LOAD-BEARING FOR THE TRUNCATION ASSERTION, and its absence made that
+   * assertion decoration. `Bun.spawn`'s stdout pipe is far more forgiving than
+   * a shell-created one, so an ~87 KB payload arrives INTACT off the buffered
+   * stream when read the normal way — measured: reverting a `--json` call site
+   * to `process.stdout.write` passed every assertion in this file, and a 750 ms
+   * drain delay did not change that.
+   *
+   * Through a shell pipe the cliff is sharp and reproducible, and it is where
+   * CI stands (`… --json | tee eval-mcp-llm-output.json`). Measured on bun
+   * 1.3.13, identical for `| wc -c` and `| tee`:
+   *
+   *     64_015 bytes → arrives intact
+   *     70_015 bytes → arrives as 65_536, silently
+   *
+   * `eval-mcp-llm-output.json` from the 2026-08-11 run is 63_024 bytes.
+   */
+  readonly shellPipe?: boolean;
 }
 
 async function runCanonicalEval(
   cwd: string,
   options: RunOptions = {},
 ): Promise<RunResult> {
+  const argv = [
+    process.execPath,
+    ...(options.preload === true ? ["--preload", PRELOAD] : []),
+    CLI_ENTRY,
+    "canonical-eval",
+    ...(options.args ?? []),
+  ];
+  // `| cat` makes stdout a shell-created pipe, which is the shape CI's `| tee`
+  // has and the only one that reproduces the truncation cliff. `set -o pipefail`
+  // mirrors the workflow so the observed exit code is still the CLI's.
+  const command = options.shellPipe === true
+    ? [
+        "bash",
+        "-c",
+        `set -o pipefail; ${argv.map((a) => `'${a.replaceAll("'", `'\\''`)}'`).join(" ")} | cat`,
+      ]
+    : argv;
+
   const proc = Bun.spawn(
-    [
-      process.execPath,
-      ...(options.preload === true ? ["--preload", PRELOAD] : []),
-      CLI_ENTRY,
-      "canonical-eval",
-      ...(options.args ?? []),
-    ],
+    command,
     {
       cwd,
       // Built from scratch rather than spread from `process.env` so an
@@ -269,6 +336,59 @@ describe("canonical-eval process exit code", () => {
   );
 
   test(
+    "failing questions exit 1, and the oversized --json body survives intact",
+    async () => {
+      // Three gaps in one run, because they share a fixture:
+      //
+      //   1. the exit code is DERIVED from the grades. Every other test returns
+      //      before `runDeterministic` grades anything, so `results.some(fail)`
+      //      was only ever evaluated against `[]` — where `some(warn)`,
+      //      `some(!pass)` and `length > 0` are all indistinguishable from it.
+      //   2. the `--json` call site is WIRED to writeStdoutSync. The 2 MB driver
+      //      test pins the helper; reverting any single call site back to
+      //      `process.stdout.write` passed every test before this one, including
+      //      the site that produces eval-mcp-llm-output.json.
+      //   3. the truncation fix works END TO END through the real CLI, not just
+      //      in a driver — this body is ~87 KB against a 65_536-byte pipe.
+      const sandbox = makeSandbox();
+      const questionsPath = writeFailingCorpus(sandbox, 40);
+
+      const { exitCode, stdout } = await runCanonicalEval(sandbox, {
+        args: ["--questions", questionsPath, "--json"],
+        preload: true,
+        env: { ATLAS_TEST_STUB_SEED: "1" },
+        // See RunOptions.shellPipe — without it this test cannot tell the two
+        // writers apart and gap (2) below is not actually closed.
+        shellPipe: true,
+      });
+
+      expect(exitCode).toBe(1);
+
+      // stdout carries a prose header before the JSON body (that mixing is
+      // #5126's, not this change's), so slice from the first brace.
+      const body = stdout.slice(stdout.indexOf("{"));
+      expect(body.length).toBeGreaterThan(65_536);
+      const parsed = JSON.parse(body) as {
+        total: number;
+        passing: number;
+        failing: number;
+      };
+      // Distinct values on purpose: 40/0/40 cannot be satisfied by a mapping
+      // that confuses passing with failing, the way 0/0/0 could.
+      expect(parsed.total).toBe(40);
+      expect(parsed.passing).toBe(0);
+      expect(parsed.failing).toBe(40);
+
+      // The header lines were written to the buffered stream and the body via
+      // writeSync; a writer-ordering regression would put the body first.
+      expect(stdout.indexOf("Atlas canonical-question eval")).toBeLessThan(
+        stdout.indexOf("{"),
+      );
+    },
+    180_000,
+  );
+
+  test(
     "a THROWN eval body still reports the restore failure as 2",
     async () => {
       // No seed fixture in the sandbox, so `installSchemaSemanticLayer` throws
@@ -310,23 +430,40 @@ describe("canonical-eval process exit code", () => {
         "canonical-eval-write-stdout-driver.ts",
       );
 
-      const read = async (mode: string): Promise<number> => {
+      const read = async (
+        mode: string,
+      ): Promise<{ length: number; code: number }> => {
         const proc = Bun.spawn(
           [process.execPath, driver, String(size), mode],
-          { stdout: "pipe", stderr: "inherit" },
+          { stdout: "pipe", stderr: "pipe" },
         );
         children.push(proc);
-        const [text] = await Promise.all([
+        const [text, stderr, code] = await Promise.all([
           new Response(proc.stdout).text(),
+          new Response(proc.stderr).text(),
           proc.exited,
         ]);
-        return text.length;
+        expect(stderr).toBe("");
+        return { length: text.length, code };
       };
 
-      expect(await read("sync")).toBe(size);
+      const sync = await read("sync");
+      expect(sync.code).toBe(0);
+      expect(sync.length).toBe(size);
+
       // The contrast, so a future "simplification" back to the buffered stream
       // cannot pass this test by making both arms agree.
-      expect(await read("buffered")).toBeLessThan(size);
+      //
+      // ⚠️ HOW MUCH survives is NOT deterministic — it is however much the
+      // reader happened to drain before `process.exit` fired, measured at
+      // 65_536 under a `| wc -c` shell pipeline and 219_264 under this test's
+      // concurrently-draining reader. Only the exit code and "strictly less
+      // than the payload, strictly more than nothing" are stable. `> 0` is what
+      // stops a driver that crashed before writing from satisfying this arm.
+      const buffered = await read("buffered");
+      expect(buffered.code).toBe(0);
+      expect(buffered.length).toBeGreaterThan(0);
+      expect(buffered.length).toBeLessThan(size);
     },
     120_000,
   );

--- a/packages/cli/bin/__tests__/canonical-eval-exit-code.test.ts
+++ b/packages/cli/bin/__tests__/canonical-eval-exit-code.test.ts
@@ -35,8 +35,9 @@ const PRELOAD = path.join(
 );
 
 /**
- * Port 1 is reserved and never listening, so `seedDemoPostgres` fails with a
- * fast ECONNREFUSED rather than a connect timeout.
+ * Port 1 is reserved and binding it requires privilege, so nothing is listening
+ * on a test runner and `seedDemoPostgres` fails with a fast ECONNREFUSED rather
+ * than a connect timeout.
  */
 const DEAD_DATASOURCE_URL = "postgres://atlas:atlas@127.0.0.1:1/atlas_demo";
 
@@ -55,9 +56,10 @@ afterEach(async () => {
   // Kill first, and AWAIT the exit before removing the sandbox: `rmSync` on a
   // directory a live child is still writing to races it. Unreachable on the
   // happy path (every test awaits `proc.exited`), live only on a test-timeout —
-  // which is exactly when a clean diagnosis matters. `test-isolated.ts` awaits
-  // `proc.exited` with no per-file timer, so a child that outlives its test
-  // hangs the whole file rather than failing it.
+  // which is exactly when a clean diagnosis matters. `packages/cli/scripts/
+  // test-isolated.ts` awaits the child's streams and then `proc.exited`, with no
+  // per-file timer — so a child that outlives its test hangs the whole file
+  // rather than failing it, and it hangs on the pipe before it hangs on exit.
   while (children.length > 0) {
     const child = children.pop();
     if (!child) continue;
@@ -122,10 +124,11 @@ function callersLayerPath(sandbox: string): string {
  * builds SQL, so this exercises the real grading loop and the real exit-code
  * derivation on a dead datasource.
  *
- * The padded id is what pushes the `--json` body past the 65_536-byte pipe
- * buffer, which is what makes this the end-to-end proof that the payload
- * survives `process.exit` — the 2 MB driver test pins the HELPER, this pins the
- * WIRING at the call site the CI artifact actually comes from.
+ * ⚠️ The 2_000-character `metric_id` is what pushes the `--json` body past the
+ * 65_536-byte pipe buffer (40 x ~2_050 B of an ~88 KB body) — shrink it and the
+ * test below silently stops proving anything about truncation. That is what
+ * makes this the end-to-end proof: the 2 MB driver test pins the HELPER, this
+ * pins the WIRING at the call site the CI artifact actually comes from.
  */
 function writeFailingCorpus(sandbox: string, count: number): string {
   const questions = Array.from({ length: count }, (_, i) => {
@@ -313,10 +316,11 @@ describe("canonical-eval process exit code", () => {
     "a clean run exits 0 — the code is derived, not a constant",
     async () => {
       // An empty question set is the one clean run reachable without Postgres:
-      // `runDeterministic` builds its `executeSql` closure per question, so
-      // zero questions means zero database work. The stdout assertion is what
-      // keeps this from being a vacuous pass — it proves the run reached the
-      // summary rather than exiting 0 by dying early.
+      // `runDeterministic`'s `executeSql` closure only touches the database when
+      // it is INVOKED (`connections.getDefault()` is inside its body), so zero
+      // questions means zero database work. The stdout assertion is what keeps
+      // this from being a vacuous pass — it proves the run reached the summary
+      // rather than exiting 0 by dying early.
       const sandbox = makeSandbox();
       const questionsPath = path.join(sandbox, "no-questions.yml");
       fs.writeFileSync(questionsPath, "questions: []\n");
@@ -353,16 +357,16 @@ describe("canonical-eval process exit code", () => {
       const sandbox = makeSandbox();
       const questionsPath = writeFailingCorpus(sandbox, 40);
 
-      const { exitCode, stdout } = await runCanonicalEval(sandbox, {
+      const { exitCode, stdout, stderr } = await runCanonicalEval(sandbox, {
         args: ["--questions", questionsPath, "--json"],
         preload: true,
         env: { ATLAS_TEST_STUB_SEED: "1" },
-        // See RunOptions.shellPipe — without it this test cannot tell the two
-        // writers apart and gap (2) below is not actually closed.
+        // Load-bearing — see RunOptions.shellPipe.
         shellPipe: true,
       });
 
       expect(exitCode).toBe(1);
+      expectNoCrash(stderr);
 
       // stdout carries a prose header before the JSON body (that mixing is
       // #5126's, not this change's), so slice from the first brace.

--- a/packages/cli/bin/__tests__/fixtures/canonical-eval-exit-code.preload.ts
+++ b/packages/cli/bin/__tests__/fixtures/canonical-eval-exit-code.preload.ts
@@ -9,50 +9,67 @@
  * a spawn that wants the untouched CLI simply omits `--preload`.
  *
  *   ATLAS_TEST_STUB_SEED=1     — make `seedDemoPostgres` a no-op, so a run can
- *                                get PAST the seed and into `--mcp-llm` without
- *                                a live Postgres.
- *   ATLAS_TEST_FAIL_RM_PATH=…  — make `fs.rmSync` throw for exactly that one
- *                                path, so `restoreSemanticLayer` fails on its
- *                                final step and returns false.
+ *                                get PAST the seed without a live Postgres.
+ *   ATLAS_TEST_FAIL_CP_FROM=…  — make `fs.cpSync` throw when copying FROM that
+ *                                path, so `restoreSemanticLayer` fails.
  *
- * Why `rmSync` and not a chmod: every directory `restoreSemanticLayer` touches
+ * ⚠️ Why the switch keys on the copy SOURCE. `restoreSemanticLayer` runs
+ * `rmSync(SEMANTIC_DIR)` → `cpSync(BACKUP_DIR → SEMANTIC_DIR)` → `rmSync(BACKUP_DIR)`.
+ * Pointing the switch at `BACKUP_DIR` as a cpSync SOURCE selects exactly one
+ * call in the whole run — `installSchemaSemanticLayer` copies FROM the seed
+ * fixture and `backupSemanticLayer` copies FROM `semantic/`, so neither is hit.
+ * It also selects the branch that MOTIVATES exit 2: the removal has already
+ * happened, so `semantic/` is genuinely gone and the CRITICAL message telling
+ * the operator where the backup is, is true. Blocking the trailing
+ * `rmSync(BACKUP_DIR)` instead would exercise a benign branch where the layer
+ * was restored fine and every line of that message is false.
+ *
+ * ⚠️ Why a stub and not a chmod: every directory `restoreSemanticLayer` touches
  * arrives via `fs.cpSync`, and cpSync does NOT preserve directory modes — a
- * read-only fixture directory is copied back as 0755, so no permission trick on
- * disk can make the restore fail. Blocking the one call is the only lever that
- * reaches it without rewriting the code under test.
+ * read-only fixture directory is copied back as 0755, measured. So no
+ * permission trick on disk can reach the restore.
+ *
+ * Verified on bun 1.3.13: `mock.module` from `bun:test` applies in a plain
+ * `bun --preload` process, not just under `bun test`.
  */
 import * as realFs from "fs";
 import { mock } from "bun:test";
 import * as realInit from "../../../src/commands/init";
 
-const failRmPath = process.env.ATLAS_TEST_FAIL_RM_PATH;
-if (failRmPath) {
+const failCpFrom = process.env.ATLAS_TEST_FAIL_CP_FROM;
+if (failCpFrom) {
   // ⚠️ Capture the real implementation BEFORE `mock.module` runs. Bun rebinds
-  // the namespace object in place, so `realFs.rmSync` read from inside the
-  // patch resolves to the PATCH — every non-blocked path then recurses until
-  // the stack blows, which surfaces as a restore failure for entirely the wrong
-  // reason and never reaches the seed at all.
-  const originalRmSync = realFs.rmSync;
-  const patchedFs = {
-    ...realFs,
-    rmSync(target: realFs.PathLike, options?: realFs.RmOptions): void {
-      if (String(target) === failRmPath) {
-        throw new Error(`EACCES: permission denied, rm '${failRmPath}'`);
-      }
-      originalRmSync(target, options);
-    },
+  // the namespace object in place, so `realFs.cpSync` read from inside the
+  // patch resolves to the PATCH — every non-blocked copy then recurses until
+  // the stack blows, which surfaces as a restore failure for entirely the
+  // wrong reason.
+  const originalCpSync = realFs.cpSync;
+  // Annotating with `typeof realFs.cpSync` rather than hand-writing the
+  // parameter types makes the substitution compiler-checked: a spread simply
+  // replaces the property, so a hand-written signature that drifts from
+  // @types/node would raise no error at all.
+  const patchedCpSync: typeof realFs.cpSync = (source, destination, options) => {
+    if (String(source) === failCpFrom) {
+      throw new Error(`EACCES: permission denied, cp '${failCpFrom}'`);
+    }
+    originalCpSync(source, destination, options);
   };
+  const patchedFs = { ...realFs, cpSync: patchedCpSync };
+  // `default` must point at the patched surface too — spreading `realFs` copies
+  // its own `default` key straight through, leaving an unpatched escape hatch.
+  const fsFactory = () => ({ ...patchedFs, default: patchedFs });
   // Both specifiers resolve to the same builtin but are separate registry keys
   // in bun, and the code under test imports the bare form.
-  mock.module("fs", () => ({ ...patchedFs, default: patchedFs }));
-  mock.module("node:fs", () => ({ ...patchedFs, default: patchedFs }));
+  void mock.module("fs", fsFactory);
+  void mock.module("node:fs", fsFactory);
 }
 
 if (process.env.ATLAS_TEST_STUB_SEED === "1") {
-  // Spread the real module: `bin/atlas.ts` re-exports six symbols from here and
-  // a partial factory would leave the rest undefined at import time.
-  mock.module("../../../src/commands/init", () => ({
+  const stubbedSeed: typeof realInit.seedDemoPostgres = async () => {};
+  // Spread the real module: `bin/atlas.ts` re-exports five symbols from here
+  // and a partial factory would leave the rest undefined at import time.
+  void mock.module("../../../src/commands/init", () => ({
     ...realInit,
-    seedDemoPostgres: async (): Promise<void> => {},
+    seedDemoPostgres: stubbedSeed,
   }));
 }

--- a/packages/cli/bin/__tests__/fixtures/canonical-eval-exit-code.preload.ts
+++ b/packages/cli/bin/__tests__/fixtures/canonical-eval-exit-code.preload.ts
@@ -1,0 +1,58 @@
+/**
+ * `bun --preload` fixture for the canonical-eval exit-code spawn tests
+ * (`../canonical-eval-exit-code.test.ts`, #5130).
+ *
+ * Those tests assert the code the CLI hands the SHELL, so the harness has to be
+ * a real child process — which rules out in-process `mock.module`. This module
+ * is preloaded into that child instead, and stubs only what the two otherwise
+ * unreachable paths need. It is inert unless one of its env switches is set, so
+ * a spawn that wants the untouched CLI simply omits `--preload`.
+ *
+ *   ATLAS_TEST_STUB_SEED=1     — make `seedDemoPostgres` a no-op, so a run can
+ *                                get PAST the seed and into `--mcp-llm` without
+ *                                a live Postgres.
+ *   ATLAS_TEST_FAIL_RM_PATH=…  — make `fs.rmSync` throw for exactly that one
+ *                                path, so `restoreSemanticLayer` fails on its
+ *                                final step and returns false.
+ *
+ * Why `rmSync` and not a chmod: every directory `restoreSemanticLayer` touches
+ * arrives via `fs.cpSync`, and cpSync does NOT preserve directory modes — a
+ * read-only fixture directory is copied back as 0755, so no permission trick on
+ * disk can make the restore fail. Blocking the one call is the only lever that
+ * reaches it without rewriting the code under test.
+ */
+import * as realFs from "fs";
+import { mock } from "bun:test";
+import * as realInit from "../../../src/commands/init";
+
+const failRmPath = process.env.ATLAS_TEST_FAIL_RM_PATH;
+if (failRmPath) {
+  // ⚠️ Capture the real implementation BEFORE `mock.module` runs. Bun rebinds
+  // the namespace object in place, so `realFs.rmSync` read from inside the
+  // patch resolves to the PATCH — every non-blocked path then recurses until
+  // the stack blows, which surfaces as a restore failure for entirely the wrong
+  // reason and never reaches the seed at all.
+  const originalRmSync = realFs.rmSync;
+  const patchedFs = {
+    ...realFs,
+    rmSync(target: realFs.PathLike, options?: realFs.RmOptions): void {
+      if (String(target) === failRmPath) {
+        throw new Error(`EACCES: permission denied, rm '${failRmPath}'`);
+      }
+      originalRmSync(target, options);
+    },
+  };
+  // Both specifiers resolve to the same builtin but are separate registry keys
+  // in bun, and the code under test imports the bare form.
+  mock.module("fs", () => ({ ...patchedFs, default: patchedFs }));
+  mock.module("node:fs", () => ({ ...patchedFs, default: patchedFs }));
+}
+
+if (process.env.ATLAS_TEST_STUB_SEED === "1") {
+  // Spread the real module: `bin/atlas.ts` re-exports six symbols from here and
+  // a partial factory would leave the rest undefined at import time.
+  mock.module("../../../src/commands/init", () => ({
+    ...realInit,
+    seedDemoPostgres: async (): Promise<void> => {},
+  }));
+}

--- a/packages/cli/bin/__tests__/fixtures/canonical-eval-exit-code.preload.ts
+++ b/packages/cli/bin/__tests__/fixtures/canonical-eval-exit-code.preload.ts
@@ -34,6 +34,12 @@
  */
 import * as realFs from "fs";
 import { mock } from "bun:test";
+// ⚠️ Hoisted above the `fs` patch below, so this module's whole graph loads
+// against the REAL `fs`. That is correct — the patch is for the CLI's later
+// restore call, not for module init — but it means the two are order-coupled:
+// if `bin/atlas.ts` ever pulls `src/commands/init` before the preload runs, the
+// cpSync patch stops applying. It fails safe (the exit-2 tests would report 1
+// and go red), just opaquely.
 import * as realInit from "../../../src/commands/init";
 
 const failCpFrom = process.env.ATLAS_TEST_FAIL_CP_FROM;
@@ -54,7 +60,10 @@ if (failCpFrom) {
     }
     originalCpSync(source, destination, options);
   };
-  const patchedFs = { ...realFs, cpSync: patchedCpSync };
+  // Annotated `typeof realFs` rather than left inferred: without it a misspelled
+  // key (`cpSyncc`) is a legal extra property on an object literal and the whole
+  // module goes out unpatched with no diagnostic. With it, TS2561 names the typo.
+  const patchedFs: typeof realFs = { ...realFs, cpSync: patchedCpSync };
   // `default` must point at the patched surface too — spreading `realFs` copies
   // its own `default` key straight through, leaving an unpatched escape hatch.
   const fsFactory = () => ({ ...patchedFs, default: patchedFs });

--- a/packages/cli/bin/__tests__/fixtures/canonical-eval-exit-code.preload.ts
+++ b/packages/cli/bin/__tests__/fixtures/canonical-eval-exit-code.preload.ts
@@ -25,21 +25,22 @@
  * was restored fine and every line of that message is false.
  *
  * ⚠️ Why a stub and not a chmod: every directory `restoreSemanticLayer` touches
- * arrives via `fs.cpSync`, and cpSync does NOT preserve directory modes — a
- * read-only fixture directory is copied back as 0755, measured. So no
- * permission trick on disk can reach the restore.
+ * arrives via `fs.cpSync`, and cpSync does NOT preserve directory modes — a 0500
+ * fixture directory is copied back as 0755, measured. So no permission trick on
+ * the COPIED directories can reach the restore. (Chmod'ing the sandbox cwd would
+ * reach it, but that breaks the earlier backup step first, and it assumes a
+ * non-root runner.)
  *
  * Verified on bun 1.3.13: `mock.module` from `bun:test` applies in a plain
  * `bun --preload` process, not just under `bun test`.
  */
 import * as realFs from "fs";
 import { mock } from "bun:test";
-// ⚠️ Hoisted above the `fs` patch below, so this module's whole graph loads
-// against the REAL `fs`. That is correct — the patch is for the CLI's later
-// restore call, not for module init — but it means the two are order-coupled:
-// if `bin/atlas.ts` ever pulls `src/commands/init` before the preload runs, the
-// cpSync patch stops applying. It fails safe (the exit-2 tests would report 1
-// and go red), just opaquely.
+// Hoisted above the `fs` patch below, so this module's graph loads against the
+// real `fs`. That is only true AT LOAD TIME and it does not weaken the patch:
+// bun rebinds the namespace in place, so an already-loaded module's later
+// `fs.cpSync` calls still go through the patch. Measured on bun 1.3.13 with a
+// helper imported by a preload before its own `mock.module("fs")`.
 import * as realInit from "../../../src/commands/init";
 
 const failCpFrom = process.env.ATLAS_TEST_FAIL_CP_FROM;
@@ -50,10 +51,10 @@ if (failCpFrom) {
   // the stack blows, which surfaces as a restore failure for entirely the
   // wrong reason.
   const originalCpSync = realFs.cpSync;
-  // Annotating with `typeof realFs.cpSync` rather than hand-writing the
-  // parameter types makes the substitution compiler-checked: a spread simply
-  // replaces the property, so a hand-written signature that drifts from
-  // @types/node would raise no error at all.
+  // `typeof realFs.cpSync` rather than hand-written parameter types: the params
+  // are then contextually typed, so no signature can drift from @types/node in
+  // the first place, and a mismatch is reported HERE rather than one line down
+  // on the object literal.
   const patchedCpSync: typeof realFs.cpSync = (source, destination, options) => {
     if (String(source) === failCpFrom) {
       throw new Error(`EACCES: permission denied, cp '${failCpFrom}'`);
@@ -67,8 +68,9 @@ if (failCpFrom) {
   // `default` must point at the patched surface too — spreading `realFs` copies
   // its own `default` key straight through, leaving an unpatched escape hatch.
   const fsFactory = () => ({ ...patchedFs, default: patchedFs });
-  // Both specifiers resolve to the same builtin but are separate registry keys
-  // in bun, and the code under test imports the bare form.
+  // Both specifiers are patched defensively. On bun 1.3.13 either call alone
+  // patches both — measured in both directions — but that equivalence is
+  // undocumented, so don't rely on it in the next fixture.
   void mock.module("fs", fsFactory);
   void mock.module("node:fs", fsFactory);
 }

--- a/packages/cli/bin/__tests__/fixtures/canonical-eval-write-stdout-driver.ts
+++ b/packages/cli/bin/__tests__/fixtures/canonical-eval-write-stdout-driver.ts
@@ -1,0 +1,22 @@
+/**
+ * Driver for the `writeStdoutSync` truncation test (`#5130`).
+ *
+ * The defect only exists in the interaction between a buffered write and
+ * `process.exit`, so it cannot be observed in-process — the test spawns this,
+ * pipes it, and counts the bytes that survive.
+ *
+ *   argv[2] — payload size in bytes
+ *   argv[3] — "sync" to use `writeStdoutSync`, anything else for the buffered
+ *             `process.stdout.write` the helper replaced
+ */
+import { writeStdoutSync } from "../../canonical-eval-run";
+
+const size = Number(process.argv[2] ?? "0");
+const payload = "x".repeat(size);
+
+if (process.argv[3] === "sync") {
+  writeStdoutSync(payload);
+} else {
+  process.stdout.write(payload);
+}
+process.exit(0);

--- a/packages/cli/bin/canonical-eval-run.ts
+++ b/packages/cli/bin/canonical-eval-run.ts
@@ -471,79 +471,41 @@ export async function handleCanonicalEval(args: string[]): Promise<void> {
     `Atlas canonical-question eval — schema=${options.schema} mode=${options.mode}\n`,
   );
 
+  const exitCode = await runStagedCanonicalEval(options, connStr);
+  process.exit(exitCode);
+}
+
+/**
+ * Stage the semantic layer, run the eval, restore, and reduce the whole run to
+ * ONE exit code for {@link handleCanonicalEval} to hand the shell.
+ *
+ * ⚠️ THE EXIT MUST LIVE OUTSIDE THIS FUNCTION, AND THE `return` MUST LIVE
+ * OUTSIDE THE `try`. Both halves were wrong until #5130 and each one silently
+ * discards a failure:
+ *
+ *   - The exit used to sit after the `try`/`finally` in the same function as
+ *     the eval body, so every `return` inside that body ran `finally` and then
+ *     left the function — skipping `process.exit(exitCode)` entirely and ending
+ *     the process on its natural code, 0. `--mcp-llm` computed its acceptance
+ *     floor, printed `FAIL: 12/20 below acceptance floor 18`, and exited 0; the
+ *     demo-seed catch did the same for BOTH modes. Splitting the body into
+ *     {@link runInstalledCanonicalEval}, whose declared `Promise<number>` makes
+ *     the compiler reject any path that fails to produce a code, is what keeps
+ *     a future early return from re-opening it.
+ *   - `return exitCode` INSIDE the `try` would capture the value at return time,
+ *     so the `finally`'s restore-failure bump to 2 would be computed and thrown
+ *     away — the same defect one layer over. The `return` below is deliberately
+ *     after the block.
+ */
+async function runStagedCanonicalEval(
+  options: CanonicalEvalOptions,
+  connStr: string,
+): Promise<number> {
   // Stage the semantic layer for the chosen schema, identical to bin/eval.ts.
   backupSemanticLayer();
   let exitCode = 0;
   try {
-    installSchemaSemanticLayer(options.schema);
-
-    // Seed the demo Postgres before running so the harness is self-contained
-    // — same hook used by bin/eval.ts. seedDemoPostgres takes a connection
-    // string, not a schema; only `ecommerce` ships today (#2021).
-    try {
-      await seedDemoPostgres(connStr);
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      process.stderr.write(
-        `\nError: failed to seed demo Postgres: ${msg}\n` +
-          `Tip: bun run db:up && export ATLAS_DATASOURCE_URL=postgres://atlas:atlas@localhost:5433/atlas_demo\n`,
-      );
-      exitCode = 1;
-      return;
-    }
-
-    // Reset cached connection / whitelist / explore-backend state so the
-    // freshly installed semantic layer is re-resolved. `connections._reset()`
-    // is intentionally synchronous — it queues async pool closes via
-    // `.catch()` handlers (verified in lib/db/connection.ts).
-    const { connections } = await import("@atlas/api/lib/db/connection");
-    const { _resetWhitelists } = await import("@atlas/api/lib/semantic");
-    const { invalidateExploreBackend } = await import(
-      "@atlas/api/lib/tools/explore"
-    );
-    connections._reset();
-    _resetWhitelists();
-    invalidateExploreBackend();
-
-    if (options.mode === "mcp-llm") {
-      const mcpExitCode = await runMcpLlmMode(options);
-      exitCode = mcpExitCode;
-      return;
-    }
-
-    const results =
-      options.mode === "llm"
-        ? await runWithAgent(options)
-        : await runDeterministic(options);
-
-    if (options.json) {
-      process.stdout.write(
-        `${JSON.stringify(
-          {
-            schema: options.schema,
-            mode: options.mode,
-            total: results.length,
-            passing: results.filter((r) => r.status === "pass").length,
-            warning: results.filter((r) => r.status === "warn").length,
-            failing: results.filter((r) => r.status === "fail").length,
-            results: results.map((r) => ({
-              id: r.question.id,
-              category: r.question.category,
-              question: r.question.question,
-              status: r.status,
-              detail: r.detail,
-              sql: r.sql,
-            })),
-          },
-          null,
-          2,
-        )}\n`,
-      );
-    } else {
-      process.stdout.write(`\n${formatSummary(results)}\n`);
-    }
-
-    if (results.some((r) => r.status === "fail")) exitCode = 1;
+    exitCode = await runInstalledCanonicalEval(options, connStr);
   } finally {
     // Surface restore failure via the exit code — silently swallowing it
     // would let a developer see an "all green" run while their original
@@ -552,7 +514,85 @@ export async function handleCanonicalEval(args: string[]): Promise<void> {
     const restored = restoreSemanticLayer();
     if (!restored) exitCode = Math.max(exitCode, 2);
   }
-  process.exit(exitCode);
+  return exitCode;
+}
+
+/**
+ * Run the eval against the freshly installed semantic layer and return the exit
+ * code it earns: 1 for a seed failure or any failing question, otherwise
+ * whatever the selected mode reports. Restoring the caller's semantic layer is
+ * {@link runStagedCanonicalEval}'s job, not this one's.
+ */
+async function runInstalledCanonicalEval(
+  options: CanonicalEvalOptions,
+  connStr: string,
+): Promise<number> {
+  installSchemaSemanticLayer(options.schema);
+
+  // Seed the demo Postgres before running so the harness is self-contained
+  // — same hook used by bin/eval.ts. seedDemoPostgres takes a connection
+  // string, not a schema; only `ecommerce` ships today (#2021).
+  try {
+    await seedDemoPostgres(connStr);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    process.stderr.write(
+      `\nError: failed to seed demo Postgres: ${msg}\n` +
+        `Tip: bun run db:up && export ATLAS_DATASOURCE_URL=postgres://atlas:atlas@localhost:5433/atlas_demo\n`,
+    );
+    return 1;
+  }
+
+  // Reset cached connection / whitelist / explore-backend state so the
+  // freshly installed semantic layer is re-resolved. `connections._reset()`
+  // is intentionally synchronous — it queues async pool closes via
+  // `.catch()` handlers (verified in lib/db/connection.ts).
+  const { connections } = await import("@atlas/api/lib/db/connection");
+  const { _resetWhitelists } = await import("@atlas/api/lib/semantic");
+  const { invalidateExploreBackend } = await import(
+    "@atlas/api/lib/tools/explore"
+  );
+  connections._reset();
+  _resetWhitelists();
+  invalidateExploreBackend();
+
+  if (options.mode === "mcp-llm") {
+    return runMcpLlmMode(options);
+  }
+
+  const results =
+    options.mode === "llm"
+      ? await runWithAgent(options)
+      : await runDeterministic(options);
+
+  if (options.json) {
+    process.stdout.write(
+      `${JSON.stringify(
+        {
+          schema: options.schema,
+          mode: options.mode,
+          total: results.length,
+          passing: results.filter((r) => r.status === "pass").length,
+          warning: results.filter((r) => r.status === "warn").length,
+          failing: results.filter((r) => r.status === "fail").length,
+          results: results.map((r) => ({
+            id: r.question.id,
+            category: r.question.category,
+            question: r.question.question,
+            status: r.status,
+            detail: r.detail,
+            sql: r.sql,
+          })),
+        },
+        null,
+        2,
+      )}\n`,
+    );
+  } else {
+    process.stdout.write(`\n${formatSummary(results)}\n`);
+  }
+
+  return results.some((r) => r.status === "fail") ? 1 : 0;
 }
 
 // ── Wiring (--mcp-llm mode, #2119 Part B) ───────────────────────────────

--- a/packages/cli/bin/canonical-eval-run.ts
+++ b/packages/cli/bin/canonical-eval-run.ts
@@ -408,8 +408,9 @@ async function runWithAgent(
       };
     }
 
-    // The `?? ""` / `?? null` are required under TS strict
-    // `noUncheckedIndexedAccess` — array index access is `T | undefined`.
+    // The `?? ""` / `?? null` are defensive, NOT compiler-required: this comment
+    // used to cite `noUncheckedIndexedAccess`, which no tsconfig in the repo
+    // sets, so index access here is `T`, not `T | undefined` (#5130 review).
     // The empty-array hard-fail below at `agent.sql.length === 0` is the
     // load-bearing guard for the empty case; these defaults only feed the
     // early-return branch's `sql: lastSql || null` mapping.
@@ -479,23 +480,30 @@ export async function handleCanonicalEval(args: string[]): Promise<void> {
  * Stage the semantic layer, run the eval, restore, and reduce the whole run to
  * ONE exit code for {@link handleCanonicalEval} to hand the shell.
  *
- * ⚠️ THE EXIT MUST LIVE OUTSIDE THIS FUNCTION, AND THE `return` MUST LIVE
- * OUTSIDE THE `try`. Both halves were wrong until #5130 and each one silently
- * discards a failure:
+ * ⚠️ THE EXIT MUST LIVE OUTSIDE THIS FUNCTION, THE `return` MUST LIVE OUTSIDE
+ * THE `try`, AND THE `try` MUST HAVE A `catch`. All three were wrong until
+ * #5130, and each one on its own silently discards a failure:
  *
  *   - The exit used to sit after the `try`/`finally` in the same function as
  *     the eval body, so every `return` inside that body ran `finally` and then
  *     left the function — skipping `process.exit(exitCode)` entirely and ending
  *     the process on its natural code, 0. `--mcp-llm` computed its acceptance
  *     floor, printed `FAIL: 12/20 below acceptance floor 18`, and exited 0; the
- *     demo-seed catch did the same for BOTH modes. Splitting the body into
- *     {@link runInstalledCanonicalEval}, whose declared `Promise<number>` makes
- *     the compiler reject any path that fails to produce a code, is what keeps
- *     a future early return from re-opening it.
+ *     demo-seed catch did the same for BOTH modes. Splitting the body out into
+ *     {@link runInstalledCanonicalEval}, declared `Promise<number>`, is what
+ *     keeps a future early `return` from re-opening it: a path that returns
+ *     without a code is then a compile error (TS2366/TS2322 — the mechanism is
+ *     `strictNullChecks`, which the root tsconfig sets via `strict`).
  *   - `return exitCode` INSIDE the `try` would capture the value at return time,
  *     so the `finally`'s restore-failure bump to 2 would be computed and thrown
  *     away — the same defect one layer over. The `return` below is deliberately
  *     after the block.
+ *   - A `throw` is the one code-less path the compiler still permits, and
+ *     without the `catch` below it discarded the bump the same way: the
+ *     exception propagated past `return exitCode` to `main().catch` in
+ *     `bin/atlas.ts`, which exits 1 unconditionally. A run that destroyed the
+ *     user's `semantic/` then reported 1 — indistinguishable from an ordinary
+ *     eval failure, on precisely the path where the distinction matters most.
  */
 async function runStagedCanonicalEval(
   options: CanonicalEvalOptions,
@@ -506,6 +514,15 @@ async function runStagedCanonicalEval(
   let exitCode = 0;
   try {
     exitCode = await runInstalledCanonicalEval(options, connStr);
+  } catch (err) {
+    // Logged here rather than re-thrown: re-throwing reaches `main().catch`,
+    // which exits 1 and would outrank the restore bump computed below. Same
+    // stack the top-level handler would have printed, so nothing is lost.
+    process.stderr.write(
+      `\nError: canonical eval failed: ${err instanceof Error ? err.message : String(err)}\n` +
+        (err instanceof Error && err.stack ? `${err.stack}\n` : ""),
+    );
+    exitCode = 1;
   } finally {
     // Surface restore failure via the exit code — silently swallowing it
     // would let a developer see an "all green" run while their original
@@ -515,6 +532,42 @@ async function runStagedCanonicalEval(
     if (!restored) exitCode = Math.max(exitCode, 2);
   }
   return exitCode;
+}
+
+/**
+ * Write to stdout with a BLOCKING syscall loop instead of the buffered stream.
+ *
+ * ⚠️ `process.exit()` DISCARDS whatever is still sitting in `process.stdout`'s
+ * buffer, with no error on either side. Measured on bun 1.3.13: a 2 MB payload
+ * written via `process.stdout.write` and followed by `process.exit` arrives at
+ * a pipe as exactly 65_536 bytes — one pipe buffer — silently truncated.
+ *
+ * That cliff is not theoretical for this command. The workflow runs
+ * `canonical-eval --mcp-llm --json | tee eval-mcp-llm-output.json` and uploads
+ * the result as the adjudication artifact; the file from the 2026-08-11 run is
+ * 63_024 bytes, 2.5 KB under the limit and growing with every field added to
+ * the payload. Until #5130 the `--mcp-llm` path left via `return` and the
+ * process ended naturally, so the stream always drained — routing it through
+ * the shared `process.exit` is what exposes this, which makes it this change's
+ * to carry.
+ *
+ * `fs.writeSync` returns only once the bytes are handed to the fd, so there is
+ * nothing left to discard. Reserved for the unbounded payloads (the `--json`
+ * bodies and the failure-artifact bundle); the fixed-size progress lines have
+ * no headroom problem and stay on the stream.
+ */
+export function writeStdoutSync(text: string): void {
+  const buf = Buffer.from(text, "utf-8");
+  let offset = 0;
+  while (offset < buf.length) {
+    try {
+      offset += fs.writeSync(1, buf, offset, buf.length - offset);
+    } catch (err) {
+      // EAGAIN is a retry, not a failure: it means the reader has not drained
+      // the pipe yet. Anything else is a real write error and propagates.
+      if ((err as NodeJS.ErrnoException).code !== "EAGAIN") throw err;
+    }
+  }
 }
 
 /**
@@ -557,7 +610,7 @@ async function runInstalledCanonicalEval(
   invalidateExploreBackend();
 
   if (options.mode === "mcp-llm") {
-    return runMcpLlmMode(options);
+    return await runMcpLlmMode(options);
   }
 
   const results =
@@ -566,7 +619,7 @@ async function runInstalledCanonicalEval(
       : await runDeterministic(options);
 
   if (options.json) {
-    process.stdout.write(
+    writeStdoutSync(
       `${JSON.stringify(
         {
           schema: options.schema,
@@ -736,7 +789,7 @@ async function runMcpLlmMode(
   }
 
   if (options.json) {
-    process.stdout.write(
+    writeStdoutSync(
       `${JSON.stringify(
         {
           schema: options.schema,
@@ -783,7 +836,7 @@ async function runMcpLlmMode(
       );
     }
     if (result.artifacts.length > 0) {
-      process.stdout.write(formatArtifactBundle(result.artifacts));
+      writeStdoutSync(formatArtifactBundle(result.artifacts));
     }
   }
 
@@ -943,7 +996,7 @@ async function runToolSelectionMode(
   const floorPct = (result.acceptanceFloor * 100).toFixed(1);
 
   if (options.json) {
-    process.stdout.write(
+    writeStdoutSync(
       `${JSON.stringify(
         {
           schema: options.schema,

--- a/packages/cli/bin/canonical-eval-run.ts
+++ b/packages/cli/bin/canonical-eval-run.ts
@@ -408,9 +408,8 @@ async function runWithAgent(
       };
     }
 
-    // The `?? ""` / `?? null` are defensive, NOT compiler-required: this comment
-    // used to cite `noUncheckedIndexedAccess`, which no tsconfig in the repo
-    // sets, so index access here is `T`, not `T | undefined` (#5130 review).
+    // The `?? ""` / `?? null` are defensive, NOT compiler-required — no tsconfig
+    // in the repo sets `noUncheckedIndexedAccess`, so index access here is `T`.
     // The empty-array hard-fail below at `agent.sql.length === 0` is the
     // load-bearing guard for the empty case; these defaults only feed the
     // early-return branch's `sql: lastSql || null` mapping.
@@ -498,7 +497,7 @@ export async function handleCanonicalEval(args: string[]): Promise<void> {
  *     so the `finally`'s restore-failure bump to 2 would be computed and thrown
  *     away — the same defect one layer over. The `return` below is deliberately
  *     after the block.
- *   - A `throw` is one of TWO code-less paths the compiler still permits, and
+ *   - A `throw` is one of the code-less paths the compiler still permits, and
  *     without the `catch` below it discarded the bump the same way: the
  *     exception propagated past `return exitCode` to `main().catch` in
  *     `bin/atlas.ts`, which exits 1 unconditionally. A run that destroyed the
@@ -511,8 +510,11 @@ export async function handleCanonicalEval(args: string[]): Promise<void> {
  *     to make, and it is strictly WORSE than the defect #5130 fixed: it skips
  *     the `finally` as well as the aggregation, leaving the caller's `semantic/`
  *     replaced by the demo fixture with no message and no restore. Return a code
- *     and let it travel. Verified clean at the time of writing: no `process.exit`
- *     exists in `runInstalledCanonicalEval`'s call graph.
+ *     and let it travel. Checked at the time of writing: no `process.exit` in the
+ *     CLI-side eval modules (`canonical-eval*.ts`, `seedDemoPostgres`). The graph
+ *     reaches `@atlas/api` and `@atlas/mcp` through dynamic imports, which a grep
+ *     cannot audit — so this is a rule to follow, not a property anything checks.
+ *     (A non-terminating loop is a third code-less path, and equally accepted.)
  */
 async function runStagedCanonicalEval(
   options: CanonicalEvalOptions,
@@ -568,11 +570,13 @@ async function runStagedCanonicalEval(
  * the three `--json` bodies and the failure-artifact bundle.
  *
  * ⚠️ STDERR HAS THE SAME CLIFF and no equivalent helper. Measured the same way:
- * 200 KB to stderr followed by `process.exit` arrives as 65_536 bytes. Every
- * diagnostic that EXPLAINS an exit code lives there — the acceptance-floor FAIL
- * line, `CRITICAL: Failed to restore semantic layer`, the harness stack. All are
- * a few hundred bytes today, so this is latent rather than live; whoever adds an
- * unbounded stderr diagnostic needs a `writeStderrSync` twin first.
+ * 200 KB to stderr followed by `process.exit` arrives as 65_536 bytes. The
+ * FAILURE-path diagnostics all live there — the acceptance-floor FAIL line,
+ * `CRITICAL: Failed to restore semantic layer`, the harness stack — at a few
+ * hundred bytes each, except the stack, which runs to a few KB. (The pass/fail
+ * DETAIL is not on stderr: that is `formatSummary` and the `--json` bodies, on
+ * stdout.) So this is latent rather than live; whoever adds an unbounded stderr
+ * diagnostic needs a `writeStderrSync` twin first.
  *
  * ⚠️ MIXING SYNCHRONOUS AND BUFFERED WRITES IS ORDER-SENSITIVE. A `writeSync`
  * bypasses `process.stdout`'s queue entirely, so it can print ahead of an
@@ -598,14 +602,17 @@ export function writeStdoutSync(text: string): void {
     try {
       written = fs.writeSync(1, buf, offset, buf.length - offset);
     } catch (err) {
-      // `.code` is read only after narrowing to Error — an `as` cast would
-      // raise a TypeError from inside the handler on a non-object throw and
-      // substitute nonsense for the real write failure.
+      // `.code` is read only after narrowing to Error. Reading it off a bare
+      // caught value raises a TypeError from inside the handler for `throw null`
+      // / `throw undefined` — substituting nonsense for the real write failure —
+      // and silently yields `undefined` for a string or number throw.
       const code = err instanceof Error ? (err as NodeJS.ErrnoException).code : undefined;
       // A reader that hung up (`… | head`, a quit pager) is not a failure and
       // must not become one: the buffered stream this replaced dropped EPIPE
       // silently, and turning `atlas canonical-eval --json | head` into exit 1
       // with a stack trace would be a regression introduced by a flush fix.
+      // intentionally ignored: the reader hung up. This is the one path here
+      // that emits nothing, and that is the correct behaviour for a pipe.
       if (code === "EPIPE") return;
       // EAGAIN drives a RETRY; it is not discarded. A `write(2)` that returns
       // EAGAIN wrote nothing, so re-driving the same offset loses no bytes, and
@@ -613,6 +620,9 @@ export function writeStdoutSync(text: string): void {
       // this branch only exists because fd 1 may arrive with O_NONBLOCK set.
       // Every other errno (ENOSPC, EBADF) is a real write failure and
       // propagates to `runStagedCanonicalEval`'s catch.
+      //
+      // ⚠️ UNTESTED: nothing in the suite can force EAGAIN on a pipe, so this
+      // branch and the sleep below are reasoning, not measurement.
       if (code !== "EAGAIN") throw err;
       Atomics.wait(idle, 0, 0, 1);
       continue;
@@ -796,8 +806,8 @@ async function runMcpLlmMode(
   // path; the grader is narrower (first-tool match, not per-mode answer
   // correctness) and the acceptance metric is an accuracy floor.
   if (options.toolSelection) {
-    // `await` for the same reason as `runMcpLlmMode` above: a rejection's
-    // stack stays in this frame.
+    // `await`ed, not returned bare: a rejection's stack then stays in this
+    // frame rather than unwinding with the caller's.
     return await runToolSelectionMode({
       ...options,
       providerLabel: `${providerType}/${modelId}`,

--- a/packages/cli/bin/canonical-eval-run.ts
+++ b/packages/cli/bin/canonical-eval-run.ts
@@ -498,12 +498,21 @@ export async function handleCanonicalEval(args: string[]): Promise<void> {
  *     so the `finally`'s restore-failure bump to 2 would be computed and thrown
  *     away — the same defect one layer over. The `return` below is deliberately
  *     after the block.
- *   - A `throw` is the one code-less path the compiler still permits, and
+ *   - A `throw` is one of TWO code-less paths the compiler still permits, and
  *     without the `catch` below it discarded the bump the same way: the
  *     exception propagated past `return exitCode` to `main().catch` in
  *     `bin/atlas.ts`, which exits 1 unconditionally. A run that destroyed the
  *     user's `semantic/` then reported 1 — indistinguishable from an ordinary
  *     eval failure, on precisely the path where the distinction matters most.
+ *   - ⚠️ The second is a call returning `never`, which `Promise<number>` also
+ *     accepts — and `process.exit` has exactly that type. **Do not call
+ *     `process.exit` anywhere below this function.** It is this CLI's house
+ *     idiom (`bin/atlas.ts` uses it eleven times), so the edit is a natural one
+ *     to make, and it is strictly WORSE than the defect #5130 fixed: it skips
+ *     the `finally` as well as the aggregation, leaving the caller's `semantic/`
+ *     replaced by the demo fixture with no message and no restore. Return a code
+ *     and let it travel. Verified clean at the time of writing: no `process.exit`
+ *     exists in `runInstalledCanonicalEval`'s call graph.
  */
 async function runStagedCanonicalEval(
   options: CanonicalEvalOptions,
@@ -539,8 +548,11 @@ async function runStagedCanonicalEval(
  *
  * ⚠️ `process.exit()` DISCARDS whatever is still sitting in `process.stdout`'s
  * buffer, with no error on either side. Measured on bun 1.3.13: a 2 MB payload
- * written via `process.stdout.write` and followed by `process.exit` arrives at
- * a pipe as exactly 65_536 bytes — one pipe buffer — silently truncated.
+ * written via `process.stdout.write` and followed by `process.exit` reaches a
+ * pipe truncated — 65_536 bytes (one pipe buffer) under `| wc -c`, 219_264 under
+ * a concurrently-draining reader. HOW MUCH survives is whatever the reader
+ * drained in time, so it is not a fixed number and not something a caller can
+ * budget against; what is fixed is that the tail is lost and nothing says so.
  *
  * That cliff is not theoretical for this command. The workflow runs
  * `canonical-eval --mcp-llm --json | tee eval-mcp-llm-output.json` and uploads
@@ -552,20 +564,28 @@ async function runStagedCanonicalEval(
  * to carry.
  *
  * `fs.writeSync` returns only once the bytes are handed to the fd, so there is
- * nothing left to discard. Reserved for the payloads whose size scales with the
- * MODEL'S OUTPUT — the three `--json` bodies and the failure-artifact bundle.
- * Everything else stays on the buffered stream.
+ * nothing left to discard. Reserved for the payloads that can cross that cliff —
+ * the three `--json` bodies and the failure-artifact bundle.
  *
- * ⚠️ MIXING THE TWO IS ORDER-SAFE ONLY BECAUSE OF THAT SPLIT, so keep it. A
- * `writeSync` bypasses `process.stdout`'s queue, so it would print ahead of an
- * earlier buffered write that was still pending. A buffered write is only ever
- * still pending once the pipe is full — 65_536 bytes — and every write left on
- * the stream in this file is bounded by the question count (a handful of header
- * lines, one ~100-char line per question, a few `note:` lines): a few KB against
- * a 20-question corpus, cumulatively far under one pipe buffer. They are
- * therefore never pending when a `writeStdoutSync` runs. Move an unbounded
- * payload onto the stream, or a bounded one onto `writeStdoutSync`, and that
- * argument stops holding.
+ * ⚠️ STDERR HAS THE SAME CLIFF and no equivalent helper. Measured the same way:
+ * 200 KB to stderr followed by `process.exit` arrives as 65_536 bytes. Every
+ * diagnostic that EXPLAINS an exit code lives there — the acceptance-floor FAIL
+ * line, `CRITICAL: Failed to restore semantic layer`, the harness stack. All are
+ * a few hundred bytes today, so this is latent rather than live; whoever adds an
+ * unbounded stderr diagnostic needs a `writeStderrSync` twin first.
+ *
+ * ⚠️ MIXING SYNCHRONOUS AND BUFFERED WRITES IS ORDER-SENSITIVE. A `writeSync`
+ * bypasses `process.stdout`'s queue entirely, so it can print ahead of an
+ * earlier buffered write that has not flushed. The interleaving is correct on
+ * every path measured on bun 1.3.13 — a 4-byte buffered write, a 60_000-byte
+ * one, and a real 40-question `--json` run all landed ahead of the following
+ * `writeStdoutSync` — but that is a MEASUREMENT of this runtime's flush timing,
+ * not a guarantee the code enforces, so do not extend the mixing on the strength
+ * of it. Note in particular that `formatSummary` (the deterministic human
+ * summary) and the `note:` lines in `resolveExpectations` are NOT bounded in
+ * principle: both interpolate caught error messages, and `--questions` is
+ * caller-supplied. They stay on the stream because the buffered path is what
+ * they have always used, not because they are known small.
  */
 export function writeStdoutSync(text: string): void {
   const buf = Buffer.from(text, "utf-8");
@@ -574,18 +594,39 @@ export function writeStdoutSync(text: string): void {
   const idle = new Int32Array(new SharedArrayBuffer(4));
   let offset = 0;
   while (offset < buf.length) {
+    let written: number;
     try {
-      offset += fs.writeSync(1, buf, offset, buf.length - offset);
+      written = fs.writeSync(1, buf, offset, buf.length - offset);
     } catch (err) {
+      // `.code` is read only after narrowing to Error — an `as` cast would
+      // raise a TypeError from inside the handler on a non-object throw and
+      // substitute nonsense for the real write failure.
+      const code = err instanceof Error ? (err as NodeJS.ErrnoException).code : undefined;
+      // A reader that hung up (`… | head`, a quit pager) is not a failure and
+      // must not become one: the buffered stream this replaced dropped EPIPE
+      // silently, and turning `atlas canonical-eval --json | head` into exit 1
+      // with a stack trace would be a regression introduced by a flush fix.
+      if (code === "EPIPE") return;
       // EAGAIN drives a RETRY; it is not discarded. A `write(2)` that returns
       // EAGAIN wrote nothing, so re-driving the same offset loses no bytes, and
       // waiting for the reader is exactly what a blocking fd would have done —
       // this branch only exists because fd 1 may arrive with O_NONBLOCK set.
-      // Every other errno (EPIPE, ENOSPC, EBADF) is a real write failure and
+      // Every other errno (ENOSPC, EBADF) is a real write failure and
       // propagates to `runStagedCanonicalEval`'s catch.
-      if ((err as NodeJS.ErrnoException).code !== "EAGAIN") throw err;
+      if (code !== "EAGAIN") throw err;
       Atomics.wait(idle, 0, 0, 1);
+      continue;
     }
+    // A zero-byte return makes no progress and raises nothing, so without this
+    // the loop spins forever with no diagnostic — a hang, which no test can
+    // falsify. Fail loudly with the offset reached instead.
+    if (written === 0) {
+      throw new Error(
+        `stdout write stalled at ${offset}/${buf.length} bytes: write(2) returned 0. ` +
+          `Refusing to spin — the remaining payload would be lost silently.`,
+      );
+    }
+    offset += written;
   }
 }
 
@@ -755,7 +796,9 @@ async function runMcpLlmMode(
   // path; the grader is narrower (first-tool match, not per-mode answer
   // correctness) and the acceptance metric is an accuracy floor.
   if (options.toolSelection) {
-    return runToolSelectionMode({
+    // `await` for the same reason as `runMcpLlmMode` above: a rejection's
+    // stack stays in this frame.
+    return await runToolSelectionMode({
       ...options,
       providerLabel: `${providerType}/${modelId}`,
       model,

--- a/packages/cli/bin/canonical-eval-run.ts
+++ b/packages/cli/bin/canonical-eval-run.ts
@@ -552,20 +552,39 @@ async function runStagedCanonicalEval(
  * to carry.
  *
  * `fs.writeSync` returns only once the bytes are handed to the fd, so there is
- * nothing left to discard. Reserved for the unbounded payloads (the `--json`
- * bodies and the failure-artifact bundle); the fixed-size progress lines have
- * no headroom problem and stay on the stream.
+ * nothing left to discard. Reserved for the payloads whose size scales with the
+ * MODEL'S OUTPUT — the three `--json` bodies and the failure-artifact bundle.
+ * Everything else stays on the buffered stream.
+ *
+ * ⚠️ MIXING THE TWO IS ORDER-SAFE ONLY BECAUSE OF THAT SPLIT, so keep it. A
+ * `writeSync` bypasses `process.stdout`'s queue, so it would print ahead of an
+ * earlier buffered write that was still pending. A buffered write is only ever
+ * still pending once the pipe is full — 65_536 bytes — and every write left on
+ * the stream in this file is bounded by the question count (a handful of header
+ * lines, one ~100-char line per question, a few `note:` lines): a few KB against
+ * a 20-question corpus, cumulatively far under one pipe buffer. They are
+ * therefore never pending when a `writeStdoutSync` runs. Move an unbounded
+ * payload onto the stream, or a bounded one onto `writeStdoutSync`, and that
+ * argument stops holding.
  */
 export function writeStdoutSync(text: string): void {
   const buf = Buffer.from(text, "utf-8");
+  // A one-word cell purely to get a blocking sleep on the EAGAIN path below;
+  // there is no synchronous `sleep` and a bare retry loop would spin at 100%.
+  const idle = new Int32Array(new SharedArrayBuffer(4));
   let offset = 0;
   while (offset < buf.length) {
     try {
       offset += fs.writeSync(1, buf, offset, buf.length - offset);
     } catch (err) {
-      // EAGAIN is a retry, not a failure: it means the reader has not drained
-      // the pipe yet. Anything else is a real write error and propagates.
+      // EAGAIN drives a RETRY; it is not discarded. A `write(2)` that returns
+      // EAGAIN wrote nothing, so re-driving the same offset loses no bytes, and
+      // waiting for the reader is exactly what a blocking fd would have done —
+      // this branch only exists because fd 1 may arrive with O_NONBLOCK set.
+      // Every other errno (EPIPE, ENOSPC, EBADF) is a real write failure and
+      // propagates to `runStagedCanonicalEval`'s catch.
       if ((err as NodeJS.ErrnoException).code !== "EAGAIN") throw err;
+      Atomics.wait(idle, 0, 0, 1);
     }
   }
 }


### PR DESCRIPTION
Closes #5130

`canonical-eval --mcp-llm` always exited 0, at any score. The acceptance floor was computed, printed as `FAIL: 12/20 below acceptance floor 18`, and thrown away — a `return` inside the staging `try` ran the `finally` and left the function, skipping the `process.exit(exitCode)` that sat after the block. The process then ended on its natural code, 0. The demo-seed catch was neutered the same way, and **that path is shared with the DETERMINISTIC job**.

## The fix

`handleCanonicalEval` splits into three:

- `runInstalledCanonicalEval(): Promise<number>` — the eval body. Every path must produce a code, and the compiler enforces it: a path that returns without one is TS2366/TS2322 (the mechanism is `strictNullChecks`, which the root tsconfig sets via `strict`). That is what keeps a future early `return` from re-opening this.
- `runStagedCanonicalEval(): Promise<number>` — owns backup/restore and returns **after** the `try`/`finally`, so the restore-failure bump to 2 is not discarded the way `return exitCode` inside the `try` would discard it.
- `handleCanonicalEval` — performs the single `process.exit`.

### Behaviour delta

|  | old | new |
|---|---|---|
| seed fails, deterministic | 0 | **1** |
| seed fails, `--mcp-llm` | 0 | **1** |
| `--mcp-llm` below floor / no key | 0 | **1** |
| seed fails AND restore fails | 0 | **2** |
| eval body throws AND restore fails | 1 | **2** |
| deterministic, a question fails | 1 | 1 |
| deterministic, all pass | 0 | 0 |
| restore fails, no early return | 2 | 2 |

Every changed row moves toward reporting failure, never away from it, so the gate can only become stricter.

### Acceptance criteria

- [x] `--mcp-llm` exits non-zero below the floor — the branch's non-zero now reaches the shell
- [x] A demo-seed failure exits non-zero in **both** modes
- [x] Restore failure still exits 2, distinguishable from an eval failure — including when the body **throws**, which previously collapsed to `main().catch`'s unconditional 1
- [x] A test spawns the CLI and asserts the **observed process exit code**, checked red against the old code (all four original tests failed with `Received: 0`)
- [x] The `eval-mcp-llm` job goes RED on a sub-floor run — verified by reading, not changed: `set -o pipefail` is already on the `| tee` step, `eval-informational-gate.sh` keys on `steps.eval.outcome`, and `SKIP_TOLERANT_LABELS` tolerates only `skipped`, never `failure`. **No workflow change needed.**

## A second defect this change exposed, and had to carry

Routing `--mcp-llm` through the shared `process.exit` newly exposed a truncation cliff: **`process.exit` discards whatever is still buffered in `process.stdout`, silently.** Measured on bun 1.3.13 through a real shell pipeline — which is what CI has (`--json | tee eval-mcp-llm-output.json`):

```
64_015 bytes -> arrives intact
70_015 bytes -> arrives as 65_536, no error on either side
```

**The real `eval-mcp-llm-output.json` from run 31453800369 is 63_024 bytes** — 2.5 KB under the cliff, and #5123 adds fields to that payload. Before this branch the `--mcp-llm` path left via `return` and the process ended naturally, so the stream always drained; that is what makes this change's to carry rather than a pre-existing bug to file.

`writeStdoutSync` hands the bytes to the fd with `fs.writeSync`, applied to the four payloads that can cross that cliff (the three `--json` bodies and the failure-artifact bundle). The fixed-cost progress lines stay on the buffered stream — deliberately, so this does not touch the write statements #5126 owns.

## Review panel — 2 rounds, stopped on the ratio rule

| round | findings | new surface | defect-in-prior-fix | duration |
|---|---|---|---|---|
| 1 | ~20 | ~20 | 0 | 7m48s / 8m37s / 7m44s (parallel) |
| 2 | ~23 | ~9 | **~14** | 6m55s / 11m56s / 11m11s (parallel) |

**Round 2's defect-in-prior-fix count exceeded its new-surface count, so the rounds closed there** rather than at the 3-round cap. That is the rule working as intended: round 1's fixes — `writeStdoutSync` above all — manufactured most of round 2's work. Every confirmed must-fix from both rounds is fixed in this PR; what changed is that no round 3 was bought to review round 2's fixes. `comment-analyzer` ran on the final diff as the closing round requires, and found eight inaccurate comment claims, all corrected.

**The sharpest finding was my own test.** Round 1's "the `--json` body survives" assertion was decoration: reverting a call site to `process.stdout.write` passed every assertion in the file, and a 750 ms drain delay did not change that, because `Bun.spawn`'s pipe is far more forgiving than a shell's. The wiring test now runs the CLI through `bash -c '… | cat'` with `set -o pipefail`, which is the shape CI has — and the mutant then fails with `Expected: > 65536 / Received: 65536`, the truncation signature itself.

### Mutants, applied one at a time against the final tree — no survivors

| mutant | killed by |
|---|---|
| `process.exit(exitCode \|\| 1)` | exit-0 test |
| `results.some(...) ? 0 : 1` | exit-0 test |
| `results.some(r => r.status === "warn")` | failing-questions test |
| remove the `catch` in `runStagedCanonicalEval` | throw test |
| `writeStdoutSync` body → `process.stdout.write` | driver + failing-questions tests |
| un-wire one `--json` call site | failing-questions test |

## Deliberately left as follow-ups

Recorded rather than fixed, because each is a distinct defect that would grow this diff into territory another issue owns:

1. **`restoreSemanticLayer` can throw past the `finally`** — `fs.existsSync` at its top and the `process.stderr.write` inside its own catch are both outside its `try`, so an EACCES/EPIPE there escapes and collapses to exit 1. Its `boolean` return already promises totality; making it true means restructuring a function this issue does not otherwise touch.
2. **`backupSemanticLayer` deletes `BACKUP_DIR` unconditionally on the next run** — after an exit-2 run that directory is the operator's only copy, and re-running the command destroys it and then exits 0. Serious, pre-existing, and a data-safety defect rather than an exit-code one.
3. **Exit 1 conflates an eval regression with a harness fault** — a missing fixture on the runner and a real 12/20 render identically to `eval-informational-gate.sh`. A distinct code would change the CI contract; belongs with #5129/#5039.
4. **An empty question corpus is a green run in every mode** — `ceil(0 * 0.9) = 0`, and `[].some(fail)` is false. The exit-0 test depends on that hole, which is noted at the test.
5. **A CI guard for `set -o pipefail`** on the `| tee` step — deleting that line is a silent, green regression of exactly this defect. New machinery in a shared workflow file.
6. **`eval-mcp-llm-output.json` is not valid JSON** — the prose header shares stdout with the body. That is #5126's stdout/stderr split, and untouched here by design.

Declined with reason: a `0 | 1 | 2` union for the exit code. All seven producers return a literal `0` or `1` in one file, `2` comes only from the `finally`, and the union buys a compile-checked domain at the cost of three signature edits for no live defect.

## Scope

Confined to `packages/cli/bin/canonical-eval-run.ts` plus new tests. No change to `canonical-eval-mcp-llm.ts`, `packages/mcp/src/eval/client.ts` (#5131), the stdout/stderr split (#5126), the keyed metric comparison (#5128), token usage (#5123), or any workflow file.

---

## Confirmed in production CI on this PR

The last acceptance box is no longer an argument from reading — the real-model eval ran on this PR and **the neutered gate visibly stopped being neutered**:

```
FAIL: 13/20 below acceptance floor 18      <- the eval's own verdict
Step outcomes: `success failure`           <- what the gate was told
⚠️ `eval-mcp-llm` failed on this PR        <- the gate's PR comment
```

Compare the run #5130 was filed from — same workflow, same corpus, on `main`:

```
FAIL: 12/20 below acceptance floor 18
gate passed (outcomes: success success)    <- job conclusion: success
```

**The score is not this PR's doing and is not a regression**: `main` scores 12/20 on its own dispatch run, this branch scores 13/20. What changed is that the failure now reaches `steps.eval.outcome`, which is the entire subject of #5130.

⚠️ **The `eval-mcp-llm` CHECK is still green, and that is by design, not a leak.** `eval.yml`'s policy makes this eval informational on PRs — the comment is the visible signal — while the same outcome exits 1 on a tag push. So merging this makes the next `/release` surface a real sub-floor score instead of a false green. That is the intended consequence the issue asks for, and #5129 (floor shape) / #5122's open follow-ups own the score itself. Per #5122 and #5130 both: **the floor must not be moved to fit the run.**
