### PR TITLE
sec(auth): block the native org-delete endpoint, which orphaned every workspace table (#5175)

### DIFF
--- a/packages/api/src/lib/auth/__tests__/server.test.ts
+++ b/packages/api/src/lib/auth/__tests__/server.test.ts
@@ -193,6 +193,83 @@ describe("organization plugin wiring", () => {
     expect(org).toBeDefined();
   });
 
+  // ── #5175 ──────────────────────────────────────────────────────────────────
+  // `POST /api/auth/organization/delete` removes the `organization` row and
+  // cascades to NOTHING — no table in db/schema.ts has an FK to it (#5160) — so
+  // it orphans every workspace-scoped table in lib/db/purge-scope.ts. The
+  // `owner` role carries `organization: ["delete"]`, so a workspace owner could
+  // reach it. The supported lifecycle is soft-delete -> `hardDeleteWorkspace`.
+  it("disableOrganizationDeletion is wired to true", () => {
+    const plugins = buildPlugins();
+    const org = plugins.find((p: { id?: string }) => p.id === "organization");
+    expect(org).toBeDefined();
+    // Same option-shape probe as the assertion above: Better Auth has shipped
+    // plugin options under `options` and `_config` across versions.
+    const opts =
+      (org as { options?: { disableOrganizationDeletion?: boolean } }).options
+      ?? (org as { _config?: { disableOrganizationDeletion?: boolean } })._config
+      ?? (org as Record<string, unknown>);
+    expect(
+      (opts as { disableOrganizationDeletion?: boolean }).disableOrganizationDeletion,
+    ).toBe(true);
+  });
+
+  // The config assertion above proves the flag is SET. This one proves it is
+  // ENFORCED, by driving the real HTTP door — a Better Auth upgrade could keep
+  // accepting the option while changing what it does, and the config test would
+  // stay green through that.
+  //
+  // ⚠️ No session is created on purpose, and that is what makes this falsifiable
+  // rather than vacuous. In better-auth 1.6.25 the disable check runs at the TOP
+  // of the handler, above `getSession`:
+  //
+  //     if (ctx.context.orgOptions.disableOrganizationDeletion) throw ...
+  //     const session = await ctx.context.getSession(ctx);
+  //
+  // so the two states are distinguishable without any auth setup:
+  //   flag ON  -> 404 "Organization deletion is disabled"
+  //   flag OFF -> 401 UNAUTHORIZED (it got past the gate and asked for a session)
+  //
+  // Verified by flipping the flag to false: this test then sees 401 and fails.
+  it("HTTP /organization/delete is refused before the session is even read", async () => {
+    const plugins = buildPlugins();
+    const org = plugins.find((p: { id?: string }) => p.id === "organization");
+    const instance = betterAuth({
+      baseURL: "http://localhost:3000",
+      // The org plugin's models must be declared up-front — the memory adapter
+      // throws "Model … not found" for a table it was not given.
+      database: memoryAdapter({
+        user: [],
+        account: [],
+        session: [],
+        verification: [],
+        organization: [],
+        member: [],
+        invitation: [],
+      }),
+      secret: "test-secret-at-least-32-characters-long",
+      emailAndPassword: { enabled: true },
+      // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- Better Auth plugin union types
+      plugins: [org] as any[],
+    });
+
+    const res = await instance.handler(
+      new Request("http://localhost:3000/api/auth/organization/delete", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ organizationId: "org_does_not_exist" }),
+      }),
+    );
+
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { message?: string; code?: string };
+    // Assert the CODE, not the prose — the message is upstream copy and can be
+    // reworded in a patch release without the block changing.
+    expect(body.code).toBe("ORGANIZATION_DELETION_DISABLED");
+
+    await instance.$context.catch(() => {});
+  });
+
   // #4046 / ADR-0027 §6 — the workspace-scoped API key path is inert unless the
   // apiKey() plugin is wired. The plugin's options (`enableMetadata` /
   // `enableSessionForAPIKeys`) are NOT introspectable on the constructed plugin

--- a/packages/api/src/lib/auth/server.ts
+++ b/packages/api/src/lib/auth/server.ts
@@ -2479,6 +2479,48 @@ export function buildPlugins() {
       // and prevent an attacker who guesses an `invitationId` from claiming
       // a row intended for someone else. Pairs with the email-OTP plugin.
       requireEmailVerificationOnInvitation: true,
+      // ── #5175 ────────────────────────────────────────────────────────────
+      // `POST /api/auth/organization/delete` deletes the `organization` row
+      // and nothing else. NO table in `db/schema.ts` has an FK to
+      // `organization` (#5160), so that cascades to nothing: it orphans every
+      // workspace-scoped table in `lib/db/purge-scope.ts` — brain claims, the
+      // knowledge base, every encrypted credential store, dashboards, audit
+      // logs — with no operator record that it happened. The `owner` role
+      // carries `organization: ["delete"]` (`org-permissions.ts:49`), so any
+      // workspace owner could reach it.
+      //
+      // It also skips `hardDeleteWorkspace`'s soft-delete precondition and
+      // its Stripe teardown, so it can strand a live subscription against a
+      // deleted org.
+      //
+      // The supported lifecycle is soft-delete -> operator purge
+      // (`hardDeleteWorkspace`). This is not a capability being withdrawn;
+      // it is a path that silently corrupted the tenant.
+      //
+      // ⚠️ Why the flag and NOT a `beforeDeleteOrganization` hook that throws.
+      // The hook does abort — it is awaited before `adapter.deleteOrganization`
+      // — but the plugin runs this FIRST, above the hook call:
+      //
+      //     if (organizationId === session.session.activeOrganizationId)
+      //       await adapter.setActiveOrganization(session.session.token, null)
+      //
+      // so a hook-based refusal still nulls the caller's active organization
+      // on every attempt: a persistent side effect from an operation that was
+      // refused. This flag throws at the top of the handler, before the
+      // session is even read, so a blocked call mutates nothing.
+      //
+      // A hook is also the wrong shape for the other posture. Wiring the real
+      // cascade there would run it OUTSIDE the plugin's delete, and #5160
+      // established the delete ORDER is load-bearing (two brain FKs are
+      // RESTRICT) — a partial failure would leave a workspace half-purged,
+      // which is worse than the orphaned-but-consistent state this prevents.
+      // If self-service deletion is ever wanted as a real feature, it should
+      // call `hardDeleteWorkspace`, not re-implement it.
+      //
+      // Refusal shape (better-auth 1.6.25, `routes/crud-org.mjs`):
+      //   404, message "Organization deletion is disabled",
+      //   code ORGANIZATION_DELETION_DISABLED
+      disableOrganizationDeletion: true,
       organizationHooks: {
         // Lives here rather than in `databaseHooks.member.create.after`
         // because the org plugin inserts the initial owner-member through


### PR DESCRIPTION
Closes #5175.

`POST /api/auth/organization/delete` deleted the `organization` row and cascaded to **nothing**. No table in `db/schema.ts` has an FK to `organization` (established by #5160), so the row vanished and every workspace-scoped table in `lib/db/purge-scope.ts` stayed behind — brain claims, the knowledge base, every encrypted credential store, dashboards, audit logs — with no operator record. The `owner` role carries `organization: ["delete"]`, so **any workspace owner could reach it**.

It also skipped `hardDeleteWorkspace`'s soft-delete precondition and Stripe teardown, so it could strand a live subscription against a deleted org.

Where #5160 was *"the purge misses ~34 tables"*, this was *"a self-service path misses all ~95"*.

## Premises verified before fixing

| Claim | Verdict |
|---|---|
| `owner` carries `organization: ["delete"]` | ✅ `org-permissions.ts:49` |
| No `beforeDeleteOrganization` hook | ✅ wired set is Create/Invitation/Member only |
| No route-level denylist | ✅ zero hits outside tests |

## ⚠️ Why the flag, not a hook that throws

This is the load-bearing design call, and it turned on reading the implementation rather than the docs.

`beforeDeleteOrganization` **does** abort — it is awaited before `adapter.deleteOrganization`. But better-auth 1.6.25 runs this immediately **above** the hook call (`routes/crud-org.mjs`):

```js
if (organizationId === session.session.activeOrganizationId)
  await adapter.setActiveOrganization(session.session.token, null, ctx);
```

So a hook-based refusal **still nulls the caller's active organization on every attempt** — a persistent side effect from an operation that was refused. `disableOrganizationDeletion` throws at the top of the handler, before the session is even read, so a blocked call mutates nothing.

The hook is also the wrong shape for the *other* posture (wiring a real cascade): it runs **outside** the plugin's delete, and #5160 established the delete ORDER is load-bearing because two brain FKs are `RESTRICT`. A partial failure would leave a workspace half-purged — worse than the orphaned-but-consistent state this prevents. If self-service deletion is ever wanted as a feature, it should call `hardDeleteWorkspace`, not re-implement it.

## Two tests, failing for different reasons

- **config assertion** — proves the flag is SET. Mirrors the existing `requireEmailVerificationOnInvitation` probe, same `options`/`_config` shape fallback.
- **HTTP test** — proves it is ENFORCED, driving the real door. A Better Auth upgrade could keep accepting the option while changing what it does, and the config test would stay green through exactly that.

The HTTP test creates **no session on purpose**, and that is what makes it falsifiable rather than vacuous — the disable check runs above `getSession`:

| | flag ON | flag OFF |
|---|---|---|
| `POST /organization/delete`, unauthenticated | **404** `ORGANIZATION_DELETION_DISABLED` | **401** UNAUTHORIZED |

Measured by flipping the flag to `false`: both tests go red and the HTTP one returns exactly the predicted 401. Restored from a backup copy, not `git checkout`.

Asserts the error **code**, not the prose — the message is upstream copy and can be reworded in a patch release without the block changing.

## Verification
- `server.test.ts` 57/57
- `--affected` 43/43 files
- `bun run type` clean, `bun run lint` clean

## Still open on the issue
AC item 4 — whether any prod region **already** has orphans from this path — is a per-region `§Residue` query, not a code change. Not blocked by this fix; if orphans exist they need cleanup regardless.

https://claude.ai/code/session_011pzBZUytobia9n8e8cDnrJ