### PR TITLE
chore(types): 0.9.0 — minor, because predicateCardinality is a reader break

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useatlas/types",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Shared types for the Atlas text-to-SQL agent",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## What

Bumps `@useatlas/types` to **0.9.0**. Step 1 of the three-step publish sequence — version only, no dependency refs move.

## Why a minor and not a patch

Two independent reasons, both found by `/audit-contracts` during the v0.2.5 cut.

**1. There is a real reader break in the window.** `ExportedBrainFact.predicateCardinality` went from required to optional (#5035). `packages/types/src/migration.ts` documents the consequence itself:

> ⚠️ **Optional rather than REMOVED, and it is still a breaking change for READERS.** A consumer that *writes* the field keeps compiling; one that *reads* it does not, because the type widened from `"single" | "multi"` to `… | undefined` — a direct assignment or an exhaustive `switch` now fails under strict mode.

The changelog line the source drafted for itself: *"reading `predicateCardinality` now requires handling `undefined`"*.

**2. npm's `0.8.0` and this repo's `0.8.0` are already different code.** The 0.8.0 bump landed in `d21aec0e8` (2026-08-01), which **predates `v0.2.4`**, and 14 commits have changed `packages/types/src/` under that unchanged version since. npm forbids republishing a version, so this cannot self-heal. A `0.8.1` would ship the reader break to anyone on a `~0.8` or `>=` range as though it were a fix.

`0.9.0` is the first version number that honestly describes what the tarball contains. Consumers on `^0.8.0` won't auto-resolve it — which is the point.

## Why no ref bumps here

Nothing in-tree resolves this version: `sdk`/`react` pin `^0.1.0`, the scaffolds pin `^0.7.0`, and every workspace consumer is `workspace:*`. Per the publish-package sequence, refs move only *after* a publish lands, and only if they need to.

## Next steps (not in this PR)

1. Merge this.
2. `git tag types-v0.9.0 && git push origin types-v0.9.0` — single tag, never >3 in one push.
3. Confirm `publish.yml` lands `@useatlas/types@0.9.0` on npm.

The `unpublished-versions` guard exempts the PR that *introduces* a bump, so this stays green — but it will fail every push after merge until the publish tag lands. Step 2 is not optional.

## Test plan

- [ ] `drift` job green (`check-unpublished-versions` exempts the introducing change)
- [ ] `check-published-symbols` green (validates against the scaffold-pinned `0.7.0`, untouched here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)