### PR TITLE
fix(eval): grade a keyed answer on its substance, not its group labels

### DIFF
--- a/packages/cli/bin/canonical-eval-mcp-llm.test.ts
+++ b/packages/cli/bin/canonical-eval-mcp-llm.test.ts
@@ -22,6 +22,7 @@ import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import {
   __forTesting__,
   classifyToolContract,
+  keyedExpectationFrom,
   readBaseline,
   writeBaseline,
   type McpLlmOutcome,
@@ -30,7 +31,7 @@ import {
 import { parseCanonicalEvalOptions } from "./canonical-eval-run";
 import type { Question } from "./canonical-eval";
 
-const { gradeMetric, gradeGlossary, gradePattern, gradeVirtual } =
+const { gradeMetric, gradeGlossary, gradePattern, gradeVirtual, labelDriftNote } =
   __forTesting__;
 
 // ── Fixture helpers ──────────────────────────────────────────────────
@@ -199,14 +200,27 @@ describe("gradeMetric", () => {
           data: {
             answer: "Ada and Grace lead by spend.",
             sql: ["SELECT ..."],
-            data: [{ columns: ["name", "spend"], rows: [{ name: "Ada" }, { name: "Grace" }] }],
+            data: [
+              {
+                columns: ["name", "spend"],
+                rows: [
+                  { name: "Ada", spend: "48210.5" },
+                  { name: "Grace", spend: "31905.75" },
+                ],
+              },
+            ],
           },
         },
       ),
     ];
+    // The fixture carries `spend` because the metric's own SQL does — a keyed
+    // expectation is graded on its MEASURES now (#5128), and a `query` answer
+    // reaches them through the nested `data` array like any other.
     const out = gradeMetric(q, calls, "Ada and Grace.", 9, {
       kind: "keyed",
-      keys: ["Ada", "Grace"],
+      groupCount: 2,
+      measures: [48210.5, 31905.75],
+      labels: ["Ada", "Grace"],
     });
     expect(out.status).toBe("pass");
   });
@@ -234,12 +248,26 @@ describe("gradeMetric", () => {
       call(
         "executeSQL",
         { sql: "SELECT carrier, COUNT(*) FROM shipments WHERE carrier <> 'USPS' GROUP BY carrier" },
-        { kind: "ok", data: { columns: ["carrier"], rows: [{ carrier: "UPS" }, { carrier: "FedEx" }] } },
+        {
+          kind: "ok",
+          data: {
+            columns: ["carrier", "shipments"],
+            rows: [
+              { carrier: "UPS", shipments: 412 },
+              { carrier: "FedEx", shipments: 288 },
+            ],
+          },
+        },
       ),
     ];
+    // USPS's 96 shipments are absent from the answer, so the measure subset
+    // rule fails — and the surviving two groups are one short of the three the
+    // metric splits into, so the cardinality rule fails too.
     const out = gradeMetric(q, calls, "", 7, {
       kind: "keyed",
-      keys: ["UPS", "FedEx", "USPS"],
+      groupCount: 3,
+      measures: [412, 288, 96],
+      labels: ["UPS", "FedEx", "USPS"],
     });
     expect(out.status).toBe("fail");
   });
@@ -549,15 +577,20 @@ describe("gradePattern", () => {
         {
           kind: "ok",
           data: {
-            columns: ["promo_status"],
-            rows: [{ promo_status: "With Promotion" }, { promo_status: "No Promotion" }],
+            columns: ["promo_status", "order_count"],
+            rows: [
+              { promo_status: "With Promotion", order_count: 1240 },
+              { promo_status: "No Promotion", order_count: 3105 },
+            ],
           },
         },
       ),
     ];
     const out = gradePattern(q, calls, "", 8, {
       kind: "keyed",
-      keys: ["With Promotion", "No Promotion"],
+      groupCount: 2,
+      measures: [1240, 3105],
+      labels: ["With Promotion", "No Promotion"],
     });
     expect(out.status).toBe("pass");
   });
@@ -633,6 +666,287 @@ describe("gradePattern", () => {
     const out = gradePattern(q, calls, "", 5, undefined);
     expect(out.status).toBe("fail");
     if (out.status === "fail") expect(out.artifact.category).toBe("tool_selection");
+  });
+});
+
+// ── Keyed comparison: substance, not labels (#5128) ───────────────────
+
+/**
+ * The `orders_with_promotions` pattern's authoritative result, as
+ * `keyedExpectationFrom` reduces it. Written out ONCE and reused so every case
+ * below argues against the same ground truth.
+ *
+ * The labels are the pattern SQL's own hand-written `CASE … THEN 'With Promo'`;
+ * the measures are its `COUNT(*)`, `AVG(total_cents)/100.0` and
+ * `SUM(total_cents)/100.0` for both groups. Deliberately six distinct values
+ * across two groups — never `{n, n}` — so no assertion below can be satisfied
+ * by two states that the fixture happened to make equal.
+ */
+const PROMO_GROUND_TRUTH = {
+  kind: "keyed",
+  groupCount: 2,
+  measures: [1240, 118.4, 146816, 3105, 92.7, 287833.5],
+  labels: ["With Promo", "No Promo"],
+} as const;
+
+function sqlAnswer(
+  sql: string,
+  columns: readonly string[],
+  rows: ReadonlyArray<Record<string, unknown>>,
+): RecordedToolCall {
+  return call("executeSQL", { sql }, { kind: "ok", data: { columns, rows } });
+}
+
+describe("keyed comparison — substance over labels (#5128)", () => {
+  const q = patternQuestion("cq-016", "Orders", "orders_with_promotions", [
+    "WHERE status != 'cancelled'",
+    "promotion_id IS NOT NULL",
+  ]);
+
+  it("passes cq-016's reproducing answer: relabelled groups AND a richer breakdown", () => {
+    // ⚠️ THE REPRODUCING CASE, VERBATIM IN SHAPE. The model computed the same
+    // categorisation (`promotion_id IS NOT NULL`), the same filter and the same
+    // measures, wrote `'With Promotion'` / `'No Promotion'` instead of the
+    // pattern author's `'With Promo'` / `'No Promo'`, and added a
+    // per-promotion-type breakdown on top. The label-set rule failed it on the
+    // display text alone — the third presentation check in a row to produce a
+    // false negative (#5122 → #5127 → this).
+    //
+    // Note the FIVE rows against a two-group ground truth: "group count equals
+    // row count" is the obvious spelling of this fix and it regresses exactly
+    // here. `promo_status` still has two DISTINCT values, which is what is
+    // actually being asserted.
+    const calls = [
+      sqlAnswer(
+        "SELECT CASE WHEN promotion_id IS NOT NULL THEN 'With Promotion' ELSE 'No Promotion' END AS promo_status, " +
+          "promotion_type, COUNT(*) AS orders, AVG(total_cents)/100.0 AS aov, SUM(total_cents)/100.0 AS revenue " +
+          "FROM orders WHERE status <> 'cancelled' GROUP BY 1, 2 WITH ROLLUP",
+        ["promo_status", "promotion_type", "orders", "aov", "revenue"],
+        [
+          { promo_status: "With Promotion", promotion_type: "ALL", orders: 1240, aov: 118.4, revenue: 146816 },
+          { promo_status: "No Promotion", promotion_type: "ALL", orders: 3105, aov: 92.7, revenue: 287833.5 },
+          { promo_status: "With Promotion", promotion_type: "percent_off", orders: 800, aov: 120.1, revenue: 96080 },
+          { promo_status: "With Promotion", promotion_type: "free_shipping", orders: 300, aov: 110, revenue: 33000 },
+          { promo_status: "With Promotion", promotion_type: "bogo", orders: 140, aov: 126.9, revenue: 17766 },
+        ],
+      ),
+    ];
+    expect(gradePattern(q, calls, "", 8, PROMO_GROUND_TRUTH).status).toBe("pass");
+  });
+
+  it("fails a dropped filter even though the labels match EXACTLY", () => {
+    // ⚠️ THIS IS THE TRADE THE FIX MAKES, AND IT GOES BOTH WAYS. The answer
+    // uses the pattern's own labels verbatim and splits into the same two
+    // groups — so the OLD label-set rule PASSED it — but it forgot
+    // `WHERE status != 'cancelled'`, so every measure is inflated. Substance
+    // catches what labels could not.
+    const calls = [
+      sqlAnswer(
+        "SELECT CASE WHEN promotion_id IS NOT NULL THEN 'With Promo' ELSE 'No Promo' END AS promo_status, " +
+          "COUNT(*) AS orders, AVG(total_cents)/100.0 AS aov, SUM(total_cents)/100.0 AS revenue FROM orders GROUP BY 1",
+        ["promo_status", "orders", "aov", "revenue"],
+        [
+          { promo_status: "With Promo", orders: 1301, aov: 117.2, revenue: 152477.2 },
+          { promo_status: "No Promo", orders: 3260, aov: 91.4, revenue: 297964 },
+        ],
+      ),
+    ];
+    // `sql_pattern` must not rescue it either — the SQL genuinely lacks the
+    // `WHERE status != 'cancelled'` needle, so this is a clean fail.
+    expect(gradePattern(q, calls, "", 8, PROMO_GROUND_TRUTH).status).toBe("fail");
+  });
+
+  it("fails when only SOME authoritative measures are present", () => {
+    // Guards `every`, not `some`. Counts and averages are right; both revenue
+    // totals are wrong, and neither wrong value is a ×100 or ÷100 of an
+    // authoritative one, so UNIT_SCALINGS cannot rescue it.
+    //
+    // The SQL deliberately spells the predicate `COALESCE(promotion_id, 0) <> 0`
+    // so it misses the `promotion_id IS NOT NULL` needle: `gradePattern` layers
+    // the value check OVER `sql_pattern`, and a fixture that satisfies the
+    // needle would pass on the substring alone and prove nothing about measures.
+    const calls = [
+      sqlAnswer(
+        "SELECT CASE WHEN COALESCE(promotion_id, 0) <> 0 THEN 'With Promo' ELSE 'No Promo' END AS promo_status, " +
+          "COUNT(*) AS orders, AVG(total_cents)/100.0 AS aov, SUM(total_cents) AS revenue " +
+          "FROM orders WHERE status != 'cancelled' GROUP BY 1",
+        ["promo_status", "orders", "aov", "revenue"],
+        [
+          { promo_status: "With Promo", orders: 1240, aov: 118.4, revenue: 151093.7 },
+          { promo_status: "No Promo", orders: 3105, aov: 92.7, revenue: 291204.3 },
+        ],
+      ),
+    ];
+    expect(gradePattern(q, calls, "", 8, PROMO_GROUND_TRUTH).status).toBe("fail");
+  });
+
+  it("fails a wrong grouping whose numbers happen to CONTAIN the authoritative ones", () => {
+    // ⚠️ THE CASE THE MEASURE-SUBSET RULE CANNOT CATCH ALONE, which is why the
+    // cardinality condition exists. Every one of the six authoritative measures
+    // appears in this result — it is a superset — but the model grouped by
+    // shipping region, into five groups rather than two. No column carries two
+    // distinct values, so the shape check fails it.
+    const calls = [
+      sqlAnswer(
+        "SELECT region, COUNT(*) AS orders, AVG(total_cents)/100.0 AS aov, SUM(total_cents)/100.0 AS revenue " +
+          "FROM orders WHERE status != 'cancelled' GROUP BY region",
+        ["region", "orders", "aov", "revenue"],
+        [
+          { region: "us-east", orders: 1240, aov: 118.4, revenue: 146816 },
+          { region: "us-west", orders: 3105, aov: 92.7, revenue: 287833.5 },
+          { region: "emea", orders: 610, aov: 101.3, revenue: 61793 },
+          { region: "apac", orders: 455, aov: 99.8, revenue: 45409 },
+          { region: "latam", orders: 190, aov: 88.2, revenue: 16758 },
+        ],
+      ),
+    ];
+    expect(gradePattern(q, calls, "", 8, PROMO_GROUND_TRUTH).status).toBe("fail");
+  });
+
+  it("still compares LABELS when the authoritative result has no measures", () => {
+    // A `SELECT DISTINCT status`-shaped ground truth: the key column IS the
+    // data, not a display label, and cardinality alone would pass any result
+    // with three distinct values. The old label-set rule is kept for exactly
+    // this case rather than deleted, so it must still bite.
+    const noMeasures = {
+      kind: "keyed",
+      groupCount: 3,
+      measures: [],
+      labels: ["shipped", "delivered", "returned"],
+    } as const;
+    const wrongValues = [
+      sqlAnswer("SELECT DISTINCT status FROM orders", ["status"], [
+        { status: "shipped" },
+        { status: "delivered" },
+        { status: "cancelled" },
+      ]),
+    ];
+    const rightValues = [
+      sqlAnswer("SELECT DISTINCT status FROM orders", ["status"], [
+        { status: "RETURNED" },
+        { status: "shipped" },
+        { status: "delivered" },
+      ]),
+    ];
+    const vq = patternQuestion("cq-021", "Orders", "order_statuses", ["nothing-matches-this"]);
+    expect(gradePattern(vq, wrongValues, "", 8, noMeasures).status).toBe("fail");
+    expect(gradePattern(vq, rightValues, "", 8, noMeasures).status).toBe("pass");
+  });
+});
+
+describe("labelDriftNote — reports a relabel without gating it (#5128)", () => {
+  const q = patternQuestion("cq-016", "Orders", "orders_with_promotions", [
+    "nothing-matches-this",
+  ]);
+  const relabelled = [
+    sqlAnswer(
+      "SELECT CASE WHEN promotion_id IS NOT NULL THEN 'With Promotion' ELSE 'No Promotion' END AS promo_status, " +
+        "COUNT(*) AS orders, AVG(total_cents)/100.0 AS aov, SUM(total_cents)/100.0 AS revenue " +
+        "FROM orders WHERE status != 'cancelled' GROUP BY 1",
+      ["promo_status", "orders", "aov", "revenue"],
+      [
+        { promo_status: "With Promotion", orders: 1240, aov: 118.4, revenue: 146816 },
+        { promo_status: "No Promotion", orders: 3105, aov: 92.7, revenue: 287833.5 },
+      ],
+    ),
+  ];
+
+  it("reports the drift on a question it just PASSED", () => {
+    const out = gradePattern(q, relabelled, "", 8, PROMO_GROUND_TRUTH);
+    expect(out.status).toBe("pass");
+    const note = labelDriftNote(out, PROMO_GROUND_TRUTH);
+    expect(note).toContain("cq-016");
+    expect(note).toContain("With Promo");
+    expect(note).toContain("relabelled");
+  });
+
+  it("says nothing when the answer used the authoritative labels", () => {
+    const onLabel = [
+      sqlAnswer(
+        "SELECT CASE WHEN promotion_id IS NOT NULL THEN 'With Promo' ELSE 'No Promo' END AS promo_status, " +
+          "COUNT(*) AS orders, AVG(total_cents)/100.0 AS aov, SUM(total_cents)/100.0 AS revenue " +
+          "FROM orders WHERE status != 'cancelled' GROUP BY 1",
+        ["promo_status", "orders", "aov", "revenue"],
+        [
+          { promo_status: "With Promo", orders: 1240, aov: 118.4, revenue: 146816 },
+          { promo_status: "No Promo", orders: 3105, aov: 92.7, revenue: 287833.5 },
+        ],
+      ),
+    ];
+    const out = gradePattern(q, onLabel, "", 8, PROMO_GROUND_TRUTH);
+    expect(out.status).toBe("pass");
+    expect(labelDriftNote(out, PROMO_GROUND_TRUTH)).toBeNull();
+  });
+
+  it("says nothing on a FAIL — a note is a report, not a second verdict", () => {
+    const wrong = [
+      sqlAnswer(
+        "SELECT CASE WHEN promotion_id IS NOT NULL THEN 'With Promotion' ELSE 'No Promotion' END AS promo_status, " +
+          "COUNT(*) AS orders FROM orders GROUP BY 1",
+        ["promo_status", "orders"],
+        [
+          { promo_status: "With Promotion", orders: 9999 },
+          { promo_status: "No Promotion", orders: 8888 },
+        ],
+      ),
+    ];
+    const out = gradePattern(q, wrong, "", 8, PROMO_GROUND_TRUTH);
+    expect(out.status).toBe("fail");
+    expect(labelDriftNote(out, PROMO_GROUND_TRUTH)).toBeNull();
+  });
+});
+
+describe("keyedExpectationFrom — harvesting ground truth (#5128)", () => {
+  it("excludes the grouping key from the measures even when the key is numeric", () => {
+    // `month` is a grouping label that happens to be a number. Harvesting it as
+    // a measure would force the model to reproduce `3` somewhere in its result
+    // — a spelling test on a calendar.
+    const e = keyedExpectationFrom(
+      ["month", "orders", "revenue"],
+      [
+        { month: 1, orders: 410, revenue: 39221.5 },
+        { month: 2, orders: 388, revenue: 35907.25 },
+        { month: 3, orders: 502, revenue: 47118 },
+      ],
+    );
+    expect(e.groupCount).toBe(3);
+    expect(e.labels).toEqual(["1", "2", "3"]);
+    expect(e.measures).toEqual([410, 39221.5, 388, 35907.25, 502, 47118]);
+  });
+
+  it("parses Postgres `numeric` measures, which arrive as strings", () => {
+    const e = keyedExpectationFrom(
+      ["channel", "gmv"],
+      [
+        { channel: "dtc", gmv: "128401.75" },
+        { channel: "marketplace", gmv: "64200.5" },
+      ],
+    );
+    expect(e.measures).toEqual([128401.75, 64200.5]);
+  });
+
+  it("counts DISTINCT normalized keys, not rows", () => {
+    // Two rows spelling one group. `groupCount` is what a model's result is
+    // shape-checked against, so a duplicated key must not inflate it.
+    const e = keyedExpectationFrom(
+      ["stock_status", "skus"],
+      [
+        { stock_status: "In Stock", skus: 90 },
+        { stock_status: "in stock ", skus: 12 },
+        { stock_status: "Out of Stock", skus: 5 },
+      ],
+    );
+    expect(e.groupCount).toBe(2);
+    expect(e.labels).toHaveLength(3);
+  });
+
+  it("yields no measures when the authoritative result is key-only", () => {
+    const e = keyedExpectationFrom(
+      ["status"],
+      [{ status: "shipped" }, { status: "delivered" }],
+    );
+    expect(e.measures).toEqual([]);
+    expect(e.groupCount).toBe(2);
   });
 });
 

--- a/packages/cli/bin/canonical-eval-mcp-llm.test.ts
+++ b/packages/cli/bin/canonical-eval-mcp-llm.test.ts
@@ -289,10 +289,10 @@ describe("gradeMetric", () => {
   it("passes a grouped METRIC answer that relabels its groups (cq-020, the gate path)", () => {
     // ⚠️ METRIC MODE IS WHERE THE VALUE CHECK IS THE GATE, not an additive
     // accept path layered over `sql_pattern` — `gradeMetric` has no substring
-    // fallback at all. Every other keyed test in this file grades a PATTERN
-    // question, so without this one the routing arm that reads
-    // `metricExpectations` is unprobed: rewriting it to read
-    // `answerExpectations` left the whole suite green.
+    // fallback at all. Every other keyed test calls its grader DIRECTLY, so
+    // without this one the `grade` → `gradeByMode` → `metricExpectations`
+    // routing arm is unprobed: rewriting it to read `answerExpectations` left
+    // the whole suite green.
     const q = metricQuestion("cq-020", "carrier_performance");
     const calls = [
       call(
@@ -708,9 +708,9 @@ describe("gradePattern", () => {
     ];
     // The pass must come from the VALUE path, not from `sql_pattern`: the
     // fixture SQL spells the filter `status <> 'cancelled'` and so misses the
-    // needle `WHERE status != 'cancelled'`. That is one character of margin, so
-    // pin the provenance rather than trusting it — with no expectation the same
-    // calls must FAIL.
+    // needle `WHERE status != 'cancelled'`. That is one token of margin — and
+    // the SQL DOES carry the other needle verbatim — so pin the provenance
+    // rather than trusting it: with no expectation the same calls must FAIL.
     expect(gradePattern(q, calls, "", 8, undefined).status).toBe("fail");
     const out = gradePattern(q, calls, "", 8, {
       kind: "keyed",
@@ -938,12 +938,14 @@ describe("keyed comparison — substance over labels (#5128)", () => {
     // wrong, and none of the wrong values is a x100 or /100 of an authoritative
     // one, so UNIT_SCALINGS cannot rescue it.
     //
-    // The SQL deliberately spells the predicate `COALESCE(promotion_id, 0) <> 0`
-    // so it misses the `promotion_id IS NOT NULL` needle: `gradePattern` layers
-    // the value check OVER `sql_pattern`, and a fixture satisfying the needle
-    // would pass on the substring alone and prove nothing about measures. The
+    // The SQL misses BOTH needles — `COALESCE(promotion_id, 0) <> 0` rather than
+    // `promotion_id IS NOT NULL`, and `status <> 'cancelled'` rather than
+    // `status != 'cancelled'` — and `findSqlMatch` requires EVERY needle, so
+    // either miss suffices. `gradePattern` layers the value check OVER
+    // `sql_pattern`, and a fixture satisfying the needles would pass on the
+    // substring alone and prove nothing about measures. The
     // `undefined`-expectation assertion pins that provenance rather than
-    // trusting a one-character margin.
+    // trusting the spelling to stay put.
     const calls = [
       sqlAnswer(
         "SELECT CASE WHEN COALESCE(promotion_id, 0) <> 0 THEN 'With Promo' ELSE 'No Promo' END AS promo_status, " +
@@ -1141,6 +1143,62 @@ describe("keyed comparison — substance over labels (#5128)", () => {
       /ground truth was not established/,
     );
   });
+
+  it("throws when EVERY authoritative grouping key is NULL", () => {
+    // ⚠️ THE SIBLING DISPOSITION, AND AN EARLIER CUT GOT IT BACKWARDS. This
+    // branch returned `true` so condition 1 could stand alone — which passes the
+    // ungrouped answer condition 2 exists to reject, AND disagreed with
+    // `labelSetMatches`, which returns `false` on the identical predicate. Which
+    // way a degenerate expectation went was then decided by whether any measure
+    // happened to parse as a number. It is a harness fault either way, so it
+    // gets the harness fault's disposition.
+    const allNull = {
+      kind: "keyed",
+      groups: [
+        { label: null, measures: [4345] },
+        { label: null, measures: [1207] },
+      ],
+    } as const satisfies MetricExpectation;
+    const ungrouped = [
+      sqlAnswer("SELECT COUNT(*) AS a, COUNT(DISTINCT id) AS b FROM orders", ["a", "b"], [
+        { a: 4345, b: 1207 },
+      ]),
+    ];
+    const nq = patternQuestion("cq-024", "Orders", "null_keyed", ["nothing-matches-this"]);
+    expect(() => gradePattern(nq, ungrouped, "", 8, allNull)).toThrow(
+      /every authoritative grouping key is NULL/,
+    );
+  });
+
+  it("pins the DISTINCT-label cardinality without a bystander column to lean on", () => {
+    // ⚠️ THE ONLY TEST THAT SEPARATES `labels.size` FROM `groups.length` WITHOUT
+    // a coincidence. Ground truth is three rows collapsing to two labels; the
+    // answer has two rows, and — deliberately — NO column carrying three
+    // distinct values, so the row-count spelling cannot be satisfied by a
+    // bystander. Without this, the row-count mutation was killed only by the
+    // COALESCE limitation test, which #5143 is expected to invert.
+    const collapsing = {
+      kind: "keyed",
+      groups: [
+        { label: "In Stock", measures: [90] },
+        { label: "in stock ", measures: [12] },
+        { label: "Out of Stock", measures: [5] },
+      ],
+    } as const satisfies MetricExpectation;
+    const answer = [
+      sqlAnswer(
+        "SELECT LOWER(stock_status) AS s, SUM(a) AS a, SUM(b) AS b FROM inventory_levels GROUP BY 1",
+        ["s", "a", "b"],
+        [
+          { s: "in stock", a: 90, b: 12 },
+          { s: "out of stock", a: 5, b: 5 },
+        ],
+      ),
+    ];
+    const invQ = patternQuestion("cq-025", "Products", "stock_health", ["nothing-matches-this"]);
+    // Column distinct counts are s:2, a:2, b:2 — nothing is 3.
+    expect(gradePattern(invQ, answer, "", 8, collapsing).status).toBe("pass");
+  });
 });
 
 describe("labelDriftNote — reports a relabel without gating it (#5128)", () => {
@@ -1154,8 +1212,39 @@ describe("labelDriftNote — reports a relabel without gating it (#5128)", () =>
     expect(out.status).toBe("pass");
     const note = labelDriftNote(out, PROMO_GROUND_TRUTH);
     expect(note).toContain("cq-016");
-    expect(note).toContain("With Promo");
     expect(note).toContain("relabelled");
+    // ⚠️ THE WHOLE BRACKETED LIST, NOT `toContain("With Promo")` — that string is
+    // a PREFIX of the model's own label `"With Promotion"`, so the assertion
+    // passed against a mutant that printed the OBSERVED labels back, producing
+    // the self-contradictory "none of [With Promotion, …] appears in any result
+    // column". A substring assertion on one label cannot tell the two apart.
+    expect(note).toContain("[With Promo, No Promo]");
+    expect(note).not.toContain("With Promotion");
+  });
+
+  it("says nothing when the answer did not match ground truth at all", () => {
+    // ⚠️ THE NOTE MUST NOT SPEAK FOR A PASS IT HAD NOTHING TO DO WITH. A pattern
+    // question can pass on `sql_pattern` while its RESULT is wrong; without the
+    // empty-match guard the note would print "grouped answer matched the
+    // authoritative measures and 2 group(s), but relabelled them" over a result
+    // that matched nothing — a false statement in the one channel whose whole
+    // job is keeping a relabel visible.
+    const passesOnSql = patternQuestion("cq-016", "Orders", "orders_with_promotions", [
+      "FROM orders",
+    ]);
+    const wrongNumbers = [
+      sqlAnswer(
+        "SELECT promo, COUNT(*) AS n FROM orders GROUP BY 1",
+        ["promo", "n"],
+        [
+          { promo: "yes", n: 11 },
+          { promo: "no", n: 22 },
+        ],
+      ),
+    ];
+    const out = gradePattern(passesOnSql, wrongNumbers, "", 8, PROMO_GROUND_TRUTH);
+    expect(out.status).toBe("pass");
+    expect(labelDriftNote(out, PROMO_GROUND_TRUTH)).toBeNull();
   });
 
   it("says nothing when the answer used the authoritative labels", () => {
@@ -1272,9 +1361,17 @@ describe("keyedExpectationFrom — harvesting ground truth (#5128)", () => {
       ),
     ];
     // `status` carries exactly TWO distinct values — the collapsed cardinality,
-    // not the three harvested rows. A row-count spelling would demand 3 and a
-    // case-sensitive one would see 2 vs 2 by luck; this fixture separates them
-    // because the model lower-cased every label.
+    // not the three harvested rows.
+    //
+    // ⚠️ THE STATED MUTATION RESULTS HERE WERE WRONG AND WERE CHECKED, NOT
+    // REASONED. An earlier comment claimed a row-count spelling "would demand 3"
+    // and a case-sensitive fold "would see 2 vs 2 by luck". Both were measured
+    // green: `skus` is `90, 12, 5` — three distinct values — so a BYSTANDER
+    // column satisfies either mutant. What this test actually proves is that a
+    // 3-row / 2-label harvest passes against a 2-group answer. The row-count and
+    // case-folding spellings are killed by `a COALESCE-rendered NULL group` and
+    // `still compares LABELS when the authoritative result has no measures`
+    // respectively.
     expect(gradePattern(invQ, twoGroupAnswer, "", 8, e).status).toBe("pass");
   });
 

--- a/packages/cli/bin/canonical-eval-mcp-llm.test.ts
+++ b/packages/cli/bin/canonical-eval-mcp-llm.test.ts
@@ -217,6 +217,13 @@ describe("gradeMetric", () => {
     // The fixture carries `spend` because the metric's own SQL does — a keyed
     // expectation is graded on its MEASURES now (#5128), and a `query` answer
     // reaches them through the nested `data` array like any other.
+    //
+    // ⚠️ TWO GROUPS HERE; THE LIVE EXPECTATION HAS TWENTY. `top_customers_by_spend`
+    // ends `LIMIT 20` — the only LIMIT in the corpus — so a model that lists its
+    // top 10 is short 10 groups and fails. That is the `top-N` entry in
+    // `keyedResultMatches`' known-limits block, and it failed identically under
+    // the rule this PR replaces. This fixture is deliberately reduced to keep
+    // the test about `query`'s nested `data` reaching the comparison at all.
     const out = gradeMetric(q, calls, "Ada and Grace.", 9, {
       kind: "keyed",
       groups: [
@@ -984,7 +991,7 @@ describe("keyed comparison — substance over labels (#5128)", () => {
     // happens to carry two distinct values; add one plausible bystander and the
     // same wrong grouping passes.
     //
-    // Recorded rather than fixed because the alternative — tying condition 2 to
+    // Recorded rather than fixed (#5143) because the alternative — tying condition 2 to
     // a specific column — needs to know which column is the grouping key on the
     // OBSERVED side, which is exactly the presentation-level guess this issue
     // exists to stop making. Condition 1 is the grading; condition 2 is a shape
@@ -1084,6 +1091,45 @@ describe("keyed comparison — substance over labels (#5128)", () => {
     ];
     const pq = patternQuestion("cq-022", "Orders", "promo_types", ["nothing-matches-this"]);
     expect(gradePattern(pq, identical, "", 8, withNullGroup).status).toBe("pass");
+  });
+
+  it("⚠️ a COALESCE-rendered NULL group still fails the shape check — the NULL fix does NOT cover it", () => {
+    // ⚠️ ASSERTS A LIMITATION, and specifically the one a reader will assume the
+    // NULL fix closed. Dropping NULL labels from the cardinality makes the
+    // BYTE-IDENTICAL answer pass (pinned above). It does NOT make
+    // `COALESCE(promotion_type, 'unknown')` pass: the model renders the null
+    // group as a value, so the observed column carries 3 distinct values against
+    // an authoritative 2.
+    //
+    // Recorded rather than fixed because it failed under the rule this PR
+    // replaces too — set equality on labels implies equality of cardinality, so
+    // `{percent_off, free_shipping, "null"}` never matched
+    // `{percent_off, free_shipping, unknown}` either. Not a regression; a
+    // pre-existing class, tracked in #5143.
+    const withNullGroup = {
+      kind: "keyed",
+      groups: [
+        { label: "percent_off", measures: [800] },
+        { label: "free_shipping", measures: [300] },
+        { label: null, measures: [3105] },
+      ],
+    } as const satisfies MetricExpectation;
+    const coalesced = [
+      sqlAnswer(
+        "SELECT COALESCE(promotion_type, 'unknown') AS t, COUNT(*) AS orders FROM orders GROUP BY 1",
+        ["t", "orders"],
+        [
+          { t: "percent_off", orders: 800 },
+          { t: "free_shipping", orders: 300 },
+          { t: "unknown", orders: 3105 },
+        ],
+      ),
+    ];
+    const pq = patternQuestion("cq-022", "Orders", "promo_types", ["nothing-matches-this"]);
+    // Condition 1 is satisfied — all three groups are represented — so this is
+    // condition 2 alone, which is what makes it a shape limitation rather than a
+    // grading disagreement.
+    expect(gradePattern(pq, coalesced, "", 8, withNullGroup).status).toBe("fail");
   });
 
   it("throws rather than failing the model when ground truth has no groups", () => {

--- a/packages/cli/bin/canonical-eval-mcp-llm.test.ts
+++ b/packages/cli/bin/canonical-eval-mcp-llm.test.ts
@@ -25,6 +25,7 @@ import {
   keyedExpectationFrom,
   readBaseline,
   writeBaseline,
+  type MetricExpectation,
   type McpLlmOutcome,
   type RecordedToolCall,
 } from "./canonical-eval-mcp-llm";
@@ -218,9 +219,10 @@ describe("gradeMetric", () => {
     // reaches them through the nested `data` array like any other.
     const out = gradeMetric(q, calls, "Ada and Grace.", 9, {
       kind: "keyed",
-      groupCount: 2,
-      measures: [48210.5, 31905.75],
-      labels: ["Ada", "Grace"],
+      groups: [
+        { label: "ada", measures: [48210.5] },
+        { label: "grace", measures: [31905.75] },
+      ],
     });
     expect(out.status).toBe("pass");
   });
@@ -243,6 +245,11 @@ describe("gradeMetric", () => {
   });
 
   it("fails a grouped answer that is missing a group", () => {
+    // ⚠️ THE ANSWER CARRIES A THIRD, WRONGLY-LABELLED ROW so that ONLY the
+    // per-group measure rule can fail it. An earlier version returned two rows,
+    // which made the cardinality rule fail too — and a fixture that trips both
+    // conditions proves neither. Here `other`'s 55 satisfies the cardinality
+    // check (three distinct carriers) while USPS's 96 appears nowhere.
     const q = metricQuestion("cq-020", "carrier_performance");
     const calls = [
       call(
@@ -255,19 +262,125 @@ describe("gradeMetric", () => {
             rows: [
               { carrier: "UPS", shipments: 412 },
               { carrier: "FedEx", shipments: 288 },
+              { carrier: "other", shipments: 55 },
             ],
           },
         },
       ),
     ];
-    // USPS's 96 shipments are absent from the answer, so the measure subset
-    // rule fails — and the surviving two groups are one short of the three the
-    // metric splits into, so the cardinality rule fails too.
     const out = gradeMetric(q, calls, "", 7, {
       kind: "keyed",
-      groupCount: 3,
-      measures: [412, 288, 96],
-      labels: ["UPS", "FedEx", "USPS"],
+      groups: [
+        { label: "ups", measures: [412] },
+        { label: "fedex", measures: [288] },
+        { label: "usps", measures: [96] },
+      ],
+    });
+    expect(out.status).toBe("fail");
+  });
+
+  it("passes a grouped METRIC answer that relabels its groups (cq-020, the gate path)", () => {
+    // ⚠️ METRIC MODE IS WHERE THE VALUE CHECK IS THE GATE, not an additive
+    // accept path layered over `sql_pattern` — `gradeMetric` has no substring
+    // fallback at all. Every other keyed test in this file grades a PATTERN
+    // question, so without this one the routing arm that reads
+    // `metricExpectations` is unprobed: rewriting it to read
+    // `answerExpectations` left the whole suite green.
+    const q = metricQuestion("cq-020", "carrier_performance");
+    const calls = [
+      call(
+        "executeSQL",
+        { sql: "SELECT UPPER(carrier) AS shipper, COUNT(*) AS n FROM shipments GROUP BY 1" },
+        {
+          kind: "ok",
+          data: {
+            columns: ["shipper", "n"],
+            rows: [
+              { shipper: "UNITED PARCEL", n: 412 },
+              { shipper: "FEDERAL EXPRESS", n: 288 },
+              { shipper: "US POSTAL", n: 96 },
+            ],
+          },
+        },
+      ),
+    ];
+    const out = grade({
+      question: q,
+      toolCalls: calls,
+      finalText: "",
+      latencyMs: 7,
+      baseline: undefined,
+      metricExpectations: {
+        carrier_performance: {
+          kind: "keyed",
+          groups: [
+            { label: "ups", measures: [412] },
+            { label: "fedex", measures: [288] },
+            { label: "usps", measures: [96] },
+          ],
+        },
+      },
+      answerExpectations: undefined,
+    });
+    expect(out.status).toBe("pass");
+  });
+
+  it("passes a grouped metric answered in DOLLARS against cents ground truth", () => {
+    // UNIT_SCALINGS is brand new on the keyed path (#5128) and was previously
+    // pinned only for scalars: removing it from `keyedResultMatches` — and
+    // widening it to ±1000x — both left the suite green.
+    const q = metricQuestion("cq-007", "revenue_dtc_vs_marketplace");
+    const calls = [
+      call(
+        "executeSQL",
+        { sql: "SELECT channel, SUM(total_cents)/100.0 AS revenue FROM orders GROUP BY 1" },
+        {
+          kind: "ok",
+          data: {
+            columns: ["channel", "revenue"],
+            rows: [
+              { channel: "dtc", revenue: "1284.01" },
+              { channel: "marketplace", revenue: "642.5" },
+            ],
+          },
+        },
+      ),
+    ];
+    const centsGroundTruth = {
+      kind: "keyed",
+      groups: [
+        { label: "dtc", measures: [128401] },
+        { label: "marketplace", measures: [64250] },
+      ],
+    } as const satisfies MetricExpectation;
+    expect(gradeMetric(q, calls, "", 7, centsGroundTruth).status).toBe("pass");
+  });
+
+  it("does NOT rescue a grouped answer that is off by 1000x", () => {
+    // Guards the guard: UNIT_SCALINGS is cents-vs-dollars and nothing wider.
+    const q = metricQuestion("cq-007", "revenue_dtc_vs_marketplace");
+    const calls = [
+      call(
+        "executeSQL",
+        { sql: "SELECT channel, SUM(total_cents)/1000.0 AS revenue FROM orders GROUP BY 1" },
+        {
+          kind: "ok",
+          data: {
+            columns: ["channel", "revenue"],
+            rows: [
+              { channel: "dtc", revenue: "128.401" },
+              { channel: "marketplace", revenue: "64.25" },
+            ],
+          },
+        },
+      ),
+    ];
+    const out = gradeMetric(q, calls, "", 7, {
+      kind: "keyed",
+      groups: [
+        { label: "dtc", measures: [128401] },
+        { label: "marketplace", measures: [64250] },
+      ],
     });
     expect(out.status).toBe("fail");
   });
@@ -586,11 +699,18 @@ describe("gradePattern", () => {
         },
       ),
     ];
+    // The pass must come from the VALUE path, not from `sql_pattern`: the
+    // fixture SQL spells the filter `status <> 'cancelled'` and so misses the
+    // needle `WHERE status != 'cancelled'`. That is one character of margin, so
+    // pin the provenance rather than trusting it — with no expectation the same
+    // calls must FAIL.
+    expect(gradePattern(q, calls, "", 8, undefined).status).toBe("fail");
     const out = gradePattern(q, calls, "", 8, {
       kind: "keyed",
-      groupCount: 2,
-      measures: [1240, 3105],
-      labels: ["With Promotion", "No Promotion"],
+      groups: [
+        { label: "with promotion", measures: [1240] },
+        { label: "no promotion", measures: [3105] },
+      ],
     });
     expect(out.status).toBe("pass");
   });
@@ -678,16 +798,22 @@ describe("gradePattern", () => {
  *
  * The labels are the pattern SQL's own hand-written `CASE … THEN 'With Promo'`;
  * the measures are its `COUNT(*)`, `AVG(total_cents)/100.0` and
- * `SUM(total_cents)/100.0` for both groups. Deliberately six distinct values
- * across two groups — never `{n, n}` — so no assertion below can be satisfied
- * by two states that the fixture happened to make equal.
+ * `SUM(total_cents)/100.0` for each group. Deliberately six distinct values
+ * across two groups — never `{n, n}`, and no value is a x100 or /100 of any
+ * other — so no assertion below can be satisfied by two states that the fixture
+ * happened to make equal, nor rescued by `UNIT_SCALINGS`.
+ *
+ * Hand-written rather than produced by `keyedExpectationFrom`: an oracle built
+ * by the code it grades agrees with it by construction and cannot falsify it.
+ * The factory gets its own tests further down.
  */
 const PROMO_GROUND_TRUTH = {
   kind: "keyed",
-  groupCount: 2,
-  measures: [1240, 118.4, 146816, 3105, 92.7, 287833.5],
-  labels: ["With Promo", "No Promo"],
-} as const;
+  groups: [
+    { label: "With Promo", measures: [1240, 118.4, 146816] },
+    { label: "No Promo", measures: [3105, 92.7, 287833.5] },
+  ],
+} as const satisfies MetricExpectation;
 
 function sqlAnswer(
   sql: string,
@@ -695,6 +821,25 @@ function sqlAnswer(
   rows: ReadonlyArray<Record<string, unknown>>,
 ): RecordedToolCall {
   return call("executeSQL", { sql }, { kind: "ok", data: { columns, rows } });
+}
+
+/**
+ * cq-016's reproducing answer, minus the richer breakdown: the authoritative
+ * numbers exactly, under the model's own group labels.
+ */
+function relabelledPromoAnswer(): RecordedToolCall[] {
+  return [
+    sqlAnswer(
+      "SELECT CASE WHEN promotion_id IS NOT NULL THEN 'With Promotion' ELSE 'No Promotion' END AS promo_status, " +
+        "COUNT(*) AS orders, AVG(total_cents)/100.0 AS aov, SUM(total_cents)/100.0 AS revenue " +
+        "FROM orders WHERE status != 'cancelled' GROUP BY 1",
+      ["promo_status", "orders", "aov", "revenue"],
+      [
+        { promo_status: "With Promotion", orders: 1240, aov: 118.4, revenue: 146816 },
+        { promo_status: "No Promotion", orders: 3105, aov: 92.7, revenue: 287833.5 },
+      ],
+    ),
+  ];
 }
 
 describe("keyed comparison — substance over labels (#5128)", () => {
@@ -756,40 +901,68 @@ describe("keyed comparison — substance over labels (#5128)", () => {
     expect(gradePattern(q, calls, "", 8, PROMO_GROUND_TRUTH).status).toBe("fail");
   });
 
-  it("fails when only SOME authoritative measures are present", () => {
-    // Guards `every`, not `some`. Counts and averages are right; both revenue
-    // totals are wrong, and neither wrong value is a ×100 or ÷100 of an
-    // authoritative one, so UNIT_SCALINGS cannot rescue it.
-    //
-    // The SQL deliberately spells the predicate `COALESCE(promotion_id, 0) <> 0`
-    // so it misses the `promotion_id IS NOT NULL` needle: `gradePattern` layers
-    // the value check OVER `sql_pattern`, and a fixture that satisfies the
-    // needle would pass on the substring alone and prove nothing about measures.
+  it("passes an answer that publishes ONE measure per group and drops the rest", () => {
+    // ⚠️ THIS IS INSTANCE #4, CAUGHT IN REVIEW BEFORE IT SHIPPED. The first cut
+    // of this fix required every authoritative measure CELL to appear. The
+    // corpus's grouped metrics publish auxiliary columns no natural answer
+    // includes — `revenue_by_category` gives revenue + order_count + units_sold
+    // for a question that asks only for revenue, `monthly_gmv_trend` gives
+    // order_count + gmv + aov for a question that asks only for GMV — so that
+    // rule flips currently-PASSING questions to fail, over an exhaustiveness
+    // difference rather than a substantive one. Per GROUP, not per cell.
     const calls = [
       sqlAnswer(
-        "SELECT CASE WHEN COALESCE(promotion_id, 0) <> 0 THEN 'With Promo' ELSE 'No Promo' END AS promo_status, " +
-          "COUNT(*) AS orders, AVG(total_cents)/100.0 AS aov, SUM(total_cents) AS revenue " +
-          "FROM orders WHERE status != 'cancelled' GROUP BY 1",
-        ["promo_status", "orders", "aov", "revenue"],
+        "SELECT CASE WHEN COALESCE(promotion_id, 0) <> 0 THEN 'Promo' ELSE 'None' END AS s, " +
+          "COUNT(*) AS orders FROM orders WHERE status <> 'cancelled' GROUP BY 1",
+        ["s", "orders"],
         [
-          { promo_status: "With Promo", orders: 1240, aov: 118.4, revenue: 151093.7 },
-          { promo_status: "No Promo", orders: 3105, aov: 92.7, revenue: 291204.3 },
+          { s: "Promo", orders: 1240 },
+          { s: "None", orders: 3105 },
         ],
       ),
     ];
+    expect(gradePattern(q, calls, "", 8, undefined).status).toBe("fail");
+    expect(gradePattern(q, calls, "", 8, PROMO_GROUND_TRUTH).status).toBe("pass");
+  });
+
+  it("fails when one whole GROUP is unrepresented", () => {
+    // The other side of per-group: `every` still means every. The With-Promo
+    // group is reproduced exactly; the No-Promo group's three numbers are all
+    // wrong, and none of the wrong values is a x100 or /100 of an authoritative
+    // one, so UNIT_SCALINGS cannot rescue it.
+    //
+    // The SQL deliberately spells the predicate `COALESCE(promotion_id, 0) <> 0`
+    // so it misses the `promotion_id IS NOT NULL` needle: `gradePattern` layers
+    // the value check OVER `sql_pattern`, and a fixture satisfying the needle
+    // would pass on the substring alone and prove nothing about measures. The
+    // `undefined`-expectation assertion pins that provenance rather than
+    // trusting a one-character margin.
+    const calls = [
+      sqlAnswer(
+        "SELECT CASE WHEN COALESCE(promotion_id, 0) <> 0 THEN 'With Promo' ELSE 'No Promo' END AS promo_status, " +
+          "COUNT(*) AS orders, AVG(total_cents)/100.0 AS aov, SUM(total_cents)/100.0 AS revenue " +
+          "FROM orders WHERE status <> 'cancelled' GROUP BY 1",
+        ["promo_status", "orders", "aov", "revenue"],
+        [
+          { promo_status: "With Promo", orders: 1240, aov: 118.4, revenue: 146816 },
+          { promo_status: "No Promo", orders: 2911, aov: 88.3, revenue: 257041.3 },
+        ],
+      ),
+    ];
+    expect(gradePattern(q, calls, "", 8, undefined).status).toBe("fail");
     expect(gradePattern(q, calls, "", 8, PROMO_GROUND_TRUTH).status).toBe("fail");
   });
 
   it("fails a wrong grouping whose numbers happen to CONTAIN the authoritative ones", () => {
-    // ⚠️ THE CASE THE MEASURE-SUBSET RULE CANNOT CATCH ALONE, which is why the
-    // cardinality condition exists. Every one of the six authoritative measures
-    // appears in this result — it is a superset — but the model grouped by
-    // shipping region, into five groups rather than two. No column carries two
-    // distinct values, so the shape check fails it.
+    // ⚠️ THE CASE THE PER-GROUP MEASURE RULE CANNOT CATCH ALONE, which is why
+    // the cardinality condition exists. Both authoritative groups are
+    // represented — 1240 and 3105 are both present — but the model grouped by
+    // shipping region, into five groups rather than two, and no column here
+    // carries two distinct values.
     const calls = [
       sqlAnswer(
         "SELECT region, COUNT(*) AS orders, AVG(total_cents)/100.0 AS aov, SUM(total_cents)/100.0 AS revenue " +
-          "FROM orders WHERE status != 'cancelled' GROUP BY region",
+          "FROM orders WHERE status <> 'cancelled' GROUP BY region",
         ["region", "orders", "aov", "revenue"],
         [
           { region: "us-east", orders: 1240, aov: 118.4, revenue: 146816 },
@@ -803,17 +976,54 @@ describe("keyed comparison — substance over labels (#5128)", () => {
     expect(gradePattern(q, calls, "", 8, PROMO_GROUND_TRUTH).status).toBe("fail");
   });
 
+  it("⚠️ a BYSTANDER column satisfies the shape check — pinning the honest weakness", () => {
+    // ⚠️ THIS TEST ASSERTS A LIMITATION, NOT A GUARANTEE, AND THAT IS THE POINT.
+    // Condition 2 accepts if ANY column has the authoritative distinct count —
+    // including a column that has nothing to do with the grouping. The
+    // wrong-grouping fixture above fails only because none of ITS columns
+    // happens to carry two distinct values; add one plausible bystander and the
+    // same wrong grouping passes.
+    //
+    // Recorded rather than fixed because the alternative — tying condition 2 to
+    // a specific column — needs to know which column is the grouping key on the
+    // OBSERVED side, which is exactly the presentation-level guess this issue
+    // exists to stop making. Condition 1 is the grading; condition 2 is a shape
+    // guard against an ungrouped answer, and it is weak on purpose. Anyone
+    // strengthening it should make this test go red deliberately.
+    const calls = [
+      sqlAnswer(
+        "SELECT region, domestic, COUNT(*) AS orders, AVG(total_cents)/100.0 AS aov, " +
+          "SUM(total_cents)/100.0 AS revenue FROM orders WHERE status <> 'cancelled' GROUP BY 1, 2",
+        ["region", "domestic", "orders", "aov", "revenue"],
+        [
+          { region: "us-east", domestic: "yes", orders: 1240, aov: 118.4, revenue: 146816 },
+          { region: "us-west", domestic: "yes", orders: 3105, aov: 92.7, revenue: 287833.5 },
+          { region: "emea", domestic: "no", orders: 610, aov: 101.3, revenue: 61793 },
+          { region: "apac", domestic: "no", orders: 455, aov: 99.8, revenue: 45409 },
+          { region: "latam", domestic: "no", orders: 190, aov: 88.2, revenue: 16758 },
+        ],
+      ),
+    ];
+    expect(gradePattern(q, calls, "", 8, PROMO_GROUND_TRUTH).status).toBe("pass");
+  });
+
+  const NO_MEASURES = {
+    kind: "keyed",
+    groups: [
+      { label: "shipped", measures: [] },
+      { label: "delivered", measures: [] },
+      { label: "returned", measures: [] },
+    ],
+  } as const satisfies MetricExpectation;
+  const statusQ = patternQuestion("cq-021", "Orders", "order_statuses", [
+    "nothing-matches-this",
+  ]);
+
   it("still compares LABELS when the authoritative result has no measures", () => {
     // A `SELECT DISTINCT status`-shaped ground truth: the key column IS the
     // data, not a display label, and cardinality alone would pass any result
     // with three distinct values. The old label-set rule is kept for exactly
     // this case rather than deleted, so it must still bite.
-    const noMeasures = {
-      kind: "keyed",
-      groupCount: 3,
-      measures: [],
-      labels: ["shipped", "delivered", "returned"],
-    } as const;
     const wrongValues = [
       sqlAnswer("SELECT DISTINCT status FROM orders", ["status"], [
         { status: "shipped" },
@@ -828,9 +1038,62 @@ describe("keyed comparison — substance over labels (#5128)", () => {
         { status: "delivered" },
       ]),
     ];
-    const vq = patternQuestion("cq-021", "Orders", "order_statuses", ["nothing-matches-this"]);
-    expect(gradePattern(vq, wrongValues, "", 8, noMeasures).status).toBe("fail");
-    expect(gradePattern(vq, rightValues, "", 8, noMeasures).status).toBe("pass");
+    expect(gradePattern(statusQ, wrongValues, "", 8, NO_MEASURES).status).toBe("fail");
+    expect(gradePattern(statusQ, rightValues, "", 8, NO_MEASURES).status).toBe("pass");
+  });
+
+  it("fails a SUPERSET of the authoritative labels on the measure-less path", () => {
+    // The label rule is set EQUALITY, not containment: a spurious extra group is
+    // as wrong as a missing one. Nothing pinned the superset direction before.
+    const extraValue = [
+      sqlAnswer("SELECT DISTINCT status FROM orders", ["status"], [
+        { status: "shipped" },
+        { status: "delivered" },
+        { status: "returned" },
+        { status: "pending" },
+      ]),
+    ];
+    expect(gradePattern(statusQ, extraValue, "", 8, NO_MEASURES).status).toBe("fail");
+  });
+
+  it("passes an identical answer when the authoritative grouping has a NULL key", () => {
+    // ⚠️ REGRESSION PIN FOR A FALSE NEGATIVE FOUND IN REVIEW. Harvest used to
+    // stringify a NULL grouping key to the label `"null"` and count it toward
+    // the cardinality, while the observed side skips nullish cells — so the
+    // model returning the BYTE-IDENTICAL authoritative rows graded `fail`. That
+    // is this issue's own defect class, one layer down. Both sides now reduce a
+    // cell through `cellKey` and neither counts a NULL as a distinct value.
+    const withNullGroup = {
+      kind: "keyed",
+      groups: [
+        { label: "percent_off", measures: [] },
+        { label: "free_shipping", measures: [] },
+        { label: null, measures: [] },
+      ],
+    } as const satisfies MetricExpectation;
+    const identical = [
+      sqlAnswer(
+        "SELECT DISTINCT promotion_type FROM orders",
+        ["promotion_type"],
+        [
+          { promotion_type: "percent_off" },
+          { promotion_type: "free_shipping" },
+          { promotion_type: null },
+        ],
+      ),
+    ];
+    const pq = patternQuestion("cq-022", "Orders", "promo_types", ["nothing-matches-this"]);
+    expect(gradePattern(pq, identical, "", 8, withNullGroup).status).toBe("pass");
+  });
+
+  it("throws rather than failing the model when ground truth has no groups", () => {
+    // An empty expectation means the harness never established ground truth.
+    // Returning `false` would print a `tool_selection` artifact blaming the
+    // model for a harness fault, 40 minutes into a paid run.
+    const empty = { kind: "keyed", groups: [] } as const satisfies MetricExpectation;
+    expect(() => gradePattern(q, relabelledPromoAnswer(), "", 8, empty)).toThrow(
+      /ground truth was not established/,
+    );
   });
 });
 
@@ -838,18 +1101,7 @@ describe("labelDriftNote — reports a relabel without gating it (#5128)", () =>
   const q = patternQuestion("cq-016", "Orders", "orders_with_promotions", [
     "nothing-matches-this",
   ]);
-  const relabelled = [
-    sqlAnswer(
-      "SELECT CASE WHEN promotion_id IS NOT NULL THEN 'With Promotion' ELSE 'No Promotion' END AS promo_status, " +
-        "COUNT(*) AS orders, AVG(total_cents)/100.0 AS aov, SUM(total_cents)/100.0 AS revenue " +
-        "FROM orders WHERE status != 'cancelled' GROUP BY 1",
-      ["promo_status", "orders", "aov", "revenue"],
-      [
-        { promo_status: "With Promotion", orders: 1240, aov: 118.4, revenue: 146816 },
-        { promo_status: "No Promotion", orders: 3105, aov: 92.7, revenue: 287833.5 },
-      ],
-    ),
-  ];
+  const relabelled = relabelledPromoAnswer();
 
   it("reports the drift on a question it just PASSED", () => {
     const out = gradePattern(q, relabelled, "", 8, PROMO_GROUND_TRUTH);
@@ -884,11 +1136,13 @@ describe("labelDriftNote — reports a relabel without gating it (#5128)", () =>
     // from the substance check and would satisfy this assertion with the
     // pass-only guard deleted. A mutation confirmed exactly that.
     //
-    // The LATENCY branch is the only place a keyed answer can match on
-    // substance and still be graded `fail`, so the note is suppressed there —
-    // the artifact already carries the expectation, and a "matched but
-    // relabelled" line beside a failure verdict reads as a second, contrary
-    // verdict.
+    // The `latency` branch is one of three places a keyed answer can match on
+    // substance and still be graded `fail` — `protocol` (unparseable) and
+    // `protocol` (transport) are the others, and all three return before
+    // `gradeByMode`. It is simply the cheapest of the three to construct. The
+    // note is suppressed on all of them: the artifact already carries the
+    // expectation, and a "matched but relabelled" line beside a failure verdict
+    // reads as a second, contrary verdict.
     const out = grade({
       question: q,
       toolCalls: relabelled,
@@ -905,56 +1159,104 @@ describe("labelDriftNote — reports a relabel without gating it (#5128)", () =>
 });
 
 describe("keyedExpectationFrom — harvesting ground truth (#5128)", () => {
-  it("excludes the grouping key from the measures even when the key is numeric", () => {
+  it("keeps each group's measures WITH its label, and excludes a numeric key", () => {
     // `month` is a grouping label that happens to be a number. Harvesting it as
     // a measure would force the model to reproduce `3` somewhere in its result
-    // — a spelling test on a calendar.
+    // — a spelling test on a calendar. And the measures must stay attached to
+    // the group that produced them: the comparison grades PER GROUP, so a flat
+    // list would make "which group is unrepresented" unanswerable.
     const e = keyedExpectationFrom(
-      ["month", "orders", "revenue"],
+      "month",
+      ["orders", "revenue"],
       [
         { month: 1, orders: 410, revenue: 39221.5 },
         { month: 2, orders: 388, revenue: 35907.25 },
         { month: 3, orders: 502, revenue: 47118 },
       ],
     );
-    expect(e.groupCount).toBe(3);
-    expect(e.labels).toEqual(["1", "2", "3"]);
-    expect(e.measures).toEqual([410, 39221.5, 388, 35907.25, 502, 47118]);
+    expect(e.groups).toEqual([
+      { label: "1", measures: [410, 39221.5] },
+      { label: "2", measures: [388, 35907.25] },
+      { label: "3", measures: [502, 47118] },
+    ]);
   });
 
   it("parses Postgres `numeric` measures, which arrive as strings", () => {
     const e = keyedExpectationFrom(
-      ["channel", "gmv"],
+      "channel",
+      ["gmv"],
       [
         { channel: "dtc", gmv: "128401.75" },
         { channel: "marketplace", gmv: "64200.5" },
       ],
     );
-    expect(e.measures).toEqual([128401.75, 64200.5]);
+    expect(e.groups.map((g) => g.measures)).toEqual([[128401.75], [64200.5]]);
   });
 
-  it("counts DISTINCT normalized keys, not rows", () => {
-    // Two rows spelling one group. `groupCount` is what a model's result is
-    // shape-checked against, so a duplicated key must not inflate it.
+  it("keeps labels VERBATIM, and the cardinality collapses them at comparison time", () => {
+    // Three rows spelling two groups. `groups.length` is 3 and the labels are
+    // untouched — an operator greps the pattern SQL for `'In Stock'`, not
+    // `in stock` — while the shape check the model is measured against is
+    // DISTINCT normalized labels, i.e. 2. Asserting that through `gradePattern`
+    // rather than off the field is the only way to see the collapse happen:
+    // reading `groups.length` would silently pass a row-count spelling.
     const e = keyedExpectationFrom(
-      ["stock_status", "skus"],
+      "stock_status",
+      ["skus"],
       [
         { stock_status: "In Stock", skus: 90 },
         { stock_status: "in stock ", skus: 12 },
         { stock_status: "Out of Stock", skus: 5 },
       ],
     );
-    expect(e.groupCount).toBe(2);
-    expect(e.labels).toHaveLength(3);
+    expect(e.groups).toHaveLength(3);
+    expect(e.groups.map((g) => g.label)).toEqual(["In Stock", "in stock ", "Out of Stock"]);
+
+    const invQ = patternQuestion("cq-023", "Products", "stock_health", ["nothing-matches-this"]);
+    const twoGroupAnswer = [
+      sqlAnswer(
+        "SELECT LOWER(stock_status) AS status, warehouse, COUNT(*) AS skus " +
+          "FROM inventory_levels GROUP BY 1, 2",
+        ["status", "warehouse", "skus"],
+        [
+          { status: "in stock", warehouse: "west", skus: 90 },
+          { status: "in stock", warehouse: "east", skus: 12 },
+          { status: "out of stock", warehouse: "west", skus: 5 },
+        ],
+      ),
+    ];
+    // `status` carries exactly TWO distinct values — the collapsed cardinality,
+    // not the three harvested rows. A row-count spelling would demand 3 and a
+    // case-sensitive one would see 2 vs 2 by luck; this fixture separates them
+    // because the model lower-cased every label.
+    expect(gradePattern(invQ, twoGroupAnswer, "", 8, e).status).toBe("pass");
+  });
+
+  it("harvests a NULL grouping key as `null`, never as the string \"null\"", () => {
+    // ⚠️ `String(cell)` HERE WAS A FALSE NEGATIVE. `"null"` counts toward a
+    // cardinality the observed side can never reach, because `columnValueSets`
+    // skips nullish cells — so the model returning the identical rows failed.
+    const e = keyedExpectationFrom(
+      "promotion_type",
+      ["orders"],
+      [
+        { promotion_type: "percent_off", orders: 800 },
+        { promotion_type: null, orders: 3105 },
+      ],
+    );
+    expect(e.groups.map((g) => g.label)).toEqual(["percent_off", null]);
   });
 
   it("yields no measures when the authoritative result is key-only", () => {
     const e = keyedExpectationFrom(
-      ["status"],
+      "status",
+      [],
       [{ status: "shipped" }, { status: "delivered" }],
     );
-    expect(e.measures).toEqual([]);
-    expect(e.groupCount).toBe(2);
+    expect(e.groups).toEqual([
+      { label: "shipped", measures: [] },
+      { label: "delivered", measures: [] },
+    ]);
   });
 });
 

--- a/packages/cli/bin/canonical-eval-mcp-llm.test.ts
+++ b/packages/cli/bin/canonical-eval-mcp-llm.test.ts
@@ -31,7 +31,7 @@ import {
 import { parseCanonicalEvalOptions } from "./canonical-eval-run";
 import type { Question } from "./canonical-eval";
 
-const { gradeMetric, gradeGlossary, gradePattern, gradeVirtual, labelDriftNote } =
+const { grade, gradeMetric, gradeGlossary, gradePattern, gradeVirtual, labelDriftNote } =
   __forTesting__;
 
 // ── Fixture helpers ──────────────────────────────────────────────────
@@ -878,20 +878,28 @@ describe("labelDriftNote — reports a relabel without gating it (#5128)", () =>
     expect(labelDriftNote(out, PROMO_GROUND_TRUTH)).toBeNull();
   });
 
-  it("says nothing on a FAIL — a note is a report, not a second verdict", () => {
-    const wrong = [
-      sqlAnswer(
-        "SELECT CASE WHEN promotion_id IS NOT NULL THEN 'With Promotion' ELSE 'No Promotion' END AS promo_status, " +
-          "COUNT(*) AS orders FROM orders GROUP BY 1",
-        ["promo_status", "orders"],
-        [
-          { promo_status: "With Promotion", orders: 9999 },
-          { promo_status: "No Promotion", orders: 8888 },
-        ],
-      ),
-    ];
-    const out = gradePattern(q, wrong, "", 8, PROMO_GROUND_TRUTH);
+  it("says nothing on a FAIL whose answer WOULD have matched — a note is a report, not a second verdict", () => {
+    // ⚠️ THE FIXTURE HAS TO FAIL FOR A REASON OTHER THAN THE COMPARISON, or it
+    // proves nothing: an answer whose measures are simply wrong returns `null`
+    // from the substance check and would satisfy this assertion with the
+    // pass-only guard deleted. A mutation confirmed exactly that.
+    //
+    // The LATENCY branch is the only place a keyed answer can match on
+    // substance and still be graded `fail`, so the note is suppressed there —
+    // the artifact already carries the expectation, and a "matched but
+    // relabelled" line beside a failure verdict reads as a second, contrary
+    // verdict.
+    const out = grade({
+      question: q,
+      toolCalls: relabelled,
+      finalText: "",
+      latencyMs: 9_000,
+      baseline: { "cq-016": 1_000 },
+      metricExpectations: undefined,
+      answerExpectations: { "cq-016": PROMO_GROUND_TRUTH },
+    });
     expect(out.status).toBe("fail");
+    if (out.status === "fail") expect(out.artifact.category).toBe("latency");
     expect(labelDriftNote(out, PROMO_GROUND_TRUTH)).toBeNull();
   });
 });

--- a/packages/cli/bin/canonical-eval-mcp-llm.ts
+++ b/packages/cli/bin/canonical-eval-mcp-llm.ts
@@ -1300,11 +1300,30 @@ function resultMatchesExpectation(data: unknown, expectation: MetricExpectation)
  * condition 1 does the grading. `keyed comparison … > a bystander column can
  * satisfy the shape check` pins the honest behaviour rather than a hoped-for one.
  *
- * ⚠️ KNOWN LIMIT: condition 2 wants ROWS. A model that answers a two-group
- * question with one pivoted row (`COUNT(*) FILTER (WHERE …) AS with_promo, …`)
- * has answered correctly and is failed here, because no column of a single row
- * has two distinct values. Rare from a model writing `GROUP BY` SQL. Recorded
- * as a known limit, not defended as ideal.
+ * ⚠️ KNOWN LIMITS, ALL OF THEM CONDITION 2, AND NONE OF THEM NEW. Condition 2
+ * wants the observed result to split into the authoritative number of groups,
+ * so it fails four correct-but-differently-shaped answers:
+ *
+ *   pivoted     one row of `COUNT(*) FILTER (WHERE …) AS with_promo, …` — no
+ *               column of a single row has two distinct values
+ *   top-N       `top_customers_by_spend` ends `LIMIT 20`, so a model that lists
+ *               its top 10 is short 10 groups. The only LIMIT in the corpus
+ *   rollup      an appended `Total` row makes the key column N+1 distinct
+ *   COALESCE    `COALESCE(channel, 'unknown')` renders a NULL group as a value,
+ *               so the observed count is N where the authoritative is N−1
+ *
+ * ⚠️ EACH OF THESE FAILED UNDER THE RULE THIS ONE REPLACES TOO, and that is the
+ * claim to check before "fixing" one. The old rule was set EQUALITY on labels,
+ * which implies equality of cardinality — so every row above was a `FAIL` on
+ * both sides of this change. This comparison is stricter on VALUES and looser
+ * on LABELS than its predecessor; on cardinality it is neither.
+ *
+ * They are not fixed here because the fix needs to know WHICH observed column
+ * is the grouping key, and guessing that from the result's presentation is the
+ * class of move #5128 exists to stop making. Tracked in #5143, together with
+ * condition 2's opposite weakness — a bystander column with the right distinct
+ * count satisfies it for free. The honest behaviour on both sides is pinned by
+ * tests rather than described and hoped for.
  *
  * Throws rather than returning `false` on an empty `groups` — that means ground
  * truth was never established, and charging it to the model would print a

--- a/packages/cli/bin/canonical-eval-mcp-llm.ts
+++ b/packages/cli/bin/canonical-eval-mcp-llm.ts
@@ -209,11 +209,63 @@ export type MetricExpectation =
   /** Single-row, single-number metric — compare the number. */
   | { readonly kind: "scalar"; readonly value: number }
   /**
-   * Grouped metric — compare the SET of grouping keys (the authoritative SQL's
-   * first column). Robust to the extra columns, aliases, and orderings a model
-   * legitimately adds, while still failing a wrong grouping or a wrong filter.
+   * Grouped metric — compared on SUBSTANCE (the measures it computed and how
+   * many groups it split into), never on what the groups are CALLED.
+   *
+   * ⚠️ THE PREVIOUS ARM CARRIED `keys: string[]` AND WAS THE THIRD PRESENTATION
+   * CHECK IN A ROW (#5128). The value grader was tightened three times and each
+   * tightening caught a *display* difference rather than a substantive one:
+   *
+   *   original   SQL text        `AVG(total_cents / 100.0)` vs `AVG(total_cents)`
+   *   fix 1      exact numbers   `11.22` vs a metric publishing `ROUND(…,1)` = `11.2`
+   *   fix 2      group labels    `'With Promotion'` vs `'With Promo'`
+   *
+   * Fix 2 is this arm's old shape. `orders_with_promotions` labels its groups
+   * with a hand-written `CASE … THEN 'With Promo'`; a model that computed the
+   * identical categorisation, filter and measures but wrote `'With Promotion'`
+   * was graded wrong. Nobody chose to make display text load-bearing — ground
+   * truth was harvested from the first column because that is what came back
+   * first, and the first column of a grouped query is a presentation column.
+   *
+   * So the labels stay, DIAGNOSTIC ONLY (see {@link labelDriftNote}), and the
+   * verdict keys on the two things a relabel cannot touch.
    */
-  | { readonly kind: "keyed"; readonly keys: readonly string[] };
+  | {
+      readonly kind: "keyed";
+      /**
+       * Distinct grouping cardinality of the authoritative result — matched
+       * against the DISTINCT-VALUE COUNT of some column of the observed result,
+       * never against its row count.
+       *
+       * ⚠️ ROW COUNT IS THE TEMPTING SPELLING AND IT REGRESSES THE VERY CASE
+       * THIS ARM EXISTS FOR. cq-016's reproducing answer was *richer* than
+       * ground truth — the model added a per-promotion-type breakdown, so it
+       * returned more rows than the authoritative two. Per-column distinct
+       * cardinality survives extra rows; a row count does not.
+       */
+      readonly groupCount: number;
+      /**
+       * Every numeric cell the authoritative SQL produced OUTSIDE its first
+       * column — i.e. the measures, not the grouping key (which is excluded
+       * even when it is itself numeric, as `month` is).
+       *
+       * Matched as a SUBSET of the observed numbers, so a richer answer passes
+       * and a dropped filter does not. Empty when the authoritative result has
+       * no numeric measures at all — see {@link keyedResultMatches} for what
+       * happens then.
+       */
+      readonly measures: readonly number[];
+      /**
+       * The authoritative result's first-column values.
+       *
+       * ⚠️ NOT PART OF THE VERDICT while `measures` is non-empty. Kept for two
+       * reasons: {@link labelDriftNote} reports a relabel so the drift is
+       * visible without gating on it, and when `measures` is EMPTY these values
+       * are the only substance the authoritative result carries, so the
+       * comparison falls back to them.
+       */
+      readonly labels: readonly string[];
+    };
 
 export interface McpLlmEvalOptions {
   readonly questionsPath?: string;
@@ -376,6 +428,15 @@ export async function runMcpLlmEval(
         });
         outcomes.push(outcome);
         if (outcome.status === "fail") artifacts.push(outcome.artifact);
+
+        // Reporting only — computed AFTER the verdict and incapable of changing
+        // it (#5128). Goes to stderr rather than the outcome so the run's JSON
+        // shape is untouched.
+        const drift = labelDriftNote(
+          outcome,
+          expectationForQuestion(q, opts.metricExpectations, opts.answerExpectations),
+        );
+        if (drift) process.stderr.write(`  note: ${drift}\n`);
       }
       return { outcomes, artifacts };
     } finally {
@@ -916,21 +977,16 @@ function gradeByMode(
   metricExpectations: McpLlmEvalOptions["metricExpectations"],
   answerExpectations: McpLlmEvalOptions["answerExpectations"],
 ): McpLlmOutcome {
+  const expectation = expectationForQuestion(q, metricExpectations, answerExpectations);
   switch (q.mode) {
     case "metric":
-      return gradeMetric(
-        q,
-        toolCalls,
-        finalText,
-        latencyMs,
-        metricExpectations?.[q.metric_id],
-      );
+      return gradeMetric(q, toolCalls, finalText, latencyMs, expectation);
     case "glossary":
       return gradeGlossary(q, toolCalls, finalText, latencyMs);
     case "pattern":
-      return gradePattern(q, toolCalls, finalText, latencyMs, answerExpectations?.[q.id]);
+      return gradePattern(q, toolCalls, finalText, latencyMs, expectation);
     case "virtual":
-      return gradeVirtual(q, toolCalls, finalText, latencyMs, answerExpectations?.[q.id]);
+      return gradeVirtual(q, toolCalls, finalText, latencyMs, expectation);
     default: {
       const _exhaustive: never = q;
       throw new Error(`unreachable mode: ${String(_exhaustive)}`);
@@ -1052,7 +1108,8 @@ function gradeMetric(
           ? "no expectation resolved"
           : expectation.kind === "scalar"
             ? `scalar ${expectation.value}`
-            : `keys [${expectation.keys.join(", ")}]`
+            : `${expectation.groupCount} group(s) carrying measures [${expectation.measures.join(", ")}]` +
+              ` — labels [${expectation.labels.join(", ")}] are NOT compared`
       })`,
   });
 }
@@ -1178,25 +1235,80 @@ function resultMatchesExpectation(data: unknown, expectation: MetricExpectation)
     );
   }
 
-  // Keyed: some column of the model's result must carry exactly the
-  // authoritative grouping keys. Compared as a SET so column aliasing, extra
-  // measure columns, and ORDER BY differences don't matter, while a missing or
-  // spurious group does.
-  const expected = new Set(expectation.keys.map(normalizeKey));
-  if (expected.size === 0) return false;
-  const byColumn = new Map<string, Set<string>>();
-  for (const row of rows) {
-    for (const [col, cell] of Object.entries(row)) {
-      if (cell === null || cell === undefined) continue;
-      let set = byColumn.get(col);
-      if (!set) {
-        set = new Set();
-        byColumn.set(col, set);
-      }
-      set.add(normalizeKey(String(cell)));
-    }
+  return keyedResultMatches(rows, expectation);
+}
+
+/**
+ * Does this grouped result carry the authoritative SUBSTANCE?
+ *
+ * Two conditions, both of which move under a wrong grouping or a dropped
+ * filter and neither of which moves under a relabel (#5128):
+ *
+ *  1. **every** authoritative measure has an approximate match among the
+ *     observed numbers, modulo {@link UNIT_SCALINGS}. SUBSET, not equality —
+ *     equality would fail the richer-than-ground-truth answer that is this
+ *     issue's actual reproducing case; and
+ *  2. **some** column's distinct-value count equals the authoritative group
+ *     count. Per-column and distinct, so extra breakdown rows don't move it.
+ *
+ * ⚠️ TWO TRADE-OFFS, STATED RATHER THAN HIDDEN — this is the fourth cut of this
+ * comparison and the previous three each shipped a false negative that looked
+ * obviously correct in review:
+ *
+ * - Condition 1 is `every`, so an answer that computes the right split but
+ *   publishes only SOME of the authoritative measures fails. Deliberate:
+ *   omitting a measure is not a presentation difference, it is a smaller
+ *   answer, and for a metric question the metric's own SQL is what "the answer"
+ *   means. The looser `some` reading would pass a result sharing one number out
+ *   of six, which is close to no check at all on a corpus where `COUNT(*)`
+ *   recurs.
+ * - Condition 2 wants ROWS. A model that answers a two-group question with one
+ *   pivoted row (`COUNT(*) FILTER (WHERE …) AS with_promo, … AS no_promo`) has
+ *   answered correctly and is failed here, because no column of a single row
+ *   has two distinct values. That shape is rare from a model writing `GROUP BY`
+ *   SQL, and the alternative — dropping the shape check — leaves the subset
+ *   rule alone to grade, which the wrong-grouping test shows is not enough.
+ *   Recorded as a known limit, not defended as ideal.
+ */
+function keyedResultMatches(
+  rows: ReadonlyArray<Record<string, unknown>>,
+  expectation: Extract<MetricExpectation, { kind: "keyed" }>,
+): boolean {
+  if (expectation.groupCount === 0) return false;
+
+  // No numeric measures at all — a `SELECT DISTINCT status`-shaped result. The
+  // key column is then the DATA rather than a display label, and cardinality
+  // alone would pass any result with the right number of distinct values, so
+  // compare the values themselves. This is the old label-set rule, kept exactly
+  // where it is still the strongest thing available.
+  if (expectation.measures.length === 0) return labelSetMatches(rows, expectation.labels);
+
+  const observed = numericValues(rows);
+  const everyMeasurePresent = expectation.measures.every((measure) =>
+    observed.some((candidate) =>
+      UNIT_SCALINGS.some((s) => approximatelyEqual(candidate * s, measure)),
+    ),
+  );
+  if (!everyMeasurePresent) return false;
+
+  for (const set of columnValueSets(rows).values()) {
+    if (set.size === expectation.groupCount) return true;
   }
-  for (const set of byColumn.values()) {
+  return false;
+}
+
+/**
+ * Some column of the result carries EXACTLY the given values, as a set — so
+ * column aliasing, extra measure columns and `ORDER BY` differences don't
+ * matter, while a missing or spurious group does.
+ */
+function labelSetMatches(
+  rows: ReadonlyArray<Record<string, unknown>>,
+  labels: readonly string[],
+): boolean {
+  const expected = new Set(labels.map(normalizeKey));
+  if (expected.size === 0) return false;
+  for (const set of columnValueSets(rows).values()) {
     if (set.size !== expected.size) continue;
     let allPresent = true;
     for (const k of expected) {
@@ -1210,8 +1322,128 @@ function resultMatchesExpectation(data: unknown, expectation: MetricExpectation)
   return false;
 }
 
+/** `columnName → set of its normalized non-null cell values`. */
+function columnValueSets(
+  rows: ReadonlyArray<Record<string, unknown>>,
+): Map<string, Set<string>> {
+  const byColumn = new Map<string, Set<string>>();
+  for (const row of rows) {
+    for (const [col, cell] of Object.entries(row)) {
+      if (cell === null || cell === undefined) continue;
+      let set = byColumn.get(col);
+      if (!set) {
+        set = new Set();
+        byColumn.set(col, set);
+      }
+      set.add(normalizeKey(String(cell)));
+    }
+  }
+  return byColumn;
+}
+
 function normalizeKey(raw: string): string {
   return raw.trim().toLowerCase();
+}
+
+/**
+ * Reduce one authoritative grouped result to its {@link MetricExpectation}.
+ *
+ * Lives beside the comparison rather than beside the SQL execution in
+ * `canonical-eval-run.ts` on purpose: harvesting and comparison are two halves
+ * of one rule, and #5128 is what a split between them looks like — ground truth
+ * was harvested from a display column while the comparison assumed it was data.
+ *
+ * `columns[0]` is the grouping key by convention across the corpus (`channel`,
+ * `carrier`, `stock_status`, `month`, `promo_status`); everything after it is a
+ * measure. The key column is excluded from `measures` even when it is numeric,
+ * so a `month` label never doubles as a value the model must reproduce.
+ */
+export function keyedExpectationFrom(
+  columns: readonly string[],
+  rows: ReadonlyArray<Record<string, unknown>>,
+): Extract<MetricExpectation, { kind: "keyed" }> {
+  const [keyColumn, ...measureColumns] = columns;
+  if (keyColumn === undefined) {
+    throw new Error("keyedExpectationFrom: a keyed result needs at least one column");
+  }
+  const labels = rows.map((r) => String(r[keyColumn]));
+  const measureRows = rows.map((r) => {
+    const out: Record<string, unknown> = {};
+    for (const c of measureColumns) out[c] = r[c];
+    return out;
+  });
+  return {
+    kind: "keyed",
+    labels,
+    groupCount: new Set(labels.map(normalizeKey)).size,
+    measures: numericValues(measureRows),
+  };
+}
+
+/**
+ * Diagnostic for a grouped answer that matched on substance while carrying
+ * NONE of the authoritative display labels — i.e. exactly the case the old
+ * label-set rule failed and this one passes.
+ *
+ * ⚠️ REPORTING, NOT GRADING. It is computed after the verdict and cannot change
+ * it. The point is that a relabel stays *visible*: if the corpus and the
+ * entity's `query_patterns` drift apart, or a model starts inventing its own
+ * vocabulary wholesale, the run says so instead of silently absorbing it.
+ *
+ * Returns `null` when there is nothing to report — a non-keyed or absent
+ * expectation, a fail, a measure-less expectation (where labels ARE the
+ * verdict, so a mismatch already failed), or a matching result that did carry
+ * the labels.
+ */
+function labelDriftNote(
+  outcome: McpLlmOutcome,
+  expectation: MetricExpectation | undefined,
+): string | null {
+  if (outcome.status !== "pass") return null;
+  if (expectation === undefined || expectation.kind !== "keyed") return null;
+  if (expectation.measures.length === 0) return null;
+
+  const matching = outcome.toolCalls
+    .filter((c) => isAnsweringCall(c) && c.result.kind === "ok")
+    .map((c) => (c.result.kind === "ok" ? collectRows(c.result.data) : []))
+    .filter((rows) => rows.length > 0 && keyedResultMatches(rows, expectation));
+
+  if (matching.length === 0) return null;
+  if (matching.some((rows) => labelSetMatches(rows, expectation.labels))) return null;
+
+  return (
+    `${outcome.questionId}: grouped answer matched the authoritative measures and ` +
+    `${expectation.groupCount} group(s), but relabelled them — none of ` +
+    `[${expectation.labels.join(", ")}] appears in any result column. ` +
+    `Not a verdict: those are display labels from the authoritative SQL, not data.`
+  );
+}
+
+/**
+ * The one place that answers "which expectation governs this question".
+ *
+ * Both {@link gradeByMode} and the run loop's drift note need it, and a second
+ * copy is how the note ends up describing a different expectation than the one
+ * that produced the verdict.
+ */
+function expectationForQuestion(
+  q: Question,
+  metricExpectations: McpLlmEvalOptions["metricExpectations"],
+  answerExpectations: McpLlmEvalOptions["answerExpectations"],
+): MetricExpectation | undefined {
+  switch (q.mode) {
+    case "metric":
+      return metricExpectations?.[q.metric_id];
+    case "pattern":
+    case "virtual":
+      return answerExpectations?.[q.id];
+    case "glossary":
+      return undefined;
+    default: {
+      const _exhaustive: never = q;
+      throw new Error(`unreachable mode: ${String(_exhaustive)}`);
+    }
+  }
 }
 
 function gradeGlossary(
@@ -1670,6 +1902,7 @@ export const __forTesting__ = {
   gradePattern,
   gradeVirtual,
   bindMcpToolsForLlm,
+  labelDriftNote,
 } as const;
 
 // ── Baseline I/O ────────────────────────────────────────────────────

--- a/packages/cli/bin/canonical-eval-mcp-llm.ts
+++ b/packages/cli/bin/canonical-eval-mcp-llm.ts
@@ -205,67 +205,75 @@ export type McpLlmOutcome =
  * strictly stronger: a spelling check passes canonical-looking SQL with a wrong
  * filter, and a value check does not.
  */
+/**
+ * One group of the authoritative grouped result — its display label and the
+ * numbers it computed, kept TOGETHER.
+ *
+ * ⚠️ ONE RECORD PER GROUP, NOT TWO PARALLEL ARRAYS. The label and its measures
+ * are two projections of one row; storing them as `labels[]` + `measures[]`
+ * lets them desync, and every consumer below cares which measure belongs to
+ * which group — {@link keyedResultMatches} grades PER GROUP.
+ */
+export interface AuthoritativeGroup {
+  /**
+   * The grouping key cell VERBATIM — or `null` when the authoritative SQL
+   * grouped on a NULL key. Case/whitespace folding happens at comparison time
+   * ({@link authoritativeLabels}) so the operator-facing note can print the
+   * label the SQL actually wrote.
+   *
+   * ⚠️ `null` IS NOT THE STRING `"null"`, AND THE DIFFERENCE WAS A LIVE FALSE
+   * NEGATIVE. An earlier cut harvested this as `String(cell)`, so a NULL group
+   * became the label `"null"` and counted toward the cardinality — while
+   * {@link columnValueSets} skips nullish cells on the observed side. A model
+   * returning the byte-identical authoritative result then graded FAIL, which
+   * is precisely the defect class #5128 exists to remove, one layer down. Both
+   * sides now reduce a cell through {@link cellKey} and neither counts a NULL
+   * as a distinct value.
+   */
+  readonly label: string | null;
+  /**
+   * The numeric cells this group's row produced OUTSIDE the key column — the
+   * measures, never the grouping key (excluded even when the key is itself
+   * numeric, as `month` is).
+   */
+  readonly measures: readonly number[];
+}
+
+/**
+ * Grouped metric — compared on SUBSTANCE (what each group computed, and how
+ * many groups there were), never on what the groups are CALLED.
+ *
+ * ⚠️ THE PREVIOUS ARM CARRIED `keys: string[]` AND WAS THE THIRD PRESENTATION
+ * CHECK IN A ROW (#5128). The value grader was tightened three times and each
+ * tightening caught a *display* difference rather than a substantive one:
+ *
+ *   original   SQL text        `AVG(total_cents / 100.0)` vs `AVG(total_cents)`
+ *   fix 1      exact numbers   `11.22` vs a metric publishing `ROUND(…,1)` = `11.2`
+ *   fix 2      group labels    `'With Promotion'` vs `'With Promo'`
+ *
+ * Fix 2 is this arm's old shape. `orders_with_promotions` labels its groups
+ * with a hand-written `CASE … THEN 'With Promo'`; a model that computed the
+ * identical categorisation, filter and measures but wrote `'With Promotion'`
+ * was graded wrong. Nobody chose to make display text load-bearing — ground
+ * truth was harvested from the first column because that is what came back
+ * first, and the first column of a grouped query is a presentation column.
+ *
+ * So the labels stay, DIAGNOSTIC ONLY (see {@link labelDriftNote}), and the
+ * verdict keys on what a relabel cannot touch.
+ *
+ * The grouping CARDINALITY is derived from `groups` rather than stored beside
+ * it ({@link authoritativeLabels}) — a count kept next to the thing it counts
+ * is a state that is only ever consistent by construction.
+ */
+export interface KeyedExpectation {
+  readonly kind: "keyed";
+  readonly groups: readonly AuthoritativeGroup[];
+}
+
 export type MetricExpectation =
   /** Single-row, single-number metric — compare the number. */
   | { readonly kind: "scalar"; readonly value: number }
-  /**
-   * Grouped metric — compared on SUBSTANCE (the measures it computed and how
-   * many groups it split into), never on what the groups are CALLED.
-   *
-   * ⚠️ THE PREVIOUS ARM CARRIED `keys: string[]` AND WAS THE THIRD PRESENTATION
-   * CHECK IN A ROW (#5128). The value grader was tightened three times and each
-   * tightening caught a *display* difference rather than a substantive one:
-   *
-   *   original   SQL text        `AVG(total_cents / 100.0)` vs `AVG(total_cents)`
-   *   fix 1      exact numbers   `11.22` vs a metric publishing `ROUND(…,1)` = `11.2`
-   *   fix 2      group labels    `'With Promotion'` vs `'With Promo'`
-   *
-   * Fix 2 is this arm's old shape. `orders_with_promotions` labels its groups
-   * with a hand-written `CASE … THEN 'With Promo'`; a model that computed the
-   * identical categorisation, filter and measures but wrote `'With Promotion'`
-   * was graded wrong. Nobody chose to make display text load-bearing — ground
-   * truth was harvested from the first column because that is what came back
-   * first, and the first column of a grouped query is a presentation column.
-   *
-   * So the labels stay, DIAGNOSTIC ONLY (see {@link labelDriftNote}), and the
-   * verdict keys on the two things a relabel cannot touch.
-   */
-  | {
-      readonly kind: "keyed";
-      /**
-       * Distinct grouping cardinality of the authoritative result — matched
-       * against the DISTINCT-VALUE COUNT of some column of the observed result,
-       * never against its row count.
-       *
-       * ⚠️ ROW COUNT IS THE TEMPTING SPELLING AND IT REGRESSES THE VERY CASE
-       * THIS ARM EXISTS FOR. cq-016's reproducing answer was *richer* than
-       * ground truth — the model added a per-promotion-type breakdown, so it
-       * returned more rows than the authoritative two. Per-column distinct
-       * cardinality survives extra rows; a row count does not.
-       */
-      readonly groupCount: number;
-      /**
-       * Every numeric cell the authoritative SQL produced OUTSIDE its first
-       * column — i.e. the measures, not the grouping key (which is excluded
-       * even when it is itself numeric, as `month` is).
-       *
-       * Matched as a SUBSET of the observed numbers, so a richer answer passes
-       * and a dropped filter does not. Empty when the authoritative result has
-       * no numeric measures at all — see {@link keyedResultMatches} for what
-       * happens then.
-       */
-      readonly measures: readonly number[];
-      /**
-       * The authoritative result's first-column values.
-       *
-       * ⚠️ NOT PART OF THE VERDICT while `measures` is non-empty. Kept for two
-       * reasons: {@link labelDriftNote} reports a relabel so the drift is
-       * visible without gating on it, and when `measures` is EMPTY these values
-       * are the only substance the authoritative result carries, so the
-       * comparison falls back to them.
-       */
-      readonly labels: readonly string[];
-    };
+  | KeyedExpectation;
 
 export interface McpLlmEvalOptions {
   readonly questionsPath?: string;
@@ -432,11 +440,26 @@ export async function runMcpLlmEval(
         // Reporting only — computed AFTER the verdict and incapable of changing
         // it (#5128). Goes to stderr rather than the outcome so the run's JSON
         // shape is untouched.
-        const drift = labelDriftNote(
-          outcome,
-          expectationForQuestion(q, opts.metricExpectations, opts.answerExpectations),
-        );
-        if (drift) process.stderr.write(`  note: ${drift}\n`);
+        //
+        // ⚠️ WRAPPED BECAUSE THE ONLY `return` IS AFTER THIS LOOP. A throw here
+        // unwinds past every outcome accumulated so far, so a reporting fault
+        // would cost a 20-question paid run its entire score and surface as a
+        // harness stack instead of a grade. Nothing on this path throws today;
+        // that is exactly why the assertion is enforced rather than trusted.
+        try {
+          const drift = labelDriftNote(
+            outcome,
+            expectationForQuestion(q, opts.metricExpectations, opts.answerExpectations),
+          );
+          if (drift) process.stderr.write(`  note: ${drift}\n`);
+        } catch (err) {
+          // Logged, never re-thrown: grading is the run's product and a
+          // diagnostic must not be able to discard it.
+          process.stderr.write(
+            `[mcp-llm-eval] drift note failed for ${q.id}: ` +
+              `${err instanceof Error ? err.message : String(err)}\n`,
+          );
+        }
       }
       return { outcomes, artifacts };
     } finally {
@@ -989,7 +1012,7 @@ function gradeByMode(
       return gradeVirtual(q, toolCalls, finalText, latencyMs, expectation);
     default: {
       const _exhaustive: never = q;
-      throw new Error(`unreachable mode: ${String(_exhaustive)}`);
+      throw new Error(unreachableModeMessage(_exhaustive));
     }
   }
 }
@@ -1108,8 +1131,10 @@ function gradeMetric(
           ? "no expectation resolved"
           : expectation.kind === "scalar"
             ? `scalar ${expectation.value}`
-            : `${expectation.groupCount} group(s) carrying measures [${expectation.measures.join(", ")}]` +
-              ` — labels [${expectation.labels.join(", ")}] are NOT compared`
+            : `${expectation.groups.length} group(s), each needing one of its own measures ` +
+              `— ${expectation.groups
+                .map((g) => `${g.label ?? "<null>"}: [${g.measures.join(", ")}]`)
+                .join(" · ")} — labels are NOT compared`
       })`,
   });
 }
@@ -1241,60 +1266,111 @@ function resultMatchesExpectation(data: unknown, expectation: MetricExpectation)
 /**
  * Does this grouped result carry the authoritative SUBSTANCE?
  *
- * Two conditions, both of which move under a wrong grouping or a dropped
- * filter and neither of which moves under a relabel (#5128):
+ * Two conditions, neither of which moves under a relabel (#5128):
  *
- *  1. **every** authoritative measure has an approximate match among the
- *     observed numbers, modulo {@link UNIT_SCALINGS}. SUBSET, not equality —
- *     equality would fail the richer-than-ground-truth answer that is this
- *     issue's actual reproducing case; and
+ *  1. **every authoritative GROUP is represented** — for each group, at least
+ *     one of the numbers it computed has an approximate match among the
+ *     observed numbers, modulo {@link UNIT_SCALINGS}. Subset, not equality; and
  *  2. **some** column's distinct-value count equals the authoritative group
  *     count. Per-column and distinct, so extra breakdown rows don't move it.
  *
- * ⚠️ TWO TRADE-OFFS, STATED RATHER THAN HIDDEN — this is the fourth cut of this
- * comparison and the previous three each shipped a false negative that looked
- * obviously correct in review:
+ * ⚠️ CONDITION 1 IS PER GROUP, NOT PER CELL, AND THE DIFFERENCE IS INSTANCE #4
+ * OF THIS ISSUE'S OWN TABLE. The obvious spelling — *every authoritative
+ * measure CELL must appear* — was written first and flips currently-PASSING
+ * questions to fail, because the corpus's metrics publish auxiliary columns no
+ * natural answer includes:
  *
- * - Condition 1 is `every`, so an answer that computes the right split but
- *   publishes only SOME of the authoritative measures fails. Deliberate:
- *   omitting a measure is not a presentation difference, it is a smaller
- *   answer, and for a metric question the metric's own SQL is what "the answer"
- *   means. The looser `some` reading would pass a result sharing one number out
- *   of six, which is close to no check at all on a corpus where `COUNT(*)`
- *   recurs.
- * - Condition 2 wants ROWS. A model that answers a two-group question with one
- *   pivoted row (`COUNT(*) FILTER (WHERE …) AS with_promo, … AS no_promo`) has
- *   answered correctly and is failed here, because no column of a single row
- *   has two distinct values. That shape is rare from a model writing `GROUP BY`
- *   SQL, and the alternative — dropping the shape check — leaves the subset
- *   rule alone to grade, which the wrong-grouping test shows is not enough.
- *   Recorded as a known limit, not defended as ideal.
+ *   revenue_by_category   revenue, order_count, units_sold  · cq-004 asks for revenue
+ *   monthly_gmv_trend     order_count, gmv, aov             · cq-009 asks for GMV
+ *   customers_by_…        customer_count, active_count, active_pct
+ *
+ * A model answering "revenue by category" with `SELECT category, SUM(revenue)`
+ * has answered the question. Failing it for omitting `units_sold` is the same
+ * "rejected a correct answer over presentation" mistake as the three before it,
+ * reintroduced as an EXHAUSTIVENESS difference. Per-group keeps what matters —
+ * a dropped filter moves every number in every group, so no group is
+ * represented; a missing group is exactly a group with nothing matched.
+ *
+ * ⚠️ CONDITION 2 IS WEAKER THAN IT READS, and that is stated rather than
+ * implied. It accepts if ANY column — including a bystander the model happened
+ * to select — carries the right number of distinct values, so at a group count
+ * of 2 a stray boolean-ish column satisfies it for free, and at a group count
+ * of 1 any constant column does. It is a shape guard against an answer with the
+ * right numbers and no grouping at all, not a second correctness check;
+ * condition 1 does the grading. `keyed comparison … > a bystander column can
+ * satisfy the shape check` pins the honest behaviour rather than a hoped-for one.
+ *
+ * ⚠️ KNOWN LIMIT: condition 2 wants ROWS. A model that answers a two-group
+ * question with one pivoted row (`COUNT(*) FILTER (WHERE …) AS with_promo, …`)
+ * has answered correctly and is failed here, because no column of a single row
+ * has two distinct values. Rare from a model writing `GROUP BY` SQL. Recorded
+ * as a known limit, not defended as ideal.
+ *
+ * Throws rather than returning `false` on an empty `groups` — that means ground
+ * truth was never established, and charging it to the model would print a
+ * `tool_selection` artifact blaming the model for a harness fault. Same
+ * disposition as {@link gradeMetric}'s missing-expectation throw.
  */
 function keyedResultMatches(
   rows: ReadonlyArray<Record<string, unknown>>,
-  expectation: Extract<MetricExpectation, { kind: "keyed" }>,
+  expectation: KeyedExpectation,
 ): boolean {
-  if (expectation.groupCount === 0) return false;
+  if (expectation.groups.length === 0) {
+    throw new Error(
+      "[harness] keyed expectation has no groups — ground truth was not established, " +
+        "so no answer can be adjudicated. A harvested expectation always has ≥1 group; " +
+        "check keyedExpectationFrom's caller.",
+    );
+  }
 
-  // No numeric measures at all — a `SELECT DISTINCT status`-shaped result. The
+  const labels = authoritativeLabels(expectation);
+
+  // No numeric measures anywhere — a `SELECT DISTINCT status`-shaped result. The
   // key column is then the DATA rather than a display label, and cardinality
   // alone would pass any result with the right number of distinct values, so
   // compare the values themselves. This is the old label-set rule, kept exactly
   // where it is still the strongest thing available.
-  if (expectation.measures.length === 0) return labelSetMatches(rows, expectation.labels);
+  if (!expectation.groups.some((g) => g.measures.length > 0)) {
+    return labelSetMatches(rows, labels);
+  }
 
   const observed = numericValues(rows);
-  const everyMeasurePresent = expectation.measures.every((measure) =>
-    observed.some((candidate) =>
-      UNIT_SCALINGS.some((s) => approximatelyEqual(candidate * s, measure)),
-    ),
+  const everyGroupRepresented = expectation.groups.every(
+    (g) =>
+      // A group the authoritative SQL gave no numbers for has nothing to match;
+      // it is carried by the cardinality check alone.
+      g.measures.length === 0 ||
+      g.measures.some((measure) =>
+        observed.some((candidate) =>
+          UNIT_SCALINGS.some((s) => approximatelyEqual(candidate * s, measure)),
+        ),
+      ),
   );
-  if (!everyMeasurePresent) return false;
+  if (!everyGroupRepresented) return false;
+
+  // Every authoritative label was NULL, so there is no cardinality to check
+  // against — `columnValueSets` cannot produce a nullish value on the observed
+  // side either. Condition 1 stands alone rather than failing by default.
+  if (labels.size === 0) return true;
 
   for (const set of columnValueSets(rows).values()) {
-    if (set.size === expectation.groupCount) return true;
+    if (set.size === labels.size) return true;
   }
   return false;
+}
+
+/**
+ * The authoritative grouping keys, normalized and de-duplicated. NULL keys are
+ * excluded, because {@link columnValueSets} cannot produce one on the observed
+ * side — counting them here would make an identical answer un-passable.
+ *
+ * `.size` is the grouping cardinality. Derived on demand rather than stored:
+ * a count kept beside the thing it counts can disagree with it.
+ */
+function authoritativeLabels(expectation: KeyedExpectation): ReadonlySet<string> {
+  const out = new Set<string>();
+  for (const g of expectation.groups) if (g.label !== null) out.add(normalizeKey(g.label));
+  return out;
 }
 
 /**
@@ -1304,9 +1380,8 @@ function keyedResultMatches(
  */
 function labelSetMatches(
   rows: ReadonlyArray<Record<string, unknown>>,
-  labels: readonly string[],
+  expected: ReadonlySet<string>,
 ): boolean {
-  const expected = new Set(labels.map(normalizeKey));
   if (expected.size === 0) return false;
   for (const set of columnValueSets(rows).values()) {
     if (set.size !== expected.size) continue;
@@ -1322,23 +1397,49 @@ function labelSetMatches(
   return false;
 }
 
-/** `columnName → set of its normalized non-null cell values`. */
+/** `columnName → set of its {@link cellKey}s. Nullish cells are not values. */
 function columnValueSets(
   rows: ReadonlyArray<Record<string, unknown>>,
 ): Map<string, Set<string>> {
   const byColumn = new Map<string, Set<string>>();
   for (const row of rows) {
     for (const [col, cell] of Object.entries(row)) {
-      if (cell === null || cell === undefined) continue;
+      const key = cellKey(cell);
+      if (key === null) continue;
       let set = byColumn.get(col);
       if (!set) {
         set = new Set();
         byColumn.set(col, set);
       }
-      set.add(normalizeKey(String(cell)));
+      set.add(key);
     }
   }
   return byColumn;
+}
+
+/**
+ * The ONE "is this cell a group at all, and what does it read as" rule, called
+ * from both sides of the comparison.
+ *
+ * ⚠️ TWO SPELLINGS OF THIS IS A FALSE NEGATIVE, MEASURED. The harvester used to
+ * do `String(cell)` while the observed side skipped nullish cells, so a NULL
+ * group harvested as the label `"null"` and counted toward a cardinality no
+ * observed result could ever reach — a model returning the byte-identical
+ * authoritative rows graded FAIL. One function, both callers.
+ *
+ * Returns the cell VERBATIM rather than normalized: {@link labelDriftNote}
+ * prints these back to an operator, and `with promo` is harder to find in a
+ * `query_patterns` block than the `'With Promo'` the SQL actually wrote.
+ * Normalization is {@link normalizeKey}'s job, applied at comparison time.
+ */
+function cellLabel(cell: unknown): string | null {
+  return cell === null || cell === undefined ? null : String(cell);
+}
+
+/** `cellLabel` + case/whitespace folding — the form the two sides compare in. */
+function cellKey(cell: unknown): string | null {
+  const label = cellLabel(cell);
+  return label === null ? null : normalizeKey(label);
 }
 
 function normalizeKey(raw: string): string {
@@ -1346,37 +1447,33 @@ function normalizeKey(raw: string): string {
 }
 
 /**
- * Reduce one authoritative grouped result to its {@link MetricExpectation}.
+ * Reduce one authoritative grouped result to its {@link KeyedExpectation}.
  *
  * Lives beside the comparison rather than beside the SQL execution in
  * `canonical-eval-run.ts` on purpose: harvesting and comparison are two halves
  * of one rule, and #5128 is what a split between them looks like — ground truth
  * was harvested from a display column while the comparison assumed it was data.
  *
- * `columns[0]` is the grouping key by convention across the corpus (`channel`,
- * `carrier`, `stock_status`, `month`, `promo_status`); everything after it is a
- * measure. The key column is excluded from `measures` even when it is numeric,
- * so a `month` label never doubles as a value the model must reproduce.
+ * `keyColumn` is the grouping key — `columns[0]` by convention across the
+ * corpus (`channel`, `carrier`, `stock_status`, `month`, `promo_status`) — and
+ * `measureColumns` is everything after it. Taking them as two parameters rather
+ * than one `columns` array consumes the non-emptiness the caller has already
+ * proved, instead of re-checking it with a throw.
  */
 export function keyedExpectationFrom(
-  columns: readonly string[],
+  keyColumn: string,
+  measureColumns: readonly string[],
   rows: ReadonlyArray<Record<string, unknown>>,
-): Extract<MetricExpectation, { kind: "keyed" }> {
-  const [keyColumn, ...measureColumns] = columns;
-  if (keyColumn === undefined) {
-    throw new Error("keyedExpectationFrom: a keyed result needs at least one column");
-  }
-  const labels = rows.map((r) => String(r[keyColumn]));
-  const measureRows = rows.map((r) => {
-    const out: Record<string, unknown> = {};
-    for (const c of measureColumns) out[c] = r[c];
-    return out;
-  });
+): KeyedExpectation {
   return {
     kind: "keyed",
-    labels,
-    groupCount: new Set(labels.map(normalizeKey)).size,
-    measures: numericValues(measureRows),
+    groups: rows.map((r) => ({
+      label: cellLabel(r[keyColumn]),
+      // Reuses `numericValues`' row shape so Postgres `numeric`-as-a-string is
+      // parsed identically on both sides. The key column is never included,
+      // so a numeric `month` label is not a value the model must reproduce.
+      measures: numericValues([Object.fromEntries(measureColumns.map((c) => [c, r[c]]))]),
+    })),
   };
 }
 
@@ -1390,10 +1487,20 @@ export function keyedExpectationFrom(
  * entity's `query_patterns` drift apart, or a model starts inventing its own
  * vocabulary wholesale, the run says so instead of silently absorbing it.
  *
- * Returns `null` when there is nothing to report — a non-keyed or absent
- * expectation, a fail, a measure-less expectation (where labels ARE the
- * verdict, so a mismatch already failed), or a matching result that did carry
- * the labels.
+ * Returns `null` when there is nothing to report: a non-keyed or absent
+ * expectation, a `fail`, no matching result, or a matching result that did
+ * carry the labels.
+ *
+ * ⚠️ SUPPRESSED ON A FAIL, AND THE GUARD IS LOAD-BEARING FOR THREE BRANCHES,
+ * NOT ONE. {@link grade} can return `fail` with a substance-matching answer via
+ * `latency`, `protocol` (unparseable) and `protocol` (transport) — in all three
+ * the artifact already carries the expectation, and a "matched but relabelled"
+ * line beside a failure verdict reads as a second, contrary verdict.
+ *
+ * A MEASURE-LESS expectation needs no guard of its own: `keyedResultMatches` is
+ * then exactly `labelSetMatches`, so anything in `matching` necessarily
+ * satisfies the label suppression below. An explicit early return for it looked
+ * like a fourth case and was dead code — a mutation deleting it changed nothing.
  */
 function labelDriftNote(
   outcome: McpLlmOutcome,
@@ -1401,20 +1508,26 @@ function labelDriftNote(
 ): string | null {
   if (outcome.status !== "pass") return null;
   if (expectation === undefined || expectation.kind !== "keyed") return null;
-  if (expectation.measures.length === 0) return null;
 
-  const matching = outcome.toolCalls
-    .filter((c) => isAnsweringCall(c) && c.result.kind === "ok")
-    .map((c) => (c.result.kind === "ok" ? collectRows(c.result.data) : []))
-    .filter((rows) => rows.length > 0 && keyedResultMatches(rows, expectation));
+  const labels = authoritativeLabels(expectation);
+  const matching = outcome.toolCalls.flatMap((c) => {
+    if (!isAnsweringCall(c) || c.result.kind !== "ok") return [];
+    const rows = collectRows(c.result.data);
+    return rows.length > 0 && keyedResultMatches(rows, expectation) ? [rows] : [];
+  });
 
   if (matching.length === 0) return null;
-  if (matching.some((rows) => labelSetMatches(rows, expectation.labels))) return null;
+  if (matching.some((rows) => labelSetMatches(rows, labels))) return null;
 
+  // Printed VERBATIM, not from the normalized `labels` set — an operator greps
+  // the entity's `query_patterns` for this string.
+  const written = expectation.groups
+    .map((g) => (g.label === null ? "<null>" : g.label))
+    .join(", ");
   return (
     `${outcome.questionId}: grouped answer matched the authoritative measures and ` +
-    `${expectation.groupCount} group(s), but relabelled them — none of ` +
-    `[${expectation.labels.join(", ")}] appears in any result column. ` +
+    `${labels.size} group(s), but relabelled them — none of ` +
+    `[${written}] appears in any result column. ` +
     `Not a verdict: those are display labels from the authoritative SQL, not data.`
   );
 }
@@ -1441,9 +1554,24 @@ function expectationForQuestion(
       return undefined;
     default: {
       const _exhaustive: never = q;
-      throw new Error(`unreachable mode: ${String(_exhaustive)}`);
+      throw new Error(unreachableModeMessage(_exhaustive));
     }
   }
+}
+
+/**
+ * ⚠️ `String(question)` RENDERS `[object Object]` — no id, no mode, nothing to
+ * grep the corpus with, on a message whose whole job is to say which row of
+ * `questions.yml` is malformed. Both exhaustive guards in this file used that
+ * spelling; this is the one place that phrases it.
+ */
+function unreachableModeMessage(q: never): string {
+  const { id, mode } = q as { id?: unknown; mode?: unknown };
+  return (
+    `unreachable question mode ${JSON.stringify(mode)} on question ` +
+    `${JSON.stringify(id) ?? "<no id>"} — loadQuestions validates \`mode\` against ` +
+    `VALID_MODES, so reaching here means the corpus and this switch disagree.`
+  );
 }
 
 function gradeGlossary(

--- a/packages/cli/bin/canonical-eval-mcp-llm.ts
+++ b/packages/cli/bin/canonical-eval-mcp-llm.ts
@@ -181,31 +181,6 @@ export type McpLlmOutcome =
     };
 
 /**
- * Ground truth for one metric question, derived by EXECUTING the metric's own
- * authoritative SQL (`findMetricById(id).sql`) against the same datasource the
- * model queries — never hand-written.
- *
- * ⚠️ THIS REPLACES `expect.sql_pattern` MATCHING IN LLM METRIC MODE, AND THE
- * REASON IS THAT THE NEEDLES COULD NEVER FAIL WHERE THEY WERE WRITTEN (#5122).
- * `total_customers`' authoritative SQL is
- * `SELECT COUNT(DISTINCT id) AS total_customers FROM customers`, and its needle
- * is `["COUNT(DISTINCT id)", "FROM customers"]` — a verbatim substring of the
- * SQL the DETERMINISTIC eval executes, so there it matches by construction and
- * tests nothing. The LLM grader then reused the identical needle to judge SQL
- * the model wrote from scratch, which turns it into a spelling test:
- *
- *   cq-002  model ran `SELECT COUNT(*) FROM customers` — correct on a primary
- *           key, and marked wrong for not saying `COUNT(DISTINCT id)`.
- *   cq-003  model ran `AVG(total_cents / 100.0)` — the same metric in dollars,
- *           and marked wrong because the needle `AVG(total_cents)` carries the
- *           closing paren. cq-001 passed only because ITS conversion happened
- *           to land outside the parens.
- *
- * Comparing values instead grades whether the question was answered. It is also
- * strictly stronger: a spelling check passes canonical-looking SQL with a wrong
- * filter, and a value check does not.
- */
-/**
  * One group of the authoritative grouped result — its display label and the
  * numbers it computed, kept TOGETHER.
  *
@@ -232,9 +207,12 @@ export interface AuthoritativeGroup {
    */
   readonly label: string | null;
   /**
-   * The numeric cells this group's row produced OUTSIDE the key column — the
-   * measures, never the grouping key (excluded even when the key is itself
-   * numeric, as `month` is).
+   * The numeric cells this group's row produced OUTSIDE the key column.
+   *
+   * The key is excluded STRUCTURALLY rather than by type, so a numeric grouping
+   * key could never become a value the model must reproduce — though no corpus
+   * key is numeric today: every `month` grouping is
+   * `TO_CHAR(created_at, 'YYYY-MM')`, which is a string.
    */
   readonly measures: readonly number[];
 }
@@ -256,7 +234,9 @@ export interface AuthoritativeGroup {
  * identical categorisation, filter and measures but wrote `'With Promotion'`
  * was graded wrong. Nobody chose to make display text load-bearing — ground
  * truth was harvested from the first column because that is what came back
- * first, and the first column of a grouped query is a presentation column.
+ * first, and the first column of a grouped query is USUALLY a presentation
+ * column. The exception — a `SELECT DISTINCT status` shape, where it is the data
+ * — is what {@link keyedResultMatches}' measure-less branch exists for.
  *
  * So the labels stay, DIAGNOSTIC ONLY (see {@link labelDriftNote}), and the
  * verdict keys on what a relabel cannot touch.
@@ -270,6 +250,31 @@ export interface KeyedExpectation {
   readonly groups: readonly AuthoritativeGroup[];
 }
 
+/**
+ * Ground truth for one metric question, derived by EXECUTING the metric's own
+ * authoritative SQL (`findMetricById(id).sql`) against the same datasource the
+ * model queries — never hand-written.
+ *
+ * ⚠️ THIS REPLACES `expect.sql_pattern` MATCHING IN LLM METRIC MODE, AND THE
+ * REASON IS THAT THE NEEDLES COULD NEVER FAIL WHERE THEY WERE WRITTEN (#5122).
+ * `total_customers`' authoritative SQL is
+ * `SELECT COUNT(DISTINCT id) AS total_customers FROM customers`, and its needle
+ * is `["COUNT(DISTINCT id)", "FROM customers"]` — a verbatim substring of the
+ * SQL the DETERMINISTIC eval executes, so there it matches by construction and
+ * tests nothing. The LLM grader then reused the identical needle to judge SQL
+ * the model wrote from scratch, which turns it into a spelling test:
+ *
+ *   cq-002  model ran `SELECT COUNT(*) FROM customers` — correct on a primary
+ *           key, and marked wrong for not saying `COUNT(DISTINCT id)`.
+ *   cq-003  model ran `AVG(total_cents / 100.0)` — the same metric in dollars,
+ *           and marked wrong because the needle `AVG(total_cents)` carries the
+ *           closing paren. cq-001 passed only because ITS conversion happened
+ *           to land outside the parens.
+ *
+ * Comparing values instead grades whether the question was answered. It is also
+ * strictly stronger: a spelling check passes canonical-looking SQL with a wrong
+ * filter, and a value check does not.
+ */
 export type MetricExpectation =
   /** Single-row, single-number metric — compare the number. */
   | { readonly kind: "scalar"; readonly value: number }
@@ -296,7 +301,16 @@ export interface McpLlmEvalOptions {
    * ⚠️ ADDITIVE, unlike metric mode. Here the value check is an EXTRA accept
    * path layered over the existing `sql_pattern` / structural checks rather
    * than a replacement, so it can only ever turn a false negative into a pass —
-   * it cannot introduce one. Metric mode could be replaced outright because its
+   * it cannot introduce one.
+   *
+   * ⚠️ ONE CARVE-OUT, ADDED WITH #5128: `keyedResultMatches` THROWS on ground
+   * truth that cannot adjudicate anything (no groups, or every key NULL), and
+   * that throw reaches this lane through `matchesAnyAnsweringResult`, aborting
+   * the run. That is not a false negative — no question is graded wrong — but it
+   * is a way this path can now end a run, where before it could only decline to
+   * help. The harvester's own failures stay non-fatal (`resolveExpectations`
+   * catches, prints a `note:`, and disables the accept path for that question),
+   * so this is reachable only from a caller-supplied expectation. Metric mode could be replaced outright because its
    * needles were provably vacuous where they were authored; the pattern needles
    * are not obviously so, and widening was the change that could be made
    * without a second round of measurement to justify it.
@@ -444,8 +458,11 @@ export async function runMcpLlmEval(
         // ⚠️ WRAPPED BECAUSE THE ONLY `return` IS AFTER THIS LOOP. A throw here
         // unwinds past every outcome accumulated so far, so a reporting fault
         // would cost a 20-question paid run its entire score and surface as a
-        // harness stack instead of a grade. Nothing on this path throws today;
-        // that is exactly why the assertion is enforced rather than trusted.
+        // harness stack instead of a grade. `keyedResultMatches` DOES throw —
+        // on ground truth that cannot adjudicate anything — and reaches here via
+        // `labelDriftNote`; it survives today only because `canonical-eval-run`
+        // rejects a zero-row harvest upstream. The invariant is enforced rather
+        // than trusted precisely because that guard is two files away.
         try {
           const drift = labelDriftNote(
             outcome,
@@ -1131,10 +1148,17 @@ function gradeMetric(
           ? "no expectation resolved"
           : expectation.kind === "scalar"
             ? `scalar ${expectation.value}`
-            : `${expectation.groups.length} group(s), each needing one of its own measures ` +
+            : // ⚠️ `authoritativeLabels(...).size`, NOT `groups.length` — those
+              // diverge whenever two rows normalize to one label or a key is
+              // NULL, and printing the row count tells an operator the grader
+              // wanted a cardinality it never asked for. Both conditions are
+              // named because condition 2 is what fails the realistic shapes.
+              `${expectation.groups.length} authoritative row(s), each needing one of its own ` +
+              `measures, AND some column carrying exactly ` +
+              `${authoritativeLabels(expectation).size} distinct value(s) ` +
               `— ${expectation.groups
-                .map((g) => `${g.label ?? "<null>"}: [${g.measures.join(", ")}]`)
-                .join(" · ")} — labels are NOT compared`
+                .map((g) => `${displayLabel(g)}: [${g.measures.join(", ")}]`)
+                .join(" · ")} — labels themselves are NOT compared`
       })`,
   });
 }
@@ -1192,7 +1216,9 @@ function numericValues(rows: ReadonlyArray<Record<string, unknown>>): number[] {
 }
 
 /**
- * Unit scalings accepted when comparing a scalar.
+ * Unit scalings accepted when comparing a scalar — and, since #5128, each
+ * group's measures on the keyed path ({@link keyedResultMatches}). Widening this
+ * constant now moves both.
  *
  * The demo layer stores money in CENTS and several metrics divide by 100 to
  * present dollars, so cents-vs-dollars is a presentation choice the model makes
@@ -1271,8 +1297,10 @@ function resultMatchesExpectation(data: unknown, expectation: MetricExpectation)
  *  1. **every authoritative GROUP is represented** — for each group, at least
  *     one of the numbers it computed has an approximate match among the
  *     observed numbers, modulo {@link UNIT_SCALINGS}. Subset, not equality; and
- *  2. **some** column's distinct-value count equals the authoritative group
- *     count. Per-column and distinct, so extra breakdown rows don't move it.
+ *  2. **some** column's distinct-value count equals the number of DISTINCT
+ *     NON-NULL authoritative labels — {@link authoritativeLabels}, **not**
+ *     `groups.length`. Per-column and distinct, so extra breakdown rows on an
+ *     existing group don't move it.
  *
  * ⚠️ CONDITION 1 IS PER GROUP, NOT PER CELL, AND THE DIFFERENCE IS INSTANCE #4
  * OF THIS ISSUE'S OWN TABLE. The obvious spelling — *every authoritative
@@ -1297,38 +1325,68 @@ function resultMatchesExpectation(data: unknown, expectation: MetricExpectation)
  * of 2 a stray boolean-ish column satisfies it for free, and at a group count
  * of 1 any constant column does. It is a shape guard against an answer with the
  * right numbers and no grouping at all, not a second correctness check;
- * condition 1 does the grading. `keyed comparison … > a bystander column can
- * satisfy the shape check` pins the honest behaviour rather than a hoped-for one.
+ * condition 1 does the grading. The bystander-column test in
+ * `canonical-eval-mcp-llm.test.ts` pins that honest behaviour rather than a
+ * hoped-for one.
  *
- * ⚠️ KNOWN LIMITS, ALL OF THEM CONDITION 2, AND NONE OF THEM NEW. Condition 2
- * wants the observed result to split into the authoritative number of groups,
- * so it fails four correct-but-differently-shaped answers:
+ * ⚠️ CONDITION 1 HAS ITS OWN WEAKNESS, AND IT IS A FALSE **POSITIVE** — the one
+ * direction this issue was not about. The observed numbers are one flat pool,
+ * searched independently and without consumption, widened ×3 by
+ * {@link UNIT_SCALINGS}. So N groups sharing a value are all satisfied by one
+ * occurrence of it. `top_customers_by_spend` groups on `full_name` with
+ * `order_count` among its measures — small integers that repeat across
+ * customers — so an answer listing the top 20 by ORDER COUNT (different
+ * customers entirely) can satisfy all 20 groups, while its own name column
+ * supplies condition 2. **The old label-set rule caught that** and this one
+ * need not. Tracked in #5143; not fixed here because a multiset/consume-on-match
+ * rule is new grading machinery arriving with no round left to review it.
+ *
+ * ⚠️ KNOWN LIMITS, ALL SHAPE-RELATED, NONE OF THEM NEW. Four
+ * correct-but-differently-shaped answers fail:
  *
  *   pivoted     one row of `COUNT(*) FILTER (WHERE …) AS with_promo, …` — no
  *               column of a single row has two distinct values
  *   top-N       `top_customers_by_spend` ends `LIMIT 20`, so a model that lists
- *               its top 10 is short 10 groups. The only LIMIT in the corpus
+ *               its top 10 is short 10 groups on condition 2 — AND on condition
+ *               1, unless the omitted customers' `order_count`s collide with a
+ *               listed one's. The only `LIMIT` among the statements
+ *               `resolveExpectations` executes; four entity `query_patterns`
+ *               carry one too, but no question reaches them
  *   rollup      an appended `Total` row makes the key column N+1 distinct
  *   COALESCE    `COALESCE(channel, 'unknown')` renders a NULL group as a value,
  *               so the observed count is N where the authoritative is N−1
  *
- * ⚠️ EACH OF THESE FAILED UNDER THE RULE THIS ONE REPLACES TOO, and that is the
- * claim to check before "fixing" one. The old rule was set EQUALITY on labels,
- * which implies equality of cardinality — so every row above was a `FAIL` on
- * both sides of this change. This comparison is stricter on VALUES and looser
- * on LABELS than its predecessor; on cardinality it is neither.
+ * Three are condition 2 alone; top-N is both, which matters because fixing
+ * condition 2 in #5143 would NOT unblock it.
  *
- * They are not fixed here because the fix needs to know WHICH observed column
+ * ⚠️ EACH OF THESE FAILED UNDER THE RULE THIS ONE REPLACES TOO — verified row by
+ * row against `origin/main`, and the claim to re-check before "fixing" one. The
+ * old rule was set equality on labels, i.e. cardinality **and** membership:
+ * pivoted, top-N and rollup failed it on cardinality, and COALESCE failed it on
+ * membership (`{…, "null"}` vs `{…, unknown}` — same size, different members).
+ *
+ * So against its predecessor this comparison is stricter on VALUES and looser on
+ * LABELS. On cardinality it is **almost** identical: the one flip is that NULL
+ * labels no longer count toward the target, which is what lets a byte-identical
+ * answer to a NULL-grouped question pass — pinned by *passes an identical answer
+ * when the authoritative grouping has a NULL key*.
+ *
+ * The four are not fixed here because the fix needs to know WHICH observed column
  * is the grouping key, and guessing that from the result's presentation is the
- * class of move #5128 exists to stop making. Tracked in #5143, together with
- * condition 2's opposite weakness — a bystander column with the right distinct
- * count satisfies it for free. The honest behaviour on both sides is pinned by
- * tests rather than described and hoped for.
+ * class of move #5128 exists to stop making. Tracked in #5143 together with
+ * condition 2's opposite weakness; the honest behaviour on both sides is pinned
+ * by tests.
  *
- * Throws rather than returning `false` on an empty `groups` — that means ground
- * truth was never established, and charging it to the model would print a
+ * Throws rather than returning `false` on ground truth that cannot adjudicate
+ * anything — empty `groups`, or every grouping key NULL. That means ground truth
+ * was never established, and charging it to the model would print a
  * `tool_selection` artifact blaming the model for a harness fault. Same
  * disposition as {@link gradeMetric}'s missing-expectation throw.
+ *
+ * ⚠️ REACHED ONLY WHEN THE MODEL RETURNED ROWS. {@link resultMatchesExpectation}
+ * short-circuits an empty result to `false` before calling here, so a harness
+ * fault paired with a model that answered nothing still reads as the model's
+ * failure. Narrow, and stated rather than implied.
  */
 function keyedResultMatches(
   rows: ReadonlyArray<Record<string, unknown>>,
@@ -1343,6 +1401,25 @@ function keyedResultMatches(
   }
 
   const labels = authoritativeLabels(expectation);
+
+  // ⚠️ EVERY GROUPING KEY WAS NULL, so there is no cardinality to compare
+  // against and no label to compare either. That is a harness fault — an
+  // all-NULL `GROUP BY` key, or a `CASE`/`NULLIF` that folded every row — and it
+  // gets the same disposition as empty ground truth above.
+  //
+  // An earlier cut returned `true` here so that condition 1 could stand alone.
+  // That was the unsafe direction twice over: it passes the ungrouped answer
+  // condition 2 exists to reject, and it DISAGREED with `labelSetMatches`, which
+  // returns `false` on the identical predicate — so which way a degenerate
+  // expectation went was decided by whether any measure happened to parse.
+  if (labels.size === 0) {
+    throw new Error(
+      "[harness] every authoritative grouping key is NULL, so the grouping " +
+        "cardinality cannot be established and no answer can be adjudicated on " +
+        "shape. Check the key column in the authoritative SQL — an all-NULL " +
+        "GROUP BY key, or a CASE/NULLIF that folded every row.",
+    );
+  }
 
   // No numeric measures anywhere — a `SELECT DISTINCT status`-shaped result. The
   // key column is then the DATA rather than a display label, and cardinality
@@ -1367,11 +1444,6 @@ function keyedResultMatches(
   );
   if (!everyGroupRepresented) return false;
 
-  // Every authoritative label was NULL, so there is no cardinality to check
-  // against — `columnValueSets` cannot produce a nullish value on the observed
-  // side either. Condition 1 stands alone rather than failing by default.
-  if (labels.size === 0) return true;
-
   for (const set of columnValueSets(rows).values()) {
     if (set.size === labels.size) return true;
   }
@@ -1388,7 +1460,15 @@ function keyedResultMatches(
  */
 function authoritativeLabels(expectation: KeyedExpectation): ReadonlySet<string> {
   const out = new Set<string>();
-  for (const g of expectation.groups) if (g.label !== null) out.add(normalizeKey(g.label));
+  // `cellKey`, not `normalizeKey` — the observed side reduces through `cellKey`,
+  // and calling the same function is a guarantee where calling an equivalent one
+  // is only a proof. `cellLabel` is the identity on strings TODAY; if it ever
+  // grows a rule (NFC folding, truncation) this line would silently reopen the
+  // two-spellings defect it was written to close.
+  for (const g of expectation.groups) {
+    const key = cellKey(g.label);
+    if (key !== null) out.add(key);
+  }
   return out;
 }
 
@@ -1416,7 +1496,7 @@ function labelSetMatches(
   return false;
 }
 
-/** `columnName → set of its {@link cellKey}s. Nullish cells are not values. */
+/** `columnName` → set of its {@link cellKey}s. Nullish cells are not values. */
 function columnValueSets(
   rows: ReadonlyArray<Record<string, unknown>>,
 ): Map<string, Set<string>> {
@@ -1440,11 +1520,17 @@ function columnValueSets(
  * The ONE "is this cell a group at all, and what does it read as" rule, called
  * from both sides of the comparison.
  *
- * ⚠️ TWO SPELLINGS OF THIS IS A FALSE NEGATIVE, MEASURED. The harvester used to
- * do `String(cell)` while the observed side skipped nullish cells, so a NULL
- * group harvested as the label `"null"` and counted toward a cardinality no
- * observed result could ever reach — a model returning the byte-identical
- * authoritative rows graded FAIL. One function, both callers.
+ * ⚠️ TWO SPELLINGS OF THIS IS A FALSE NEGATIVE. `origin/main` harvested with
+ * `String(cell)` while the observed side skipped nullish cells, so a NULL group
+ * harvested as the label `"null"` and counted toward a cardinality no observed
+ * result could ever reach — a model returning the byte-identical authoritative
+ * rows would have graded FAIL. One function, both callers.
+ *
+ * LATENT, NOT OBSERVED, and worth the distinction: no corpus grouping key is
+ * nullable today — `acquisition_source` is populated for every seeded row, and
+ * every other keyed question groups on a `CASE`, a `TO_CHAR`, a join key or
+ * `full_name` — so this never fired in a paid run. Found in review, pinned by a
+ * test, not measured on a score.
  *
  * Returns the cell VERBATIM rather than normalized: {@link labelDriftNote}
  * prints these back to an operator, and `with promo` is harder to find in a
@@ -1453,6 +1539,11 @@ function columnValueSets(
  */
 function cellLabel(cell: unknown): string | null {
   return cell === null || cell === undefined ? null : String(cell);
+}
+
+/** How a group's label reads in operator-facing text. Spelled once, not twice. */
+function displayLabel(g: AuthoritativeGroup): string {
+  return g.label === null ? "<null>" : g.label;
 }
 
 /** `cellLabel` + case/whitespace folding — the form the two sides compare in. */
@@ -1540,9 +1631,7 @@ function labelDriftNote(
 
   // Printed VERBATIM, not from the normalized `labels` set — an operator greps
   // the entity's `query_patterns` for this string.
-  const written = expectation.groups
-    .map((g) => (g.label === null ? "<null>" : g.label))
-    .join(", ");
+  const written = expectation.groups.map(displayLabel).join(", ");
   return (
     `${outcome.questionId}: grouped answer matched the authoritative measures and ` +
     `${labels.size} group(s), but relabelled them — none of ` +
@@ -1581,14 +1670,23 @@ function expectationForQuestion(
 /**
  * ⚠️ `String(question)` RENDERS `[object Object]` — no id, no mode, nothing to
  * grep the corpus with, on a message whose whole job is to say which row of
- * `questions.yml` is malformed. Both exhaustive guards in this file used that
- * spelling; this is the one place that phrases it.
+ * `questions.yml` is malformed. The one pre-existing guard (`gradeByMode`) used
+ * that spelling and the new `expectationForQuestion` guard would have copied it;
+ * this is the one place that phrases it.
  */
 function unreachableModeMessage(q: never): string {
-  const { id, mode } = q as { id?: unknown; mode?: unknown };
+  // No cast: `never` is assignable to every type, so the annotation alone reads
+  // the fields. `JSON.stringify(x) ?? fallback` would look dead to a reader —
+  // `lib.d.ts` types the return as `string` — while firing at runtime, because
+  // `JSON.stringify(undefined)` really is `undefined`. Spelled as a ternary so
+  // the live branch is visible, and applied to BOTH fields: an absent `mode` is
+  // as likely as an absent id in a malformed corpus row.
+  const { id, mode }: { id?: unknown; mode?: unknown } = q;
+  const show = (v: unknown, absent: string) =>
+    v === undefined ? absent : JSON.stringify(v);
   return (
-    `unreachable question mode ${JSON.stringify(mode)} on question ` +
-    `${JSON.stringify(id) ?? "<no id>"} — loadQuestions validates \`mode\` against ` +
+    `unreachable question mode ${show(mode, "<no mode>")} on question ` +
+    `${show(id, "<no id>")} — loadQuestions validates \`mode\` against ` +
     `VALID_MODES, so reaching here means the corpus and this switch disagree.`
   );
 }

--- a/packages/cli/bin/canonical-eval-run.ts
+++ b/packages/cli/bin/canonical-eval-run.ts
@@ -990,17 +990,11 @@ async function resolveExpectations(questionsPath: string): Promise<{
           `keyed result. Ground truth must be one or the other for the answer comparison to mean anything.`,
       );
     }
-    // ⚠️ HARVESTED BY THE COMPARISON'S OWN FACTORY, NOT BY HAND HERE (#5128).
-    // The old line was `keys: rows.map(r => String(r[firstColumn]))` — ground
-    // truth read straight off a DISPLAY column, which is how a hand-written
-    // `CASE … THEN 'With Promo'` became load-bearing for a correctness check
-    // that has nothing to do with labels. `keyedExpectationFrom` takes each
-    // group's measures too, and lives next to the code that compares them so
-    // the two cannot drift apart again.
-    //
-    // `firstColumn` is passed as its own argument because the guard above has
-    // already proved it non-undefined; the factory consumes that proof rather
-    // than re-checking it.
+    // ⚠️ HARVESTED BY THE COMPARISON'S OWN FACTORY, NOT BY HAND HERE (#5128) —
+    // see `MetricExpectation` for why reading ground truth off a display column
+    // was the defect. `firstColumn` is passed separately because the guard above
+    // has already proved it non-undefined; the factory consumes that proof
+    // rather than re-checking it.
     return keyedExpectationFrom(firstColumn, columns.slice(1), rows);
   }
 

--- a/packages/cli/bin/canonical-eval-run.ts
+++ b/packages/cli/bin/canonical-eval-run.ts
@@ -937,9 +937,15 @@ async function runMcpLlmMode(
  * check vacuous and the LLM eval's check a spelling test (#5122).
  *
  * Shape classification is structural, not configured: a 1×1 numeric result is a
- * scalar metric; anything else is a grouped metric keyed on the FIRST column,
- * which is the grouping key by convention across the corpus (`channel`,
- * `carrier`, `stock_status`, `month`).
+ * scalar metric; anything else is a grouped result whose FIRST column is the
+ * grouping key by convention across the corpus (`channel`, `carrier`,
+ * `stock_status`, `month`) and whose remaining columns are its measures.
+ *
+ * ⚠️ THE FIRST COLUMN IS A LABEL, NOT GROUND TRUTH (#5128). It used to be the
+ * whole of a grouped expectation, which made a hand-written
+ * `CASE … THEN 'With Promo'` load-bearing for a correctness check. The reduction
+ * now happens in `keyedExpectationFrom`, next to the comparison that consumes
+ * it, and takes the measures as well — see {@link MetricExpectation}.
  *
  * A metric that cannot be resolved or executed THROWS. A missing expectation
  * would otherwise silently downgrade that question's grading, and a gate that
@@ -951,6 +957,11 @@ async function resolveExpectations(questionsPath: string): Promise<{
 }> {
   const lookups = await import("@atlas/api/lib/semantic/lookups");
   const { connections } = await import("@atlas/api/lib/db/connection");
+  // Dynamic, like its siblings above: this module's top-level import of
+  // `canonical-eval-mcp-llm` is deliberately TYPE-ONLY so `--help` / `--llm`
+  // never pull the MCP eval graph. Only `--mcp-llm` reaches here, and it has
+  // already imported the module, so this resolves from cache.
+  const { keyedExpectationFrom } = await import("./canonical-eval-mcp-llm");
 
   /** Execute one authoritative statement and reduce it to an expectation. */
   async function expectationFor(label: string, sql: string): Promise<MetricExpectation> {
@@ -979,7 +990,14 @@ async function resolveExpectations(questionsPath: string): Promise<{
           `keyed result. Ground truth must be one or the other for the answer comparison to mean anything.`,
       );
     }
-    return { kind: "keyed", keys: rows.map((r) => String(r[firstColumn])) };
+    // ⚠️ HARVESTED BY THE COMPARISON'S OWN FACTORY, NOT BY HAND HERE (#5128).
+    // The old line was `keys: rows.map(r => String(r[firstColumn]))` — ground
+    // truth read straight off a DISPLAY column, which is how a hand-written
+    // `CASE … THEN 'With Promo'` became load-bearing for a correctness check
+    // that has nothing to do with labels. `keyedExpectationFrom` takes the
+    // measures too, and lives next to the code that compares them so the two
+    // cannot drift apart again.
+    return keyedExpectationFrom(columns, rows);
   }
 
   const questions = loadQuestions(questionsPath);

--- a/packages/cli/bin/canonical-eval-run.ts
+++ b/packages/cli/bin/canonical-eval-run.ts
@@ -994,10 +994,14 @@ async function resolveExpectations(questionsPath: string): Promise<{
     // The old line was `keys: rows.map(r => String(r[firstColumn]))` — ground
     // truth read straight off a DISPLAY column, which is how a hand-written
     // `CASE … THEN 'With Promo'` became load-bearing for a correctness check
-    // that has nothing to do with labels. `keyedExpectationFrom` takes the
-    // measures too, and lives next to the code that compares them so the two
-    // cannot drift apart again.
-    return keyedExpectationFrom(columns, rows);
+    // that has nothing to do with labels. `keyedExpectationFrom` takes each
+    // group's measures too, and lives next to the code that compares them so
+    // the two cannot drift apart again.
+    //
+    // `firstColumn` is passed as its own argument because the guard above has
+    // already proved it non-undefined; the factory consumes that proof rather
+    // than re-checking it.
+    return keyedExpectationFrom(firstColumn, columns.slice(1), rows);
   }
 
   const questions = loadQuestions(questionsPath);


### PR DESCRIPTION
Closes #5128.

cq-016 was the last failing question in the LLM eval and it failed on **display text**. The `orders_with_promotions` pattern labels its groups with a hand-written `CASE … THEN 'With Promo'`; the model wrote `'With Promotion'`, computed the same categorisation (`promotion_id IS NOT NULL`), the same filter and the same measures, and added a per-promotion-type breakdown on top.

The keyed comparison matched on the **set of group-key strings**, so a human-authored label was load-bearing for a correctness check that has nothing to do with labels.

## The counter-reading is rejected — this is a comparison change

The issue records a defensible counter-reading: the question names a `query_pattern` and the model wrote its own SQL, so failing it may be correct. Rejected in triage, and I agree with the reasoning:

1. **"Used the pattern" is not observable.** No tool dispatches a named `query_pattern`; the only trace is SQL-text similarity, which is **instance #1 in this issue's own table** and which #5122 removed.
2. **Metric mode can assert dispatch because dispatch exists; pattern mode cannot.** The grader's asymmetry should follow the semantic layer's.
3. **The label coupling was an artifact of harvesting** — the first column of a grouped query is usually a presentation column.

## The fix

`MetricExpectation`'s keyed arm is now `KeyedExpectation { groups: { label: string | null; measures: number[] }[] }` — one record per authoritative group, so a label and its measures cannot desync, and the cardinality is **derived** rather than stored beside the thing it counts.

A grouped result matches when:

1. **every authoritative GROUP is represented** — for each group, at least one of *its own* numbers has an approximate match among the observed numbers, modulo the existing `UNIT_SCALINGS` and `approximatelyEqual`; **and**
2. **some** column's distinct-value count equals the number of distinct non-null authoritative labels.

Labels are kept and still do two jobs: `labelDriftNote` reports a relabel as a stderr `note:` **after** the verdict, and they remain the comparison when the authoritative result has no numeric measures (a `SELECT DISTINCT`-shaped truth, where the key column *is* the data).

### ⚠️ Condition 1 is per GROUP, not per cell — and that difference is instance #4, caught in review

The first cut required every authoritative measure **cell** to appear. Review found that flips **currently-passing** questions to fail, because the corpus's metrics publish auxiliary columns no natural answer includes:

| metric | publishes | the question asks for |
|---|---|---|
| `revenue_by_category` | revenue, order_count, units_sold | revenue (cq-004) |
| `monthly_gmv_trend` | order_count, gmv, aov | GMV (cq-009) |
| `customers_by_acquisition_source` | customer_count, active_count, active_pct | customer_count |

A model answering "revenue by category" with `SELECT category, SUM(revenue)` **has answered the question**. Failing it for omitting `units_sold` is the same "rejected a correct answer over presentation" mistake as the three before it, reintroduced as an *exhaustiveness* difference. Verified against the YAML, not assumed.

### Behaviour delta vs the rule this replaces

| input class | old (label set) | per-cell (rejected) | **shipped (per-group)** |
|---|---|---|---|
| relabelled groups, same numbers | FAIL | pass | **pass** ← the issue |
| richer than ground truth | FAIL | pass | **pass** |
| one measure per group, rest omitted | pass | FAIL | **pass** ← instance #4 |
| dropped filter, labels match exactly | pass | FAIL | **FAIL** |
| one whole group unrepresented | FAIL | FAIL | **FAIL** |
| wrong grouping, superset of numbers | FAIL | FAIL | **FAIL** |

Stricter on **values**, looser on **labels**. On cardinality it is almost identical — the one flip is that NULL labels no longer count toward the target.

## Falsifiers — 22 mutations, all killed

Applied one at a time, reverted from a file copy. Every condition, guard and diagnostic has a killer:

| mutation | dies on |
|---|---|
| per-group rule disabled | dropped filter · unrepresented group · missing group · 1000× · drift-note-no-match |
| within a group, ALL measures required (**the rejected per-cell rule**) | one-measure-per-group |
| only SOME group need be represented | unrepresented group · missing group |
| cardinality disabled / **row count** instead of distinct labels | wrong grouping · distinct-label pin · COALESCE |
| **old label-set rule restored** (the defect) | 9 tests |
| measure-less fallback removed / superset allowed | measure-less LABELS · superset |
| `UNIT_SCALINGS` dropped / widened to 1000× | dollars-vs-cents · 1000× negative |
| NULL stringified / NULL counted / labels not normalized | 3 NULL tests · distinct-label pin |
| empty-truth throw removed / all-NULL throw removed / all-NULL returns true | the two harness-fault tests |
| grouping key harvested as a measure | factory test |
| drift note: suppression / pass-guard / no-match guard / prints observed labels | 4 drift tests |
| metric questions routed to `answerExpectations` | metric-mode gate test |

## Review panel — stopped on the RATIO rule, not the cap

**Round 1: ~26 findings, all new surface.** Two HIGH were load-bearing:
- **the per-cell rule regresses cq-004/cq-009** (above) — this is the round that saved the PR from being instance #4;
- **NULL grouping keys** harvested as the string `"null"` counted toward a cardinality the observed side can never produce, so a byte-identical answer graded FAIL.

**Round 2: ~26 findings — ~8 new surface, ~18 defect-in-prior-fix.** Defect-in-prior-fix **exceeded** new surface, so the rounds stopped that round rather than at the 3-round cap. The rise was concentrated in one place, and it is the honest lesson here: **round 1 added a lot of confident prose, and the comment sweep found seven claims in it that were false or overstated.** A diff whose entire argument is "this reasoning can be trusted" cannot ship prose nobody checked.

All of round 2's confirmed findings are fixed. What they were:
- `labels.size === 0` (every key NULL) returned **true** so condition 1 could stand alone — unsafe twice over: it passes the ungrouped answer condition 2 exists to reject, **and** it disagreed with `labelSetMatches`, which returns `false` on the identical predicate. Which way a degenerate expectation went was decided by whether a measure happened to parse. Now throws, like empty ground truth.
- `authoritativeLabels` called `normalizeKey` where the observed side calls `cellKey` — the one site that opted out of the two-spellings fix's own rule.
- The failure artifact printed `groups.length` while the check enforces the distinct label count. Those diverge in exactly the two cases round 1 introduced.
- `toContain("With Promo")` is a **prefix** of the model's own `"With Promotion"`, so it passed against a mutant that printed the observed labels back. Asserts the whole bracketed list now.
- A test comment stated two mutation results that were both **green** when actually run — a bystander `skus` column satisfies either mutant.
- Seven false/overstated source claims, each re-verified: *"on cardinality it is neither"* (falsified by this PR's own NULL test), *"all of them condition 2"* (top-N fails both), the COALESCE mechanism (membership, not cardinality), *"as `month` is"* (no corpus key is numeric), *"MEASURED"/"LIVE"* on a defect that was latent, *"both exhaustive guards"* (one), *"the only LIMIT in the corpus"*.
- The `#5122` rationale docblock was orphaned by round 1's insertion, leaving `MetricExpectation` undocumented. Moved back.

`fix-vs-finding` returned **REPRODUCED** once and **CLEAN** once. The REPRODUCED was adjudicated rather than accepted: it named top-N / rollup / COALESCE as correct answers the new rule rejects, measured against an *ideal* rule. Against the rule this PR **replaces** — set equality on labels, which implies equality of cardinality — all three failed identically. Verified row by row and recorded in the docstring.

## ⚠️ Residue — consciously deferred to #5143

- **Condition 1 can pass a wrong answer the OLD rule caught.** The observed numbers are one flat pool, searched without consumption: `top_customers_by_spend`'s `order_count` values repeat across customers, so an answer listing the top 20 *by order count* — different customers — can satisfy all 20 groups. A multiset/consume-on-match rule fixes it and is new grading machinery arriving with no round left to review it. **This is a false positive, the direction #5128 was not about, and it is named in the docstring rather than left implied.**
- **`measures.length === 0` is still a value-time discriminator** — it cannot tell "key-only by design" from "the measures failed to parse". Needs a structural `keyOnly` field. Latent: every grouped metric in the seed publishes an always-numeric measure.
- **`collectRows` merges a `query` answer's sub-results** into one numeric pool, so a scratch query's numbers can satisfy groups the answer got wrong. Pre-existing; this PR raised the stakes.
- **`resolveExpectations` has no test at all** — passing `columns` instead of `columns.slice(1)` survives the whole suite, and that is the harvest/comparison seam #5128 came from.

Two known limits are pinned by tests that assert the *honest* verdict (`⚠️ a BYSTANDER column satisfies the shape check`, `⚠️ a COALESCE-rendered NULL group still fails`), so a future fix has to invert a named assertion deliberately rather than silently.

## ✅ Verified on a real-model run — and the evidence is the drift note

`eval-llm.yml`'s `pull_request` trigger lists both files this PR touches, so the **paid gateway lane fired automatically** — four runs on this branch, `provider=gateway model=anthropic/claude-haiku-4.5`, gateway key preflight OK.

**The decisive artifact is from the run at `7f0c7b17c`,** where the model produced the reproducing shape: labels `'With Promotion'` / `'No Promotion'`, plus extra `pct_of_orders`, `min`, `max`, `stddev` columns. cq-016 **passed**, and the run log carries:

```
note: cq-016: grouped answer matched the authoritative measures and 2 group(s),
but relabelled them — none of [No Promo, With Promo] appears in any result column.
Not a verdict: those are display labels from the authoritative SQL, not data.
```

That note is only emitted when `keyedResultMatches` returns **true** *and* the result carries none of the authoritative labels — so it is direct evidence, on real model output, that:

- the comparison accepts a **relabelled** grouped answer (the old label-set rule returns `false` on exactly this input — none of its labels appear);
- it accepts one that is **richer** than ground truth;
- the label mismatch is **reported without gating the verdict** — the note sits beside a `pass`.

⚠️ **One honest qualification.** That particular SQL also satisfies both `sql_pattern` needles, so the *verdict* is not solely attributable to this change — `gradePattern` layers the value check over the substring check. What the note proves is that the **comparison itself** did the right thing on the real reproducing data, which is what the criterion is about. In the final run at `2c3b526e2` the model wrote the pattern's SQL verbatim, labels included, so no note fired — correct suppression, on real output, in the same lane.

**Scores across the branch: 19 / 19 / 18 / 19 of 20**, all at or above the acceptance floor of 18. The failing questions were **cq-013** (a glossary question — *"never called searchGlossary"*, a different grader entirely) and **cq-001** (a scalar metric). Neither touches the keyed comparison, and #5127 already recorded cq-001, cq-016 and cq-019 as flipping between runs on the same corpus and model. **No question regressed on any of the four SHAs.**

Acceptance criteria:
- [x] cq-016 passes when the model relabels the groups but computes the same split — proven by the note above
- [x] cq-016 still passes when the answer is **richer** than ground truth — same run, extra columns
- [x] A wrong grouping or a dropped filter still fails, with tests that go red against the fix — 22 mutations, all killed
- [x] A label mismatch is still reported as a note, without gating the verdict — quoted above, from CI
- [x] Verified on a real-model run, not only unit tests

## Scope note

`McpLlmOutcome` and `McpLlmEvalResult` are untouched — #5123 reshapes both and is held to land after this. That is why the drift note goes to stderr rather than into the outcome. `MetricExpectation` **is** reshaped, which the issue's Agent Brief explicitly puts in scope.

## Verification

- `packages/cli` full isolated suite: **50/50 files**, `canonical-eval-mcp-llm.test.ts` **110/110**.
- `bun run type` clean across the monorepo; `bun run lint` clean.
- 22 mutations applied and reverted; tree verified byte-identical to the pristine copy afterwards (one SIGPIPE'd run did leave a mutant, caught by the isolated runner before commit).
