### PR TITLE
docs(agents): comment-analyzer enforces concise plain-English (de-slop) comment rules

### DIFF
--- a/.claude/agents/comment-analyzer.md
+++ b/.claude/agents/comment-analyzer.md
@@ -1,6 +1,6 @@
 ---
 name: comment-analyzer
-description: Reviews comments added or changed in a diff for accuracy, long-term value, and fit with surrounding code. Use after writing doc comments or before opening a PR. Flags comment rot (claims that don't match the code), restate-the-obvious noise, and comments that miss Atlas's idioms (e.g. the `// intentionally ignored:` convention). Advisory only.
+description: Reviews comments added or changed in a diff for accuracy, long-term value, prose style, and fit with surrounding code. Use after writing doc comments or before opening a PR. Flags comment rot (claims that don't match the code), restate-the-obvious noise, AI-tell prose (verbose, antithesis-laden comments that should be concise plain English), and comments that miss Atlas's idioms (e.g. the `// intentionally ignored:` convention). Advisory only.
 tools: Read, Grep, Glob, Bash
 model: inherit
 color: green
@@ -16,6 +16,21 @@ You are a meticulous code-comment analyzer for the Atlas codebase. You approach 
 2. **Completeness without redundancy** — critical assumptions/preconditions, non-obvious side effects, important error conditions, and the *rationale* for non-obvious business logic are captured. A comment that merely restates the code is noise.
 3. **Long-term value** — comments explaining *why* beat comments explaining *what*. Flag comments tied to transitional/temporary states, and TODO/FIXME that may already be resolved.
 4. **Misleading elements** — ambiguous wording, stale references to refactored code, examples that no longer match, assumptions that no longer hold.
+5. **Prose style (de-slop)** — comments read as concise, plain English written by the maintainer, not as AI-generated prose. The rules below.
+
+## De-slop: concise, plain-English comments
+
+Comments in this repo are written with AI assistance, so AI-tell prose leaks into them. Sweep every comment in the diff against these rules (adapted from the blog's editorial law; scope stays the diff — this is not a license to rewrite the whole file's comments):
+
+- **Concise first.** A comment should be the shortest plain-English sentence that carries the constraint. If words can be cut without losing meaning, flag it and suggest the shorter form. A one-line fact does not need a three-line preamble.
+- **Antithesis / define-by-negation.** The #1 tell: "it's not X, it's Y" · "not a Z, but a W" · "X, not just Y". State the thing positively. Keep a contrast only when it is genuinely load-bearing (e.g. documenting which of two plausible behaviors was chosen), phrased naturally — never the formulaic pair.
+- **Em-dash pile-ups.** One aside per comment, at most. Multiple appositive `—` clauses in a single comment is a tell; prefer commas and full stops, or split into two sentences.
+- **LLM buzzwords.** Flag *legible, seamless, robust, leverage, delve, crucial, testament, comprehensive, elegant* and their kin. Replace with the concrete word for what the code actually does.
+- **Self-narrating / precious prose.** No aphorisms, no "notably/importantly/interestingly" throat-clearing, no comments that admire the code ("this elegantly handles…"). State the fact.
+- **Tricolon-of-fragments filler.** "Handles retries. Bounds the queue. Keeps callers honest." — rhetorical triples are for essays, not comments. One plain sentence.
+- **No reviewer-directed commentary.** Comments that justify the change to a reviewer ("this is now correct because…", "fixed to properly handle…") die at merge. A comment states what the *next reader* needs: the constraint the code can't show.
+
+When flagging a style issue, quote the comment and give the rewritten plain-English version — the fix should be copy-pasteable. Style findings on an otherwise-accurate comment are **Improvement Opportunities**, not Critical Issues; a comment that is both verbose *and* inaccurate is Critical for the inaccuracy.
 
 ## Atlas idioms (the conventions you enforce)
 

--- a/.claude/commands/review-panel.md
+++ b/.claude/commands/review-panel.md
@@ -67,7 +67,7 @@ Every round:
 - `Agent(pr-test-analyzer)` — test coverage & discipline
 
 Final round only (or with `--final`):
-- `Agent(comment-analyzer)` — comment accuracy & idiom
+- `Agent(comment-analyzer)` — comment accuracy, idiom & prose de-slop (concise plain-English comments; the style rules live in the agent definition)
 
 Each is read-only/advisory. Give every agent the same context: the base ref, the changed files, and the scope rule below.
 


### PR DESCRIPTION
## What

Makes the final-round comment sweep also police prose style, so going forward every diff that reaches a verdict gets its comments checked for AI-tell prose and rewritten as concise plain English.

- **`.claude/agents/comment-analyzer.md`** — new check 5 (Prose style) plus a **De-slop** section adapted from `/blog`'s "Kill these AI tells" for the comment register: antithesis / define-by-negation, em-dash pile-ups, LLM buzzwords, self-narrating prose, tricolon filler, and reviewer-directed commentary. Concision is the first rule. Scope stays the diff (explicitly not a license to rewrite a whole file's comments); style-only findings rank as Improvement Opportunities, never Critical; every flag must quote the comment and supply a copy-pasteable rewrite.
- **`.claude/commands/review-panel.md`** — the final-round bullet names the de-slop pass and points at the agent definition for the rules.

## Why

Comments here are written with AI assistance, so blog-post tells leak into them. The rules already existed in `/blog`; this moves the comment-relevant subset into the one reviewer that runs on every final round, instead of relying on authors to remember them.