### PR TITLE
fix(brain): regenerate the stale bundle-identity mutation table

### DIFF
--- a/packages/api/scripts/mutations/bundle-identity.md
+++ b/packages/api/scripts/mutations/bundle-identity.md
@@ -39,8 +39,8 @@ Every number is the count of tests that FAIL in that suite under that mutation, 
 |---|---|---|---|---|---|---|
 | the importer RE-DERIVES a v3 fact's keys instead of carrying them | 2 | 0 | 0 | 0 | 0 | 1 |
 | a store-local `entity:` id travels verbatim | 1 | 0 | 0 | 2 | 0 | 1 |
-| a LEGACY bundle's facts are left unkeyed | 4 | 3 | 0 | 0 | 0 | 4 |
-| the legacy arm keys against an EMPTY vocabulary (the load deleted) | 2 | 0 | 0 | 0 | 0 | 2 |
+| a LEGACY bundle's facts are left unkeyed | 5 | 3 | 0 | 0 | 0 | 4 |
+| the legacy arm keys against an EMPTY vocabulary (the load deleted) | 3 | 0 | 0 | 0 | 0 | 2 |
 | `provisional` is never written for a nulled row | 1 | 0 | 0 | 0 | 0 | 0 |
 | `provisional` is written for EVERY imported row | 1 | 0 | 0 | 0 | 0 | 0 |
 | `readStoredComparable` skips the PAYLOAD fixpoint check | 0 | 0 | 0 | 2 | 0 | 1 |
@@ -63,9 +63,9 @@ Every number is the count of tests that FAIL in that suite under that mutation, 
 | the required-sections gate reads `=== CURRENT` again | 0 | 1 | 0 | 0 | 0 | 0 |
 | the exporter stops projecting the identity columns | 1 | 0 | 0 | 0 | 1 | 0 |
 | the exporter feeds identity values through a cast instead of `textOrNull` | 0 | 0 | 2 | 0 | 0 | 0 |
-| the importer writes `predicate_cardinality` again (from the legacy field) | 8 | 0 | 0 | 0 | 1 | 0 |
+| the importer writes `predicate_cardinality` again (from the legacy field) | 9 | 0 | 0 | 0 | 1 | 0 |
 
-Suite sizes: **roundtrip-pg** 14 tests (`src/lib/residency/__tests__/migrate-roundtrip-pg.test.ts`) · **admin-migrate** 96 tests (`src/api/__tests__/admin-migrate.test.ts`) · **export** 24 tests (`src/lib/residency/__tests__/export.test.ts`) · **object-cmp** 64 tests (`src/lib/brain/__tests__/object-cmp.test.ts`) · **v3 pin** 6 tests (`src/lib/residency/__tests__/bundle-identity-v3.test.ts`) · **logging** 9 tests (`src/lib/residency/__tests__/migrate-identity-logging.test.ts`).
+Suite sizes: **roundtrip-pg** 15 tests (`src/lib/residency/__tests__/migrate-roundtrip-pg.test.ts`) · **admin-migrate** 96 tests (`src/api/__tests__/admin-migrate.test.ts`) · **export** 24 tests (`src/lib/residency/__tests__/export.test.ts`) · **object-cmp** 64 tests (`src/lib/brain/__tests__/object-cmp.test.ts`) · **v3 pin** 6 tests (`src/lib/residency/__tests__/bundle-identity-v3.test.ts`) · **logging** 9 tests (`src/lib/residency/__tests__/migrate-identity-logging.test.ts`).
 
 ## Notes
 


### PR DESCRIPTION
Unblocks `main`. One generated file, four numbers.

## What's broken

`mutation-tables` has failed on **every push to `main` since 2026-08-10** — eight consecutive commits, none of which caused it.

**Why no PR caught it.** The job branches on event:

```bash
if [ "$EVENT_NAME" = "pull_request" ]; then
  bash scripts/check-mutation-tables.sh --affected "$BASE_SHA"
else
  bash scripts/check-mutation-tables.sh --all      # push: main
fi
```

PRs verify only specs their diff reaches; `push: main` sweeps all 8. Recent PRs haven't touched this spec's dependency set, so only main has been reporting it.

## The cause

**#5114** (`813f4248d`) added a 15th test to `migrate-roundtrip-pg.test.ts` without regenerating the table that measures that suite.

⚠️ **The gate was not blind to this — it caught it.** `--affected` lists `src/lib/residency/__tests__/migrate-roundtrip-pg.test.ts` in `bundle-identity`'s dependency set, and #5114's own PR check went red with this exact message:

```
STALE scripts/mutations/bundle-identity.mutations.ts
error  scripts/mutations/bundle-identity.md is stale.
```

`19:01:29` STALE → `19:08:35` merged, with the `ci` umbrella red. So the fix here is one line of `git`; the thing worth taking from it is that a required check went red on a PR and the PR merged anyway.

## The diff, and why it's benign

Regenerated with `mutate.ts`, never hand-edited (#5060). Four numbers changed, and the last line of the table explains all of them — **roundtrip-pg went 14 → 15 tests**, and that one new test kills three mutants:

| mutation | roundtrip-pg |
|---|---|
| a LEGACY bundle's facts are left unkeyed | 4 → **5** |
| the legacy arm keys against an EMPTY vocabulary | 2 → **3** |
| the importer writes `predicate_cardinality` again (from the legacy field) | 8 → **9** |

Every delta is `+1`, in one suite, upward. **No suite lost a kill and no mutant newly survived** — this is recorded coverage catching up with real coverage, not a regression being blessed. #5114's test ("merge two vocabularies on import — union approved edges, refuse cycles") plausibly kills all three.

## How it was measured

Two traps on the way, both worth recording:

1. ⚠️ **`mutate.ts` silently zeroes every `-pg` column when `TEST_DATABASE_URL` is unset**, and it is unset by default locally. The regeneration command CI prints, run verbatim, would have written a column of fabricated zeros over a real measurement — replacing one stale cell with a dozen wrong ones. Measured against a dedicated scratch database instead, also keeping it clear of other work on the box (a contended measurement is the other way this goes wrong).

2. **The first attempt refused outright**, and the refusal was correct:

   > `baseline for roundtrip-pg is RED — 1 failing. Every mutation count would be this breakage plus the mutation's, which is indistinguishable from a strong result. Fix the tree first.`

   Cause was a fresh worktree with no `node_modules` — `@useatlas/types` unresolvable. The CI job builds `@useatlas/types` + `@useatlas/plugin-sdk` explicitly before verifying, for exactly this reason. After building: 15 pass / 0 fail, and the `/15` denominators then matched CI's log.

## Verification

`push: main` runs `--all`, so this SHA's own CI run is the real check — if any other table is also stale, it will say so here rather than after merge.