### PR TITLE
docs(agents): comment-analyzer reports adjacent de-slop candidates, advisory only

### DIFF
--- a/.claude/agents/comment-analyzer.md
+++ b/.claude/agents/comment-analyzer.md
@@ -1,6 +1,6 @@
 ---
 name: comment-analyzer
-description: Reviews comments added or changed in a diff for accuracy, long-term value, prose style, and fit with surrounding code. Use after writing doc comments or before opening a PR. Flags comment rot (claims that don't match the code), restate-the-obvious noise, AI-tell prose (verbose, antithesis-laden comments that should be concise plain English), and comments that miss Atlas's idioms (e.g. the `// intentionally ignored:` convention). Advisory only.
+description: Reviews comments added or changed in a diff for accuracy, long-term value, prose style, and fit with surrounding code. Use after writing doc comments or before opening a PR. Flags comment rot (claims that don't match the code), restate-the-obvious noise, AI-tell prose (verbose, antithesis-laden comments that should be concise plain English), and comments that miss Atlas's idioms (e.g. the `// intentionally ignored:` convention). Also returns capped, never-gating de-slop suggestions for comments in the enclosing block. Advisory only.
 tools: Read, Grep, Glob, Bash
 model: inherit
 color: green
@@ -20,7 +20,7 @@ You are a meticulous code-comment analyzer for the Atlas codebase. You approach 
 
 ## De-slop: concise, plain-English comments
 
-Comments in this repo are written with AI assistance, so AI-tell prose leaks into them. Sweep every comment in the diff against these rules (adapted from the blog's editorial law; scope stays the diff — this is not a license to rewrite the whole file's comments):
+Comments in this repo are written with AI assistance, so AI-tell prose leaks into them. Sweep every comment in the diff against these rules (adapted from the blog's editorial law; scope stays the diff, with one bounded exception under *Adjacent comments* below — this is not a license to rewrite the whole file's comments):
 
 - **Concise first.** A comment should be the shortest plain-English sentence that carries the constraint. If words can be cut without losing meaning, flag it and suggest the shorter form. A one-line fact does not need a three-line preamble.
 - **Antithesis / define-by-negation.** The #1 tell: "it's not X, it's Y" · "not a Z, but a W" · "X, not just Y". State the thing positively. Keep a contrast only when it is genuinely load-bearing (e.g. documenting which of two plausible behaviors was chosen), phrased naturally — never the formulaic pair.
@@ -31,6 +31,18 @@ Comments in this repo are written with AI assistance, so AI-tell prose leaks int
 - **No reviewer-directed commentary.** Comments that justify the change to a reviewer ("this is now correct because…", "fixed to properly handle…") die at merge. A comment states what the *next reader* needs: the constraint the code can't show.
 
 When flagging a style issue, quote the comment and give the rewritten plain-English version — the fix should be copy-pasteable. Style findings on an otherwise-accurate comment are **Improvement Opportunities**, not Critical Issues; a comment that is both verbose *and* inaccurate is Critical for the inaccuracy.
+
+## Adjacent comments (advisory only)
+
+The diff is the scope for everything above. The one exception: comments in the **enclosing function or block** of a diff hunk, which the author had to read to make the change. Sweep those too, and report them under **Adjacent Candidates**.
+
+Three limits, all load-bearing:
+
+- **Never a must-fix.** Adjacent findings never gate a round or a verdict. `/review-panel` closes on the diff; unrelated debt must not hold a PR open.
+- **At most five**, worst first. If more remain, say how many and name the file. A file with dozens needs its own de-slop pass.
+- **Style only.** Flag prose that breaks the de-slop rules above. Do not call an adjacent comment factually wrong unless you have read the code it describes and can state what makes it false; otherwise say it needs checking and leave it.
+
+The third limit is why this stays advisory. Rewriting a comment asserts something about code, and comment fixes are this panel's most frequent source of *new* false claims: the sweep on #5158 found nine false assertions, three of them introduced by the author's own earlier fixes. The author has just read the diff. Adjacent code is what they have not.
 
 ## Atlas idioms (the conventions you enforce)
 
@@ -55,6 +67,11 @@ When flagging a style issue, quote the comment and give the rewritten plain-Engl
 **Recommended Removals** — comments that add no value or create confusion
 - Location: `file:line`
 - Rationale: [why]
+
+**Adjacent Candidates** — de-slop opportunities in the enclosing block, outside the diff. Advisory: never must-fix, five at most.
+- Location: `file:line`
+- Current: [the comment, quoted]
+- Suggestion: [shorter plain-English form]
 
 **Positive Findings** — well-written comments worth emulating
 

--- a/.claude/commands/review-panel.md
+++ b/.claude/commands/review-panel.md
@@ -67,7 +67,7 @@ Every round:
 - `Agent(pr-test-analyzer)` — test coverage & discipline
 
 Final round only (or with `--final`):
-- `Agent(comment-analyzer)` — comment accuracy, idiom & prose de-slop (concise plain-English comments; the style rules live in the agent definition)
+- `Agent(comment-analyzer)` — comment accuracy, idiom & prose de-slop (concise plain-English comments; the style rules live in the agent definition). Also returns capped, advisory **Adjacent candidates** for the enclosing block, which never gate the verdict
 
 Each is read-only/advisory. Give every agent the same context: the base ref, the changed files, and the scope rule below.
 
@@ -100,9 +100,14 @@ Merge the four reports. Drop duplicates (e.g. an untested error path flagged by 
 
 ### Comment sweep
 - <`run` with its findings folded in above · or `deferred — not the final round`>
+
+### Adjacent candidates (advisory)
+- <comment-analyzer's out-of-diff de-slop suggestions, verbatim · or `none`>
 ```
 
 End with a one-line verdict: **CLEAN** (nothing must-fix) or **CHANGES REQUESTED** (≥1 must-fix). Callers gate on this verdict. A **CLEAN** verdict asserts the comment sweep ran on this diff — if it didn't, the verdict is not CLEAN yet.
+
+**Adjacent candidates never count toward the verdict.** They are `comment-analyzer`'s de-slop suggestions for the enclosing block, outside the diff, capped at five. Pass them through for the author to take or drop; a round is never held open for one, and taking one is never required to reach CLEAN. Fixing them is optional even when the fix is obvious — an adjacent comment describes code this diff did not touch, so a rewrite there is an unreviewed claim about unread code.
 
 **Step 5: Triage each must-fix BEFORE fixing it**
 


### PR DESCRIPTION
## What

`comment-analyzer` swept only comments **inside** the diff, so a file's existing AI-tell prose survived until someone ran a dedicated pass. This widens the sweep to the **enclosing function or block** of each hunk — the code the author had to read to make the change — and reports the results as **Adjacent Candidates**.

## The three limits

Bounded deliberately, because unbounded file-scope trades one problem for three worse ones (diff noise, rounds that cannot close, and parallel workers colliding on churn neither needed):

- **Never a must-fix** — a round never stays open on unrelated debt, and CLEAN is reachable without touching one
- **Five at most**, worst first; if more remain, the count and the file are named, which routes a genuinely slopped file to its own pass
- **Style only** — an adjacent comment is called factually wrong only when the reviewer has read the code it describes; otherwise it is reported as needing checking

## Why advisory rather than gating

Rewriting a comment asserts something about code, and comment fixes are this panel's most frequent source of *new* false claims. #5158's sweep found nine false assertions, three of them introduced by the author's own earlier fixes; its round 2 then found four defects that reproduced inside round 1's fixes, one of them inside the CI guard round 1 had just added. Adjacent code is exactly the code the author has **not** just read, so a confident rewrite there is an unreviewed claim about unread code.

## Drift guard

`/review-panel` gained the matching section plus an explicit statement that adjacent candidates never count toward the verdict. That file already warns that `comment-analyzer`'s two scheduling rules drifted apart once (#5077 merged with no sweep at all) — so the consuming side says out loud whether this gates, rather than leaving it inferred.

## Scope

Two markdown files. No code, no CI, no runtime behaviour.