### PR TITLE
fix(eval): make stdout under `--json` carry the JSON payload and nothing else

### DIFF
--- a/.github/workflows/eval-llm.yml
+++ b/.github/workflows/eval-llm.yml
@@ -315,6 +315,40 @@ jobs:
           set -o pipefail
           bun packages/cli/bin/atlas.ts canonical-eval --mcp-llm --json | tee eval-mcp-llm-output.json
 
+      - name: Assert the eval artifact is valid JSON
+        # ⚠️ THE ONLY CHECK THAT CAN SEE A WRITER WE DO NOT OWN. Everything else
+        # guarding fd 1 for this command is a unit test or a source grep over
+        # OUR modules — and #5126's third polluter was already one file further
+        # out than the fix's author looked. The `--json` process also pulls in
+        # `@atlas/api`, `@atlas/mcp`, better-auth, pino and pg through dynamic
+        # imports; any of those can print to fd 1 (there is a `console.debug`
+        # on an `@atlas/api` cache self-heal path today), and no grep over this
+        # repo's eval modules would ever see it.
+        #
+        # It is also the check whose absence is the whole issue: the artifact
+        # had never parsed, for its entire life, and nothing noticed, because
+        # `eval-informational-gate.sh` reads `steps.*.outcome` and never opens
+        # the file.
+        #
+        # Deliberately does NOT fire on a missing or empty file: that means the
+        # eval died before writing, which the gate step below already reports.
+        # Failing here too would bury a real failure under a derived one.
+        if: ${{ always() && env.ATLAS_LLM_EVAL_SKIPPED != '1' && steps.eval.outcome != 'skipped' }}
+        run: |
+          set -euo pipefail
+          if [ ! -s eval-mcp-llm-output.json ]; then
+            echo "::notice::eval-mcp-llm-output.json is absent or empty — the eval produced no payload; see the eval step."
+            exit 0
+          fi
+          if ! jq empty eval-mcp-llm-output.json 2>/tmp/jq-err; then
+            echo "::error::eval-mcp-llm-output.json is not valid JSON — something wrote to stdout alongside the --json payload (#5126)."
+            cat /tmp/jq-err
+            echo "First 400 bytes:"
+            head -c 400 eval-mcp-llm-output.json
+            exit 1
+          fi
+          echo "eval-mcp-llm-output.json parses ($(wc -c < eval-mcp-llm-output.json) bytes)"
+
       - name: Upload eval artifacts on failure
         # Captured regardless of pass/fail so a baseline drift on a
         # green run is still inspectable; the retention budget is small

--- a/.github/workflows/eval-llm.yml
+++ b/.github/workflows/eval-llm.yml
@@ -85,6 +85,9 @@ on:
       - "packages/cli/bin/canonical-eval-mcp-llm.ts"
       - "packages/cli/bin/canonical-eval-run.ts"
       - "packages/cli/bin/canonical-eval-tool-selection.ts"
+      # Keeps fd 1 clean for the `tee` below (#5126) — a break here is invisible
+      # in the job's status and shows up only as an unparseable artifact.
+      - "packages/cli/bin/eval-log-destination.ts"
       - "eval/canonical-questions/**"
       # The published init flow the eval auth fixture drives.
       - "plugins/mcp/src/init/hosted.ts"
@@ -277,6 +280,23 @@ jobs:
         # finalText, response payloads) for the upload-artifact step
         # below — the human-readable summary truncates `finalText` and
         # would lose the recovery-class diagnostic data.
+        #
+        # ⚠️ THE `tee` CAPTURES fd 1 WHOLESALE, WHICH IS WHY THE DRIVER HAS TO
+        # KEEP fd 1 CLEAN — this line cannot defend itself. Until #5126 it could
+        # not: the driver wrote its banner and progress lines to fd 1 alongside
+        # the payload, and the app logger's pino default destination is fd 1 too,
+        # pretty-printed and COLOURIZED because the eval runs with `NODE_ENV`
+        # unset (#5121). `eval-mcp-llm-output.json` had therefore never parsed,
+        # and `eval-informational-gate.sh` never noticed because it reads
+        # `steps.*.outcome` and never opens the file.
+        #
+        # Since #5126 stdout under `--json` is the payload and nothing else, and
+        # the human transcript is on fd 2 — so it still reaches this step's log,
+        # unpiped, while `tee` writes a file that parses. That is a property of
+        # `packages/cli/bin/canonical-eval-run.ts` and
+        # `packages/cli/bin/eval-log-destination.ts`, pinned by
+        # `packages/cli/bin/__tests__/eval-json-stdout.test.ts`; nothing here
+        # needed to change, and a `2>&1` added here would undo all of it.
         #
         # pipefail is load-bearing: the default step shell is `bash -e {0}`
         # (NO pipefail), so without it the step's outcome is `tee`'s exit 0

--- a/.github/workflows/eval-llm.yml
+++ b/.github/workflows/eval-llm.yml
@@ -85,9 +85,18 @@ on:
       - "packages/cli/bin/canonical-eval-mcp-llm.ts"
       - "packages/cli/bin/canonical-eval-run.ts"
       - "packages/cli/bin/canonical-eval-tool-selection.ts"
-      # Keeps fd 1 clean for the `tee` below (#5126) — a break here is invisible
-      # in the job's status and shows up only as an unparseable artifact.
+      # The four files that keep fd 1 clean for the `tee` below (#5126). A break
+      # in any of them is invisible in the job's status — the eval passes and
+      # the uploaded artifact is unparseable — so they are triggers even though
+      # three of them are not "the eval's harness" in any other sense:
+      # `eval-log-destination.ts` stamps the logger's destination,
+      # `bin/atlas.ts` holds the import ORDER that stamp depends on,
+      # `lib/logger.ts` is the switch it sets, and `init.ts`'s
+      # `seedDemoPostgres` is the third writer, called before every mode branch.
       - "packages/cli/bin/eval-log-destination.ts"
+      - "packages/cli/bin/atlas.ts"
+      - "packages/api/src/lib/logger.ts"
+      - "packages/cli/src/commands/init.ts"
       - "eval/canonical-questions/**"
       # The published init flow the eval auth fixture drives.
       - "plugins/mcp/src/init/hosted.ts"

--- a/.github/workflows/eval-llm.yml
+++ b/.github/workflows/eval-llm.yml
@@ -91,7 +91,7 @@ on:
       # three of them are not "the eval's harness" in any other sense:
       # `eval-log-destination.ts` stamps the logger's destination,
       # `bin/atlas.ts` holds the import ORDER that stamp depends on,
-      # `lib/logger.ts` is the switch it sets, and `init.ts`'s
+      # `lib/logger.ts` is the switch that stamp sets, and `init.ts`'s
       # `seedDemoPostgres` is the third writer, called before every mode branch.
       - "packages/cli/bin/eval-log-destination.ts"
       - "packages/cli/bin/atlas.ts"
@@ -330,18 +330,39 @@ jobs:
         # `eval-informational-gate.sh` reads `steps.*.outcome` and never opens
         # the file.
         #
-        # Deliberately does NOT fire on a missing or empty file: that means the
-        # eval died before writing, which the gate step below already reports.
-        # Failing here too would bury a real failure under a derived one.
-        if: ${{ always() && env.ATLAS_LLM_EVAL_SKIPPED != '1' && steps.eval.outcome != 'skipped' }}
+        # ⚠️ `continue-on-error` + an outcome threaded into the gate step, NOT a
+        # bare `exit 1`. Every other failure in this job routes through
+        # `eval-informational-gate.sh`, which owns the policy at the top of this
+        # file: informational-but-visible on PRs, blocking on tags. A step that
+        # reddens the job directly would promote this eval to a blocking gate on
+        # PRs — the thing #2025/#2074 declined — and worse, the gate would still
+        # see `success success` and refresh its comment to ✅ beside a red check.
+        #
+        # ⚠️ NOT on `cancelled`. `always()` runs this after a job timeout too,
+        # and a killed run leaves a half-written payload that fails `jq` — which
+        # would report a truncation as an fd-1 polluter, naming one cause with
+        # certainty and the wrong one.
+        id: artifact
+        continue-on-error: true
+        if: ${{ always() && env.ATLAS_LLM_EVAL_SKIPPED != '1' && (steps.eval.outcome == 'success' || steps.eval.outcome == 'failure') }}
+        env:
+          EVAL_OUTCOME: ${{ steps.eval.outcome }}
         run: |
           set -euo pipefail
           if [ ! -s eval-mcp-llm-output.json ]; then
-            echo "::notice::eval-mcp-llm-output.json is absent or empty — the eval produced no payload; see the eval step."
+            # Empty is only benign when the eval itself failed — then it died
+            # before writing, and the gate reports that. An eval that exits 0
+            # having written nothing means the `--json` emitter did not run,
+            # which is a defect this step is exactly positioned to catch.
+            if [ "$EVAL_OUTCOME" = "success" ]; then
+              echo "::error::the eval exited 0 but wrote no payload to stdout — the --json emitter did not run."
+              exit 1
+            fi
+            echo "::notice::eval-mcp-llm-output.json is absent or empty — the eval died before writing; see the eval step."
             exit 0
           fi
           if ! jq empty eval-mcp-llm-output.json 2>/tmp/jq-err; then
-            echo "::error::eval-mcp-llm-output.json is not valid JSON — something wrote to stdout alongside the --json payload (#5126)."
+            echo "::error::eval-mcp-llm-output.json is not valid JSON. Either something wrote to stdout alongside the --json payload (#5126 — look for a console.* in a module the eval pulls in), or the payload is truncated. jq says:"
             cat /tmp/jq-err
             echo "First 400 bytes:"
             head -c 400 eval-mcp-llm-output.json
@@ -372,10 +393,17 @@ jobs:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           PREFLIGHT_OUTCOME: ${{ steps.preflight.outcome }}
           EVAL_OUTCOME: ${{ steps.eval.outcome }}
+          # The artifact-parses check (#5126). The script takes N outcomes and
+          # applies the same PR-comment / tag-blocking split to the set, so an
+          # unparseable bundle is visible on a PR and blocking on a tag —
+          # exactly like a failing eval. `skipped` is fatal by default there and
+          # `eval-mcp-llm` is on SKIP_TOLERANT_LABELS, so the no-secret path is
+          # unaffected.
+          ARTIFACT_OUTCOME: ${{ steps.artifact.outcome }}
         # Both `skipped` (no AI_GATEWAY_API_KEY wired) and `success` pass —
         # the skip only because `eval-mcp-llm` is on the gate script's
         # SKIP_TOLERANT_LABELS list (#5040), and it emits a ::warning::
         # saying the run proved nothing. A failed preflight (rejected key)
         # or failed eval goes through the PR-comment / tag-blocking split
         # in the script.
-        run: bash scripts/eval-informational-gate.sh eval-mcp-llm "$PREFLIGHT_OUTCOME" "$EVAL_OUTCOME"
+        run: bash scripts/eval-informational-gate.sh eval-mcp-llm "$PREFLIGHT_OUTCOME" "$EVAL_OUTCOME" "$ARTIFACT_OUTCOME"

--- a/packages/api/src/lib/__tests__/fixtures/logger-destination-driver.ts
+++ b/packages/api/src/lib/__tests__/fixtures/logger-destination-driver.ts
@@ -16,7 +16,8 @@ createLogger("logger-destination-probe").error(
   {
     probe: "logger-destination",
     // ⚠️ A REDACTED FIELD, ON PURPOSE. `buildRootLogger` now has THREE `pino(…)`
-    // call sites where there used to be one, each spreading `rootLoggerOptions`.
+    // call sites where there used to be one, each carrying `rootLoggerOptions`
+    // (spread on the dev branch, passed positionally on the other two).
     // A branch that dropped the spread — `pino({ level }, destination)` — would
     // still print this line on the right fd, so every fd assertion would pass
     // while redaction, the err serializer, the scrub formatter and the requestId

--- a/packages/api/src/lib/__tests__/fixtures/logger-destination-driver.ts
+++ b/packages/api/src/lib/__tests__/fixtures/logger-destination-driver.ts
@@ -13,6 +13,16 @@
 import { createLogger } from "@atlas/api/lib/logger";
 
 createLogger("logger-destination-probe").error(
-  { probe: "logger-destination" },
+  {
+    probe: "logger-destination",
+    // ⚠️ A REDACTED FIELD, ON PURPOSE. `buildRootLogger` now has THREE `pino(…)`
+    // call sites where there used to be one, each spreading `rootLoggerOptions`.
+    // A branch that dropped the spread — `pino({ level }, destination)` — would
+    // still print this line on the right fd, so every fd assertion would pass
+    // while redaction, the err serializer, the scrub formatter and the requestId
+    // mixin had all silently stopped applying on that branch. The value below is
+    // what makes the options set part of the claim.
+    password: "hunter2",
+  },
   "probe log line",
 );

--- a/packages/api/src/lib/__tests__/fixtures/logger-destination-driver.ts
+++ b/packages/api/src/lib/__tests__/fixtures/logger-destination-driver.ts
@@ -1,0 +1,18 @@
+/**
+ * Driver for `../logger-destination.test.ts` (#5126).
+ *
+ * The property under test is which FILE DESCRIPTOR the root logger writes to,
+ * and that is decided once — at module evaluation, from `process.env` — so it
+ * cannot be observed in-process: a second arm would need a second module
+ * instance, and on the dev branch the destination belongs to a `pino-pretty`
+ * worker thread that never existed in this process at all. Each arm is a spawn.
+ *
+ * No arguments: both switches (`ATLAS_LOG_STDERR`, `NODE_ENV`) are env-borne
+ * exactly as they are in production, so the driver has nothing to configure.
+ */
+import { createLogger } from "@atlas/api/lib/logger";
+
+createLogger("logger-destination-probe").error(
+  { probe: "logger-destination" },
+  "probe log line",
+);

--- a/packages/api/src/lib/__tests__/logger-destination.test.ts
+++ b/packages/api/src/lib/__tests__/logger-destination.test.ts
@@ -52,6 +52,17 @@ interface Streams {
 }
 
 /**
+ * Assert the line on `carrier` actually carries the whole options set, not just
+ * the message. `redactPaths` covers `password`, so a branch that dropped the
+ * spread of `rootLoggerOptions` prints `hunter2` verbatim while every fd
+ * assertion still passes.
+ */
+function expectRedactedProbe(carrier: string): void {
+  expect(carrier).toContain("[Redacted]");
+  expect(carrier).not.toContain("hunter2");
+}
+
+/**
  * `env` is built from scratch rather than spread from `process.env`, because
  * the runner sets `NODE_ENV=test` and that is the switch selecting the branch
  * under test — inheriting it would silently collapse the dev arms onto the
@@ -66,11 +77,14 @@ async function runDriver(env: Record<string, string>): Promise<Streams> {
     stderr: "pipe",
   });
   children.push(proc);
-  const [stdout, stderr] = await Promise.all([
+  const [stdout, stderr, exitCode] = await Promise.all([
     new Response(proc.stdout).text(),
     new Response(proc.stderr).text(),
     proc.exited,
   ]);
+  // A driver that logged and then crashed would satisfy every fd assertion
+  // below; this is what keeps them anchored to a completed run.
+  expect(exitCode).toBe(0);
   return { stdout, stderr };
 }
 
@@ -89,6 +103,7 @@ describe("root logger destination", () => {
       // Unset NODE_ENV really did take the pretty+colour branch — without this
       // the dev arm could be silently testing the production one.
       expect(dev.stdout).toContain(ESC);
+      expectRedactedProbe(dev.stdout);
 
       const prod = await runDriver({ NODE_ENV: "production" });
       expect(prod.stdout).toContain("probe log line");
@@ -96,6 +111,7 @@ describe("root logger destination", () => {
       // Structured JSON, no transport: the contrast that proves the two arms
       // are genuinely different branches and not the same one twice.
       expect(prod.stdout).not.toContain(ESC);
+      expectRedactedProbe(prod.stdout);
     },
     120_000,
   );
@@ -110,6 +126,7 @@ describe("root logger destination", () => {
       const { stdout, stderr } = await runDriver({ ATLAS_LOG_STDERR: "1" });
       expect(stderr).toContain("probe log line");
       expect(stderr).toContain(ESC);
+      expectRedactedProbe(stderr);
       expect(stdout).toBe("");
     },
     120_000,
@@ -125,6 +142,7 @@ describe("root logger destination", () => {
       expect(stderr).toContain("probe log line");
       expect(stdout).toBe("");
       expect(stderr).not.toContain(ESC);
+      expectRedactedProbe(stderr);
     },
     120_000,
   );
@@ -142,6 +160,7 @@ describe("root logger destination", () => {
           NODE_ENV: "production",
         });
         expect(stdout).toContain("probe log line");
+        expectRedactedProbe(stdout);
         expect(stderr).toBe("");
       }
     },

--- a/packages/api/src/lib/__tests__/logger-destination.test.ts
+++ b/packages/api/src/lib/__tests__/logger-destination.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Which fd the root logger writes to, and — the load-bearing half — that the
+ * DEFAULT did not move (#5126).
+ *
+ * `atlas canonical-eval --json` pipes stdout into `eval-mcp-llm-output.json`
+ * and uploads it as the adjudication artifact. The root logger's pino default
+ * destination is fd 1, so every log frame the eval emitted landed in that file;
+ * with `NODE_ENV` unset (deliberately, #5121) the dev branch is taken, so the
+ * frames were `pino-pretty` output WITH ANSI COLOUR. `ATLAS_LOG_STDERR=1` moves
+ * them to fd 2 for that one process.
+ *
+ * ⚠️ EVERY TEST HERE IS A SPAWN, AND NOT BY PREFERENCE. `rootLogger` is a
+ * module-scope `const` — pino resolves the destination once, at construction —
+ * so two arms need two module instances, which module caching forbids in one
+ * process. On the dev branch it is worse still: the destination lives inside a
+ * `pino-pretty` worker thread with its own fds, so there is nothing on the main
+ * thread to intercept even in principle.
+ *
+ * ⚠️ BOTH BRANCHES ARE COVERED BECAUSE BOTH BRANCHES CHANGED. `isDev` selects
+ * between a `pino-pretty` transport (whose `destination` is pino-pretty's own
+ * option, read in the worker) and a plain `pino.destination`. Those are
+ * different mechanisms with no shared implementation, so a fix that works on
+ * one says nothing about the other — and the eval, running with `NODE_ENV`
+ * unset, is on the branch that is easiest to forget is the CI one.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import * as path from "path";
+
+const DRIVER = path.join(
+  import.meta.dir,
+  "fixtures",
+  "logger-destination-driver.ts",
+);
+
+/** ESC (0x1b) — present only when the pretty transport colourizes. */
+const ESC = "\u001b";
+
+const children: Array<{ kill: () => void; exited: Promise<number> }> = [];
+
+afterEach(async () => {
+  while (children.length > 0) {
+    const child = children.pop();
+    if (!child) continue;
+    child.kill();
+    await child.exited;
+  }
+});
+
+interface Streams {
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+/**
+ * `env` is built from scratch rather than spread from `process.env`, because
+ * the runner sets `NODE_ENV=test` and that is the switch selecting the branch
+ * under test — inheriting it would silently collapse the dev arms onto the
+ * production one.
+ */
+async function runDriver(env: Record<string, string>): Promise<Streams> {
+  const proc = Bun.spawn([process.execPath, DRIVER], {
+    // packages/api, so pino-pretty's transport worker resolves its own deps.
+    cwd: path.resolve(import.meta.dir, "..", "..", ".."),
+    env: { PATH: process.env.PATH ?? "", HOME: process.env.HOME ?? "", ...env },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  children.push(proc);
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  return { stdout, stderr };
+}
+
+describe("root logger destination", () => {
+  test(
+    "defaults to fd 1 — the deployed contract, on both branches",
+    async () => {
+      // ⚠️ THIS IS THE TEST THAT MATTERS MOST. Structured logs on stdout is the
+      // twelve-factor convention the deployments rely on (Railway reads fd 1),
+      // so "fix the eval artifact" must not become "move production's logs".
+      // Both arms assert fd 1 AND an empty fd 2, so a change that broadcast to
+      // both streams would fail here rather than look like a pass.
+      const dev = await runDriver({});
+      expect(dev.stdout).toContain("probe log line");
+      expect(dev.stderr).toBe("");
+      // Unset NODE_ENV really did take the pretty+colour branch — without this
+      // the dev arm could be silently testing the production one.
+      expect(dev.stdout).toContain(ESC);
+
+      const prod = await runDriver({ NODE_ENV: "production" });
+      expect(prod.stdout).toContain("probe log line");
+      expect(prod.stderr).toBe("");
+      // Structured JSON, no transport: the contrast that proves the two arms
+      // are genuinely different branches and not the same one twice.
+      expect(prod.stdout).not.toContain(ESC);
+    },
+    120_000,
+  );
+
+  test(
+    "ATLAS_LOG_STDERR=1 moves it to fd 2 on the dev branch",
+    async () => {
+      // The branch the eval is actually on: NODE_ENV unset, so `pino-pretty`
+      // with `colorize: true`. The escapes have to travel WITH the line —
+      // asserting only that stdout is empty would also pass if the logger had
+      // stopped emitting.
+      const { stdout, stderr } = await runDriver({ ATLAS_LOG_STDERR: "1" });
+      expect(stderr).toContain("probe log line");
+      expect(stderr).toContain(ESC);
+      expect(stdout).toBe("");
+    },
+    120_000,
+  );
+
+  test(
+    "ATLAS_LOG_STDERR=1 moves it to fd 2 on the production branch too",
+    async () => {
+      const { stdout, stderr } = await runDriver({
+        ATLAS_LOG_STDERR: "1",
+        NODE_ENV: "production",
+      });
+      expect(stderr).toContain("probe log line");
+      expect(stdout).toBe("");
+      expect(stderr).not.toContain(ESC);
+    },
+    120_000,
+  );
+
+  test(
+    "any value other than exactly \"1\" leaves the default alone",
+    async () => {
+      // A `!== undefined` reading of the switch would make `ATLAS_LOG_STDERR=0`
+      // — the spelling an operator reaches for to say NO — turn it on. Two
+      // values, because `""` and `"0"` fail different plausible predicates
+      // (truthiness and presence respectively).
+      for (const value of ["0", ""]) {
+        const { stdout, stderr } = await runDriver({
+          ATLAS_LOG_STDERR: value,
+          NODE_ENV: "production",
+        });
+        expect(stdout).toContain("probe log line");
+        expect(stderr).toBe("");
+      }
+    },
+    120_000,
+  );
+});

--- a/packages/api/src/lib/logger.ts
+++ b/packages/api/src/lib/logger.ts
@@ -393,7 +393,12 @@ export function scrubLogFormatter(
   }
 }
 
-const rootLoggerOptions: pino.LoggerOptions = {
+// `satisfies`, not an annotation: an annotation erases the options' own generic
+// (`LoggerOptions<CustomLevels>` collapses to `LoggerOptions<never, boolean>`),
+// so a future `customLevels` would still typecheck here and fail at every call
+// site of the returned logger instead. `satisfies` keeps both the inference and
+// the excess-property check.
+const rootLoggerOptions = {
   level: process.env.ATLAS_LOG_LEVEL ?? "info",
   redact: redactPaths,
   serializers: { err: scrubErrSerializer },
@@ -408,7 +413,7 @@ const rootLoggerOptions: pino.LoggerOptions = {
     }
     return base;
   },
-};
+} satisfies pino.LoggerOptions;
 
 /**
  * Pin the root logger to fd 2 (stderr) instead of fd 1 (stdout).
@@ -454,6 +459,14 @@ function buildRootLogger(): pino.Logger {
     // `sync: true` for the same reason `packages/mcp/src/logger.ts` uses it: a
     // short-lived CLI process may `process.exit` before an async buffer
     // flushes, and a diagnostic that never lands is worse than a slow one.
+    //
+    // ⚠️ IT COVERS THIS BRANCH ONLY, AND NOT THE ONE THE EVAL RUNS ON. The eval
+    // runs with `NODE_ENV` unset (#5121), so `isDev` is true and it takes the
+    // `pino-pretty` transport above — a worker thread with no equivalent flush
+    // guarantee, whose queued frames `process.exit` can still drop. That is
+    // accepted rather than solved: on that path the log frames are a secondary
+    // diagnostic, and the record that matters is the fd-2 human transcript,
+    // which `canonical-eval-run.ts` writes with blocking syscalls.
     return pino(rootLoggerOptions, pino.destination({ dest: 2, sync: true }));
   }
   return pino(rootLoggerOptions);

--- a/packages/api/src/lib/logger.ts
+++ b/packages/api/src/lib/logger.ts
@@ -5,6 +5,8 @@
  * - Pino mixin + AsyncLocalStorage binds requestId to all log lines within a request
  * - Redaction paths prevent secrets from leaking into logs
  * - ATLAS_LOG_LEVEL env var controls verbosity (default: "info")
+ * - ATLAS_LOG_STDERR=1 pins the destination to fd 2; see `logToStderr` below
+ *   for why the default (fd 1) must stay the default
  */
 
 import pino from "pino";
@@ -391,7 +393,7 @@ export function scrubLogFormatter(
   }
 }
 
-const rootLogger = pino({
+const rootLoggerOptions: pino.LoggerOptions = {
   level: process.env.ATLAS_LOG_LEVEL ?? "info",
   redact: redactPaths,
   serializers: { err: scrubErrSerializer },
@@ -406,13 +408,58 @@ const rootLogger = pino({
     }
     return base;
   },
-  ...(isDev && {
-    transport: {
-      target: "pino-pretty",
-      options: { colorize: true },
-    },
-  }),
-});
+};
+
+/**
+ * Pin the root logger to fd 2 (stderr) instead of fd 1 (stdout).
+ *
+ * ⚠️ OFF BY DEFAULT, AND THE DEFAULT IS THE LOAD-BEARING PART. Structured logs
+ * on **stdout** is the twelve-factor convention this app's deployments rely on
+ * — Railway reads fd 1 — so the destination is not something to "fix" globally.
+ * This switch exists for a process whose stdout is a MACHINE channel rather
+ * than a diagnostic one: `atlas canonical-eval --json` pipes stdout into
+ * `eval-mcp-llm-output.json`, and one pretty-printed frame there makes the
+ * artifact unparseable (#5126). `packages/mcp/src/logger.ts` has the same shape
+ * permanently (JSON-RPC owns stdout on the stdio transport) and pins fd 2
+ * unconditionally; this is the opt-in form, for a process that is only
+ * SOMETIMES in that shape.
+ *
+ * ⚠️ IT MUST BE SET BEFORE THIS MODULE IS FIRST IMPORTED, and there is no
+ * runtime substitute. `rootLogger` is a module-scope `const`, pino resolves its
+ * destination once at construction, and in the dev branch that destination
+ * belongs to a `pino-pretty` WORKER THREAD with its own fds — so a later
+ * `process.env` assignment changes nothing on either branch. The CLI stamps it
+ * from `packages/cli/bin/eval-log-destination.ts`, which is `bin/atlas.ts`'s
+ * first import for exactly this reason.
+ *
+ * Deliberately NOT in `SAAS_ENV_KEYS`: it is a per-process CLI knob, not part
+ * of the SaaS boot contract, and no deployment should ever set it.
+ */
+const logToStderr = process.env.ATLAS_LOG_STDERR === "1";
+
+function buildRootLogger(): pino.Logger {
+  if (isDev) {
+    return pino({
+      ...rootLoggerOptions,
+      transport: {
+        target: "pino-pretty",
+        // `destination` is pino-pretty's OWN option, read inside the transport
+        // worker. Spreading `false` is a no-op, so with the switch off this
+        // object is byte-identical to what shipped before #5126.
+        options: { colorize: true, ...(logToStderr && { destination: 2 }) },
+      },
+    });
+  }
+  if (logToStderr) {
+    // `sync: true` for the same reason `packages/mcp/src/logger.ts` uses it: a
+    // short-lived CLI process may `process.exit` before an async buffer
+    // flushes, and a diagnostic that never lands is worse than a slow one.
+    return pino(rootLoggerOptions, pino.destination({ dest: 2, sync: true }));
+  }
+  return pino(rootLoggerOptions);
+}
+
+const rootLogger = buildRootLogger();
 
 /**
  * Get the root logger. Request context (requestId) is injected

--- a/packages/cli/bin/__tests__/canonical-eval-exit-code.test.ts
+++ b/packages/cli/bin/__tests__/canonical-eval-exit-code.test.ts
@@ -422,7 +422,7 @@ describe("canonical-eval process exit code", () => {
   );
 
   test(
-    "the JSON payload survives process.exit — writeStdoutSync is not buffered",
+    "payloads survive process.exit on both fds — the sync writers are not buffered",
     async () => {
       // 2 MB against a 64 KiB pipe buffer. `process.exit` discards whatever is
       // still buffered in `process.stdout`, silently and with no error on
@@ -438,19 +438,22 @@ describe("canonical-eval process exit code", () => {
 
       const read = async (
         mode: string,
+        fd: 1 | 2 = 1,
       ): Promise<{ length: number; code: number }> => {
         const proc = Bun.spawn(
-          [process.execPath, driver, String(size), mode],
+          [process.execPath, driver, String(size), mode, String(fd)],
           { stdout: "pipe", stderr: "pipe" },
         );
         children.push(proc);
-        const [text, stderr, code] = await Promise.all([
+        const [out, err, code] = await Promise.all([
           new Response(proc.stdout).text(),
           new Response(proc.stderr).text(),
           proc.exited,
         ]);
-        expect(stderr).toBe("");
-        return { length: text.length, code };
+        // The fd NOT under test must be silent — otherwise a driver that wrote
+        // to both would let either arm carry the other's measurement.
+        expect(fd === 1 ? err : out).toBe("");
+        return { length: (fd === 1 ? out : err).length, code };
       };
 
       const sync = await read("sync");
@@ -470,6 +473,23 @@ describe("canonical-eval process exit code", () => {
       expect(buffered.code).toBe(0);
       expect(buffered.length).toBeGreaterThan(0);
       expect(buffered.length).toBeLessThan(size);
+
+      // ⚠️ fd 2, SAME CLIFF, AND SINCE #5126 IT IS LIVE RATHER THAN LATENT.
+      // Under `--json` the whole human transcript moves to stderr — the banner,
+      // every progress line, and the `note:` lines, which interpolate caught
+      // error messages over a caller-supplied `--questions` corpus. Without
+      // these two arms `writeStderrSync` is a surviving mutation: reverting
+      // `humanWriter`'s stderr side to the buffered stream passes every other
+      // test in the repo, because the largest transcript any of them produces
+      // is ~2 KB against a 65_536-byte cliff.
+      const syncErr = await read("sync", 2);
+      expect(syncErr.code).toBe(0);
+      expect(syncErr.length).toBe(size);
+
+      const bufferedErr = await read("buffered", 2);
+      expect(bufferedErr.code).toBe(0);
+      expect(bufferedErr.length).toBeGreaterThan(0);
+      expect(bufferedErr.length).toBeLessThan(size);
     },
     120_000,
   );

--- a/packages/cli/bin/__tests__/canonical-eval-exit-code.test.ts
+++ b/packages/cli/bin/__tests__/canonical-eval-exit-code.test.ts
@@ -370,7 +370,7 @@ describe("canonical-eval process exit code", () => {
 
       // No slicing: since #5126, stdout under `--json` is the JSON body and
       // nothing else — the prose header this used to skip past now goes to
-      // stderr. `../eval-json-stdout.test.ts` owns that property; here it just
+      // stderr. `./eval-json-stdout.test.ts` owns that property; here it just
       // means the truncation assertion measures the payload rather than the
       // payload plus a header.
       const body = stdout;
@@ -477,11 +477,15 @@ describe("canonical-eval process exit code", () => {
       // ⚠️ fd 2, SAME CLIFF, AND SINCE #5126 IT IS LIVE RATHER THAN LATENT.
       // Under `--json` the whole human transcript moves to stderr — the banner,
       // every progress line, and the `note:` lines, which interpolate caught
-      // error messages over a caller-supplied `--questions` corpus. Without
-      // these two arms `writeStderrSync` is a surviving mutation: reverting
-      // `humanWriter`'s stderr side to the buffered stream passes every other
-      // test in the repo, because the largest transcript any of them produces
-      // is ~2 KB against a 65_536-byte cliff.
+      // error messages over a caller-supplied `--questions` corpus.
+      //
+      // These arms pin `writeFdSync(2, …)`: they kill a mutation that hard-codes
+      // fd 1 or drops the blocking loop for fd 2. Be precise about what that
+      // does NOT cover — the driver calls `writeFdSync` directly, so nothing
+      // here reaches `humanWriter`. That is exactly why `humanWriter` closes
+      // over `writeFdSync` rather than over a per-fd pair of one-line wrappers:
+      // a wrapper would sit between this proof and the caller, and reverting it
+      // to the buffered stream would survive the whole repo.
       const syncErr = await read("sync", 2);
       expect(syncErr.code).toBe(0);
       expect(syncErr.length).toBe(size);

--- a/packages/cli/bin/__tests__/canonical-eval-exit-code.test.ts
+++ b/packages/cli/bin/__tests__/canonical-eval-exit-code.test.ts
@@ -368,9 +368,12 @@ describe("canonical-eval process exit code", () => {
       expect(exitCode).toBe(1);
       expectNoCrash(stderr);
 
-      // stdout carries a prose header before the JSON body (that mixing is
-      // #5126's, not this change's), so slice from the first brace.
-      const body = stdout.slice(stdout.indexOf("{"));
+      // No slicing: since #5126, stdout under `--json` is the JSON body and
+      // nothing else — the prose header this used to skip past now goes to
+      // stderr. `../eval-json-stdout.test.ts` owns that property; here it just
+      // means the truncation assertion measures the payload rather than the
+      // payload plus a header.
+      const body = stdout;
       expect(body.length).toBeGreaterThan(65_536);
       const parsed = JSON.parse(body) as {
         total: number;
@@ -383,11 +386,10 @@ describe("canonical-eval process exit code", () => {
       expect(parsed.passing).toBe(0);
       expect(parsed.failing).toBe(40);
 
-      // The header lines were written to the buffered stream and the body via
-      // writeSync; a writer-ordering regression would put the body first.
-      expect(stdout.indexOf("Atlas canonical-question eval")).toBeLessThan(
-        stdout.indexOf("{"),
-      );
+      // The header still exists — it moved to fd 2, it was not deleted. Without
+      // this the `--json` body could pass every assertion above while the human
+      // transcript had silently stopped being emitted at all.
+      expect(stderr).toContain("Atlas canonical-question eval");
     },
     180_000,
   );

--- a/packages/cli/bin/__tests__/eval-json-stdout.test.ts
+++ b/packages/cli/bin/__tests__/eval-json-stdout.test.ts
@@ -2,23 +2,29 @@
  * `atlas canonical-eval --json` writes JSON to stdout and NOTHING ELSE (#5126).
  *
  * `eval-mcp-llm-output.json` — the failure bundle `.github/workflows/eval-llm.yml`
- * uploads for post-mortems — had never been valid JSON. Two independent writers
- * put non-JSON on fd 1 and the workflow captures fd 1 wholesale:
+ * uploads for post-mortems — had never been valid JSON. THREE independent
+ * writers put non-JSON on fd 1 and the workflow captures fd 1 wholesale:
  *
  *   1. the driver's own human preamble, written unconditionally before any mode
  *      branch, and sufficient on its own;
  *   2. the app's root logger, whose pino default destination is fd 1 — and
  *      because the eval runs with `NODE_ENV` unset (deliberately, #5121) the
  *      dev branch is taken, so the frames arrive PRETTY-PRINTED AND COLOURIZED.
- *      Interleaved, not a strippable prefix.
+ *      Interleaved, not a strippable prefix;
+ *   3. `seedDemoPostgres`'s demo label — OUTSIDE the eval driver entirely, on
+ *      the unconditional path before any mode branch. The first cut of this fix
+ *      covered 1 and 2 and missed it, which is why the guards below are
+ *      process-wide rather than driver-scoped.
  *
- * ⚠️ THE TWO POLLUTERS NEED TWO DIFFERENT PROOFS AND ONE OF THEM CANNOT BE
+ * ⚠️ THE THREE POLLUTERS NEED THREE DIFFERENT PROOFS AND ONE OF THEM CANNOT BE
  * WRITTEN IN-PROCESS. The first is a call-site property; the second is a
  * MODULE-EVALUATION-ORDER property — `rootLogger` is a module-scope `const`, so
  * whether it lands on fd 1 or fd 2 is decided once, before `handleCanonicalEval`
  * exists, by whether `packages/cli/bin/eval-log-destination.ts` ran first. No
  * in-process assertion can observe that; every test here that touches it spawns
- * the real CLI and reads the real fds.
+ * the real CLI and reads the real fds. The third is in another package, and is
+ * held by a function-scoped grep here plus an in-process spy in
+ * `src/__tests__/seed-demo-report.test.ts`.
  *
  * ⚠️ AND THE SPAWN ALONE IS NOT ENOUGH EITHER, which is the subtle part. These
  * spawns use `--preload`, and a preload module is evaluated BEFORE the entry
@@ -32,6 +38,26 @@ import { afterEach, describe, expect, test } from "bun:test";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
+import { writeFdSync, type HumanWriter } from "../canonical-eval-run";
+import { STDOUT_CONSOLE_METHODS } from "./fixtures/stdout-console-methods";
+
+/**
+ * ⚠️ THE BRAND'S ONLY FALSIFIER, AND IT IS A TYPE-LEVEL ONE ON PURPOSE.
+ * `HumanWriter` exists so an unbranded writer cannot be passed to a human seam,
+ * and until round 2 nothing failed if the brand were deleted — `bun run test`
+ * does not type-check, and every call site still compiles with a plain
+ * `(text: string) => void`. A guard with no negative case is a claim.
+ *
+ * `packages/cli/tsconfig.json` includes `bin/**` , so `bun run type` checks this
+ * file: delete the brand and the assignment below becomes legal, which makes
+ * the directive itself an unused-`@ts-expect-error` error (TS2578) and fails
+ * the type gate. The value is a real unbranded writer of the shape the brand
+ * exists to reject.
+ */
+const unbrandedWriter: (text: string) => void = (text) => writeFdSync(1, text);
+// @ts-expect-error — an unbranded writer must not satisfy HumanWriter.
+const _brandHolds: HumanWriter = unbrandedWriter;
+void _brandHolds;
 
 const REPO_ROOT = path.resolve(import.meta.dir, "..", "..", "..", "..");
 const CLI_ENTRY = path.join(REPO_ROOT, "packages", "cli", "bin", "atlas.ts");
@@ -109,9 +135,15 @@ function topLevelFunctionBody(source: string, signature: string): string {
  *
  * ⚠️ `fs.writeSync(1` is listed but `fs.writeSync(fd` is not — the latter IS
  * `writeFdSync`'s own body, which is the one sanctioned writer.
+ *
+ * ⚠️ THE CONSOLE HALF IS BUILT FROM `STDOUT_CONSOLE_METHODS` rather than
+ * hand-written — see that fixture for why two hand-maintained copies of this
+ * list drifted on their first outing, in the same direction, past both arms.
  */
-const FD1_WRITE =
-  /(?:process\.stdout|console\.(?:log|info|debug|dir|table|trace)\s*\(|Bun\.stdout|fs\.writeSync\(\s*1\b)/g;
+const FD1_WRITE = new RegExp(
+  `(?:process\\.stdout|console\\.(?:${STDOUT_CONSOLE_METHODS.join("|")})\\s*\\(|Bun\\.stdout|fs\\.writeSync\\(\\s*1\\b)`,
+  "g",
+);
 
 /**
  * Strip comments before matching, so the prose that DESCRIBES the forbidden
@@ -121,16 +153,38 @@ const FD1_WRITE =
  * tell a quotation from an assertion, and `canonical-eval-run.ts`'s comments
  * necessarily name `process.stdout` to explain why it is banned. Stripping is
  * the honest answer; an allowlist would be a hole shaped like the thing being
- * guarded. Only whole-line `//` comments are dropped, so a `//` inside a string
- * literal (`postgres://…`) survives — which fails SAFE, since the worst case is
- * a false positive on a trailing comment that names a banned spelling.
+ * guarded.
+ *
+ * ⚠️ LINE COMMENTS ARE DROPPED FIRST, AND THE ORDER IS THE WHOLE CORRECTNESS
+ * ARGUMENT. Block-stripping first turns any `/*` sequence inside a `//` comment
+ * into an unterminated strip that runs to the next `*` + `/` ANYWHERE in the
+ * file — measured on the real tree, `init.ts`'s
+ * `// … no parallel \`cli/lib/profilers/*\` home` opened one that a docstring 56
+ * lines later closed, losing 30 lines of live code between them — the
+ * plugin-profiler imports, `DEMO_DATASET`, and `parseDemoArg`. A guard that deletes the code it is scanning reports green forever,
+ * which is this issue's own defect wearing a test's clothes. The self-check in
+ * the test below is what keeps that closed rather than this comment.
  */
 function stripComments(source: string): string {
   return source
-    .replace(/\/\*[\s\S]*?\*\//g, "")
     .split("\n")
     .filter((line) => !/^\s*\/\//.test(line))
-    .join("\n");
+    .join("\n")
+    .replace(/\/\*[\s\S]*?\*\//g, "");
+}
+
+/**
+ * Assert the stripper removed only comment lines — nothing that could hide a
+ * violation. Cheap, and it is the falsifier for the ordering above: run it
+ * against the block-first version and `init.ts` fails immediately.
+ */
+function expectStripLosesOnlyComments(file: string, raw: string): void {
+  const stripped = stripComments(raw);
+  const lost = raw
+    .split("\n")
+    .filter((line) => !/^\s*(?:\/\/|\*|\/\*|$)/.test(line))
+    .filter((line) => !stripped.includes(line));
+  expect({ file, lost }).toEqual({ file, lost: [] });
 }
 
 /** ESC. `pino-pretty` with `colorize: true` emits these; JSON never does. */
@@ -369,11 +423,10 @@ describe("canonical-eval --json keeps stdout machine-readable", () => {
 
       const { exitCode, stdout } = await runCanonicalEval(sandbox, {
         args: ["--questions", questionsPath],
-        // ⚠️ EMIT_LOG is on here too, and it is not symmetry for its own sake:
-        // without it, nothing in this suite asserts the STAMP is conditional.
-        // Delete the `if` in `eval-log-destination.ts` — leaving a bare
-        // `ATLAS_LOG_STDERR = "1"` that fires for every command — and every
-        // other test still passes, because they all pass `--json`.
+        // ⚠️ EMIT_LOG is on here too, so the negative is END-TO-END rather than
+        // only argv-level. The stamp-matrix test below is the primary falsifier
+        // for the conditional; this arm proves a real non-`--json` run still
+        // gets its logger on fd 1, colour and all.
         env: { ATLAS_TEST_STUB_SEED: "1", ATLAS_TEST_EMIT_LOG: "1" },
       });
 
@@ -476,8 +529,11 @@ describe("canonical-eval --json keeps stdout machine-readable", () => {
     // the more likely regression by far: it is what the surrounding CLI code
     // uses everywhere, and no `no-console` rule is configured for this package.
     for (const file of FD1_GUARDED_SOURCES) {
-      const source = stripComments(fs.readFileSync(file, "utf-8"));
-      expect({ file, hits: source.match(FD1_WRITE) ?? [] }).toEqual({
+      const raw = fs.readFileSync(file, "utf-8");
+      // Before trusting the scan, prove the stripper did not eat the code it
+      // was meant to scan — see `stripComments`' ordering note.
+      expectStripLosesOnlyComments(file, raw);
+      expect({ file, hits: stripComments(raw).match(FD1_WRITE) ?? [] }).toEqual({
         file,
         hits: [],
       });
@@ -486,19 +542,61 @@ describe("canonical-eval --json keeps stdout machine-readable", () => {
     // Anchored: the writers these were replaced with are still there, so the
     // test cannot pass by the file having been gutted out from under it.
     const driver = fs.readFileSync(DRIVER_SRC, "utf-8");
-    expect(driver).toContain("function writeFdSync(");
+    expect(driver).toContain("export function writeFdSync(");
     expect(driver).toContain("function humanWriter(");
   });
+
+  test(
+    "the stamp fires for `canonical-eval --json` and for nothing else",
+    async () => {
+      // ⚠️ THE `canonical-eval` HALF WAS UNFALSIFIABLE. Every other spawn in
+      // this file passes that token, so narrowing the condition to just
+      // `--json` — which would stamp `atlas query --json`, `atlas eval --json`
+      // and every other command — survived the whole suite. The module header
+      // claims the scan "is narrow on purpose: both tokens must be present, so
+      // no other subcommand is affected"; this is that claim, tested.
+      const driver = path.join(
+        import.meta.dir, "fixtures", "eval-log-destination-driver.ts",
+      );
+      const stampFor = async (args: string[]): Promise<string> => {
+        const proc = Bun.spawn([process.execPath, driver, ...args], {
+          env: { PATH: process.env.PATH ?? "", HOME: process.env.HOME ?? "" },
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        children.push(proc);
+        const [text, code] = await Promise.all([
+          new Response(proc.stderr).text(),
+          proc.exited,
+        ]);
+        expect(code).toBe(0);
+        return text.trim();
+      };
+
+      expect(await stampFor(["canonical-eval", "--json"])).toBe(
+        "ATLAS_LOG_STDERR=1",
+      );
+      // The three negatives, each failing a DIFFERENT wrong predicate: `--json`
+      // alone kills "only check --json", and `canonical-eval` alone kills "only
+      // check the subcommand".
+      expect(await stampFor(["--json"])).toBe("ATLAS_LOG_STDERR=<unset>");
+      expect(await stampFor(["canonical-eval"])).toBe("ATLAS_LOG_STDERR=<unset>");
+      // `query --json` is the real sibling command. Its own stdout is already
+      // clean (verified — see `eval-log-destination.ts`), so this pins that the
+      // stamp stays narrow rather than that the sibling is unfixable.
+      expect(await stampFor(["query", "--json"])).toBe("ATLAS_LOG_STDERR=<unset>");
+    },
+    60_000,
+  );
 
   test("seedDemoPostgres's own body reaches fd 1 only through its injected sink", () => {
     // The function-scoped arm. `init.ts` as a whole owns fd 1 legitimately, so
     // the guard is narrowed to the one function `canonical-eval` runs — which
     // is where the third polluter lived, and where the LIKELIEST regression is
     // someone matching the file's house style and reaching for `console.log`.
-    const body = topLevelFunctionBody(
-      stripComments(fs.readFileSync(SEED_SRC, "utf-8")),
-      SEED_FN_SIGNATURE,
-    );
+    const raw = fs.readFileSync(SEED_SRC, "utf-8");
+    expectStripLosesOnlyComments(SEED_SRC, raw);
+    const body = topLevelFunctionBody(stripComments(raw), SEED_FN_SIGNATURE);
     // The slice really is the whole body — a brace-naive cut that stopped early
     // would trivially find no violations.
     expect(body).toContain("await pool.end()");
@@ -512,22 +610,48 @@ describe("canonical-eval --json keeps stdout machine-readable", () => {
     // masked. Move the stamp down and every `--json` run pollutes again while
     // the rest of this suite stays green.
     //
-    // ⚠️ FIRST MODULE REQUEST, NOT FIRST `import`. `export … from` is a
-    // module-graph edge evaluated in source order exactly like `import`, and
-    // `bin/atlas.ts` is mostly made of them — including the profiler
-    // re-exports, which are precisely what pulls in `@atlas/api/lib/logger`.
-    // A guard matching only `^import` would miss the single most likely edit to
-    // that file (hoisting or adding a re-export block above line 46).
+    // ⚠️ FIRST MODULE REQUEST, NOT FIRST `import` — AND MULTI-LINE. `export …
+    // from` is a module-graph edge evaluated in source order exactly like
+    // `import`, and `bin/atlas.ts` is mostly made of them. Two rounds of this
+    // guard were green on the regression they named:
+    //
+    //   round 0: `/^import\b/` — missed every `export … from`.
+    //   round 1: `…[^\n]*?["']…` — matched `export`, but `[^\n]` cannot cross a
+    //            newline, so it saw 11 of ~20 edges and MISSED the multi-line
+    //            `export { … } from "@atlas/api/lib/profiler";` block, which is
+    //            the exact edge that pulls in `@atlas/api/lib/logger` and the
+    //            one this comment has named as the risk since round 0.
+    //
+    // `[\s\S]*?` is lazy, so it stops at the first quote after the keyword — the
+    // specifier — for both `import "x";` and `import {\n a,\n} from "x";`.
     const source = fs.readFileSync(CLI_ENTRY, "utf-8");
     const requests = [
-      ...source.matchAll(/^(?:import|export)\b[^\n]*?["']([^"']+)["'];?\s*$/gm),
+      ...source.matchAll(/^(?:import|export)\b[\s\S]*?["']([^"']+)["']/gm),
     ].map((m) => m[1]);
     expect(requests[0]).toBe("./eval-log-destination");
 
-    // …and the stamp must have no graph of its own: an import inside it would
-    // evaluate before its own assignment and could reach the logger first.
+    // A count anchor, so the guard cannot silently go blind again the way it
+    // did twice: if a future regex stops seeing multi-line edges, this drops
+    // well below the file's real edge count and fails here rather than passing
+    // vacuously. Deliberately a floor, not an equality — adding an import is a
+    // normal edit and must not fail this test.
+    expect(requests.length).toBeGreaterThanOrEqual(
+      (source.match(/\bfrom\s+["']/g) ?? []).length,
+    );
+    // The specifier that actually matters, positionally — independent of the
+    // regex entirely, so a third regex bug cannot take this down with it.
+    expect(source.indexOf('import "./eval-log-destination";')).toBeLessThan(
+      source.indexOf("@atlas/api/lib/profiler"),
+    );
+
+    // …and the stamp must have no graph of its own: any module edge inside it
+    // would evaluate before its own assignment and could reach the logger
+    // first. Matching on the SPECIFIER rather than on `from`, because the
+    // dangerous spelling — `import "@atlas/api/lib/logger";` — has no `from`,
+    // and is the very spelling `bin/atlas.ts` uses to pull this module in.
+    // The trailing `export {};` has no specifier and is correctly permitted.
     expect(fs.readFileSync(STAMP_SRC, "utf-8")).not.toMatch(
-      /^(?:import|export)\b[^\n]*\bfrom\b/m,
+      /^(?:import|export)\b[\s\S]*?["']/m,
     );
   });
 });

--- a/packages/cli/bin/__tests__/eval-json-stdout.test.ts
+++ b/packages/cli/bin/__tests__/eval-json-stdout.test.ts
@@ -57,15 +57,11 @@ const PRELOAD = path.join(
  * a guard over one file is not it — the third polluter was a `console.log` in a
  * file no driver-scoped guard would ever have opened.
  *
- * ⚠️ `src/commands/init.ts` is deliberately NOT here, and the reason is the
- * general shape of this kind of guard. That file legitimately owns fd 1 — it is
- * the interactive `init` command, 50-odd `console.log`s of it — and only
- * `seedDemoPostgres` inside it is on the eval path. A lexical guard cannot
- * express "this function but not its neighbours" without slicing source by
- * brace-matching, which is a worse guard than none. It is covered BEHAVIOURALLY
- * instead, by `src/__tests__/seed-demo-report.test.ts`, which spies every
- * console method that reaches fd 1 for the duration of the real call — stronger
- * than a grep, because it also catches a helper the function delegates to.
+ * ⚠️ `src/commands/init.ts` is not on this WHOLE-FILE list, because it
+ * legitimately owns fd 1 — it is the interactive `init` command, 50-odd
+ * `console.log`s of it — and only `seedDemoPostgres` inside it is on the eval
+ * path. It gets a function-scoped arm of the same guard instead; see
+ * {@link SEED_FN_SIGNATURE}.
  */
 const FD1_GUARDED_SOURCES = [
   "packages/cli/bin/canonical-eval-run.ts",
@@ -74,6 +70,38 @@ const FD1_GUARDED_SOURCES = [
   "packages/cli/bin/canonical-eval-tool-selection.ts",
   "packages/cli/bin/eval-log-destination.ts",
 ].map((p) => path.join(REPO_ROOT, p));
+
+const SEED_SRC = path.join(REPO_ROOT, "packages/cli/src/commands/init.ts");
+
+/**
+ * The one function in `init.ts` that runs inside `canonical-eval`.
+ *
+ * ⚠️ THIS ARM EXISTS BECAUSE THE BEHAVIOURAL SUBSTITUTE WAS WEAKER THAN THE
+ * GREP IT REPLACED, which is the same defect as the bug being fixed, one layer
+ * over. `src/__tests__/seed-demo-report.test.ts` spies `console` methods and
+ * `process.stdout.write` during the real call — genuinely stronger for a helper
+ * the function DELEGATES to, and that is why it stays — but it cannot see
+ * `Bun.stdout` or `fs.writeSync(1, …)`, two of the four spellings this file
+ * declares forbidden three lines up. Neither check subsumes the other: the spy
+ * covers delegation, the grep covers spellings. Both, or the class is open.
+ */
+const SEED_FN_SIGNATURE = "export async function seedDemoPostgres(";
+
+/**
+ * Slice one top-level function's body out of a source file.
+ *
+ * Brace-naive on purpose: it ends at the first line that is exactly `}`, which
+ * in a prettier-formatted file is the function's own closing brace and nothing
+ * else. It fails LOUD rather than silently returning too little — the callers
+ * assert the slice actually contains the body's last statement.
+ */
+function topLevelFunctionBody(source: string, signature: string): string {
+  const start = source.indexOf(signature);
+  expect(start).toBeGreaterThan(-1);
+  const end = source.indexOf("\n}\n", start);
+  expect(end).toBeGreaterThan(start);
+  return source.slice(start, end);
+}
 
 /**
  * Ways to reach fd 1 that are not `writeFdSync`. `console.error` / `.warn` are
@@ -460,6 +488,22 @@ describe("canonical-eval --json keeps stdout machine-readable", () => {
     const driver = fs.readFileSync(DRIVER_SRC, "utf-8");
     expect(driver).toContain("function writeFdSync(");
     expect(driver).toContain("function humanWriter(");
+  });
+
+  test("seedDemoPostgres's own body reaches fd 1 only through its injected sink", () => {
+    // The function-scoped arm. `init.ts` as a whole owns fd 1 legitimately, so
+    // the guard is narrowed to the one function `canonical-eval` runs — which
+    // is where the third polluter lived, and where the LIKELIEST regression is
+    // someone matching the file's house style and reaching for `console.log`.
+    const body = topLevelFunctionBody(
+      stripComments(fs.readFileSync(SEED_SRC, "utf-8")),
+      SEED_FN_SIGNATURE,
+    );
+    // The slice really is the whole body — a brace-naive cut that stopped early
+    // would trivially find no violations.
+    expect(body).toContain("await pool.end()");
+    expect(body).toContain("report(");
+    expect(body.match(FD1_WRITE) ?? []).toEqual([]);
   });
 
   test("bin/atlas.ts requests the log-destination stamp before any other module", () => {

--- a/packages/cli/bin/__tests__/eval-json-stdout.test.ts
+++ b/packages/cli/bin/__tests__/eval-json-stdout.test.ts
@@ -1,0 +1,311 @@
+/**
+ * `atlas canonical-eval --json` writes JSON to stdout and NOTHING ELSE (#5126).
+ *
+ * `eval-mcp-llm-output.json` — the failure bundle `.github/workflows/eval-llm.yml`
+ * uploads for post-mortems — had never been valid JSON. Two independent writers
+ * put non-JSON on fd 1 and the workflow captures fd 1 wholesale:
+ *
+ *   1. the driver's own human preamble, written unconditionally before any mode
+ *      branch, and sufficient on its own;
+ *   2. the app's root logger, whose pino default destination is fd 1 — and
+ *      because the eval runs with `NODE_ENV` unset (deliberately, #5121) the
+ *      dev branch is taken, so the frames arrive PRETTY-PRINTED AND COLOURIZED.
+ *      Interleaved, not a strippable prefix.
+ *
+ * ⚠️ THE TWO POLLUTERS NEED TWO DIFFERENT PROOFS AND ONE OF THEM CANNOT BE
+ * WRITTEN IN-PROCESS. The first is a call-site property; the second is a
+ * MODULE-EVALUATION-ORDER property — `rootLogger` is a module-scope `const`, so
+ * whether it lands on fd 1 or fd 2 is decided once, before `handleCanonicalEval`
+ * exists, by whether `packages/cli/bin/eval-log-destination.ts` ran first. No
+ * in-process assertion can observe that; every test here that touches it spawns
+ * the real CLI and reads the real fds.
+ *
+ * ⚠️ AND THE SPAWN ALONE IS NOT ENOUGH EITHER, which is the subtle part. These
+ * spawns use `--preload`, and a preload module is evaluated BEFORE the entry
+ * module — so in this harness the fixture, not `bin/atlas.ts`, is what reaches
+ * the logger first. The fixture therefore imports the same stamp module (see its
+ * header), and the position of that import inside `bin/atlas.ts` is asserted
+ * separately, against the source, by the last test in this file. Together those
+ * two cover what neither covers alone.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+const REPO_ROOT = path.resolve(import.meta.dir, "..", "..", "..", "..");
+const CLI_ENTRY = path.join(REPO_ROOT, "packages", "cli", "bin", "atlas.ts");
+const DRIVER_SRC = path.join(
+  REPO_ROOT,
+  "packages",
+  "cli",
+  "bin",
+  "canonical-eval-run.ts",
+);
+const PRELOAD = path.join(
+  import.meta.dir,
+  "fixtures",
+  "canonical-eval-exit-code.preload.ts",
+);
+
+/** ESC. `pino-pretty` with `colorize: true` emits these; JSON never does. */
+const ESC = "\u001b";
+
+const sandboxes: string[] = [];
+const children: Array<{ kill: () => void; exited: Promise<number> }> = [];
+
+afterEach(async () => {
+  while (children.length > 0) {
+    const child = children.pop();
+    if (!child) continue;
+    child.kill();
+    await child.exited;
+  }
+  while (sandboxes.length > 0) {
+    const dir = sandboxes.pop();
+    if (dir) fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+/**
+ * A cwd the CLI can stage into — a seed fixture for `--schema ecommerce` plus a
+ * pre-existing `semantic/`. Mirrors `canonical-eval-exit-code.test.ts`; both
+ * files need it and neither owns it, so it is duplicated rather than shared
+ * through a helper module that would then be a third thing to keep in step.
+ */
+function makeSandbox(): string {
+  const dir = fs.realpathSync(
+    fs.mkdtempSync(path.join(os.tmpdir(), "canonical-eval-json-")),
+  );
+  sandboxes.push(dir);
+
+  const seedEntities = path.join(
+    dir, "packages", "cli", "data", "seeds", "ecommerce", "semantic", "entities",
+  );
+  fs.mkdirSync(seedEntities, { recursive: true });
+  fs.writeFileSync(
+    path.join(seedEntities, "orders.yml"),
+    "name: orders\ntable: orders\n",
+  );
+
+  const originalEntities = path.join(dir, "semantic", "entities");
+  fs.mkdirSync(originalEntities, { recursive: true });
+  fs.writeFileSync(
+    path.join(originalEntities, "mine.yml"),
+    "name: mine\ntable: mine\n",
+  );
+  return dir;
+}
+
+/**
+ * Questions that all grade `fail` with no database — `resolveQuestion` returns
+ * `fail` for an unknown `metric_id` before it ever builds SQL, so the run
+ * exercises the real grading loop and the real per-question progress writer
+ * without a live Postgres.
+ *
+ * Small on purpose: the 65_536-byte truncation cliff is
+ * `canonical-eval-exit-code.test.ts`'s subject and is proved there with a
+ * deliberately oversized corpus. What this file needs from the body is only
+ * that it PARSES, and a short one keeps each spawn cheap.
+ */
+function writeCorpus(sandbox: string, count: number): string {
+  const questions = Array.from({ length: count }, (_, i) => {
+    const id = `cq-${String(i + 1).padStart(3, "0")}`;
+    return [
+      `  - id: ${id}`,
+      `    question: "what is ${id}?"`,
+      `    mode: metric`,
+      `    category: simple_metric`,
+      `    metric_id: no_such_metric_${i}`,
+      `    expect: {}`,
+    ].join("\n");
+  });
+  const file = path.join(sandbox, "questions.yml");
+  fs.writeFileSync(file, `questions:\n${questions.join("\n")}\n`);
+  return file;
+}
+
+interface RunResult {
+  readonly exitCode: number;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+interface RunOptions {
+  readonly args?: string[];
+  readonly env?: Record<string, string>;
+  /**
+   * Run through a real shell pipeline (`… | cat`) rather than `Bun.spawn`'s own
+   * pipe. That is the shape CI stands in (`… --json | tee eval-mcp-llm-output.json`)
+   * and, per `canonical-eval-exit-code.test.ts`, the only one that reproduces
+   * the 65_536-byte truncation cliff. Kept on for the `--json` tests so this
+   * file's "the artifact parses" claim is a claim about the artifact CI
+   * actually gets, not about a friendlier pipe.
+   */
+  readonly shellPipe?: boolean;
+}
+
+async function runCanonicalEval(
+  cwd: string,
+  options: RunOptions = {},
+): Promise<RunResult> {
+  const argv = [
+    process.execPath,
+    "--preload",
+    PRELOAD,
+    CLI_ENTRY,
+    "canonical-eval",
+    ...(options.args ?? []),
+  ];
+  const command =
+    options.shellPipe === true
+      ? [
+          "bash",
+          "-c",
+          `set -o pipefail; ${argv
+            .map((a) => `'${a.replaceAll("'", `'\\''`)}'`)
+            .join(" ")} | cat`,
+        ]
+      : argv;
+
+  const proc = Bun.spawn(command, {
+    cwd,
+    // Built from scratch, not spread from `process.env`. NODE_ENV in
+    // particular MUST be absent: it is what puts the logger on its dev branch
+    // (`pino-pretty`, `colorize: true`), which is the CI shape (#5121) and the
+    // only one that can emit the ANSI escapes asserted below.
+    env: {
+      PATH: process.env.PATH ?? "",
+      HOME: process.env.HOME ?? "",
+      ATLAS_DATASOURCE_URL: "postgres://atlas:atlas@127.0.0.1:1/atlas_demo",
+      ATLAS_DEPLOY_MODE: "self-hosted",
+      ATLAS_DEPLOY_ENV: "development",
+      ...(options.env ?? {}),
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  children.push(proc);
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  return { exitCode, stdout, stderr };
+}
+
+describe("canonical-eval --json keeps stdout machine-readable", () => {
+  test(
+    "stdout parses with no stripping while a log frame and the preamble land on stderr",
+    async () => {
+      const sandbox = makeSandbox();
+      const questionsPath = writeCorpus(sandbox, 3);
+
+      const { exitCode, stdout, stderr } = await runCanonicalEval(sandbox, {
+        args: ["--questions", questionsPath, "--json"],
+        env: { ATLAS_TEST_STUB_SEED: "1", ATLAS_TEST_EMIT_LOG: "1" },
+        shellPipe: true,
+      });
+
+      // NO SLICING. `JSON.parse` on the whole stream is the acceptance
+      // criterion verbatim; the pre-#5126 behaviour fails here on the first
+      // character of the banner.
+      const parsed = JSON.parse(stdout) as {
+        total: number;
+        passing: number;
+        failing: number;
+        results: unknown[];
+      };
+      // 3/0/3 rather than 0/0/0: a mapping that confused passing with failing,
+      // or emitted a fixed shape, cannot satisfy all four at once.
+      expect(parsed.total).toBe(3);
+      expect(parsed.passing).toBe(0);
+      expect(parsed.failing).toBe(3);
+      expect(parsed.results).toHaveLength(3);
+      expect(exitCode).toBe(1);
+
+      // Polluter 1 — the driver's own preamble, now on fd 2. Both halves
+      // asserted: present on stderr AND absent from stdout. Present-only would
+      // pass if the line were written to both.
+      expect(stderr).toContain("Atlas canonical-question eval");
+      expect(stdout).not.toContain("Atlas canonical-question eval");
+      // …including the per-question progress lines, which are the writer that
+      // interleaves rather than prefixes.
+      expect(stderr).toContain("cq-001 simple_metric");
+      expect(stdout).not.toContain("cq-001 simple_metric");
+
+      // Polluter 2 — the app logger. Same two halves.
+      expect(stderr).toContain("probe log line");
+      expect(stdout).not.toContain("probe log line");
+
+      // ⚠️ The ANSI assertion needs BOTH arms or it proves nothing: `colorize`
+      // silently off would satisfy "stdout has no ESC" while telling us
+      // nothing about where the frames went. Requiring ESC on stderr pins that
+      // the run really did take the pretty+colour branch.
+      expect(stderr).toContain(ESC);
+      expect(stdout).not.toContain(ESC);
+    },
+    180_000,
+  );
+
+  test(
+    "without --json the human transcript stays on stdout",
+    async () => {
+      // The counterpart arm. Without it every assertion above is satisfied by
+      // "route the preamble to stderr always", which would silently break the
+      // interactive command this eval is also used as.
+      const sandbox = makeSandbox();
+      const questionsPath = writeCorpus(sandbox, 3);
+
+      const { exitCode, stdout } = await runCanonicalEval(sandbox, {
+        args: ["--questions", questionsPath],
+        env: { ATLAS_TEST_STUB_SEED: "1" },
+      });
+
+      expect(stdout).toContain("Atlas canonical-question eval");
+      expect(stdout).toContain("cq-001 simple_metric");
+      // `formatSummary`, the non-`--json` body, on fd 1 as it always was. The
+      // full line, so the three counts are distinct and the assertion cannot be
+      // satisfied by a summary that confuses pass with fail.
+      expect(stdout).toContain("0/3 passing  (0 warn, 3 fail)");
+      expect(exitCode).toBe(1);
+    },
+    180_000,
+  );
+
+  test("canonical-eval-run.ts never writes to stdout except through the fd writer", () => {
+    // The grep IS the guard. Every assertion above is about the call sites that
+    // exist today; this one is about the next one somebody adds — a fresh
+    // `process.stdout` write is the whole defect, and it would sail past a
+    // suite that only re-checks the known lines.
+    //
+    // ⚠️ Matched as a CALL (trailing paren) so the prose above `writeFdSync`,
+    // which names the pattern, is not itself a violation. Comments in that file
+    // deliberately spell it without the paren for the same reason.
+    const source = fs.readFileSync(DRIVER_SRC, "utf-8");
+    const calls = source.match(/process\.stdout\.write\s*\(/g) ?? [];
+    expect(calls).toEqual([]);
+
+    // Anchored: the writer this replaced them with is still there, so the test
+    // cannot pass by the file having been renamed out from under it.
+    expect(source).toContain("function writeFdSync(");
+    expect(source).toContain("function humanWriter(");
+  });
+
+  test("bin/atlas.ts imports the log-destination stamp before anything else", () => {
+    // The one property the spawns above structurally cannot see: they preload a
+    // fixture that reaches the logger first, so `bin/atlas.ts`'s own ordering is
+    // masked. Move the stamp below `../src/env-check` in production and every
+    // `--json` run pollutes again while this suite stays green — which is the
+    // regression this test exists for.
+    const source = fs.readFileSync(CLI_ENTRY, "utf-8");
+    const firstImport = source.search(/^import\b/m);
+    expect(firstImport).toBeGreaterThan(-1);
+    // Sliced to a bounded window purely so a failure prints the offending
+    // import rather than the whole 400-line entrypoint.
+    expect(source.slice(firstImport, firstImport + 120)).toStartWith(
+      'import "./eval-log-destination";',
+    );
+  });
+});

--- a/packages/cli/bin/__tests__/eval-json-stdout.test.ts
+++ b/packages/cli/bin/__tests__/eval-json-stdout.test.ts
@@ -42,11 +42,68 @@ const DRIVER_SRC = path.join(
   "bin",
   "canonical-eval-run.ts",
 );
+const STAMP_SRC = path.join(
+  REPO_ROOT, "packages", "cli", "bin", "eval-log-destination.ts",
+);
 const PRELOAD = path.join(
   import.meta.dir,
   "fixtures",
   "canonical-eval-exit-code.preload.ts",
 );
+
+/**
+ * Every module the `canonical-eval` process runs through whose ENTIRE fd-1
+ * surface belongs to the eval. The property the artifact needs is process-wide;
+ * a guard over one file is not it — the third polluter was a `console.log` in a
+ * file no driver-scoped guard would ever have opened.
+ *
+ * ⚠️ `src/commands/init.ts` is deliberately NOT here, and the reason is the
+ * general shape of this kind of guard. That file legitimately owns fd 1 — it is
+ * the interactive `init` command, 50-odd `console.log`s of it — and only
+ * `seedDemoPostgres` inside it is on the eval path. A lexical guard cannot
+ * express "this function but not its neighbours" without slicing source by
+ * brace-matching, which is a worse guard than none. It is covered BEHAVIOURALLY
+ * instead, by `src/__tests__/seed-demo-report.test.ts`, which spies every
+ * console method that reaches fd 1 for the duration of the real call — stronger
+ * than a grep, because it also catches a helper the function delegates to.
+ */
+const FD1_GUARDED_SOURCES = [
+  "packages/cli/bin/canonical-eval-run.ts",
+  "packages/cli/bin/canonical-eval.ts",
+  "packages/cli/bin/canonical-eval-mcp-llm.ts",
+  "packages/cli/bin/canonical-eval-tool-selection.ts",
+  "packages/cli/bin/eval-log-destination.ts",
+].map((p) => path.join(REPO_ROOT, p));
+
+/**
+ * Ways to reach fd 1 that are not `writeFdSync`. `console.error` / `.warn` are
+ * fd 2 and deliberately absent.
+ *
+ * ⚠️ `fs.writeSync(1` is listed but `fs.writeSync(fd` is not — the latter IS
+ * `writeFdSync`'s own body, which is the one sanctioned writer.
+ */
+const FD1_WRITE =
+  /(?:process\.stdout|console\.(?:log|info|debug|dir|table|trace)\s*\(|Bun\.stdout|fs\.writeSync\(\s*1\b)/g;
+
+/**
+ * Strip comments before matching, so the prose that DESCRIBES the forbidden
+ * spellings is not itself a violation.
+ *
+ * ⚠️ This is the reword-not-exempt problem in miniature: a lexical guard cannot
+ * tell a quotation from an assertion, and `canonical-eval-run.ts`'s comments
+ * necessarily name `process.stdout` to explain why it is banned. Stripping is
+ * the honest answer; an allowlist would be a hole shaped like the thing being
+ * guarded. Only whole-line `//` comments are dropped, so a `//` inside a string
+ * literal (`postgres://…`) survives — which fails SAFE, since the worst case is
+ * a false positive on a trailing comment that names a banned spelling.
+ */
+function stripComments(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .split("\n")
+    .filter((line) => !/^\s*\/\//.test(line))
+    .join("\n");
+}
 
 /** ESC. `pino-pretty` with `colorize: true` emits these; JSON never does. */
 const ESC = "\u001b";
@@ -212,17 +269,33 @@ describe("canonical-eval --json keeps stdout machine-readable", () => {
       // criterion verbatim; the pre-#5126 behaviour fails here on the first
       // character of the banner.
       const parsed = JSON.parse(stdout) as {
+        mode: string;
         total: number;
         passing: number;
+        warning: number;
         failing: number;
-        results: unknown[];
+        results: Array<{ id: string; status: string }>;
       };
-      // 3/0/3 rather than 0/0/0: a mapping that confused passing with failing,
-      // or emitted a fixed shape, cannot satisfy all four at once.
+      // ⚠️ COUNTS ALONE CANNOT CARRY THIS. An all-fail corpus pins `passing`,
+      // `warning` and `total - failing` to the same degenerate 0, so `total`
+      // and `failing` are indistinguishable and swapping those two keys in the
+      // emitter stays green. The per-result arrays are what make the shape
+      // falsifiable without a database.
       expect(parsed.total).toBe(3);
       expect(parsed.passing).toBe(0);
+      expect(parsed.warning).toBe(0);
       expect(parsed.failing).toBe(3);
-      expect(parsed.results).toHaveLength(3);
+      expect(parsed.mode).toBe("deterministic");
+      expect(parsed.results.map((r) => r.id)).toEqual([
+        "cq-001",
+        "cq-002",
+        "cq-003",
+      ]);
+      expect(parsed.results.map((r) => r.status)).toEqual([
+        "fail",
+        "fail",
+        "fail",
+      ]);
       expect(exitCode).toBe(1);
 
       // Polluter 1 — the driver's own preamble, now on fd 2. Both halves
@@ -238,6 +311,14 @@ describe("canonical-eval --json keeps stdout machine-readable", () => {
       // Polluter 2 — the app logger. Same two halves.
       expect(stderr).toContain("probe log line");
       expect(stdout).not.toContain("probe log line");
+
+      // Polluter 3 — `seedDemoPostgres`'s demo label, the one OUTSIDE this
+      // module and the one the first cut of this fix missed entirely. The
+      // preload's stub reports it through the injected sink, so what this
+      // actually asserts is that `runInstalledCanonicalEval` passes `human`
+      // rather than a `console.log` default.
+      expect(stderr).toContain("E-commerce demo loaded");
+      expect(stdout).not.toContain("E-commerce demo loaded");
 
       // ⚠️ The ANSI assertion needs BOTH arms or it proves nothing: `colorize`
       // silently off would satisfy "stdout has no ESC" while telling us
@@ -260,11 +341,21 @@ describe("canonical-eval --json keeps stdout machine-readable", () => {
 
       const { exitCode, stdout } = await runCanonicalEval(sandbox, {
         args: ["--questions", questionsPath],
-        env: { ATLAS_TEST_STUB_SEED: "1" },
+        // ⚠️ EMIT_LOG is on here too, and it is not symmetry for its own sake:
+        // without it, nothing in this suite asserts the STAMP is conditional.
+        // Delete the `if` in `eval-log-destination.ts` — leaving a bare
+        // `ATLAS_LOG_STDERR = "1"` that fires for every command — and every
+        // other test still passes, because they all pass `--json`.
+        env: { ATLAS_TEST_STUB_SEED: "1", ATLAS_TEST_EMIT_LOG: "1" },
       });
 
       expect(stdout).toContain("Atlas canonical-question eval");
       expect(stdout).toContain("cq-001 simple_metric");
+      expect(stdout).toContain("E-commerce demo loaded");
+      // The logger stays on fd 1 — the app-wide default — for an interactive
+      // run, colour and all.
+      expect(stdout).toContain("probe log line");
+      expect(stdout).toContain(ESC);
       // `formatSummary`, the non-`--json` body, on fd 1 as it always was. The
       // full line, so the three counts are distinct and the assertion cannot be
       // satisfied by a summary that confuses pass with fail.
@@ -274,38 +365,125 @@ describe("canonical-eval --json keeps stdout machine-readable", () => {
     180_000,
   );
 
-  test("canonical-eval-run.ts never writes to stdout except through the fd writer", () => {
-    // The grep IS the guard. Every assertion above is about the call sites that
-    // exist today; this one is about the next one somebody adds — a fresh
-    // `process.stdout` write is the whole defect, and it would sail past a
-    // suite that only re-checks the known lines.
-    //
-    // ⚠️ Matched as a CALL (trailing paren) so the prose above `writeFdSync`,
-    // which names the pattern, is not itself a violation. Comments in that file
-    // deliberately spell it without the paren for the same reason.
-    const source = fs.readFileSync(DRIVER_SRC, "utf-8");
-    const calls = source.match(/process\.stdout\.write\s*\(/g) ?? [];
-    expect(calls).toEqual([]);
+  test(
+    "--mcp-llm --json keeps its own preamble off stdout",
+    async () => {
+      // ⚠️ THIS IS THE BRANCH THE CI ARTIFACT ACTUALLY COMES FROM, and it looked
+      // untestable — `runMcpLlmMode` is behind a provider check. It is not:
+      // `providerKeyMissing` returns null for `ollama`, so the run reaches the
+      // provider line, the baseline line and `resolveExpectations` before dying
+      // in ground-truth resolution on the unknown metric ids. Four `human` call
+      // sites in the mode that produces `eval-mcp-llm-output.json`, for one
+      // spawn and no API key.
+      //
+      // It stops before the payload, so there is no JSON to parse — which makes
+      // `stdout === ""` the whole assertion, and a strong one: any of those
+      // writes reverting to fd 1 fails it.
+      const sandbox = makeSandbox();
+      const questionsPath = writeCorpus(sandbox, 3);
 
-    // Anchored: the writer this replaced them with is still there, so the test
-    // cannot pass by the file having been renamed out from under it.
-    expect(source).toContain("function writeFdSync(");
-    expect(source).toContain("function humanWriter(");
+      const { stdout, stderr } = await runCanonicalEval(sandbox, {
+        args: ["--questions", questionsPath, "--mcp-llm", "--json"],
+        env: {
+          ATLAS_TEST_STUB_SEED: "1",
+          ATLAS_TEST_EMIT_LOG: "1",
+          ATLAS_PROVIDER: "ollama",
+          ATLAS_MODEL: "llama3",
+        },
+        shellPipe: true,
+      });
+
+      expect(stdout).toBe("");
+      // Named individually rather than by a single "stderr is non-empty", so a
+      // run that died before `runMcpLlmMode` cannot satisfy this.
+      expect(stderr).toContain("using LLM provider=ollama");
+      expect(stderr).toContain("E-commerce demo loaded");
+      expect(stderr).toContain("probe log line");
+    },
+    180_000,
+  );
+
+  test(
+    "--tool-selection --json keeps its own preamble off stdout",
+    async () => {
+      // Same trick for the third mode. `runToolSelectionMode` writes the
+      // fixture line before it calls the grader, so one spawn reaches it.
+      const sandbox = makeSandbox();
+      const questionsPath = writeCorpus(sandbox, 3);
+      const fixturePath = path.join(sandbox, "tool-selection.json");
+      fs.writeFileSync(
+        fixturePath,
+        JSON.stringify({ rubric: { acceptance_floor: 0.9 }, items: [] }),
+      );
+
+      const { stdout, stderr } = await runCanonicalEval(sandbox, {
+        args: [
+          "--questions", questionsPath,
+          "--mcp-llm", "--tool-selection",
+          "--tool-selection-fixture", fixturePath,
+          "--json",
+        ],
+        env: {
+          ATLAS_TEST_STUB_SEED: "1",
+          ATLAS_PROVIDER: "ollama",
+          ATLAS_MODEL: "llama3",
+        },
+        shellPipe: true,
+      });
+
+      expect(stdout).toBe("");
+      expect(stderr).toContain("tool-selection fixture:");
+    },
+    180_000,
+  );
+
+  test("no eval module writes to fd 1 outside the sanctioned writer", () => {
+    // The grep IS the guard, and it is the ONLY falsifier for any branch a
+    // spawn cannot reach. Every spawn above is about the call sites that exist
+    // today; this is about the next one somebody adds.
+    //
+    // ⚠️ THE SPELLING MATTERS MORE THAN THE FILE. The first cut of this guard
+    // matched `process.stdout.write(` in one file, and the defect that shipped
+    // past it was a `console.log` in a DIFFERENT file. `console.log` is also
+    // the more likely regression by far: it is what the surrounding CLI code
+    // uses everywhere, and no `no-console` rule is configured for this package.
+    for (const file of FD1_GUARDED_SOURCES) {
+      const source = stripComments(fs.readFileSync(file, "utf-8"));
+      expect({ file, hits: source.match(FD1_WRITE) ?? [] }).toEqual({
+        file,
+        hits: [],
+      });
+    }
+
+    // Anchored: the writers these were replaced with are still there, so the
+    // test cannot pass by the file having been gutted out from under it.
+    const driver = fs.readFileSync(DRIVER_SRC, "utf-8");
+    expect(driver).toContain("function writeFdSync(");
+    expect(driver).toContain("function humanWriter(");
   });
 
-  test("bin/atlas.ts imports the log-destination stamp before anything else", () => {
+  test("bin/atlas.ts requests the log-destination stamp before any other module", () => {
     // The one property the spawns above structurally cannot see: they preload a
     // fixture that reaches the logger first, so `bin/atlas.ts`'s own ordering is
-    // masked. Move the stamp below `../src/env-check` in production and every
-    // `--json` run pollutes again while this suite stays green — which is the
-    // regression this test exists for.
+    // masked. Move the stamp down and every `--json` run pollutes again while
+    // the rest of this suite stays green.
+    //
+    // ⚠️ FIRST MODULE REQUEST, NOT FIRST `import`. `export … from` is a
+    // module-graph edge evaluated in source order exactly like `import`, and
+    // `bin/atlas.ts` is mostly made of them — including the profiler
+    // re-exports, which are precisely what pulls in `@atlas/api/lib/logger`.
+    // A guard matching only `^import` would miss the single most likely edit to
+    // that file (hoisting or adding a re-export block above line 46).
     const source = fs.readFileSync(CLI_ENTRY, "utf-8");
-    const firstImport = source.search(/^import\b/m);
-    expect(firstImport).toBeGreaterThan(-1);
-    // Sliced to a bounded window purely so a failure prints the offending
-    // import rather than the whole 400-line entrypoint.
-    expect(source.slice(firstImport, firstImport + 120)).toStartWith(
-      'import "./eval-log-destination";',
+    const requests = [
+      ...source.matchAll(/^(?:import|export)\b[^\n]*?["']([^"']+)["'];?\s*$/gm),
+    ].map((m) => m[1]);
+    expect(requests[0]).toBe("./eval-log-destination");
+
+    // …and the stamp must have no graph of its own: an import inside it would
+    // evaluate before its own assignment and could reach the logger first.
+    expect(fs.readFileSync(STAMP_SRC, "utf-8")).not.toMatch(
+      /^(?:import|export)\b[^\n]*\bfrom\b/m,
     );
   });
 });

--- a/packages/cli/bin/__tests__/eval-seed-sink.test.ts
+++ b/packages/cli/bin/__tests__/eval-seed-sink.test.ts
@@ -1,0 +1,70 @@
+/**
+ * `atlas eval`'s seed-progress sink picks the right fd (#5126).
+ *
+ * ⚠️ THIS CALL SITE HAD NO TEST OF ANY KIND. `handleEval` is untested end to
+ * end, and the sink was written inline as
+ * `(csvOutput || jsonOutput ? process.stderr : process.stdout).write(text)` —
+ * three plausible one-character mutations from reproducing #5126 one command
+ * over, all of which survived the whole repo: drop the ternary, swap the arms,
+ * or forget `csvOutput` (which would pollute the CSV body instead of the JSON
+ * one). Extracting the resolver is what makes those four lines falsifiable
+ * without spawning the LLM benchmark.
+ *
+ * The truth table is the point, so all four input classes are asserted rather
+ * than the two that motivated the change.
+ */
+import { describe, expect, test } from "bun:test";
+import { evalSeedSink } from "../eval";
+
+/** Capture what the returned sink writes, and to which stream. */
+function capture(
+  options: { csvOutput: boolean; jsonOutput: boolean },
+): { fd: 1 | 2; text: string } {
+  const seen: Array<{ fd: 1 | 2; text: string }> = [];
+  const originalOut = process.stdout.write;
+  const originalErr = process.stderr.write;
+  process.stdout.write = ((chunk: unknown) => {
+    seen.push({ fd: 1, text: String(chunk) });
+    return true;
+  }) as typeof process.stdout.write;
+  process.stderr.write = ((chunk: unknown) => {
+    seen.push({ fd: 2, text: String(chunk) });
+    return true;
+  }) as typeof process.stderr.write;
+  try {
+    evalSeedSink(options)("demo loaded\n");
+  } finally {
+    process.stdout.write = originalOut;
+    process.stderr.write = originalErr;
+  }
+  // Exactly one write: a sink that echoed to both streams would otherwise
+  // satisfy whichever arm the caller happened to assert.
+  expect(seen).toHaveLength(1);
+  const only = seen[0];
+  if (!only) throw new Error("unreachable — length asserted above");
+  return only;
+}
+
+describe("evalSeedSink", () => {
+  test("routes to fd 2 whenever a machine body owns stdout", () => {
+    // Each of the three separately, so dropping either disjunct fails.
+    expect(capture({ csvOutput: false, jsonOutput: true }).fd).toBe(2);
+    expect(capture({ csvOutput: true, jsonOutput: false }).fd).toBe(2);
+    expect(capture({ csvOutput: true, jsonOutput: true }).fd).toBe(2);
+  });
+
+  test("routes to fd 1 for the human default", () => {
+    // The counterpart arm: without it, "always stderr" passes everything above
+    // and silently moves the interactive command's progress line.
+    expect(capture({ csvOutput: false, jsonOutput: false }).fd).toBe(1);
+  });
+
+  test("passes the text through unchanged", () => {
+    // The sink must not add or trim a newline — `seedDemoPostgres` owns that
+    // now, and a sink that re-added `console.log`'s implicit `\n` would produce
+    // a blank line in every mode.
+    expect(capture({ csvOutput: false, jsonOutput: false }).text).toBe(
+      "demo loaded\n",
+    );
+  });
+});

--- a/packages/cli/bin/__tests__/fixtures/canonical-eval-exit-code.preload.ts
+++ b/packages/cli/bin/__tests__/fixtures/canonical-eval-exit-code.preload.ts
@@ -12,6 +12,9 @@
  *                                get PAST the seed without a live Postgres.
  *   ATLAS_TEST_FAIL_CP_FROM=…  — make `fs.cpSync` throw when copying FROM that
  *                                path, so `restoreSemanticLayer` fails.
+ *   ATLAS_TEST_EMIT_LOG=1      — with the seed stub, emit one real app-logger
+ *                                line from inside the run (#5126). Requires
+ *                                ATLAS_TEST_STUB_SEED=1; see the stub below.
  *
  * ⚠️ Why the switch keys on the copy SOURCE. `restoreSemanticLayer` runs
  * `rmSync(SEMANTIC_DIR)` → `cpSync(BACKUP_DIR → SEMANTIC_DIR)` → `rmSync(BACKUP_DIR)`.
@@ -34,6 +37,18 @@
  * Verified on bun 1.3.13: `mock.module` from `bun:test` applies in a plain
  * `bun --preload` process, not just under `bun test`.
  */
+// ⚠️ FIRST, AND FOR THE SAME REASON IT IS FIRST IN `bin/atlas.ts` (#5126). A
+// `--preload` module is evaluated BEFORE the entry module, so this fixture —
+// not `bin/atlas.ts` — is what reaches `@atlas/api/lib/logger` first here, via
+// the `realInit` import below. Without this line the logger is constructed on
+// fd 1 before the CLI's own stamp ever runs, and every `--json` spawn in this
+// suite would see the pre-#5126 behaviour no matter what the CLI does.
+//
+// It imports the REAL stamp module rather than assigning the env var by hand,
+// so a stamp whose argv condition is wrong fails these tests instead of being
+// papered over. What it cannot cover is the stamp's POSITION in `bin/atlas.ts`,
+// which `../eval-json-stdout.test.ts` asserts against the source directly.
+import "../../eval-log-destination";
 import * as realFs from "fs";
 import { mock } from "bun:test";
 // Hoisted above the `fs` patch below, so this module's graph loads against the
@@ -76,7 +91,21 @@ if (failCpFrom) {
 }
 
 if (process.env.ATLAS_TEST_STUB_SEED === "1") {
-  const stubbedSeed: typeof realInit.seedDemoPostgres = async () => {};
+  const stubbedSeed: typeof realInit.seedDemoPostgres = async () => {
+    // ⚠️ Emitted from INSIDE the run, through the real `createLogger`, because
+    // that is the mechanism (#5126): the polluting frames come from modules the
+    // eval pulls in mid-flight, not from anything the driver writes. A line
+    // emitted at preload time instead would land before the first driver write
+    // and could be stripped by a `tail`, which is exactly the diagnosis the
+    // issue rules out. `seedDemoPostgres` runs after the banner and before the
+    // question loop, so this lands mid-stream like the real ones.
+    if (process.env.ATLAS_TEST_EMIT_LOG !== "1") return;
+    const { createLogger } = await import("@atlas/api/lib/logger");
+    createLogger("canonical-eval-probe").error(
+      { probe: "eval-log-destination" },
+      "probe log line",
+    );
+  };
   // Spread the real module: `bin/atlas.ts` re-exports five symbols from here
   // and a partial factory would leave the rest undefined at import time.
   void mock.module("../../../src/commands/init", () => ({

--- a/packages/cli/bin/__tests__/fixtures/canonical-eval-exit-code.preload.ts
+++ b/packages/cli/bin/__tests__/fixtures/canonical-eval-exit-code.preload.ts
@@ -91,7 +91,19 @@ if (failCpFrom) {
 }
 
 if (process.env.ATLAS_TEST_STUB_SEED === "1") {
-  const stubbedSeed: typeof realInit.seedDemoPostgres = async () => {
+  const stubbedSeed: typeof realInit.seedDemoPostgres = async (_conn, report) => {
+    // ⚠️ THE STUB REPORTS THE LABEL THROUGH THE INJECTED SINK. It must, and the
+    // reason is the sharpest lesson of #5126's review: the real
+    // `seedDemoPostgres` was the THIRD writer on fd 1, and a stub that simply
+    // did nothing deleted the polluter and then let the suite confirm the
+    // polluter was absent — the artifact parsed in a world where the bug had
+    // been removed by the fixture. Reporting through `report` instead makes
+    // this an assertion about the CALL SITE: does `runInstalledCanonicalEval`
+    // hand `seedDemoPostgres` the resolved human writer, or `console.log`?
+    // (The real function's own use of the sink is covered in-process by
+    // `../seed-demo-report.test.ts`, which the stub cannot reach.)
+    report(`${realInit.DEMO_DATASET.label}\n`);
+
     // ⚠️ Emitted from INSIDE the run, through the real `createLogger`, because
     // that is the mechanism (#5126): the polluting frames come from modules the
     // eval pulls in mid-flight, not from anything the driver writes. A line

--- a/packages/cli/bin/__tests__/fixtures/canonical-eval-exit-code.preload.ts
+++ b/packages/cli/bin/__tests__/fixtures/canonical-eval-exit-code.preload.ts
@@ -8,8 +8,11 @@
  * unreachable paths need. It is inert unless one of its env switches is set, so
  * a spawn that wants the untouched CLI simply omits `--preload`.
  *
- *   ATLAS_TEST_STUB_SEED=1     — make `seedDemoPostgres` a no-op, so a run can
- *                                get PAST the seed without a live Postgres.
+ *   ATLAS_TEST_STUB_SEED=1     — replace `seedDemoPostgres` with a stub that
+ *                                REPORTS THE LABEL THROUGH THE INJECTED SINK
+ *                                (see below — a no-op would delete the very
+ *                                polluter the suite exists to detect) and skips
+ *                                the live Postgres.
  *   ATLAS_TEST_FAIL_CP_FROM=…  — make `fs.cpSync` throw when copying FROM that
  *                                path, so `restoreSemanticLayer` fails.
  *   ATLAS_TEST_EMIT_LOG=1      — with the seed stub, emit one real app-logger
@@ -101,7 +104,7 @@ if (process.env.ATLAS_TEST_STUB_SEED === "1") {
     // this an assertion about the CALL SITE: does `runInstalledCanonicalEval`
     // hand `seedDemoPostgres` the resolved human writer, or `console.log`?
     // (The real function's own use of the sink is covered in-process by
-    // `../seed-demo-report.test.ts`, which the stub cannot reach.)
+    // `../../../src/__tests__/seed-demo-report.test.ts`, which the stub cannot reach.)
     report(`${realInit.DEMO_DATASET.label}\n`);
 
     // ⚠️ Emitted from INSIDE the run, through the real `createLogger`, because

--- a/packages/cli/bin/__tests__/fixtures/canonical-eval-write-stdout-driver.ts
+++ b/packages/cli/bin/__tests__/fixtures/canonical-eval-write-stdout-driver.ts
@@ -1,21 +1,34 @@
 /**
- * Driver for the `writeStdoutSync` truncation test (`#5130`).
+ * Driver for the blocking-write truncation tests (`#5130`, extended to fd 2 by
+ * `#5126`).
  *
  * The defect only exists in the interaction between a buffered write and
  * `process.exit`, so it cannot be observed in-process — the test spawns this,
  * pipes it, and counts the bytes that survive.
  *
  *   argv[2] — payload size in bytes
- *   argv[3] — "sync" to use `writeStdoutSync`, anything else for the buffered
- *             `process.stdout.write` the helper replaced
+ *   argv[3] — "sync" for the blocking helper, anything else for the buffered
+ *             stream write the helper replaced
+ *   argv[4] — "2" to exercise fd 2, anything else (or absent) for fd 1
+ *
+ * ⚠️ fd 2 IS NOT SYMMETRY. Until #5126 the only things on fd 2 were bounded
+ * failure diagnostics, so the cliff there was latent and `writeStderrSync` did
+ * not exist. Under `--json` the entire human transcript moves to fd 2 —
+ * unbounded in principle, since the `note:` lines interpolate caught error
+ * messages and `--questions` is caller-supplied — which is what made the twin
+ * necessary and what makes this arm a real falsifier rather than a mirror.
  */
-import { writeStdoutSync } from "../../canonical-eval-run";
+import { writeStdoutSync, writeStderrSync } from "../../canonical-eval-run";
 
 const size = Number(process.argv[2] ?? "0");
 const payload = "x".repeat(size);
+const useStderr = process.argv[4] === "2";
 
 if (process.argv[3] === "sync") {
-  writeStdoutSync(payload);
+  if (useStderr) writeStderrSync(payload);
+  else writeStdoutSync(payload);
+} else if (useStderr) {
+  process.stderr.write(payload);
 } else {
   process.stdout.write(payload);
 }

--- a/packages/cli/bin/__tests__/fixtures/canonical-eval-write-stdout-driver.ts
+++ b/packages/cli/bin/__tests__/fixtures/canonical-eval-write-stdout-driver.ts
@@ -18,16 +18,20 @@
  * messages and `--questions` is caller-supplied — which is what made the twin
  * necessary and what makes this arm a real falsifier rather than a mirror.
  */
-import { writeStdoutSync, writeStderrSync } from "../../canonical-eval-run";
+// `writeFdSync`, not the `writeStdoutSync` / `writeStderrSync` wrappers — those
+// are module-private on purpose. Each is assignable to every `(text: string) =>
+// void` sink in the codebase, so exporting one put a ready-made wrong argument
+// one import away from the call sites that caused #5126. `(fd, text)` fits no
+// sink, and the wrappers are one-line aliases with nothing of their own to test.
+import { writeFdSync } from "../../canonical-eval-run";
 
 const size = Number(process.argv[2] ?? "0");
 const payload = "x".repeat(size);
-const useStderr = process.argv[4] === "2";
+const fd = process.argv[4] === "2" ? 2 : 1;
 
 if (process.argv[3] === "sync") {
-  if (useStderr) writeStderrSync(payload);
-  else writeStdoutSync(payload);
-} else if (useStderr) {
+  writeFdSync(fd, payload);
+} else if (fd === 2) {
   process.stderr.write(payload);
 } else {
   process.stdout.write(payload);

--- a/packages/cli/bin/__tests__/fixtures/eval-log-destination-driver.ts
+++ b/packages/cli/bin/__tests__/fixtures/eval-log-destination-driver.ts
@@ -1,0 +1,14 @@
+/**
+ * Driver for the stamp's argv matrix (#5126).
+ *
+ * Imports the real stamp module for its side effect and prints the resulting
+ * `ATLAS_LOG_STDERR`. A spawn per argv shape is the only way to test this: the
+ * stamp reads `process.argv` at module-evaluation time, so one process can
+ * observe exactly one answer.
+ *
+ * Writes to fd 2 on purpose — this driver's own stdout is irrelevant to what it
+ * measures, and keeping it clear means a future assertion can use either fd.
+ */
+import "../../eval-log-destination";
+
+process.stderr.write(`ATLAS_LOG_STDERR=${process.env.ATLAS_LOG_STDERR ?? "<unset>"}\n`);

--- a/packages/cli/bin/__tests__/fixtures/stdout-console-methods.ts
+++ b/packages/cli/bin/__tests__/fixtures/stdout-console-methods.ts
@@ -1,0 +1,43 @@
+/**
+ * The `console` methods that reach **fd 1**, as one list (#5126).
+ *
+ * ⚠️ ONE LIST BECAUSE TWO LISTS DRIFTED IMMEDIATELY. The fd-1 guard's regex
+ * (`bin/__tests__/eval-json-stdout.test.ts`) and the spy in
+ * `src/__tests__/seed-demo-report.test.ts` each hand-maintained
+ * `log|info|debug|dir|table|trace`, in two packages, agreeing only by
+ * maintenance — and both were wrong the same way. Measured on bun 1.3.13 with
+ * stdout redirected to a file, `console.group` and `console.count` land on
+ * fd 1 and were in neither, so a `console.group` added beside the demo seed's
+ * sink was a live surviving mutation past both arms.
+ *
+ * It lives in `fixtures/` rather than in either test file because importing a
+ * `*.test.ts` from another test file would re-run its suite in the importer's
+ * process.
+ *
+ * Measured on bun 1.3.13 in this worktree, stdout redirected to a file:
+ *
+ *   fd 1 — log, info, debug, dir, table, group, groupCollapsed, count, TRACE
+ *   fd 2 — error, warn, timeEnd, timeLog
+ *
+ * So `error` and `warn` are absent deliberately. `trace` is here on bun's own
+ * behaviour, not as over-coverage — an earlier draft of this comment had it on
+ * fd 2 and dismissed it as harmless, which was backwards on the runtime that
+ * actually produces the CI artifact. `timeEnd` and `timeLog` ARE the
+ * over-coverage case: fd 2 on bun, fd 1 in node, listed because the placement
+ * is runtime-dependent and costs nothing to keep.
+ */
+export const STDOUT_CONSOLE_METHODS = [
+  "log",
+  "info",
+  "debug",
+  "dir",
+  "table",
+  "group",
+  "groupCollapsed",
+  "groupEnd",
+  "count",
+  "countReset",
+  "trace",
+  "timeEnd",
+  "timeLog",
+] as const;

--- a/packages/cli/bin/atlas.ts
+++ b/packages/cli/bin/atlas.ts
@@ -41,8 +41,9 @@
 // ⚠️ MUST STAY FIRST. Side-effect only: it pins the app logger to stderr for
 // `canonical-eval … --json`, and it has to run before anything below pulls
 // `@atlas/api/lib/logger` (the profiler re-exports do). See that module's
-// header, and `bin/__tests__/eval-log-destination.test.ts`, which fails if this
-// line moves.
+// header, and `bin/__tests__/eval-json-stdout.test.ts`, whose last test fails
+// if this line moves — including if a re-export block is added above it, since
+// `export … from` is a module-graph edge evaluated in source order too.
 import "./eval-log-destination";
 import { checkEnvFile } from "../src/env-check";
 import {

--- a/packages/cli/bin/atlas.ts
+++ b/packages/cli/bin/atlas.ts
@@ -38,6 +38,12 @@
  * Supports PostgreSQL, MySQL, ClickHouse, Snowflake, DuckDB, and Salesforce.
  */
 
+// ⚠️ MUST STAY FIRST. Side-effect only: it pins the app logger to stderr for
+// `canonical-eval … --json`, and it has to run before anything below pulls
+// `@atlas/api/lib/logger` (the profiler re-exports do). See that module's
+// header, and `bin/__tests__/eval-log-destination.test.ts`, which fails if this
+// line moves.
+import "./eval-log-destination";
 import { checkEnvFile } from "../src/env-check";
 import {
   SUBCOMMAND_HELP,

--- a/packages/cli/bin/canonical-eval-run.ts
+++ b/packages/cli/bin/canonical-eval-run.ts
@@ -340,7 +340,7 @@ function toGlossaryMatches(
 async function evalEachQuestion(
   questions: readonly Question[],
   label: string,
-  human: (text: string) => void,
+  human: HumanWriter,
   resolve: (q: Question) => Promise<QuestionResult>,
 ): Promise<QuestionResult[]> {
   const results: QuestionResult[] = [];
@@ -376,7 +376,7 @@ async function runDeterministic(
   };
 
   const questions = loadQuestions(options.questionsPath);
-  return evalEachQuestion(questions, "", humanWriter(options.json), (q) =>
+  return evalEachQuestion(questions, "", humanWriter(options), (q) =>
     resolveQuestion(q, harnessOpts),
   );
 }
@@ -390,7 +390,7 @@ async function runWithAgent(
   const lookups = await import("@atlas/api/lib/semantic/lookups");
 
   const questions = loadQuestions(options.questionsPath);
-  return evalEachQuestion(questions, " (--llm)", humanWriter(options.json), async (q) => {
+  return evalEachQuestion(questions, " (--llm)", humanWriter(options), async (q) => {
     // Glossary mode never invokes the agent — we assert the
     // disambiguation contract by checking semantic-layer state directly.
     if (q.mode === "glossary") {
@@ -474,7 +474,7 @@ export async function handleCanonicalEval(args: string[]): Promise<void> {
     process.exit(1);
   }
 
-  humanWriter(options.json)(
+  humanWriter(options)(
     `Atlas canonical-question eval — schema=${options.schema} mode=${options.mode}\n`,
   );
 
@@ -664,10 +664,35 @@ export function writeStdoutSync(text: string): void {
   writeFdSync(1, text);
 }
 
-/** Blocking write to fd 2. See {@link writeFdSync}'s stderr-cliff note. */
-function writeStderrSync(text: string): void {
+/**
+ * Blocking write to fd 2. See {@link writeFdSync}'s stderr-cliff note.
+ *
+ * Exported for the same reason its fd-1 twin is: the truncation it prevents
+ * only exists in a spawned process, so `__tests__/fixtures/
+ * canonical-eval-write-stdout-driver.ts` drives it directly. Without that, this
+ * whole function was a surviving mutation — reverting `humanWriter`'s stderr arm
+ * to `process.stderr.write` passed every test in the suite, because the largest
+ * transcript any of them produces is ~2 KB against a 65_536-byte cliff.
+ */
+export function writeStderrSync(text: string): void {
   writeFdSync(2, text);
 }
+
+declare const HumanChannel: unique symbol;
+
+/**
+ * A writer that has been RESOLVED against `--json`. Nominal on purpose.
+ *
+ * ⚠️ THE BRAND IS ON THE OUTPUT, NOT THE PARAMETER, AND THAT DISTINCTION IS THE
+ * WHOLE POINT. A plain `(text: string) => void` parameter is satisfied by
+ * `process.stdout.write`, by `console.log`, and — the one that would actually
+ * happen — by the exported `writeStdoutSync` sitting three lines up, which is
+ * this module's sanctioned way to write fd 1. `evalEachQuestion(qs, "",
+ * writeStdoutSync, resolve)` would then compile and silently reopen #5126.
+ * {@link humanWriter} is the only producer of this type, so an unbranded
+ * sibling producer cannot satisfy the destination.
+ */
+type HumanWriter = ((text: string) => void) & { readonly [HumanChannel]: true };
 
 /**
  * The fd this run's HUMAN-READABLE output goes to.
@@ -680,12 +705,20 @@ function writeStderrSync(text: string): void {
  * place — payload-emission time — and this is what makes it gate every other
  * write instead.
  *
- * Resolved from `options.json` at each use site rather than stored alongside it,
- * so the channel and the flag cannot disagree. The logger is the OTHER writer on
- * fd 1 and it is not reachable from here — see `bin/eval-log-destination.ts`.
+ * Takes the OPTIONS rather than a bare boolean: `CanonicalEvalOptions` carries
+ * three booleans, all in scope at every call site here, and `humanWriter(
+ * options.writeBaseline)` would compile and route the transcript down the wrong
+ * channel. Resolved at each use site rather than stored alongside `json`, so the
+ * flag and the channel cannot disagree.
+ *
+ * The logger is the OTHER writer on fd 1 and is not reachable from here — see
+ * `bin/eval-log-destination.ts` — and `seedDemoPostgres` was the third, which is
+ * why it now takes this writer as a required argument.
  */
-function humanWriter(json: boolean): (text: string) => void {
-  return json ? writeStderrSync : writeStdoutSync;
+function humanWriter(options: Pick<CanonicalEvalOptions, "json">): HumanWriter {
+  // The one cast in this module, and the reason the brand holds: every other
+  // route to a `HumanWriter` has to come through here.
+  return (options.json ? writeStderrSync : writeStdoutSync) as HumanWriter;
 }
 
 /**
@@ -698,13 +731,19 @@ async function runInstalledCanonicalEval(
   options: CanonicalEvalOptions,
   connStr: string,
 ): Promise<number> {
+  const human = humanWriter(options);
   installSchemaSemanticLayer(options.schema);
 
   // Seed the demo Postgres before running so the harness is self-contained
   // — same hook used by bin/eval.ts. seedDemoPostgres takes a connection
   // string, not a schema; only `ecommerce` ships today (#2021).
+  //
+  // ⚠️ The sink is not decoration. This call is UNCONDITIONAL and runs before
+  // any mode branch, so the demo label it prints was the first line of every
+  // `--json` artifact — the third fd-1 writer, and the only one outside this
+  // file (#5126). A fix confined to this module would not have reached it.
   try {
-    await seedDemoPostgres(connStr);
+    await seedDemoPostgres(connStr, human);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     process.stderr.write(
@@ -760,7 +799,7 @@ async function runInstalledCanonicalEval(
       )}\n`,
     );
   } else {
-    humanWriter(options.json)(`\n${formatSummary(results)}\n`);
+    human(`\n${formatSummary(results)}\n`);
   }
 
   return results.some((r) => r.status === "fail") ? 1 : 0;
@@ -810,7 +849,7 @@ async function runMcpLlmMode(
     "@atlas/mcp/eval/failure-artifact"
   );
   const { getModelForConfig } = await import("@atlas/api/lib/providers");
-  const human = humanWriter(options.json);
+  const human = humanWriter(options);
 
   // Resolve provider + model from env. Wrap getModelForConfig errors
   // with eval-context framing so a CI maintainer hitting "ATLAS_MODEL
@@ -998,7 +1037,7 @@ async function runMcpLlmMode(
  */
 async function resolveExpectations(
   questionsPath: string,
-  human: (text: string) => void,
+  human: HumanWriter,
 ): Promise<{
   metricExpectations: Record<string, MetricExpectation>;
   answerExpectations: Record<string, MetricExpectation>;
@@ -1106,7 +1145,7 @@ async function runToolSelectionMode(
   options: ToolSelectionModeOptions,
 ): Promise<number> {
   const { runToolSelectionEval } = await import("./canonical-eval-tool-selection");
-  const human = humanWriter(options.json);
+  const human = humanWriter(options);
 
   human(`  tool-selection fixture: ${options.toolSelectionFixturePath}\n`);
 

--- a/packages/cli/bin/canonical-eval-run.ts
+++ b/packages/cli/bin/canonical-eval-run.ts
@@ -333,16 +333,21 @@ function toGlossaryMatches(
 // Iterate questions printing a per-question progress line. The resolver
 // closure isolates the deterministic-vs-LLM behavioral difference; this
 // helper just owns the I/O and the result accumulator.
+//
+// `human` is passed rather than derived here because this helper has no
+// options in scope — see {@link humanWriter} for why it is never stdout under
+// `--json`.
 async function evalEachQuestion(
   questions: readonly Question[],
   label: string,
+  human: (text: string) => void,
   resolve: (q: Question) => Promise<QuestionResult>,
 ): Promise<QuestionResult[]> {
   const results: QuestionResult[] = [];
   for (const q of questions) {
-    process.stdout.write(`  ${q.id} ${q.category}${label} ... `);
+    human(`  ${q.id} ${q.category}${label} ... `);
     const r = await resolve(q);
-    process.stdout.write(`${r.status}\n`);
+    human(`${r.status}\n`);
     results.push(r);
   }
   return results;
@@ -371,7 +376,9 @@ async function runDeterministic(
   };
 
   const questions = loadQuestions(options.questionsPath);
-  return evalEachQuestion(questions, "", (q) => resolveQuestion(q, harnessOpts));
+  return evalEachQuestion(questions, "", humanWriter(options.json), (q) =>
+    resolveQuestion(q, harnessOpts),
+  );
 }
 
 // ── Wiring (LLM mode) ────────────────────────────────────────────────────
@@ -383,7 +390,7 @@ async function runWithAgent(
   const lookups = await import("@atlas/api/lib/semantic/lookups");
 
   const questions = loadQuestions(options.questionsPath);
-  return evalEachQuestion(questions, " (--llm)", async (q) => {
+  return evalEachQuestion(questions, " (--llm)", humanWriter(options.json), async (q) => {
     // Glossary mode never invokes the agent — we assert the
     // disambiguation contract by checking semantic-layer state directly.
     if (q.mode === "glossary") {
@@ -467,7 +474,7 @@ export async function handleCanonicalEval(args: string[]): Promise<void> {
     process.exit(1);
   }
 
-  process.stdout.write(
+  humanWriter(options.json)(
     `Atlas canonical-question eval — schema=${options.schema} mode=${options.mode}\n`,
   );
 
@@ -546,13 +553,14 @@ async function runStagedCanonicalEval(
 }
 
 /**
- * Write to stdout with a BLOCKING syscall loop instead of the buffered stream.
+ * Write to a standard fd with a BLOCKING syscall loop instead of the buffered
+ * `process.stdout` / `process.stderr` stream.
  *
- * ⚠️ `process.exit()` DISCARDS whatever is still sitting in `process.stdout`'s
- * buffer, with no error on either side. Measured on bun 1.3.13: a 2 MB payload
- * written via `process.stdout.write` and followed by `process.exit` reaches a
- * pipe truncated — 65_536 bytes (one pipe buffer) under `| wc -c`, 219_264 under
- * a concurrently-draining reader. HOW MUCH survives is whatever the reader
+ * ⚠️ `process.exit()` DISCARDS whatever is still sitting in a buffered stream,
+ * with no error on either side. Measured on bun 1.3.13: a 2 MB payload written
+ * via `process.stdout.write` and followed by `process.exit` reaches a pipe
+ * truncated — 65_536 bytes (one pipe buffer) under `| wc -c`, 219_264 under a
+ * concurrently-draining reader. HOW MUCH survives is whatever the reader
  * drained in time, so it is not a fixed number and not something a caller can
  * budget against; what is fixed is that the tail is lost and nothing says so.
  *
@@ -566,32 +574,39 @@ async function runStagedCanonicalEval(
  * to carry.
  *
  * `fs.writeSync` returns only once the bytes are handed to the fd, so there is
- * nothing left to discard. Reserved for the payloads that can cross that cliff —
- * the three `--json` bodies and the failure-artifact bundle.
+ * nothing left to discard.
  *
- * ⚠️ STDERR HAS THE SAME CLIFF and no equivalent helper. Measured the same way:
- * 200 KB to stderr followed by `process.exit` arrives as 65_536 bytes. The
- * FAILURE-path diagnostics all live there — the acceptance-floor FAIL line,
- * `CRITICAL: Failed to restore semantic layer`, the harness stack — at a few
- * hundred bytes each, except the stack, which runs to a few KB. (The pass/fail
- * DETAIL is not on stderr: that is `formatSummary` and the `--json` bodies, on
- * stdout.) So this is latent rather than live; whoever adds an unbounded stderr
- * diagnostic needs a `writeStderrSync` twin first.
+ * ⚠️ STDERR HAS THE SAME CLIFF — measured the same way: 200 KB to stderr
+ * followed by `process.exit` arrives as 65_536 bytes. It used to be latent,
+ * because the only things on fd 2 were the failure-path diagnostics at a few
+ * hundred bytes each. #5126 made it live: under `--json` the whole human
+ * transcript moves to stderr, including the `note:` lines in
+ * `resolveExpectations` and the per-question progress lines, neither of which
+ * is bounded in principle (the notes interpolate caught error messages, and
+ * `--questions` is caller-supplied). The `writeStderrSync` twin the old comment
+ * here said "whoever adds an unbounded stderr diagnostic needs first" is
+ * therefore below, and it is why this helper is parameterised by fd at all.
  *
- * ⚠️ MIXING SYNCHRONOUS AND BUFFERED WRITES IS ORDER-SENSITIVE. A `writeSync`
- * bypasses `process.stdout`'s queue entirely, so it can print ahead of an
- * earlier buffered write that has not flushed. The interleaving is correct on
- * every path measured on bun 1.3.13 — a 4-byte buffered write, a 60_000-byte
- * one, and a real 40-question `--json` run all landed ahead of the following
- * `writeStdoutSync` — but that is a MEASUREMENT of this runtime's flush timing,
- * not a guarantee the code enforces, so do not extend the mixing on the strength
- * of it. Note in particular that `formatSummary` (the deterministic human
- * summary) and the `note:` lines in `resolveExpectations` are NOT bounded in
- * principle: both interpolate caught error messages, and `--questions` is
- * caller-supplied. They stay on the stream because the buffered path is what
- * they have always used, not because they are known small.
+ * ⚠️ EVERY STDOUT WRITE IN THIS MODULE GOES THROUGH HERE, AND NOTHING ELSE MAY
+ * TOUCH fd 1. That is not tidiness — it is what lets
+ * `__tests__/eval-json-stdout.test.ts` assert the invariant by GREP (the file
+ * contains no `process.stdout.write` call at all) rather than by inspection,
+ * and a grep is the only check that survives a call site added later.
+ *
+ * The buffered fd-2 writes on the FAILURE paths are deliberately left alone:
+ * they are #5130's reasoned exit-code paths, they are bounded, and making them
+ * throw on a bad fd 2 would let a write error escape `restoreSemanticLayer`'s
+ * catch and discard the exit-2 bump that catch exists to produce.
+ *
+ * Mixing the two write paths on ONE fd was also order-sensitive (a `writeSync`
+ * bypasses the stream's queue entirely and can print ahead of an earlier
+ * buffered write that has not flushed). On fd 1 that mixing is now gone. It
+ * remains on fd 2 in the `--json` shape — human transcript via `writeStderrSync`,
+ * failure diagnostics via the stream — where the ordering measured on bun 1.3.13
+ * held on every path, but it is a measurement rather than a guarantee, and fd 2
+ * is a diagnostic channel where a reordered line costs nothing that parses.
  */
-export function writeStdoutSync(text: string): void {
+function writeFdSync(fd: 1 | 2, text: string): void {
   const buf = Buffer.from(text, "utf-8");
   // A one-word cell purely to get a blocking sleep on the EAGAIN path below;
   // there is no synchronous `sleep` and a bare retry loop would spin at 100%.
@@ -600,7 +615,7 @@ export function writeStdoutSync(text: string): void {
   while (offset < buf.length) {
     let written: number;
     try {
-      written = fs.writeSync(1, buf, offset, buf.length - offset);
+      written = fs.writeSync(fd, buf, offset, buf.length - offset);
     } catch (err) {
       // `.code` is read only after narrowing to Error. Reading it off a bare
       // caught value raises a TypeError from inside the handler for `throw null`
@@ -617,7 +632,7 @@ export function writeStdoutSync(text: string): void {
       // EAGAIN drives a RETRY; it is not discarded. A `write(2)` that returns
       // EAGAIN wrote nothing, so re-driving the same offset loses no bytes, and
       // waiting for the reader is exactly what a blocking fd would have done —
-      // this branch only exists because fd 1 may arrive with O_NONBLOCK set.
+      // this branch only exists because the fd may arrive with O_NONBLOCK set.
       // Every other errno (ENOSPC, EBADF) is a real write failure and
       // propagates to `runStagedCanonicalEval`'s catch.
       //
@@ -632,12 +647,45 @@ export function writeStdoutSync(text: string): void {
     // falsify. Fail loudly with the offset reached instead.
     if (written === 0) {
       throw new Error(
-        `stdout write stalled at ${offset}/${buf.length} bytes: write(2) returned 0. ` +
+        `fd ${fd} write stalled at ${offset}/${buf.length} bytes: write(2) returned 0. ` +
           `Refusing to spin — the remaining payload would be lost silently.`,
       );
     }
     offset += written;
   }
+}
+
+/**
+ * Blocking write to fd 1. Exported because the truncation proof in
+ * `__tests__/fixtures/canonical-eval-write-stdout-driver.ts` drives it directly
+ * — the defect it pins only exists in a spawned process.
+ */
+export function writeStdoutSync(text: string): void {
+  writeFdSync(1, text);
+}
+
+/** Blocking write to fd 2. See {@link writeFdSync}'s stderr-cliff note. */
+function writeStderrSync(text: string): void {
+  writeFdSync(2, text);
+}
+
+/**
+ * The fd this run's HUMAN-READABLE output goes to.
+ *
+ * ⚠️ UNDER `--json`, STDOUT IS A MACHINE CHANNEL AND NOTHING HUMAN MAY TOUCH
+ * IT. The workflow pipes it into `eval-mcp-llm-output.json` and uploads that as
+ * the adjudication artifact; the banner, the provider line, the per-question
+ * progress lines and the `note:` lines were all on fd 1 unconditionally, so the
+ * artifact had never parsed (#5126). `options.json` was consulted at exactly one
+ * place — payload-emission time — and this is what makes it gate every other
+ * write instead.
+ *
+ * Resolved from `options.json` at each use site rather than stored alongside it,
+ * so the channel and the flag cannot disagree. The logger is the OTHER writer on
+ * fd 1 and it is not reachable from here — see `bin/eval-log-destination.ts`.
+ */
+function humanWriter(json: boolean): (text: string) => void {
+  return json ? writeStderrSync : writeStdoutSync;
 }
 
 /**
@@ -712,7 +760,7 @@ async function runInstalledCanonicalEval(
       )}\n`,
     );
   } else {
-    process.stdout.write(`\n${formatSummary(results)}\n`);
+    humanWriter(options.json)(`\n${formatSummary(results)}\n`);
   }
 
   return results.some((r) => r.status === "fail") ? 1 : 0;
@@ -762,6 +810,7 @@ async function runMcpLlmMode(
     "@atlas/mcp/eval/failure-artifact"
   );
   const { getModelForConfig } = await import("@atlas/api/lib/providers");
+  const human = humanWriter(options.json);
 
   // Resolve provider + model from env. Wrap getModelForConfig errors
   // with eval-context framing so a CI maintainer hitting "ATLAS_MODEL
@@ -797,9 +846,7 @@ async function runMcpLlmMode(
     return 1;
   }
 
-  process.stdout.write(
-    `  using LLM provider=${providerType} model=${modelId}\n`,
-  );
+  human(`  using LLM provider=${providerType} model=${modelId}\n`);
 
   // Branch into the held-out tool-selection fixture (#2075) when
   // requested. The MCP transport boot is identical to the canonical
@@ -817,11 +864,11 @@ async function runMcpLlmMode(
 
   const baseline = readBaseline(options.baselinePath);
   if (baseline) {
-    process.stdout.write(
+    human(
       `  loaded baseline from ${options.baselinePath} (${Object.keys(baseline).length} entries)\n`,
     );
   } else {
-    process.stdout.write(
+    human(
       `  no baseline file at ${options.baselinePath} — latency check skipped (run with --write-baseline to seed)\n`,
     );
   }
@@ -831,8 +878,9 @@ async function runMcpLlmMode(
   // LLM metric mode grades the ANSWER now, not the SQL's spelling (#5122).
   const { metricExpectations, answerExpectations } = await resolveExpectations(
     options.questionsPath,
+    human,
   );
-  process.stdout.write(
+  human(
     `  resolved ${Object.keys(metricExpectations).length} metric + ` +
       `${Object.keys(answerExpectations).length} pattern/virtual expectations from the semantic layer\n`,
   );
@@ -855,9 +903,7 @@ async function runMcpLlmMode(
   // on to read the next CI step.
   if (options.writeBaseline) {
     writeBaseline(options.baselinePath, result.outcomes);
-    process.stdout.write(
-      `  wrote per-question latency baseline to ${options.baselinePath}\n`,
-    );
+    human(`  wrote per-question latency baseline to ${options.baselinePath}\n`);
   }
 
   if (options.json) {
@@ -898,17 +944,22 @@ async function runMcpLlmMode(
       )}\n`,
     );
   } else {
-    process.stdout.write(
+    human(
       `\nMCP LLM canonical eval — ${passing}/${result.outcomes.length} passing (${failing} failing)\n`,
     );
     for (const o of result.outcomes) {
       const tag = o.status === "pass" ? "[PASS]" : "[FAIL]";
-      process.stdout.write(
+      human(
         `  ${tag} ${o.questionId.padEnd(7)} ${String(o.latencyMs).padStart(5)}ms tools=${o.toolCalls.map((c) => c.name).join(",") || "<none>"}\n`,
       );
     }
     if (result.artifacts.length > 0) {
-      writeStdoutSync(formatArtifactBundle(result.artifacts));
+      // `human`, not `writeStdoutSync`: this branch is unreachable under
+      // `--json` today, but the bundle is the largest human payload the command
+      // produces and hard-wiring it to fd 1 is precisely the shape that made the
+      // artifact unparseable. Routed through the same writer, it is stdout here
+      // and would follow the rest to stderr if the branch ever moved.
+      human(formatArtifactBundle(result.artifacts));
     }
   }
 
@@ -945,7 +996,10 @@ async function runMcpLlmMode(
  * would otherwise silently downgrade that question's grading, and a gate that
  * stops checking without saying so is the failure mode this whole issue is about.
  */
-async function resolveExpectations(questionsPath: string): Promise<{
+async function resolveExpectations(
+  questionsPath: string,
+  human: (text: string) => void,
+): Promise<{
   metricExpectations: Record<string, MetricExpectation>;
   answerExpectations: Record<string, MetricExpectation>;
 }> {
@@ -1012,7 +1066,7 @@ async function resolveExpectations(questionsPath: string): Promise<{
         ? findPatternSqlFromDisk(q.entity, q.pattern, SEMANTIC_DIR)
         : q.sql;
     if (!sql) {
-      process.stdout.write(
+      human(
         `  note: no authoritative SQL for ${q.id} — value accept path disabled for it\n`,
       );
       continue;
@@ -1020,7 +1074,7 @@ async function resolveExpectations(questionsPath: string): Promise<{
     try {
       answerExpectations[q.id] = await expectationFor(`${q.mode} question ${q.id}`, sql);
     } catch (err) {
-      process.stdout.write(
+      human(
         `  note: ${q.id} ground truth unavailable (${err instanceof Error ? err.message : String(err)}) — ` +
           `value accept path disabled for it\n`,
       );
@@ -1052,10 +1106,9 @@ async function runToolSelectionMode(
   options: ToolSelectionModeOptions,
 ): Promise<number> {
   const { runToolSelectionEval } = await import("./canonical-eval-tool-selection");
+  const human = humanWriter(options.json);
 
-  process.stdout.write(
-    `  tool-selection fixture: ${options.toolSelectionFixturePath}\n`,
-  );
+  human(`  tool-selection fixture: ${options.toolSelectionFixturePath}\n`);
 
   const result = await runToolSelectionEval({
     fixturePath: options.toolSelectionFixturePath,
@@ -1094,13 +1147,13 @@ async function runToolSelectionMode(
       )}\n`,
     );
   } else {
-    process.stdout.write(
+    human(
       `\nMCP tool-selection eval — ${passing}/${result.outcomes.length} accurate (${accuracyPct}%; floor ${floorPct}%)\n`,
     );
     for (const o of result.outcomes) {
       const tag = o.passed ? "[PASS]" : "[FAIL]";
       const firstTool = o.firstTool ?? "<none>";
-      process.stdout.write(
+      human(
         `  ${tag} ${o.id.padEnd(20)} ${String(o.latencyMs).padStart(5)}ms first=${firstTool} expected=${o.expected.join("|")} sequence=${o.toolSequence.join(",") || "<none>"}\n`,
       );
     }

--- a/packages/cli/bin/canonical-eval-run.ts
+++ b/packages/cli/bin/canonical-eval-run.ts
@@ -65,8 +65,8 @@ const SCHEMAS_DIR = path.resolve(
 const BACKUP_DIR = path.resolve(".semantic-backup-canonical-eval");
 
 interface CanonicalEvalOptions {
-  schema: ValidSchema;
-  questionsPath: string;
+  readonly schema: ValidSchema;
+  readonly questionsPath: string;
   /**
    * Mutually exclusive: `deterministic` is the default typed-dispatch
    * path; `llm` runs the full agent loop and asserts on the snapshot
@@ -75,16 +75,16 @@ interface CanonicalEvalOptions {
    * (rather than two booleans) makes the mutual exclusion enforceable
    * at parse time.
    */
-  mode: "deterministic" | "llm" | "mcp-llm";
-  json: boolean;
+  readonly mode: "deterministic" | "llm" | "mcp-llm";
+  readonly json: boolean;
   /**
    * Path to the `--mcp-llm` latency baseline JSON. Defaults to
    * `eval/canonical-questions/mcp-llm-baseline.json`. Missing entries
    * are treated as "no baseline yet" by the grader.
    */
-  baselinePath: string;
+  readonly baselinePath: string;
   /** When true and `mode === "mcp-llm"`, write the run's per-question latencies back to `baselinePath`. */
-  writeBaseline: boolean;
+  readonly writeBaseline: boolean;
   /**
    * When true, swap the canonical-question path for the held-out
    * tool-selection fixture — `eval/canonical-questions/tool-selection.json`
@@ -93,9 +93,9 @@ interface CanonicalEvalOptions {
    * when accuracy < `rubric.acceptance_floor` (default 0.9). Only
    * meaningful with `--mcp-llm`. Drives the #2075 audit's success metric.
    */
-  toolSelection: boolean;
+  readonly toolSelection: boolean;
   /** Path to the tool-selection fixture (#2075). Defaults to `eval/canonical-questions/tool-selection.json`. */
-  toolSelectionFixturePath: string;
+  readonly toolSelectionFixturePath: string;
 }
 
 const DEFAULT_BASELINE_PATH = path.resolve(
@@ -583,9 +583,9 @@ async function runStagedCanonicalEval(
  * transcript moves to stderr, including the `note:` lines in
  * `resolveExpectations` and the per-question progress lines, neither of which
  * is bounded in principle (the notes interpolate caught error messages, and
- * `--questions` is caller-supplied). The `writeStderrSync` twin the old comment
- * here said "whoever adds an unbounded stderr diagnostic needs first" is
- * therefore below, and it is why this helper is parameterised by fd at all.
+ * `--questions` is caller-supplied). The fd-2 twin the old comment here said
+ * "whoever adds an unbounded stderr diagnostic needs first" is therefore what
+ * this helper's `fd` parameter provides, and `humanWriter` binds it.
  *
  * ⚠️ EVERY STDOUT WRITE IN THIS MODULE GOES THROUGH HERE, AND NOTHING ELSE MAY
  * TOUCH fd 1. That is not tidiness — it is what lets
@@ -594,19 +594,20 @@ async function runStagedCanonicalEval(
  * and a grep is the only check that survives a call site added later.
  *
  * The buffered fd-2 writes on the FAILURE paths are deliberately left alone:
- * they are #5130's reasoned exit-code paths, they are bounded, and making them
+ * they are #5130's reasoned exit-code paths, they are small (a few hundred bytes
+ * each, except the harness stack, which runs to a few KB), and making them
  * throw on a bad fd 2 would let a write error escape `restoreSemanticLayer`'s
  * catch and discard the exit-2 bump that catch exists to produce.
  *
  * Mixing the two write paths on ONE fd was also order-sensitive (a `writeSync`
  * bypasses the stream's queue entirely and can print ahead of an earlier
  * buffered write that has not flushed). On fd 1 that mixing is now gone. It
- * remains on fd 2 in the `--json` shape — human transcript via `writeStderrSync`,
+ * remains on fd 2 in the `--json` shape — human transcript via `humanWriter`,
  * failure diagnostics via the stream — where the ordering measured on bun 1.3.13
  * held on every path, but it is a measurement rather than a guarantee, and fd 2
  * is a diagnostic channel where a reordered line costs nothing that parses.
  */
-function writeFdSync(fd: 1 | 2, text: string): void {
+export function writeFdSync(fd: 1 | 2, text: string): void {
   const buf = Buffer.from(text, "utf-8");
   // A one-word cell purely to get a blocking sleep on the EAGAIN path below;
   // there is no synchronous `sleep` and a bare retry loop would spin at 100%.
@@ -626,6 +627,14 @@ function writeFdSync(fd: 1 | 2, text: string): void {
       // must not become one: the buffered stream this replaced dropped EPIPE
       // silently, and turning `atlas canonical-eval --json | head` into exit 1
       // with a stack trace would be a regression introduced by a flush fix.
+      //
+      // ⚠️ That reason was written for fd 1 and has to be re-derived for fd 2,
+      // which this now also serves: on stderr the swallow discards the REST OF
+      // THE HUMAN TRANSCRIPT, which under `--json` is the run's only human
+      // record. Still correct — it matches what `process.stderr.write` does
+      // with a closed fd 2, and neither the exit code nor the fd-1 payload is
+      // affected — but the cost is larger than the fd-1 argument implies.
+      //
       // intentionally ignored: the reader hung up. This is the one path here
       // that emits nothing, and that is the correct behaviour for a pipe.
       if (code === "EPIPE") return;
@@ -655,29 +664,6 @@ function writeFdSync(fd: 1 | 2, text: string): void {
   }
 }
 
-/**
- * Blocking write to fd 1. Exported because the truncation proof in
- * `__tests__/fixtures/canonical-eval-write-stdout-driver.ts` drives it directly
- * — the defect it pins only exists in a spawned process.
- */
-export function writeStdoutSync(text: string): void {
-  writeFdSync(1, text);
-}
-
-/**
- * Blocking write to fd 2. See {@link writeFdSync}'s stderr-cliff note.
- *
- * Exported for the same reason its fd-1 twin is: the truncation it prevents
- * only exists in a spawned process, so `__tests__/fixtures/
- * canonical-eval-write-stdout-driver.ts` drives it directly. Without that, this
- * whole function was a surviving mutation — reverting `humanWriter`'s stderr arm
- * to `process.stderr.write` passed every test in the suite, because the largest
- * transcript any of them produces is ~2 KB against a 65_536-byte cliff.
- */
-export function writeStderrSync(text: string): void {
-  writeFdSync(2, text);
-}
-
 declare const HumanChannel: unique symbol;
 
 /**
@@ -685,14 +671,24 @@ declare const HumanChannel: unique symbol;
  *
  * ⚠️ THE BRAND IS ON THE OUTPUT, NOT THE PARAMETER, AND THAT DISTINCTION IS THE
  * WHOLE POINT. A plain `(text: string) => void` parameter is satisfied by
- * `process.stdout.write`, by `console.log`, and — the one that would actually
- * happen — by the exported `writeStdoutSync` sitting three lines up, which is
- * this module's sanctioned way to write fd 1. `evalEachQuestion(qs, "",
- * writeStdoutSync, resolve)` would then compile and silently reopen #5126.
+ * `process.stdout.write` and by `console.log`, so `evalEachQuestion(qs, "",
+ * console.log, resolve)` would compile and silently reopen #5126.
  * {@link humanWriter} is the only producer of this type, so an unbranded
  * sibling producer cannot satisfy the destination.
+ *
+ * It does NOT cover `seedDemoPostgres`'s `report`, which is a plain sink in
+ * another package — that one is held by the function-scoped lexical guard and
+ * the in-process spy in `src/__tests__/seed-demo-report.test.ts`.
+ *
+ * Exported ONLY so `__tests__/eval-json-stdout.test.ts` can hold a
+ * `@ts-expect-error` against it. Deleting the brand makes that line compile,
+ * which turns the directive itself into TS2578 and fails `bun run type` — the
+ * brand's own falsifier, which it did not have until round 2 pointed out that a
+ * type-level guard with no negative case is a claim rather than a guard.
  */
-type HumanWriter = ((text: string) => void) & { readonly [HumanChannel]: true };
+export type HumanWriter = ((text: string) => void) & {
+  readonly [HumanChannel]: true;
+};
 
 /**
  * The fd this run's HUMAN-READABLE output goes to.
@@ -701,24 +697,35 @@ type HumanWriter = ((text: string) => void) & { readonly [HumanChannel]: true };
  * IT. The workflow pipes it into `eval-mcp-llm-output.json` and uploads that as
  * the adjudication artifact; the banner, the provider line, the per-question
  * progress lines and the `note:` lines were all on fd 1 unconditionally, so the
- * artifact had never parsed (#5126). `options.json` was consulted at exactly one
- * place — payload-emission time — and this is what makes it gate every other
- * write instead.
+ * artifact had never parsed (#5126). `options.json` was consulted only at
+ * payload-emission time — three sites, one per mode — and this is what makes it
+ * gate every other write instead.
  *
  * Takes the OPTIONS rather than a bare boolean: `CanonicalEvalOptions` carries
  * three booleans, all in scope at every call site here, and `humanWriter(
  * options.writeBaseline)` would compile and route the transcript down the wrong
  * channel. Resolved at each use site rather than stored alongside `json`, so the
- * flag and the channel cannot disagree.
+ * flag and the channel cannot disagree — which holds only because every field of
+ * `CanonicalEvalOptions` is `readonly`. Six call sites; at most four run in any
+ * one invocation, since the mode functions are mutually exclusive.
  *
  * The logger is the OTHER writer on fd 1 and is not reachable from here — see
  * `bin/eval-log-destination.ts` — and `seedDemoPostgres` was the third, which is
  * why it now takes this writer as a required argument.
  */
 function humanWriter(options: Pick<CanonicalEvalOptions, "json">): HumanWriter {
-  // The one cast in this module, and the reason the brand holds: every other
-  // route to a `HumanWriter` has to come through here.
-  return (options.json ? writeStderrSync : writeStdoutSync) as HumanWriter;
+  const fd = options.json ? 2 : 1;
+  // ⚠️ CLOSES OVER {@link writeFdSync} DIRECTLY rather than over a per-fd pair
+  // of one-line wrappers. Those existed for one round and were a coverage hole
+  // with a test-shaped lid on it: when they went module-private the truncation
+  // driver stopped importing them, so reverting either to its buffered stream
+  // survived the whole repo — while a comment claimed the fd-2 truncation arms
+  // caught exactly that. With no wrappers there is nothing to revert: every
+  // byte this module writes goes through the one function those arms drive.
+  //
+  // The cast is the only one in this module, and it is what makes the brand
+  // hold: every other route to a `HumanWriter` has to come through here.
+  return ((text: string) => writeFdSync(fd, text)) as HumanWriter;
 }
 
 /**
@@ -776,7 +783,8 @@ async function runInstalledCanonicalEval(
       : await runDeterministic(options);
 
   if (options.json) {
-    writeStdoutSync(
+    writeFdSync(
+      1,
       `${JSON.stringify(
         {
           schema: options.schema,
@@ -946,7 +954,8 @@ async function runMcpLlmMode(
   }
 
   if (options.json) {
-    writeStdoutSync(
+    writeFdSync(
+      1,
       `${JSON.stringify(
         {
           schema: options.schema,
@@ -993,7 +1002,7 @@ async function runMcpLlmMode(
       );
     }
     if (result.artifacts.length > 0) {
-      // `human`, not `writeStdoutSync`: this branch is unreachable under
+      // `human`, not a raw fd-1 write: this branch is unreachable under
       // `--json` today, but the bundle is the largest human payload the command
       // produces and hard-wiring it to fd 1 is precisely the shape that made the
       // artifact unparseable. Routed through the same writer, it is stdout here
@@ -1160,7 +1169,8 @@ async function runToolSelectionMode(
   const floorPct = (result.acceptanceFloor * 100).toFixed(1);
 
   if (options.json) {
-    writeStdoutSync(
+    writeFdSync(
+      1,
       `${JSON.stringify(
         {
           schema: options.schema,

--- a/packages/cli/bin/eval-log-destination.ts
+++ b/packages/cli/bin/eval-log-destination.ts
@@ -1,0 +1,45 @@
+/**
+ * Move the app logger off stdout for `atlas canonical-eval … --json` (#5126).
+ *
+ * ⚠️ THIS MODULE EXISTS ENTIRELY FOR ITS IMPORT-TIME SIDE EFFECT, AND IT MUST
+ * STAY `bin/atlas.ts`'S FIRST IMPORT. `bin/atlas.ts` re-exports from
+ * `@atlas/api/lib/profiler`, which imports `@atlas/api/lib/logger`, whose
+ * `rootLogger` is a module-scope `const` — pino resolves the destination once,
+ * at construction, and on the dev branch that destination lives in a
+ * `pino-pretty` worker thread. So there is no later moment at which this can be
+ * done: by the time `handleCanonicalEval` runs, the logger has existed for the
+ * whole of module evaluation. Moving this import below any other one silently
+ * restores the defect, which is why `__tests__/eval-log-destination.test.ts`
+ * asserts its position in the source.
+ *
+ * Under `--json` stdout is a MACHINE channel: the workflow runs
+ * `… canonical-eval --mcp-llm --json | tee eval-mcp-llm-output.json` and uploads
+ * the result as the adjudication artifact. That file had never parsed — two
+ * independent writers put prose on fd 1, and the logger's was the one that also
+ * carried ANSI escapes, because the eval runs with `NODE_ENV` unset (#5121) so
+ * `isDev` is true even in CI and the transport is `pino-pretty` with
+ * `colorize: true`.
+ *
+ * ⚠️ THE ARGV SCAN IS DELIBERATELY DUPLICATED FROM `parseCanonicalEvalOptions`,
+ * not shared with it. That parser is the real one and it stays the real one —
+ * but it runs from inside `handleCanonicalEval`, hundreds of module
+ * evaluations too late to matter here. A positional pre-scan is the only thing
+ * available at this point in the process's life. It is narrow on purpose: both
+ * tokens must be present, so no other subcommand is affected, and the two
+ * spellings cannot drift far because `--json` is `canonical-eval`'s flag.
+ *
+ * ⚠️ IT OVERRIDES AN EXISTING VALUE, INCLUDING `ATLAS_LOG_STDERR=0`. Under
+ * `--json` a clean stdout is a correctness property of the artifact, not a
+ * preference — an operator who wants the logger back on stdout wants a run
+ * without `--json`.
+ *
+ * Sibling not covered, and recorded rather than half-fixed: `atlas query --json`
+ * writes its own human preamble to stdout as well, so stamping this for it
+ * would fix the logger half and leave the artifact just as unparseable. That
+ * command needs the same treatment its own driver got here, in its own change.
+ */
+if (process.argv.includes("canonical-eval") && process.argv.includes("--json")) {
+  process.env.ATLAS_LOG_STDERR = "1";
+}
+
+export {};

--- a/packages/cli/bin/eval-log-destination.ts
+++ b/packages/cli/bin/eval-log-destination.ts
@@ -8,9 +8,12 @@
  * at construction, and on the dev branch that destination lives in a
  * `pino-pretty` worker thread. So there is no later moment at which this can be
  * done: by the time `handleCanonicalEval` runs, the logger has existed for the
- * whole of module evaluation. Moving this import below any other one silently
- * restores the defect, which is why `__tests__/eval-log-destination.test.ts`
- * asserts its position in the source.
+ * whole of module evaluation. Moving this import below any other module-graph
+ * edge — an `import`, or an `export … from`, of which `bin/atlas.ts` is mostly
+ * made — silently restores the defect, which is why
+ * `__tests__/eval-json-stdout.test.ts` asserts its position in the source, and
+ * why this module deliberately has NO IMPORTS OF ITS OWN: one would evaluate
+ * before the assignment below and could reach the logger first.
  *
  * Under `--json` stdout is a MACHINE channel: the workflow runs
  * `… canonical-eval --mcp-llm --json | tee eval-mcp-llm-output.json` and uploads

--- a/packages/cli/bin/eval-log-destination.ts
+++ b/packages/cli/bin/eval-log-destination.ts
@@ -36,10 +36,19 @@
  * preference — an operator who wants the logger back on stdout wants a run
  * without `--json`.
  *
- * Sibling not covered, and recorded rather than half-fixed: `atlas query --json`
- * writes its own human preamble to stdout as well, so stamping this for it
- * would fix the logger half and leave the artifact just as unparseable. That
- * command needs the same treatment its own driver got here, in its own change.
+ * Sibling not covered, and the reason is NOT the one an earlier draft of this
+ * comment gave. It said `atlas query --json` writes its own human preamble to
+ * stdout, so a stamp here would fix only half of it — that is false, and it
+ * argued against a fix that would probably work. Verified: `query`'s only
+ * preamble is `io.err("Thinking...")`, which is `console.error` (fd 2) AND
+ * gated behind `!jsonOutput && !csvOutput`, so on the `--json` success path
+ * stdout carries the payload and nothing else. The logger is therefore its ONLY
+ * fd-1 polluter and stamping it would likely be the whole fix.
+ *
+ * Left out anyway, deliberately: it is a different command, nothing in CI
+ * captures `query`'s stdout, and widening the stamp at the close of #5126's
+ * review would ship an unreviewed behaviour change to a user-facing command.
+ * Its own issue, with its own verification that no error branch writes to fd 1.
  */
 if (process.argv.includes("canonical-eval") && process.argv.includes("--json")) {
   process.env.ATLAS_LOG_STDERR = "1";

--- a/packages/cli/bin/eval.ts
+++ b/packages/cli/bin/eval.ts
@@ -752,7 +752,15 @@ export async function handleEval(args: string[]): Promise<void> {
 
       // Setup phase — errors here affect all cases in this schema
       try {
-        await seedDemoPostgres(connStr);
+        // The channel the surrounding block already uses: this command's
+        // `--json` / `--csv` bodies own fd 1, so the seed's progress line goes
+        // to fd 2 there. ⚠️ That does NOT make `atlas eval --json` clean — its
+        // own preamble still writes prose to fd 1 (lines 466-500), which is the
+        // same defect #5126 fixed one command over and is out of this change's
+        // scope. This call site is correct; the command around it is not.
+        await seedDemoPostgres(connStr, (text) =>
+          (csvOutput || jsonOutput ? process.stderr : process.stdout).write(text),
+        );
         installSchemaSemanticLayer(schema);
         resetCaches();
         process.env.ATLAS_DATASOURCE_URL = connStr;

--- a/packages/cli/bin/eval.ts
+++ b/packages/cli/bin/eval.ts
@@ -754,10 +754,19 @@ export async function handleEval(args: string[]): Promise<void> {
       try {
         // The channel the surrounding block already uses: this command's
         // `--json` / `--csv` bodies own fd 1, so the seed's progress line goes
-        // to fd 2 there. ⚠️ That does NOT make `atlas eval --json` clean — its
-        // own preamble still writes prose to fd 1 (lines 466-500), which is the
-        // same defect #5126 fixed one command over and is out of this change's
-        // scope. This call site is correct; the command around it is not.
+        // to fd 2 there.
+        //
+        // ⚠️ That does NOT make `atlas eval --json` clean, and the writers that
+        // spoil it are NOT `printSummary` — that is behind the `else` of the
+        // same `jsonOutput` check and never runs in this mode. The live ones
+        // are `console.log("Resuming: …")` under `--resume`, the
+        // `Baseline saved to: …` line, and `printRegressionReport` under
+        // `--compare`, which prints ANSI *after* the JSON body. That is the
+        // same defect #5126 fixed one command over, and it is out of this
+        // change's scope: this call site is correct, the command around it is
+        // not. (Named precisely because the first draft of this comment pointed
+        // at the wrong function — a wrong cause in a comment is what stops the
+        // next person looking.)
         await seedDemoPostgres(connStr, (text) =>
           (csvOutput || jsonOutput ? process.stderr : process.stdout).write(text),
         );

--- a/packages/cli/bin/eval.ts
+++ b/packages/cli/bin/eval.ts
@@ -639,6 +639,38 @@ function loadBaseline(filePath: string): EvalResult[] {
   return results;
 }
 
+/**
+ * Where `seedDemoPostgres`'s progress line goes for this run of `atlas eval`.
+ *
+ * `seedDemoPostgres` requires an explicit sink since #5126 — it used to
+ * `console.log`, which put prose on fd 1 in every mode including the ones whose
+ * stdout is a machine channel. This command's `--json` and `--csv` bodies own
+ * fd 1, so the line goes to fd 2 in both.
+ *
+ * ⚠️ EXTRACTED SO IT CAN BE TESTED. Inline it was three plausible one-character
+ * mutations away from reproducing #5126 here — drop the ternary, swap the arms,
+ * or forget `csvOutput` — and `handleEval` has no test at all, so all three
+ * survived. See `__tests__/eval-seed-sink.test.ts`.
+ *
+ * ⚠️ THIS CALL SITE IS CORRECT; THE COMMAND AROUND IT IS NOT. `atlas eval
+ * --json` still writes prose to fd 1 — and the writers are NOT `printSummary`,
+ * which sits behind the `else` of the same `jsonOutput` check and never runs in
+ * that mode. The live ones are the `Resuming: …` line under `--resume`, the
+ * `Baseline saved to: …` line, and `printRegressionReport` under `--compare`,
+ * which prints ANSI *after* the JSON body. Same defect as #5126, one command
+ * over, out of that issue's scope. (Named precisely because the first draft of
+ * this comment pointed at the wrong function, and a wrong cause in a comment is
+ * what stops the next person looking.)
+ */
+export function evalSeedSink(options: {
+  readonly csvOutput: boolean;
+  readonly jsonOutput: boolean;
+}): (text: string) => void {
+  const machineOwnsStdout = options.csvOutput || options.jsonOutput;
+  return (text) =>
+    void (machineOwnsStdout ? process.stderr : process.stdout).write(text);
+}
+
 // --- Main entry point ---
 
 export async function handleEval(args: string[]): Promise<void> {
@@ -752,24 +784,7 @@ export async function handleEval(args: string[]): Promise<void> {
 
       // Setup phase — errors here affect all cases in this schema
       try {
-        // The channel the surrounding block already uses: this command's
-        // `--json` / `--csv` bodies own fd 1, so the seed's progress line goes
-        // to fd 2 there.
-        //
-        // ⚠️ That does NOT make `atlas eval --json` clean, and the writers that
-        // spoil it are NOT `printSummary` — that is behind the `else` of the
-        // same `jsonOutput` check and never runs in this mode. The live ones
-        // are `console.log("Resuming: …")` under `--resume`, the
-        // `Baseline saved to: …` line, and `printRegressionReport` under
-        // `--compare`, which prints ANSI *after* the JSON body. That is the
-        // same defect #5126 fixed one command over, and it is out of this
-        // change's scope: this call site is correct, the command around it is
-        // not. (Named precisely because the first draft of this comment pointed
-        // at the wrong function — a wrong cause in a comment is what stops the
-        // next person looking.)
-        await seedDemoPostgres(connStr, (text) =>
-          (csvOutput || jsonOutput ? process.stderr : process.stdout).write(text),
-        );
+        await seedDemoPostgres(connStr, evalSeedSink({ csvOutput, jsonOutput }));
         installSchemaSemanticLayer(schema);
         resetCaches();
         process.env.ATLAS_DATASOURCE_URL = connStr;

--- a/packages/cli/src/__tests__/seed-demo-report.test.ts
+++ b/packages/cli/src/__tests__/seed-demo-report.test.ts
@@ -1,0 +1,112 @@
+/**
+ * `seedDemoPostgres` reports through its injected sink and never touches fd 1
+ * directly (#5126).
+ *
+ * ⚠️ THIS IS THE HALF THE SPAWN TESTS STRUCTURALLY CANNOT REACH, and its
+ * absence is what let the original fix ship broken. `canonical-eval` calls
+ * `seedDemoPostgres` unconditionally, before any mode branch, and it used to
+ * end with `console.log(DEMO_DATASET.label)` — fd 1, ahead of the `--json`
+ * payload, inside the `| tee eval-mcp-llm-output.json` the workflow uploads. It
+ * was the THIRD writer on that fd and the only one outside the eval driver.
+ *
+ * Every spawn in `bin/__tests__/eval-json-stdout.test.ts` runs with
+ * `ATLAS_TEST_STUB_SEED=1`, so the preload replaces this exact function. That
+ * stub now REPORTS through the sink, which makes those tests a real assertion
+ * about the CALL SITE — does `runInstalledCanonicalEval` hand over the resolved
+ * human writer? — but it can say nothing about the function itself. This file
+ * is the other half: the real body, with `pg` mocked, asserting the label goes
+ * to the sink and that no `console` method is called at all.
+ */
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+const queries: string[] = [];
+let ended = 0;
+let queryError: Error | null = null;
+
+// Mocked before importing the module under test, so `init.ts`'s
+// `import { Pool } from "pg"` binds to this. Only `Pool` is used by
+// `seedDemoPostgres`; the CLI's other pg consumers are not in this graph.
+void mock.module("pg", () => ({
+  Pool: class MockPool {
+    async query(sql: string) {
+      queries.push(sql);
+      if (queryError) throw queryError;
+      return { rows: [] };
+    }
+    async end() {
+      ended += 1;
+    }
+  },
+}));
+
+const { seedDemoPostgres, DEMO_DATASET } = await import("../commands/init");
+
+/** Every `console` method that reaches fd 1. `error`/`warn` are fd 2 and fine. */
+const STDOUT_CONSOLE_METHODS = [
+  "log",
+  "info",
+  "debug",
+  "dir",
+  "table",
+  "trace",
+] as const;
+
+let restoreConsole: Array<() => void> = [];
+const consoleCalls: string[] = [];
+
+beforeEach(() => {
+  queries.length = 0;
+  consoleCalls.length = 0;
+  ended = 0;
+  queryError = null;
+  // Recorded per METHOD, not into one shared sink, so the assertion can name
+  // which one leaked rather than only that something did.
+  restoreConsole = STDOUT_CONSOLE_METHODS.map((name) => {
+    const original = console[name];
+    console[name] = ((...args: unknown[]) => {
+      consoleCalls.push(`${name}: ${args.map(String).join(" ")}`);
+    }) as typeof original;
+    return () => {
+      console[name] = original;
+    };
+  });
+});
+
+afterEach(() => {
+  for (const restore of restoreConsole) restore();
+  restoreConsole = [];
+});
+
+describe("seedDemoPostgres reporting", () => {
+  test("the label goes to the injected sink, and nothing goes to a console stdout method", async () => {
+    const reported: string[] = [];
+    await seedDemoPostgres("postgres://unused/db", (text) => reported.push(text));
+
+    // The exact label plus the trailing newline the sink now owns — asserting
+    // "something was reported" would pass for a sink handed the empty string.
+    expect(reported).toEqual([`${DEMO_DATASET.label}\n`]);
+    // The falsifier for the defect itself. Reverting the body to
+    // `console.log(DEMO_DATASET.label)` leaves `reported` empty AND puts an
+    // entry here, so both assertions fail — neither can carry it alone.
+    expect(consoleCalls).toEqual([]);
+    // Anchors the run to the success path: on the throw path below the report
+    // is correctly skipped, so a test that never queried would pass vacuously.
+    expect(queries).toHaveLength(1);
+    expect(ended).toBe(1);
+  });
+
+  test("a failed seed reports nothing and still closes the pool", async () => {
+    // The counterpart arm. Without it, a body that reported unconditionally —
+    // claiming the demo loaded when the query threw — satisfies the test above.
+    queryError = new Error("relation already exists");
+    const reported: string[] = [];
+
+    await expect(
+      seedDemoPostgres("postgres://unused/db", (text) => reported.push(text)),
+    ).rejects.toThrow("Failed to seed demo data into Postgres");
+
+    expect(reported).toEqual([]);
+    expect(consoleCalls).toEqual([]);
+    expect(ended).toBe(1);
+  });
+});

--- a/packages/cli/src/__tests__/seed-demo-report.test.ts
+++ b/packages/cli/src/__tests__/seed-demo-report.test.ts
@@ -18,38 +18,47 @@
  * to the sink and that nothing at all reaches fd 1 while it runs.
  */
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+// The SAME list the lexical guard builds its regex from, so the spy below and
+// `FD1_WRITE` cannot drift. They did drift on their first outing — both were
+// missing `console.group` and `console.count`, which reach fd 1 on bun 1.3.13.
+import { STDOUT_CONSOLE_METHODS } from "../../bin/__tests__/fixtures/stdout-console-methods";
 
 const queries: string[] = [];
 let ended = 0;
 let queryError: Error | null = null;
 
+class MockPool {
+  async query(sql: string) {
+    queries.push(sql);
+    if (queryError) throw queryError;
+    return { rows: [] };
+  }
+  async end() {
+    ended += 1;
+  }
+}
+
 // Mocked before importing the module under test, so `init.ts`'s
-// `import { Pool } from "pg"` binds to this. Only `Pool` is used by
-// `seedDemoPostgres`; the CLI's other pg consumers are not in this graph.
-void mock.module("pg", () => ({
-  Pool: class MockPool {
-    async query(sql: string) {
-      queries.push(sql);
-      if (queryError) throw queryError;
-      return { rows: [] };
-    }
-    async end() {
-      ended += 1;
-    }
-  },
-}));
+// `import { Pool } from "pg"` binds to this.
+//
+// ⚠️ ALL EXPORTS, not just `Pool` (CLAUDE.md). Only `Pool` is used by
+// `seedDemoPostgres` TODAY — but `init.ts` pulls `@atlas/api/lib/profiler` and
+// `@atlas/api/lib/semantic/generate` at module scope, and the first of those to
+// touch `pg.types` (an ordinary date-parser registration) would turn a partial
+// mock into an `undefined is not a function` at import time. Mirrors the
+// export set in `doctor.test.ts`, beside it.
+const pgMock = {
+  Pool: MockPool,
+  Client: MockPool,
+  Query: class {},
+  defaults: {},
+  types: { setTypeParser: () => {}, getTypeParser: () => (v: unknown) => v },
+  escapeIdentifier: (s: string) => `"${s}"`,
+  escapeLiteral: (s: string) => `'${s}'`,
+};
+void mock.module("pg", () => ({ ...pgMock, default: pgMock }));
 
 const { seedDemoPostgres, DEMO_DATASET } = await import("../commands/init");
-
-/** Every `console` method that reaches fd 1. `error`/`warn` are fd 2 and fine. */
-const STDOUT_CONSOLE_METHODS = [
-  "log",
-  "info",
-  "debug",
-  "dir",
-  "table",
-  "trace",
-] as const;
 
 /**
  * ⚠️ `process.stdout.write` IS SPIED TOO, AND ITS ABSENCE WAS A REAL DEFECT IN
@@ -83,7 +92,10 @@ beforeEach(() => {
       console[name] = original;
     };
   });
-  const originalWrite = process.stdout.write.bind(process.stdout);
+  // The method itself, not a bound copy: restoring a bound wrapper would leave
+  // `process.stdout.write.call(otherStream, …)` misrouted for the rest of the
+  // process. The patch never calls through, so nothing needs the binding.
+  const originalWrite = process.stdout.write;
   process.stdout.write = ((chunk: unknown, ...rest: unknown[]) => {
     stdoutCalls.push(`process.stdout.write: ${String(chunk)}`);
     void rest;
@@ -133,5 +145,36 @@ describe("seedDemoPostgres reporting", () => {
     expect(reported).toEqual([]);
     expect(stdoutCalls).toEqual([]);
     expect(ended).toBe(1);
+  });
+
+  test("a throwing sink is NOT relabelled as a Postgres failure", async () => {
+    // ⚠️ The sink can throw, and that is new: it used to be `console.log`, which
+    // cannot. The eval passes `writeFdSync`, which propagates every errno except
+    // EPIPE/EAGAIN (ENOSPC, EBADF) plus its own write-stalled guard. With the
+    // report inside the try, that catch relabelled the write failure as
+    // `Failed to seed demo data into Postgres` — and `canonical-eval` would then
+    // tell the operator to `bun run db:up` on a run whose database work had
+    // already succeeded, while `bin/eval.ts` persisted that wrong cause into
+    // every result row.
+    //
+    // Both halves asserted: the real error survives AND the wrong label is
+    // absent. Asserting only the first would pass for a wrapped message that
+    // still names Postgres.
+    const sinkError = new Error("ENOSPC: no space left on device, write");
+
+    await expect(
+      seedDemoPostgres("postgres://unused/db", () => {
+        throw sinkError;
+      }),
+    ).rejects.toThrow("ENOSPC: no space left on device");
+
+    const raised = await seedDemoPostgres("postgres://unused/db", () => {
+      throw sinkError;
+    }).catch((err: unknown) => err);
+    expect(String(raised)).not.toContain("Failed to seed demo data into Postgres");
+
+    // The pool is still closed — the `finally` runs before the report either
+    // way, which is the property that made moving the line safe.
+    expect(ended).toBe(2);
   });
 });

--- a/packages/cli/src/__tests__/seed-demo-report.test.ts
+++ b/packages/cli/src/__tests__/seed-demo-report.test.ts
@@ -15,7 +15,7 @@
  * about the CALL SITE — does `runInstalledCanonicalEval` hand over the resolved
  * human writer? — but it can say nothing about the function itself. This file
  * is the other half: the real body, with `pg` mocked, asserting the label goes
- * to the sink and that no `console` method is called at all.
+ * to the sink and that nothing at all reaches fd 1 while it runs.
  */
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
@@ -51,44 +51,69 @@ const STDOUT_CONSOLE_METHODS = [
   "trace",
 ] as const;
 
-let restoreConsole: Array<() => void> = [];
-const consoleCalls: string[] = [];
+/**
+ * ⚠️ `process.stdout.write` IS SPIED TOO, AND ITS ABSENCE WAS A REAL DEFECT IN
+ * THIS FILE. The first cut spied only `console` methods — which is exactly the
+ * "covered the writers I happened to look at" mistake this whole issue is
+ * about, reproduced inside the test written to catch it. `init.ts`'s own house
+ * spelling for this very call is `(text) => process.stdout.write(text)`, so the
+ * uncovered spelling was the one most likely to appear.
+ *
+ * Two spellings this still cannot see — `Bun.stdout` and `fs.writeSync(1, …)` —
+ * are covered lexically by the function-scoped arm in
+ * `bin/__tests__/eval-json-stdout.test.ts`. Neither check subsumes the other:
+ * this one follows delegation into a helper, that one covers every spelling.
+ */
+let restoreWriters: Array<() => void> = [];
+const stdoutCalls: string[] = [];
 
 beforeEach(() => {
   queries.length = 0;
-  consoleCalls.length = 0;
+  stdoutCalls.length = 0;
   ended = 0;
   queryError = null;
-  // Recorded per METHOD, not into one shared sink, so the assertion can name
-  // which one leaked rather than only that something did.
-  restoreConsole = STDOUT_CONSOLE_METHODS.map((name) => {
+  // Recorded with the writer's NAME, not into one anonymous sink, so a failure
+  // says which route leaked rather than only that something did.
+  restoreWriters = STDOUT_CONSOLE_METHODS.map((name) => {
     const original = console[name];
     console[name] = ((...args: unknown[]) => {
-      consoleCalls.push(`${name}: ${args.map(String).join(" ")}`);
+      stdoutCalls.push(`console.${name}: ${args.map(String).join(" ")}`);
     }) as typeof original;
     return () => {
       console[name] = original;
     };
   });
+  const originalWrite = process.stdout.write.bind(process.stdout);
+  process.stdout.write = ((chunk: unknown, ...rest: unknown[]) => {
+    stdoutCalls.push(`process.stdout.write: ${String(chunk)}`);
+    void rest;
+    return true;
+  }) as typeof process.stdout.write;
+  restoreWriters.push(() => {
+    process.stdout.write = originalWrite;
+  });
 });
 
 afterEach(() => {
-  for (const restore of restoreConsole) restore();
-  restoreConsole = [];
+  // Restored in reverse, so `process.stdout.write` is back before anything the
+  // console restores might print — a swallowed stdout would otherwise hide a
+  // later test's output.
+  for (const restore of restoreWriters.reverse()) restore();
+  restoreWriters = [];
 });
 
 describe("seedDemoPostgres reporting", () => {
-  test("the label goes to the injected sink, and nothing goes to a console stdout method", async () => {
+  test("the label goes to the injected sink, and nothing reaches fd 1", async () => {
     const reported: string[] = [];
     await seedDemoPostgres("postgres://unused/db", (text) => reported.push(text));
 
     // The exact label plus the trailing newline the sink now owns — asserting
     // "something was reported" would pass for a sink handed the empty string.
     expect(reported).toEqual([`${DEMO_DATASET.label}\n`]);
-    // The falsifier for the defect itself. Reverting the body to
-    // `console.log(DEMO_DATASET.label)` leaves `reported` empty AND puts an
-    // entry here, so both assertions fail — neither can carry it alone.
-    expect(consoleCalls).toEqual([]);
+    // The falsifier for the defect itself, and it covers a write ALONGSIDE the
+    // sink as well as one replacing it — `reported` alone would pass for a body
+    // that reported correctly and ALSO logged, which is the historical shape.
+    expect(stdoutCalls).toEqual([]);
     // Anchors the run to the success path: on the throw path below the report
     // is correctly skipped, so a test that never queried would pass vacuously.
     expect(queries).toHaveLength(1);
@@ -106,7 +131,7 @@ describe("seedDemoPostgres reporting", () => {
     ).rejects.toThrow("Failed to seed demo data into Postgres");
 
     expect(reported).toEqual([]);
-    expect(consoleCalls).toEqual([]);
+    expect(stdoutCalls).toEqual([]);
     expect(ended).toBe(1);
   });
 });

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -155,7 +155,6 @@ export async function seedDemoPostgres(
   const pool = new Pool({ connectionString, max: 1 });
   try {
     await pool.query(sql);
-    report(`${DEMO_DATASET.label}\n`);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     throw new Error(
@@ -165,6 +164,18 @@ export async function seedDemoPostgres(
   } finally {
     await pool.end();
   }
+  // ⚠️ OUTSIDE THE TRY, AND NOT FOR TIDINESS. `report` is a caller-supplied fd
+  // sink and it CAN throw — the eval passes `writeFdSync`, which propagates
+  // every errno except EPIPE/EAGAIN (ENOSPC, EBADF) plus its own write-stalled
+  // guard, and a stream sink throws ERR_STREAM_DESTROYED. Inside the try, that
+  // catch would relabel a write failure as `Failed to seed demo data into
+  // Postgres`, and `canonical-eval` would then tell the operator to
+  // `bun run db:up` on a run whose database work had already succeeded —
+  // `bin/eval.ts` would persist that wrong cause into every result row.
+  //
+  // Moving it out also preserves the existing contract that a failed seed
+  // reports nothing: the throw above skips this line, exactly as before.
+  report(`${DEMO_DATASET.label}\n`);
 }
 
 // --- Index CLI handler ---

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -125,8 +125,27 @@ function copyDirRecursive(src: string, dest: string): void {
 
 // --- Demo data seeding ---
 
+/**
+ * Seed the canonical NovaMart demo into Postgres.
+ *
+ * ⚠️ `report` IS REQUIRED, AND DELIBERATELY HAS NO DEFAULT (#5126). This
+ * function used to `console.log` its one progress line, which is fd 1 — and it
+ * is called unconditionally by `canonical-eval`, whose stdout under `--json` is
+ * the machine channel piped into `eval-mcp-llm-output.json`. So the demo
+ * label sat at the top of every uploaded artifact and that file had never
+ * parsed. It was the THIRD writer on that fd and the only one outside the eval
+ * driver, which is exactly why a fix confined to the driver missed it.
+ *
+ * A default would have made this a silent trap for the next caller: it would
+ * compile, run, and put prose on whichever fd happened to be wrong. Requiring
+ * the sink makes the channel a decision every call site has to take, and there
+ * are only three. Callers pass raw text INCLUDING the trailing newline —
+ * `console.log`'s implicit `\n` is not reproduced here, so nothing depends on
+ * which sink is supplied.
+ */
 export async function seedDemoPostgres(
   connectionString: string,
+  report: (text: string) => void,
 ): Promise<void> {
   const sqlFile = path.resolve(import.meta.dir, "../../data", DEMO_DATASET.pg);
   if (!fs.existsSync(sqlFile)) {
@@ -136,7 +155,7 @@ export async function seedDemoPostgres(
   const pool = new Pool({ connectionString, max: 1 });
   try {
     await pool.query(sql);
-    console.log(DEMO_DATASET.label);
+    report(`${DEMO_DATASET.label}\n`);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     throw new Error(
@@ -425,7 +444,8 @@ async function profileDatasource(
       throw new Error(`--demo is not supported for ${dbType}.`);
     }
     console.log(`Seeding ecommerce demo data (${dbType})...`);
-    await seedDemoPostgres(connStr);
+    // stdout: `init` is the interactive command, its whole output is human.
+    await seedDemoPostgres(connStr, (text) => process.stdout.write(text));
     console.log("");
   }
 


### PR DESCRIPTION
## What

`eval-mcp-llm-output.json` — the failure bundle `.github/workflows/eval-llm.yml` uploads for post-mortems — had never been valid JSON. Under `--json`, stdout now carries the payload and nothing else.

Closes #5126.

## THREE writers, not two

The issue named two. There were three, and the third is why the first cut of this fix did not work:

1. **The driver's own preamble.** `options.json` was consulted at payload-emission time only — three sites, one per mode — so the banner, the provider/baseline lines, the per-question progress lines and `resolveExpectations`'s `note:` lines all went to fd 1 unconditionally.
2. **The app logger.** pino's default destination is fd 1, and the eval runs with `NODE_ENV` unset (deliberately — #5121), so `isDev` is true even in CI and the transport is `pino-pretty` with `colorize: true`. ANSI escapes, interleaved mid-payload rather than a strippable prefix.
3. **`seedDemoPostgres`.** `console.log(DEMO_DATASET.label)` — outside the eval driver entirely, on the unconditional path before any mode branch. **The issue's own evidence block contains that line and I read it as a driver write.** All three round-1 reviewers found it independently.

Each needs a different mechanism, which is why the fix is not one edit:

- **(1)** Every human write in `canonical-eval-run.ts` goes through `humanWriter(options)` → fd 2 under `--json`, fd 1 otherwise. Resolved from the flag at each use site (never stored beside it), and it returns a **branded** `HumanWriter` so an unbranded sibling writer cannot satisfy a human seam.
- **(2)** `ATLAS_LOG_STDERR=1` pins the root logger to fd 2. It must be an env var read before module evaluation: `rootLogger` is a module-scope `const`, pino resolves the destination once, and on the dev branch that destination lives in a `pino-pretty` **worker thread**. `bin/eval-log-destination.ts` stamps it and is `bin/atlas.ts`'s first import for exactly that reason.
- **(3)** `seedDemoPostgres` takes a **required** `report` sink — no default, because a default is a silent trap for the next caller. Three call sites, each naming its channel.

⚠️ **The app-wide logger default is unchanged, and that is the point.** Structured logs on stdout is the convention the deployments rely on (Railway reads fd 1). This is opt-in per process, and *three of the four* tests in `logger-destination.test.ts` exist to hold the default in place rather than to prove the switch works.

## Review — 2 rounds, stopped on the ratio rule

| round | findings | new surface | defect-in-prior-fix |
|---|---|---|---|
| 1 | ~21 | ~21 | 0 |
| 2 | ~24 | ~8 | **~16** |

Round 2's defect-in-prior-fix count exceeded its new surface, so **the rounds stopped there** per `/ship-issue` Step 3. Not a halt — every confirmed must-fix is fixed, the closing round's `comment-analyzer` sweep ran on the final diff, and every falsifier is built and measured. The residue left as follow-ups is listed below.

**The through-line, because it is the issue's own defect wearing a test's clothes:** every guard round 1 added was a *lexical* guard whose regex or preprocessing had a blind spot in exactly the direction the bug travels — one spelling, one syntax form, or one file further out than I looked. **Three of them were green on the regression their own comment named.**

- `stripComments` block-stripped *before* dropping line comments, so a `/*` inside a `//` comment opened a strip running to the next `*/` anywhere in the file. Measured on the real tree: `init.ts`'s `// … no parallel \`cli/lib/profilers/*\` home` opened one that a docstring 56 lines later closed, **deleting 30 lines of live code before the scan**.
- The import-order regex used `[^\n]*?`, so it saw 11 of ~20 module edges and missed the multi-line `export { … } from "@atlas/api/lib/profiler"` block — the exact edge that pulls in the logger.
- The stamp's "no imports of its own" assertion required `from` on the same line, so `import "@atlas/api/lib/logger";` passed.
- Both console-method lists were `log|info|debug|dir|table|trace`, hand-maintained in two packages. `console.group` and `console.count` reach fd 1 on bun 1.3.13 and were in neither; `console.trace` is fd 1 there too and the comment said fd 2.

`fix-vs-finding` returned **REPRODUCED** once, on the round-1 fix: I dropped `init.ts` from the lexical guard claiming the behavioural spy was "stronger than a grep", when the spy covered one of the four forbidden spellings. Fixed in-round with both arms — the spy also intercepts `process.stdout.write` (so it catches a write *alongside* the sink), and a function-scoped lexical arm covers every spelling.

## Falsifiers — 25 mutations, each applied, run, reverted

All 25 killed. Nine of them target code no test in the *previous* commit could have caught.

| mutation | killed by |
|---|---|
| `seedConsole` — the CRITICAL: seed back to `console.log` | seed unit test + E2E |
| `seedStdoutWrite` / `seedAlongside` / `seedFsWriteSync` / `seedGroup` | spy + function-scoped grep |
| `seedCallSite` — call site passes a console default | E2E |
| `reportInsideTry` — sink error relabelled as a Postgres failure | seed unit test |
| `stamp` / `stampUnconditional` / `stampJsonOnly` / `stampBareImport` | E2E + argv matrix + stamp guard |
| `logger` / `loggerPresence` / `loggerOptionsDropped` | 4 logger spawns |
| `human` / `fdIgnored` | E2E + fd-2 truncation arms |
| `greppable` / `greppableConsole` / `greppableSibling` | widened fd-1 grep |
| `order` / `orderReexport` / `orderMultilineHoist` | import-order guard |
| `stripperOrder` | `expectStripLosesOnlyComments` |
| `evalSinkAlwaysStdout` / `evalSinkJsonOnly` | `evalSeedSink` truth table |
| brand deleted | `bun run type` → **TS2578** |

Two of them reproduce the issue's own evidence verbatim (`JSON Parse error: Unexpected identifier "Atlas"`; a log frame landing *inside* the payload).

⚠️ **Two mutations were left applied by a repeated battery run and were caught by the `--affected` sweep, not by `git status`** — reverted, and every non-comment added source line re-read against `origin/main` to confirm the tree is what the commits claim.

## Sibling audit (acceptance criterion 5)

**Fixed, not deferred:** `--tool-selection`, `--mcp-llm` and the deterministic/`--llm` modes had the identical defect and are all closed by the same mechanism. Both LLM modes turned out to be testable without an API key — `providerKeyMissing` returns `null` for `ollama` — so `--mcp-llm --json` and `--tool-selection --json` now have real end-to-end arms asserting `stdout === ""`.

**Recorded, not fixed:**
- `atlas eval --json` — its own preamble still writes to fd 1. The live writers are the `--resume` line, `Baseline saved to: …`, and `printRegressionReport` under `--compare` (which prints ANSI *after* the JSON body). Its seed call site is correct; the command around it is not.
- `atlas query --json` — **and the earlier note on this was wrong.** It claimed `query` writes its own preamble to stdout, so a stamp would be a half-fix. Verified false: its only preamble is `io.err("Thinking...")`, which is `console.error` (fd 2) *and* gated behind `!jsonOutput && !csvOutput`. The logger is its **only** fd-1 polluter, so a stamp there would likely be the whole fix. Left out because it is a different, user-facing command and widening the stamp at the close of this review would ship an unreviewed behaviour change.

## Consciously deferred (round 2, with reasons)

- **`writeFdSync`'s EAGAIN retry is unbounded** — no deadline, no diagnostic, and the branch is already documented as untestable. Adding a deadline is new machinery on a #5130 path; it hangs rather than corrupts.
- **Degradation notes are not in the JSON payload** — `resolveExpectations` disables a value-accept path non-fatally and says so on fd 2, but the adjudicated artifact has no field for it. Real gap; it is a payload-shape change and **#5123 is adding fields to that same payload**.
- **`resolveExpectations`'s two `note:` writers are not reached by any test** — the `--mcp-llm` corpus dies in the metric loop first. Reaching them needs a corpus that lets the run proceed into `runMcpLlmEval`, which would make a network call to a non-existent ollama and risk a flaky timeout.
- **EPIPE / zero-write branches of `writeFdSync` are untested** — pre-existing #5130 code; the zero-write arm is cheaply testable with `mock.module("fs")`.
- Uncovered `human` call sites requiring a completed LLM run (`loaded baseline from`, `--write-baseline`, the non-`--json` MCP and tool-selection summaries) are recorded as uncovered rather than counted as covered.

## Workflow

The `tee` line captures fd 1 wholesale and cannot defend itself, so it now has a note naming the modules that do, and `2>&1` called out as the edit that would undo it. `paths:` gains the four files that keep fd 1 clean — a break in any is invisible in the job's status.

A **`jq empty` artifact-parses step** was added, because after two rounds the recurring class was "an fd-1 writer one file further out than I looked", and every other guard here is a unit test or a grep over modules *we own*. The `--json` process also pulls `@atlas/api`, `@atlas/mcp`, better-auth, pino and pg through dynamic imports — there is a `console.debug` on an `@atlas/api` cache self-heal path today that no grep here would ever see. It is `continue-on-error` with its outcome threaded into `eval-informational-gate.sh` as a third argument, so it follows the same informational-on-PRs / blocking-on-tags policy as everything else in the job rather than reddening it directly.

The COST comment block is untouched — #5123 owns it.

## Acceptance criteria

- [x] Stdout of `canonical-eval --mcp-llm --json` parses as JSON with no stripping — `JSON.parse(stdout)` with no slice, through a real shell pipe
- [x] The human summary and all log output still reach CI logs (on stderr)
- [x] ANSI escapes never appear in the uploaded artifact — both arms, so `colorize` silently off cannot masquerade as a pass
- [x] A test pins "stdout under `--json` is parseable" — plus grep guards for the branches a test cannot reach, plus a CI-level check for writers we do not own
- [x] Sibling modes audited — all three fixed; two sibling *commands* recorded with verified reasons
- [x] The application-wide default logger destination is unchanged — asserted on both `isDev` branches, with a redacted field proving the options set travels

## Local pre-flight

`bun run type` clean · `bun run lint` clean (pre-existing warnings only) · `packages/api` `--affected` 331/331 · `packages/cli` `--affected` 53/53 · `check-test-discipline.sh` pass · workflow YAML parses. `check-mutation-tables.sh --affected` SKIPPED locally (no `TEST_DATABASE_URL`); no mutation spec targets `canonical-eval*`, `lib/logger` or `commands/init`, and remote CI's `mutation-tables` is the gate.
