### PR TITLE
feat(brain): the class coverage contract — vendor-public, staleness capability, denominator source (#5212)

### DIFF
--- a/packages/api/src/lib/brain/__tests__/class-contract-logging.test.ts
+++ b/packages/api/src/lib/brain/__tests__/class-contract-logging.test.ts
@@ -9,11 +9,15 @@
  * ## Why this file exists rather than trusting the log calls to stay put
  *
  * Measured, not suspected. Deleting ONE `warnUnresolvable` call left the
- * sibling suite at 21 pass / 0 fail; deleting ALL THREE did too. So the entire
- * loudness half of the module header's claim — "every one of those arms fails
- * CLOSED and says so in the log … withhold, loudly" — had no test, and the
- * payload decisions under it (the `null` spelling, the truncation, the
- * consequence text, the `{...meta}` spread) had none either.
+ * sibling suite fully green; deleting ALL THREE did too. So the entire loudness
+ * half of the module header's claim — "every one of those arms fails CLOSED and
+ * says so in the log … withhold, loudly" — had no test, and the payload
+ * decisions under it (the `null` spelling, the truncation, the consequence text,
+ * the caller's context fields) had none either.
+ *
+ * Absolute pass counts are deliberately not quoted anywhere in this file: the
+ * suites grow, and a tally is exactly the kind of measurement an unrelated
+ * commit silently invalidates. State the direction, not the number.
  *
  * That is the same gap `acl-logging.test.ts` was created for, in the same words:
  * the ENFORCEMENT is structural and entirely independent of the REPORTING, so a
@@ -60,11 +64,15 @@ void mock.module("@atlas/api/lib/logger", () => ({
   hashShareToken: (token: string) => token,
 }));
 
-const { classDenominator, coverageLabelPolicy, stalenessVerdict } = await import(
-  "@atlas/api/lib/brain/class-contract"
-);
+const { CLASS_VALUE_LOG_MAX, classDenominator, coverageLabelPolicy, stalenessVerdict } =
+  await import("@atlas/api/lib/brain/class-contract");
 const { CHAT_CLASS, EMAIL_CLASS, EPISODE_SOURCE_CLASSES } = await import(
   "@atlas/api/lib/brain/sources"
+);
+
+/** The classes that declare an enumerable universe — every class but `human`. */
+const SURVEYABLE_CLASSES = EPISODE_SOURCE_CLASSES.filter(
+  (cls) => classDenominator(cls).surveyable,
 );
 
 const META = { workspaceId: "ws_5212", requestId: "req_5212" } as const;
@@ -179,7 +187,10 @@ describe("the logged class value is legible and bounded", () => {
     expect(warns().map((w) => w.payload.classValue)).toEqual([
       "null",
       "object",
-      "object",
+      // An array used to log as `object` too — the least actionable value the
+      // field can take, and the residue of the legibility argument the `null`
+      // spelling was built on.
+      "array",
       "undefined",
     ]);
     // The sentinels are deliberately UNQUOTED while strings are quoted — that
@@ -202,8 +213,10 @@ describe("the logged class value is legible and bounded", () => {
     const logged = warn?.payload.classValue ?? "";
     // EXACT, not an upper bound. The rationale is a log-aggregation size limit,
     // so the constant is the thing that matters — `toBeLessThan(200)` let it
-    // move to 190 silently. 128 chars + the ellipsis, then JSON quotes.
-    expect(logged).toBe(`"${"z".repeat(128)}…"`);
+    // move to 190 silently. The opening quote counts toward the bound because
+    // the bound is on the EMITTED field.
+    expect(logged).toBe(`"${"z".repeat(127)}…"`);
+    expect(logged.length).toBe(CLASS_VALUE_LOG_MAX + 2);
     expect(logged.startsWith('"zzz')).toBe(true);
     expect(logged.endsWith('…"')).toBe(true);
     // The length is what makes the truncation diagnosable rather than
@@ -212,19 +225,56 @@ describe("the logged class value is legible and bounded", () => {
     expect(warn?.payload.classValueLength).toBe(5_000);
   });
 
+  test("the bound governs the EMITTED field, not the input — escaping expands", () => {
+    // ⚠️ Every other truncation fixture is plain ASCII, where escaping is a
+    // no-op — so the deliberately-exact bound above measured only the best case.
+    // Truncating before escaping bounded the wrong string: 128 NUL characters
+    // emitted a 770-character field, roughly six times the intended size and
+    // past the 512 the cited precedent holds.
+    const controls = "\u0000".repeat(400);
+    const quotes = '"'.repeat(400);
+    const backslashes = "\\".repeat(400);
+    classDenominator(controls, META);
+    classDenominator(quotes, META);
+    classDenominator(backslashes, META);
+
+    for (const warn of warns()) {
+      expect(warn.payload.classValue?.length).toBeLessThanOrEqual(CLASS_VALUE_LOG_MAX + 2);
+    }
+    expect(warns().length).toBe(3);
+  });
+
+  test("a quote or a control character cannot break the field apart", () => {
+    // The whole difference between `JSON.stringify` and a naive `"${…}"` was
+    // untested: no fixture contained a quote, a backslash or a control char, so
+    // both spellings were green. A stored `", "chat` would log as `"", "chat"`
+    // under the naive one and read as two fields.
+    classDenominator('", "chat', META);
+    classDenominator("line\nbreak", META);
+
+    const [embedded, newline] = warns();
+    expect(embedded?.payload.classValue).toBe('"\\", \\"chat"');
+    expect(newline?.payload.classValue).toBe('"line\\nbreak"');
+    // Neither contains a raw newline, so neither can forge a log line.
+    for (const warn of warns()) {
+      expect(warn.payload.classValue).not.toContain("\n");
+    }
+  });
+
   test("truncation fires just PAST the bound, not at it", () => {
     // The only fixture was 5,000 chars, so `>` → `>=` was silent. Both sides of
     // the boundary, so the comparison itself is pinned.
-    const atBound = "a".repeat(128);
-    const overBound = "b".repeat(129);
+    // The bound is on the QUOTED form, so a string of N plain chars emits N+2.
+    const atBound = "a".repeat(CLASS_VALUE_LOG_MAX - 2);
+    const overBound = "b".repeat(CLASS_VALUE_LOG_MAX - 1);
     classDenominator(atBound, META);
     classDenominator(overBound, META);
 
     const [at, over] = warns();
     expect(at?.payload.classValue).toBe(`"${atBound}"`);
-    expect(at?.payload.classValueLength).toBe(128);
-    expect(over?.payload.classValue).toBe(`"${"b".repeat(128)}…"`);
-    expect(over?.payload.classValueLength).toBe(129);
+    expect(at?.payload.classValueLength).toBe(CLASS_VALUE_LOG_MAX - 2);
+    expect(over?.payload.classValue).toBe(`"${"b".repeat(CLASS_VALUE_LOG_MAX - 1)}…"`);
+    expect(over?.payload.classValueLength).toBe(CLASS_VALUE_LOG_MAX - 1);
   });
 
   test("a short value is logged whole, and its length travels with it", () => {
@@ -235,6 +285,30 @@ describe("the logged class value is legible and bounded", () => {
     const [warn] = warns();
     expect(warn?.payload.classValue).toBe('"docs"');
     expect(warn?.payload.classValueLength).toBe(4);
+  });
+
+  test("a POSITIVE disclosure assertion on a non-surveyable class is loud", () => {
+    // The routine non-surveyable refusal is silent, deliberately — it is a
+    // decision, not a degradation. But a caller asserting that a human
+    // deliberately acted on a unit of a class that declares it has none is
+    // asserting something that cannot have been computed correctly, and for
+    // `human` the unit would be a PERSON. Refused either way; the assertion is
+    // what gets logged, so volume is bounded by a caller bug rather than by
+    // unit count.
+    expect(
+      coverageLabelPolicy("human", { deliberateAct: true, vendorReportsPublic: false }, META),
+    ).toEqual({ policy: "count-only", reason: "non-surveyable-class" });
+    expect(warns().length).toBe(1);
+    expect(warns()[0]?.message).toContain("non-surveyable class");
+    expect(warns()[0]?.payload.workspaceId).toBe("ws_5212");
+
+    // …and the routine case stays silent, which is the contrast that makes the
+    // loud one findable.
+    logCalls.length = 0;
+    coverageLabelPolicy("human", { deliberateAct: false, vendorReportsPublic: false }, META);
+    expect(logCalls).toEqual([]);
+    coverageLabelPolicy("docs", UNIT, META);
+    expect(warns().length).toBe(1);
   });
 
   test("a string is QUOTED, so it can never be read as one of the sentinels", () => {
@@ -261,7 +335,13 @@ describe("the logged class value is legible and bounded", () => {
     classDenominator(null, META);
     classDenominator({ class: "chat" }, META);
     classDenominator(42, META);
-    for (const warn of warns()) {
+    const seen = warns();
+    // ⚠️ NON-VACUITY, and this is the third spelling of the same defect in this
+    // file. A `for … of` over an empty array asserts NOTHING — measured, this
+    // was the sole survivor of the inert-recorder mutation after round 2 fixed
+    // the two `toEqual([])` spellings beside it.
+    expect(seen.length).toBe(3);
+    for (const warn of seen) {
       expect(warn.payload.classValueLength).toBeUndefined();
     }
   });
@@ -277,28 +357,38 @@ describe("a RESOLVABLE class is silent", () => {
     // on its own contract.
     for (const cls of EPISODE_SOURCE_CLASSES) {
       coverageLabelPolicy(cls, UNIT, META);
-      coverageLabelPolicy(cls, { deliberateAct: true, vendorReportsPublic: true }, META);
       stalenessVerdict(cls, META);
       classDenominator(cls, META);
     }
     expect(logCalls).toEqual([]);
+    // The asserting call is swept separately over the SURVEYABLE classes only:
+    // on a non-surveyable class it is a caller bug and is deliberately loud, so
+    // folding it in here would either weaken this claim or hide that one.
+    for (const cls of SURVEYABLE_CLASSES) {
+      coverageLabelPolicy(cls, { deliberateAct: true, vendorReportsPublic: true }, META);
+    }
+    expect(logCalls).toEqual([]);
     // ⚠️ NON-VACUITY. `toEqual([])` alone passes whenever log capture is
     // BROKEN — a mock that never installed, a recorder wired to nothing — which
-    // is the single condition this assertion would need to survive. Measured:
-    // with the recorder made a no-op, 8 of this file's 10 tests fail and the
-    // silence assertions are the survivors. So every silence claim fires a
-    // deliberately loud call afterwards and checks the SAME array fills.
+    // is the single condition this assertion would need to survive. So every
+    // silence claim fires a deliberately loud call afterwards and checks the
+    // SAME array fills. Measured: with the recorder made a no-op, every test in
+    // this file goes red.
     classDenominator("docs", META);
     expect(warns().length).toBe(1);
   });
 
-  test("the non-surveyable refusal is silent too — it is a decision, not a degradation", () => {
-    // `human` returns `count-only` / `non-surveyable-class`, which is the
-    // module working as designed rather than something an operator must act on.
-    // Warning here would put a line in the log for every correctly-refused
-    // unit and teach the reader to ignore the arm that does matter.
-    expect(coverageLabelPolicy("human", { deliberateAct: true, vendorReportsPublic: true }, META))
-      .toEqual({ policy: "count-only", reason: "non-surveyable-class" });
+  test("the ROUTINE non-surveyable refusal is silent — it is a decision, not a degradation", () => {
+    // `human` with no disclosure fact asserted returns `count-only` /
+    // `non-surveyable-class`, which is the module working as designed rather
+    // than something an operator must act on. Warning here would put a line in
+    // the log for every correctly-refused unit and teach the reader to ignore
+    // the arm that does matter. (The case where a caller ASSERTS a disclosure
+    // fact is the loud one — see the positive-assertion test above.)
+    expect(coverageLabelPolicy("human", UNIT, META)).toEqual({
+      policy: "count-only",
+      reason: "non-surveyable-class",
+    });
     expect(logCalls).toEqual([]);
     // …while the shape it is most confusable with — an unresolvable class,
     // same `count-only` policy — is loud. That contrast is the whole point.

--- a/packages/api/src/lib/brain/__tests__/class-contract-logging.test.ts
+++ b/packages/api/src/lib/brain/__tests__/class-contract-logging.test.ts
@@ -1,0 +1,265 @@
+/**
+ * The "and says so in the log" half of `class-contract.ts`'s stated posture
+ * (#5212) — every fail-closed arm withholds *loudly*.
+ *
+ * Split into its own file because it needs `mock.module("@atlas/api/lib/logger")`
+ * installed before the module under test is imported, and `class-contract.test.ts`
+ * deliberately runs with no module mocking at all.
+ *
+ * ## Why this file exists rather than trusting the log calls to stay put
+ *
+ * Measured, not suspected. Deleting ONE `warnUnresolvable` call left the
+ * sibling suite at 21 pass / 0 fail; deleting ALL THREE did too. So the entire
+ * loudness half of the module header's claim — "every one of those arms fails
+ * CLOSED and says so in the log … withhold, loudly" — had no test, and the
+ * payload decisions under it (the `null` spelling, the truncation, the
+ * consequence text, the `{...meta}` spread) had none either.
+ *
+ * That is the same gap `acl-logging.test.ts` was created for, in the same words:
+ * the ENFORCEMENT is structural and entirely independent of the REPORTING, so a
+ * suite that only checks the returned decision cannot see the log disappear. It
+ * matters more here than the usual logging test, because the fail-closed answer
+ * is deliberately indistinguishable from a correct one at a glance — a class
+ * that quietly stops being surveyed looks exactly like a class that has nothing
+ * to survey, and the warn is the only thing that says which.
+ *
+ * Every VALUE export of `lib/logger.ts` is stubbed, per the mock-all-exports
+ * rule: a partial factory works right up until some module in the import graph
+ * reaches a missing name, and then fails at link time in a file that has nothing
+ * to do with this one.
+ */
+
+import { beforeEach, describe, expect, test, mock } from "bun:test";
+
+type LogCall = { level: "error" | "warn" | "info" | "debug"; payload: unknown; message: string };
+const logCalls: LogCall[] = [];
+
+void mock.module("@atlas/api/lib/logger", () => ({
+  createLogger: () => ({
+    error: (payload: unknown, message: string) =>
+      logCalls.push({ level: "error", payload, message }),
+    warn: (payload: unknown, message: string) => logCalls.push({ level: "warn", payload, message }),
+    info: (payload: unknown, message: string) => logCalls.push({ level: "info", payload, message }),
+    debug: (payload: unknown, message: string) =>
+      logCalls.push({ level: "debug", payload, message }),
+  }),
+  getLogger: () => ({
+    error: () => {},
+    warn: () => {},
+    info: () => {},
+    debug: () => {},
+    level: "info",
+  }),
+  setLogLevel: () => true,
+  getRequestContext: () => undefined,
+  ACTOR_KINDS: ["human", "agent", "mcp", "scheduler", "api_key"] as const,
+  withRequestContext: <T,>(_ctx: unknown, fn: () => T): T => fn(),
+  redactPaths: [] as string[],
+  scrubErrSerializer: (value: unknown) => value,
+  scrubLogFormatter: (obj: unknown) => obj,
+  hashShareToken: (token: string) => token,
+}));
+
+const { classDenominator, coverageLabelPolicy, stalenessVerdict } = await import(
+  "@atlas/api/lib/brain/class-contract"
+);
+const { CHAT_CLASS, EMAIL_CLASS, EPISODE_SOURCE_CLASSES } = await import(
+  "@atlas/api/lib/brain/sources"
+);
+
+const META = { workspaceId: "ws_5212", requestId: "req_5212" } as const;
+const UNIT = { deliberateAct: false, vendorReportsPublic: false } as const;
+
+/** The payload shape the module actually emits, as a reader-friendly type. */
+type WarnPayload = {
+  workspaceId?: string;
+  requestId?: string;
+  derivation?: string;
+  classValue?: string;
+  classValueLength?: number;
+};
+
+function warns(): ReadonlyArray<{ payload: WarnPayload; message: string }> {
+  return logCalls
+    .filter((c) => c.level === "warn")
+    .map((c) => ({ payload: c.payload as WarnPayload, message: c.message }));
+}
+
+beforeEach(() => {
+  logCalls.length = 0;
+});
+
+describe("the fail-closed arms log, one line per derivation", () => {
+  test("each derivation emits exactly one warn NAMING ITSELF", () => {
+    // Deleting any ONE of the three `warnUnresolvable` calls has to fail here.
+    // A test that only counted warns in total would survive deleting one and
+    // adding a duplicate elsewhere; keying on `derivation` is what makes each
+    // call site individually load-bearing.
+    coverageLabelPolicy("docs", UNIT, META);
+    stalenessVerdict("docs", META);
+    classDenominator("docs", META);
+
+    expect(warns().map((w) => w.payload.derivation)).toEqual([
+      "coverageLabelPolicy",
+      "stalenessVerdict",
+      "classDenominator",
+    ]);
+    expect(logCalls.every((c) => c.level === "warn")).toBe(true);
+  });
+
+  test("the message states the CONSEQUENCE, and a different one per derivation", () => {
+    // "Failing closed" describes the mechanism; an operator needs to know which
+    // part of the page just went quiet. Asserted as three DISTINCT messages
+    // rather than three matching greps, because a single generic sentence would
+    // satisfy any per-derivation substring check that was loose enough.
+    coverageLabelPolicy("docs", UNIT, META);
+    stalenessVerdict("docs", META);
+    classDenominator("docs", META);
+
+    const messages = warns().map((w) => w.message);
+    expect(new Set(messages).size).toBe(3);
+    expect(messages[0]).toContain("will be named");
+    expect(messages[1]).toContain("measured lag");
+    expect(messages[2]).toContain("falls out of every ratio");
+    // Each still identifies the subsystem and the posture, so a log search for
+    // the class of event finds all three.
+    for (const message of messages) {
+      expect(message).toContain("brain class contract");
+      expect(message).toContain("failing closed");
+    }
+  });
+
+  test("correlation context survives the spread, and a caller cannot shadow the diagnostics", () => {
+    // `workspaceId` is required on the meta type precisely so this line can do
+    // its job in a 3-region multi-tenant deploy. The shadow half matters
+    // because the diagnostic fields come AFTER `...meta` in the spread: a
+    // caller passing its own `derivation` must not be able to relabel which
+    // derivation reported.
+    const hostile = { ...META, derivation: "not-this-one", classValue: "not-this-either" };
+    classDenominator("docs", hostile as typeof META);
+
+    const [warn] = warns();
+    expect(warn?.payload.workspaceId).toBe("ws_5212");
+    expect(warn?.payload.requestId).toBe("req_5212");
+    expect(warn?.payload.derivation).toBe("classDenominator");
+    expect(warn?.payload.classValue).toBe("docs");
+  });
+});
+
+describe("the logged class value is legible and bounded", () => {
+  test("`null` is spelled out — it is the likeliest real input, not a curiosity", () => {
+    // The plausible production producer of an unresolvable class is
+    // `episodeSourceClassOf(row.source)`, which returns `null` for exactly the
+    // region-import lane these arms exist for. Under a bare `typeof` that logs
+    // as "object" — indistinguishable from the two cases below, so the highest
+    // probability input produced the least legible line.
+    classDenominator(null, META);
+    classDenominator({ class: "chat" }, META);
+    classDenominator(["chat"], META);
+    classDenominator(undefined, META);
+
+    expect(warns().map((w) => w.payload.classValue)).toEqual([
+      "null",
+      "object",
+      "object",
+      "undefined",
+    ]);
+  });
+
+  test("an unbounded stored value is TRUNCATED, and its true length still travels", () => {
+    // `brain_episodes.source` is plain `text` with no CHECK and the region
+    // import restores it verbatim, so this value has no bound at rest. An
+    // oversized field pushes the structured ones past log-aggregation size
+    // limits — which would drop the `workspaceId` the line above exists to
+    // carry — so the same posture as `error-scrub.ts`.
+    const huge = "z".repeat(5_000);
+    classDenominator(huge, META);
+
+    const [warn] = warns();
+    const logged = warn?.payload.classValue ?? "";
+    expect(logged.length).toBeLessThan(200);
+    expect(logged.startsWith("zzz")).toBe(true);
+    expect(logged.endsWith("…")).toBe(true);
+    // The length is what makes the truncation diagnosable rather than
+    // misleading: without it an operator cannot tell a 129-char value from a
+    // 5,000-char one.
+    expect(warn?.payload.classValueLength).toBe(5_000);
+  });
+
+  test("a short value is logged whole, with no length field to read as truncation", () => {
+    classDenominator("docs", META);
+    const [warn] = warns();
+    expect(warn?.payload.classValue).toBe("docs");
+    expect(warn?.payload.classValueLength).toBe(4);
+  });
+});
+
+describe("a RESOLVABLE class is silent", () => {
+  test("no warn for any real class, through any derivation", () => {
+    // The noise regression, and the half that a "does it log?" test cannot
+    // catch on its own. `coverageLabelPolicy` is called per SURVEY UNIT, so a
+    // warn on the resolvable path is one line per channel per page render —
+    // which is how a genuinely useful signal becomes one an operator filters
+    // out. Swept over the whole class set so a new class cannot start warning
+    // on its own contract.
+    for (const cls of EPISODE_SOURCE_CLASSES) {
+      coverageLabelPolicy(cls, UNIT, META);
+      coverageLabelPolicy(cls, { deliberateAct: true, vendorReportsPublic: true }, META);
+      stalenessVerdict(cls, META);
+      classDenominator(cls, META);
+    }
+    expect(logCalls).toEqual([]);
+  });
+
+  test("the non-surveyable refusal is silent too — it is a decision, not a degradation", () => {
+    // `human` returns `count-only` / `non-surveyable-class`, which is the
+    // module working as designed rather than something an operator must act on.
+    // Warning here would put a line in the log for every correctly-refused
+    // unit and teach the reader to ignore the arm that does matter.
+    expect(coverageLabelPolicy("human", { deliberateAct: true, vendorReportsPublic: true }, META))
+      .toEqual({ policy: "count-only", reason: "non-surveyable-class" });
+    expect(logCalls).toEqual([]);
+    // …while the shape it is most confusable with — an unresolvable class,
+    // same `count-only` policy — is loud. That contrast is the whole point.
+    coverageLabelPolicy("docs", UNIT, META);
+    expect(warns().length).toBe(1);
+  });
+
+  test("an ordinary withhold on a real class is silent", () => {
+    // A mailbox nobody named is the single commonest decision this module will
+    // ever make. If that logged, nothing else in the file would be findable.
+    expect(coverageLabelPolicy(EMAIL_CLASS, UNIT, META)).toEqual({
+      policy: "count-only",
+      reason: "no-clause",
+    });
+    expect(coverageLabelPolicy(CHAT_CLASS, UNIT, META)).toEqual({
+      policy: "count-only",
+      reason: "no-clause",
+    });
+    expect(logCalls).toEqual([]);
+  });
+});
+
+describe("the log is optional context, never a precondition", () => {
+  test("every derivation works with no meta at all, and still logs", () => {
+    // `meta` is optional-or-complete: a caller omits it entirely rather than
+    // passing a partial one. The arms must not depend on it — a fail-closed
+    // answer that needed request context to be produced would fail OPEN in
+    // exactly the callers least likely to have it.
+    expect(coverageLabelPolicy("docs", UNIT)).toEqual({
+      policy: "count-only",
+      reason: "unresolvable-class",
+    });
+    expect(stalenessVerdict("docs")).toEqual({
+      kind: "unverified-since",
+      reason: "unresolvable-class",
+    });
+    expect(classDenominator("docs")).toEqual({ surveyable: false, reason: "unresolvable-class" });
+
+    expect(warns().length).toBe(3);
+    for (const warn of warns()) {
+      expect(warn.payload.workspaceId).toBeUndefined();
+      expect(warn.payload.derivation).toBeDefined();
+    }
+  });
+});

--- a/packages/api/src/lib/brain/__tests__/class-contract-logging.test.ts
+++ b/packages/api/src/lib/brain/__tests__/class-contract-logging.test.ts
@@ -129,20 +129,38 @@ describe("the fail-closed arms log, one line per derivation", () => {
     }
   });
 
-  test("correlation context survives the spread, and a caller cannot shadow the diagnostics", () => {
+  test("correlation context travels, and a wider caller object cannot leak or shadow", () => {
     // `workspaceId` is required on the meta type precisely so this line can do
-    // its job in a 3-region multi-tenant deploy. The shadow half matters
-    // because the diagnostic fields come AFTER `...meta` in the spread: a
-    // caller passing its own `derivation` must not be able to relabel which
-    // derivation reported.
-    const hostile = { ...META, derivation: "not-this-one", classValue: "not-this-either" };
+    // its job in a 3-region multi-tenant deploy.
+    //
+    // The other half is that the two context fields are NAMED rather than
+    // spread. Excess-property checking only fires on a fresh literal, so a
+    // caller passing a WIDER variable — a request context, a job record — used
+    // to put every field it happened to carry into a line whose stated job is
+    // to stay small enough that `workspaceId` survives aggregation limits. That
+    // also makes "a caller cannot shadow the diagnostics" structural instead of
+    // a fact about spread order.
+    const hostile = {
+      ...META,
+      derivation: "not-this-one",
+      classValue: "not-this-either",
+      sessionToken: "should-never-be-logged",
+    };
     classDenominator("docs", hostile as typeof META);
 
     const [warn] = warns();
     expect(warn?.payload.workspaceId).toBe("ws_5212");
     expect(warn?.payload.requestId).toBe("req_5212");
     expect(warn?.payload.derivation).toBe("classDenominator");
-    expect(warn?.payload.classValue).toBe("docs");
+    expect(warn?.payload.classValue).toBe('"docs"');
+    // The extra field never reaches the payload at all.
+    expect(Object.keys(warn?.payload ?? {}).toSorted()).toEqual([
+      "classValue",
+      "classValueLength",
+      "derivation",
+      "requestId",
+      "workspaceId",
+    ]);
   });
 });
 
@@ -164,6 +182,11 @@ describe("the logged class value is legible and bounded", () => {
       "object",
       "undefined",
     ]);
+    // The sentinels are deliberately UNQUOTED while strings are quoted — that
+    // asymmetry is what makes them tell each other apart at a glance.
+    for (const warn of warns()) {
+      expect(warn.payload.classValue?.startsWith('"')).toBe(false);
+    }
   });
 
   test("an unbounded stored value is TRUNCATED, and its true length still travels", () => {
@@ -177,20 +200,70 @@ describe("the logged class value is legible and bounded", () => {
 
     const [warn] = warns();
     const logged = warn?.payload.classValue ?? "";
-    expect(logged.length).toBeLessThan(200);
-    expect(logged.startsWith("zzz")).toBe(true);
-    expect(logged.endsWith("…")).toBe(true);
+    // EXACT, not an upper bound. The rationale is a log-aggregation size limit,
+    // so the constant is the thing that matters — `toBeLessThan(200)` let it
+    // move to 190 silently. 128 chars + the ellipsis, then JSON quotes.
+    expect(logged).toBe(`"${"z".repeat(128)}…"`);
+    expect(logged.startsWith('"zzz')).toBe(true);
+    expect(logged.endsWith('…"')).toBe(true);
     // The length is what makes the truncation diagnosable rather than
     // misleading: without it an operator cannot tell a 129-char value from a
     // 5,000-char one.
     expect(warn?.payload.classValueLength).toBe(5_000);
   });
 
-  test("a short value is logged whole, with no length field to read as truncation", () => {
+  test("truncation fires just PAST the bound, not at it", () => {
+    // The only fixture was 5,000 chars, so `>` → `>=` was silent. Both sides of
+    // the boundary, so the comparison itself is pinned.
+    const atBound = "a".repeat(128);
+    const overBound = "b".repeat(129);
+    classDenominator(atBound, META);
+    classDenominator(overBound, META);
+
+    const [at, over] = warns();
+    expect(at?.payload.classValue).toBe(`"${atBound}"`);
+    expect(at?.payload.classValueLength).toBe(128);
+    expect(over?.payload.classValue).toBe(`"${"b".repeat(128)}…"`);
+    expect(over?.payload.classValueLength).toBe(129);
+  });
+
+  test("a short value is logged whole, and its length travels with it", () => {
+    // The name used to say "with no length field", which its own last line
+    // measures to be false — the field IS emitted for short values, and that is
+    // correct: it is what tells an operator a value was not truncated.
     classDenominator("docs", META);
     const [warn] = warns();
-    expect(warn?.payload.classValue).toBe("docs");
+    expect(warn?.payload.classValue).toBe('"docs"');
     expect(warn?.payload.classValueLength).toBe(4);
+  });
+
+  test("a string is QUOTED, so it can never be read as one of the sentinels", () => {
+    // The `null` spelling fixed one instance; these are the rest of the class.
+    // Unquoted, each of these was unreadable: an empty string looked like a
+    // missing field, the whitespace near-miss looked like the real class name,
+    // and a stored value of literally `null` was the sentinel for a real one.
+    classDenominator("", META);
+    classDenominator("human ", META);
+    classDenominator("null", META);
+    classDenominator(null, META);
+
+    expect(warns().map((w) => w.payload.classValue)).toEqual(['""', '"human "', '"null"', "null"]);
+    // The sentinel and the string that spells it are now distinguishable, which
+    // is the whole point and is what an operator actually needs.
+    const [, , asString, asSentinel] = warns();
+    expect(asString?.payload.classValue).not.toBe(asSentinel?.payload.classValue);
+  });
+
+  test("the length field is ABSENT for a non-string, never zero", () => {
+    // `0` would read to an operator as "an empty string", which is the exact
+    // legibility failure the `null` spelling was written to prevent. Measured
+    // through the real logger, pino drops an `undefined` key entirely.
+    classDenominator(null, META);
+    classDenominator({ class: "chat" }, META);
+    classDenominator(42, META);
+    for (const warn of warns()) {
+      expect(warn.payload.classValueLength).toBeUndefined();
+    }
   });
 });
 
@@ -209,6 +282,14 @@ describe("a RESOLVABLE class is silent", () => {
       classDenominator(cls, META);
     }
     expect(logCalls).toEqual([]);
+    // ⚠️ NON-VACUITY. `toEqual([])` alone passes whenever log capture is
+    // BROKEN — a mock that never installed, a recorder wired to nothing — which
+    // is the single condition this assertion would need to survive. Measured:
+    // with the recorder made a no-op, 8 of this file's 10 tests fail and the
+    // silence assertions are the survivors. So every silence claim fires a
+    // deliberately loud call afterwards and checks the SAME array fills.
+    classDenominator("docs", META);
+    expect(warns().length).toBe(1);
   });
 
   test("the non-surveyable refusal is silent too — it is a decision, not a degradation", () => {
@@ -237,6 +318,10 @@ describe("a RESOLVABLE class is silent", () => {
       reason: "no-clause",
     });
     expect(logCalls).toEqual([]);
+    // Non-vacuity, same reason as above — an empty array has to mean silence
+    // rather than a dead recorder.
+    coverageLabelPolicy("docs", UNIT, META);
+    expect(warns().length).toBe(1);
   });
 });
 

--- a/packages/api/src/lib/brain/__tests__/class-contract.test.ts
+++ b/packages/api/src/lib/brain/__tests__/class-contract.test.ts
@@ -1,0 +1,392 @@
+/**
+ * The class coverage contract (#5212, ADR-0041 declared at ADR-0040's site).
+ *
+ * ## What this file is defending
+ *
+ * Three properties, each of which fails in a direction that is invisible from
+ * the outside:
+ *
+ *   - **`vendorPublic`** gates a DISCLOSURE. Flipping it open on `email` names
+ *     mailboxes on an admin page — "naming a mailbox is naming a person" —
+ *     and nothing about the page's shape changes when it does.
+ *   - **`activityMetadata`** gates a WORD. Flipping it to `reports` on a class
+ *     that cannot read vendor activity lets the surface say "stale" about a lag
+ *     it did not measure, which is the guess ADR-0041 refuses in both
+ *     directions.
+ *   - **the denominator** gates a NUMBER. A class that gained a universe it
+ *     cannot enumerate contributes a count with nothing behind it, and
+ *     ADR-0041's fabrication discipline calls that a false statement rather than
+ *     an error state.
+ *
+ * So the assertions are about the ANSWERS, pinned as a table, and about the
+ * fail-closed arms, exercised through the derivations rather than reasoned
+ * about. The table is deliberately a literal: a test that read each answer back
+ * out of `CLASS_CONTRACTS` and compared it to itself would stay green for every
+ * possible contract, which is the self-referential agreement `sources.test.ts`
+ * exists to defeat one file over.
+ *
+ * ## The hypothetical-new-class arm
+ *
+ * A class the compiler CAN see is a compile error without a contract — that is
+ * the Record's totality gate, asserted below with `@ts-expect-error`. The
+ * runtime arm covers the class the compiler CANNOT see: a value arriving through
+ * a cast, a region import, a separately-compiled plugin. Every derivation gets
+ * the same hostile inputs, and the claim is uniform — no label under either
+ * clause, never the word stale, no denominator.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  CLASS_CONTRACTS,
+  classDenominator,
+  coverageLabelPolicy,
+  stalenessVerdictKind,
+  type ClassContract,
+  type SurveyUnitDisclosureFacts,
+} from "@atlas/api/lib/brain/class-contract";
+import {
+  CHAT_CLASS,
+  EMAIL_CLASS,
+  EPISODE_SOURCE_CLASSES,
+  TRANSCRIPT_CLASS,
+  WAREHOUSE_CLASS,
+  type EpisodeSourceClass,
+} from "@atlas/api/lib/brain/sources";
+
+/**
+ * Values that are not a class this deploy can resolve.
+ *
+ * Three families, and each one is a real lane rather than a hostile-input
+ * flourish. `docs`/`wiki`/`code`/`drive` are ADR-0036 classes that have NOT
+ * shipped — the literal hypothetical-new-class case. `slack`/`zoom`/`outlook`
+ * are legal stored SOURCE values that are not classes, which is `sources.ts`'s
+ * two-axes hazard arriving at a disclosure gate; `human ` and `Chat` are the
+ * whitespace and casing near-misses of real class names. The prototype keys are
+ * the ones a bare index would resolve to a FUNCTION whose `.coverage` is
+ * `undefined` — measured, not assumed: dropping the narrow in `contractOf`
+ * reddens three of the tests below.
+ */
+const UNRESOLVABLE: readonly unknown[] = [
+  "docs",
+  "wiki",
+  "drive",
+  "code",
+  "slack",
+  "zoom",
+  "outlook",
+  "human ",
+  "Chat",
+  "",
+  "toString",
+  "constructor",
+  "hasOwnProperty",
+  "valueOf",
+  "__proto__",
+  null,
+  undefined,
+  42,
+  { class: "chat" },
+  ["chat"],
+];
+
+/** Both per-unit inputs, every combination — the label policy's whole domain. */
+const UNIT_FACTS: readonly SurveyUnitDisclosureFacts[] = [
+  { deliberateAct: false, vendorReportsPublic: false },
+  { deliberateAct: false, vendorReportsPublic: true },
+  { deliberateAct: true, vendorReportsPublic: false },
+  { deliberateAct: true, vendorReportsPublic: true },
+];
+
+describe("the class contract Record (#5212)", () => {
+  test("is TOTAL over the class set — one entry per class, no orphan key", () => {
+    // Both directions. A MISSING class is already a compile error (the
+    // `satisfies Record<EpisodeSourceClass, …>` on the map) and an EXTRA key is
+    // one too (`_CONTRACT_KEYS_IN_SYNC`), so what this adds is the runtime
+    // statement of the same fact — the thing a reader can check without running
+    // `tsc`, and the thing that stays true if either compile-time guard is ever
+    // weakened by a refactor.
+    expect(Object.keys(CLASS_CONTRACTS).toSorted()).toEqual([...EPISODE_SOURCE_CLASSES].toSorted());
+    for (const cls of EPISODE_SOURCE_CLASSES) {
+      expect([cls, CLASS_CONTRACTS[cls]]).not.toEqual([cls, undefined]);
+      expect([cls, typeof CLASS_CONTRACTS[cls].coverage.vendorPublic]).toEqual([cls, "boolean"]);
+    }
+  });
+
+  test("adding a class WITHOUT a contract is a compile error", () => {
+    // The Record's whole structural claim, and the only instrument that can pin
+    // it. Both lines fail to compile TODAY, so weakening the annotation to
+    // `Partial<Record<…>>` — the natural "fix" when a new class does not
+    // compile — turns them into unused-@ts-expect-error errors instead of
+    // silently admitting a class with no coverage answer.
+    // @ts-expect-error a contract map missing a class is not assignable
+    const partial: Record<EpisodeSourceClass, ClassContract> = {
+      chat: CLASS_CONTRACTS.chat,
+      transcript: CLASS_CONTRACTS.transcript,
+      email: CLASS_CONTRACTS.email,
+      warehouse: CLASS_CONTRACTS.warehouse,
+    };
+    // …and a class outside the closed set cannot be indexed for one, so a
+    // consumer cannot reach past the Record to invent an answer either.
+    // @ts-expect-error `docs` is an ADR-0036 class that has not shipped
+    const unshipped: ClassContract = CLASS_CONTRACTS.docs;
+    void partial;
+    void unshipped;
+  });
+
+  test("declares EXACTLY the three coverage properties — no invented field", () => {
+    // Excess-property checking only fires on a fresh object literal and
+    // `Object.freeze(...)` is a call result, so the per-entry `satisfies` inside
+    // the map is what restores it — and a `satisfies` cannot be asserted after
+    // the fact. A typo'd field (`vendorPublik`) on a disclosure gate is exactly
+    // the shape that produces confidence in something nothing reads.
+    for (const cls of EPISODE_SOURCE_CLASSES) {
+      expect([cls, Object.keys(CLASS_CONTRACTS[cls]).toSorted()]).toEqual([cls, ["coverage"]]);
+      expect([cls, Object.keys(CLASS_CONTRACTS[cls].coverage).toSorted()]).toEqual([
+        cls,
+        ["activityMetadata", "denominator", "vendorPublic"],
+      ]);
+    }
+  });
+
+  test("is FROZEN all the way down — the disclosure gate cannot be rewritten at runtime", () => {
+    // `Object.freeze` is shallow and the gate lives two levels down, so the
+    // top-level freeze alone would leave `CLASS_CONTRACTS.email.coverage
+    // .vendorPublic = true` working. Every reader would then see the same
+    // mutated map and stay agreed while all of them were wrong — no log, no
+    // throw, no red test. Asserted per level rather than only on the root.
+    expect(Object.isFrozen(CLASS_CONTRACTS)).toBe(true);
+    for (const cls of EPISODE_SOURCE_CLASSES) {
+      expect([cls, Object.isFrozen(CLASS_CONTRACTS[cls])]).toEqual([cls, true]);
+      expect([cls, Object.isFrozen(CLASS_CONTRACTS[cls].coverage)]).toEqual([cls, true]);
+      expect([cls, Object.isFrozen(CLASS_CONTRACTS[cls].coverage.denominator)]).toEqual([cls, true]);
+    }
+    // And the freeze BITES rather than merely being reported: ESM modules are
+    // strict, so the write throws. A test that only read `Object.isFrozen`
+    // would pass against a sealed-but-writable object.
+    expect(() => {
+      (CLASS_CONTRACTS.email.coverage as { vendorPublic: boolean }).vendorPublic = true;
+    }).toThrow(TypeError);
+    expect(CLASS_CONTRACTS.email.coverage.vendorPublic).toBe(false);
+  });
+});
+
+describe("the three coverage answers, per class", () => {
+  test("the whole table, pinned to literals", () => {
+    // The one place the answers are anchored to values rather than to each
+    // other. Every other assertion in this file is about agreement or about a
+    // derivation, so without this line a coordinated edit — flip `vendorPublic`
+    // in the map, flip the expectation in a derivation test — stays green.
+    //
+    // Read the `vendorPublic` column as CLASS-LEVEL ADMISSIBILITY, not as "these
+    // units are public": `chat` is the only class ADR-0041 argues open, and the
+    // per-unit half is ANDed in `coverageLabelPolicy` below.
+    expect(
+      Object.fromEntries(
+        EPISODE_SOURCE_CLASSES.map((cls) => {
+          const { vendorPublic, activityMetadata, denominator } = CLASS_CONTRACTS[cls].coverage;
+          return [
+            cls,
+            [
+              vendorPublic,
+              activityMetadata,
+              denominator.surveyable ? denominator.enumeratedFrom : null,
+            ],
+          ];
+        }),
+      ),
+    ).toEqual({
+      chat: [true, "reports", "chat-channel-roster"],
+      transcript: [false, "reports", "granted-recording-scopes"],
+      email: [false, "reports", "mailbox-list"],
+      warehouse: [false, "absent", "semantic-layer-enrollment"],
+      human: [false, "absent", null],
+    });
+  });
+
+  test("vendorPublic defaults CLOSED — chat is the only class argued open", () => {
+    // Stated as a rule over the whole set rather than only in the table above,
+    // so a NEW class declaring `true` fails here with a reason attached rather
+    // than merely editing a literal. ADR-0041: the clause leans on each vendor's
+    // notion of "public", so a class must argue its way open.
+    const open = EPISODE_SOURCE_CLASSES.filter((cls) => CLASS_CONTRACTS[cls].coverage.vendorPublic);
+    expect(open).toEqual([CHAT_CLASS]);
+  });
+
+  test("`human` is explicitly NON-SURVEYABLE, and it is the only one", () => {
+    // The AC that omission would have satisfied far more weakly: an absent row
+    // is indistinguishable from an unfinished one. Asserted through the
+    // derivation as well as off the map, because the derivation is what the
+    // Coverage Surface will call and it has its own fail-closed arm that could
+    // produce the same `{surveyable: false}` for the wrong reason.
+    expect(classDenominator("human")).toEqual({ surveyable: false });
+    const nonSurveyable = EPISODE_SOURCE_CLASSES.filter(
+      (cls) => !CLASS_CONTRACTS[cls].coverage.denominator.surveyable,
+    );
+    expect(nonSurveyable).toEqual(["human"]);
+  });
+
+  test("no two classes share a denominator origin — the layers stay incommensurable", () => {
+    // ADR-0041's "No single number, permanently", made structural. A shared
+    // origin slug is the first thing that would make a blend across classes look
+    // defensible, and the blend is the refusal the ADR expects to be asked for
+    // repeatedly.
+    const origins = EPISODE_SOURCE_CLASSES.flatMap((cls) => {
+      const denominator = CLASS_CONTRACTS[cls].coverage.denominator;
+      return denominator.surveyable ? [denominator.enumeratedFrom] : [];
+    });
+    // Non-vacuity first: with an empty list the uniqueness assertion below is
+    // `0 === 0` and would hold for a Record that had stopped declaring
+    // denominators at all.
+    expect(origins.length).toBeGreaterThan(1);
+    expect(new Set(origins).size).toBe(origins.length);
+  });
+});
+
+describe("the coverage label policy — ADR-0041's two clauses", () => {
+  test("names a unit under the deliberate-act clause, whatever the class", () => {
+    // The clause that does not depend on any vendor's notion of "public": the
+    // admin typed the id, so showing it back discloses nothing they did not
+    // supply. True for `email` too, which is the sharp case — a mailbox nobody
+    // named stays counted-only, and one an admin entered on the install form
+    // does not.
+    for (const cls of EPISODE_SOURCE_CLASSES) {
+      expect([cls, coverageLabelPolicy(cls, { deliberateAct: true, vendorReportsPublic: false })])
+        .toEqual([cls, { policy: "name", clause: "deliberate-act" }]);
+    }
+  });
+
+  test("the vendor-public clause needs BOTH halves — class admissibility AND the vendor's answer", () => {
+    // The AND is the whole design, and each half is checked with the other one
+    // held wrong so neither can be carrying the test alone.
+    //
+    // Half one — the class says yes, the vendor says no (a PRIVATE Slack
+    // channel). No label: `chat`'s `vendorPublic: true` is admissibility, not a
+    // blanket verdict over the class's units.
+    expect(coverageLabelPolicy(CHAT_CLASS, { deliberateAct: false, vendorReportsPublic: false }))
+      .toEqual({ policy: "count-only", reason: "no-clause" });
+    // Half two — the vendor says yes, the class says no. No label: a caller's
+    // per-unit claim cannot open a class a human declined to open, which is the
+    // direction that matters because the claim comes from vendor data.
+    for (const cls of [TRANSCRIPT_CLASS, EMAIL_CLASS, WAREHOUSE_CLASS, "human"] as const) {
+      expect([cls, coverageLabelPolicy(cls, { deliberateAct: false, vendorReportsPublic: true })])
+        .toEqual([cls, { policy: "count-only", reason: "no-clause" }]);
+    }
+    // Both halves — the only combination that labels under this clause.
+    expect(coverageLabelPolicy(CHAT_CLASS, { deliberateAct: false, vendorReportsPublic: true }))
+      .toEqual({ policy: "name", clause: "vendor-public" });
+  });
+
+  test("reports WHICH clause fired, so the two cannot be swapped unnoticed", () => {
+    // The decision carries the clause rather than a bare boolean precisely so
+    // this is falsifiable. `warehouse` is the case that makes it worth having:
+    // its units are freely namable, and they get there by DELIBERATE ACT
+    // (enrollment, ADR-0039) while the class declares `vendorPublic: false`. A
+    // boolean return would report the same `true` under either reading, and an
+    // edit that opened `warehouse`'s vendor-public flag to "fix" a page would
+    // look like a no-op.
+    expect(
+      coverageLabelPolicy(WAREHOUSE_CLASS, { deliberateAct: true, vendorReportsPublic: true }),
+    ).toEqual({ policy: "name", clause: "deliberate-act" });
+    // …and chat with only the vendor half is the other clause, from the same
+    // input shape. The two results differ in the `clause` field alone, which is
+    // the assertion a bare boolean could not make.
+    expect(
+      coverageLabelPolicy(CHAT_CLASS, { deliberateAct: false, vendorReportsPublic: true }),
+    ).toEqual({ policy: "name", clause: "vendor-public" });
+  });
+
+  test("deliberate-act WINS when both clauses would admit the unit", () => {
+    // Order is a real decision (the older clause, and the one whose
+    // justification survives a vendor redefining "public"), so it is pinned
+    // rather than left to fall out of the `if` order.
+    expect(
+      coverageLabelPolicy(CHAT_CLASS, { deliberateAct: true, vendorReportsPublic: true }),
+    ).toEqual({ policy: "name", clause: "deliberate-act" });
+  });
+});
+
+describe("the fail-closed arms — a class this deploy cannot resolve", () => {
+  test("gets NO label, under EITHER clause", () => {
+    // The hypothetical-new-class AC, exercised across the label policy's whole
+    // input domain rather than only on the natural `{false, false}` case. The
+    // `deliberateAct: true` rows are the ones that carry the argument: every act
+    // that clause enumerates is class-specific machinery (an install form, an
+    // exclusion list, an enrollment), so a class with no contract has none of it
+    // built and a caller asserting the flag is asserting a fact about a form
+    // that does not exist.
+    for (const cls of UNRESOLVABLE) {
+      for (const unit of UNIT_FACTS) {
+        expect([String(cls), unit.deliberateAct, coverageLabelPolicy(cls, unit)]).toEqual([
+          String(cls),
+          unit.deliberateAct,
+          { policy: "count-only", reason: "unresolvable-class" },
+        ]);
+      }
+    }
+  });
+
+  test("distinguishes the fail-closed withhold from the ordinary one", () => {
+    // `no-clause` and `unresolvable-class` are different sentences to an admin —
+    // "we counted this and correctly did not name it" versus "we do not know
+    // what this is" — and only the second is a bug. Collapsing them to one
+    // `count-only` would pass every other assertion in this describe block,
+    // which is why the reasons are asserted against EACH OTHER here.
+    const ordinary = coverageLabelPolicy(EMAIL_CLASS, {
+      deliberateAct: false,
+      vendorReportsPublic: true,
+    });
+    const failClosed = coverageLabelPolicy("docs", {
+      deliberateAct: false,
+      vendorReportsPublic: true,
+    });
+    expect(ordinary).toEqual({ policy: "count-only", reason: "no-clause" });
+    expect(failClosed).toEqual({ policy: "count-only", reason: "unresolvable-class" });
+    expect(ordinary).not.toEqual(failClosed);
+  });
+
+  test("never yields a staleness verdict that could read as `stale`", () => {
+    for (const cls of UNRESOLVABLE) {
+      expect([String(cls), stalenessVerdictKind(cls)]).toEqual([String(cls), "unverified-since"]);
+    }
+  });
+
+  test("has no denominator — a count with no universe behind it is a fabrication", () => {
+    for (const cls of UNRESOLVABLE) {
+      expect([String(cls), classDenominator(cls)]).toEqual([String(cls), { surveyable: false }]);
+    }
+  });
+});
+
+describe("the staleness capability, per class", () => {
+  test("only a class that reads vendor activity may say `stale`", () => {
+    // Derivation against the declared capability, class by class. NOT a literal
+    // list of the three connector classes: that would agree with a derivation
+    // that stopped consulting `activityMetadata` at all — the same coincidence
+    // `sources.test.ts` guards against — and it would silently exclude the next
+    // connector class to arrive.
+    for (const cls of EPISODE_SOURCE_CLASSES) {
+      expect([cls, stalenessVerdictKind(cls)]).toEqual([
+        cls,
+        CLASS_CONTRACTS[cls].coverage.activityMetadata === "reports"
+          ? "measured-lag"
+          : "unverified-since",
+      ]);
+    }
+    // …plus the value anchor, so a coordinated rename of the capability arm and
+    // the verdict arm cannot pass. `warehouse` is the one worth spelling: it is
+    // surveyable AND connect-and-it-works, so "it must be able to report
+    // staleness" is the reading someone will have.
+    expect(stalenessVerdictKind(WAREHOUSE_CLASS)).toBe("unverified-since");
+    expect(stalenessVerdictKind("human")).toBe("unverified-since");
+    expect(stalenessVerdictKind(CHAT_CLASS)).toBe("measured-lag");
+  });
+
+  test("a non-surveyable class still answers the staleness question", () => {
+    // `human` has no denominator, and the two properties are independent: a
+    // derivation that short-circuited on `surveyable: false` would return
+    // something else here, and the surface would have no sentence for a class it
+    // still has to account for.
+    expect(classDenominator("human")).toEqual({ surveyable: false });
+    expect(stalenessVerdictKind("human")).toBe("unverified-since");
+  });
+});

--- a/packages/api/src/lib/brain/__tests__/class-contract.test.ts
+++ b/packages/api/src/lib/brain/__tests__/class-contract.test.ts
@@ -44,8 +44,11 @@ import {
   coverageLabelPolicy,
   stalenessVerdict,
   type ClassContract,
+  type ClassContractLogMeta,
   type ClassCoverageContract,
   type ClassDenominator,
+  type CoverageLabelDecision,
+  type StalenessVerdict,
   type SurveyUnitDisclosureFacts,
 } from "@atlas/api/lib/brain/class-contract";
 import {
@@ -91,7 +94,25 @@ const UNRESOLVABLE: readonly unknown[] = [
   42,
   { class: "chat" },
   ["chat"],
+  // ⚠️ `ToPrimitive` THROWS on this one — both own props shadow
+  // `Object.prototype` and neither is callable — so `String(value)` cannot
+  // render it. It survives `JSON.parse`, so a region import really can carry
+  // it, and `sources.test.ts` uses the same family for the same lane. It could
+  // not be listed here until the labeller below stopped using `String()`.
+  JSON.parse(String.raw`{"toString": 1, "valueOf": 2}`),
 ];
+
+/**
+ * A label for one hostile fixture that cannot itself throw.
+ *
+ * `String(value)` is the obvious spelling and it takes the suite down on the
+ * `ToPrimitive` trap above — the harness failing on the input the module
+ * survives. `typeof` never throws, and `JSON.stringify` returns `undefined`
+ * rather than throwing for a symbol or a function, so the `??` covers it.
+ */
+function label(value: unknown): string {
+  return `${typeof value}:${JSON.stringify(value) ?? "?"}`;
+}
 
 /** Both per-unit inputs, every combination — the label policy's whole domain. */
 const UNIT_FACTS: readonly SurveyUnitDisclosureFacts[] = [
@@ -188,6 +209,41 @@ describe("the class contract Record (#5212)", () => {
     void lvl3;
   });
 
+  test("log meta is optional-or-COMPLETE — a partial one is refused", () => {
+    // Round 1 made `workspaceId` required on the argument that a warn with no
+    // tenant cannot explain why a class went quiet in a 3-region deploy. That
+    // argument had no guard: reverting the field to optional is a pure widening,
+    // so `tsc` and both suites stayed green. `oversight.ts`'s `CountMeta` draws
+    // the same line — the PARAMETER is what a caller omits, never a field.
+    // @ts-expect-error a meta without its workspace is not a meta
+    const partialMeta: ClassContractLogMeta = { requestId: "req_5212" };
+    void partialMeta;
+    // …and the parameter itself stays optional, which is the half that must NOT
+    // break: a pure derivation that needed request context to answer would fail
+    // open in exactly the callers least likely to have it.
+    expect(classDenominator("docs")).toEqual({
+      surveyable: false,
+      reason: "unresolvable-class",
+    });
+  });
+
+  test("the decision vocabularies are CLOSED — a fourth reason must be handled", () => {
+    // Each reason is asserted as a distinct value elsewhere, but nothing pinned
+    // the unions' MEMBERSHIP — so a fourth reason could arrive with no consumer
+    // forced to handle it, which is what the "three different sentences to an
+    // admin" argument exists to protect. `@ts-expect-error` is the only
+    // instrument for it: the assignment is legal the moment the union widens.
+    // @ts-expect-error `count-only` admits exactly three reasons
+    const invented: CoverageLabelDecision = { policy: "count-only", reason: "invented" };
+    // @ts-expect-error a denominator refusal admits exactly two reasons
+    const inventedDenominator: ClassDenominator = { surveyable: false, reason: "invented" };
+    // @ts-expect-error `unverified-since` admits exactly two reasons
+    const inventedStaleness: StalenessVerdict = { kind: "unverified-since", reason: "invented" };
+    void invented;
+    void inventedDenominator;
+    void inventedStaleness;
+  });
+
   test("carries a `satisfies` at EVERY level — pinned in source text", () => {
     // The one guard here that is not about values, because it CANNOT be. A
     // `satisfies` is erased at runtime and asserts nothing about itself, so
@@ -213,7 +269,10 @@ describe("the class contract Record (#5212)", () => {
     )?.[1];
     // Not vacuous: a rename or a reshape must fail here rather than silently
     // running every assertion below against `undefined`.
-    expect(map).toBeDefined();
+    expect(
+      map,
+      "could not find the CLASS_CONTRACTS literal — if you renamed or reshaped the declaration, update this regex; nothing is actually broken",
+    ).toBeDefined();
     const body = map ?? "";
     // One `satisfies` per level per entry. COUNTED rather than merely present,
     // so deleting ONE of the five at any level is red — which is precisely the
@@ -226,9 +285,26 @@ describe("the class contract Record (#5212)", () => {
     ] as const) {
       expect([level, body.split(annotation).length - 1]).toEqual([level, classCount]);
     }
+    // ⚠️ The three levels above are TODAY's shape, and this file's own header
+    // schedules more: ADR-0040's arms join as siblings of `coverage`. A pin that
+    // only counts the levels it knows about stays green when a fourth arrives
+    // unannotated — the same "guard that lies about its own scope" this test was
+    // written to end.
+    //
+    // So pair the counts instead: every `Object.freeze(` inside the map must
+    // have an `as const satisfies` of its own. That holds for any depth, and a
+    // new frozen sibling added without an annotation breaks it without anyone
+    // having to remember this test exists.
+    expect([
+      "frozen literals",
+      body.split("Object.freeze(").length - 1,
+    ]).toEqual(["frozen literals", body.split("as const satisfies").length - 1]);
     // …and the map-level totality annotation, a different guarantee (every
-    // class present) held by a different construct.
-    expect(code).toContain("satisfies Record<EpisodeSourceClass, ClassContract>");
+    // class present) held by a different construct. Whitespace-normalised so a
+    // human reflow across lines is not a false failure on a claim about types.
+    expect(code.replace(/\s+/g, " ")).toContain(
+      "satisfies Record<EpisodeSourceClass, ClassContract>",
+    );
   });
 
   test("declares EXACTLY the three coverage properties — no invented field", () => {
@@ -242,6 +318,14 @@ describe("the class contract Record (#5212)", () => {
       expect([cls, Object.keys(CLASS_CONTRACTS[cls].coverage).toSorted()]).toEqual([
         cls,
         ["activityMetadata", "denominator", "vendorPublic"],
+      ]);
+      // Level 3 too — the thinnest level, and the one where an invented field
+      // (`weight: 3`) would be the first step toward the blended score
+      // ADR-0041 refuses.
+      const denominator = CLASS_CONTRACTS[cls].coverage.denominator;
+      expect([cls, Object.keys(denominator).toSorted()]).toEqual([
+        cls,
+        denominator.surveyable ? ["enumeratedFrom", "surveyable"] : ["reason", "surveyable"],
       ]);
     }
   });
@@ -330,6 +414,15 @@ describe("the three coverage answers, per class", () => {
     // fail-closed one have to differ in the RETURN VALUE or the surface cannot
     // render "cannot establish" for the second.
     expect(classDenominator("human")).not.toEqual(classDenominator("docs"));
+    // …and no DECLARED denominator may carry the fail-closed reason. That value
+    // means "this deploy could not resolve the class", which is never a true
+    // statement about an entry that is sitting right there in the map.
+    for (const cls of EPISODE_SOURCE_CLASSES) {
+      const denominator = CLASS_CONTRACTS[cls].coverage.denominator;
+      if (!denominator.surveyable) {
+        expect([cls, denominator.reason]).toEqual([cls, "not-a-surveyable-region"]);
+      }
+    }
   });
 
   test("the denominator DERIVATION returns each class's declared universe", () => {
@@ -511,8 +604,8 @@ describe("the fail-closed arms — a class this deploy cannot resolve", () => {
     // that does not exist.
     for (const cls of UNRESOLVABLE) {
       for (const unit of UNIT_FACTS) {
-        expect([String(cls), unit.deliberateAct, coverageLabelPolicy(cls, unit)]).toEqual([
-          String(cls),
+        expect([label(cls), unit.deliberateAct, coverageLabelPolicy(cls, unit)]).toEqual([
+          label(cls),
           unit.deliberateAct,
           { policy: "count-only", reason: "unresolvable-class" },
         ]);
@@ -541,8 +634,8 @@ describe("the fail-closed arms — a class this deploy cannot resolve", () => {
 
   test("never yields a staleness verdict that could read as `stale`", () => {
     for (const cls of UNRESOLVABLE) {
-      expect([String(cls), stalenessVerdict(cls)]).toEqual([
-        String(cls),
+      expect([label(cls), stalenessVerdict(cls)]).toEqual([
+        label(cls),
         { kind: "unverified-since", reason: "unresolvable-class" },
       ]);
     }
@@ -553,8 +646,8 @@ describe("the fail-closed arms — a class this deploy cannot resolve", () => {
 
   test("has no denominator — a count with no universe behind it is a fabrication", () => {
     for (const cls of UNRESOLVABLE) {
-      expect([String(cls), classDenominator(cls)]).toEqual([
-        String(cls),
+      expect([label(cls), classDenominator(cls)]).toEqual([
+        label(cls),
         { surveyable: false, reason: "unresolvable-class" },
       ]);
     }

--- a/packages/api/src/lib/brain/__tests__/class-contract.test.ts
+++ b/packages/api/src/lib/brain/__tests__/class-contract.test.ts
@@ -36,12 +36,16 @@
  */
 
 import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import {
   CLASS_CONTRACTS,
   classDenominator,
   coverageLabelPolicy,
-  stalenessVerdictKind,
+  stalenessVerdict,
   type ClassContract,
+  type ClassCoverageContract,
+  type ClassDenominator,
   type SurveyUnitDisclosureFacts,
 } from "@atlas/api/lib/brain/class-contract";
 import {
@@ -107,17 +111,24 @@ describe("the class contract Record (#5212)", () => {
     // weakened by a refactor.
     expect(Object.keys(CLASS_CONTRACTS).toSorted()).toEqual([...EPISODE_SOURCE_CLASSES].toSorted());
     for (const cls of EPISODE_SOURCE_CLASSES) {
-      expect([cls, CLASS_CONTRACTS[cls]]).not.toEqual([cls, undefined]);
       expect([cls, typeof CLASS_CONTRACTS[cls].coverage.vendorPublic]).toEqual([cls, "boolean"]);
     }
   });
 
   test("adding a class WITHOUT a contract is a compile error", () => {
-    // The Record's whole structural claim, and the only instrument that can pin
-    // it. Both lines fail to compile TODAY, so weakening the annotation to
-    // `Partial<Record<…>>` — the natural "fix" when a new class does not
-    // compile — turns them into unused-@ts-expect-error errors instead of
-    // silently admitting a class with no coverage answer.
+    // The Record's whole structural claim. Both lines fail to compile TODAY, so
+    // a reshape that made either legal turns them into unused-@ts-expect-error
+    // errors rather than silently admitting a class with no coverage answer.
+    //
+    // ⚠️ These are locally annotated, so they pin the SHAPE and not the map's
+    // own annotation — measured, and the distinction matters because the
+    // obvious escape hatch is on the map. Weakening it to
+    // `satisfies Partial<Record<…>>` keeps `tsc` clean and these two lines
+    // green. What still catches a genuinely missing class is
+    // `_CONTRACT_KEYS_IN_SYNC` (a TS2322 in the module itself) plus every sweep
+    // in this file that indexes `CLASS_CONTRACTS[cls]` over the class set — so
+    // totality survives that edit, by a route this comment used to misattribute
+    // to the pins below.
     // @ts-expect-error a contract map missing a class is not assignable
     const partial: Record<EpisodeSourceClass, ClassContract> = {
       chat: CLASS_CONTRACTS.chat,
@@ -131,6 +142,93 @@ describe("the class contract Record (#5212)", () => {
     const unshipped: ClassContract = CLASS_CONTRACTS.docs;
     void partial;
     void unshipped;
+  });
+
+  test("an invented field is a compile error at EVERY level of the map", () => {
+    // ⚠️ These three lines exist because the guarantee was CLAIMED and did not
+    // hold. The first draft carried one `as const satisfies ClassContract` on
+    // the outer entry literal and a docstring saying it caught invented fields;
+    // measured, `vendorPublik: true` inside `coverage` and `weight: 3` inside
+    // `denominator` both compiled clean. Excess-property checking only fires on
+    // a FRESH object literal, and `Object.freeze(...)` is a call result — so a
+    // `satisfies` guards only the literal it is attached to, and this map is
+    // three levels deep.
+    //
+    // ⚠️ **These pin the TYPES, not the MAP.** Each literal below is annotated
+    // locally, so its error comes from that annotation — none of them reference
+    // `CLASS_CONTRACTS`, and deleting a `satisfies` from an entry in the map
+    // leaves every one of them green. Measured: removing
+    // `as const satisfies ClassCoverageContract` from the `chat` entry keeps
+    // `tsc` clean, and `vendorPublik: true` beside `vendorPublic` then compiles.
+    // An earlier draft of this comment claimed otherwise — the same
+    // false-guarantee defect it was written to fix, one file over.
+    //
+    // What they DO guarantee is worth having and is the other half: that
+    // `ClassCoverageContract` and `ClassDenominator` are CLOSED, so the map's
+    // `satisfies` has something to bite on. The map's own per-level annotations
+    // are pinned by `carries a satisfies at every level` below, which reads the
+    // source text because no type can assert its own annotation.
+    // @ts-expect-error level 1 — an arm that is not part of the contract yet
+    const lvl1: ClassContract = { coverage: CLASS_CONTRACTS.chat.coverage, trigger: "on-connect" };
+    const lvl2: ClassCoverageContract = {
+      vendorPublic: false,
+      // @ts-expect-error level 2 — the typo the disclosure gate would not notice
+      vendorPublik: true,
+      activityMetadata: "absent",
+      denominator: { surveyable: false, reason: "not-a-surveyable-region" },
+    };
+    const lvl3: ClassDenominator = {
+      surveyable: true,
+      enumeratedFrom: "mailbox-list",
+      // @ts-expect-error level 3 — an invented weight is how a blended score starts
+      weight: 3,
+    };
+    void lvl1;
+    void lvl2;
+    void lvl3;
+  });
+
+  test("carries a `satisfies` at EVERY level — pinned in source text", () => {
+    // The one guard here that is not about values, because it CANNOT be. A
+    // `satisfies` is erased at runtime and asserts nothing about itself, so
+    // deleting one from an entry is invisible to every behavioural test and to
+    // `tsc` alike — measured: removing `chat`'s level-2 `satisfies` leaves the
+    // whole suite green AND `tsc` clean, and `vendorPublik: true` then compiles
+    // into the map. Only the runtime key-set test below catches the CONSEQUENCE
+    // (a field that was actually added), never the guard's removal.
+    //
+    // Same instrument and same reason as `sources.test.ts`'s "DELEGATES rather
+    // than re-deriving — pinned in source text". Comments are stripped first,
+    // because the docstring above the map discusses these annotations at length
+    // and a guard that tripped on its own explanation would force the
+    // explanation to be deleted to stay green.
+    const code = readFileSync(join(import.meta.dir, "..", "class-contract.ts"), "utf8")
+      .replace(/\/\*[\s\S]*?\*\//g, "")
+      .replace(/(^|[^:])\/\/.*$/gm, "$1");
+    // Scoped to the map's own literal, not the file: a file-wide count would be
+    // satisfied by any three `satisfies` anywhere, including a future unrelated
+    // constant in the same module.
+    const map = /export const CLASS_CONTRACTS = Object\.freeze\(\{([\s\S]*?)\n\}\) satisfies/.exec(
+      code,
+    )?.[1];
+    // Not vacuous: a rename or a reshape must fail here rather than silently
+    // running every assertion below against `undefined`.
+    expect(map).toBeDefined();
+    const body = map ?? "";
+    // One `satisfies` per level per entry. COUNTED rather than merely present,
+    // so deleting ONE of the five at any level is red — which is precisely the
+    // mutation that is otherwise silent.
+    const classCount = EPISODE_SOURCE_CLASSES.length;
+    for (const [level, annotation] of [
+      ["1 (entry)", "as const satisfies ClassContract"],
+      ["2 (coverage)", "as const satisfies ClassCoverageContract"],
+      ["3 (denominator)", "as const satisfies ClassDenominator"],
+    ] as const) {
+      expect([level, body.split(annotation).length - 1]).toEqual([level, classCount]);
+    }
+    // …and the map-level totality annotation, a different guarantee (every
+    // class present) held by a different construct.
+    expect(code).toContain("satisfies Record<EpisodeSourceClass, ClassContract>");
   });
 
   test("declares EXACTLY the three coverage properties — no invented field", () => {
@@ -218,11 +316,49 @@ describe("the three coverage answers, per class", () => {
     // derivation as well as off the map, because the derivation is what the
     // Coverage Surface will call and it has its own fail-closed arm that could
     // produce the same `{surveyable: false}` for the wrong reason.
-    expect(classDenominator("human")).toEqual({ surveyable: false });
+    expect(classDenominator("human")).toEqual({
+      surveyable: false,
+      reason: "not-a-surveyable-region",
+    });
     const nonSurveyable = EPISODE_SOURCE_CLASSES.filter(
       (cls) => !CLASS_CONTRACTS[cls].coverage.denominator.surveyable,
     );
     expect(nonSurveyable).toEqual(["human"]);
+    // …and the reason is what makes the two refusals distinguishable. Asserted
+    // against each other, because identical objects here were the round-1
+    // defect: a page cannot read a `log.warn`, so a declared refusal and a
+    // fail-closed one have to differ in the RETURN VALUE or the surface cannot
+    // render "cannot establish" for the second.
+    expect(classDenominator("human")).not.toEqual(classDenominator("docs"));
+  });
+
+  test("the denominator DERIVATION returns each class's declared universe", () => {
+    // ⚠️ Added because its absence was measured, not suspected. Every call to
+    // `classDenominator` in the first draft was either `human` or an
+    // unresolvable value, and all of them expected `{surveyable: false}` — so
+    // the derivation's ONLY asserted answer was its fail-closed one, and
+    // replacing its final line with `return { surveyable: false, reason: … }`
+    // left the whole suite green. The production failure that hides: every
+    // class reports no universe, and every ratio on the Coverage Surface
+    // silently disappears — ADR-0041's "a silent zero here is a false
+    // statement, not an error state", arriving through the one function written
+    // to prevent it.
+    //
+    // The other two derivations were already swept over the whole class set;
+    // this one was the asymmetry.
+    for (const cls of EPISODE_SOURCE_CLASSES) {
+      expect([cls, classDenominator(cls)]).toEqual([
+        cls,
+        CLASS_CONTRACTS[cls].coverage.denominator,
+      ]);
+    }
+    // …plus a value anchor, so a coordinated edit of the map and the derivation
+    // cannot pass — the loop above is an agreement assertion and would survive
+    // one.
+    expect(classDenominator(CHAT_CLASS)).toEqual({
+      surveyable: true,
+      enumeratedFrom: "chat-channel-roster",
+    });
   });
 
   test("no two classes share a denominator origin — the layers stay incommensurable", () => {
@@ -243,16 +379,70 @@ describe("the three coverage answers, per class", () => {
 });
 
 describe("the coverage label policy — ADR-0041's two clauses", () => {
-  test("names a unit under the deliberate-act clause, whatever the class", () => {
+  test("names a unit under the deliberate-act clause, for every SURVEYABLE class", () => {
     // The clause that does not depend on any vendor's notion of "public": the
     // admin typed the id, so showing it back discloses nothing they did not
     // supply. True for `email` too, which is the sharp case — a mailbox nobody
     // named stays counted-only, and one an admin entered on the install form
     // does not.
-    for (const cls of EPISODE_SOURCE_CLASSES) {
-      expect([cls, coverageLabelPolicy(cls, { deliberateAct: true, vendorReportsPublic: false })])
-        .toEqual([cls, { policy: "name", clause: "deliberate-act" }]);
+    //
+    // ⚠️ SURVEYABLE classes only, and the narrowing is the round-1 fix. This
+    // loop used to run over every class including `human`, pinning the
+    // permissive answer for the one class whose "units" are PEOPLE.
+    const surveyable = EPISODE_SOURCE_CLASSES.filter(
+      (cls) => CLASS_CONTRACTS[cls].coverage.denominator.surveyable,
+    );
+    expect(surveyable.length).toBeGreaterThan(1);
+    for (const cls of surveyable) {
+      expect([
+        cls,
+        coverageLabelPolicy(cls, { deliberateAct: true, vendorReportsPublic: false }),
+      ]).toEqual([cls, { policy: "name", clause: "deliberate-act" }]);
     }
+  });
+
+  test("a NON-SURVEYABLE class is never named — not even under the deliberate-act clause", () => {
+    // ADR-0041 refuses this population by name: "Everything else is counted,
+    // never named: mailboxes …, recording owners, individual persons." `human`
+    // is the class whose survey units WOULD be persons, and it declares it has
+    // no enumerable units at all — so a caller asking whether to name one is
+    // asking about a unit that should not exist.
+    //
+    // The whole input domain, because the `deliberateAct: true` rows are the
+    // ones that changed: the class-level refusal is checked BEFORE either
+    // clause, so a single caller-supplied boolean can no longer name a person.
+    for (const unit of UNIT_FACTS) {
+      expect([unit.deliberateAct, unit.vendorReportsPublic, coverageLabelPolicy("human", unit)])
+        .toEqual([
+          unit.deliberateAct,
+          unit.vendorReportsPublic,
+          { policy: "count-only", reason: "non-surveyable-class" },
+        ]);
+    }
+    // …and its reason is distinct from BOTH the ordinary withhold and the
+    // fail-closed one. Three different sentences to an admin: "counted and
+    // correctly not named", "this class has no units", "we do not know what
+    // this is" — and collapsing any two would pass every other assertion here.
+    const nonSurveyable = coverageLabelPolicy("human", {
+      deliberateAct: false,
+      vendorReportsPublic: false,
+    });
+    const ordinary = coverageLabelPolicy(EMAIL_CLASS, {
+      deliberateAct: false,
+      vendorReportsPublic: false,
+    });
+    const failClosed = coverageLabelPolicy("docs", {
+      deliberateAct: false,
+      vendorReportsPublic: false,
+    });
+    expect(new Set([nonSurveyable.policy, ordinary.policy, failClosed.policy])).toEqual(
+      new Set(["count-only"]),
+    );
+    expect([nonSurveyable, ordinary, failClosed]).toEqual([
+      { policy: "count-only", reason: "non-surveyable-class" },
+      { policy: "count-only", reason: "no-clause" },
+      { policy: "count-only", reason: "unresolvable-class" },
+    ]);
   });
 
   test("the vendor-public clause needs BOTH halves — class admissibility AND the vendor's answer", () => {
@@ -267,9 +457,14 @@ describe("the coverage label policy — ADR-0041's two clauses", () => {
     // Half two — the vendor says yes, the class says no. No label: a caller's
     // per-unit claim cannot open a class a human declined to open, which is the
     // direction that matters because the claim comes from vendor data.
-    for (const cls of [TRANSCRIPT_CLASS, EMAIL_CLASS, WAREHOUSE_CLASS, "human"] as const) {
-      expect([cls, coverageLabelPolicy(cls, { deliberateAct: false, vendorReportsPublic: true })])
-        .toEqual([cls, { policy: "count-only", reason: "no-clause" }]);
+    // Surveyable classes only — `human` refuses this clause too, but under
+    // `non-surveyable-class`, and it has its own test. Lumping it in here would
+    // assert the wrong reason for the right answer.
+    for (const cls of [TRANSCRIPT_CLASS, EMAIL_CLASS, WAREHOUSE_CLASS] as const) {
+      expect([
+        cls,
+        coverageLabelPolicy(cls, { deliberateAct: false, vendorReportsPublic: true }),
+      ]).toEqual([cls, { policy: "count-only", reason: "no-clause" }]);
     }
     // Both halves — the only combination that labels under this clause.
     expect(coverageLabelPolicy(CHAT_CLASS, { deliberateAct: false, vendorReportsPublic: true }))
@@ -346,13 +541,22 @@ describe("the fail-closed arms — a class this deploy cannot resolve", () => {
 
   test("never yields a staleness verdict that could read as `stale`", () => {
     for (const cls of UNRESOLVABLE) {
-      expect([String(cls), stalenessVerdictKind(cls)]).toEqual([String(cls), "unverified-since"]);
+      expect([String(cls), stalenessVerdict(cls)]).toEqual([
+        String(cls),
+        { kind: "unverified-since", reason: "unresolvable-class" },
+      ]);
     }
+    // The reason separates it from the DECLARED `no-activity-metadata` answer,
+    // which is the same sentence for a completely different cause.
+    expect(stalenessVerdict("docs")).not.toEqual(stalenessVerdict(WAREHOUSE_CLASS));
   });
 
   test("has no denominator — a count with no universe behind it is a fabrication", () => {
     for (const cls of UNRESOLVABLE) {
-      expect([String(cls), classDenominator(cls)]).toEqual([String(cls), { surveyable: false }]);
+      expect([String(cls), classDenominator(cls)]).toEqual([
+        String(cls),
+        { surveyable: false, reason: "unresolvable-class" },
+      ]);
     }
   });
 });
@@ -365,20 +569,26 @@ describe("the staleness capability, per class", () => {
     // `sources.test.ts` guards against — and it would silently exclude the next
     // connector class to arrive.
     for (const cls of EPISODE_SOURCE_CLASSES) {
-      expect([cls, stalenessVerdictKind(cls)]).toEqual([
+      expect([cls, stalenessVerdict(cls)]).toEqual([
         cls,
         CLASS_CONTRACTS[cls].coverage.activityMetadata === "reports"
-          ? "measured-lag"
-          : "unverified-since",
+          ? { kind: "measured-lag" }
+          : { kind: "unverified-since", reason: "no-activity-metadata" },
       ]);
     }
     // …plus the value anchor, so a coordinated rename of the capability arm and
     // the verdict arm cannot pass. `warehouse` is the one worth spelling: it is
     // surveyable AND connect-and-it-works, so "it must be able to report
     // staleness" is the reading someone will have.
-    expect(stalenessVerdictKind(WAREHOUSE_CLASS)).toBe("unverified-since");
-    expect(stalenessVerdictKind("human")).toBe("unverified-since");
-    expect(stalenessVerdictKind(CHAT_CLASS)).toBe("measured-lag");
+    expect(stalenessVerdict(WAREHOUSE_CLASS)).toEqual({
+      kind: "unverified-since",
+      reason: "no-activity-metadata",
+    });
+    expect(stalenessVerdict("human")).toEqual({
+      kind: "unverified-since",
+      reason: "no-activity-metadata",
+    });
+    expect(stalenessVerdict(CHAT_CLASS)).toEqual({ kind: "measured-lag" });
   });
 
   test("a non-surveyable class still answers the staleness question", () => {
@@ -386,7 +596,13 @@ describe("the staleness capability, per class", () => {
     // derivation that short-circuited on `surveyable: false` would return
     // something else here, and the surface would have no sentence for a class it
     // still has to account for.
-    expect(classDenominator("human")).toEqual({ surveyable: false });
-    expect(stalenessVerdictKind("human")).toBe("unverified-since");
+    expect(classDenominator("human")).toEqual({
+      surveyable: false,
+      reason: "not-a-surveyable-region",
+    });
+    expect(stalenessVerdict("human")).toEqual({
+      kind: "unverified-since",
+      reason: "no-activity-metadata",
+    });
   });
 });

--- a/packages/api/src/lib/brain/__tests__/class-contract.test.ts
+++ b/packages/api/src/lib/brain/__tests__/class-contract.test.ts
@@ -122,6 +122,29 @@ const UNIT_FACTS: readonly SurveyUnitDisclosureFacts[] = [
   { deliberateAct: true, vendorReportsPublic: true },
 ];
 
+describe("the hostile corpus itself", () => {
+  test("is NON-EMPTY and covers every family it claims", () => {
+    // ⚠️ The corpus drives three sweeps that carry this module's central claim,
+    // and every one of them passes on zero iterations. Measured: emptying
+    // `UNRESOLVABLE` leaves the file at 24 pass / 0 fail while the `expect()`
+    // count drops from 219 to 93 — 126 assertions vanishing in silence. The
+    // realistic path is not deletion but a stray `.filter(…)` or a move to a
+    // shared fixture. The same instrument is already applied twice in this file
+    // (the origin-uniqueness and surveyable-classes counts); this is its largest
+    // corpus and it had none.
+    expect(UNRESOLVABLE.length).toBeGreaterThan(15);
+    expect(UNIT_FACTS.length).toBe(4);
+    // …and the families, so a future trim cannot quietly drop the one that
+    // matters. Prototype keys are the only inputs that make the derivations
+    // THROW rather than fail closed when the narrow is removed.
+    expect(UNRESOLVABLE.filter((v) => typeof v === "string")).not.toHaveLength(0);
+    expect(UNRESOLVABLE.filter((v) => typeof v !== "string")).not.toHaveLength(0);
+    for (const prototypeKey of ["toString", "constructor", "valueOf", "__proto__"]) {
+      expect([prototypeKey, UNRESOLVABLE.includes(prototypeKey)]).toEqual([prototypeKey, true]);
+    }
+  });
+});
+
 describe("the class contract Record (#5212)", () => {
   test("is TOTAL over the class set — one entry per class, no orphan key", () => {
     // Both directions. A MISSING class is already a compile error (the
@@ -189,14 +212,17 @@ describe("the class contract Record (#5212)", () => {
     // `satisfies` has something to bite on. The map's own per-level annotations
     // are pinned by `carries a satisfies at every level` below, which reads the
     // source text because no type can assert its own annotation.
-    // @ts-expect-error level 1 — an arm that is not part of the contract yet
-    const lvl1: ClassContract = { coverage: CLASS_CONTRACTS.chat.coverage, trigger: "on-connect" };
+    // @ts-expect-error level 1 — a field that is not part of the contract.
+    // Deliberately NOT `trigger`, which is ADR-0040's first scheduled arm: the
+    // day that lands, a pin using its name goes unused and reds the build for a
+    // legitimate change. A permanently-fictional name keeps the pin meaningful.
+    const lvl1: ClassContract = { coverage: CLASS_CONTRACTS.chat.coverage, coverrage: 1 };
     const lvl2: ClassCoverageContract = {
       vendorPublic: false,
       // @ts-expect-error level 2 — the typo the disclosure gate would not notice
       vendorPublik: true,
       activityMetadata: "absent",
-      denominator: { surveyable: false, reason: "not-a-surveyable-region" },
+      denominator: { surveyable: false, reason: "non-surveyable-class" },
     };
     const lvl3: ClassDenominator = {
       surveyable: true,
@@ -227,12 +253,17 @@ describe("the class contract Record (#5212)", () => {
     });
   });
 
-  test("the decision vocabularies are CLOSED — a fourth reason must be handled", () => {
-    // Each reason is asserted as a distinct value elsewhere, but nothing pinned
-    // the unions' MEMBERSHIP — so a fourth reason could arrive with no consumer
-    // forced to handle it, which is what the "three different sentences to an
-    // admin" argument exists to protect. `@ts-expect-error` is the only
-    // instrument for it: the assignment is legal the moment the union widens.
+  test("the decision vocabularies refuse an invented reason, and are pinned CLOSED", () => {
+    // ⚠️ Two different guarantees, and an earlier draft of this test claimed the
+    // second while only delivering the first.
+    //
+    // These directives pin that the unions are not `string` — measured, widening
+    // `reason` to `string` turns each into an unused-directive error. They do
+    // NOT pin MEMBERSHIP: adding a fourth member leaves `tsc` clean, because an
+    // invented literal is still not assignable to the widened union. Membership
+    // is pinned by `_LABEL_REASONS_CLOSED` and its siblings in the module, on
+    // `_CONTRACT_KEYS_IN_SYNC`'s terms — mutual assignability, so BOTH growth
+    // and shrinkage are errors there.
     // @ts-expect-error `count-only` admits exactly three reasons
     const invented: CoverageLabelDecision = { policy: "count-only", reason: "invented" };
     // @ts-expect-error a denominator refusal admits exactly two reasons
@@ -247,11 +278,13 @@ describe("the class contract Record (#5212)", () => {
   test("carries a `satisfies` at EVERY level — pinned in source text", () => {
     // The one guard here that is not about values, because it CANNOT be. A
     // `satisfies` is erased at runtime and asserts nothing about itself, so
-    // deleting one from an entry is invisible to every behavioural test and to
-    // `tsc` alike — measured: removing `chat`'s level-2 `satisfies` leaves the
-    // whole suite green AND `tsc` clean, and `vendorPublik: true` then compiles
-    // into the map. Only the runtime key-set test below catches the CONSEQUENCE
-    // (a field that was actually added), never the guard's removal.
+    // deleting one from an entry is invisible to `tsc` and to every BEHAVIOURAL
+    // test — measured: removing `chat`'s level-2 `satisfies` keeps `tsc` clean
+    // and makes `vendorPublik: true` compile into the map, and this source-text
+    // count is the only assertion in the suite that goes red. (An earlier draft
+    // of this comment said "leaves the whole suite green", which this very test
+    // falsifies.) The runtime key-set test below catches the CONSEQUENCE — a
+    // field actually added — never the guard's removal.
     //
     // Same instrument and same reason as `sources.test.ts`'s "DELEGATES rather
     // than re-deriving — pinned in source text". Comments are stripped first,
@@ -281,7 +314,7 @@ describe("the class contract Record (#5212)", () => {
     for (const [level, annotation] of [
       ["1 (entry)", "as const satisfies ClassContract"],
       ["2 (coverage)", "as const satisfies ClassCoverageContract"],
-      ["3 (denominator)", "as const satisfies ClassDenominator"],
+      ["3 (denominator)", "as const satisfies DeclaredDenominator"],
     ] as const) {
       expect([level, body.split(annotation).length - 1]).toEqual([level, classCount]);
     }
@@ -302,9 +335,19 @@ describe("the class contract Record (#5212)", () => {
     // …and the map-level totality annotation, a different guarantee (every
     // class present) held by a different construct. Whitespace-normalised so a
     // human reflow across lines is not a false failure on a claim about types.
-    expect(code.replace(/\s+/g, " ")).toContain(
-      "satisfies Record<EpisodeSourceClass, ClassContract>",
-    );
+    const flat = code.replace(/\s+/g, " ");
+    expect(flat).toContain("satisfies Record<EpisodeSourceClass, ClassContract>");
+    // The other compile-time ties, for the same reason and by the same
+    // instrument: each is erased at runtime, so deleting any of them is silent
+    // in both suites and in `tsc`. Measured — each deletion was green before
+    // these three lines existed.
+    for (const tie of [
+      "const _CONTRACT_KEYS_IN_SYNC",
+      "const _DERIVATION_NAMES_IN_SYNC",
+      "const _LABEL_REASONS_CLOSED",
+    ]) {
+      expect([tie, flat.includes(tie)]).toEqual([tie, true]);
+    }
   });
 
   test("declares EXACTLY the three coverage properties — no invented field", () => {
@@ -337,6 +380,24 @@ describe("the class contract Record (#5212)", () => {
     // mutated map and stay agreed while all of them were wrong — no log, no
     // throw, no red test. Asserted per level rather than only on the root.
     expect(Object.isFrozen(CLASS_CONTRACTS)).toBe(true);
+    // ⚠️ RECURSIVE, because the enumerated assertions below are depth-blind in
+    // exactly the way the source-text pin used to be. Measured: an unfrozen,
+    // unannotated `trigger:` sibling of `coverage` — which is precisely the
+    // shape ADR-0040's next arm will take — passes every enumerated check and
+    // the paired invariant, and is then mutable at runtime on a map this file
+    // calls a DISCLOSURE gate. This walk holds at any depth and needs no edit
+    // when that arm lands.
+    let walked = 0;
+    const walk = (node: object): void => {
+      walked++;
+      expect(Object.isFrozen(node)).toBe(true);
+      for (const value of Object.values(node)) {
+        if (value !== null && typeof value === "object") walk(value);
+      }
+    };
+    walk(CLASS_CONTRACTS);
+    // Non-vacuity: a walk that visited only the root would assert almost nothing.
+    expect(walked).toBeGreaterThan(EPISODE_SOURCE_CLASSES.length * 3);
     for (const cls of EPISODE_SOURCE_CLASSES) {
       expect([cls, Object.isFrozen(CLASS_CONTRACTS[cls])]).toEqual([cls, true]);
       expect([cls, Object.isFrozen(CLASS_CONTRACTS[cls].coverage)]).toEqual([cls, true]);
@@ -402,7 +463,7 @@ describe("the three coverage answers, per class", () => {
     // produce the same `{surveyable: false}` for the wrong reason.
     expect(classDenominator("human")).toEqual({
       surveyable: false,
-      reason: "not-a-surveyable-region",
+      reason: "non-surveyable-class",
     });
     const nonSurveyable = EPISODE_SOURCE_CLASSES.filter(
       (cls) => !CLASS_CONTRACTS[cls].coverage.denominator.surveyable,
@@ -420,7 +481,7 @@ describe("the three coverage answers, per class", () => {
     for (const cls of EPISODE_SOURCE_CLASSES) {
       const denominator = CLASS_CONTRACTS[cls].coverage.denominator;
       if (!denominator.surveyable) {
-        expect([cls, denominator.reason]).toEqual([cls, "not-a-surveyable-region"]);
+        expect([cls, denominator.reason]).toEqual([cls, "non-surveyable-class"]);
       }
     }
   });
@@ -691,7 +752,7 @@ describe("the staleness capability, per class", () => {
     // still has to account for.
     expect(classDenominator("human")).toEqual({
       surveyable: false,
-      reason: "not-a-surveyable-region",
+      reason: "non-surveyable-class",
     });
     expect(stalenessVerdict("human")).toEqual({
       kind: "unverified-since",

--- a/packages/api/src/lib/brain/class-contract.ts
+++ b/packages/api/src/lib/brain/class-contract.ts
@@ -163,6 +163,16 @@ export type ClassDenominator =
  * sentence, and the second one is a bug the page must be able to see.
  */
 export type StalenessVerdict =
+  /**
+   * A lag is COMPUTABLE for this class — not "this unit is stale", and not a
+   * lag anyone has measured yet.
+   *
+   * ⚠️ The threshold it would be measured against is NOT in this contract. See
+   * {@link stalenessVerdict} — the cadence ADR-0041 says the class contract owns
+   * has no declaration site yet, and a consumer must not substitute one. Stated
+   * on the member as well as on the function because a consumer that destructures
+   * the union never reads the function's docstring.
+   */
   | { readonly kind: "measured-lag" }
   | {
       readonly kind: "unverified-since";
@@ -417,13 +427,19 @@ export interface ClassContractLogMeta {
  *
  * ⚠️ **What happens next was MEASURED, and it is not what it looks like.** The
  * obvious reading is that the derivations would read `undefined` and fail closed
- * by accident — `vendorPublic` falsy, `activityMetadata` unequal to `"reports"`.
- * They would not. Dropping the narrow and indexing bare gives
- * `TypeError: undefined is not an object (evaluating 'contract.coverage.vendorPublic')`,
- * because the missing property is `coverage` and every derivation reaches
- * through it. So the cost of losing this narrow is a THROWN page render, not a
+ * by accident — a falsy flag here, an unequal comparison there. They would not.
+ * The missing property is `coverage` ITSELF, and every derivation reaches
+ * through it, so dropping the narrow and indexing bare gives a
+ * `TypeError: undefined is not an object` while evaluating `contract.coverage.*`
+ * in all three. The cost of losing this narrow is a THROWN page render, not a
  * withheld label — worse than fail-closed, and worth knowing before anyone
  * decides the narrow is redundant.
+ *
+ * Deliberately NOT quoting which property the message names. An earlier draft
+ * did, and the guard added one commit later (the non-surveyable refusal, which
+ * reads `denominator` before anything else) silently made the quote wrong — a
+ * measurement invalidated by an edit two functions away. The claim that survives
+ * reordering is the one about `coverage`.
  *
  * So there is deliberately no `Object.hasOwn` guard on the index, the way
  * `specOf` carries one in `sources.ts`. That function's parameter is typed
@@ -458,7 +474,18 @@ const FAIL_CLOSED_CONSEQUENCE = {
   classDenominator: "this class has no enumerable universe, so it falls out of every ratio",
 } as const;
 
-/** The derivations that can meet an unresolvable class — a closed set, so a rename cannot desync the log. */
+/**
+ * The derivations that can meet an unresolvable class.
+ *
+ * ⚠️ This closed set ties the call sites to the MAP above — NOT to the function
+ * names. On its own it lets a rename of `coverageLabelPolicy` leave the map key,
+ * the call-site literal and the logged `derivation` all spelling the dead name,
+ * with `tsc` clean and the logging test green (it asserts the string, not the
+ * binding). `_DERIVATION_NAMES_IN_SYNC` below is what actually closes that, and
+ * it is there rather than here because a comment claiming the tie was this
+ * module's third measured-false guarantee — the ratchet says the third one gets
+ * a mechanism.
+ */
 type ClassContractDerivation = keyof typeof FAIL_CLOSED_CONSEQUENCE;
 
 /** How long a stored class value may be before the log line truncates it. */
@@ -480,11 +507,21 @@ const CLASS_VALUE_LOG_MAX = 128;
  * `error-scrub.ts` truncates for the same stated reason — an oversized field
  * pushes the structured ones past log-aggregation size limits, which loses the
  * `workspaceId` this line exists to carry.
+ *
+ * ⚠️ **Strings are QUOTED, which is the same argument as the `null` spelling
+ * applied to the whole class rather than to one instance.** Unquoted, three real
+ * inputs were unreadable: `""` looked like a missing field, `"human "` (the
+ * whitespace near-miss that is exactly what an operator is debugging) looked
+ * like `human`, and a stored value of literally `"null"` was the sentinel for a
+ * real `null`. The only discriminant was whether `classValueLength` happened to
+ * be present — a rule nobody reading a log knows.
  */
 function describeClassValue(value: unknown): string {
   if (value === null) return "null";
   if (typeof value !== "string") return typeof value;
-  return value.length > CLASS_VALUE_LOG_MAX ? `${value.slice(0, CLASS_VALUE_LOG_MAX)}…` : value;
+  const shown =
+    value.length > CLASS_VALUE_LOG_MAX ? `${value.slice(0, CLASS_VALUE_LOG_MAX)}…` : value;
+  return JSON.stringify(shown);
 }
 
 /**
@@ -497,8 +534,12 @@ function describeClassValue(value: unknown): string {
  * rendering — but it is the line an operator needs to explain why a class went
  * quiet after a deploy.
  *
- * The diagnostic fields come AFTER the caller's `meta` in the spread, so a
- * caller cannot shadow them with its own `derivation` or `classValue`.
+ * The two context fields are named rather than spread. Excess-property checking
+ * only fires on a fresh literal, so `{...meta}` let a caller passing a WIDER
+ * variable — a request context, a job record — put every field it happened to
+ * carry into a line whose stated job is to stay small enough that `workspaceId`
+ * survives aggregation limits. Naming them also makes "a caller cannot shadow
+ * the diagnostics" structural instead of a fact about spread order.
  */
 function warnUnresolvable(
   value: unknown,
@@ -507,7 +548,8 @@ function warnUnresolvable(
 ): void {
   log.warn(
     {
-      ...meta,
+      workspaceId: meta?.workspaceId,
+      requestId: meta?.requestId,
       derivation,
       classValue: describeClassValue(value),
       classValueLength: typeof value === "string" ? value.length : undefined,
@@ -633,18 +675,9 @@ export function coverageLabelPolicy(
   unit: SurveyUnitDisclosureFacts,
   meta?: ClassContractLogMeta,
 ): CoverageLabelDecision {
-  // BEHAVIOUR DELTA — input classes × old vs new. Every changed row moves toward
-  // withholding; no row moves toward disclosure, and the new arm is an ADDITIVE
-  // refusal in front of the clauses rather than an edit to either one, so it
-  // cannot permit anything the old code refused.
-  //
-  //                                          old                      new
-  //   surveyable, deliberateAct              name/deliberate-act      unchanged
-  //   surveyable, class+unit both public     name/vendor-public       unchanged
-  //   surveyable, neither                    count/no-clause          unchanged
-  //   NON-surveyable, deliberateAct          name/deliberate-act  →   count/non-surveyable-class  ← CHANGED
-  //   NON-surveyable, neither                count/no-clause      →   count/non-surveyable-class  ← CHANGED (reason only)
-  //   unresolvable, any                      count/unresolvable       unchanged
+  // Order is load-bearing: see § "A NON-SURVEYABLE class gets no label either".
+  // The full old-vs-new input-class table lives in the commit that introduced
+  // the refusal, which is where "old" is unambiguous.
   const contract = contractOf(cls);
   if (!contract) {
     warnUnresolvable(cls, "coverageLabelPolicy", meta);
@@ -730,3 +763,31 @@ export function classDenominator(cls: unknown, meta?: ClassContractLogMeta): Cla
   }
   return contract.coverage.denominator;
 }
+
+
+/**
+ * Ties every {@link FAIL_CLOSED_CONSEQUENCE} key to the EXPORT that logs under
+ * it — SHORTHAND properties, so renaming a derivation without renaming its key
+ * is a `TS2304: Cannot find name`.
+ *
+ * The mechanism the type alias above cannot be. `ClassContractDerivation` is
+ * `keyof typeof FAIL_CLOSED_CONSEQUENCE`, which ties the call sites to the MAP
+ * and says nothing about the functions: rename `coverageLabelPolicy` and the
+ * key, the call-site literal and the logged `derivation` all keep the dead name
+ * with `tsc` clean and the logging test green, because that test asserts the
+ * string `"coverageLabelPolicy"` rather than the binding. An operator then greps
+ * a `derivation` field naming a function that no longer exists.
+ *
+ * Written as a mechanism rather than as a warning because a comment asserting
+ * this tie was the third measured-false guarantee in this module, and the repo's
+ * rule is that a principle violated twice gets a check rather than a third
+ * comment.
+ *
+ * Function declarations hoist, so this sits below them and still binds.
+ */
+const _DERIVATION_NAMES_IN_SYNC: Record<ClassContractDerivation, unknown> = {
+  coverageLabelPolicy,
+  stalenessVerdict,
+  classDenominator,
+};
+void _DERIVATION_NAMES_IN_SYNC;

--- a/packages/api/src/lib/brain/class-contract.ts
+++ b/packages/api/src/lib/brain/class-contract.ts
@@ -1,0 +1,520 @@
+/**
+ * The per-CLASS contract — ADR-0040's declaration site, carrying ADR-0041's
+ * three coverage properties (#5212).
+ *
+ * ## What this file is, and what it deliberately is not yet
+ *
+ * ADR-0040 decided that what the Atlas does with a connected source is a
+ * property of the source's CLASS, and named the declaration site: "a class-keyed
+ * sibling of `lib/brain/sources.ts` — a `Record<EpisodeSourceClass,
+ * ClassContract>` — not an extension of `EPISODE_SOURCE_SPECS`, whose keys are
+ * vendor-grained and would hand every vendor a slot to restate the trigger in".
+ * That Record is {@link CLASS_CONTRACTS}, and this is its first arrival in code.
+ *
+ * It arrives carrying ADR-0041's three properties ONLY — vendor-public,
+ * staleness capability, denominator source. ADR-0040's own arms (on-connect
+ * trigger, extraction, ACL derivation, perimeter) are prose in that ADR and have
+ * no implementation scheduled; they join {@link ClassContract} as siblings of
+ * {@link ClassContract.coverage} when they do. The nesting exists for exactly
+ * that reason and for no other: the coverage properties are a different
+ * decision's, and grouping them keeps a later reader able to see which ADR put
+ * each field here without consulting `git blame`.
+ *
+ * ## The one structural guarantee
+ *
+ * Record TOTALITY. `satisfies Record<EpisodeSourceClass, ClassContract>` makes a
+ * class added to `EPISODE_SOURCE_CLASSES` (`sources.ts`) without a contract a COMPILE
+ * ERROR rather than a silently missing row — ADR-0041's "Totality at compile
+ * time" and ADR-0040's "the Record forces the contract into the same one-line PR
+ * that adds the class", which is the same requirement stated from both ends.
+ *
+ * That guarantee holds only for a class the compiler can see. Every DERIVATION
+ * below therefore also carries a runtime arm for a class it cannot resolve — a
+ * value arriving through a cast, a separately-compiled plugin, a region import —
+ * and every one of those arms fails CLOSED and says so in the log. The posture
+ * is `classifyToken`'s unrecognised-principal arm (`oversight.ts`), copied
+ * deliberately: withhold, loudly, rather than fall through to a plausible
+ * answer.
+ *
+ * ## Why the coverage properties live HERE rather than in `coverage.ts`
+ *
+ * ADR-0041 makes `lib/brain/coverage.ts` a sibling module composing oversight,
+ * and these three fields are its inputs rather than its internals. Two of them
+ * gate DISCLOSURE ({@link ClassCoverageContract.vendorPublic}) and the honesty of
+ * a verdict ({@link ClassCoverageContract.activityMetadata}); putting them in the
+ * consumer would make each new consumer a new place the answer could be decided.
+ * The class contract is where a class answers for itself, once.
+ *
+ * ## Data and types only
+ *
+ * Nothing here knows how to call a vendor. `chat-channel-roster` names WHERE a
+ * denominator comes from; how Slack's `conversations.list` is paged, which
+ * scopes it needs and what it does on a 429 stay in connector code, which is
+ * ADR-0040's "vendor variation is confined to mechanics" applied to this file.
+ * A vendor-shaped import appearing here is the signal that the boundary moved.
+ */
+
+import { createLogger } from "@atlas/api/lib/logger";
+import { isEpisodeSourceClass, type EpisodeSourceClass } from "@atlas/api/lib/brain/sources";
+
+const log = createLogger("brain-class-contract");
+
+/**
+ * Can the class ask its vendor when a survey unit last moved?
+ *
+ * ADR-0041 defines stale as a MEASURED LAG — "vendor activity metadata shows
+ * source movement newer than our newest observed evidence by more than the
+ * class's sync cadence" — so a class that cannot read activity metadata cannot
+ * compute the lag, and must say "unverified since \<date\>" instead of guessing
+ * in either direction. See {@link stalenessVerdictKind}, which is the only place
+ * that consequence is spelled.
+ *
+ * `absent` is not a defect to be fixed later. For `human` there is no vendor to
+ * ask at all, and for `warehouse` the honest answer is that no general one
+ * exists: a survey unit there is an (entity, dimension) pair, and asking when it
+ * last moved means a freshness query per entity against the customer's own
+ * warehouse — which not every entity can answer (many have no timestamp column)
+ * and which ADR-0041 rules out on the page anyway ("never live vendor calls on
+ * page view"). Declaring `absent` is what makes those units read "unverified
+ * since" rather than silently never appearing stale.
+ */
+export type VendorActivityMetadata = "reports" | "absent";
+
+/**
+ * Where a class's enumerable universe comes from — the DENOMINATOR side of every
+ * ratio on the Coverage Surface.
+ *
+ * A closed vocabulary rather than free text, and NO TWO CLASSES SHARE A MEMBER.
+ * That is not tidiness: it is ADR-0041's "No single number, permanently" made
+ * structural. The layers are incommensurable — a channel is not a mailbox is not
+ * an entity-dimension — so any blend across them needs invented weights, and a
+ * shared origin slug is the first thing that would make a blend look defensible.
+ * `class-contract.test.ts` asserts the uniqueness so a future class cannot
+ * quietly reuse one.
+ *
+ * Every member is also CREDENTIAL-RELATIVE by construction, which is ADR-0041's
+ * other refusal: `chat-channel-roster` is the roster under granted scopes, not
+ * every channel the workspace has, and `granted-recording-scopes` says so in its
+ * name. No member of this vocabulary means "the company".
+ */
+export type SurveyUnitOrigin =
+  /** The channel roster the granted scopes can enumerate. Units are channels. */
+  | "chat-channel-roster"
+  /** The recordings inside granted recording scopes. Units are recordings. */
+  | "granted-recording-scopes"
+  /** The mailboxes the install can enumerate. Units are mailboxes — counted, never named. */
+  | "mailbox-list"
+  /** Semantic-layer entities crossed with the dimensions a human enrolled (ADR-0039). */
+  | "semantic-layer-enrollment";
+
+/**
+ * A class's denominator, or its explicit refusal to have one.
+ *
+ * A discriminated union rather than `SurveyUnitOrigin | null`, because
+ * `surveyable: false` is a POSITIVE claim this file makes about `human` —
+ * ADR-0041's "human: none — not a surveyable region" — and reading it off an
+ * absent field would make "we decided there is no universe here" indistinguishable
+ * from "nobody has filled this in yet". The Coverage Surface must render those
+ * two differently: the first is a class that correctly never appears in a ratio,
+ * the second is a bug.
+ */
+export type ClassDenominator =
+  | { readonly surveyable: true; readonly enumeratedFrom: SurveyUnitOrigin }
+  | { readonly surveyable: false };
+
+/** ADR-0041's three properties, as one class answers them. */
+export interface ClassCoverageContract {
+  /**
+   * May this class's units EVER qualify for the vendor-public label clause?
+   *
+   * ⚠️ **A class-level admissibility gate, not a per-unit verdict** — read the
+   * two together or you will get this backwards. ADR-0041's second label clause
+   * is "vendor-public existence — the unit's existence is unconditionally
+   * visible to every member of the vendor workspace (a public Slack channel's
+   * name, by Slack's own definition)". Whether a PARTICULAR channel is public is
+   * the vendor's answer about that channel; this flag says whether the class has
+   * any such notion for the clause to lean on at all.
+   *
+   * The two are ANDed in {@link coverageLabelPolicy}, so a class declaring
+   * `false` cannot be overridden by a caller claiming a unit is public — which
+   * is the direction that matters, because the caller's claim comes from vendor
+   * data and this flag is where a human decided the vendor's notion of "public"
+   * is one Atlas will disclose on.
+   *
+   * **Defaults closed.** `true` on `chat` alone today, and that entry carries
+   * the argument. A class must argue its way open, the same posture
+   * `classifyToken`'s unknown-namespace arm takes: the clause leans on each
+   * vendor's notion of "public", and a class that has not been examined has not
+   * had that notion examined either.
+   */
+  readonly vendorPublic: boolean;
+
+  /** See {@link VendorActivityMetadata} — whether "stale" is computable at all. */
+  readonly activityMetadata: VendorActivityMetadata;
+
+  /** See {@link ClassDenominator} — the enumerable universe, or the refusal of one. */
+  readonly denominator: ClassDenominator;
+}
+
+/**
+ * What one class declares about itself.
+ *
+ * One field today. ADR-0040's arms — on-connect trigger, extraction, ACL
+ * derivation, perimeter — join as siblings of {@link coverage} when that ADR's
+ * implementation is scheduled; nothing about the coverage shape has to move when
+ * they do, which is the whole reason for the nesting.
+ */
+export interface ClassContract {
+  readonly coverage: ClassCoverageContract;
+}
+
+/**
+ * THE contract, per class — ADR-0040's declaration site.
+ *
+ * Frozen at every level, not merely `as const`. `as const` is a TYPE-level
+ * assertion and leaves the object mutable at runtime, and this map is a
+ * DISCLOSURE gate: a single write to `CLASS_CONTRACTS.email.coverage.vendorPublic`
+ * would open mailbox naming — the disclosure ADR-0041 refuses by name — with no
+ * log, no throw and no red test, because every reader would see the same mutated
+ * map and stay agreed while all of them were wrong. That is `sources.ts`'s
+ * argument for freezing `EPISODE_SOURCE_SPECS`, and it applies with the same
+ * force one seam over. The nested objects need their own freeze because
+ * `Object.freeze` is shallow, and the gate lives two levels down.
+ *
+ * `satisfies Record<EpisodeSourceClass, ClassContract>` on the frozen result is
+ * the totality gate; the per-entry `satisfies` inside is not redundant with it.
+ * `Object.freeze(...)` is a CALL RESULT rather than a fresh object literal, and
+ * TypeScript only runs excess-property checking against a fresh literal — so
+ * without the inner ones, an invented field (`vendorPublik`, `stale`) lands in
+ * the contract unnoticed, on the map whose job is to be the single place a class
+ * answers for itself.
+ *
+ * ⚠️ What NEITHER check does is verify the answer is RIGHT. Nothing in the type
+ * system knows what "vendor-public" means; a new class declaring `vendorPublic:
+ * true` compiles clean. The defaults are what make that survivable — a class
+ * copied from `human` discloses nothing — and `class-contract.test.ts`'s pinned
+ * table is what forces an author to confront each answer deliberately.
+ */
+export const CLASS_CONTRACTS = Object.freeze({
+  /**
+   * The one class that argues its way open on `vendorPublic`, and the only one
+   * ADR-0041 names: a public Slack channel's name is visible to every member of
+   * the workspace by Slack's own definition, so labelling one on the Coverage
+   * Surface discloses to an admin nothing that any member could not already read
+   * off the channel browser. Private channels in the same class are NOT thereby
+   * disclosable — that is the per-unit half, and {@link coverageLabelPolicy} ANDs
+   * the two.
+   */
+  chat: Object.freeze({
+    coverage: Object.freeze({
+      vendorPublic: true,
+      activityMetadata: "reports",
+      denominator: Object.freeze({ surveyable: true, enumeratedFrom: "chat-channel-roster" }),
+    }),
+  } as const satisfies ClassContract),
+
+  /**
+   * `vendorPublic: false`. A recording's existence is not workspace-public: a
+   * meeting is visible to its participants and to whoever holds the recording
+   * scope, which is the same population whose ACL the transcript class derives
+   * from a frozen participant list (`sources.ts`, `TRANSCRIPT_CLASS`). Naming a
+   * recording names a meeting a reader may not have been in.
+   */
+  transcript: Object.freeze({
+    coverage: Object.freeze({
+      vendorPublic: false,
+      activityMetadata: "reports",
+      denominator: Object.freeze({ surveyable: true, enumeratedFrom: "granted-recording-scopes" }),
+    }),
+  } as const satisfies ClassContract),
+
+  /**
+   * `vendorPublic: false`, and this is the class where the refusal is sharpest:
+   * ADR-0041 spells it out — "naming a mailbox is naming a person" — so the
+   * email class's state-2 display is "N mailboxes enumerated, M surveyed" with no
+   * list. The denominator still exists and is still counted; it is the LABEL that
+   * is withheld, which is the whole of the counts-always/labels-by-clause split.
+   */
+  email: Object.freeze({
+    coverage: Object.freeze({
+      vendorPublic: false,
+      activityMetadata: "reports",
+      denominator: Object.freeze({ surveyable: true, enumeratedFrom: "mailbox-list" }),
+    }),
+  } as const satisfies ClassContract),
+
+  /**
+   * The one surveyable class whose units are freely NAMABLE anyway, and it gets
+   * there by the other clause rather than this one. `vendorPublic: false` because
+   * a warehouse has no notion of workspace-public entities; the labels appear
+   * because enrollment is a DELIBERATE ACT (ADR-0039 — a human enrolled the
+   * dimension) and because the admin authored the semantic layer the entities
+   * come from. Pinning that distinction is why {@link CoverageLabelDecision}
+   * carries the clause that fired rather than a bare boolean.
+   *
+   * `activityMetadata: "absent"` — see {@link VendorActivityMetadata}.
+   */
+  warehouse: Object.freeze({
+    coverage: Object.freeze({
+      vendorPublic: false,
+      activityMetadata: "absent",
+      denominator: Object.freeze({
+        surveyable: true,
+        enumeratedFrom: "semantic-layer-enrollment",
+      }),
+    }),
+  } as const satisfies ClassContract),
+
+  /**
+   * Explicitly non-surveyable, and present for exactly that reason. A person's
+   * own recorded words (`correct_fact`'s correction episode) come from no
+   * connector, no credential enumerates "the set of humans who might state
+   * something", and ADR-0041's map has no cell for them: `human: none — not a
+   * surveyable region`.
+   *
+   * Omitting the class would have said the same thing far more weakly — an
+   * absent row is indistinguishable from an unfinished one, and the Record's
+   * totality gate exists precisely so that no class is absent. Declaring the
+   * refusal is what lets the Coverage Surface leave `human` out of every ratio on
+   * purpose rather than by accident.
+   */
+  human: Object.freeze({
+    coverage: Object.freeze({
+      vendorPublic: false,
+      activityMetadata: "absent",
+      denominator: Object.freeze({ surveyable: false }),
+    }),
+  } as const satisfies ClassContract),
+}) satisfies Record<EpisodeSourceClass, ClassContract>;
+
+/**
+ * Compile-time tie between the Record's KEYS and the closed class set, in the
+ * shape `sources.ts` uses for the same job (`_CLASS_AXIS_IN_SYNC`).
+ *
+ * The `satisfies` above already makes a MISSING class an error. This catches the
+ * other direction — a key that is not a class — which `satisfies` does not,
+ * because `Object.freeze(...)` is a call result and excess-property checking
+ * only fires on a fresh literal. An extra key is harmless at runtime (nothing
+ * would read it) and corrosive on the page: it is a contract somebody wrote for
+ * a class that does not exist, and it would sit here looking answered.
+ */
+type MutuallyAssignable<A, B> = [A] extends [B] ? ([B] extends [A] ? true : never) : never;
+const _CONTRACT_KEYS_IN_SYNC: MutuallyAssignable<
+  keyof typeof CLASS_CONTRACTS,
+  EpisodeSourceClass
+> = true;
+void _CONTRACT_KEYS_IN_SYNC;
+
+/** Diagnostic context a caller can attach to the fail-closed log lines. */
+export interface ClassContractLogMeta {
+  readonly workspaceId?: string;
+  readonly requestId?: string;
+}
+
+/**
+ * The contract for a class, or `null` when the value is not one this deploy can
+ * resolve — the total lookup every derivation below is built on.
+ *
+ * `unknown` rather than `EpisodeSourceClass` for the same reason
+ * `episodeSourceClassOf` takes it: the values that make a fail-closed arm worth
+ * having are exactly the ones no type system has checked. A region import
+ * restores a bundle's stored `source` verbatim (`sources.ts`, § "Where that lane
+ * is closed"), a separately-compiled plugin reaches the registry as data, and
+ * `row.source as EpisodeSource` is the cast someone writes when neither of those
+ * is on their mind.
+ *
+ * The narrow is what makes the bare index below safe, and it carries two jobs
+ * rather than one. Obviously it refuses `"docs"`. Less obviously it refuses
+ * `"toString"` and `"constructor"` — `CLASS_CONTRACTS["toString"]` would
+ * otherwise resolve up the PROTOTYPE CHAIN to a function whose `.coverage` is
+ * `undefined`, and a derivation reading `vendorPublic` off that gets `undefined`
+ * (falsy, so the disclosure gate happens to hold) while `activityMetadata`
+ * compares unequal to `"reports"` (so that one happens to hold too). Both would
+ * fail closed BY ACCIDENT — not a property worth relying on, and not one that
+ * survives the next field added here.
+ *
+ * So there is deliberately no `Object.hasOwn` guard on the index, the way
+ * `specOf` carries one in `sources.ts`. That function's parameter is typed
+ * `EpisodeSource` with no runtime narrow in front of it, so its guard is the
+ * only thing standing between a cast and the prototype chain; here the narrow is
+ * already that thing, and a second guard behind it would be an arm no input can
+ * reach carrying a comment claiming it does work. `class-contract.test.ts` puts
+ * the prototype keys through every derivation, which is where that claim is
+ * checked rather than asserted.
+ *
+ * Not exported. Every caller wants one of the three derivations, each of which
+ * has its own fail-closed answer and its own log line; handing out the `null`
+ * would make each new consumer a new place to decide what `null` means.
+ */
+function contractOf(value: unknown): ClassContract | null {
+  return isEpisodeSourceClass(value) ? CLASS_CONTRACTS[value] : null;
+}
+
+/**
+ * Log an unresolvable class once, in one voice, from whichever derivation met it.
+ *
+ * `log.warn` and not `debug`: reaching any of these with a class this deploy
+ * cannot resolve means a survey unit is being counted whose contract nobody has
+ * written, and the surface is about to under-report it. Not an error — the
+ * fail-closed answer is a correct answer, and ADR-0041 wants the page to keep
+ * rendering — but it is the line an operator needs to explain why a class went
+ * quiet after a deploy.
+ */
+function warnUnresolvable(value: unknown, derivation: string, meta?: ClassContractLogMeta): void {
+  log.warn(
+    { ...meta, derivation, classValue: typeof value === "string" ? value : typeof value },
+    "brain class contract: no contract for this source class — failing closed",
+  );
+}
+
+/** Why a survey unit's label may be shown, or why it may not. */
+export type CoverageLabelDecision =
+  | {
+      readonly policy: "name";
+      /**
+       * Which of ADR-0041's two clauses admitted it. Carried rather than
+       * collapsed to a boolean because the clauses are separately revocable and
+       * separately arguable, and because a test that cannot tell them apart
+       * cannot catch a change that swaps which one is doing the work — the
+       * warehouse entry is exactly that case, labelled under `deliberate-act`
+       * while declaring `vendorPublic: false`.
+       */
+      readonly clause: "deliberate-act" | "vendor-public";
+    }
+  | {
+      readonly policy: "count-only";
+      /**
+       * `no-clause` is the ordinary withhold — an enumerated mailbox nobody
+       * named. `unresolvable-class` is the fail-closed arm, kept distinct so the
+       * surface can tell "we counted this and correctly did not name it" from
+       * "we do not know what this is", which are different sentences to an
+       * admin and only one of them is a bug.
+       */
+      readonly reason: "no-clause" | "unresolvable-class";
+    };
+
+/** What the caller knows about ONE survey unit, as opposed to about its class. */
+export interface SurveyUnitDisclosureFacts {
+  /**
+   * Did a human deliberately act on this unit — install-form entry, membership,
+   * exclusion, enrollment? ADR-0041's first label clause, unchanged from
+   * `classifyToken`'s `configured` arm: the admin typed the id, so showing it
+   * back discloses nothing they did not supply.
+   */
+  readonly deliberateAct: boolean;
+
+  /**
+   * Does the VENDOR report this unit's existence as unconditionally visible to
+   * every member of the vendor workspace?
+   *
+   * Named apart from {@link ClassCoverageContract.vendorPublic} on purpose.
+   * `sources.ts`'s header spends a section on two axes spelled identically and
+   * the constants that make them interchangeable; two booleans both called
+   * `vendorPublic` would be that hazard rebuilt at a disclosure gate, where
+   * swapping them silently turns a class-level refusal into a per-unit one.
+   * This one is the vendor's answer about this unit; that one is whether the
+   * class will lean on the vendor's answer at all.
+   */
+  readonly vendorReportsPublic: boolean;
+}
+
+/**
+ * May the Coverage Surface NAME this survey unit, or only count it?
+ *
+ * ADR-0041's label rule, whole: **counts are always disclosable; a label appears
+ * only under the deliberate-act clause or the vendor-public clause.** Everything
+ * else is counted and never named.
+ *
+ * Deliberate-act is checked FIRST, and the order is visible in the result rather
+ * than hidden: when both clauses would admit a unit the decision reports
+ * `deliberate-act`, because that clause is the older one, is the one that does
+ * not depend on any vendor's notion of "public", and is the one whose
+ * justification survives the vendor changing that notion.
+ *
+ * ## The fail-closed arm, and why it suppresses BOTH clauses
+ *
+ * A class this deploy cannot resolve yields `count-only` /
+ * `unresolvable-class` — no label, under either clause, whatever the caller
+ * passed.
+ *
+ * The deliberate-act clause is not itself class-dependent, so suppressing it
+ * needs its own argument, and it is this: every act the clause enumerates is
+ * CLASS-SPECIFIC MACHINERY — an install form for chat, an exclusion list, an
+ * enrollment for the warehouse. A class with no contract here has none of that
+ * machinery built, so a caller asserting `deliberateAct: true` for one is
+ * asserting a fact about a form that does not exist. The flag would be arriving
+ * from somewhere that cannot have computed it correctly, and a disclosure gate
+ * is the wrong place to extend the benefit of the doubt.
+ *
+ * Counts are untouched by any of this — {@link classDenominator} decides
+ * separately whether the class has a universe to count, and ADR-0041's whole
+ * point is that a count carries no claim content and no audience content.
+ */
+export function coverageLabelPolicy(
+  cls: unknown,
+  unit: SurveyUnitDisclosureFacts,
+  meta?: ClassContractLogMeta,
+): CoverageLabelDecision {
+  const contract = contractOf(cls);
+  if (!contract) {
+    warnUnresolvable(cls, "coverageLabelPolicy", meta);
+    return { policy: "count-only", reason: "unresolvable-class" };
+  }
+  if (unit.deliberateAct) return { policy: "name", clause: "deliberate-act" };
+  if (contract.coverage.vendorPublic && unit.vendorReportsPublic) {
+    return { policy: "name", clause: "vendor-public" };
+  }
+  return { policy: "count-only", reason: "no-clause" };
+}
+
+/**
+ * Which staleness sentence a class's units are entitled to.
+ *
+ * `measured-lag` licenses "stale" — the class can read vendor activity metadata,
+ * so the surface may compare source movement against our newest observed
+ * evidence and report a lag it actually measured. `unverified-since` is the
+ * other sentence and the only other one: "unverified since \<date of last
+ * successful cycle\>", which claims nothing about whether the source moved.
+ *
+ * ⚠️ This answers the CAPABILITY question only. A class that can measure the lag
+ * still shows "unverified since" whenever the pipe is sick, because a broken
+ * cycle means we did not look — ADR-0041 puts both cases on the same sentence.
+ * That arm is runtime state and belongs to the coverage module; nothing in this
+ * file can see it, so `measured-lag` here means "stale is computable for this
+ * class", never "this unit is stale".
+ *
+ * Unresolvable class → `unverified-since`. Fail-closed in the honest direction:
+ * the alternative would let a class nobody has written a contract for produce
+ * the word "stale" about a source no code in this deploy knows how to look at.
+ */
+export function stalenessVerdictKind(
+  cls: unknown,
+  meta?: ClassContractLogMeta,
+): "measured-lag" | "unverified-since" {
+  const contract = contractOf(cls);
+  if (!contract) {
+    warnUnresolvable(cls, "stalenessVerdictKind", meta);
+    return "unverified-since";
+  }
+  return contract.coverage.activityMetadata === "reports" ? "measured-lag" : "unverified-since";
+}
+
+/**
+ * The class's enumerable universe, or its refusal to have one.
+ *
+ * Unresolvable class → `{ surveyable: false }`. This is the arm ADR-0041's
+ * fabrication discipline decides: a denominator for a class whose enumeration
+ * nothing in this deploy knows how to perform would be a number with no universe
+ * behind it, and "a silent zero here is a false statement, not an error state".
+ * Refusing to be surveyable makes the class fall out of every ratio, which is
+ * the same treatment `human` gets by declaration and the same shape the map edge
+ * takes: a mark, never a number.
+ */
+export function classDenominator(cls: unknown, meta?: ClassContractLogMeta): ClassDenominator {
+  const contract = contractOf(cls);
+  if (!contract) {
+    warnUnresolvable(cls, "classDenominator", meta);
+    return { surveyable: false };
+  }
+  return contract.coverage.denominator;
+}

--- a/packages/api/src/lib/brain/class-contract.ts
+++ b/packages/api/src/lib/brain/class-contract.ts
@@ -43,9 +43,9 @@
  * below therefore also carries a runtime arm for a class it cannot resolve — a
  * value arriving through a cast, a separately-compiled plugin, a region import —
  * and every one of those arms fails CLOSED and says so in the log. The posture
- * is `classifyToken`'s unrecognised-principal arm (`oversight.ts`), copied
- * deliberately: withhold, loudly, rather than fall through to a plausible
- * answer.
+ * is the one `classifyToken` takes on an unrecognised principal kind
+ * (`oversight.ts`), copied deliberately: withhold, loudly, rather than fall
+ * through to a plausible answer.
  *
  * ## Why the coverage properties live HERE rather than in `coverage.ts`
  *
@@ -122,34 +122,43 @@ export type SurveyUnitOrigin =
  * A class's denominator, or its explicit refusal to have one.
  *
  * A discriminated union rather than `SurveyUnitOrigin | null`, because
- * `surveyable: false` is a POSITIVE claim this file makes about `human` —
- * ADR-0041's "human: none — not a surveyable region" — and reading it off an
- * absent field would make "we decided there is no universe here" indistinguishable
- * from "nobody has filled this in yet". The Coverage Surface must render those
- * two differently: the first is a class that correctly never appears in a ratio,
- * the second is a bug.
+ * `surveyable: false` is a POSITIVE claim this file makes about `human`.
+ * ADR-0040's contract table gives that class no connector and no perimeter
+ * ("not connectable … the person's own statement"), so no credential enumerates
+ * it; *not a surveyable region* is issue #5212's phrasing for that consequence,
+ * and this module's name for it — NOT a quote from either ADR. Reading the
+ * refusal off an absent field would make "we decided there is no universe here"
+ * indistinguishable from "nobody has filled this in yet". The Coverage Surface
+ * must render those two differently: the first is a class that correctly never
+ * appears in a ratio, the second is a bug.
+ */
+/**
+ * What a class may DECLARE about its universe, in {@link CLASS_CONTRACTS}.
+ *
+ * `non-surveyable-class` is `human`'s declared refusal — an affirmative product
+ * statement, and a class that correctly never appears in a ratio.
+ *
+ * ⚠️ The fail-closed reason is deliberately NOT in this union. "We could not
+ * resolve this class" is never a true statement about an entry sitting in the
+ * map, and the map is the only producer of a declared denominator — so a
+ * contract declaring it is unrepresentable rather than merely untested.
+ */
+export type DeclaredDenominator =
+  | { readonly surveyable: true; readonly enumeratedFrom: SurveyUnitOrigin }
+  | { readonly surveyable: false; readonly reason: "non-surveyable-class" };
+
+/**
+ * What a DERIVATION returns — a declaration, or the fail-closed refusal.
+ *
+ * The reason is what the surface renders differently, and its omission was the
+ * original defect: without it the two refusals are byte-identical and only a
+ * `log.warn` separates them, which a page cannot read. ADR-0041 calls a silent
+ * zero here "a false statement, not an error state", so the page owes a "cannot
+ * establish" arm for the fail-closed one rather than a clean absence.
  */
 export type ClassDenominator =
-  | { readonly surveyable: true; readonly enumeratedFrom: SurveyUnitOrigin }
-  | {
-      readonly surveyable: false;
-      /**
-       * WHY there is no universe, which the surface must render differently.
-       *
-       * `not-a-surveyable-region` is `human`'s declared refusal — an affirmative
-       * product statement, and a class that correctly never appears in a ratio.
-       * `unresolvable-class` is the fail-closed arm: we do not know what this is,
-       * and ADR-0041 calls a silent zero here "a false statement, not an error
-       * state", so the page owes a "cannot establish" arm rather than a clean
-       * absence.
-       *
-       * Carried for the same reason {@link CoverageLabelDecision} carries its
-       * reason, and the omission was the defect: without it the two arms are
-       * byte-identical and only a `log.warn` separates them — and a page cannot
-       * read a log.
-       */
-      readonly reason: "not-a-surveyable-region" | "unresolvable-class";
-    };
+  | DeclaredDenominator
+  | { readonly surveyable: false; readonly reason: "unresolvable-class" };
 
 /**
  * Which staleness sentence a class's units are entitled to.
@@ -200,17 +209,17 @@ export interface ClassCoverageContract {
    *
    * **Defaults closed.** `true` on `chat` alone today, and that entry carries
    * the argument. A class must argue its way open, the same posture
-   * `classifyToken`'s unknown-namespace arm takes: the clause leans on each
-   * vendor's notion of "public", and a class that has not been examined has not
-   * had that notion examined either.
+   * `classifyToken` takes on an unrecognised principal kind: the clause leans on
+   * each vendor's notion of "public", and a class that has not been examined has
+   * not had that notion examined either.
    */
   readonly vendorPublic: boolean;
 
   /** See {@link VendorActivityMetadata} — whether "stale" is computable at all. */
   readonly activityMetadata: VendorActivityMetadata;
 
-  /** See {@link ClassDenominator} — the enumerable universe, or the refusal of one. */
-  readonly denominator: ClassDenominator;
+  /** See {@link DeclaredDenominator} — the enumerable universe, or the refusal of one. */
+  readonly denominator: DeclaredDenominator;
 }
 
 /**
@@ -261,7 +270,7 @@ export interface ClassContract {
  * (`class-contract.test.ts`, "carries a `satisfies` at EVERY level"), because
  * nothing else can: a `satisfies` is erased at runtime and asserts nothing about
  * itself, so deleting one here is invisible to `tsc` and to every behavioural
- * test. Measured — removing this entry's level-2 annotation leaves both clean.
+ * test. Measured — removing an entry's level-2 annotation leaves both clean.
  * The `@ts-expect-error` pins beside it are a DIFFERENT guarantee: they hold
  * that {@link ClassCoverageContract} and {@link ClassDenominator} are closed, so
  * that these annotations have something to bite on.
@@ -271,6 +280,16 @@ export interface ClassContract {
  * true` compiles clean. The defaults are what make that survivable — a class
  * copied from `human` discloses nothing — and `class-contract.test.ts`'s pinned
  * table is what forces an author to confront each answer deliberately.
+ *
+ * ⚠️ **Exported for DECLARATION and for the contract tests, not for lookup.**
+ * Read a class's answer through {@link coverageLabelPolicy},
+ * {@link stalenessVerdict} or {@link classDenominator} — every one of them
+ * carries a fail-closed arm and a log line for a class this deploy cannot
+ * resolve. Indexing this map directly (`CLASS_CONTRACTS[row.source as
+ * EpisodeSourceClass]`) bypasses all three silently, which is precisely the
+ * "each new consumer is a new place the answer could be decided" failure the
+ * unexported {@link contractOf} exists to prevent — arriving through this
+ * export instead.
  */
 export const CLASS_CONTRACTS = Object.freeze({
   /**
@@ -289,7 +308,7 @@ export const CLASS_CONTRACTS = Object.freeze({
       denominator: Object.freeze({
         surveyable: true,
         enumeratedFrom: "chat-channel-roster",
-      } as const satisfies ClassDenominator),
+      } as const satisfies DeclaredDenominator),
     } as const satisfies ClassCoverageContract),
   } as const satisfies ClassContract),
 
@@ -307,7 +326,7 @@ export const CLASS_CONTRACTS = Object.freeze({
       denominator: Object.freeze({
         surveyable: true,
         enumeratedFrom: "granted-recording-scopes",
-      } as const satisfies ClassDenominator),
+      } as const satisfies DeclaredDenominator),
     } as const satisfies ClassCoverageContract),
   } as const satisfies ClassContract),
 
@@ -325,7 +344,7 @@ export const CLASS_CONTRACTS = Object.freeze({
       denominator: Object.freeze({
         surveyable: true,
         enumeratedFrom: "mailbox-list",
-      } as const satisfies ClassDenominator),
+      } as const satisfies DeclaredDenominator),
     } as const satisfies ClassCoverageContract),
   } as const satisfies ClassContract),
 
@@ -347,16 +366,17 @@ export const CLASS_CONTRACTS = Object.freeze({
       denominator: Object.freeze({
         surveyable: true,
         enumeratedFrom: "semantic-layer-enrollment",
-      } as const satisfies ClassDenominator),
+      } as const satisfies DeclaredDenominator),
     } as const satisfies ClassCoverageContract),
   } as const satisfies ClassContract),
 
   /**
    * Explicitly non-surveyable, and present for exactly that reason. A person's
    * own recorded words (`correct_fact`'s correction episode) come from no
-   * connector, no credential enumerates "the set of humans who might state
-   * something", and ADR-0041's map has no cell for them: `human: none — not a
-   * surveyable region`.
+   * connector, and no credential enumerates "the set of humans who might state
+   * something" — ADR-0040's contract table gives the class no perimeter at all
+   * ("not connectable"). ADR-0041 never assigns it a denominator because that
+   * ADR only ever discusses classes a credential can enumerate.
    *
    * Omitting the class would have said the same thing far more weakly — an
    * absent row is indistinguishable from an unfinished one, and the Record's
@@ -370,8 +390,8 @@ export const CLASS_CONTRACTS = Object.freeze({
       activityMetadata: "absent",
       denominator: Object.freeze({
         surveyable: false,
-        reason: "not-a-surveyable-region",
-      } as const satisfies ClassDenominator),
+        reason: "non-surveyable-class",
+      } as const satisfies DeclaredDenominator),
     } as const satisfies ClassCoverageContract),
   } as const satisfies ClassContract),
 }) satisfies Record<EpisodeSourceClass, ClassContract>;
@@ -393,6 +413,51 @@ const _CONTRACT_KEYS_IN_SYNC: MutuallyAssignable<
   EpisodeSourceClass
 > = true;
 void _CONTRACT_KEYS_IN_SYNC;
+
+
+/**
+ * The three reason vocabularies, pinned CLOSED — mutual assignability, so BOTH
+ * growth and shrinkage are errors here rather than somewhere downstream.
+ *
+ * The `@ts-expect-error` pins in `class-contract.test.ts` were believed to do
+ * this and measurably do not: an invented literal is not assignable to a union
+ * whether or not a fourth member exists, so those directives pin only that the
+ * field is not `string`. Adding a fourth reason left `tsc` clean — the module's
+ * fourth measured-false guarantee, and by the same ratchet it gets a mechanism
+ * rather than a corrected comment.
+ *
+ * Why it matters: each reason is a different SENTENCE the Coverage Surface says
+ * to an admin. A fourth arriving with no consumer forced to handle it is how one
+ * of those sentences silently becomes "some other case", which is the fabrication
+ * ADR-0041 refuses.
+ */
+const _LABEL_REASONS_CLOSED: MutuallyAssignable<
+  Extract<CoverageLabelDecision, { policy: "count-only" }>["reason"],
+  "no-clause" | "non-surveyable-class" | "unresolvable-class"
+> = true;
+void _LABEL_REASONS_CLOSED;
+
+const _DENOMINATOR_REASONS_CLOSED: MutuallyAssignable<
+  Extract<ClassDenominator, { surveyable: false }>["reason"],
+  "non-surveyable-class" | "unresolvable-class"
+> = true;
+void _DENOMINATOR_REASONS_CLOSED;
+
+const _STALENESS_REASONS_CLOSED: MutuallyAssignable<
+  Extract<StalenessVerdict, { kind: "unverified-since" }>["reason"],
+  "no-activity-metadata" | "unresolvable-class"
+> = true;
+void _STALENESS_REASONS_CLOSED;
+
+/**
+ * …and the DECLARED denominator's reason, which is narrower than the derived
+ * one on purpose: the map may never declare the fail-closed reason.
+ */
+const _DECLARED_DENOMINATOR_REASON_CLOSED: MutuallyAssignable<
+  Extract<DeclaredDenominator, { surveyable: false }>["reason"],
+  "non-surveyable-class"
+> = true;
+void _DECLARED_DENOMINATOR_REASON_CLOSED;
 
 /**
  * Diagnostic context a caller attaches to the fail-closed log lines.
@@ -425,28 +490,35 @@ export interface ClassContractLogMeta {
  * `"toString"` and `"constructor"`: `CLASS_CONTRACTS["toString"]` resolves up the
  * PROTOTYPE CHAIN to a function, whose `.coverage` is `undefined`.
  *
- * ⚠️ **What happens next was MEASURED, and it is not what it looks like.** The
- * obvious reading is that the derivations would read `undefined` and fail closed
- * by accident — a falsy flag here, an unequal comparison there. They would not.
- * The missing property is `coverage` ITSELF, and every derivation reaches
- * through it, so dropping the narrow and indexing bare gives a
- * `TypeError: undefined is not an object` while evaluating `contract.coverage.*`
- * in all three. The cost of losing this narrow is a THROWN page render, not a
- * withheld label — worse than fail-closed, and worth knowing before anyone
- * decides the narrow is redundant.
+ * ⚠️ **What happens next was MEASURED, and it SPLITS** — which matters, because
+ * both of the tidy one-line answers are wrong. For an unknown slug (`"docs"`),
+ * for `null`, for a number or a plain object, the bare index yields `undefined`,
+ * `!contract` catches it, and the derivations fail closed exactly as they do
+ * today — by accident, but correctly. The PROTOTYPE keys are the other half:
+ * `CLASS_CONTRACTS["toString"]` resolves to a FUNCTION, which is truthy, so
+ * `!contract` misses it and reading through `contract.coverage` throws
+ * `TypeError: undefined is not an object` (bun's wording; V8 says "Cannot read
+ * properties of undefined").
  *
- * Deliberately NOT quoting which property the message names. An earlier draft
+ * Measured over `class-contract.test.ts`'s hostile corpus: 6 throw, 15 fail
+ * closed. So the cost of losing this narrow is a THROWN page render on the six
+ * — worse than fail-closed, and worth knowing before anyone decides the narrow
+ * is redundant.
+ *
+ * Deliberately NOT quoting WHICH property the message names. An earlier draft
  * did, and the guard added one commit later (the non-surveyable refusal, which
- * reads `denominator` before anything else) silently made the quote wrong — a
- * measurement invalidated by an edit two functions away. The claim that survives
- * reordering is the one about `coverage`.
+ * reads `denominator` before anything else) silently made the quote wrong. The
+ * three derivations do not even agree with each other — two throw on
+ * `denominator`, one on `activityMetadata` — so any single property name would
+ * have been wrong for at least one arm from the day it was written.
  *
  * So there is deliberately no `Object.hasOwn` guard on the index, the way
- * `specOf` carries one in `sources.ts`. That function's parameter is typed
- * `EpisodeSource` with no runtime narrow in front of it, so its guard is the
- * only thing standing between a cast and the prototype chain; here the narrow is
- * already that thing, and a second guard behind it would be an arm no input can
- * reach carrying a comment claiming it does work. `class-contract.test.ts` puts
+ * `specOf` carries one in `sources.ts`. That function does not narrow its own
+ * parameter, so its guard is the BACKSTOP for a caller that skipped
+ * `isEpisodeSource` — its own docstring says exactly that, "the backstop, not
+ * the gate". Here the narrow is in front of the index, so a second guard behind
+ * it would be an arm no input can reach, carrying a comment claiming it does
+ * work. `class-contract.test.ts` puts
  * the prototype keys through every derivation, and dropping this narrow reddens
  * exactly three of its tests — which is where the claim is checked rather than
  * asserted.
@@ -466,7 +538,7 @@ function contractOf(value: unknown): ClassContract | null {
  * mechanism. "Failing closed" describes what the code did; an operator needs to
  * know which part of the page just went quiet, and the three are genuinely
  * different. Same posture as `oversight.ts`'s opaque-handle warn, which spells
- * out its consequence and even scopes it ("counts are unaffected").
+ * out its consequence and even scopes it ("Counts are unaffected").
  */
 const FAIL_CLOSED_CONSEQUENCE = {
   coverageLabelPolicy: "no unit of this class will be named; its counts are unaffected",
@@ -478,18 +550,21 @@ const FAIL_CLOSED_CONSEQUENCE = {
  * The derivations that can meet an unresolvable class.
  *
  * ⚠️ This closed set ties the call sites to the MAP above — NOT to the function
- * names. On its own it lets a rename of `coverageLabelPolicy` leave the map key,
- * the call-site literal and the logged `derivation` all spelling the dead name,
- * with `tsc` clean and the logging test green (it asserts the string, not the
- * binding). `_DERIVATION_NAMES_IN_SYNC` below is what actually closes that, and
- * it is there rather than here because a comment claiming the tie was this
- * module's third measured-false guarantee — the ratchet says the third one gets
- * a mechanism.
+ * names. {@link _DERIVATION_NAMES_IN_SYNC} at the bottom of this file is what
+ * closes that, and carries the argument.
  */
 type ClassContractDerivation = keyof typeof FAIL_CLOSED_CONSEQUENCE;
 
-/** How long a stored class value may be before the log line truncates it. */
-const CLASS_VALUE_LOG_MAX = 128;
+/**
+ * How long the EMITTED `classValue` field may be before it truncates.
+ *
+ * On the quoted form, not the raw one — see {@link describeClassValue}. Exported
+ * so `class-contract-logging.test.ts` asserts the bound against the constant
+ * rather than a second copy of the number: a test that spells its own 128 keeps
+ * passing when the constant moves, which is the drift that made an earlier
+ * `toBeLessThan(200)` unable to see a 128 -> 190 change.
+ */
+export const CLASS_VALUE_LOG_MAX = 128;
 
 /**
  * Describe an unresolvable class value for the log, without trusting it.
@@ -504,7 +579,7 @@ const CLASS_VALUE_LOG_MAX = 128;
  *
  * Strings are truncated because `brain_episodes.source` is plain `text` with no
  * CHECK and the region import restores it verbatim, so the value is unbounded.
- * `error-scrub.ts` truncates for the same stated reason — an oversized field
+ * `lib/audit/error-scrub.ts` truncates for the same stated reason — an oversized field
  * pushes the structured ones past log-aggregation size limits, which loses the
  * `workspaceId` this line exists to carry.
  *
@@ -514,14 +589,26 @@ const CLASS_VALUE_LOG_MAX = 128;
  * whitespace near-miss that is exactly what an operator is debugging) looked
  * like `human`, and a stored value of literally `"null"` was the sentinel for a
  * real `null`. The only discriminant was whether `classValueLength` happened to
- * be present — a rule nobody reading a log knows.
+ * be present — a rule nobody reading a log knows. `JSON.stringify` also escapes
+ * control characters and newlines, so a tenant-controlled value cannot forge a
+ * line at a console sink.
+ *
+ * ⚠️ **Quote FIRST, then bound — the order is the whole point of the bound.**
+ * Truncating the input and escaping afterwards bounds the wrong string: escaping
+ * expands, so 128 NUL characters emitted a 770-character field, roughly six
+ * times the intended size and past the 512 the cited precedent holds. The
+ * rationale here is an OUTPUT property, so the bound has to be on the output.
+ * The ellipsis goes inside the closing quote so the field still reads as a
+ * quoted string rather than as truncated JSON.
  */
 function describeClassValue(value: unknown): string {
   if (value === null) return "null";
+  if (Array.isArray(value)) return "array";
   if (typeof value !== "string") return typeof value;
-  const shown =
-    value.length > CLASS_VALUE_LOG_MAX ? `${value.slice(0, CLASS_VALUE_LOG_MAX)}…` : value;
-  return JSON.stringify(shown);
+  const quoted = JSON.stringify(value);
+  return quoted.length > CLASS_VALUE_LOG_MAX
+    ? `${quoted.slice(0, CLASS_VALUE_LOG_MAX)}…"`
+    : quoted;
 }
 
 /**
@@ -675,15 +762,33 @@ export function coverageLabelPolicy(
   unit: SurveyUnitDisclosureFacts,
   meta?: ClassContractLogMeta,
 ): CoverageLabelDecision {
-  // Order is load-bearing: see § "A NON-SURVEYABLE class gets no label either".
-  // The full old-vs-new input-class table lives in the commit that introduced
-  // the refusal, which is where "old" is unambiguous.
+  // Order is load-bearing: the non-surveyable check must precede both clauses,
+  // or a caller-supplied `deliberateAct` names a person. See § "A NON-SURVEYABLE
+  // class gets no label either"; the input-class table is in `db8c5fc85`.
   const contract = contractOf(cls);
   if (!contract) {
     warnUnresolvable(cls, "coverageLabelPolicy", meta);
     return { policy: "count-only", reason: "unresolvable-class" };
   }
   if (!contract.coverage.denominator.surveyable) {
+    if (unit.deliberateAct || unit.vendorReportsPublic) {
+      // A caller ASSERTED a disclosure fact about a unit of a class that
+      // declares it has none — for `human` that unit would be a PERSON.
+      // Refused either way; logged because the assertion cannot have been
+      // computed correctly, and because this arm is otherwise the module's
+      // sharpest attempted disclosure with no trace at all. Predicated on the
+      // assertion rather than on the arm, so the volume is bounded by a caller
+      // bug instead of by unit count.
+      log.warn(
+        {
+          workspaceId: meta?.workspaceId,
+          requestId: meta?.requestId,
+          derivation: "coverageLabelPolicy",
+          classValue: describeClassValue(cls),
+        },
+        "brain class contract: a disclosure fact was asserted for a non-surveyable class — refusing; no unit of this class is ever named",
+      );
+    }
     return { policy: "count-only", reason: "non-surveyable-class" };
   }
   if (unit.deliberateAct) return { policy: "name", clause: "deliberate-act" };
@@ -768,7 +873,9 @@ export function classDenominator(cls: unknown, meta?: ClassContractLogMeta): Cla
 /**
  * Ties every {@link FAIL_CLOSED_CONSEQUENCE} key to the EXPORT that logs under
  * it — SHORTHAND properties, so renaming a derivation without renaming its key
- * is a `TS2304: Cannot find name`.
+ * fails to compile here ("No value exists in scope for the shorthand property").
+ * The diagnostic NUMBER is deliberately not quoted; that is the detail a `tsc`
+ * upgrade renumbers, and this module has already shipped one wrong one.
  *
  * The mechanism the type alias above cannot be. `ClassContractDerivation` is
  * `keyof typeof FAIL_CLOSED_CONSEQUENCE`, which ties the call sites to the MAP
@@ -783,9 +890,20 @@ export function classDenominator(cls: unknown, meta?: ClassContractLogMeta): Cla
  * rule is that a principle violated twice gets a check rather than a third
  * comment.
  *
- * Function declarations hoist, so this sits below them and still binds.
+ * Placed BELOW the declarations it references, so it binds however they are
+ * spelled. (Do not "simplify" by moving it up on the belief that hoisting
+ * protects it: the moment any derivation becomes an arrow const, a reference
+ * above it is a use-before-declaration error. Compile-caught rather than silent,
+ * but there is no reason to invite it.)
+ *
+ * The shorthand is load-bearing and it is a CONVENTION, not a guarantee: writing
+ * `coverageLabelPolicy: "anything"` binds nothing and silently retires the tie.
+ * The function-shaped value type below is what makes that at least type-visible.
  */
-const _DERIVATION_NAMES_IN_SYNC: Record<ClassContractDerivation, unknown> = {
+const _DERIVATION_NAMES_IN_SYNC: Record<
+  ClassContractDerivation,
+  (...args: never[]) => unknown
+> = {
   coverageLabelPolicy,
   stalenessVerdict,
   classDenominator,

--- a/packages/api/src/lib/brain/class-contract.ts
+++ b/packages/api/src/lib/brain/class-contract.ts
@@ -13,12 +13,23 @@
  *
  * It arrives carrying ADR-0041's three properties ONLY — vendor-public,
  * staleness capability, denominator source. ADR-0040's own arms (on-connect
- * trigger, extraction, ACL derivation, perimeter) are prose in that ADR and have
- * no implementation scheduled; they join {@link ClassContract} as siblings of
- * {@link ClassContract.coverage} when they do. The nesting exists for exactly
- * that reason and for no other: the coverage properties are a different
- * decision's, and grouping them keeps a later reader able to see which ADR put
- * each field here without consulting `git blame`.
+ * trigger, extraction, ACL derivation, perimeter) are prose in that ADR; they
+ * join {@link ClassContract} as siblings of {@link ClassContract.coverage} as
+ * each is implemented. The nesting exists for exactly that reason and for no
+ * other: the coverage properties are a different decision's, and grouping them
+ * keeps a later reader able to see which ADR put each field here without
+ * consulting `git blame`.
+ *
+ * ⚠️ **This is NOT the only class-keyed Record in the tree, and a reader told
+ * "ADR-0040's arms join here" will otherwise not find the one that already
+ * shipped.** `AUDIENCE_GRAIN` in `ingest/types.ts` is a
+ * `Record<EpisodeSourceClass, AudienceGrain>` deciding at what grain each
+ * class's audiences are refreshed, and it makes the same completeness-over-
+ * membership argument this file does. The boundary between them: that map is
+ * INGEST MECHANICS — which classes need a per-object re-verifier registered —
+ * while this one is CONTRACT POLICY. They are candidates to merge the day the
+ * ACL-derivation arm lands here; until then, edit the one whose question you
+ * are answering, and do not assume either is the whole class axis.
  *
  * ## The one structural guarantee
  *
@@ -66,7 +77,7 @@ const log = createLogger("brain-class-contract");
  * source movement newer than our newest observed evidence by more than the
  * class's sync cadence" — so a class that cannot read activity metadata cannot
  * compute the lag, and must say "unverified since \<date\>" instead of guessing
- * in either direction. See {@link stalenessVerdictKind}, which is the only place
+ * in either direction. See {@link stalenessVerdict}, which is the only place
  * that consequence is spelled.
  *
  * `absent` is not a defect to be fixed later. For `human` there is no vendor to
@@ -120,7 +131,43 @@ export type SurveyUnitOrigin =
  */
 export type ClassDenominator =
   | { readonly surveyable: true; readonly enumeratedFrom: SurveyUnitOrigin }
-  | { readonly surveyable: false };
+  | {
+      readonly surveyable: false;
+      /**
+       * WHY there is no universe, which the surface must render differently.
+       *
+       * `not-a-surveyable-region` is `human`'s declared refusal — an affirmative
+       * product statement, and a class that correctly never appears in a ratio.
+       * `unresolvable-class` is the fail-closed arm: we do not know what this is,
+       * and ADR-0041 calls a silent zero here "a false statement, not an error
+       * state", so the page owes a "cannot establish" arm rather than a clean
+       * absence.
+       *
+       * Carried for the same reason {@link CoverageLabelDecision} carries its
+       * reason, and the omission was the defect: without it the two arms are
+       * byte-identical and only a `log.warn` separates them — and a page cannot
+       * read a log.
+       */
+      readonly reason: "not-a-surveyable-region" | "unresolvable-class";
+    };
+
+/**
+ * Which staleness sentence a class's units are entitled to.
+ *
+ * `measured-lag` licenses the word "stale" — the class can read vendor activity
+ * metadata, so the surface may compare source movement against our newest
+ * observed evidence and report a lag it actually measured. `unverified-since` is
+ * the other sentence and the only other one, and it carries its reason for the
+ * same reason {@link ClassDenominator} does: a class that DECLARED it cannot
+ * measure lag and a class nobody has written a contract for produce the same
+ * sentence, and the second one is a bug the page must be able to see.
+ */
+export type StalenessVerdict =
+  | { readonly kind: "measured-lag" }
+  | {
+      readonly kind: "unverified-since";
+      readonly reason: "no-activity-metadata" | "unresolvable-class";
+    };
 
 /** ADR-0041's three properties, as one class answers them. */
 export interface ClassCoverageContract {
@@ -189,6 +236,26 @@ export interface ClassContract {
  * the contract unnoticed, on the map whose job is to be the single place a class
  * answers for itself.
  *
+ * ⚠️ **A `satisfies` guards only the literal it is ATTACHED TO, and this map is
+ * three levels deep — so there is one on every level.** The first draft carried
+ * a single `as const satisfies ClassContract` on the outer literal and the
+ * docstring claimed it caught invented fields; measured, it did not. That
+ * literal is `{ coverage: <call result> }`, so excess-property checking fires on
+ * the key `coverage` and stops there: `vendorPublik: true` beside `vendorPublic`
+ * and `weight: 3` inside a denominator both compiled clean. `sources.ts` gets
+ * this right for free because `EPISODE_SOURCE_SPECS`'s entries are LEAF literals
+ * and its `satisfies` sits on them; copying the idiom to a nested shape without
+ * moving it down is how the guarantee silently evaporates.
+ *
+ * What keeps it from evaporating again is a SOURCE-TEXT pin
+ * (`class-contract.test.ts`, "carries a `satisfies` at EVERY level"), because
+ * nothing else can: a `satisfies` is erased at runtime and asserts nothing about
+ * itself, so deleting one here is invisible to `tsc` and to every behavioural
+ * test. Measured — removing this entry's level-2 annotation leaves both clean.
+ * The `@ts-expect-error` pins beside it are a DIFFERENT guarantee: they hold
+ * that {@link ClassCoverageContract} and {@link ClassDenominator} are closed, so
+ * that these annotations have something to bite on.
+ *
  * ⚠️ What NEITHER check does is verify the answer is RIGHT. Nothing in the type
  * system knows what "vendor-public" means; a new class declaring `vendorPublic:
  * true` compiles clean. The defaults are what make that survivable — a class
@@ -209,8 +276,11 @@ export const CLASS_CONTRACTS = Object.freeze({
     coverage: Object.freeze({
       vendorPublic: true,
       activityMetadata: "reports",
-      denominator: Object.freeze({ surveyable: true, enumeratedFrom: "chat-channel-roster" }),
-    }),
+      denominator: Object.freeze({
+        surveyable: true,
+        enumeratedFrom: "chat-channel-roster",
+      } as const satisfies ClassDenominator),
+    } as const satisfies ClassCoverageContract),
   } as const satisfies ClassContract),
 
   /**
@@ -224,8 +294,11 @@ export const CLASS_CONTRACTS = Object.freeze({
     coverage: Object.freeze({
       vendorPublic: false,
       activityMetadata: "reports",
-      denominator: Object.freeze({ surveyable: true, enumeratedFrom: "granted-recording-scopes" }),
-    }),
+      denominator: Object.freeze({
+        surveyable: true,
+        enumeratedFrom: "granted-recording-scopes",
+      } as const satisfies ClassDenominator),
+    } as const satisfies ClassCoverageContract),
   } as const satisfies ClassContract),
 
   /**
@@ -239,8 +312,11 @@ export const CLASS_CONTRACTS = Object.freeze({
     coverage: Object.freeze({
       vendorPublic: false,
       activityMetadata: "reports",
-      denominator: Object.freeze({ surveyable: true, enumeratedFrom: "mailbox-list" }),
-    }),
+      denominator: Object.freeze({
+        surveyable: true,
+        enumeratedFrom: "mailbox-list",
+      } as const satisfies ClassDenominator),
+    } as const satisfies ClassCoverageContract),
   } as const satisfies ClassContract),
 
   /**
@@ -261,8 +337,8 @@ export const CLASS_CONTRACTS = Object.freeze({
       denominator: Object.freeze({
         surveyable: true,
         enumeratedFrom: "semantic-layer-enrollment",
-      }),
-    }),
+      } as const satisfies ClassDenominator),
+    } as const satisfies ClassCoverageContract),
   } as const satisfies ClassContract),
 
   /**
@@ -282,8 +358,11 @@ export const CLASS_CONTRACTS = Object.freeze({
     coverage: Object.freeze({
       vendorPublic: false,
       activityMetadata: "absent",
-      denominator: Object.freeze({ surveyable: false }),
-    }),
+      denominator: Object.freeze({
+        surveyable: false,
+        reason: "not-a-surveyable-region",
+      } as const satisfies ClassDenominator),
+    } as const satisfies ClassCoverageContract),
   } as const satisfies ClassContract),
 }) satisfies Record<EpisodeSourceClass, ClassContract>;
 
@@ -305,9 +384,17 @@ const _CONTRACT_KEYS_IN_SYNC: MutuallyAssignable<
 > = true;
 void _CONTRACT_KEYS_IN_SYNC;
 
-/** Diagnostic context a caller can attach to the fail-closed log lines. */
+/**
+ * Diagnostic context a caller attaches to the fail-closed log lines.
+ *
+ * `workspaceId` is REQUIRED, on `oversight.ts`'s `CountMeta` terms exactly: the
+ * whole value of these lines is telling an operator why a class went quiet, and
+ * in a 3-region multi-tenant deploy a warn with no workspace cannot do that.
+ * Optional-or-complete, never partial — the `meta` parameter itself is what a
+ * caller omits.
+ */
 export interface ClassContractLogMeta {
-  readonly workspaceId?: string;
+  readonly workspaceId: string;
   readonly requestId?: string;
 }
 
@@ -325,13 +412,18 @@ export interface ClassContractLogMeta {
  *
  * The narrow is what makes the bare index below safe, and it carries two jobs
  * rather than one. Obviously it refuses `"docs"`. Less obviously it refuses
- * `"toString"` and `"constructor"` — `CLASS_CONTRACTS["toString"]` would
- * otherwise resolve up the PROTOTYPE CHAIN to a function whose `.coverage` is
- * `undefined`, and a derivation reading `vendorPublic` off that gets `undefined`
- * (falsy, so the disclosure gate happens to hold) while `activityMetadata`
- * compares unequal to `"reports"` (so that one happens to hold too). Both would
- * fail closed BY ACCIDENT — not a property worth relying on, and not one that
- * survives the next field added here.
+ * `"toString"` and `"constructor"`: `CLASS_CONTRACTS["toString"]` resolves up the
+ * PROTOTYPE CHAIN to a function, whose `.coverage` is `undefined`.
+ *
+ * ⚠️ **What happens next was MEASURED, and it is not what it looks like.** The
+ * obvious reading is that the derivations would read `undefined` and fail closed
+ * by accident — `vendorPublic` falsy, `activityMetadata` unequal to `"reports"`.
+ * They would not. Dropping the narrow and indexing bare gives
+ * `TypeError: undefined is not an object (evaluating 'contract.coverage.vendorPublic')`,
+ * because the missing property is `coverage` and every derivation reaches
+ * through it. So the cost of losing this narrow is a THROWN page render, not a
+ * withheld label — worse than fail-closed, and worth knowing before anyone
+ * decides the narrow is redundant.
  *
  * So there is deliberately no `Object.hasOwn` guard on the index, the way
  * `specOf` carries one in `sources.ts`. That function's parameter is typed
@@ -339,8 +431,9 @@ export interface ClassContractLogMeta {
  * only thing standing between a cast and the prototype chain; here the narrow is
  * already that thing, and a second guard behind it would be an arm no input can
  * reach carrying a comment claiming it does work. `class-contract.test.ts` puts
- * the prototype keys through every derivation, which is where that claim is
- * checked rather than asserted.
+ * the prototype keys through every derivation, and dropping this narrow reddens
+ * exactly three of its tests — which is where the claim is checked rather than
+ * asserted.
  *
  * Not exported. Every caller wants one of the three derivations, each of which
  * has its own fail-closed answer and its own log line; handing out the `null`
@@ -351,7 +444,51 @@ function contractOf(value: unknown): ClassContract | null {
 }
 
 /**
- * Log an unresolvable class once, in one voice, from whichever derivation met it.
+ * What each derivation's fail-closed answer COSTS, in the operator's terms.
+ *
+ * Keyed by derivation so the log line states the consequence rather than the
+ * mechanism. "Failing closed" describes what the code did; an operator needs to
+ * know which part of the page just went quiet, and the three are genuinely
+ * different. Same posture as `oversight.ts`'s opaque-handle warn, which spells
+ * out its consequence and even scopes it ("counts are unaffected").
+ */
+const FAIL_CLOSED_CONSEQUENCE = {
+  coverageLabelPolicy: "no unit of this class will be named; its counts are unaffected",
+  stalenessVerdict: 'this class can never report a measured lag; its units read "unverified since"',
+  classDenominator: "this class has no enumerable universe, so it falls out of every ratio",
+} as const;
+
+/** The derivations that can meet an unresolvable class — a closed set, so a rename cannot desync the log. */
+type ClassContractDerivation = keyof typeof FAIL_CLOSED_CONSEQUENCE;
+
+/** How long a stored class value may be before the log line truncates it. */
+const CLASS_VALUE_LOG_MAX = 128;
+
+/**
+ * Describe an unresolvable class value for the log, without trusting it.
+ *
+ * `null` is spelled out rather than left to `typeof`, and that is the case most
+ * likely to actually occur: the plausible production producer of an unresolvable
+ * class is `episodeSourceClassOf(row.source)` (`sources.ts`), which returns
+ * `null` for exactly the region-import lane these arms exist for. Under a bare
+ * `typeof` that logs as `"object"` — indistinguishable from `{ class: "chat" }`
+ * and from `["chat"]`, so the highest-probability real input produced the least
+ * legible line.
+ *
+ * Strings are truncated because `brain_episodes.source` is plain `text` with no
+ * CHECK and the region import restores it verbatim, so the value is unbounded.
+ * `error-scrub.ts` truncates for the same stated reason — an oversized field
+ * pushes the structured ones past log-aggregation size limits, which loses the
+ * `workspaceId` this line exists to carry.
+ */
+function describeClassValue(value: unknown): string {
+  if (value === null) return "null";
+  if (typeof value !== "string") return typeof value;
+  return value.length > CLASS_VALUE_LOG_MAX ? `${value.slice(0, CLASS_VALUE_LOG_MAX)}…` : value;
+}
+
+/**
+ * Log an unresolvable class, in one voice, from whichever derivation met it.
  *
  * `log.warn` and not `debug`: reaching any of these with a class this deploy
  * cannot resolve means a survey unit is being counted whose contract nobody has
@@ -359,11 +496,23 @@ function contractOf(value: unknown): ClassContract | null {
  * fail-closed answer is a correct answer, and ADR-0041 wants the page to keep
  * rendering — but it is the line an operator needs to explain why a class went
  * quiet after a deploy.
+ *
+ * The diagnostic fields come AFTER the caller's `meta` in the spread, so a
+ * caller cannot shadow them with its own `derivation` or `classValue`.
  */
-function warnUnresolvable(value: unknown, derivation: string, meta?: ClassContractLogMeta): void {
+function warnUnresolvable(
+  value: unknown,
+  derivation: ClassContractDerivation,
+  meta?: ClassContractLogMeta,
+): void {
   log.warn(
-    { ...meta, derivation, classValue: typeof value === "string" ? value : typeof value },
-    "brain class contract: no contract for this source class — failing closed",
+    {
+      ...meta,
+      derivation,
+      classValue: describeClassValue(value),
+      classValueLength: typeof value === "string" ? value.length : undefined,
+    },
+    `brain class contract: no contract for this source class — failing closed; ${FAIL_CLOSED_CONSEQUENCE[derivation]}`,
   );
 }
 
@@ -389,8 +538,13 @@ export type CoverageLabelDecision =
        * surface can tell "we counted this and correctly did not name it" from
        * "we do not know what this is", which are different sentences to an
        * admin and only one of them is a bug.
+       *
+       * `non-surveyable-class` is the third, and it is neither: the class
+       * declared it has no enumerable units at all, so a caller asking whether
+       * to name one is asking about a unit that should not exist. For `human`
+       * that unit would be a PERSON, which ADR-0041 refuses by name.
        */
-      readonly reason: "no-clause" | "unresolvable-class";
+      readonly reason: "no-clause" | "non-surveyable-class" | "unresolvable-class";
     };
 
 /** What the caller knows about ONE survey unit, as opposed to about its class. */
@@ -446,19 +600,58 @@ export interface SurveyUnitDisclosureFacts {
  * from somewhere that cannot have computed it correctly, and a disclosure gate
  * is the wrong place to extend the benefit of the doubt.
  *
- * Counts are untouched by any of this — {@link classDenominator} decides
- * separately whether the class has a universe to count, and ADR-0041's whole
- * point is that a count carries no claim content and no audience content.
+ * ## A NON-SURVEYABLE class gets no label either, and that arm is about `human`
+ *
+ * A class declaring `surveyable: false` has no enumerable units, so a caller
+ * asking whether to name one is asking about a unit that should not exist. The
+ * answer is to withhold — and for `human` this is the sharpest disclosure in the
+ * module, because that class's "units" are PEOPLE, and ADR-0041 refuses them by
+ * name: "Everything else is counted, never named: mailboxes …, recording owners,
+ * individual persons."
+ *
+ * Checked BEFORE either clause, so it also suppresses deliberate-act. The
+ * posture was otherwise inverted: a class this deploy cannot resolve got a loud
+ * withhold, while a class that had positively declared it has no units got a
+ * silent name off a single caller-supplied boolean.
+ *
+ * ## Counts are untouched by any of this
+ *
+ * {@link classDenominator} decides separately whether the class has a universe
+ * to count, and ADR-0041's whole point is that a count carries no claim content
+ * and no audience content.
+ *
+ * ⚠️ One obligation this hands the caller, since nothing here can enforce it: a
+ * unit whose decision is `unresolvable-class` or `non-surveyable-class` must not
+ * be totalled into a ratio. Both reasons travel with a denominator that refuses
+ * to exist, so accumulating a numerator against them yields "N of 0" — a number
+ * with no universe behind it, which is the fabrication ADR-0041 refuses. It is
+ * also what keeps the warn above from firing per unit: a class with no
+ * denominator should never have had its units enumerated in the first place.
  */
 export function coverageLabelPolicy(
   cls: unknown,
   unit: SurveyUnitDisclosureFacts,
   meta?: ClassContractLogMeta,
 ): CoverageLabelDecision {
+  // BEHAVIOUR DELTA — input classes × old vs new. Every changed row moves toward
+  // withholding; no row moves toward disclosure, and the new arm is an ADDITIVE
+  // refusal in front of the clauses rather than an edit to either one, so it
+  // cannot permit anything the old code refused.
+  //
+  //                                          old                      new
+  //   surveyable, deliberateAct              name/deliberate-act      unchanged
+  //   surveyable, class+unit both public     name/vendor-public       unchanged
+  //   surveyable, neither                    count/no-clause          unchanged
+  //   NON-surveyable, deliberateAct          name/deliberate-act  →   count/non-surveyable-class  ← CHANGED
+  //   NON-surveyable, neither                count/no-clause      →   count/non-surveyable-class  ← CHANGED (reason only)
+  //   unresolvable, any                      count/unresolvable       unchanged
   const contract = contractOf(cls);
   if (!contract) {
     warnUnresolvable(cls, "coverageLabelPolicy", meta);
     return { policy: "count-only", reason: "unresolvable-class" };
+  }
+  if (!contract.coverage.denominator.surveyable) {
+    return { policy: "count-only", reason: "non-surveyable-class" };
   }
   if (unit.deliberateAct) return { policy: "name", clause: "deliberate-act" };
   if (contract.coverage.vendorPublic && unit.vendorReportsPublic) {
@@ -483,38 +676,57 @@ export function coverageLabelPolicy(
  * file can see it, so `measured-lag` here means "stale is computable for this
  * class", never "this unit is stale".
  *
- * Unresolvable class → `unverified-since`. Fail-closed in the honest direction:
- * the alternative would let a class nobody has written a contract for produce
- * the word "stale" about a source no code in this deploy knows how to look at.
+ * ⚠️ **The THRESHOLD this licenses is not in the contract yet, and a consumer
+ * must not invent one.** ADR-0041 defines the lag as exceeding "the class's sync
+ * cadence — a divergence whose only constant is the cadence the class contract
+ * already owns", and then forbids a knob for it: "No staleness knob — not env,
+ * not the settings registry." That cadence has no declaration site today; this
+ * contract carries the CAPABILITY and not the constant, which is #5212's stated
+ * scope. So `measured-lag` means "a lag is computable for this class", and the
+ * cadence it is measured against is a fourth contract property that belongs
+ * HERE when the coverage module needs it — not a constant in that module, which
+ * would be exactly the "each new consumer is a new place the answer could be
+ * decided" failure this file exists to prevent.
+ *
+ * Unresolvable class → `unverified-since` / `unresolvable-class`. Fail-closed in
+ * the honest direction: the alternative would let a class nobody has written a
+ * contract for produce the word "stale" about a source no code in this deploy
+ * knows how to look at. The reason discriminates that from `warehouse`'s and
+ * `human`'s DECLARED `no-activity-metadata`, which is the same sentence for a
+ * completely different reason and is not a bug.
  */
-export function stalenessVerdictKind(
-  cls: unknown,
-  meta?: ClassContractLogMeta,
-): "measured-lag" | "unverified-since" {
+export function stalenessVerdict(cls: unknown, meta?: ClassContractLogMeta): StalenessVerdict {
   const contract = contractOf(cls);
   if (!contract) {
-    warnUnresolvable(cls, "stalenessVerdictKind", meta);
-    return "unverified-since";
+    warnUnresolvable(cls, "stalenessVerdict", meta);
+    return { kind: "unverified-since", reason: "unresolvable-class" };
   }
-  return contract.coverage.activityMetadata === "reports" ? "measured-lag" : "unverified-since";
+  return contract.coverage.activityMetadata === "reports"
+    ? { kind: "measured-lag" }
+    : { kind: "unverified-since", reason: "no-activity-metadata" };
 }
 
 /**
  * The class's enumerable universe, or its refusal to have one.
  *
- * Unresolvable class → `{ surveyable: false }`. This is the arm ADR-0041's
- * fabrication discipline decides: a denominator for a class whose enumeration
- * nothing in this deploy knows how to perform would be a number with no universe
- * behind it, and "a silent zero here is a false statement, not an error state".
- * Refusing to be surveyable makes the class fall out of every ratio, which is
- * the same treatment `human` gets by declaration and the same shape the map edge
- * takes: a mark, never a number.
+ * Unresolvable class → `{ surveyable: false, reason: "unresolvable-class" }`.
+ * This is the arm ADR-0041's fabrication discipline decides: a denominator for a
+ * class whose enumeration nothing in this deploy knows how to perform would be a
+ * number with no universe behind it, and "a silent zero here is a false
+ * statement, not an error state". Refusing to be surveyable makes the class fall
+ * out of every ratio, which is the same shape the map edge takes: a mark, never
+ * a number.
+ *
+ * ⚠️ The reason is what stops that being the same answer `human` gets. Both
+ * refuse a universe; only one of them is a decision. ADR-0041 wants the page to
+ * render "cannot establish" for the second — a page cannot read a `log.warn`,
+ * so the distinction has to travel in the return value.
  */
 export function classDenominator(cls: unknown, meta?: ClassContractLogMeta): ClassDenominator {
   const contract = contractOf(cls);
   if (!contract) {
     warnUnresolvable(cls, "classDenominator", meta);
-    return { surveyable: false };
+    return { surveyable: false, reason: "unresolvable-class" };
   }
   return contract.coverage.denominator;
 }


### PR DESCRIPTION
Closes #5212.

ADR-0041 gives every source class three coverage properties and declares them at ADR-0040's declaration site — the class-keyed `Record<EpisodeSourceClass, ClassContract>` sibling of `lib/brain/sources.ts`. That Record did not exist in code yet, so this creates it carrying ADR-0041's three properties and nothing else. ADR-0040's own arms join as siblings of `.coverage` as each is implemented; the nesting is what lets them, without the coverage shape moving.

Three files, all new. No migration, no schema change, no env var, no route, **no production consumer yet** — `lib/brain/coverage.ts` is a later issue, and these three fields are its inputs.

## The three properties

| class | `vendorPublic` | `activityMetadata` | denominator origin |
|---|---|---|---|
| `chat` | **true** | `reports` | `chat-channel-roster` |
| `transcript` | false | `reports` | `granted-recording-scopes` |
| `email` | false | `reports` | `mailbox-list` |
| `warehouse` | false | `absent` | `semantic-layer-enrollment` |
| `human` | false | `absent` | *not surveyable* |

**`vendorPublic` is CLASS-LEVEL ADMISSIBILITY, not a per-unit verdict** — the one thing to get right when reading this diff. Whether a *particular* channel is public is the vendor's answer about that channel; this flag says whether the class has any such notion for the clause to lean on. The two are **ANDed**, so a class a human declined to open cannot be opened by a caller's per-unit claim — the direction that matters, since that claim comes from vendor data. Defaults closed; `chat` alone argues its way open.

**`activityMetadata`** is whether a *measured lag* is computable at all. `absent` is a declaration, not a gap: `human` has no vendor to ask, and for `warehouse` no general answer exists. It is what makes those units read *"unverified since"* rather than silently never appearing stale.

**The denominator** is a discriminated union, so `human`'s refusal is a **positive claim** rather than an absent field — the surface must render "correctly never in a ratio" differently from "nobody filled this in". No two classes share an origin slug, and a test pins that: the layers stay incommensurable, which is ADR-0041's *"no single number, permanently"* made structural rather than merely argued.

## Fail-closed, at compile time and at runtime

Totality is a compile error in both directions (`satisfies Record<…>` plus `_CONTRACT_KEYS_IN_SYNC`), pinned with `@ts-expect-error`. Every derivation also carries an arm for a class the compiler cannot see — a cast, a region import, a separately-compiled plugin — and each fails closed and logs: **no label under any clause, never the word "stale", no denominator.**

Three refusals, three different sentences to an admin, deliberately not collapsed: `no-clause` ("counted and correctly not named"), `non-surveyable-class` ("this class has no units"), `unresolvable-class` ("we do not know what this is"). Only the last is a bug, and a page cannot read a `log.warn`, so the distinction travels in the return value.

**`coverageLabelPolicy` refuses a non-surveyable class before both clauses.** For `human` the "unit" would be a **person**, which ADR-0041 refuses by name. A positive disclosure assertion on such a class is logged — the refusal is right either way, but the caller bug that produced the assertion was otherwise unfindable.

## Review panel — three rounds, then the cap

| round | findings | new surface | defect-in-prior-fix | reviewers | wall clock |
|---|---|---|---|---|---|
| 1 | 27 | 27 | 0 | 3 code | ~12m |
| 2 | 25 | 16 | 9 | 3 code | ~14m |
| 3 (closing) | 39 | 31 | 8 | 4 (+ `comment-analyzer`) | ~14m |

**Read the round-3 total carefully: it rose only because a fourth reviewer joined.** On the three code reviewers alone the curve is **27 → 25 → 24**, and defect-in-prior-fix never exceeded new surface in any round — so neither the yield rule nor the ratio rule fired, and the rounds ran to the cap on merit. All four round-3 reviewers independently returned **no blockers, 0 CRITICAL**. Wall clock is each round's slowest agent (they run in parallel), taken from agent-reported durations.

The panel's own scorecard moved R1 → R3: invariant expression **6 → 8**, enforcement **6 → 8.5**, encapsulation **7 → 8**, usefulness steady at **9**.

### What the panel actually found: eight false claims in my own comments

Every one was a claim about a guarantee, a measurement, or the state of the tree, and **not one was caught by reading** — each took running something.

1. "the per-entry `satisfies` catches an invented field" — it did not, two levels down. `Object.freeze(...)` is a call result, so excess-property checking never fired below level 1.
2. "dropping the narrow fails closed by accident" — it *throws*.
3. "ADR-0040's arms have no implementation scheduled" — `AUDIENCE_GRAIN` already ships one.
4. "the `@ts-expect-error` pins keep the `satisfies` from evaporating" — they pin locally-annotated literals and would not. **Caught by `fix-vs-finding`: the fix for #1 re-committed #1.**
5. "a closed set, so a rename cannot desync the log" — it ties the call sites to the map, not to the function names.
6. **A FABRICATED ADR QUOTE.** `"human: none — not a surveyable region"` was cited to ADR-0041 twice as the whole justification for the one class declaring `surveyable: false`. It is in *neither* ADR — it is verbatim from this issue's own body, and ADR-0041 has no per-class map at all.
7. "the vocabularies are CLOSED — a fourth reason must be handled" — measured, adding a fourth reason left `tsc` clean. Those directives pin *not `string`*, not membership.
8. "a THROWN page render" — true for 6 of 21 hostile inputs, not all; `null`, which the same docstring calls the likeliest real input, fails closed correctly.

Plus `TS2304` where the compiler emits `TS18004`, and two stale tallies a growing suite had silently invalidated.

**Where a principle was violated twice, it became a mechanism rather than a third comment** (the repo's ratchet, applied to the panel's own output): a source-text pin counting one `satisfies` per level per entry *paired* with the freeze count so it holds at any depth; `_DERIVATION_NAMES_IN_SYNC` tying each log key to its actual export; four `MutuallyAssignable` ties making a fourth reason a compile error; a recursive freeze walk; and a ban on quoting absolute pass counts in these files at all.

### Three inert tests, found by mutation

- `classDenominator`'s resolvable path was never asserted — returning `{surveyable:false}` unconditionally was green.
- All three `warnUnresolvable` calls were deletable green.
- Two `expect(logCalls).toEqual([])` assertions passed whenever log capture broke — *observed happening*, with 8 of 10 tests failing and those two surviving. A third spelling (`for … of` over a possibly-empty array) survived round 2's fix and was the sole survivor in round 3.

The inert-recorder mutation now reddens **all 16** logging tests: **2 → 1 → 0 survivors** across the rounds. `UNRESOLVABLE` also gained a non-vacuity guard after measurement showed emptying it left the file green while `expect()` calls fell from 219 to 93 — 126 assertions vanishing in silence.

### Falsifiers — 48 mutations, all RED

12 (original) + 16 (round 1) + 8 (round 2) + 12 (round 3), each against a **baseline asserted green first**.

⚠️ **One battery measured nothing and had to be re-run.** It ran both spec files in a single `bun test` process, where `mock.module` leaks across files and the baseline is *already red* — so all 16 "RED" results were the leak. That is why this repo mandates the isolated runner. Every battery since asserts a green baseline before trusting a single result.

## Deferred deliberately, with reasons

- **The `deepFreeze` reshape** — a reviewer measured it end-to-end and it works, but written the natural way `deepFreeze({...}) satisfies Record<…>` infers from an uncontextualised literal and the `satisfies` lands on a call result, **silently losing every excess-property guarantee at every level**. Only `deepFreeze<Record<EpisodeSourceClass, ClassContract>>({...})` works. Landing that at the round cap would ship a construct whose correct and incorrect spellings differ by one type argument and whose incorrect spelling is green. The recursive freeze walk banks most of its value now.
- **The sync cadence as a fourth property** — ADR-0041 says the class contract owns it and it has no declaration site. Outside this issue's AC, so it is a documented gap with an explicit *"a consumer must not substitute a threshold of its own"* warning on the `measured-lag` member itself, where a destructuring consumer will actually meet it.
- **Cross-field nonsense** (a non-surveyable class declaring `vendorPublic: true`) stays value-pinned; the type fix flattens `denominator` into the coverage union, which fights ADR-0040's arms joining as siblings. Reconsider when the first arm lands.

## Verification

- `class-contract.test.ts` 25 pass · `class-contract-logging.test.ts` 16 pass — **one process per spec** (they are process-coupled by design; the logging spec installs `mock.module`, the sibling deliberately runs unmocked)
- `bun run lint` / `lint:type-aware` / `tsc` — zero findings on all three files
- 48 falsifier mutations, all RED against verified-green baselines
