### PR TITLE
docs(guides): the Claim Vocabulary approval surface gets a guide (#5158)

### DIFF
--- a/apps/docs/content/docs/guides/meta.json
+++ b/apps/docs/content/docs/guides/meta.json
@@ -24,6 +24,7 @@
     "brain-temporal-model",
     "brain-corrections",
     "brain-conflicts",
+    "brain-vocabulary",
     "brain-sources",
     "brain-chat-webhook",
     "brain-connector-authoring",

--- a/apps/docs/content/self-hosted/guides/meta.json
+++ b/apps/docs/content/self-hosted/guides/meta.json
@@ -11,6 +11,7 @@
     "brain-temporal-model",
     "brain-corrections",
     "brain-conflicts",
+    "brain-vocabulary",
     "brain-sources",
     "brain-chat-webhook",
     "brain-connector-authoring",

--- a/apps/docs/content/shared/guides/brain-conflicts.mdx
+++ b/apps/docs/content/shared/guides/brain-conflicts.mdx
@@ -26,7 +26,7 @@ When a `single`-cardinality claim arrives that disagrees with an existing one, A
 
 ### Where cardinality comes from
 
-Cardinality is a property of the **canonical predicate**, curated by a human on the **Claim Vocabulary** surface. It is not a field on the claim, and there is **no database default** — absence is the ordinary state and it means `multi`.
+Cardinality is a property of the **canonical predicate**, curated by a human on the [Claim Vocabulary](/guides/brain-vocabulary) surface. It is not a field on the claim, and there is **no database default** — absence is the ordinary state and it means `multi`.
 
 A *stored* `multi` is a different fact from absence: it records a human who looked and declined the question, which is what stops the automatic proposer raising it again. Only an **approved** entry counts. A proposer that watches human corrections can suggest `single`; it can never approve one, and nothing autonomous can.
 
@@ -99,4 +99,5 @@ So arbitration stays a **human verb**. Resolving a conflict means [superseding](
 ## Related
 
 - [Company Atlas — Corrections](/guides/brain-corrections) — the verbs that resolve a conflict
+- [Company Atlas — Claim Vocabulary](/guides/brain-vocabulary) — where a predicate is curated `single`, and where two spellings become one slot
 - [Company Atlas — Temporal Model](/guides/brain-temporal-model) — why a superseded claim stays readable

--- a/apps/docs/content/shared/guides/brain-vocabulary.mdx
+++ b/apps/docs/content/shared/guides/brain-vocabulary.mdx
@@ -9,25 +9,25 @@ Your corpus says `is priced at` in a contract, `priced at` in a spreadsheet, and
 
 The **Claim Vocabulary** is where somebody says otherwise. It lives at **`/admin/brain/vocabulary`** in the admin console, and it holds two kinds of decision: an **alias** (two spellings name one thing) and a **curated predicate** (this relation holds one value at a time — see [Conflicts](/guides/brain-conflicts#where-cardinality-comes-from)).
 
-This page is about the alias half, and about the judgement the surface is built to support. Atlas will not make it for you, and the reason is the whole design.
+This page is about the alias half, and about the judgement the surface is built to support.
 
 ---
 
 ## Why a person decides
 
-The obvious mechanism is similarity: `priced at` and `is priced at` differ by a copula, so collapse them. Atlas refuses, and refuses **structurally** — the normalizer that produces a claim's slot key does case-folding, separator unification, trimming and run-collapsing, and **nothing else**. No stemming, no lemmatisation, no copula-stripping, no edit distance.
+The obvious mechanism is similarity: `priced at` and `is priced at` differ by a copula, so collapse them. Atlas refuses, and refuses **structurally** — the normalizer that produces a claim's slot key does ASCII-only case folding (`A`–`Z`; `É` is left exactly as it is), separator unification, trimming and run-collapsing, and **nothing else**. No stemming, no lemmatisation, no copula-stripping, no edit distance.
 
-That refusal is not conservatism about a feature that would mostly work. It is a refusal to ship a rule whose first and highest-ranked output is wrong:
+Atlas refuses because the first and highest-ranked output of any such rule is wrong:
 
 <Callout type="warn" title="A similarity rule ranks `led_by` / `leads` first">
   They share a stem, they are one character apart after stemming, and they are **inverse relations**. `A led_by B` and `B leads A` say the same thing from opposite ends; merging the spellings merges the ends. Every claim in the manager graph moves into one slot, where the two directions now read as rivals rather than as each other.
 
   ADR-0037 states the consequence in one line, in two places: approving that pair **"stamps `valid_to` across the manager graph"**. If the merged predicate is curated single-valued — and *"who does this person report to"* is exactly the relation somebody curates single-valued — then a person's manager and a person's reports collide in one slot, and the [publish gate](/guides/brain-temporal-model) closes the validity window on one of them. There is no un-supersede verb anywhere in Atlas.
 
-  `priced at` / `is priced at` and `led_by` / `leads` are the same distance apart lexically and opposite in meaning. No rule available to Atlas separates them. A person separates them without effort, which is why the person is the mechanism rather than the fallback.
+  `priced at` / `is priced at` and `led_by` / `leads` are the same distance apart lexically and opposite in meaning. No rule available to Atlas separates them. A person separates them without effort.
 </Callout>
 
-So an alias is never inferred from how two strings look. It is proposed from **structural evidence**, or authored by hand — and in both cases the write happens because somebody approved it.
+So an alias is never inferred from how two strings look. It is proposed from **structural evidence**, or authored by hand. Every predicate-position write goes through a person; the one class that does not is the narrow warehouse-key case described [below](#the-auto-approval-boundary).
 
 ## What an alias claims, and what it does not
 
@@ -35,25 +35,32 @@ An alias is a directed edge between two **norms** — the folded spellings — a
 
 | Position | What it merges | Who may approve |
 |---|---|---|
-| `predicate` | Two spellings of a relation (`is priced at` → `priced at`) | Any authenticated member |
-| `subject` | Two spellings of the entity in the subject slot | Owner or admin |
-| `object` | Two spellings of the entity in the object slot | Owner or admin |
+| `predicate` | Two spellings of a relation (`is priced at` → `priced at`) | Any admin or owner — the whole admin console is admin-gated, and this position adds nothing on top |
+| `subject` | Two spellings of the entity in the subject slot | Owner or admin **of this workspace** |
+| `object` | Two spellings of the entity in the object slot | Owner or admin **of this workspace** |
+
+That distinction is easy to skim past and is the real asymmetry: reaching this surface at all requires an admin, owner or platform-admin session, so no ordinary member approves anything here. What the entity positions add is a *second*, workspace-scoped check — your role in the workspace being written, not merely the role your session carries.
 
 Three things it is **not**:
 
-- **Not a claim.** An alias is not a `brain_facts` row. It has no review status of its own, no validity window, and no provenance chain. It is a statement about vocabulary, adjudicated once.
+- **Not a claim.** An alias is not a `brain_facts` row. It carries no claim review status, no validity window and no provenance edges — it is a statement about vocabulary, adjudicated once. (The *proposal* behind it does have its own `pending`/`approved`/`rejected` status; that is the queue below, not the claim lifecycle.)
 - **Not position-portable.** Approving `is priced at → priced at` at the predicate position re-keys predicates only. A predicate decision can never re-key subjects, which is why the position is part of the entry rather than a filter over it.
-- **Not per-team.** The vocabulary is workspace-scoped and carries no access control, permanently and by decision. Per-team terminology is refused by ADR-0037 §6, not merely unimplemented. What *is* scoped is your **visibility of** entity-position entries: you are shown one only where you can read at least one claim on each side, and the counts always disclose how many you cannot see rather than silently omitting them.
+- **Not per-team.** The vocabulary is workspace-scoped and carries no access control, permanently and by decision. Grant-scoped aliasing is refused in ADR-0037's rejected alternatives, with the cost named in §6 — it is not merely unimplemented. What *is* scoped is your **visibility of** entity-position entries: you are shown one only where you can read at least one claim on each side, and the counts always disclose how many you cannot see rather than silently omitting them.
 
 ## What approving one re-keys
 
-Approving an alias rewrites the identity key of **every live claim whose norm at that position folds to the child spelling**, onto the parent's key. Workspace-wide. Retroactively, and for every claim that arrives afterwards.
+Approving an alias rewrites the identity key of **every claim whose norm at that position folds to the child spelling**, onto the parent's key. Workspace-wide. Retroactively, and for every claim that arrives afterwards.
 
 The page says it in the confirmation line before you commit:
 
 > Every claim whose predicate folds to "is priced at" will be re-keyed onto "priced at", and every future one will be too. This is reversible: removing the alias re-keys them back.
 
-The write is atomic — the proposal row, the edge, the closure rebuild and the workspace-wide re-key commit together or not at all. A re-key that fails leaves no proposal row and no edge.
+**"Every claim" includes retracted and superseded rows**, and that is deliberate rather than an oversight — the re-key carries no status, `invalidatedAt` or `validTo` filter. A tombstoned row left on a stale key is one whose surface and key disagree permanently, and removal's undo re-derives each claim's key *from its surface*; skipping the dead rows on the way in would strand them somewhere neither vocabulary ever put them.
+
+The write is atomic — the proposal row, the edge, the closure rebuild and the workspace-wide re-key commit together or not at all. What a failure leaves behind differs by route, and the difference matters if you are deciding whether to retry:
+
+- **A failed approval** rolls back whole: no edge, no partial re-key, and the proposal is left exactly `pending` for somebody to decide again. It is never left half-applied.
+- **A failed authoring** leaves no proposal row either, because authoring created that row in the same transaction.
 
 **What changes downstream depends on the position, and the difference is not cosmetic:**
 
@@ -63,7 +70,7 @@ The write is atomic — the proposal row, the edge, the closure rebuild and the 
 <Callout type="warn" title="An approved object alias does not withdraw the contradiction flags it makes stale">
   Corroboration and tension are evaluated once, at ingest, per episode. The approval rewrites the object's identity key and nothing else — nothing deletes an `in-tension-with` edge. So every advisory contradiction between two claims Atlas now treats as agreeing is **left in place**, still flagging a disagreement that the decision just resolved.
 
-  The blast-radius preview counts them and says so explicitly before you approve. It is the one consequence of this surface that no other page will tell you about later.
+  The blast-radius preview counts them and says so explicitly before you approve. Nothing flags them afterwards — unlike a superseded rival in a [conflict cluster](/guides/brain-conflicts#what-a-conflict-cluster-shows), which at least carries a label saying what happened to it.
 </Callout>
 
 ### Direction is never guessed
@@ -78,11 +85,15 @@ On a workspace with no warehouse producer, **every** proposal is undirected. Tha
 
 ## Reading the blast-radius preview
 
-Every approval and every removal goes behind a preview, and the **Approve** button stays disabled until one has come back successfully. The preview is not advisory: this decision re-keys the corpus, so the blast radius is not optional.
+Every approval and every removal **on this page** goes behind a preview: the **Approve** button stays disabled until one has come back successfully, and a preview that merely failed does not satisfy it.
 
-It does not answer with a number. It answers with one of several **shapes**, and the shapes are not interchangeable — which is the point, because most of them can produce the digit `0` while meaning entirely different things.
+<Callout type="info" title="The preview gate is the console's, not the seam's">
+  `/preview` is a separate endpoint, and `/decide`, `/author` and `/remove` carry no preview token or precondition. A caller going straight at the REST surface can approve a workspace-wide re-key having previewed nothing, and the API will not refuse it. So this is a discipline the admin console imposes on the human path — worth reproducing if you build your own client, because nothing upstream will.
+</Callout>
 
-### "At least N, today"
+The preview does not answer with a number. `BlastRadius` is a discriminated union with **three arms**, and they are not interchangeable — which is the point, because two of them can produce the digit `0` while meaning entirely different things.
+
+### Arm 1 — `computed`: "at least N, today"
 
 The supersession radius has two sides — what **becomes supersedable** if you approve, and what **becomes safe again** — and both are floors, always:
 
@@ -92,7 +103,7 @@ The word *at least* is doing real work. The count is not a batch size. A decisio
 
 If the alias chain was deeper than Atlas walks, the preview says so — both numbers then describe a **smaller** population than you asked about, which is a different fact from the numbers disagreeing.
 
-### The object-position shape
+### Arm 2 — `object-position`
 
 An object-position alias gets a **different query over a different relation**, and it is rendered as one so it can never read like a smaller supersession radius. Three numbers instead of two:
 
@@ -102,27 +113,46 @@ An object-position alias gets a **different query over a different relation**, a
 | **Separating** | The removal's half: pairs that agree today and would stop agreeing. Nothing splits them retroactively either, and no contradiction is flagged for them until one is re-observed |
 | **Tension** | Contradictions Atlas has already flagged that would stop being contradictions — **and whose flags are not withdrawn** |
 
-A pair whose values *prove* they differ appears in none of these. The merge makes the two claims share a slot and they stay in tension, which is correct and is the thing an approver most needs not to be told otherwise.
+A pair whose values *prove* they differ appears in none of these: the merge makes the two claims share a slot and they stay in tension. That is correct, and it is the one thing the preview must not imply it resolved.
 
-### "This cannot produce pairs"
+These three are **floors on the same terms the supersession counts are** — each renders as *"at least N … and this applies to every future claim in the slot"* — and this arm carries the same deep-chain truncation warning. Neither property is weaker here just because the question is a different one.
 
-A `structurally-empty` answer names one of five reasons: an object-position alias, a predicate already curated single-valued, a predicate never curated at all, a surface that normalizes away to nothing, or a removal naming a norm with no approved parent.
+### Arm 3 — `structurally-empty`: "this cannot produce pairs"
+
+Rather than return a zero, the preview returns a **reason**. There are five, and they do not all belong to the same verb — which matters, because only two of them can reach you from an alias decision:
+
+| Reason | Which decision produces it |
+|---|---|
+| `unkeyable-surface` — the surface normalizes away to nothing, so it occupies no slot and can join nothing | **Alias** approval or removal |
+| `no-such-edge` — no approved edge starts at that norm, so the removal would do nothing | **Alias** removal |
+| `already-single` — the predicate is already curated single-valued, so there is nothing to flip | Curated-predicate **flip** |
+| `not-curated` — the predicate has no approved single-valued entry, so there is nothing to un-curate | Curated-predicate **removal** |
+| `object-position` | Reachable only from the supersession planner. An object-position alias takes **arm 2** instead — see above |
 
 <Callout type="warn" title="Zero and cannot-be-non-zero are the same number and opposite facts">
   *"0 pairs"* invites the conclusion that the decision is harmless. *"This decision cannot produce a supersession pair at all"* says its consequences are of a different kind and are not measured by this number. The preview reports the reason rather than a count precisely so those two can never be read as the same answer.
 </Callout>
 
-### "Unknown, not zero"
+Two more things ride on the arms above rather than being arms of their own. Both are easy to mistake for a fourth and fifth answer, and both can appear *alongside* a real count.
 
-When a count could not be established — the two statements Atlas reads disagreed, or a scoped read did not answer — the preview says so in those words and tells you to reload before deciding. It never renders an unestablished count as an all-clear. A failed preview and an empty preview are opposite facts, and this whole surface exists because they are easy to confuse.
+### Riding on the arms — "unknown, not zero"
 
-### The compound case
+Every side of every count carries its own consistency flag, so "Atlas could not establish this" is reported rather than absorbed. **How it reads depends on whether there is a number beside it:**
 
-One warning has no other home. If the predicate you are aliasing **into** is already curated single-valued, the preview says so beside the count:
+- **A side that is zero and unestablished** renders as **unknown, not zero** in those words, and tells you to reload before deciding.
+- **A side with a non-zero total whose statements disagreed** renders instead as *"these two counts disagreed, so treat them as approximate rather than as facts"* — no reload instruction, because there is still a magnitude to read.
+
+What never happens is an unestablished count rendering as an all-clear: every "nothing changes here" sentence on this surface is gated on the zeros being *known*, not merely on their being zero. A failed preview and an empty preview are opposite facts, and this whole surface exists because they are easy to confuse.
+
+### Riding on the arms — the compound case
+
+One warning has no other home, and it arrives **on** a computed count rather than instead of one. If the predicate you are aliasing **into** is already curated single-valued, the preview says so beside the count:
 
 > ⚠️ `priced at` is already curated single-valued. This decision moves the whole population of the aliased predicate into `priced at`'s slot — a slot where supersession is already armed. Any pairs counted above become supersedable not because a claim changed, but because it now shares a slot with a rule that was already in force.
 
-Nothing about those claims changed. They moved into a slot where a rule was waiting. A count alone gives you the magnitude and not the kind, and this is the one interaction where the kind is the surprise.
+A count alone gives you the magnitude and not the kind, and this is the one interaction where the kind is the surprise.
+
+Aliasing into an **uncurated** predicate says nothing here, deliberately — an explicit "the target is not curated" would be an all-clear about a hazard nobody asked about. But note that silence is not the same as the question being inapplicable: at the subject position, and for both cardinality verbs, the question genuinely does not arise, and the wire distinguishes the two cases even though the page renders neither.
 
 ## What the coverage statement means when Pending is empty
 
@@ -143,18 +173,20 @@ The same discipline applies to failure: if the queue could not load, the page sa
 ## Direct authoring is the useful path first
 
 <Callout type="info" title="The honest day-one shape">
-  The structural proposer raises a candidate only where **two distinct subjects** have live claims that agree about a **non-null comparable object** under two different predicate spellings. A comparable object is one Atlas could parse into a typed canonical value — a money amount with an explicit ISO currency code, a bare number, a date, a boolean. The parser is deliberately cowardly: anything ambiguous stores `null`, because refusing to parse costs a missed proposal while parsing wrongly costs an irreversible stamp.
+  The structural proposer raises a candidate only where **two distinct subjects** have live claims that agree about a **non-null comparable object** under two different predicate spellings. A comparable object is one Atlas could parse into a typed canonical value — for example a money amount carrying an explicit ISO currency code, a bare number, a date, an instant with an explicit offset, or a boolean. The parser is deliberately cowardly: anything ambiguous stores `null`, because refusing to parse costs a missed proposal while parsing wrongly costs an irreversible stamp. Bare `$499` does not qualify, since `$` names a dozen currencies.
 
-  Most claims therefore carry no comparable object, and on day one **the proposer returns zero rows**. The cardinality proposer needs three repeated corrections at one predicate before it says anything at all.
+  Most claims therefore carry no comparable object, and on day one **the proposer returns zero rows**. The cardinality proposer needs corrections at one predicate across **three distinct subjects** before it says anything — three corrections to the *same* slot trip nothing, because they tell Atlas about that slot rather than about the predicate.
 
   **Authoring works immediately**, which is why the authoring card sits above the queue rather than as a secondary button under an empty table. It is also the *only* route by which some entries are ever written: the structural proposer covers restatements — two claims that agree — and provably cannot cover contradictions, where the two claims disagree about the object. An alias for a disagreeing pair has to be authored by a person.
 </Callout>
 
-Authoring is a **picker on both sides**, never a text box, and the reason is a specific silent failure. The folded norm is not something a human can reliably predict: `499 a month`, `499 A Month` and `499-a-month` do not all fold the same way. Guess wrong and you author an edge whose child norm no claim has ever produced — it inserts cleanly, the closure recomputes, the re-key moves zero rows and the preview reads `0`. **Indistinguishable from a merge that worked.** So both sides are chosen from the norms your corpus actually contains, each shown with its commonest surface, its live claim count, and how many spellings it already merges. The search box filters that list; it never supplies a value.
+Authoring is a **picker on both sides**, never a text box, and the reason is that you cannot reliably predict what the pipeline produced. The folding is narrower than it looks and surprises in both directions: `499 a month`, `499 A Month` and `499-a-month` all collapse to the **same** norm (`-` and `_` are separators, so `-499` and `499` collide too), while `Café` and `CAFÉ` stay **different**, because only `A`–`Z` folds. Guessing a norm and typing it is how you author an edge whose child side no claim has ever produced.
 
-Authoring is refused outright when either norm has no live claim at that position, and the refusal names **which** side is empty. It is also refused for any pair carrying rejection memory — see below.
+That failure is genuinely closed rather than merely discouraged: authoring is **refused outright** when either norm has no live claim at that position, and the refusal names *which* side is empty. Without it the write would insert cleanly, recompute the closure, move zero rows and preview `0` — indistinguishable from a merge that worked. So both sides are chosen from the norms your corpus actually contains, each shown with its commonest surface, its live claim count, and how many spellings it already merges. The search box filters that list; it never supplies a value.
 
-Two entitlements, and they are deliberately different. **Approving** a predicate alias adjudicates evidence a producer gathered; any authenticated member may do it. **Authoring** one creates the assertion from nothing — no evidence, no producer, no threshold — and produces a workspace-wide re-key, so it takes owner or admin at *every* position. Removal takes the authoring bar too: a reader who could not author an edge must not be able to delete it.
+Authoring is also refused for any pair carrying rejection memory — see below.
+
+Two entitlements, and they are deliberately different. **Approving** a predicate alias adjudicates evidence a producer already gathered, so the seam asks nothing beyond the admin session the console already required. **Authoring** one creates the assertion from nothing — no evidence, no producer, no threshold — and produces a workspace-wide re-key, so it takes owner or admin *of this workspace*, at every position. Removal takes the authoring bar too: a reader who could not author an edge must not be able to delete it.
 
 ## Removing an alias
 
@@ -170,19 +202,40 @@ One hole is fail-closed and worth knowing about: an entity-position edge withhel
 
 ## The auto-approval boundary
 
-Some alias edges skip review. The boundary is narrow on purpose, and it is four conditions, all of which must hold:
+Some alias edges may skip review. The boundary is narrow on purpose, and it is four conditions, all of which must hold:
 
 1. The position is **`subject` or `object`**. A predicate-position proposal can never auto-approve — and since the structural proposer only ever proposes at the predicate position, **nothing it raises is ever eligible.**
 2. The source class is listed in **`ATLAS_BRAIN_ALIAS_AUTO_APPROVE_SOURCES`**, which ships as `warehouse_key` alone.
 3. The proposal's confidence clears **`ATLAS_BRAIN_ALIAS_AUTO_APPROVE_THRESHOLD`**, which ships as `1`.
-4. Atlas has successfully read this workspace's settings. If the settings tier never loaded, every proposal queues, because an override that cannot be read is indistinguishable from one that was never written.
+4. Atlas could consult this workspace's setting overrides. On a deployment with an internal DB whose settings never loaded, every proposal queues — an override that cannot be read is indistinguishable from one that was never written. A deployment with **no** internal DB satisfies this by design rather than failing it: there env vars and defaults are the whole configuration, so there is no override tier to miss.
 
-`warehouse_key` means *two surfaces are the same row in your warehouse, joined on a primary key*. That is certain by construction, which is why it is the only class admitted by default. The threshold is `1` rather than a fraction for the same reason: a fraction would let some future producer's merely-probable edge auto-approve on a knob nobody re-read. Leave the threshold **empty** to queue everything, and note that a garbled value **disables** auto-approval rather than falling back to the shipped default.
+There are exactly four source classes, and the knob takes them as a comma-separated list — spell them exactly:
+
+| Class | What it means |
+|---|---|
+| `warehouse_key` | A warehouse primary key: two surfaces are the same row. Certain by construction — the only class admitted by default |
+| `extractor` | A language model's guess that two spellings name one thing |
+| `seam` | The structural proposer's own candidates, raised from your corpus |
+| `human` | Somebody authored the edge directly |
+
+<Callout type="info" title="Today this boundary is a forward guarantee, not a live path">
+  No shipped producer proposes an alias at an entity position. The structural proposer emits `seam` at the **predicate** position only, and direct authoring is a person by definition — nothing in the tree currently emits `warehouse_key` or `extractor` at all. Condition 1 therefore excludes everything that exists, and on a stock deployment **no alias auto-approves**.
+
+  The section is worth reading anyway, because the knobs are live and outlast the gap: they decide what happens the day a warehouse producer or an extractor-backed proposer does ship. Set them for the deployment you will have, not the one you have now.
+</Callout>
+
+Note that `seam` is not on the default list *and* could not benefit from being on it, since condition 1 already excludes everything the structural proposer raises. The threshold is `1` rather than a fraction for the same reason `warehouse_key` stands alone: a fraction would let some future producer's merely-probable edge auto-approve on a knob nobody re-read. Leave the threshold **empty** to queue everything.
+
+<Callout type="warn" title="The two knobs fail differently when you garble them">
+  A **threshold** that is unparseable or outside `0.0`–`1.0` **disables** auto-approval for that workspace rather than falling back to the shipped `1` — a garbled knob must never be more permissive than the operator who garbled it intended.
+
+  A **sources** list behaves differently: an unrecognized token is logged and **dropped**, and the rest of the list still applies. So `warehouse_key,extractr` does not fail closed — it silently means `warehouse_key`. A typo therefore removes a class you meant to add rather than disabling the feature, which is the safe direction but is *not* the same rule as the threshold's. Check the boot logs after editing it.
+</Callout>
 
 <Callout type="warn" title="Widening `..._SOURCES` to `extractor` is a decision, not a tuning step">
   An `extractor` edge is a language model's guess about which two spellings mean the same thing. Auto-approving it **re-keys the record with nobody in front of it**.
 
-  The specific hazard is not that a model is often wrong. It is that an extractor asked *"what is the canonical predicate here"* **cannot abstain** — it always produces one — so it fills the queue with confident, unfalsifiable answers, and `led_by` / `leads` is among the first things it offers. That pair is exactly what the structural proposer is built to never raise and what a person is here to refuse. Widening this knob routes it around both.
+  The specific hazard is not that a model is often wrong. It is that an extractor asked *"what is the canonical predicate here"* **cannot abstain** — it always produces one — so it fills the queue with confident, unfalsifiable answers, and `led_by` / `leads` is among the first things it offers. That pair is exactly what the structural proposer is built to never raise and what a person is here to refuse. Widening this knob would route it around both, the day such a producer exists.
 
   Both knobs are workspace-scoped; the reference rows are in [Environment variables → Company Atlas](/reference/environment-variables#company-atlas).
 </Callout>
@@ -196,6 +249,8 @@ Two proposal kinds share **one queue**, one set of filters and one pair of decid
 | **Alias** | Distinct subjects whose live claims agree about one object under both spellings, with examples | **2** distinct subjects |
 | **Curated predicate** | Distinct subjects a human has superseded at that predicate, *and* how many supersessions produced them | **3** distinct subjects |
 
+Structural evidence exists only for **predicate** pairs — it looks for two claims about one subject that agree about the object under different verbs. At an entity position that question cannot be asked at all, so such a proposal carries none, and the queue says so in as many words rather than showing a zero. *No evidence found* and *the question does not apply here* are different facts; judge the second on where the proposal came from.
+
 Both counts are distinct-subject counts, but they are **not comparable magnitudes**: agreement-without-a-slot is positive and typed evidence, while a correction event is circumstantial. Rendering them in one column at equal weight would invert the ranking those thresholds encode.
 
 Every count travels with its own threshold, because the evidence is **re-derived when you open the page** — nothing is stored at proposal time. The corpus moves, so an entry can honestly read *below* the bar that raised it, and the page says exactly that rather than hiding the discrepancy. A count Atlas could not read is reported as **unknown, not zero**, with no explanation attached — a specific, confident, wrong story about a number nobody read is worse than admitting the read failed.
@@ -203,7 +258,7 @@ Every count travels with its own threshold, because the evidence is **re-derived
 The `rank` on an alias row orders the queue. It is not a probability, and the page says so.
 
 <Callout type="info" title="Entity-position proposals you cannot see are counted, not hidden">
-  Predicate-position proposals are shown to every approver — a verb phrase discloses nothing you could not have guessed. Entity-position ones are gated on your being able to read at least one claim on **each** side, so you are never shown a merge between two populations you have no standing in. The withheld count is always rendered: *"12 entity edges you cannot see"* and *"none"* are opposite facts that a scoped list renders identically.
+  Predicate-position proposals are shown to every approver — a verb phrase discloses nothing you could not have guessed. Entity-position ones are gated on your being able to read at least one claim on **each** side, so you are never shown a merge between two populations you have no standing in. The withheld count is always rendered, as its own badge on the queue and as a sentence in the coverage statement — a list that silently omitted them would render "12 you cannot see" and "none" identically.
 </Callout>
 
 ## Related

--- a/apps/docs/content/shared/guides/brain-vocabulary.mdx
+++ b/apps/docs/content/shared/guides/brain-vocabulary.mdx
@@ -1,0 +1,215 @@
+---
+title: Company Atlas — Claim Vocabulary
+description: The surface where a person decides that two spellings name one thing — what approving an alias re-keys, how to read the blast-radius preview, why an inverse relation must never be approved, and what the coverage statement means when nothing is pending.
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+
+Your corpus says `is priced at` in a contract, `priced at` in a spreadsheet, and `costs` in a Slack thread. Three spellings, one relation. Atlas keys claims on the spelling it was given, so until somebody says otherwise those are three different relations and a claim under one can neither corroborate nor replace a claim under another.
+
+The **Claim Vocabulary** is where somebody says otherwise. It lives at **`/admin/brain/vocabulary`** in the admin console, and it holds two kinds of decision: an **alias** (two spellings name one thing) and a **curated predicate** (this relation holds one value at a time — see [Conflicts](/guides/brain-conflicts#where-cardinality-comes-from)).
+
+This page is about the alias half, and about the judgement the surface is built to support. Atlas will not make it for you, and the reason is the whole design.
+
+---
+
+## Why a person decides
+
+The obvious mechanism is similarity: `priced at` and `is priced at` differ by a copula, so collapse them. Atlas refuses, and refuses **structurally** — the normalizer that produces a claim's slot key does case-folding, separator unification, trimming and run-collapsing, and **nothing else**. No stemming, no lemmatisation, no copula-stripping, no edit distance.
+
+That refusal is not conservatism about a feature that would mostly work. It is a refusal to ship a rule whose first and highest-ranked output is wrong:
+
+<Callout type="warn" title="A similarity rule ranks `led_by` / `leads` first">
+  They share a stem, they are one character apart after stemming, and they are **inverse relations**. `A led_by B` and `B leads A` say the same thing from opposite ends; merging the spellings merges the ends. Every claim in the manager graph moves into one slot, where the two directions now read as rivals rather than as each other.
+
+  ADR-0037 states the consequence in one line, in two places: approving that pair **"stamps `valid_to` across the manager graph"**. If the merged predicate is curated single-valued — and *"who does this person report to"* is exactly the relation somebody curates single-valued — then a person's manager and a person's reports collide in one slot, and the [publish gate](/guides/brain-temporal-model) closes the validity window on one of them. There is no un-supersede verb anywhere in Atlas.
+
+  `priced at` / `is priced at` and `led_by` / `leads` are the same distance apart lexically and opposite in meaning. No rule available to Atlas separates them. A person separates them without effort, which is why the person is the mechanism rather than the fallback.
+</Callout>
+
+So an alias is never inferred from how two strings look. It is proposed from **structural evidence**, or authored by hand — and in both cases the write happens because somebody approved it.
+
+## What an alias claims, and what it does not
+
+An alias is a directed edge between two **norms** — the folded spellings — at one **slot position**:
+
+| Position | What it merges | Who may approve |
+|---|---|---|
+| `predicate` | Two spellings of a relation (`is priced at` → `priced at`) | Any authenticated member |
+| `subject` | Two spellings of the entity in the subject slot | Owner or admin |
+| `object` | Two spellings of the entity in the object slot | Owner or admin |
+
+Three things it is **not**:
+
+- **Not a claim.** An alias is not a `brain_facts` row. It has no review status of its own, no validity window, and no provenance chain. It is a statement about vocabulary, adjudicated once.
+- **Not position-portable.** Approving `is priced at → priced at` at the predicate position re-keys predicates only. A predicate decision can never re-key subjects, which is why the position is part of the entry rather than a filter over it.
+- **Not per-team.** The vocabulary is workspace-scoped and carries no access control, permanently and by decision. Per-team terminology is refused by ADR-0037 §6, not merely unimplemented. What *is* scoped is your **visibility of** entity-position entries: you are shown one only where you can read at least one claim on each side, and the counts always disclose how many you cannot see rather than silently omitting them.
+
+## What approving one re-keys
+
+Approving an alias rewrites the identity key of **every live claim whose norm at that position folds to the child spelling**, onto the parent's key. Workspace-wide. Retroactively, and for every claim that arrives afterwards.
+
+The page says it in the confirmation line before you commit:
+
+> Every claim whose predicate folds to "is priced at" will be re-keyed onto "priced at", and every future one will be too. This is reversible: removing the alias re-keys them back.
+
+The write is atomic — the proposal row, the edge, the closure rebuild and the workspace-wide re-key commit together or not at all. A re-key that fails leaves no proposal row and no edge.
+
+**What changes downstream depends on the position, and the difference is not cosmetic:**
+
+- A **predicate** or **subject** alias changes what occupies one slot, so it changes what can **supersede** what. That is the destructive direction: closing a validity window is recoverable by no verb.
+- An **object** alias changes what Atlas treats as **agreeing** and what it flags as **contested**. The supersession rule never reads the object's identity at all, so an object alias cannot make a published claim supersedable — it moves corroboration and tension instead.
+
+<Callout type="warn" title="An approved object alias does not withdraw the contradiction flags it makes stale">
+  Corroboration and tension are evaluated once, at ingest, per episode. The approval rewrites the object's identity key and nothing else — nothing deletes an `in-tension-with` edge. So every advisory contradiction between two claims Atlas now treats as agreeing is **left in place**, still flagging a disagreement that the decision just resolved.
+
+  The blast-radius preview counts them and says so explicitly before you approve. It is the one consequence of this surface that no other page will tell you about later.
+</Callout>
+
+### Direction is never guessed
+
+A pending alias proposal is a **pair**, not an arrow. Approving it requires you to pick which spelling becomes canonical, and Atlas refuses to prefill:
+
+> Pick a direction. Nothing in the evidence says which spelling is canonical, and Atlas will not guess: the two directions re-key opposite sets of claims.
+
+The tempting heuristic — merge the rarer spelling into the commoner one — points **backwards** during exactly the migration this feature performs. A newly-adopted canonical spelling is rarer than the sloppy one it is replacing. So the two orderings are presented in the row's own stored order, never sorted by population, and an undirected proposal approved without a direction is refused (`direction-required`) rather than resolved by a default. A proposal that *does* carry a direction may be confirmed but never flipped (`direction-conflict`) — you read one direction, and afterwards the two are indistinguishable.
+
+On a workspace with no warehouse producer, **every** proposal is undirected. That is the common case, not an edge case.
+
+## Reading the blast-radius preview
+
+Every approval and every removal goes behind a preview, and the **Approve** button stays disabled until one has come back successfully. The preview is not advisory: this decision re-keys the corpus, so the blast radius is not optional.
+
+It does not answer with a number. It answers with one of several **shapes**, and the shapes are not interchangeable — which is the point, because most of them can produce the digit `0` while meaning entirely different things.
+
+### "At least N, today"
+
+The supersession radius has two sides — what **becomes supersedable** if you approve, and what **becomes safe again** — and both are floors, always:
+
+> At least 3 published claims become supersedable today, and this applies to every future claim in the slot.
+
+The word *at least* is doing real work. The count is not a batch size. A decision applies to every claim that arrives in the slot afterwards, so a small number is not a small decision, and the count is deliberately over-stated in one direction too: it counts colliding live drafts including ones the publish classifier will later refuse.
+
+If the alias chain was deeper than Atlas walks, the preview says so — both numbers then describe a **smaller** population than you asked about, which is a different fact from the numbers disagreeing.
+
+### The object-position shape
+
+An object-position alias gets a **different query over a different relation**, and it is rendered as one so it can never read like a smaller supersession radius. Three numbers instead of two:
+
+| The number | What it counts |
+|---|---|
+| **Corroborating** | Pairs of live claims that would start agreeing about the object. They are not merged retroactively — the next re-observation of either attaches to one row instead of minting a second belief |
+| **Separating** | The removal's half: pairs that agree today and would stop agreeing. Nothing splits them retroactively either, and no contradiction is flagged for them until one is re-observed |
+| **Tension** | Contradictions Atlas has already flagged that would stop being contradictions — **and whose flags are not withdrawn** |
+
+A pair whose values *prove* they differ appears in none of these. The merge makes the two claims share a slot and they stay in tension, which is correct and is the thing an approver most needs not to be told otherwise.
+
+### "This cannot produce pairs"
+
+A `structurally-empty` answer names one of five reasons: an object-position alias, a predicate already curated single-valued, a predicate never curated at all, a surface that normalizes away to nothing, or a removal naming a norm with no approved parent.
+
+<Callout type="warn" title="Zero and cannot-be-non-zero are the same number and opposite facts">
+  *"0 pairs"* invites the conclusion that the decision is harmless. *"This decision cannot produce a supersession pair at all"* says its consequences are of a different kind and are not measured by this number. The preview reports the reason rather than a count precisely so those two can never be read as the same answer.
+</Callout>
+
+### "Unknown, not zero"
+
+When a count could not be established — the two statements Atlas reads disagreed, or a scoped read did not answer — the preview says so in those words and tells you to reload before deciding. It never renders an unestablished count as an all-clear. A failed preview and an empty preview are opposite facts, and this whole surface exists because they are easy to confuse.
+
+### The compound case
+
+One warning has no other home. If the predicate you are aliasing **into** is already curated single-valued, the preview says so beside the count:
+
+> ⚠️ `priced at` is already curated single-valued. This decision moves the whole population of the aliased predicate into `priced at`'s slot — a slot where supersession is already armed. Any pairs counted above become supersedable not because a claim changed, but because it now shares a slot with a rule that was already in force.
+
+Nothing about those claims changed. They moved into a slot where a rule was waiting. A count alone gives you the magnitude and not the kind, and this is the one interaction where the kind is the surprise.
+
+## What the coverage statement means when Pending is empty
+
+Empty is the **primary state** of this queue for a while, and the page never says *"you're all caught up"* — because there is no caught-up state for a vocabulary. There is what has been decided, and what has not yet been observed, and a congratulation collapses those into one.
+
+Instead, **Where this workspace stands** says what is in force and why Pending is empty *specifically*. Three different sentences, for three different situations:
+
+| The situation | What Atlas says |
+|---|---|
+| No live claims at all | *"Nothing is proposed, and nothing could be: this workspace has no live claims yet, so neither producer has anything to read."* |
+| Live claims, none with a comparable object | *"…the structural proposer only fires on claims with comparable objects, and 0 of your 47 live claims currently qualify; the cardinality proposer needs three repeated corrections at one predicate. Authoring below does not wait for either."* |
+| Comparable claims exist, nothing proposed yet | *"…the structural proposer reads the 12 of your 47 live claims that carry a comparable object, and raises a proposal only where two distinct subjects agree under two predicate spellings."* |
+
+An approver who reads *"0 of your 47 live claims currently qualify"* knows the producer is working and has nothing to work on. That is a different conclusion from *"nothing needs doing"*, and it is the one that tells you to go and author something.
+
+The same discipline applies to failure: if the queue could not load, the page says the list is empty **because the request failed** — not because there is nothing awaiting a decision.
+
+## Direct authoring is the useful path first
+
+<Callout type="info" title="The honest day-one shape">
+  The structural proposer raises a candidate only where **two distinct subjects** have live claims that agree about a **non-null comparable object** under two different predicate spellings. A comparable object is one Atlas could parse into a typed canonical value — a money amount with an explicit ISO currency code, a bare number, a date, a boolean. The parser is deliberately cowardly: anything ambiguous stores `null`, because refusing to parse costs a missed proposal while parsing wrongly costs an irreversible stamp.
+
+  Most claims therefore carry no comparable object, and on day one **the proposer returns zero rows**. The cardinality proposer needs three repeated corrections at one predicate before it says anything at all.
+
+  **Authoring works immediately**, which is why the authoring card sits above the queue rather than as a secondary button under an empty table. It is also the *only* route by which some entries are ever written: the structural proposer covers restatements — two claims that agree — and provably cannot cover contradictions, where the two claims disagree about the object. An alias for a disagreeing pair has to be authored by a person.
+</Callout>
+
+Authoring is a **picker on both sides**, never a text box, and the reason is a specific silent failure. The folded norm is not something a human can reliably predict: `499 a month`, `499 A Month` and `499-a-month` do not all fold the same way. Guess wrong and you author an edge whose child norm no claim has ever produced — it inserts cleanly, the closure recomputes, the re-key moves zero rows and the preview reads `0`. **Indistinguishable from a merge that worked.** So both sides are chosen from the norms your corpus actually contains, each shown with its commonest surface, its live claim count, and how many spellings it already merges. The search box filters that list; it never supplies a value.
+
+Authoring is refused outright when either norm has no live claim at that position, and the refusal names **which** side is empty. It is also refused for any pair carrying rejection memory — see below.
+
+Two entitlements, and they are deliberately different. **Approving** a predicate alias adjudicates evidence a producer gathered; any authenticated member may do it. **Authoring** one creates the assertion from nothing — no evidence, no producer, no threshold — and produces a workspace-wide re-key, so it takes owner or admin at *every* position. Removal takes the authoring bar too: a reader who could not author an edge must not be able to delete it.
+
+## Removing an alias
+
+Removal is a **recomputation**, not a destructive write. The edge is dropped, the position's closure is rebuilt from what remains — so an edge this one was hiding takes effect again — and every affected claim is re-keyed from its **surface**, which is the only expression that gets the undo direction right.
+
+What removal is *not* is a clean slate. It leaves **permanent rejection memory**, and that is what makes it stick:
+
+> Atlas remembers the removal permanently, so its own producers will not re-propose this pair — and neither can you re-author it from this page.
+
+Without that memory the next producer run would re-write what a human just removed, which makes the removal decorative. An alias edge copied in by a region import travels without its proposal row, so removing one of those **creates** the memory rather than removing an edge nothing can remember.
+
+One hole is fail-closed and worth knowing about: an entity-position edge withheld because you cannot read its populations is also one you **cannot remove**. A workspace whose only admin cannot see a bad edge's populations has no in-product recovery path; the refusal is logged server-side rather than skipped silently. An edge withheld only because its claims have all been retracted is not in that position — the removal gate counts retracted claims, so it stays recoverable.
+
+## The auto-approval boundary
+
+Some alias edges skip review. The boundary is narrow on purpose, and it is four conditions, all of which must hold:
+
+1. The position is **`subject` or `object`**. A predicate-position proposal can never auto-approve — and since the structural proposer only ever proposes at the predicate position, **nothing it raises is ever eligible.**
+2. The source class is listed in **`ATLAS_BRAIN_ALIAS_AUTO_APPROVE_SOURCES`**, which ships as `warehouse_key` alone.
+3. The proposal's confidence clears **`ATLAS_BRAIN_ALIAS_AUTO_APPROVE_THRESHOLD`**, which ships as `1`.
+4. Atlas has successfully read this workspace's settings. If the settings tier never loaded, every proposal queues, because an override that cannot be read is indistinguishable from one that was never written.
+
+`warehouse_key` means *two surfaces are the same row in your warehouse, joined on a primary key*. That is certain by construction, which is why it is the only class admitted by default. The threshold is `1` rather than a fraction for the same reason: a fraction would let some future producer's merely-probable edge auto-approve on a knob nobody re-read. Leave the threshold **empty** to queue everything, and note that a garbled value **disables** auto-approval rather than falling back to the shipped default.
+
+<Callout type="warn" title="Widening `..._SOURCES` to `extractor` is a decision, not a tuning step">
+  An `extractor` edge is a language model's guess about which two spellings mean the same thing. Auto-approving it **re-keys the record with nobody in front of it**.
+
+  The specific hazard is not that a model is often wrong. It is that an extractor asked *"what is the canonical predicate here"* **cannot abstain** — it always produces one — so it fills the queue with confident, unfalsifiable answers, and `led_by` / `leads` is among the first things it offers. That pair is exactly what the structural proposer is built to never raise and what a person is here to refuse. Widening this knob routes it around both.
+
+  Both knobs are workspace-scoped; the reference rows are in [Environment variables → Company Atlas](/reference/environment-variables#company-atlas).
+</Callout>
+
+## Reading the evidence on a pending proposal
+
+Two proposal kinds share **one queue**, one set of filters and one pair of decide verbs, so neither gets a bespoke approval path that can drift from the other. Their **evidence** is deliberately not shared, and there is no common *"seen N times"* column:
+
+| Kind | The evidence | The gate |
+|---|---|---|
+| **Alias** | Distinct subjects whose live claims agree about one object under both spellings, with examples | **2** distinct subjects |
+| **Curated predicate** | Distinct subjects a human has superseded at that predicate, *and* how many supersessions produced them | **3** distinct subjects |
+
+Both counts are distinct-subject counts, but they are **not comparable magnitudes**: agreement-without-a-slot is positive and typed evidence, while a correction event is circumstantial. Rendering them in one column at equal weight would invert the ranking those thresholds encode.
+
+Every count travels with its own threshold, because the evidence is **re-derived when you open the page** — nothing is stored at proposal time. The corpus moves, so an entry can honestly read *below* the bar that raised it, and the page says exactly that rather than hiding the discrepancy. A count Atlas could not read is reported as **unknown, not zero**, with no explanation attached — a specific, confident, wrong story about a number nobody read is worse than admitting the read failed.
+
+The `rank` on an alias row orders the queue. It is not a probability, and the page says so.
+
+<Callout type="info" title="Entity-position proposals you cannot see are counted, not hidden">
+  Predicate-position proposals are shown to every approver — a verb phrase discloses nothing you could not have guessed. Entity-position ones are gated on your being able to read at least one claim on **each** side, so you are never shown a merge between two populations you have no standing in. The withheld count is always rendered: *"12 entity edges you cannot see"* and *"none"* are opposite facts that a scoped list renders identically.
+</Callout>
+
+## Related
+
+- [Company Atlas — Conflicts](/guides/brain-conflicts) — what a curated `single` predicate arms, and why Atlas refuses to arbitrate
+- [Company Atlas — Corrections](/guides/brain-corrections) — the verbs a reviewer uses on individual claims
+- [Company Atlas — Temporal Model](/guides/brain-temporal-model) — what closing a validity window does, and why it has no inverse
+- [Environment variables → Company Atlas](/reference/environment-variables#company-atlas) — the two auto-approval knobs
+- <AudienceLink saas="/api-reference/admin-claim-vocabulary/postAdminBrainVocabularyDecide">API Reference — Admin: Claim Vocabulary</AudienceLink> — the eight endpoints behind this surface

--- a/apps/docs/content/shared/guides/brain-vocabulary.mdx
+++ b/apps/docs/content/shared/guides/brain-vocabulary.mdx
@@ -35,11 +35,15 @@ An alias is a directed edge between two **norms** — the folded spellings — a
 
 | Position | What it merges | Who may approve |
 |---|---|---|
-| `predicate` | Two spellings of a relation (`is priced at` → `priced at`) | Any admin or owner — the whole admin console is admin-gated, and this position adds nothing on top |
+| `predicate` | Two spellings of a relation (`is priced at` → `priced at`) | Nothing beyond the admin session the console already required |
 | `subject` | Two spellings of the entity in the subject slot | Owner or admin **of this workspace** |
 | `object` | Two spellings of the entity in the object slot | Owner or admin **of this workspace** |
 
-That distinction is easy to skim past and is the real asymmetry: reaching this surface at all requires an admin, owner or platform-admin session, so no ordinary member approves anything here. What the entity positions add is a *second*, workspace-scoped check — your role in the workspace being written, not merely the role your session carries.
+That distinction is easy to skim past and is the real asymmetry. On a deployment with authentication, the admin console admits only an admin, owner or platform-admin session, and the predicate position asks nothing further — note that a platform admin clears it while holding no role in the workspace at all. The entity positions add a *second* check that a platform admin does **not** automatically clear: your role in the workspace being written, rather than the role your session carries.
+
+<Callout type="info" title="On `ATLAS_AUTH_MODE=none` there is no such bar">
+  A self-hosted deployment running without authentication has declared the local operator to be the only identity there is. Every check on this page — approving, authoring, removing, at every position — treats that operator as entitled, because there is no second principal to distinguish them from. If you want the entitlement split described here, you need an auth mode that produces sessions.
+</Callout>
 
 Three things it is **not**:
 
@@ -60,7 +64,7 @@ The page says it in the confirmation line before you commit:
 The write is atomic — the proposal row, the edge, the closure rebuild and the workspace-wide re-key commit together or not at all. What a failure leaves behind differs by route, and the difference matters if you are deciding whether to retry:
 
 - **A failed approval** rolls back whole: no edge, no partial re-key, and the proposal is left exactly `pending` for somebody to decide again. It is never left half-applied.
-- **A failed authoring** leaves no proposal row either, because authoring created that row in the same transaction.
+- **A failed authoring** rolls back whole too, but what survives depends on whether the pair was new. A proposal row this authoring inserted goes with the rollback. A `pending` proposal a producer had already queued for the same pair was committed by an earlier transaction and **stays** — authoring *converges* onto such a row rather than inserting a second one, since the store permits only one row per unordered pair. So authoring a pair already in the queue and approving it from the queue are the same act, and a failure leaves the queue entry where it was.
 
 **What changes downstream depends on the position, and the difference is not cosmetic:**
 
@@ -123,11 +127,11 @@ Rather than return a zero, the preview returns a **reason**. There are five, and
 
 | Reason | Which decision produces it |
 |---|---|
-| `unkeyable-surface` — the surface normalizes away to nothing, so it occupies no slot and can join nothing | **Alias** approval or removal |
+| `unkeyable-surface` — the surface normalizes away to nothing, so it occupies no slot and can join nothing | **Any** of the four decisions — an alias verb or a curated-predicate verb |
 | `no-such-edge` — no approved edge starts at that norm, so the removal would do nothing | **Alias** removal |
 | `already-single` — the predicate is already curated single-valued, so there is nothing to flip | Curated-predicate **flip** |
 | `not-curated` — the predicate has no approved single-valued entry, so there is nothing to un-curate | Curated-predicate **removal** |
-| `object-position` | Reachable only from the supersession planner. An object-position alias takes **arm 2** instead — see above |
+| `object-position` | **Nothing produces it today.** Since object aliases were given arm 2, no live path reaches it; it remains in the contract so the reason has a defined meaning if one ever does |
 
 <Callout type="warn" title="Zero and cannot-be-non-zero are the same number and opposite facts">
   *"0 pairs"* invites the conclusion that the decision is harmless. *"This decision cannot produce a supersession pair at all"* says its consequences are of a different kind and are not measured by this number. The preview reports the reason rather than a count precisely so those two can never be read as the same answer.

--- a/packages/api/src/lib/brain/vocabulary-decide.ts
+++ b/packages/api/src/lib/brain/vocabulary-decide.ts
@@ -1371,7 +1371,15 @@ function authorEntitled(ctx: BrainPrincipalContext): boolean {
  *
  * @throws when the underlying write fails — including a closure that does not
  *   converge (`VocabularyClosureError`). The transaction has already rolled
- *   back, so there is no proposal row and no edge.
+ *   back, so there is no edge, and no proposal row THIS CALL inserted.
+ *
+ *   ⚠️ Not "no proposal row". On the convergence path the row was committed by
+ *   an earlier `proposeAliasEdge` transaction, so it survives the rollback and
+ *   stays `pending` — which is correct (a producer's queue entry is not this
+ *   caller's to destroy) but is the opposite of what the flat sentence says.
+ *   The flat version was copied verbatim into a customer-facing guide, where a
+ *   fix-vs-finding pass caught it; corrected at the source so the next copy is
+ *   right.
  */
 export async function authorAliasEdge(
   workspaceId: string,

--- a/scripts/__tests__/check-brain-settings-doc.test.sh
+++ b/scripts/__tests__/check-brain-settings-doc.test.sh
@@ -382,8 +382,30 @@ restore_guide
 # so a legitimate reword empties its subject. It must fail loudly rather than
 # scan the whole docs tree and report success.
 mutate "$GUIDE" "$GUIDE_BACKUP" 's/which ships as/which is shipped as/g'
-check fail "REWORDING the shipped-default phrase fails loudly rather than going blind" \
-  'ships as `value`" sentence found anywhere'
+check fail "REWORDING every shipped-default phrase fails loudly rather than going blind" \
+  'no longer carries a'
+restore_guide
+
+# ⚠️ THE GRANULARITY ARM, and the one the first cut of check 4 failed. The
+# fixture above rewords BOTH claims, which is the only shape an aggregate
+# `length === 0` floor can detect — so it proved a floor existed and could not
+# falsify its granularity. Rewording ONE claim is the realistic copy edit, and
+# it used to leave that claim silently unguarded while the other kept the run
+# green. Anchored on THRESHOLD specifically so the SOURCES claim still matches.
+mutate "$GUIDE" "$GUIDE_BACKUP" 's/which ships as `1`/whose shipped value is `1`/'
+check fail "rewording ONE claim is caught — the floor is per-claim, not aggregate" \
+  'ATLAS_BRAIN_ALIAS_AUTO_APPROVE_THRESHOLD` … ships as `value`'
+restore_guide
+
+# The MISPAIRING arm: the spans must not cross another backticked token, or a
+# sentence naming two keys binds the first to the second's value and skips the
+# real pair. Fails as a registry mismatch (`warehouse_key` != `1`) rather than
+# silently — and would NOT fail if the regex used `[^\n]`.
+# With the loose `[^\n]` spans, SOURCES would bind to THRESHOLD's `1` and fail
+# as a mismatch; with `[^`\n]` it cannot reach past THRESHOLD's backticks, so
+# each key binds to its own value and the run stays green.
+mutate "$GUIDE" "$GUIDE_BACKUP" 's/^3\. The proposal.s confidence clears/3. Unlike `ATLAS_BRAIN_ALIAS_AUTO_APPROVE_SOURCES`, the confidence clears/'
+check pass "a sentence naming two keys binds each to its OWN value, not the neighbour's"
 restore_guide
 
 # --- restored tree passes again ----------------------------------------------

--- a/scripts/__tests__/check-brain-settings-doc.test.sh
+++ b/scripts/__tests__/check-brain-settings-doc.test.sh
@@ -50,6 +50,7 @@ ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 GUARD="$SCRIPT_DIR/check-brain-settings-doc.ts"
 DOC="$ROOT/apps/docs/content/shared/reference/environment-variables.mdx"
 REG="$ROOT/packages/api/src/lib/settings.ts"
+GUIDE="$ROOT/apps/docs/content/shared/guides/brain-vocabulary.mdx"
 
 if [ ! -f "$GUARD" ]; then
   echo "::error::guard under test not found at $GUARD" >&2
@@ -100,11 +101,16 @@ GUARD_BACKUP="$(mktemp)" || exit 2
 DOC_SHA="$(git -C "$ROOT" hash-object "$DOC")" || exit 2
 REG_SHA="$(git -C "$ROOT" hash-object "$REG")" || exit 2
 GUARD_SHA="$(git -C "$ROOT" hash-object "$GUARD")" || exit 2
-for pair in "$DOC:$DOC_BACKUP" "$REG:$REG_BACKUP" "$GUARD:$GUARD_BACKUP"; do
+# Check 4's subject is a GUIDE, not the reference page — the drift it exists to
+# catch is a default restated in prose somewhere the table-parsing checks above
+# never look.
+GUIDE_BACKUP="$(mktemp)" || exit 2
+GUIDE_SHA="$(git -C "$ROOT" hash-object "$GUIDE")" || exit 2
+for pair in "$DOC:$DOC_BACKUP" "$REG:$REG_BACKUP" "$GUARD:$GUARD_BACKUP" "$GUIDE:$GUIDE_BACKUP"; do
   src="${pair%:*}"; dst="${pair##*:}"
   if ! cp "$src" "$dst" || ! cmp -s "$src" "$dst"; then
     echo "::error::could not take a verified backup of $src (TMPDIR full or read-only?). Refusing to run — nothing has been mutated." >&2
-    rm -f "$DOC_BACKUP" "$REG_BACKUP" "$GUARD_BACKUP"
+    rm -f "$DOC_BACKUP" "$REG_BACKUP" "$GUARD_BACKUP" "$GUIDE_BACKUP"
     exit 2
   fi
 done
@@ -126,10 +132,10 @@ restore() {
   # stay in the tree behind a green run.
   [ "$RESTORED" -eq 1 ] && return 0
   local b
-  for b in "$DOC_BACKUP" "$REG_BACKUP" "$GUARD_BACKUP"; do
+  for b in "$DOC_BACKUP" "$REG_BACKUP" "$GUARD_BACKUP" "$GUIDE_BACKUP"; do
     if [ ! -f "$b" ]; then
       echo "::error::backup $b vanished before restore — the tree may still hold a fixture mutation." >&2
-      echo "::error::Recover with: git checkout -- '$DOC' '$REG' '$GUARD'" >&2
+      echo "::error::Recover with: git checkout -- '$DOC' '$REG' '$GUARD' '$GUIDE'" >&2
       return 1
     fi
   done
@@ -137,18 +143,20 @@ restore() {
   cp --preserve=timestamps "$DOC_BACKUP" "$DOC" || rc=1
   cp --preserve=timestamps "$REG_BACKUP" "$REG" || rc=1
   cp --preserve=timestamps "$GUARD_BACKUP" "$GUARD" || rc=1
+  cp --preserve=timestamps "$GUIDE_BACKUP" "$GUIDE" || rc=1
   if [ "$rc" -ne 0 ] ||
      [ "$(git -C "$ROOT" hash-object "$DOC")" != "$DOC_SHA" ] ||
      [ "$(git -C "$ROOT" hash-object "$REG")" != "$REG_SHA" ] ||
-     [ "$(git -C "$ROOT" hash-object "$GUARD")" != "$GUARD_SHA" ]; then
+     [ "$(git -C "$ROOT" hash-object "$GUARD")" != "$GUARD_SHA" ] ||
+     [ "$(git -C "$ROOT" hash-object "$GUIDE")" != "$GUIDE_SHA" ]; then
     echo "::error::RESTORE FAILED — a fixture mutation may still be in the tree." >&2
     echo "::error::Backups KEPT. Recover NON-DESTRUCTIVELY first:" >&2
-    echo "::error::  cp '$DOC_BACKUP' '$DOC' && cp '$REG_BACKUP' '$REG' && cp '$GUARD_BACKUP' '$GUARD'" >&2
-    echo "::error::Only if those are gone: git checkout -- '$DOC' '$REG' '$GUARD'  (discards any unrelated uncommitted edits to them)" >&2
+    echo "::error::  cp '$DOC_BACKUP' '$DOC' && cp '$REG_BACKUP' '$REG' && cp '$GUARD_BACKUP' '$GUARD' && cp '$GUIDE_BACKUP' '$GUIDE'" >&2
+    echo "::error::Only if those are gone: git checkout -- '$DOC' '$REG' '$GUARD' '$GUIDE'  (discards any unrelated uncommitted edits to them)" >&2
     return 1
   fi
   RESTORED=1
-  rm -f "$DOC_BACKUP" "$REG_BACKUP" "$GUARD_BACKUP"
+  rm -f "$DOC_BACKUP" "$REG_BACKUP" "$GUARD_BACKUP" "$GUIDE_BACKUP"
 }
 
 # ⚠️ `trap restore EXIT` alone is NOT enough. A non-zero RETURN from an EXIT
@@ -228,6 +236,9 @@ restore_verified() {
 }
 restore_doc() {
   restore_verified "$DOC" "$DOC_BACKUP" "$DOC_SHA"
+}
+restore_guide() {
+  restore_verified "$GUIDE" "$GUIDE_BACKUP" "$GUIDE_SHA"
 }
 restore_reg() {
   restore_verified "$REG" "$REG_BACKUP" "$REG_SHA"
@@ -356,6 +367,24 @@ mutate "$GUARD" "$GUARD_BACKUP" 's/^const BRAIN_KEY_PREFIX = "ATLAS_BRAIN_";$/co
 check fail "a stale registry-key prefix trips its own vacuity floor" \
   'no settings-registry keys start with'
 restore_guard
+
+# --- check 4: a default RESTATED IN A GUIDE ----------------------------------
+# Checks 1-3 parse the reference TABLE. A guide that repeats a default in prose
+# is invisible to all of them, and the guide is what a reader acts on. Both arms
+# below were run by hand against the commit that added check 4; they live here
+# so the next change to the registry has to face them.
+mutate "$GUIDE" "$GUIDE_BACKUP" 's/which ships as `1`/which ships as `0.9`/'
+check fail "a guide restating a STALE default is caught" \
+  'ships as `0.9`, but the registry default is `1`'
+restore_guide
+
+# The vacuity twin, on this file's standing rule: the matcher is phrase-pinned,
+# so a legitimate reword empties its subject. It must fail loudly rather than
+# scan the whole docs tree and report success.
+mutate "$GUIDE" "$GUIDE_BACKUP" 's/which ships as/which is shipped as/g'
+check fail "REWORDING the shipped-default phrase fails loudly rather than going blind" \
+  'ships as `value`" sentence found anywhere'
+restore_guide
 
 # --- restored tree passes again ----------------------------------------------
 check pass "restored doc + registry + guard are in sync again"

--- a/scripts/check-brain-settings-doc.ts
+++ b/scripts/check-brain-settings-doc.ts
@@ -238,7 +238,13 @@ if (!claimedWorkspace) {
 // pinned, because a phrase-free version would have to guess which of a
 // sentence's backticks is the default and would answer wrongly rather than not
 // at all.
-const PROSE_DEFAULT_RE = /`(ATLAS_BRAIN_[A-Z0-9_]+)`[^\n]*?\bships as\b[^\n]*?`([^`\n]+)`/g;
+//
+// ⚠️ The spans are `[^`\n]` and NOT `[^\n]`, so a match cannot cross another
+// backticked token. With `[^\n]` the sentence "`KEY_A` is unrelated to `KEY_B`,
+// which ships as `1`" binds KEY_A to KEY_B's value, and `matchAll`'s lastIndex
+// then skips past the real pair — a MISPAIRING that reads as a confident
+// finding about the wrong key, and goes silent whenever the two defaults agree.
+const PROSE_DEFAULT_RE = /`(ATLAS_BRAIN_[A-Z0-9_]+)`[^`\n]*?\bships as\b[^`\n]*?`([^`\n]+)`/g;
 const proseClaims: { file: string; key: string; claimed: string }[] = [];
 for (const rel of listMdx(join(ROOT, "apps/docs/content"))) {
   const text = readFileSync(rel, "utf8");
@@ -247,15 +253,46 @@ for (const rel of listMdx(join(ROOT, "apps/docs/content"))) {
   }
 }
 
-// ⚠️ VACUITY FLOOR, on this file's standing rule: a matcher that matches
-// nothing must fail rather than report success. Zero is not a legitimate
-// answer while any guide restates a default — and if every such sentence is
-// ever deliberately removed, DELETE this check rather than leaving a pattern
-// that scans the whole docs tree and always passes.
-if (proseClaims.length === 0) {
-  console.error(`FAIL: no "\`ATLAS_BRAIN_…\` … ships as \`value\`" sentence found anywhere in apps/docs/content.`);
-  console.error("      The phrasing changed and this gate went blind — update PROSE_DEFAULT_RE, do not delete this check.");
-  process.exit(1);
+// ⚠️ THE CLOSURE, not an aggregate floor — check 1b's lesson applied to check 4.
+//
+// The first cut asked only `proseClaims.length === 0`, which detects TOTAL
+// blindness and nothing finer. With two claims live, rewording ONE of them
+// ("whose shipped value is `1`") leaves the other matching, the floor silent,
+// and that claim unguarded forever — the exact drift this check exists to
+// catch, reproduced inside the check. Caught by a fix-vs-finding pass on the
+// commit that added it, which is the second time that pass has found an
+// assumed closure in this file.
+//
+// So the expected claims are ENUMERATED. A guide that stops restating a default
+// must be removed from this list deliberately, which is a reviewable act;
+// silence is not.
+const EXPECTED_PROSE_CLAIMS: readonly { readonly file: string; readonly key: string }[] = [
+  {
+    file: "apps/docs/content/shared/guides/brain-vocabulary.mdx",
+    key: "ATLAS_BRAIN_ALIAS_AUTO_APPROVE_SOURCES",
+  },
+  {
+    file: "apps/docs/content/shared/guides/brain-vocabulary.mdx",
+    key: "ATLAS_BRAIN_ALIAS_AUTO_APPROVE_THRESHOLD",
+  },
+];
+
+for (const expected of EXPECTED_PROSE_CLAIMS) {
+  const found = proseClaims.some(
+    (c) => c.key === expected.key && c.file === join(ROOT, expected.file),
+  );
+  if (!found) {
+    console.error(
+      `FAIL: ${expected.file} no longer carries a "\`${expected.key}\` … ships as \`value\`" sentence.`,
+    );
+    console.error(
+      "      Either the phrasing drifted (update PROSE_DEFAULT_RE) or the claim was removed on purpose",
+    );
+    console.error(
+      "      (drop its entry from EXPECTED_PROSE_CLAIMS). Do NOT leave the claim unmatched and unchecked.",
+    );
+    process.exit(1);
+  }
 }
 
 for (const { file, key, claimed } of proseClaims) {

--- a/scripts/check-brain-settings-doc.ts
+++ b/scripts/check-brain-settings-doc.ts
@@ -22,7 +22,7 @@
  * Run locally: bun scripts/check-brain-settings-doc.ts
  */
 
-import { readFileSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -40,6 +40,17 @@ const SECTION_HEADING = "## Company Atlas";
 const BRAIN_KEY_PREFIX = "ATLAS_BRAIN_";
 
 const failures: string[] = [];
+
+/** Every `.mdx` under `dir`, recursively — check 4's scan surface. */
+function listMdx(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...listMdx(full));
+    else if (entry.name.endsWith(".mdx")) out.push(full);
+  }
+  return out;
+}
 
 const doc = readFileSync(DOC, "utf8");
 
@@ -206,6 +217,57 @@ if (!claimedWorkspace) {
     failures.push(
       `The page says "${claimedWorkspace[1]} are workspace-scoped" but ${actualWorkspace.length} of the ` +
         `documented keys carry scope: "workspace" (${actualWorkspace.join(", ")}).`,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 4. Defaults RESTATED IN PROSE elsewhere in the docs (#5158).
+// ---------------------------------------------------------------------------
+// Checks 1-3 hold the reference table to the registry. They do not see a GUIDE
+// that repeats a default in a sentence — `guides/brain-vocabulary.mdx` says the
+// auto-approve knobs "ship as `warehouse_key`" and "ship as `1`" — and that
+// restatement is what a reader acts on, since nobody consults a reference table
+// to learn what the shipped behaviour is. A default changed in the registry
+// updates the table through check 1 and leaves the guide asserting the old
+// value, with every gate green.
+//
+// The matcher is deliberately narrow: a backticked ATLAS_BRAIN_ key, then
+// "ships as", then the first backticked token on the same line. It is a
+// CONCEPT matcher only in that it accepts any key and any value — the phrase is
+// pinned, because a phrase-free version would have to guess which of a
+// sentence's backticks is the default and would answer wrongly rather than not
+// at all.
+const PROSE_DEFAULT_RE = /`(ATLAS_BRAIN_[A-Z0-9_]+)`[^\n]*?\bships as\b[^\n]*?`([^`\n]+)`/g;
+const proseClaims: { file: string; key: string; claimed: string }[] = [];
+for (const rel of listMdx(join(ROOT, "apps/docs/content"))) {
+  const text = readFileSync(rel, "utf8");
+  for (const m of text.matchAll(PROSE_DEFAULT_RE)) {
+    proseClaims.push({ file: rel, key: m[1], claimed: m[2] });
+  }
+}
+
+// ⚠️ VACUITY FLOOR, on this file's standing rule: a matcher that matches
+// nothing must fail rather than report success. Zero is not a legitimate
+// answer while any guide restates a default — and if every such sentence is
+// ever deliberately removed, DELETE this check rather than leaving a pattern
+// that scans the whole docs tree and always passes.
+if (proseClaims.length === 0) {
+  console.error(`FAIL: no "\`ATLAS_BRAIN_…\` … ships as \`value\`" sentence found anywhere in apps/docs/content.`);
+  console.error("      The phrasing changed and this gate went blind — update PROSE_DEFAULT_RE, do not delete this check.");
+  process.exit(1);
+}
+
+for (const { file, key, claimed } of proseClaims) {
+  const def = byKey.get(key);
+  if (!def) {
+    failures.push(`${file} states a shipped default for ${key}, which is not in the settings registry.`);
+    continue;
+  }
+  if (def.default !== claimed) {
+    failures.push(
+      `${file} says ${key} ships as \`${claimed}\`, but the registry default is \`${String(def.default)}\`. ` +
+        `A guide's restatement is what a reader acts on — update the prose, or change the registry deliberately.`,
     );
   }
 }


### PR DESCRIPTION
Closes #5158

M4's headline user-facing feature — the **Claim Vocabulary** approval surface at `/admin/brain/vocabulary`, where a person decides that two spellings name one thing — was documented nowhere except the auto-generated API reference, which describes endpoints rather than the decision an approver is making. This adds the guide.

## What landed

`apps/docs/content/shared/guides/brain-vocabulary.mdx`, the seventh `brain-*` guide, in the house style `brain-conflicts.mdx` set. Linked from both guides indexes and from `brain-conflicts.mdx`.

Every claim was **verified against the shipped code** — the eight route handlers, the `lib/brain/vocabulary-*` engine, `alias-proposal.ts`'s actual SQL, and the four `admin/brain/vocabulary` components. The quoted UI copy, refusal codes and the five `structurally-empty` reasons are the ones the surface actually emits.

Plus a CI guard (below) that this PR's own review proved was needed.

| AC | Where |
|---|---|
| What an alias claims, what approving re-keys | *What an alias claims…* · *What approving one re-keys* |
| Reading the blast-radius preview | *Reading the blast-radius preview* — three union arms + the two things that ride on them |
| Coverage statement when Pending is empty | *What the coverage statement means…* — the three sentences, table-quoted |
| Honest day-one shape (#5087) | *Direct authoring is the useful path first* |
| `led_by`/`leads` via the inverse-relation argument | *Why a person decides* — the opening callout |
| Auto-approval boundary | *The auto-approval boundary* — the four real conjuncts |
| Linked from index + `brain-conflicts.mdx` | Both `guides/meta.json`; `brain-conflicts.mdx` in-prose + Related |
| `check-docs-links.ts` passes | ✅ 686 pages, both mounts |

## Review panel — the curve, and why the rounds closed

**Round 1 — 5 agents (`--final`, docs-heavy diff): ~26 findings, ALL new surface, 0 defect-in-prior-fix.**
Four criticals were independently confirmed by two or more reviewers. Nine were outright false claims, including three I had introduced rather than inherited:

- The worked normalizer example **proved the opposite of its point** — `499 a month` / `499 A Month` / `499-a-month` all fold identically (`-` is a separator). Replaced with two examples measured against `lexicalNorm`: `-499` and `499` **collide**, `Café` and `CAFÉ` stay **different**.
- "every **live** claim" understated the re-key — it is deliberately unscoped by liveness, because removal's undo re-derives each key from its surface.
- "Any authenticated member" may approve — the console is admin-gated.
- "three repeated corrections" → three **distinct subjects**, which the guide's own table already said.

**Round 2 — Step 5d fix-vs-finding over round 1's fixes: 4 REPRODUCED, ALL defect-in-prior-fix, 0 new surface.**

That ratio is the documented hard stop, so the rounds closed there. One root cause: each round-1 fix stated a universal from the **main** path and missed a reachable secondary one — the convergence path, `ATLAS_AUTH_MODE=none`, the cardinality verbs. The fourth is the sharpest and is why the ratchet below exists: **round 1's new guard contained the drift class it was built to guard.**

Stopping is safe here by construction, not by judgement: every round-2 fix is a *qualification* of an existing claim, and narrowing a claim cannot introduce a new over-claim in the permitting direction.

**Closing-round costs paid:** `comment-analyzer` ran on this diff (round 1, via `--final`); every named falsifier was built **and run**.

## The ratchet (Step 5b)

`check-brain-settings-doc.ts` held only the env-var **reference table** to the settings registry. This guide restates two defaults in prose — which is what a reader actually acts on — and no gate saw it. Added **check 4**, then had to fix it in round 2:

- Claims are **enumerated** (`EXPECTED_PROSE_CLAIMS`), not counted. The first cut's `length === 0` floor detected only *total* blindness: rewording one of two claims left it silent and that claim unguarded forever — the exact drift the check exists to catch, reproduced inside the check.
- Regex spans tightened `[^\n]` → `` [^`\n] `` so a match cannot cross another backticked key and bind it to the neighbour's value.

**Falsifiers — 21/21 fixtures (was 17), each run:** stale default ⇒ RED · reword one claim ⇒ RED · reword both ⇒ RED · two keys in one sentence ⇒ GREEN, and *proven load-bearing* by reverting the span to `[^\n]`, which turns that fixture RED.

## One source fix outside `apps/docs`

`authorAliasEdge`'s `@throws` docstring said a failed authoring leaves "no proposal row and no edge". False on the convergence path — the row was committed by an earlier producer transaction and survives the rollback. I copied that sentence into the guide verbatim, which is how it was caught. Corrected at the source so the next copy is right. Comment-only; no behaviour change.

## URL convention (deliberate)

Lands at **`/guides/brain-vocabulary`**, consistent with its six siblings, per ADR-0038's customer-copy-vs-identifier split — the prose says **Atlas** throughout; only the slug keeps the old noun. **#5083 sweeps all seven `brain-*` guides to `atlas-*` in one pass.** Inventing an `atlas-*` URL ahead of that sweep would leave this page inconsistent with every sibling and hand #5083 a second shape to handle.

No changelog entry — that belongs to `/release`.

## Deferred, with reasons

- **No PR-time docs build.** `apps/docs` has no `next build` in CI, so an MDX error would surface on the Railway deploy, not here. Standing gap, not introduced by this PR — and `ci.yml`'s comment justifying the `.mdx` path filter claims *"apps/docs is a Next.js app covered by `bun run build`"*, which is false (`build` is web-only). Worth its own issue.
- **Backlinks** from `brain-corrections.mdx` / `brain-temporal-model.mdx` were not added — the AC named `brain-conflicts.mdx` specifically, and #5083 is about to touch all seven anyway.

## Gates

`check-docs-links` PASS (686 pages, both mounts) · `check-brain-settings-doc` PASS · its fixtures 21/21 · `apps/docs` suite 179/179 · `test-isolated --affected` 9/9 · `lint` 0 · `type` 0.
