### PR TITLE
perf(ci): shard mutation-tables four ways, and retire the "free" claim

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -657,6 +657,16 @@ jobs:
           # The label must agree with the position the runner actually assigned,
           # or `shard: [1, 1, 2]` would type-check as a matrix and leave one
           # residue class unowned while every job went green.
+          #
+          # ⚠️ Check that job-index is a NUMBER first. `set -u` does not catch a
+          # set-but-empty variable in arithmetic — bash reads it as 0 — so an
+          # empty job-index made shard 1 pass this assertion and reddened only
+          # shards 2-4, with a message blaming the wrong thing. Same class as the
+          # `[ 1x -gt 4 ]` bug: a malformed value read as a passing value.
+          if ! [[ "$SHARD_JOB_INDEX" =~ ^[0-9]+$ ]] || ! [[ "$SHARD_TOTAL" =~ ^[1-9][0-9]*$ ]]; then
+            echo "::error::strategy.job-index / job-total did not render as numbers (got '$SHARD_JOB_INDEX' / '$SHARD_TOTAL')"
+            exit 1
+          fi
           if [ "$SHARD" != "$((SHARD_JOB_INDEX + 1))" ]; then
             echo "::error::matrix.shard $SHARD does not match job-index $SHARD_JOB_INDEX + 1"
             exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -510,8 +510,10 @@ jobs:
   # docs/development/branch-protection.md. `if: always()` so the check is
   # present even when a dependent job fails.
   #
-  # `needs.api-tests.result` aggregates the matrix: it is `success` only if
-  # all four shards succeeded. ee-stub-build may legitimately be `skipped`
+  # `needs.<job>.result` aggregates a matrix: `api-tests` and `mutation-tables`
+  # are each `success` only if all four shards succeeded. Neither is a required
+  # context by name — only `ci` is — so renaming their shards cannot strand
+  # branch protection. ee-stub-build may legitimately be `skipped`
   # (path-gated on the `changes` job — docs-only PRs); everything else must
   # be `success`, including `changes` itself.
   ci:
@@ -564,35 +566,55 @@ jobs:
     # ⚠️ Its OWN job rather than a step in `api-tests`, which would run the sweep
     # once per api-tests shard.
     #
-    # It landed last, which the previous version of this comment named as the
-    # signal that the "free" claim had expired: that claim rested on `Built
-    # image (docs)` taking ~25 minutes, and the docs image is path-gated and
-    # SKIPS on an ordinary PR. Measured across four PRs from one batch —
-    # 15.6, 15.9, 18.4 and 31.0 minutes here against 3.9 for the next slowest
-    # job in the same runs. So it was the whole critical path, not a passenger
-    # on someone else's.
+    # This job is NOT free. The old justification was that `Built image (docs)`
+    # took ~25 minutes anyway, so the sweep ran inside someone else's critical
+    # path. That job lives in image-scan.yml as `built-images`, path-gated on
+    # Dockerfiles / package.json / bun.lock / deploy/, so it skips on most PRs.
     #
-    # Hence the shard. Same specs, same work, four machines: the selection is
-    # unchanged and `--shard` only slices what `--affected`/`--all` already
-    # chose. Expect the long pole to be whichever single spec has the most
-    # mutations — cost tracks mutation count, not spec count, so no assignment
-    # beats it. Going below that needs `mutate.ts` to partition its own mutation
+    # Measured 2026-08-14 via `gh api repos/AtlasDevHQ/atlas/actions/runs/<id>/jobs`.
+    # When the sweep is at `--all` — every push to main, plus a PR touching a
+    # spec's targets — it ran 15.6 and 18.4 min (pushes 31826451943, 31825282540)
+    # and 15.9 and 31.0 min (PR #5222, runs 31825661154, 31822641685), against
+    # ~3.7-4.2 for the next slowest job (`drift`, `test-others`). On a PR that
+    # touches no spec, `--affected` selects nothing and this job is under a
+    # minute. So the cost is real but concentrated: this sets the wall clock
+    # exactly when it widens.
+    #
+    # Sharded four ways. `--shard` slices whatever `--affected`/`--all` already
+    # selected, so the scope is unchanged. Each shard repeats the selection pass
+    # — git plumbing plus `mutate.ts --files`, cheap — and only the mutation runs
+    # are divided.
+    #
+    # Balance is lumpy: cost tracks a spec's mutation COUNT and round-robin
+    # ignores it. Measured by generated table rows (266 mutations over 13 specs)
+    # the shards carry 87 / 53 / 91 / 35, so the long pole is ~34% of the sweep
+    # against a ~20% floor set by the heaviest single spec (vocabulary-decide,
+    # 53). Going under that floor needs `mutate.ts` to partition its own mutation
     # list, which is a change to the runner and wants its own PR.
     #
-    # `ci-local.sh` still runs the `--affected` subset unsharded, because
-    # ~16 minutes added to a ~10-minute pre-PR loop is how a gate gets deleted.
+    # `ci-local.sh` still runs the `--affected` subset unsharded: one machine,
+    # and a full sweep added to a ~10-minute pre-PR loop is how a gate gets
+    # deleted.
     #
     # There is deliberately no `timeout-minutes` here: a sweep killed halfway
-    # reports nothing while looking like a verdict. Slow shows up as slow.
-    name: mutation-tables (${{ matrix.shard }}/4)
+    # reports nothing while looking like a verdict. Without one, a sweep that
+    # outgrows the runner shows up as a slow job rather than a red gate.
+    name: mutation-tables (${{ matrix.shard }}/${{ strategy.job-total }})
     runs-on: ubuntu-latest
     strategy:
-      # ⚠️ false, so one stale table does not cancel the siblings still
-      # measuring. A cancelled shard reports nothing, and "nothing" next to a
-      # real failure reads as "only one table drifted" when three more might
-      # have.
+      # fail-fast off: a stale table on one shard must not cancel the other
+      # three. A cancelled shard reports nothing, and nothing beside a real
+      # failure reads as "one table drifted" when four might have.
       fail-fast: false
       matrix:
+        # ⚠️ The ONLY place the shard count is written. The divisor passed to
+        # `--shard` comes from `strategy.job-total`, so resharding is this one
+        # edit. An earlier cut hardcoded `/4` in the job name and both run-step
+        # invocations: growing the matrix then failed loudly ("index exceeds
+        # total"), but SHRINKING it silently orphaned every spec at the dropped
+        # positions — verified by nobody, four green jobs — which is the same
+        # defect the round-robin exists to prevent, moved from spec names to a
+        # hand-copied integer.
         shard: [1, 2, 3, 4]
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
@@ -620,26 +642,29 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           SHARD: ${{ matrix.shard }}
+          SHARD_TOTAL: ${{ strategy.job-total }}
+          SHARD_JOB_INDEX: ${{ strategy.job-index }}
         run: |
           set -euo pipefail
           # ⚠️ The SWEEP still happens — it MOVED, it was not deleted. #5077's
           # finding was that four of eight tables were stale on `main` because
           # `--check` existed and nothing ran it; `push: main` below is what
           # keeps that closed. What changed is only WHEN a full sweep blocks:
-          # not on a PR whose diff cannot have touched a table.
+          # not on a PR whose diff cannot have touched a table. `--affected`
+          # widens to `--all` on any unresolvable diff, so the narrow path can
+          # never silently verify nothing.
           #
-          # The `--all` justification this job shipped with was "14 minutes is
-          # FREE, jobs run in parallel and `Built image (docs)` already takes
-          # ~25". That premise is conditional on a job that is itself
-          # path-gated — when the image scan skips, this job IS the critical
-          # path, and it gated every docs-only and ROADMAP-only PR on a
-          # 14-minute Postgres sweep. `--affected` widens to `--all` on any
-          # unresolvable diff, so the narrow path can never silently verify
-          # nothing.
+          # The label must agree with the position the runner actually assigned,
+          # or `shard: [1, 1, 2]` would type-check as a matrix and leave one
+          # residue class unowned while every job went green.
+          if [ "$SHARD" != "$((SHARD_JOB_INDEX + 1))" ]; then
+            echo "::error::matrix.shard $SHARD does not match job-index $SHARD_JOB_INDEX + 1"
+            exit 1
+          fi
           if [ "$EVENT_NAME" = "pull_request" ]; then
-            bash scripts/check-mutation-tables.sh --affected "$BASE_SHA" --shard "$SHARD/4"
+            bash scripts/check-mutation-tables.sh --affected "$BASE_SHA" --shard "$SHARD/$SHARD_TOTAL"
           else
-            bash scripts/check-mutation-tables.sh --all --shard "$SHARD/4"
+            bash scripts/check-mutation-tables.sh --all --shard "$SHARD/$SHARD_TOTAL"
           fi
     services:
       postgres:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -561,25 +561,39 @@ jobs:
     # `escapeCell` row had been a dead ANCHOR since #5060/#4389 rewrote the
     # escape it pointed at.
     #
-    # ⚠️ Its OWN job rather than a step in `api-tests`, which is a 4-way shard
-    # matrix and would run this four times over. The full sweep is 15m48s
-    # measured at thirteen specs (PR #5222; it was 832s at eight, #5077 —
-    # `scripts/check-mutation-tables.sh`'s header carries both). That is FREE
-    # here: jobs run in parallel and `Built image (docs)` already takes ~25
-    # minutes, so this lands inside the existing critical path. `ci-local.sh`
-    # runs the `--affected` subset instead, because ~16 minutes added to a
-    # ~10-minute pre-PR loop is how a gate gets deleted.
+    # ⚠️ Its OWN job rather than a step in `api-tests`, which would run the sweep
+    # once per api-tests shard.
     #
-    # Re-take the measurement whenever a spec is added; the "free" claim is the
-    # half that expires, and it rests on a number rather than on an argument.
+    # It landed last, which the previous version of this comment named as the
+    # signal that the "free" claim had expired: that claim rested on `Built
+    # image (docs)` taking ~25 minutes, and the docs image is path-gated and
+    # SKIPS on an ordinary PR. Measured across four PRs from one batch —
+    # 15.6, 15.9, 18.4 and 31.0 minutes here against 3.9 for the next slowest
+    # job in the same runs. So it was the whole critical path, not a passenger
+    # on someone else's.
+    #
+    # Hence the shard. Same specs, same work, four machines: the selection is
+    # unchanged and `--shard` only slices what `--affected`/`--all` already
+    # chose. Expect the long pole to be whichever single spec has the most
+    # mutations — cost tracks mutation count, not spec count, so no assignment
+    # beats it. Going below that needs `mutate.ts` to partition its own mutation
+    # list, which is a change to the runner and wants its own PR.
+    #
+    # `ci-local.sh` still runs the `--affected` subset unsharded, because
+    # ~16 minutes added to a ~10-minute pre-PR loop is how a gate gets deleted.
     #
     # There is deliberately no `timeout-minutes` here: a sweep killed halfway
-    # reports nothing while looking like a verdict. Without one, outgrowing the
-    # docs image shows up as slow CI rather than a red gate. If this job starts
-    # landing last, it has outgrown it, and that script's header ("a gate that
-    # doubles the loop gets commented out") has begun applying to this one.
-    name: mutation-tables
+    # reports nothing while looking like a verdict. Slow shows up as slow.
+    name: mutation-tables (${{ matrix.shard }}/4)
     runs-on: ubuntu-latest
+    strategy:
+      # ⚠️ false, so one stale table does not cancel the siblings still
+      # measuring. A cancelled shard reports nothing, and "nothing" next to a
+      # real failure reads as "only one table drifted" when three more might
+      # have.
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
@@ -605,6 +619,7 @@ jobs:
           TEST_DATABASE_URL: postgresql://atlas:atlas@localhost:5432/atlas
           EVENT_NAME: ${{ github.event_name }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          SHARD: ${{ matrix.shard }}
         run: |
           set -euo pipefail
           # ⚠️ The SWEEP still happens — it MOVED, it was not deleted. #5077's
@@ -622,9 +637,9 @@ jobs:
           # unresolvable diff, so the narrow path can never silently verify
           # nothing.
           if [ "$EVENT_NAME" = "pull_request" ]; then
-            bash scripts/check-mutation-tables.sh --affected "$BASE_SHA"
+            bash scripts/check-mutation-tables.sh --affected "$BASE_SHA" --shard "$SHARD/4"
           else
-            bash scripts/check-mutation-tables.sh --all
+            bash scripts/check-mutation-tables.sh --all --shard "$SHARD/4"
           fi
     services:
       postgres:

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -77,8 +77,10 @@ cd packages/api && bun run scripts/mutate.ts scripts/mutations/<name>.mutations.
 
 Hand-editing a cell is the thing this exists to prevent: a stored count is a
 claim nothing can falsify, so adding one test silently makes N cells false.
-`scripts/check-mutation-tables.sh` is the CI gate (`--affected` locally, `--all`
-in CI); it globs the directory, so a new spec is covered the moment it lands.
+`scripts/check-mutation-tables.sh` is the CI gate (`--affected` locally and on
+PRs, `--all` on push to `main`, sharded four ways in CI); it globs the directory,
+so a new spec is covered the moment it lands, and shard ownership follows from
+its position in that glob.
 
 **`-pg` specs need a scratch database.** Without `TEST_DATABASE_URL` those
 suites self-skip, the baseline is deflated, and the runner ABORTS rather than

--- a/scripts/__tests__/check-mutation-tables.test.sh
+++ b/scripts/__tests__/check-mutation-tables.test.sh
@@ -8,9 +8,11 @@
 # gate against the real repo, where the honest answer takes ~16 minutes
 # (`check-mutation-tables.sh`'s header carries the measurements).
 #
-# So each fixture builds a throwaway packages/api tree with ONE two-test target
-# and ONE spec, points the gate at it via MUTATION_SPEC_GLOB, and runs the real
-# script end to end — the real `mutate.ts`, the real git plumbing, no mocks.
+# So the fixtures build throwaway packages/api trees and point the gate at them
+# via MUTATION_SPEC_GLOB. Most carry ONE two-test target and ONE spec and run the
+# real script end to end — the real `mutate.ts`, the real git plumbing, no mocks.
+# The partition fixtures carry only empty spec files, because the paths they
+# exercise decide ownership before any spec is loaded.
 #
 # Locks in, in the order they would hurt:
 #   1. a hand-edited generated table is CAUGHT             (the #5060 threat model)
@@ -19,6 +21,10 @@
 #   4. TEST_DATABASE_URL unset exits 3, not 0              (SKIP, never PASS)
 #   5. POSITIVE CONTROL: a current table passes            (or the above is vacuous)
 #   6. HEAD == base exits 3, and HEAD-ahead still exits 0  (#5151, a PAIR)
+#   7. every spec lands on exactly one shard               (the partition)
+#   8. a malformed --shard is a hard error                 (never a silent no-op)
+#   9. an empty shard is honest, an impossible one is not  (the exit-0 path)
+#  10. --affected + --shard still covers the affected set  (what CI runs on a PR)
 #
 # ⚠️ EVERY fixture here was proven sensitive by DELETING the guard it pins and
 # confirming it goes red. Two more (`.todo` refused, dead anchor refused) were
@@ -184,16 +190,19 @@ check 0 "HEAD ahead of base, no spec dep touched — still a genuine PASS" "$T" 
 # 7. The shard partition is TOTAL and DISJOINT.
 #
 # The threat is a spec that lands on no shard: verified by nothing, green
-# forever — the same outcome as the four stale tables in this file's header,
+# forever — the same outcome as the four stale tables in check-mutation-tables.sh's header,
 # reached through a new door. Enumerating spec names in the CI matrix would
 # produce exactly that the next time someone adds a spec, which is why the
 # partition is round-robin by position and why this fixture exists to hold it.
 #
-# Cheap on purpose. `--list-only` prints the selection without running a
-# mutation, so the property is checked in milliseconds; proving it against the
-# real specs would cost a full sweep per shard, and a test that expensive is one
-# nobody runs. 13 specs over 4 shards also leaves the count indivisible, so an
-# off-by-one in the modulo cannot hide behind an even split.
+# `--list-only` prints the selection without running a mutation, so this costs
+# milliseconds; proving the property against the real specs would cost a full
+# sweep per shard, and a test that expensive is one nobody runs.
+#
+# The assertion is on the UNION: 13 selections, 13 distinct. An off-by-one in
+# the modulo drops a whole residue class, which shows up as a short union. 13 is
+# the fixture's own count, chosen not to divide by 4 so an uneven split is
+# exercised too; it does not have to track the real spec count.
 make_spec_tree() { # $1 = how many empty spec files
   local n="$1" tmp i; tmp="$(mktemp -d)"
   mkdir -p "$tmp/packages/api/scripts/mutations" "$tmp/scripts"
@@ -203,9 +212,14 @@ make_spec_tree() { # $1 = how many empty spec files
 }
 
 shard_selection() { # $1 tree  $2 shard  $3 total
-  ( cd "$1" && TEST_DATABASE_URL=x MUTATION_SPEC_GLOB="scripts/mutations/*.mutations.ts" \
-      bash scripts/check-mutation-tables.sh --all --list-only --shard "$2/$3" 2>/dev/null \
-      | sed -n 's/^SELECTED //p' )
+  # ⚠️ Capture first, THEN filter. `--list-only` exits 3 ("declined to verify"),
+  # and piping it straight into sed under `pipefail` aborts this whole suite at
+  # the first call — which looked like the fixture had vanished rather than
+  # failed. `|| true` is correct here and only here: 3 is the expected status.
+  local out
+  out=$( cd "$1" && TEST_DATABASE_URL=x MUTATION_SPEC_GLOB="scripts/mutations/*.mutations.ts" \
+         bash scripts/check-mutation-tables.sh --all --list-only --shard "$2/$3" 2>/dev/null ) || true
+  printf '%s\n' "$out" | sed -n 's/^SELECTED //p'
 }
 
 SPEC_N=13
@@ -223,17 +237,155 @@ else
 fi
 rm -rf "$T"
 
-# A malformed --shard must be a hard error. Falling through to "no sharding"
-# would run every spec on every shard (slow, green, unnoticed); falling through
-# to "empty" would verify NOTHING on all four and still exit 0.
+# 8. A malformed --shard is a hard error. See the validation comment in the
+# script for why a fall-through is a false-clean.
+#
+# ⚠️ Each case asserts a DISCRIMINATING PHRASE, not a bare exit 1. Five paths in
+# this script exit 1 — no specs found, unknown argument, --shard missing its
+# value, the pattern rejection, and the STALE verdict — so an exit-code-only
+# assertion cannot tell "the guard fired" from "my fixture tree was broken."
+# Measured: the first cut of this fixture asserted `rc == 1` for `9/4` and
+# reported "ok" against a tree containing NO spec files at all, where the 1 came
+# from "no specs found". The file header already names that as why two earlier
+# fixtures were deleted rather than shipped green.
+#
+# The first three cases below all passed the original `[1-9]*/[1-9]*` glob:
+# `1a/4` and `1/4x` ran every spec with exit 0, and `1/4/9` silently became a
+# 9-way partition.
+shard_reject() { # $1 label  $2 shard-arg  $3 phrase the stderr must contain
+  local tmp; tmp=$(make_spec_tree 5)
+  local rc=0 out
+  out=$( cd "$tmp" && TEST_DATABASE_URL=x MUTATION_SPEC_GLOB="scripts/mutations/*.mutations.ts" \
+         bash scripts/check-mutation-tables.sh --all --list-only --shard "$2" 2>&1 ) || rc=$?
+  # `--` before the pattern: every phrase here starts with `--shard`, and grep
+  # reads that as an option otherwise.
+  if [ "$rc" = "1" ] && printf '%s' "$out" | grep -qF -- "$3"; then
+    echo "  ok    --shard $2 rejected ($1)"; PASS=$((PASS + 1))
+  else
+    echo "  FAIL  --shard $2 ($1) — expected exit 1 containing '$3', got $rc"
+    printf '%s' "$out" | sed 's/^/        /' | tail -6
+    FAIL=$((FAIL + 1))
+  fi
+  rm -rf "$tmp"
+}
+
+shard_reject "trailing junk in the index" "1a/4"  "--shard expects I/N"
+shard_reject "trailing junk in the total" "1/4x" "--shard expects I/N"
+shard_reject "three fields"               "1/4/9" "--shard expects I/N"
+shard_reject "zero index"                 "0/4"   "--shard expects I/N"
+shard_reject "no slash"                   "4"     "--shard expects I/N"
+shard_reject "index past total"           "9/4"   "index exceeds total"
+
+# 9. The empty-shard exit 0, which `--list-only` STRUCTURALLY CANNOT REACH — it
+# returns before this branch — so fixture 7 can never cover it however far it is
+# extended. It is also the common case in production: an affected set of 1-3
+# specs against a 4-shard matrix empties at least one shard on most PRs.
 T=$(make_spec_tree 2)
 rc=0
-( cd "$T" && TEST_DATABASE_URL=x MUTATION_SPEC_GLOB="scripts/mutations/*.mutations.ts" \
-    bash scripts/check-mutation-tables.sh --all --list-only --shard 9/4 >/dev/null 2>&1 ) || rc=$?
-if [ "$rc" = "1" ]; then
-  echo "  ok    --shard 9/4 (index past total) is a hard error, not a silent no-op (exit $rc)"; PASS=$((PASS + 1))
+out=$( cd "$T" && TEST_DATABASE_URL=x MUTATION_SPEC_GLOB="scripts/mutations/*.mutations.ts" \
+       bash scripts/check-mutation-tables.sh --all --shard 4/4 2>&1 ) || rc=$?
+if [ "$rc" = "0" ] && printf '%s' "$out" | grep -qF "no spec at positions"; then
+  echo "  ok    an empty shard (2 specs, 4 shards) exits 0 and says so"; PASS=$((PASS + 1))
 else
-  echo "  FAIL  --shard 9/4 — expected exit 1, got $rc"; FAIL=$((FAIL + 1))
+  echo "  FAIL  empty shard — expected exit 0 naming the empty residue class, got $rc"
+  printf '%s' "$out" | sed 's/^/        /' | tail -6; FAIL=$((FAIL + 1))
+fi
+rm -rf "$T"
+
+# The negative half of the pair. With MORE specs than shards, round-robin gives
+# every shard at least one, so an empty slice means the partition is broken —
+# and every path that produces one otherwise ends in green jobs having verified
+# nothing. A fixture asserting only the 0 above would pass a script that always
+# returned an empty shard.
+#
+# ⚠️ Assert on the PHRASE, not the exit code. These trees hold empty spec files,
+# so a shard that receives work proceeds to verification and exits 1 STALE — the
+# same 1 the impossible-empty guard uses. An exit-code assertion here would pass
+# for the wrong reason, which is the defect this whole fixture block was
+# rewritten to remove.
+T=$(make_spec_tree 8)
+rc=0
+out=$( cd "$T" && TEST_DATABASE_URL=x MUTATION_SPEC_GLOB="scripts/mutations/*.mutations.ts" \
+       bash scripts/check-mutation-tables.sh --all --shard 1/2 2>&1 ) || rc=$?
+if ! printf '%s' "$out" | grep -qF "is empty, but"; then
+  echo "  ok    8 specs over 2 shards never reports an impossible empty shard"; PASS=$((PASS + 1))
+else
+  echo "  FAIL  8 specs over 2 shards reported an impossible empty shard"
+  printf '%s' "$out" | sed 's/^/        /' | tail -6; FAIL=$((FAIL + 1))
+fi
+rm -rf "$T"
+
+# 10. OWNERSHIP COMES FROM `SPECS`, NOT `SELECTED` — the fix for the defect that
+# makes widen-never-narrow narrow the union.
+#
+# `SELECTED` is the selector's output and the selector widens per process, so
+# one runner can widen while three do not. If ownership were computed from
+# `SELECTED`, widening one shard would RENUMBER the positions and a spec would
+# fall through the gap, verified by nobody, all shards green.
+#
+# The falsifier: build three real specs, make only the THIRD affected. Its
+# position in the glob is 2, so shard 3 of 4 must own it. If ownership were
+# taken from `SELECTED` it would sit at position 0 of a one-element list and
+# shard 1 would claim it. Asserting the OWNER — not merely that some shard has
+# it — is what discriminates the two implementations.
+make_multi_spec_tree() { # builds 3 real specs; only c is touched
+  local tmp; tmp="$(mktemp -d)"
+  mkdir -p "$tmp/packages/api/scripts/mutations" "$tmp/packages/api/src" "$tmp/scripts"
+  for f in mutate.ts mutation-core.ts mutation-spec.ts signal-retry.ts; do
+    cp "$REPO_ROOT/packages/api/scripts/$f" "$tmp/packages/api/scripts/"
+  done
+  ln -s "$REPO_ROOT/node_modules" "$tmp/node_modules"
+  cp "$SCRIPT" "$tmp/scripts/check-mutation-tables.sh"
+  local n
+  for n in a b c; do
+    cat >"$tmp/packages/api/src/$n.ts" <<TS
+export function v$n(): number {
+  return 1;
+}
+TS
+    cat >"$tmp/packages/api/src/$n.test.ts" <<TS
+import { expect, test } from "bun:test";
+import { v$n } from "./$n";
+test("x", () => { expect(v$n()).toBe(1); });
+test("y", () => { expect(v$n()).toBe(1); });
+test("z", () => { expect(1).toBe(1); });
+TS
+    cat >"$tmp/packages/api/scripts/mutations/$n.mutations.ts" <<SPEC
+import type { MutationSpec } from "../mutation-spec";
+const spec: MutationSpec = {
+  title: "$n",
+  out: "scripts/mutations/$n.md",
+  targets: [{ name: "$n", file: "src/$n.test.ts" }],
+  mutations: [
+    { label: "$n wrong", edits: [{ file: "src/$n.ts", oldString: "  return 1;", newString: "  return 0;" }] },
+  ],
+};
+export default spec;
+SPEC
+  done
+  ( cd "$tmp" && git init --quiet -b main && git config user.email t@t.t && git config user.name t \
+      && git add -A >/dev/null && git commit --quiet -m base && git branch base-ref HEAD \
+      && echo "// touched" >> packages/api/src/c.ts && git add -A >/dev/null \
+      && git commit --quiet -m "touch c only" )
+  echo "$tmp"
+}
+
+T=$(make_multi_spec_tree)
+OWNER=""
+UNION=""
+for s in 1 2 3 4; do
+  raw=$( cd "$T" && TEST_DATABASE_URL=x MUTATION_SPEC_GLOB="scripts/mutations/*.mutations.ts" \
+         bash scripts/check-mutation-tables.sh --affected base-ref --shard "$s/4" --list-only 2>/dev/null ) || true
+  got=$( printf '%s\n' "$raw" | sed -n 's/^SELECTED //p' )
+  if [ -n "$got" ]; then OWNER="$s"; UNION="${UNION}${got}"$'\n'; fi
+done
+COVERED=$(printf '%s' "$UNION" | grep -c 'c.mutations.ts' || true)
+if [ "$OWNER" = "3" ] && [ "$COVERED" = "1" ]; then
+  echo "  ok    the affected spec is owned by its SPECS position (shard 3), not its SELECTED position"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL  affected-spec ownership — expected sole owner shard 3 and exactly one covering, got owner='$OWNER' covered=$COVERED"
+  FAIL=$((FAIL + 1))
 fi
 rm -rf "$T"
 

--- a/scripts/__tests__/check-mutation-tables.test.sh
+++ b/scripts/__tests__/check-mutation-tables.test.sh
@@ -181,5 +181,61 @@ T=$(make_tree "$GOOD_TARGET" '"  return 42;"' \
    'git branch base-ref HEAD && echo note > ../../notes.md && git add -A >/dev/null && git commit --quiet -m irrelevant')
 check 0 "HEAD ahead of base, no spec dep touched — still a genuine PASS" "$T" --affected base-ref
 
+# 7. The shard partition is TOTAL and DISJOINT.
+#
+# The threat is a spec that lands on no shard: verified by nothing, green
+# forever — the same outcome as the four stale tables in this file's header,
+# reached through a new door. Enumerating spec names in the CI matrix would
+# produce exactly that the next time someone adds a spec, which is why the
+# partition is round-robin by position and why this fixture exists to hold it.
+#
+# Cheap on purpose. `--list-only` prints the selection without running a
+# mutation, so the property is checked in milliseconds; proving it against the
+# real specs would cost a full sweep per shard, and a test that expensive is one
+# nobody runs. 13 specs over 4 shards also leaves the count indivisible, so an
+# off-by-one in the modulo cannot hide behind an even split.
+make_spec_tree() { # $1 = how many empty spec files
+  local n="$1" tmp i; tmp="$(mktemp -d)"
+  mkdir -p "$tmp/packages/api/scripts/mutations" "$tmp/scripts"
+  cp "$SCRIPT" "$tmp/scripts/check-mutation-tables.sh"
+  for i in $(seq 1 "$n"); do : >"$tmp/packages/api/scripts/mutations/s$i.mutations.ts"; done
+  echo "$tmp"
+}
+
+shard_selection() { # $1 tree  $2 shard  $3 total
+  ( cd "$1" && TEST_DATABASE_URL=x MUTATION_SPEC_GLOB="scripts/mutations/*.mutations.ts" \
+      bash scripts/check-mutation-tables.sh --all --list-only --shard "$2/$3" 2>/dev/null \
+      | sed -n 's/^SELECTED //p' )
+}
+
+SPEC_N=13
+SHARD_N=4
+T=$(make_spec_tree "$SPEC_N")
+UNION=""
+for s in $(seq 1 "$SHARD_N"); do UNION="${UNION}$(shard_selection "$T" "$s" "$SHARD_N")"$'\n'; done
+TOTAL=$(printf '%s' "$UNION" | grep -c . || true)
+DISTINCT=$(printf '%s' "$UNION" | sort -u | grep -c . || true)
+if [ "$TOTAL" = "$SPEC_N" ] && [ "$DISTINCT" = "$SPEC_N" ]; then
+  echo "  ok    shard partition is total and disjoint ($SPEC_N specs over $SHARD_N shards)"; PASS=$((PASS + 1))
+else
+  echo "  FAIL  shard partition — expected $SPEC_N selections and $SPEC_N distinct, got $TOTAL and $DISTINCT"
+  FAIL=$((FAIL + 1))
+fi
+rm -rf "$T"
+
+# A malformed --shard must be a hard error. Falling through to "no sharding"
+# would run every spec on every shard (slow, green, unnoticed); falling through
+# to "empty" would verify NOTHING on all four and still exit 0.
+T=$(make_spec_tree 2)
+rc=0
+( cd "$T" && TEST_DATABASE_URL=x MUTATION_SPEC_GLOB="scripts/mutations/*.mutations.ts" \
+    bash scripts/check-mutation-tables.sh --all --list-only --shard 9/4 >/dev/null 2>&1 ) || rc=$?
+if [ "$rc" = "1" ]; then
+  echo "  ok    --shard 9/4 (index past total) is a hard error, not a silent no-op (exit $rc)"; PASS=$((PASS + 1))
+else
+  echo "  FAIL  --shard 9/4 — expected exit 1, got $rc"; FAIL=$((FAIL + 1))
+fi
+rm -rf "$T"
+
 echo ":: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]

--- a/scripts/__tests__/check-mutation-tables.test.sh
+++ b/scripts/__tests__/check-mutation-tables.test.sh
@@ -275,6 +275,11 @@ shard_reject "three fields"               "1/4/9" "--shard expects I/N"
 shard_reject "zero index"                 "0/4"   "--shard expects I/N"
 shard_reject "no slash"                   "4"     "--shard expects I/N"
 shard_reject "index past total"           "9/4"   "index exceeds total"
+# Anchoring constrained syntax but not magnitude: this overflowed `[`, which
+# returned status 2 inside an `if` condition, which bash read as false — so the
+# range check was bypassed and the run proceeded with a bogus index. The `{0,3}`
+# bound in the pattern is what closes it.
+shard_reject "total out of range"         "1/99999999999999999999" "--shard expects I/N"
 
 # 9. The empty-shard exit 0, which `--list-only` STRUCTURALLY CANNOT REACH — it
 # returns before this branch — so fixture 7 can never cover it however far it is
@@ -284,7 +289,7 @@ T=$(make_spec_tree 2)
 rc=0
 out=$( cd "$T" && TEST_DATABASE_URL=x MUTATION_SPEC_GLOB="scripts/mutations/*.mutations.ts" \
        bash scripts/check-mutation-tables.sh --all --shard 4/4 2>&1 ) || rc=$?
-if [ "$rc" = "0" ] && printf '%s' "$out" | grep -qF "no spec at positions"; then
+if [ "$rc" = "0" ] && printf '%s' "$out" | grep -qF "no selected spec at positions"; then
   echo "  ok    an empty shard (2 specs, 4 shards) exits 0 and says so"; PASS=$((PASS + 1))
 else
   echo "  FAIL  empty shard — expected exit 0 naming the empty residue class, got $rc"
@@ -328,7 +333,8 @@ rm -rf "$T"
 # taken from `SELECTED` it would sit at position 0 of a one-element list and
 # shard 1 would claim it. Asserting the OWNER — not merely that some shard has
 # it — is what discriminates the two implementations.
-make_multi_spec_tree() { # builds 3 real specs; only c is touched
+make_multi_spec_tree() { # $1 = how many specs (default 3)  $2 = which to touch (default "c")
+  local count="${1:-3}" touch_list="${2:-c}"
   local tmp; tmp="$(mktemp -d)"
   mkdir -p "$tmp/packages/api/scripts/mutations" "$tmp/packages/api/src" "$tmp/scripts"
   for f in mutate.ts mutation-core.ts mutation-spec.ts signal-retry.ts; do
@@ -336,8 +342,9 @@ make_multi_spec_tree() { # builds 3 real specs; only c is touched
   done
   ln -s "$REPO_ROOT/node_modules" "$tmp/node_modules"
   cp "$SCRIPT" "$tmp/scripts/check-mutation-tables.sh"
-  local n
-  for n in a b c; do
+  local names n
+  names=$(printf 'a b c d e f g h' | cut -d' ' -f1-"$count")
+  for n in $names; do
     cat >"$tmp/packages/api/src/$n.ts" <<TS
 export function v$n(): number {
   return 1;
@@ -364,28 +371,86 @@ export default spec;
 SPEC
   done
   ( cd "$tmp" && git init --quiet -b main && git config user.email t@t.t && git config user.name t \
-      && git add -A >/dev/null && git commit --quiet -m base && git branch base-ref HEAD \
-      && echo "// touched" >> packages/api/src/c.ts && git add -A >/dev/null \
-      && git commit --quiet -m "touch c only" )
+      && git add -A >/dev/null && git commit --quiet -m base && git branch base-ref HEAD )
+  local t
+  for t in $touch_list; do echo "// touched" >> "$tmp/packages/api/src/$t.ts"; done
+  ( cd "$tmp" && git add -A >/dev/null && git commit --quiet -m "touch $touch_list" )
   echo "$tmp"
 }
 
 T=$(make_multi_spec_tree)
-OWNER=""
+#
+# ⚠️ Collect ALL owners and the union SIZE, not "the last shard that had
+# something". The first cut assigned OWNER inside the loop, so it held the
+# highest-numbered non-empty shard while its FAIL message claimed "sole owner" —
+# an assertion weaker than the message describing it. Dropping the SELECTED
+# intersection entirely (each shard verifies its whole positional slice, turning
+# every PR into a full sweep) left OWNER=3 and reported ok.
+OWNERS=""
 UNION=""
 for s in 1 2 3 4; do
   raw=$( cd "$T" && TEST_DATABASE_URL=x MUTATION_SPEC_GLOB="scripts/mutations/*.mutations.ts" \
          bash scripts/check-mutation-tables.sh --affected base-ref --shard "$s/4" --list-only 2>/dev/null ) || true
   got=$( printf '%s\n' "$raw" | sed -n 's/^SELECTED //p' )
-  if [ -n "$got" ]; then OWNER="$s"; UNION="${UNION}${got}"$'\n'; fi
+  if [ -n "$got" ]; then OWNERS="${OWNERS}${s} "; UNION="${UNION}${got}"$'\n'; fi
 done
+TOTAL=$(printf '%s' "$UNION" | grep -c . || true)
 COVERED=$(printf '%s' "$UNION" | grep -c 'c.mutations.ts' || true)
-if [ "$OWNER" = "3" ] && [ "$COVERED" = "1" ]; then
-  echo "  ok    the affected spec is owned by its SPECS position (shard 3), not its SELECTED position"
+if [ "$OWNERS" = "3 " ] && [ "$TOTAL" = "1" ] && [ "$COVERED" = "1" ]; then
+  echo "  ok    the affected spec is owned by its SPECS position (shard 3 alone), not its SELECTED position"
   PASS=$((PASS + 1))
 else
-  echo "  FAIL  affected-spec ownership — expected sole owner shard 3 and exactly one covering, got owner='$OWNER' covered=$COVERED"
+  echo "  FAIL  affected-spec ownership — expected owners='3 ' union=1 covered=1, got owners='$OWNERS' union=$TOTAL covered=$COVERED"
   FAIL=$((FAIL + 1))
+fi
+rm -rf "$T"
+
+# 11. A LEGITIMATELY empty shard on --affected is a PASS, not an accusation.
+#
+# This is the true negative half of fixture 9, and the one that catches the
+# guard being written against the wrong operand. Ownership ranges over SPECS;
+# SELECTED filters it; so a shard can own positions and legitimately hold none
+# of the affected ones. Four specs, only positions 1 and 3 (b, d) affected:
+# shard 2 of 2 owns positions 1 and 3 and takes both, shard 1 owns 0 and 2 and
+# takes NEITHER — and must say so with exit 0.
+#
+# Measured against the first cut: shard 1 exited 1 with "is empty, but 2 spec(s)
+# were selected — the partition is wrong". The partition was right. Any PR with
+# >= 4 affected specs that missed a residue class would have reddened CI.
+T=$(make_multi_spec_tree 4 "b d")
+rc1=0
+out1=$( cd "$T" && TEST_DATABASE_URL=x MUTATION_SPEC_GLOB="scripts/mutations/*.mutations.ts" \
+        bash scripts/check-mutation-tables.sh --affected base-ref --shard 1/2 --list-only 2>&1 ) || rc1=$?
+if [ "$rc1" = "3" ] && printf '%s' "$out1" | grep -qF "0 of 2 selected"; then
+  echo "  ok    an --affected shard owning no SELECTED spec is honest, not an accusation"; PASS=$((PASS + 1))
+else
+  echo "  FAIL  legitimate empty --affected shard — expected exit 3 and '0 of 2 selected', got $rc1"
+  printf '%s' "$out1" | sed 's/^/        /' | tail -6; FAIL=$((FAIL + 1))
+fi
+rm -rf "$T"
+
+# 12. --list-only declines: exit 3, never 0. Both helpers above discard the
+# status with `|| true`, so nothing observed the 0 -> 3 change until this.
+T=$(make_spec_tree 5)
+rc=0
+out=$( cd "$T" && TEST_DATABASE_URL=x MUTATION_SPEC_GLOB="scripts/mutations/*.mutations.ts" \
+       bash scripts/check-mutation-tables.sh --all --list-only 2>&1 ) || rc=$?
+if [ "$rc" = "3" ] && printf '%s' "$out" | grep -qF "nothing verified"; then
+  echo "  ok    --list-only exits 3 (declined), not 0 (verified)"; PASS=$((PASS + 1))
+else
+  echo "  FAIL  --list-only — expected exit 3 saying nothing verified, got $rc"; FAIL=$((FAIL + 1))
+fi
+rm -rf "$T"
+
+# 13. --shard twice is an error, not last-wins.
+T=$(make_spec_tree 5)
+rc=0
+out=$( cd "$T" && TEST_DATABASE_URL=x MUTATION_SPEC_GLOB="scripts/mutations/*.mutations.ts" \
+       bash scripts/check-mutation-tables.sh --all --list-only --shard 1/4 --shard 2/4 2>&1 ) || rc=$?
+if [ "$rc" = "1" ] && printf '%s' "$out" | grep -qF "given twice"; then
+  echo "  ok    a repeated --shard is rejected rather than silently last-wins"; PASS=$((PASS + 1))
+else
+  echo "  FAIL  repeated --shard — expected exit 1 saying 'given twice', got $rc"; FAIL=$((FAIL + 1))
 fi
 rm -rf "$T"
 

--- a/scripts/check-mutation-tables.sh
+++ b/scripts/check-mutation-tables.sh
@@ -31,13 +31,21 @@
 #   --affected [base]   Verify only the specs whose dependency set the branch
 #                       touched. The common PR touches none and the gate is
 #                       instant. This is what ci-local.sh runs.
-#   --all               Every spec. What CI runs, and still FREE at 15m48s
-#                       (thirteen specs): jobs run in parallel and `Built image
-#                       (docs)` takes ~25 minutes, so this finishes inside the
-#                       existing critical path. It stays free only while that
-#                       holds — past the docs image this job IS the critical
-#                       path, and the header's argument starts applying to this
-#                       gate rather than to `/ci`.
+#   --all               Every spec. What CI runs.
+#   --shard I/N         Only this shard's slice of the selection, round-robin by
+#                       position, 1-based. CI runs four in parallel; the slices
+#                       are disjoint and their union is the whole selection.
+#   --list-only         Print the selection and exit 0 without verifying. A seam
+#                       for testing the partition — see the fixture suite.
+#
+# ⚠️ The "still FREE" claim that stood here was already conditional on `Built
+# image (docs)` running, and that condition does NOT hold on an ordinary PR: the
+# docs image is path-gated and skips, which this job's own run-step comment says
+# in the workflow. Measured on four PRs from this batch — 15.6, 15.9, 18.4 and
+# 31.0 minutes for `mutation-tables`, against 3.9 for the next slowest job in
+# the same runs. It was not free; it was the entire critical path. Hence the
+# shard: the work is unchanged and spread over four machines. Re-read those
+# numbers off a real run before trusting them again.
 #
 # A spec's dependencies come from `mutate.ts --files` — the loaded spec's own
 # target and edit paths — rather than from a grep, because they sit behind
@@ -69,6 +77,9 @@ ROOT="$SCRIPT_DIR/.."
 
 MODE="all"
 BASE="origin/main"
+SHARD_INDEX=""
+SHARD_TOTAL=""
+LIST_ONLY=0
 while [ $# -gt 0 ]; do
   case "$1" in
     --all) MODE="all"; shift ;;
@@ -76,6 +87,31 @@ while [ $# -gt 0 ]; do
       MODE="affected"; shift
       if [ $# -gt 0 ] && [ "${1#--}" = "$1" ]; then BASE="$1"; shift; fi
       ;;
+    --shard)
+      shift
+      if [ $# -eq 0 ]; then echo "check-mutation-tables: --shard needs I/N (1-based)" >&2; exit 1; fi
+      # ⚠️ Validate LOUDLY. A malformed --shard that fell through to "no
+      # sharding" would run every spec on every shard — slow but green, so
+      # nobody would notice; one that fell through to "empty" would verify
+      # NOTHING on every shard and still exit 0. Both are false-cleans of the
+      # exact class this whole file exists to refuse, so an unparseable value
+      # is a hard error rather than a default.
+      case "$1" in
+        [1-9]*/[1-9]*) : ;;
+        *) echo "check-mutation-tables: --shard expects I/N with I,N >= 1 (got '$1')" >&2; exit 1 ;;
+      esac
+      SHARD_INDEX="${1%%/*}"; SHARD_TOTAL="${1##*/}"
+      if [ "$SHARD_INDEX" -gt "$SHARD_TOTAL" ]; then
+        echo "check-mutation-tables: --shard $1 — index exceeds total." >&2; exit 1
+      fi
+      shift
+      ;;
+    # Print the selection and exit without running any mutation. The partition
+    # below has to be TOTAL — every spec on exactly one shard — and proving that
+    # against the real specs would cost a full sweep per shard, so the property
+    # gets a seam of its own rather than going untested. Same reasoning as
+    # MUTATION_SPEC_GLOB.
+    --list-only) LIST_ONLY=1; shift ;;
     *) echo "check-mutation-tables: unknown argument: $1" >&2; exit 1 ;;
   esac
 done
@@ -223,6 +259,44 @@ $UNTRACKED"
   fi
 fi
 if [ "$MODE" = "all" ]; then SELECTED=("${SPECS[@]}"); fi
+
+# --- Shard ------------------------------------------------------------------
+# AFTER selection, deliberately. Sharding is a way to spend the same work on
+# more machines; it must not change WHICH specs are in scope, and every
+# widen-never-narrow and exit-3 decision above stays the sole authority on that.
+#
+# Round-robin by position, so the matrix is N fixed entries and never names a
+# spec. A shard list that enumerated spec names would leave a NEWLY ADDED spec
+# on no shard at all — verified by nothing, green forever — which is the same
+# defect as the four stale tables in this file's header, arriving by a new door.
+# `SPECS` is a sorted glob, so position is stable within a run.
+#
+# Balance is lumpy on purpose: cost tracks a spec's mutation COUNT, not its
+# existence, so the long pole is whichever single spec has the most mutations
+# and no assignment can beat it. Sharding finer than "by spec" needs mutate.ts
+# to partition its own mutation list.
+if [ -n "$SHARD_TOTAL" ]; then
+  SHARDED=()
+  for i in "${!SELECTED[@]}"; do
+    if [ $(( i % SHARD_TOTAL )) -eq $(( SHARD_INDEX - 1 )) ]; then SHARDED+=("${SELECTED[$i]}"); fi
+  done
+  echo "check-mutation-tables: shard $SHARD_INDEX/$SHARD_TOTAL — ${#SHARDED[@]} of ${#SELECTED[@]} selected spec(s)."
+  SELECTED=(${SHARDED[@]+"${SHARDED[@]}"})
+fi
+
+if [ "$LIST_ONLY" -eq 1 ]; then
+  for spec in ${SELECTED[@]+"${SELECTED[@]}"}; do echo "SELECTED $spec"; done
+  echo "check-mutation-tables: --list-only, ${#SELECTED[@]} spec(s) listed, nothing verified."
+  exit 0
+fi
+
+# An empty shard is honest work: the specs exist and another shard has them.
+# This is NOT the empty-affected-set case above, which exits 3 because nothing
+# anywhere would verify them.
+if [ ${#SELECTED[@]} -eq 0 ]; then
+  echo "check-mutation-tables: shard ${SHARD_INDEX:-1}/${SHARD_TOTAL:-1} has no specs — verified by its siblings."
+  exit 0
+fi
 
 echo "check-mutation-tables: verifying ${#SELECTED[@]} generated table(s)…"
 echo "  (each spec re-runs its suites under every mutation — minutes, not seconds)"

--- a/scripts/check-mutation-tables.sh
+++ b/scripts/check-mutation-tables.sh
@@ -13,15 +13,16 @@
 #
 # ## Two modes, because the full sweep is MINUTES, not seconds
 #
-# Two measurements, each read off a real CI run rather than estimated:
-#   - #5077, EIGHT specs:    832s (~14 min)
-#   - #5061, THIRTEEN specs: 948s (15m48s), PR #5222
+# Two sample sets, each read off real CI runs rather than estimated:
+#   - #5077, EIGHT specs:    832s
+#   - #5061, THIRTEEN specs: 908-1859s across nine runs, median ~950s
 #
-# ⚠️ RE-MEASURE WHEN YOU ADD A SPEC; do not scale the number in your head. The
-# two points above are 1.6x the suite-runs apart and only 14% apart in wall
-# clock, so the relationship is not linear and extrapolating from a spec count
-# will mislead you. Both digits are hand-typed and nothing regenerates them;
-# read the duration off the `mutation-tables` job on your own PR.
+# ⚠️ Do not quote a single figure. That spread is the same thirteen specs on the
+# same runner class, so any one-decimal number implies precision this
+# measurement does not have — an earlier draft here reasoned from a single 948s
+# point to "the relationship is not linear", and the 14% delta that argument
+# rested on is inside the run-to-run noise. Re-read the range off the
+# `mutation-tables` job on your own PR before relying on it.
 #
 # The argument does not depend on the digits: `/ci` is ~10 minutes in total, so
 # an always-full gate would MORE THAN DOUBLE the pre-PR loop — and a gate that
@@ -31,21 +32,19 @@
 #   --affected [base]   Verify only the specs whose dependency set the branch
 #                       touched. The common PR touches none and the gate is
 #                       instant. This is what ci-local.sh runs.
-#   --all               Every spec. What CI runs.
-#   --shard I/N         Only this shard's slice of the selection, round-robin by
-#                       position, 1-based. CI runs four in parallel; the slices
+#   --all               Every spec. Every push to main.
+#   --shard I/N         Only this shard's slice, round-robin by position over the
+#                       spec glob, 1-based. CI runs four in parallel; the slices
 #                       are disjoint and their union is the whole selection.
-#   --list-only         Print the selection and exit 0 without verifying. A seam
-#                       for testing the partition — see the fixture suite.
+#   --list-only         Print the selection and exit 3 without verifying. Seam
+#                       for `scripts/__tests__/check-mutation-tables.test.sh`.
 #
-# ⚠️ The "still FREE" claim that stood here was already conditional on `Built
-# image (docs)` running, and that condition does NOT hold on an ordinary PR: the
-# docs image is path-gated and skips, which this job's own run-step comment says
-# in the workflow. Measured on four PRs from this batch — 15.6, 15.9, 18.4 and
-# 31.0 minutes for `mutation-tables`, against 3.9 for the next slowest job in
-# the same runs. It was not free; it was the entire critical path. Hence the
-# shard: the work is unchanged and spread over four machines. Re-read those
-# numbers off a real run before trusting them again.
+# ⚠️ This gate is NOT free, and where the cost lands is narrower than it looks.
+# It is paid in full whenever the sweep is at `--all`: every push to main, and
+# any PR touching a spec's targets. On a PR that touches none, `--affected`
+# selects nothing and the job is under a minute. Cost and the retired "it runs
+# inside the docs image's shadow" claim: the `mutation-tables` job in
+# `.github/workflows/ci.yml`.
 #
 # A spec's dependencies come from `mutate.ts --files` — the loaded spec's own
 # target and edit paths — rather than from a grep, because they sit behind
@@ -72,6 +71,14 @@
 
 set -euo pipefail
 
+# ⚠️ Shard ownership is derived from a spec's POSITION in the glob below, and
+# glob expansion is collated. Under en_US.UTF-8 punctuation carries no primary
+# weight, so `vocabulary` sorts before `vocabulary-decide`; under C it does not,
+# and three specs change shard between the two. Runners share an image today, so
+# the order happens to agree — pinning it here makes that constructed rather
+# than ambient, and a workflow-level LANG can no longer repartition the sweep.
+export LC_ALL=C
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="$SCRIPT_DIR/.."
 
@@ -90,27 +97,30 @@ while [ $# -gt 0 ]; do
     --shard)
       shift
       if [ $# -eq 0 ]; then echo "check-mutation-tables: --shard needs I/N (1-based)" >&2; exit 1; fi
-      # ⚠️ Validate LOUDLY. A malformed --shard that fell through to "no
-      # sharding" would run every spec on every shard — slow but green, so
-      # nobody would notice; one that fell through to "empty" would verify
-      # NOTHING on every shard and still exit 0. Both are false-cleans of the
-      # exact class this whole file exists to refuse, so an unparseable value
-      # is a hard error rather than a default.
-      case "$1" in
-        [1-9]*/[1-9]*) : ;;
-        *) echo "check-mutation-tables: --shard expects I/N with I,N >= 1 (got '$1')" >&2; exit 1 ;;
-      esac
+      if [ -n "$SHARD_TOTAL" ]; then
+        echo "check-mutation-tables: --shard given twice; the second would silently win." >&2; exit 1
+      fi
+      # ⚠️ ANCHORED, and `[[ =~ ]]` rather than a `case` glob. The first cut used
+      # `case "$1" in [1-9]*/[1-9]*)`, where `*` matches any run of characters
+      # INCLUDING a slash, so it constrained one character per field and nothing
+      # else. Measured: `1x/4` passed the glob, then `[ 1x -gt 4 ]` returned
+      # status 2 — inside an `if` CONDITION, where set -e does not fire — which
+      # bash read as false, and the `$(( ))` below aborted the shard block while
+      # the script carried on with all 13 specs and exit 0. `1/4/9` became a
+      # 9-way partition because `##*/` takes the last field. Those are the two
+      # false-cleans this comment claims to refuse, and they were both live
+      # under the comment asserting they were not.
+      if ! [[ "$1" =~ ^[1-9][0-9]*/[1-9][0-9]*$ ]]; then
+        echo "check-mutation-tables: --shard expects I/N, both integers >= 1 (got '$1')" >&2; exit 1
+      fi
       SHARD_INDEX="${1%%/*}"; SHARD_TOTAL="${1##*/}"
       if [ "$SHARD_INDEX" -gt "$SHARD_TOTAL" ]; then
         echo "check-mutation-tables: --shard $1 — index exceeds total." >&2; exit 1
       fi
       shift
       ;;
-    # Print the selection and exit without running any mutation. The partition
-    # below has to be TOTAL — every spec on exactly one shard — and proving that
-    # against the real specs would cost a full sweep per shard, so the property
-    # gets a seam of its own rather than going untested. Same reasoning as
-    # MUTATION_SPEC_GLOB.
+    # Print the selection and exit without verifying. Seam for the partition
+    # fixture; same reasoning as MUTATION_SPEC_GLOB.
     --list-only) LIST_ONLY=1; shift ;;
     *) echo "check-mutation-tables: unknown argument: $1" >&2; exit 1 ;;
   esac
@@ -261,40 +271,81 @@ fi
 if [ "$MODE" = "all" ]; then SELECTED=("${SPECS[@]}"); fi
 
 # --- Shard ------------------------------------------------------------------
-# AFTER selection, deliberately. Sharding is a way to spend the same work on
-# more machines; it must not change WHICH specs are in scope, and every
-# widen-never-narrow and exit-3 decision above stays the sole authority on that.
+# AFTER selection, deliberately. Sharding spends the same work on more machines;
+# it must not change WHICH specs are in scope, and every widen-never-narrow and
+# exit-3 decision above stays the sole authority on that.
+#
+# ⚠️ OWNERSHIP IS COMPUTED FROM `SPECS`, NOT `SELECTED`, and that is the whole
+# correctness argument. `SELECTED` is the selector's output, and the selector
+# widens on a transient failure of any of four git calls — per process, so one
+# runner can widen while three do not. Partitioning `SELECTED` makes a slice
+# depend on that decision: widening one shard RENUMBERS the positions, and a
+# spec drops through the gap. Measured on a fixture tree — affected set
+# {s11,s12}, shard 2 widened, s12 owned by nobody, all four shards exit 0.
+# Widen-never-narrow becomes narrow-the-union the moment its output is the
+# thing being cut.
+#
+# `SPECS` is the sorted glob: identical in every process, so ownership is a pure
+# function of (position, N). Intersecting afterwards means a widen can only ever
+# make one shard verify MORE, never move work out of a sibling's slice. Both
+# properties then hold by construction rather than by fixture.
 #
 # Round-robin by position, so the matrix is N fixed entries and never names a
-# spec. A shard list that enumerated spec names would leave a NEWLY ADDED spec
-# on no shard at all — verified by nothing, green forever — which is the same
-# defect as the four stale tables in this file's header, arriving by a new door.
-# `SPECS` is a sorted glob, so position is stable within a run.
+# spec. A shard list of spec names would leave a NEWLY ADDED spec on no shard —
+# verified by nothing, green forever, the same defect as the four stale tables
+# in this file's header.
 #
-# Balance is lumpy on purpose: cost tracks a spec's mutation COUNT, not its
-# existence, so the long pole is whichever single spec has the most mutations
-# and no assignment can beat it. Sharding finer than "by spec" needs mutate.ts
-# to partition its own mutation list.
+# Balance is lumpy: cost tracks a spec's mutation COUNT and round-robin ignores
+# it. Measured 2026-08-14 by generated table rows (266 mutations over 13 specs):
+# the four shards carry 87 / 53 / 91 / 35, so the long pole is ~34% of the sweep
+# against a ~20% floor set by the heaviest single spec (vocabulary-decide, 53).
+# Weighted assignment would close part of that; going under the floor needs
+# mutate.ts to partition its own mutation list.
 if [ -n "$SHARD_TOTAL" ]; then
+  PRE_SHARD_COUNT=${#SELECTED[@]}
   SHARDED=()
-  for i in "${!SELECTED[@]}"; do
-    if [ $(( i % SHARD_TOTAL )) -eq $(( SHARD_INDEX - 1 )) ]; then SHARDED+=("${SELECTED[$i]}"); fi
+  for i in "${!SPECS[@]}"; do
+    [ $(( i % SHARD_TOTAL )) -eq $(( SHARD_INDEX - 1 )) ] || continue
+    for s in ${SELECTED[@]+"${SELECTED[@]}"}; do
+      if [ "$s" = "${SPECS[$i]}" ]; then SHARDED+=("$s"); break; fi
+    done
   done
-  echo "check-mutation-tables: shard $SHARD_INDEX/$SHARD_TOTAL — ${#SHARDED[@]} of ${#SELECTED[@]} selected spec(s)."
+  echo "check-mutation-tables: shard $SHARD_INDEX/$SHARD_TOTAL — ${#SHARDED[@]} of $PRE_SHARD_COUNT selected spec(s)."
   SELECTED=(${SHARDED[@]+"${SHARDED[@]}"})
 fi
 
 if [ "$LIST_ONLY" -eq 1 ]; then
   for spec in ${SELECTED[@]+"${SELECTED[@]}"}; do echo "SELECTED $spec"; done
-  echo "check-mutation-tables: --list-only, ${#SELECTED[@]} spec(s) listed, nothing verified."
-  exit 0
+  echo "check-mutation-tables: --list-only — ${#SELECTED[@]} spec(s) listed, nothing verified."
+  # ⚠️ 3, not 0, for the reason stated at the top of this file: this run declined
+  # to verify. Exiting 0 would put a green PASS row in ci-local.sh's table for a
+  # gate that measured nothing, which is the defect class the whole file refuses.
+  # It is a documented flag, so anyone can reach it — not just the fixture.
+  exit 3
 fi
 
-# An empty shard is honest work: the specs exist and another shard has them.
-# This is NOT the empty-affected-set case above, which exits 3 because nothing
-# anywhere would verify them.
 if [ ${#SELECTED[@]} -eq 0 ]; then
-  echo "check-mutation-tables: shard ${SHARD_INDEX:-1}/${SHARD_TOTAL:-1} has no specs — verified by its siblings."
+  if [ -z "$SHARD_TOTAL" ]; then
+    # No shard in play, so there are no siblings to have covered it. Every
+    # legitimate empty selection above already exited with its own verdict, so
+    # reaching here means the selector produced nothing for a reason this script
+    # cannot name — "cannot tell", which never renders as a green PASS.
+    echo "check-mutation-tables: empty selection with no shard in play — declining." >&2
+    exit 3
+  fi
+  # ⚠️ An empty shard is only legitimate when there were fewer specs than
+  # shards. Round-robin gives every shard at least floor(n/N) >= 1 whenever
+  # n >= N, so an empty slice with n >= N means the partition did not do what
+  # it says — a bad divisor, a mangled index — and every one of those paths
+  # otherwise ends in four green jobs having verified nothing.
+  if [ "$SHARD_TOTAL" -le "$PRE_SHARD_COUNT" ]; then
+    echo "check-mutation-tables: shard $SHARD_INDEX/$SHARD_TOTAL is empty, but $PRE_SHARD_COUNT spec(s) were selected." >&2
+    echo "  Round-robin gives every shard at least one spec when specs >= shards, so the partition is wrong." >&2
+    exit 1
+  fi
+  # Says only what this process knows. Whether the other slices ran is a
+  # property of the matrix wiring, not something this run can observe.
+  echo "check-mutation-tables: shard $SHARD_INDEX/$SHARD_TOTAL — no spec at positions congruent to $(( SHARD_INDEX - 1 )) (mod $SHARD_TOTAL) among ${#SPECS[@]} spec(s)."
   exit 0
 fi
 

--- a/scripts/check-mutation-tables.sh
+++ b/scripts/check-mutation-tables.sh
@@ -71,14 +71,6 @@
 
 set -euo pipefail
 
-# ⚠️ Shard ownership is derived from a spec's POSITION in the glob below, and
-# glob expansion is collated. Under en_US.UTF-8 punctuation carries no primary
-# weight, so `vocabulary` sorts before `vocabulary-decide`; under C it does not,
-# and three specs change shard between the two. Runners share an image today, so
-# the order happens to agree — pinning it here makes that constructed rather
-# than ambient, and a workflow-level LANG can no longer repartition the sweep.
-export LC_ALL=C
-
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="$SCRIPT_DIR/.."
 
@@ -86,6 +78,17 @@ MODE="all"
 BASE="origin/main"
 SHARD_INDEX=""
 SHARD_TOTAL=""
+# ⚠️ Initialised, not merely assigned under the shard branch. `PRE_SHARD_COUNT`
+# and `SHARD_OWNED` are written inside `if [ -n "$SHARD_TOTAL" ]` and read below
+# it; that was safe only by an argument about which paths can reach the read,
+# and one of the two supporting branches turned out to be unreachable. Under
+# `set -u` an unbound read exits 1 — which is this script's code for STALE, so a
+# config crash would have rendered as a drifted table.
+PRE_SHARD_COUNT=0
+SHARD_OWNED=0
+SHARD_RESIDUE=0
+SHARD_RESIDUE_OF=1
+SHARD_LABEL="1/1"
 LIST_ONLY=0
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -100,23 +103,36 @@ while [ $# -gt 0 ]; do
       if [ -n "$SHARD_TOTAL" ]; then
         echo "check-mutation-tables: --shard given twice; the second would silently win." >&2; exit 1
       fi
-      # ⚠️ ANCHORED, and `[[ =~ ]]` rather than a `case` glob. The first cut used
-      # `case "$1" in [1-9]*/[1-9]*)`, where `*` matches any run of characters
-      # INCLUDING a slash, so it constrained one character per field and nothing
-      # else. Measured: `1x/4` passed the glob, then `[ 1x -gt 4 ]` returned
+      # ⚠️ ANCHORED, and BOUNDED, and `[[ =~ ]]` rather than a `case` glob.
+      #
+      # The first cut used `case "$1" in [1-9]*/[1-9]*)`, where `*` matches any
+      # run of characters INCLUDING a slash, so it constrained one character per
+      # field and nothing else. `1x/4` passed it, then `[ 1x -gt 4 ]` returned
       # status 2 — inside an `if` CONDITION, where set -e does not fire — which
-      # bash read as false, and the `$(( ))` below aborted the shard block while
-      # the script carried on with all 13 specs and exit 0. `1/4/9` became a
-      # 9-way partition because `##*/` takes the last field. Those are the two
-      # false-cleans this comment claims to refuse, and they were both live
-      # under the comment asserting they were not.
-      if ! [[ "$1" =~ ^[1-9][0-9]*/[1-9][0-9]*$ ]]; then
-        echo "check-mutation-tables: --shard expects I/N, both integers >= 1 (got '$1')" >&2; exit 1
+      # bash read as false, and the run carried on with every spec and exit 0.
+      # `1/4/9` became a 9-way partition because `##*/` takes the last field.
+      #
+      # The `{0,3}` bound closes the SAME mechanism one class over: anchoring
+      # constrained syntax but not magnitude, so `1/99999999999999999999` still
+      # overflowed `[`, still returned status 2 in a condition, and still
+      # bypassed the range check below. Bounding the digits here is structural;
+      # a second `[` whose status-2 arm nobody reads would not be.
+      if ! [[ "$1" =~ ^[1-9][0-9]{0,3}/[1-9][0-9]{0,3}$ ]]; then
+        echo "check-mutation-tables: --shard expects I/N, both integers 1-9999 (got '$1')" >&2; exit 1
       fi
       SHARD_INDEX="${1%%/*}"; SHARD_TOTAL="${1##*/}"
       if [ "$SHARD_INDEX" -gt "$SHARD_TOTAL" ]; then
         echo "check-mutation-tables: --shard $1 — index exceeds total." >&2; exit 1
       fi
+      # ⚠️ Normalise ONCE, here, the way packages/api/scripts/test-isolated.ts
+      # does. The 1-based CLI value and the 0-based residue used by the modulo
+      # were previously converted at two separate sites — the predicate and the
+      # operator-facing message — so the two could drift and the message would
+      # misreport which residue class was empty. Below this line there is no
+      # shard arithmetic, only these names.
+      SHARD_RESIDUE=$(( SHARD_INDEX - 1 ))
+      SHARD_RESIDUE_OF="$SHARD_TOTAL"
+      SHARD_LABEL="$SHARD_INDEX/$SHARD_TOTAL"
       shift
       ;;
     # Print the selection and exit without verifying. Seam for the partition
@@ -133,6 +149,21 @@ cd "$ROOT/packages/api"
 # CATCHES a hand-edited table and a skipped target; without an override it could
 # only ever be run against the real specs, which is a ~16-minute assertion.
 SPECS=(${MUTATION_SPEC_GLOB:-scripts/mutations/*.mutations.ts})
+# ⚠️ Shard ownership is a spec's POSITION in this list, so the ORDER is part of
+# the partition's contract and must not depend on the ambient locale. Glob
+# expansion is collated: under glibc's en_US.UTF-8 punctuation carries no
+# primary weight, so `vocabulary.mutations.ts` and `vocabulary-rekey.mutations.ts`
+# compare as `vocabularymutationsts` vs `vocabularyrekeymutationsts` and swap
+# against C, where `-` (0x2D) sorts before `.` (0x2E). Two of the thirteen specs
+# change shard between the two collations.
+#
+# Sorted here rather than by exporting LC_ALL for the whole process: the locale
+# is scoped to the one command whose order matters, ordering becomes a function
+# of the file set rather than of the environment, and nothing else in the script
+# — git, grep, realpath, or the suites `mutate.ts` spawns — changes behaviour.
+if [ ${#SPECS[@]} -gt 0 ]; then
+  mapfile -t SPECS < <(printf '%s\n' "${SPECS[@]}" | LC_ALL=C sort)
+fi
 if [ ${#SPECS[@]} -eq 0 ] || [ ! -e "${SPECS[0]}" ]; then
   echo "check-mutation-tables: no specs found under packages/api/scripts/mutations/ — did the directory move?" >&2
   exit 1
@@ -202,7 +233,17 @@ $UNTRACKED"
     for f in scripts/mutate.ts scripts/mutation-core.ts scripts/mutation-spec.ts scripts/signal-retry.ts; do
       if printf '%s\n' "$CHANGED" | grep -qxF "packages/api/$f"; then RUNNER_TOUCHED=1; fi
     done
-    if [ "$RUNNER_TOUCHED" -eq 1 ]; then
+    if [ "$MODE" = "all" ]; then
+      # ⚠️ A widen above already decided every table is in scope. Without this
+      # arm, execution fell straight into the selector below, which can exit 0
+      # with "nothing to verify" — so the gate ANNOUNCED a widen and then did
+      # the opposite. Only the base-diff widen worked, because it skips this
+      # whole `else`; the working-tree and untracked widens were dead. Measured
+      # with a git shim failing `git diff --name-only --no-renames HEAD` against
+      # an uncommitted target edit: "falling back to --all" followed by "nothing
+      # to verify", exit 0.
+      :
+    elif [ "$RUNNER_TOUCHED" -eq 1 ]; then
       echo "check-mutation-tables: the runner/renderer changed — every table's bytes are in scope."
       MODE="all"
     else
@@ -305,12 +346,13 @@ if [ -n "$SHARD_TOTAL" ]; then
   PRE_SHARD_COUNT=${#SELECTED[@]}
   SHARDED=()
   for i in "${!SPECS[@]}"; do
-    [ $(( i % SHARD_TOTAL )) -eq $(( SHARD_INDEX - 1 )) ] || continue
+    [ $(( i % SHARD_RESIDUE_OF )) -eq "$SHARD_RESIDUE" ] || continue
+    SHARD_OWNED=$(( SHARD_OWNED + 1 ))
     for s in ${SELECTED[@]+"${SELECTED[@]}"}; do
       if [ "$s" = "${SPECS[$i]}" ]; then SHARDED+=("$s"); break; fi
     done
   done
-  echo "check-mutation-tables: shard $SHARD_INDEX/$SHARD_TOTAL — ${#SHARDED[@]} of $PRE_SHARD_COUNT selected spec(s)."
+  echo "check-mutation-tables: shard $SHARD_LABEL — ${#SHARDED[@]} of $PRE_SHARD_COUNT selected spec(s)."
   SELECTED=(${SHARDED[@]+"${SHARDED[@]}"})
 fi
 
@@ -333,19 +375,38 @@ if [ ${#SELECTED[@]} -eq 0 ]; then
     echo "check-mutation-tables: empty selection with no shard in play — declining." >&2
     exit 3
   fi
-  # ⚠️ An empty shard is only legitimate when there were fewer specs than
-  # shards. Round-robin gives every shard at least floor(n/N) >= 1 whenever
-  # n >= N, so an empty slice with n >= N means the partition did not do what
-  # it says — a bad divisor, a mangled index — and every one of those paths
-  # otherwise ends in four green jobs having verified nothing.
-  if [ "$SHARD_TOTAL" -le "$PRE_SHARD_COUNT" ]; then
-    echo "check-mutation-tables: shard $SHARD_INDEX/$SHARD_TOTAL is empty, but $PRE_SHARD_COUNT spec(s) were selected." >&2
-    echo "  Round-robin gives every shard at least one spec when specs >= shards, so the partition is wrong." >&2
+  # ⚠️ THE TEST IS ON OWNERSHIP, NOT ON THE SELECTION COUNT.
+  #
+  # Round-robin partitions `SPECS`, so shard I owns position I-1 whenever there
+  # are at least N specs — that is arithmetic and cannot fail. `SELECTED` is
+  # then a FILTER over those positions, and a filter may legitimately empty any
+  # slice no matter how many specs it kept.
+  #
+  # The first cut compared `SHARD_TOTAL` against the selected count, which is
+  # the pre-fix mental model: correct while ownership came from `SELECTED`,
+  # wrong the moment it came from `SPECS`. Measured — 4 specs, a commit touching
+  # positions 1 and 3, `--shard 2/2`: a CORRECT partition exited 1 with "the
+  # partition is wrong". Any PR with >= 4 affected specs that misses a residue
+  # class would have reddened a shard. It was also inert on the common 1-3 spec
+  # PR, where a genuinely mangled divisor still exited 0 — off where it was
+  # needed, on where it was not.
+  #
+  # ⚠️ NO FIXTURE COVERS THIS ARM, and that is honest rather than an omission.
+  # Validation already forces 1 <= I <= N, so with N <= #SPECS position I-1
+  # always exists and SHARD_OWNED is always >= 1: no CLI input can reach here.
+  # Deleting the whole arm leaves the suite green, and a fixture claiming to
+  # cover it would be asserting nothing — the shape this file deleted two
+  # earlier fixtures for. It stays as a backstop against a future edit to the
+  # residue arithmetic, which is exactly the edit that would otherwise produce
+  # four green jobs having verified nothing.
+  if [ "$SHARD_OWNED" -eq 0 ] && [ "${#SPECS[@]}" -ge "$SHARD_TOTAL" ]; then
+    echo "check-mutation-tables: shard $SHARD_LABEL owns no position among ${#SPECS[@]} spec(s)." >&2
+    echo "  With specs >= shards every shard owns at least one position, so the divisor or index is wrong." >&2
     exit 1
   fi
   # Says only what this process knows. Whether the other slices ran is a
   # property of the matrix wiring, not something this run can observe.
-  echo "check-mutation-tables: shard $SHARD_INDEX/$SHARD_TOTAL — no spec at positions congruent to $(( SHARD_INDEX - 1 )) (mod $SHARD_TOTAL) among ${#SPECS[@]} spec(s)."
+  echo "check-mutation-tables: shard $SHARD_LABEL — no selected spec at positions congruent to $SHARD_RESIDUE (mod $SHARD_RESIDUE_OF) among ${#SPECS[@]} spec(s)."
   exit 0
 fi
 

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -275,9 +275,9 @@ wait
 # on a branch that touches the runner it widens to --all, which is ~16 minutes
 # of continuous mutation.
 #
-# --affected, NOT --all: the full sweep would more than double this script. CI's
-# `mutation-tables` job runs everything in parallel, where that sweep costs no
-# wall clock. Skips entirely without TEST_DATABASE_URL.
+# --affected, NOT --all: the full sweep would more than double this script. CI
+# runs --all sharded four ways on push to main; here there is one machine.
+# Skips entirely without TEST_DATABASE_URL.
 status "stage 2: tree-writing gates (serial — these mutate sources in place) …"
 # ⚠️ `gate-fixtures` MOVED HERE from Stage 1 (#5165), for the same correctness
 # reason as `mutation-tables` above and not for load. Several of the adversarial


### PR DESCRIPTION
## The measurement

`mutation-tables` is the whole critical path, not a passenger on someone else's. Across four PRs from one batch:

| job | duration |
|---|---|
| `mutation-tables` | **15.6m · 15.9m · 18.4m · 31.0m** |
| next slowest in the same runs (`drift`, `test-others`) | 3.9m |

The job justified its cost by finishing inside `Built image (docs)` at ~25 minutes. **That job is path-gated and skips on an ordinary PR**, so there was nothing to hide inside. The header comment had already written down the tell — *"if this job starts landing last, it has outgrown it"* — and it had.

## What changed

`--shard I/N` slices the selection round-robin by position. It runs **after** every `--affected` / `--all` and widen-never-narrow decision, so **which** specs are in scope is unchanged; sharding only decides which machine verifies them. CI runs four shards with `fail-fast: false`. `ci-local.sh` is untouched and still runs the unsharded `--affected` subset.

Round-robin by position, **not** a list of spec names in the matrix. A name list leaves a newly added spec on no shard — verified by nothing, green forever. That is the same defect as the four stale tables this gate exists for, arriving through a new door.

Real specs today: 4 / 3 / 3 / 3 across the four shards, zero duplicates.

## Falsifiers

Both new fixtures were proven sensitive by breaking the guard they pin, per this suite's standing rule:

| fixture | mutation | result |
|---|---|---|
| partition is total and disjoint | modulo offset off by one | 13 selections → 9, **RED** |
| malformed `--shard` is a hard error | remove the range check | exit 1 → 0, **RED** |

13 specs over 4 shards is indivisible on purpose, so an off-by-one cannot hide behind an even split. `--list-only` exists so this is checkable in milliseconds rather than a full sweep per shard — same reasoning as the existing `MUTATION_SPEC_GLOB` seam. Suite: **9 passed, 0 failed**.

## What this PR will NOT show

Its own CI. This branch touches `check-mutation-tables.sh`, which is not one of the four runner/renderer files that widen the selection to `--all`, so `--affected` will select little or nothing here and the shards will mostly no-op. **The measurement lands on the push to `main` after merge (which runs `--all`), and on the next brain PR.** I'll read it off there rather than claim a speedup this run cannot demonstrate.

## Expected ceiling

The long pole is whichever single spec has the most mutations — `vocabulary-decide-pg` is 53. Cost tracks mutation count, not spec count, so no assignment beats that. Expect roughly halving, not quartering. Going finer needs `mutate.ts` to partition its own mutation list; that is a change to the runner itself and wants its own PR with its own falsifiers.

## Also

Corrected the stale cost claim in both places it lived (the workflow job header and the script header). #5061 had already softened it to "still FREE at 15m48s … it stays free only while that holds"; the condition it named does not hold.