### PR TITLE
chore(audits): three audit checks that were silently passing

### DIFF
--- a/.claude/commands/audit-prod.md
+++ b/.claude/commands/audit-prod.md
@@ -44,7 +44,7 @@ The deployed surface as of writing: `api.useatlas.dev`, `api-eu.useatlas.dev`, `
    grep -rEn '\.json\(\s*\{[^}]*\}\s*,\s*500\b' packages/api/src/ --include='*.ts' | grep -v requestId
    ```
 4. **Scheduler instrumentation** — does each scheduled task type emit a span / metric / log when it fires, succeeds, fails? Read `packages/api/src/lib/scheduler/` end-to-end.
-5. **Abuse counter wiring** — `packages/api/src/lib/security/abuse.ts` increments counters; do those counters export to a telemetry sink (OTel metrics? a dashboard endpoint?) or are they purely in-memory? In-memory-only is a finding.
+5. **Abuse counter wiring** — ⚠️ **re-pointed 2026-08-12.** `packages/api/src/lib/security/abuse.ts` is now a **delegating shim**; the engine moved to `ee/src/abuse-prevention/engine.ts` (post-#4000 WS5). Audit the engine, not the shim — a check aimed at the shim finds no counters and silently passes. As of the re-point the counters **do** export: `engine.ts:34` imports `abuseEscalations` from `@atlas/api/lib/metrics` and increments the OTel Counter on every level transition, with `engine.test.ts:653` pinning the wiring. Verify that still holds; in-memory-only would be the finding.
 6. **Plugin health surface** — each plugin can register a health check. Grep for plugins that don't, or whose health endpoint doesn't surface to the admin console / OTel.
 
 ### Findings to flag
@@ -140,7 +140,7 @@ For each upstream dependency, walk the failure path top-to-bottom and document w
    - Connection pool `pool.perOrg.*` defaults (5 / 30000 / 50 / 2 / 5) — fine for trial-tier, undersized for Business?
    - `ATLAS_RATE_LIMIT_RPM_CHAT` (memory: F-74 separate-bucket chat ceiling) — what's the actual production value vs default?
    - `ATLAS_CONVERSATION_STEP_CAP` default 500 — fine
-4. **Hot-reloadable vs startup-only correctness** — the lock mechanism now exists: `SAAS_IMMUTABLE_KEYS` (in `lib/effect/saas-env.ts`) blocks runtime mutation of boot-guard-dependent keys. Audit its MEMBERSHIP, not its existence: every setting whose value a boot guard validated (DPA email vendor, encryption keys, deploy mode, plan-tier enforcement) must be in the immutable set or have a hot-reload path that re-runs the guard. A guard-validated key that's runtime-mutable is the finding.
+4. **Hot-reloadable vs startup-only correctness** — the lock mechanism now exists: `SAAS_IMMUTABLE_KEYS` (in `packages/api/src/lib/settings.ts`, built from `SAAS_IMMUTABLE_KEYS_LITERAL`; **not** in `saas-env.ts`, where this command wrongly placed it until 2026-08-12 — no `ATLAS_BRAIN_*` or any other key appears in `saas-env.ts`'s immutable set because there isn't one there) blocks runtime mutation of boot-guard-dependent keys. Audit its MEMBERSHIP, not its existence: every setting whose value a boot guard validated (DPA email vendor, encryption keys, deploy mode, plan-tier enforcement) must be in the immutable set or have a hot-reload path that re-runs the guard. A guard-validated key that's runtime-mutable is the finding.
 5. **Required-but-undocumented env vars** — `/audit-docs` Part A handles this for the docs site, but cross-check that `.env.example` and the docs page agree with what the **deployed** API actually reads in prod paths (vs dev/test-only).
 
 ### Findings to flag

--- a/.claude/commands/audit-readme.md
+++ b/.claude/commands/audit-readme.md
@@ -137,7 +137,7 @@ The README's Security table is a **public claim about isolation**, which puts it
 | Omits the tier that is actually the default in prod | **HIGH** — misleads self-hosters about what they're getting |
 | Validation-layer copy diverges from the canonical phrasing | MEDIUM |
 
-**Worked example (2026-07-27):** the table read "nsjail / Firecracker / sidecar". **Firecracker is not an Atlas tier** — it appears in the codebase only as a comment about Vercel Sandbox's underlying MMDS. The row simultaneously omitted `vercel-sandbox`, which is the actual SaaS default.
+**Worked example (2026-07-27) — VERIFIED FIXED 2026-08-12, do not re-derive.** The table read "nsjail / Firecracker / sidecar". **Firecracker is not an Atlas tier** — it appears in the codebase only as a comment about Vercel Sandbox's underlying MMDS. The row simultaneously omitted `vercel-sandbox`, which is the actual SaaS default. `README.md:243` now reads "Vercel Sandbox, nsjail, or the sidecar — with e2b, Daytona, and Railway available as bring-your-own-cloud backends": Firecracker is gone and the SaaS default is named. Re-check that it still holds; don't re-open it from scratch.
 
 ---
 

--- a/docs/agents/docs-audit/i-cross-cutting.md
+++ b/docs/agents/docs-audit/i-cross-cutting.md
@@ -25,16 +25,23 @@ the gate can't see:
   *resolves* (no 404), but sends a `/self-hosted` reader on a cross-section
   jump — judge whether audience-appropriate phrasing or `<AudienceLink>` fits
 
-### I3. Notebook Docs Currency
+### I3. Notebook Docs Currency — RETIRED 2026-08-12
 
-**Docs:** `apps/docs/content/docs/guides/notebook.mdx`
-**Source:** `packages/web/src/ui/components/notebook/`
+**Deleted, not skipped.** Both sides of this check stopped existing at `8a552d375` —
+*"refactor(notebook): retire the notebook surface end-to-end (ADR-0035) (#4589)"* — which
+removed `apps/docs/content/docs/guides/notebook.mdx` and
+`packages/web/src/ui/components/notebook/` in the same commit, along with the three source
+files this check read (`use-keyboard-nav.ts`, `use-notebook.ts`, `notebook-export.ts`).
 
-Check that the docs page reflects the CURRENT state of the notebook by reading the source files. Don't assume what's shipped — verify against code:
-- Current keyboard shortcuts (read `use-keyboard-nav.ts`)
-- Current cell operations (read `use-notebook.ts` — includes text cells, fork, reorder, export)
-- Persistence model (read `use-notebook.ts` — server-side with localStorage cache)
-- Export capabilities (read `notebook-export.ts` — Markdown + HTML)
+It had therefore been **silently passing** ever since: a check whose docs page and source
+tree are both gone matches nothing and reports nothing.
+
+The number is kept as a tombstone rather than renumbering, because `audit-docs.md` and
+this file both reference **I4** by name.
+
+The only remaining "notebook" strings in the content trees are in
+`shared/comparisons/{cube,vanna,index}.mdx`, all describing **competitors'** notebooks —
+correct, and not an Atlas claim. Nothing to re-add here.
 
 ### I4. Audience Drift (content-level — the build gate can't catch this)
 


### PR DESCRIPTION
Found by running the full `audit-*` battery on 2026-08-12 (the pre-milestone cleanup pass). Docs and command files only — no source, no tests.

Per `docs/agents/audits.md`, *"the audit's first deliverable is a correct audit"*, and a check whose source path no longer exists has been passing without looking at anything.

| Check | Was | Now |
|---|---|---|
| `docs-audit` **I3** Notebook Docs Currency | Reads a docs page and three source files, **all deleted** at `8a552d375` (ADR-0035, #4589) | Retired, as a numbered tombstone — `audit-docs.md` references **I4** by name, so renumbering would break it |
| `audit-prod` **Part C** | `SAAS_IMMUTABLE_KEYS` in `lib/effect/saas-env.ts` | `packages/api/src/lib/settings.ts`. There is no immutable set in `saas-env.ts` at all |
| `audit-prod` **Part A step 5** | Audits `lib/security/abuse.ts` | That's a delegating shim; the engine is `ee/src/abuse-prevention/engine.ts` (post-#4000 WS5). Counters **do** export to OTel |
| `audit-readme` **Part E** | Firecracker worked example | Marked verified-fixed — `README.md:243` names Vercel Sandbox and drops Firecracker |

Two of these are the promote-to-CI ratchet's second data point for their class, noted in the issues filed alongside this pass.

Same battery also produced #5160–#5165.