### PR TITLE
sec(brain): brand the snapshot REQUEST, not just the verdict (#5230)

### DIFF
--- a/packages/api/src/lib/brain/__tests__/warehouse-producer-bypass.test.ts
+++ b/packages/api/src/lib/brain/__tests__/warehouse-producer-bypass.test.ts
@@ -3,12 +3,12 @@
  *
  * ## WHY THIS FILE EXISTS
  *
- * `warehouse-producer.ts` brands the SQL gate's PASSING verdict so that no object
- * literal can assert *"the product's SELECT-only / single-statement /
- * whitelist-scoped check said yes"*. That closes the hole a plain
- * `{ valid: boolean }` left — but the brand's own docstring then makes a claim the
- * TYPE cannot keep: that grepping for the cast is the whole list of places the gate
- * is bypassed. A cast is greppable; nothing fails when a fifth one appears.
+ * `warehouse-producer.ts` brands the REQUEST the SQL gate passed, and the passing
+ * verdict carries it — so no object literal can assert *"the product's SELECT-only /
+ * single-statement / whitelist-scoped check said yes"*. That closes the hole a plain
+ * `{ valid: boolean }` left, but it leaves a claim the TYPE cannot keep: that
+ * grepping for the assertion is the whole list of places the gate is bypassed. An
+ * assertion is greppable; nothing fails when a fifth one appears.
  *
  * ## FIVE names, because #5230 moved the brand onto the REQUEST
  *
@@ -20,19 +20,15 @@
  * VERDICT union, the VALIDATOR seam type, the DEPS interface that holds it, or the
  * RUNNER type whose parameter is the branded request.
  *
- * ⚠️ **The last four are here because the docstrings claimed they were refused, and
- * that was measured false — twice, with two different wrong explanations.** The
- * mechanism, measured against the repo's own checker: the brand only ADDS a
- * property, so the branded request is assignable to the bare one, and `as` succeeds
- * whenever EITHER direction is comparable — the reverse direction carries all of
- * them. What IS refused is the shape where the reverse direction also fails: a
- * NULLARY mint (a 1-parameter function type is not assignable to a 0-parameter one)
- * or a literal with an excess property. Pinning `valid` with `as const` does not
- * close it; that was the second wrong explanation, and it was the one this file
- * shipped in round 1. Such a validator returns its own argument, so the run loop's
- * identity check waves it through: the gate never ran and nothing downstream can
- * tell. Matching only the first two would have left this guard green over the one
- * bypass the brand does not close.
+ * ⚠️ **All five have to be matched, and the reason is one property of the brand.**
+ * It only ADDS a field, so a branded request is assignable to a bare one, and `as`
+ * succeeds whenever EITHER direction is comparable — the reverse direction carries
+ * every seam name. Refused only where the reverse direction also fails: a NULLARY
+ * mint (a 1-parameter function type is not assignable to a 0-parameter one), or a
+ * literal with an excess property. `as const` on `valid` does not close it. Measured
+ * against the repo's own checker, because the two obvious explanations for this were
+ * both wrong. Such a validator returns its own argument, so the run loop's identity
+ * check waves it through: the gate never ran and nothing downstream can tell.
  *
  * ⚠️ **The pattern is not written out in this file's prose, and that is the point
  * rather than fastidiousness.** A lexical guard cannot tell a quotation from an
@@ -42,13 +38,6 @@
  * guarded, and the next real instance gets written inside it. The exact spelling
  * lives in {@link BYPASS_RE} below, where a reader can still see it and the scan
  * cannot trip over it.
- *
- * This is the repo's standing ratchet applied on a shorter cycle than usual: the
- * same principle was swept for twice inside one PR — once when the gate moved out
- * of `defaultRunSnapshot`, and again when the seam that replaced it turned out to
- * be as skippable as the thing it replaced — and prose does not scale to new
- * surface, which is exactly where it kept failing. So the enumeration is asserted
- * as what it is.
  *
  * ## What a new entry means
  *
@@ -67,17 +56,15 @@
  * laundering are all REFUSED by the COMPILER.
  *
  * ⚠️ **What this scan holds is a different question, and conflating the two is how
- * this header has now been wrong twice.** What it holds is exactly: *an assertion
- * that puts the keyword and one of the five names on ONE PHYSICAL LINE.* So it DOES
- * catch a double assertion through `unknown` written on one line — an earlier draft
- * listed that as escaping, which was measurably false and is corrected here. What
- * genuinely escapes: an angle-bracket assertion; a local type alias; an import that
- * renames one of these types OUT to another local name; an indexed lookup of the
- * runner's parameter; a line break between keyword and name (the character class
- * below bars a newline); and `any`-typed wiring or a `Partial<T>`-shaped generic
- * builder, which need no assertion at all. Chasing those is a regex arms race the
- * honest sentence wins; the sentence is here so nobody reads a green run as more
- * than it is.
+ * this header has been wrong twice.** What it holds is exactly: *an assertion that
+ * puts the keyword and one of the five names on ONE PHYSICAL LINE.* So it DOES catch
+ * a double assertion through `unknown` written on one line. What genuinely escapes:
+ * an angle-bracket assertion; a local type alias (including one aliasing an indexed
+ * lookup of the runner's parameter); an import that renames one of these types OUT
+ * to another local name; a line break between keyword and name, since the character
+ * class below bars a newline; and `any`-typed wiring or a `Partial<T>`-shaped
+ * generic builder, which need no assertion at all. The list is not exhaustive and
+ * cannot be — read a green run as *"no new file names one"*, nothing more.
  *
  * It also does not pin the ANTI-REPLAY half. A mint listed below hands back a token
  * for the request it was given; a mint that hands back a token for some OTHER
@@ -133,9 +120,11 @@ const ROOTS: readonly { readonly dir: string; readonly label: string }[] = [
  * belongs here. An entry is a place to LOOK, not a finding.
  *
  * ⚠️ ONE production entry, deliberately. It is the single point where the product's
- * gate answering yes becomes a value the run will act on. Note the module also names
- * these types in prose, so it would keep matching even if its cast were removed —
- * this test cannot tell you the cast is still there, only that no NEW file names one.
+ * gate answering yes becomes a value the run will act on. Measured: the module
+ * matches on that cast's line alone — no prose line in it puts the keyword and a
+ * matched name together — so deleting the cast without deleting this entry REDS the
+ * test. Deleting both together is silent; an entry is a claim about the tree, not a
+ * lock on the file.
  */
 const KNOWN_BYPASSES: readonly { file: string; why: string }[] = [
   {
@@ -183,11 +172,9 @@ const KNOWN_BYPASSES: readonly { file: string; why: string }[] = [
  * matches — a false positive rather than a hole, since it fails loudly and the fix
  * is to rename the local. An import that renames one of these types OUT to a
  * different local name does NOT match, and that direction is a real escape, listed
- * with the others in the header. A round-1 draft asserted the opposite direction and
- * called it a false positive; both halves were wrong, and the correction is measured
- * rather than reasoned. Neither spelling is written out here — writing one put THIS
- * FILE into its own result set on the first run, which is the quotation trap
- * arriving exactly where the header says it does.
+ * with the others in the header. Neither spelling is written out here: writing one
+ * put THIS FILE into its own result set on the first run, which is the quotation
+ * trap arriving exactly where the header says it does.
  */
 const BYPASS_RE =
   /\bas\b[^;=\n]*\b(?:ValidatedSnapshotRequest|SnapshotSqlVerdict|SnapshotSqlValidator|WarehouseProducerDeps|WarehouseSnapshotRunner)\b/;
@@ -246,8 +233,8 @@ describe("the SQL-gate bypass set (#5042, #5230)", () => {
     // file that has not imported the type writes it this way.
     const qualified = `const v = x as import("./warehouse-producer").Snapshot${"SqlVerdict"};`;
     expect(BYPASS_RE.test(qualified)).toBe(true);
-    // #5230's spelling — the one the four sites below actually use. Without this
-    // arm the matcher could lose the request alternative entirely and every
+    // #5230's spelling — the one the four sites listed ABOVE actually use. Without
+    // this arm the matcher could lose the request alternative entirely and every
     // assertion here would still pass on the verdict one.
     const branded = `const v = { valid: true, request: r as Validated${"SnapshotRequest"} };`;
     expect(BYPASS_RE.test(branded)).toBe(true);

--- a/packages/api/src/lib/brain/__tests__/warehouse-producer-bypass.test.ts
+++ b/packages/api/src/lib/brain/__tests__/warehouse-producer-bypass.test.ts
@@ -1,5 +1,5 @@
 /**
- * The `SnapshotSqlVerdict` bypass set (#5042).
+ * The SQL-gate bypass set (#5042, re-pointed at #5230's spelling).
  *
  * ## WHY THIS FILE EXISTS
  *
@@ -9,6 +9,17 @@
  * `{ valid: boolean }` left — but the brand's own docstring then makes a claim the
  * TYPE cannot keep: that grepping for the cast is the whole list of places the gate
  * is bypassed. A cast is greppable; nothing fails when a fifth one appears.
+ *
+ * ## TWO names, because #5230 moved the brand onto the REQUEST
+ *
+ * The passing verdict now carries the request it validated, and that request is
+ * what is branded — which is how replay (a cached token for some other statement)
+ * and ordering (a runner reachable with an unvalidated request) got closed. So a
+ * bypass can be spelled two ways: an assertion naming the branded request type, or
+ * one naming the verdict union — the two differ only by the brand, which makes them
+ * comparable, so a whole-verdict assertion compiles just as well. {@link BYPASS_RE}
+ * matches both; matching only the first would have re-opened this guard on the
+ * exact spelling the previous version pinned.
  *
  * ⚠️ **The pattern is not written out in this file's prose, and that is the point
  * rather than fastidiousness.** A lexical guard cannot tell a quotation from an
@@ -44,6 +55,12 @@
  * `any`-typed wiring — `JSON.parse`, an untyped mock, a dynamic `import()`. This
  * file pins the half a grep can hold; the rest is stated in the type's docstring
  * rather than claimed away.
+ *
+ * It also does not pin the ANTI-REPLAY half. A mint listed below hands back a token
+ * for the request it was given; a mint that hands back a token for some OTHER
+ * request is a source-identical line this scan cannot tell apart, and it is the run
+ * loop's identity check that refuses it. `warehouse-producer.test.ts` drives that
+ * refusal.
  *
  * A source-text test, and it says so: it proves what the tree CONTAINS, never what
  * runs.
@@ -100,8 +117,15 @@ const KNOWN_BYPASSES: readonly { file: string; why: string }[] = [
  * position rather than spanning statements. The regex is also the canonical
  * spelling of the pattern: writing it out in prose would put this file into its own
  * result set, which is why the header describes it instead.
+ *
+ * ⚠️ **TWO alternatives, both required (#5230).** The brand moved onto the request,
+ * so a mint ordinarily names the branded request type — but the verdict union is
+ * *comparable* to an object literal carrying an unvalidated request, so asserting
+ * the union is an equally compiling second door. Dropping the second alternative
+ * would leave this guard reporting a smaller set than the tree contains, which is
+ * the silent-empty failure the note above is about, one name over.
  */
-const BYPASS_RE = /\bas\b[^;=\n]*\bSnapshotSqlVerdict\b/;
+const BYPASS_RE = /\bas\b[^;=\n]*\b(?:ValidatedSnapshotRequest|SnapshotSqlVerdict)\b/;
 
 function* walk(dir: string): Generator<string> {
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
@@ -115,7 +139,7 @@ function* walk(dir: string): Generator<string> {
   }
 }
 
-describe("the SnapshotSqlVerdict bypass set (#5042)", () => {
+describe("the SQL-gate bypass set (#5042, #5230)", () => {
   test("exactly the known sites assert a passing SQL verdict", () => {
     const found: string[] = [];
     for (const file of walk(SRC_ROOT)) {
@@ -138,14 +162,22 @@ describe("the SnapshotSqlVerdict bypass set (#5042)", () => {
     // above passes by finding nothing — the shape a guard test fails in silently.
     // ASSEMBLED, never written whole — see the header. A literal here would put this
     // file back in its own result set.
-    const planted = `const v = ({ valid: true }) as Snapshot${"SqlVerdict"};`;
+    const planted = `const v = ({ valid: true, request: r }) as Snapshot${"SqlVerdict"};`;
     expect(BYPASS_RE.test(planted)).toBe(true);
     // The QUALIFIED spelling, which the first version of this matcher missed — a
     // file that has not imported the type writes it this way.
     const qualified = `const v = x as import("./warehouse-producer").Snapshot${"SqlVerdict"};`;
     expect(BYPASS_RE.test(qualified)).toBe(true);
-    // And a negative control, so the matcher is not simply true of everything:
-    // naming the TYPE is not asserting a pass.
+    // #5230's spelling — the one the four sites below actually use. Without this
+    // arm the matcher could lose the request alternative entirely and every
+    // assertion here would still pass on the verdict one.
+    const branded = `const v = { valid: true, request: r as Validated${"SnapshotRequest"} };`;
+    expect(BYPASS_RE.test(branded)).toBe(true);
+    const brandedQualified = `const v = r as import("./warehouse-producer").Validated${"SnapshotRequest"};`;
+    expect(BYPASS_RE.test(brandedQualified)).toBe(true);
+    // And negative controls, so the matcher is not simply true of everything:
+    // naming a TYPE is not asserting a pass.
     expect(BYPASS_RE.test(`let v: Snapshot${"SqlVerdict"};`)).toBe(false);
+    expect(BYPASS_RE.test(`let r: Validated${"SnapshotRequest"};`)).toBe(false);
   });
 });

--- a/packages/api/src/lib/brain/__tests__/warehouse-producer-bypass.test.ts
+++ b/packages/api/src/lib/brain/__tests__/warehouse-producer-bypass.test.ts
@@ -10,16 +10,27 @@
  * TYPE cannot keep: that grepping for the cast is the whole list of places the gate
  * is bypassed. A cast is greppable; nothing fails when a fifth one appears.
  *
- * ## TWO names, because #5230 moved the brand onto the REQUEST
+ * ## FOUR names, because #5230 moved the brand onto the REQUEST
  *
  * The passing verdict now carries the request it validated, and that request is
  * what is branded — which is how replay (a cached token for some other statement)
- * and ordering (a runner reachable with an unvalidated request) got closed. So a
- * bypass can be spelled two ways: an assertion naming the branded request type, or
- * one naming the verdict union — the two differ only by the brand, which makes them
- * comparable, so a whole-verdict assertion compiles just as well. {@link BYPASS_RE}
- * matches both; matching only the first would have re-opened this guard on the
- * exact spelling the previous version pinned.
+ * and ordering (a runner reachable with an unvalidated request) got closed. A bypass
+ * can therefore be spelled four ways, and {@link BYPASS_RE} matches all of them:
+ *
+ *   1. an assertion naming the branded REQUEST type — what a mint ordinarily writes;
+ *   2. one naming the VERDICT union — the two differ only by the brand, which makes
+ *      them comparable, so a whole-verdict assertion compiles just as well;
+ *   3. one naming the VALIDATOR seam type, and
+ *   4. one naming the DEPS interface that holds it.
+ *
+ * ⚠️ **3 and 4 are here because the docstrings claimed they were refused, and that
+ * was measured false.** The nullary mint is refused; a mint that TAKES A PARAMETER
+ * is not, because its return literal's `valid` widens to `boolean` and the
+ * discriminated-arm check is skipped — and the parameterised form is the only useful
+ * one now that the passing arm must carry a request. Worse, such a validator returns
+ * its own argument, so the run loop's identity check waves it through: the gate never
+ * ran and nothing downstream can tell. Matching only 1 and 2 would have left this
+ * guard green over the one bypass the brand does not close.
  *
  * ⚠️ **The pattern is not written out in this file's prose, and that is the point
  * rather than fastidiousness.** A lexical guard cannot tell a quotation from an
@@ -49,12 +60,21 @@
  * ## What this does NOT prove
  *
  * The brand is not the only bypass, and saying so here is the honest half. Measured
- * against the repo's own `tsc`: an object literal, `as const`, `satisfies`, a
- * spread of the refusing arm, and even `as SnapshotSqlValidator` are all REFUSED.
- * What still gets through without a hit below is `as unknown as`, and any
- * `any`-typed wiring — `JSON.parse`, an untyped mock, a dynamic `import()`. This
- * file pins the half a grep can hold; the rest is stated in the type's docstring
- * rather than claimed away.
+ * against the repo's own `tsc`: an object literal, `as const`, `satisfies`, a spread
+ * of the refusing arm, and the identity form of generic-inference laundering are all
+ * REFUSED. What still gets through with no hit below is `as unknown as`, any
+ * `any`-typed wiring (`JSON.parse`, an untyped mock, a dynamic `import()`), and a
+ * `Partial<T>`-shaped generic builder.
+ *
+ * ⚠️ **The accepted list used to be written as *"`as unknown as` plus `any`"*, and
+ * that was measurably wrong in a way worth stating precisely.** What this scan
+ * actually holds is: *an assertion that puts the keyword and one of the four names
+ * on ONE PHYSICAL LINE.* An angle-bracket assertion, a local type alias or a
+ * renaming import of the same type, an indexed lookup of the runner's parameter, or
+ * a line break between keyword and name all compile and all escape — because the
+ * character class below bars a newline. Chasing those is a regex arms race the
+ * honest sentence wins; the sentence is here so nobody reads a green run as more
+ * than it is.
  *
  * It also does not pin the ANTI-REPLAY half. A mint listed below hands back a token
  * for the request it was given; a mint that hands back a token for some OTHER
@@ -67,7 +87,7 @@
  */
 
 import { describe, expect, test } from "bun:test";
-import { readFileSync, readdirSync } from "fs";
+import { existsSync, readFileSync, readdirSync } from "fs";
 import { join } from "path";
 
 // `src/`, from `src/lib/brain/__tests__/`. Resolved off `import.meta.url` rather
@@ -75,6 +95,21 @@ import { join } from "path";
 // the working directory, and a cwd-relative root would silently scan nothing under
 // one of them.
 const SRC_ROOT = new URL("../../../", import.meta.url).pathname;
+
+/**
+ * `ee/src/` too — a second root, not decoration.
+ *
+ * ⚠️ All four matched names are EXPORTED, and `ee/` imports `@atlas/api/*` freely:
+ * only the reverse direction is gated. A scan of this package alone would prove a
+ * claim strictly narrower than the one this suite's failure message makes, so a mint
+ * added under `ee/` would sit outside the enumeration while the guard stayed green —
+ * the same silent-empty shape {@link BYPASS_RE}'s own note is written to prevent,
+ * one axis over.
+ */
+const ROOTS: readonly { readonly dir: string; readonly label: string }[] = [
+  { dir: SRC_ROOT, label: "" },
+  { dir: new URL("../../../../../../ee/src/", import.meta.url).pathname, label: "ee/src/" },
+];
 
 /**
  * Every site that may assert a passing SQL verdict, with why.
@@ -118,14 +153,21 @@ const KNOWN_BYPASSES: readonly { file: string; why: string }[] = [
  * spelling of the pattern: writing it out in prose would put this file into its own
  * result set, which is why the header describes it instead.
  *
- * ⚠️ **TWO alternatives, both required (#5230).** The brand moved onto the request,
- * so a mint ordinarily names the branded request type — but the verdict union is
- * *comparable* to an object literal carrying an unvalidated request, so asserting
- * the union is an equally compiling second door. Dropping the second alternative
- * would leave this guard reporting a smaller set than the tree contains, which is
- * the silent-empty failure the note above is about, one name over.
+ * ⚠️ **FOUR alternatives (#5230), and the header says why each is load-bearing.**
+ * Only the first has instances in the tree today; the other three are pinned by the
+ * planted controls below, which is deliberate — a matcher whose arms are exercised
+ * only by real instances loses the arm the moment the tree stops containing one, and
+ * these three exist precisely for the mint nobody has written yet.
+ *
+ * ⚠️ A renaming IMPORT — one that binds a local name to a matched type inside the
+ * braces — also matches. That is a false positive rather than a hole: it fails
+ * loudly, and the fix is to add the file or rename the local. It is described rather
+ * than written out for the header's reason; writing the spelling here put THIS FILE
+ * into its own result set on the first run, which is the quotation trap arriving
+ * exactly where the header says it does.
  */
-const BYPASS_RE = /\bas\b[^;=\n]*\b(?:ValidatedSnapshotRequest|SnapshotSqlVerdict)\b/;
+const BYPASS_RE =
+  /\bas\b[^;=\n]*\b(?:ValidatedSnapshotRequest|SnapshotSqlVerdict|SnapshotSqlValidator|WarehouseProducerDeps)\b/;
 
 function* walk(dir: string): Generator<string> {
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
@@ -140,11 +182,24 @@ function* walk(dir: string): Generator<string> {
 }
 
 describe("the SQL-gate bypass set (#5042, #5230)", () => {
+  test("every scanned root exists — a moved path must RED, not shrink the scan", () => {
+    // ⚠️ Asserted rather than filtered. `existsSync`-and-skip would turn a renamed
+    // directory into a silently smaller scan that still passes, which is the exact
+    // failure the two-root change was made to close.
+    for (const { dir, label } of ROOTS) {
+      expect(existsSync(dir), `scan root missing: ${label || "packages/api/src/"} (${dir})`).toBe(
+        true,
+      );
+    }
+  });
+
   test("exactly the known sites assert a passing SQL verdict", () => {
     const found: string[] = [];
-    for (const file of walk(SRC_ROOT)) {
-      if (BYPASS_RE.test(readFileSync(file, "utf8"))) {
-        found.push(file.slice(SRC_ROOT.length));
+    for (const { dir, label } of ROOTS) {
+      for (const file of walk(dir)) {
+        if (BYPASS_RE.test(readFileSync(file, "utf8"))) {
+          found.push(label + file.slice(dir.length));
+        }
       }
     }
     expect(
@@ -175,9 +230,26 @@ describe("the SQL-gate bypass set (#5042, #5230)", () => {
     expect(BYPASS_RE.test(branded)).toBe(true);
     const brandedQualified = `const v = r as import("./warehouse-producer").Validated${"SnapshotRequest"};`;
     expect(BYPASS_RE.test(brandedQualified)).toBe(true);
+    // The SEAM spellings, and these two are the reason the header's claim changed.
+    // A mint asserted onto the validator type — with a PARAMETER, which is the only
+    // useful shape — compiles, so the matcher has to see it. The tree contains no
+    // instance, so these controls are the arms' only coverage.
+    const seam = `const v = (async (r) => ({ valid: true, request: r })) as SnapshotSql${"Validator"};`;
+    expect(BYPASS_RE.test(seam)).toBe(true);
+    const deps = `const d = { validateSnapshotSql: mint } as WarehouseProducer${"Deps"};`;
+    expect(BYPASS_RE.test(deps)).toBe(true);
     // And negative controls, so the matcher is not simply true of everything:
     // naming a TYPE is not asserting a pass.
     expect(BYPASS_RE.test(`let v: Snapshot${"SqlVerdict"};`)).toBe(false);
     expect(BYPASS_RE.test(`let r: Validated${"SnapshotRequest"};`)).toBe(false);
+    expect(BYPASS_RE.test(`const f: SnapshotSql${"Validator"} = realGate;`)).toBe(false);
+    expect(BYPASS_RE.test(`function run(d: WarehouseProducer${"Deps"}) {}`)).toBe(false);
+    // ⚠️ A NEGATIVE control of legitimate PROSE, not only of legitimate code. Every
+    // positive above is hand-planted by the same author as the matcher, so they pass
+    // by construction; this is the arm that catches an over-broad one. The sentence
+    // below is the shape a docstring in this module actually writes.
+    expect(
+      BYPASS_RE.test(`// the runner is reachable only as a consequence of the gate passing`),
+    ).toBe(false);
   });
 });

--- a/packages/api/src/lib/brain/__tests__/warehouse-producer-bypass.test.ts
+++ b/packages/api/src/lib/brain/__tests__/warehouse-producer-bypass.test.ts
@@ -10,27 +10,29 @@
  * TYPE cannot keep: that grepping for the cast is the whole list of places the gate
  * is bypassed. A cast is greppable; nothing fails when a fifth one appears.
  *
- * ## FOUR names, because #5230 moved the brand onto the REQUEST
+ * ## FIVE names, because #5230 moved the brand onto the REQUEST
  *
  * The passing verdict now carries the request it validated, and that request is
  * what is branded — which is how replay (a cached token for some other statement)
  * and ordering (a runner reachable with an unvalidated request) got closed. A bypass
- * can therefore be spelled four ways, and {@link BYPASS_RE} matches all of them:
+ * can therefore be spelled five ways, and {@link BYPASS_RE} matches all of them: an
+ * assertion naming the branded REQUEST type (what a mint ordinarily writes), the
+ * VERDICT union, the VALIDATOR seam type, the DEPS interface that holds it, or the
+ * RUNNER type whose parameter is the branded request.
  *
- *   1. an assertion naming the branded REQUEST type — what a mint ordinarily writes;
- *   2. one naming the VERDICT union — the two differ only by the brand, which makes
- *      them comparable, so a whole-verdict assertion compiles just as well;
- *   3. one naming the VALIDATOR seam type, and
- *   4. one naming the DEPS interface that holds it.
- *
- * ⚠️ **3 and 4 are here because the docstrings claimed they were refused, and that
- * was measured false.** The nullary mint is refused; a mint that TAKES A PARAMETER
- * is not, because its return literal's `valid` widens to `boolean` and the
- * discriminated-arm check is skipped — and the parameterised form is the only useful
- * one now that the passing arm must carry a request. Worse, such a validator returns
- * its own argument, so the run loop's identity check waves it through: the gate never
- * ran and nothing downstream can tell. Matching only 1 and 2 would have left this
- * guard green over the one bypass the brand does not close.
+ * ⚠️ **The last four are here because the docstrings claimed they were refused, and
+ * that was measured false — twice, with two different wrong explanations.** The
+ * mechanism, measured against the repo's own checker: the brand only ADDS a
+ * property, so the branded request is assignable to the bare one, and `as` succeeds
+ * whenever EITHER direction is comparable — the reverse direction carries all of
+ * them. What IS refused is the shape where the reverse direction also fails: a
+ * NULLARY mint (a 1-parameter function type is not assignable to a 0-parameter one)
+ * or a literal with an excess property. Pinning `valid` with `as const` does not
+ * close it; that was the second wrong explanation, and it was the one this file
+ * shipped in round 1. Such a validator returns its own argument, so the run loop's
+ * identity check waves it through: the gate never ran and nothing downstream can
+ * tell. Matching only the first two would have left this guard green over the one
+ * bypass the brand does not close.
  *
  * ⚠️ **The pattern is not written out in this file's prose, and that is the point
  * rather than fastidiousness.** A lexical guard cannot tell a quotation from an
@@ -60,19 +62,20 @@
  * ## What this does NOT prove
  *
  * The brand is not the only bypass, and saying so here is the honest half. Measured
- * against the repo's own `tsc`: an object literal, `as const`, `satisfies`, a spread
- * of the refusing arm, and the identity form of generic-inference laundering are all
- * REFUSED. What still gets through with no hit below is `as unknown as`, any
- * `any`-typed wiring (`JSON.parse`, an untyped mock, a dynamic `import()`), and a
- * `Partial<T>`-shaped generic builder.
+ * against the repo's own checker: an object literal, `as const`, `satisfies`, a
+ * spread of the refusing arm, `unknown`, and the identity form of generic-inference
+ * laundering are all REFUSED by the COMPILER.
  *
- * ⚠️ **The accepted list used to be written as *"`as unknown as` plus `any`"*, and
- * that was measurably wrong in a way worth stating precisely.** What this scan
- * actually holds is: *an assertion that puts the keyword and one of the four names
- * on ONE PHYSICAL LINE.* An angle-bracket assertion, a local type alias or a
- * renaming import of the same type, an indexed lookup of the runner's parameter, or
- * a line break between keyword and name all compile and all escape — because the
- * character class below bars a newline. Chasing those is a regex arms race the
+ * ⚠️ **What this scan holds is a different question, and conflating the two is how
+ * this header has now been wrong twice.** What it holds is exactly: *an assertion
+ * that puts the keyword and one of the five names on ONE PHYSICAL LINE.* So it DOES
+ * catch a double assertion through `unknown` written on one line — an earlier draft
+ * listed that as escaping, which was measurably false and is corrected here. What
+ * genuinely escapes: an angle-bracket assertion; a local type alias; an import that
+ * renames one of these types OUT to another local name; an indexed lookup of the
+ * runner's parameter; a line break between keyword and name (the character class
+ * below bars a newline); and `any`-typed wiring or a `Partial<T>`-shaped generic
+ * builder, which need no assertion at all. Chasing those is a regex arms race the
  * honest sentence wins; the sentence is here so nobody reads a green run as more
  * than it is.
  *
@@ -97,25 +100,42 @@ import { join } from "path";
 const SRC_ROOT = new URL("../../../", import.meta.url).pathname;
 
 /**
- * `ee/src/` too — a second root, not decoration.
+ * Every root that can hold a mint — three of them, not decoration.
  *
- * ⚠️ All four matched names are EXPORTED, and `ee/` imports `@atlas/api/*` freely:
- * only the reverse direction is gated. A scan of this package alone would prove a
- * claim strictly narrower than the one this suite's failure message makes, so a mint
- * added under `ee/` would sit outside the enumeration while the guard stayed green —
- * the same silent-empty shape {@link BYPASS_RE}'s own note is written to prevent,
- * one axis over.
+ * ⚠️ All five matched names are EXPORTED, and both `ee/` and `packages/cli/` import
+ * `@atlas/api/*` freely: only the api→ee direction is gated. A scan of this package
+ * alone proved a claim strictly narrower than the one the failure message made, so a
+ * mint added under either would sit outside the enumeration while the guard stayed
+ * green — the same silent-empty shape {@link BYPASS_RE}'s own note is written to
+ * prevent, one axis over. `packages/cli/` is the concrete case: it already imports
+ * `@atlas/api/lib/db/*` and `@atlas/api/lib/semantic/*`, so an `atlas brain produce`
+ * command is a plausible sixth site.
+ *
+ * ⚠️ **The roots are NAMED in the failure message too.** An enumeration is only as
+ * honest as its scope, and the previous message asserted a tree-wide claim over one
+ * directory. If a root is added here, add it there.
  */
 const ROOTS: readonly { readonly dir: string; readonly label: string }[] = [
   { dir: SRC_ROOT, label: "" },
   { dir: new URL("../../../../../../ee/src/", import.meta.url).pathname, label: "ee/src/" },
+  {
+    dir: new URL("../../../../../cli/src/", import.meta.url).pathname,
+    label: "packages/cli/src/",
+  },
 ];
 
 /**
- * Every site that may assert a passing SQL verdict, with why.
+ * Every site that MAY ASSERT one of the guarded names, with why.
+ *
+ * ⚠️ "May assert", not "does bypass" — and the difference is real now that five
+ * names are matched. A deps assertion carrying no `validateSnapshotSql`, or a
+ * validator assertion returning only the refusing arm, bypasses nothing and still
+ * belongs here. An entry is a place to LOOK, not a finding.
  *
  * ⚠️ ONE production entry, deliberately. It is the single point where the product's
- * gate answering yes becomes a value the run will act on.
+ * gate answering yes becomes a value the run will act on. Note the module also names
+ * these types in prose, so it would keep matching even if its cast were removed —
+ * this test cannot tell you the cast is still there, only that no NEW file names one.
  */
 const KNOWN_BYPASSES: readonly { file: string; why: string }[] = [
   {
@@ -153,21 +173,24 @@ const KNOWN_BYPASSES: readonly { file: string; why: string }[] = [
  * spelling of the pattern: writing it out in prose would put this file into its own
  * result set, which is why the header describes it instead.
  *
- * ⚠️ **FOUR alternatives (#5230), and the header says why each is load-bearing.**
- * Only the first has instances in the tree today; the other three are pinned by the
+ * ⚠️ **FIVE alternatives (#5230), and the header says why each is load-bearing.**
+ * Only the first has instances in the tree today; the other four are pinned by the
  * planted controls below, which is deliberate — a matcher whose arms are exercised
  * only by real instances loses the arm the moment the tree stops containing one, and
- * these three exist precisely for the mint nobody has written yet.
+ * these four exist precisely for the mint nobody has written yet.
  *
- * ⚠️ A renaming IMPORT — one that binds a local name to a matched type inside the
- * braces — also matches. That is a false positive rather than a hole: it fails
- * loudly, and the fix is to add the file or rename the local. It is described rather
- * than written out for the header's reason; writing the spelling here put THIS FILE
- * into its own result set on the first run, which is the quotation trap arriving
- * exactly where the header says it does.
+ * ⚠️ A single-line import that renames some OTHER binding INTO one of these names
+ * matches — a false positive rather than a hole, since it fails loudly and the fix
+ * is to rename the local. An import that renames one of these types OUT to a
+ * different local name does NOT match, and that direction is a real escape, listed
+ * with the others in the header. A round-1 draft asserted the opposite direction and
+ * called it a false positive; both halves were wrong, and the correction is measured
+ * rather than reasoned. Neither spelling is written out here — writing one put THIS
+ * FILE into its own result set on the first run, which is the quotation trap
+ * arriving exactly where the header says it does.
  */
 const BYPASS_RE =
-  /\bas\b[^;=\n]*\b(?:ValidatedSnapshotRequest|SnapshotSqlVerdict|SnapshotSqlValidator|WarehouseProducerDeps)\b/;
+  /\bas\b[^;=\n]*\b(?:ValidatedSnapshotRequest|SnapshotSqlVerdict|SnapshotSqlValidator|WarehouseProducerDeps|WarehouseSnapshotRunner)\b/;
 
 function* walk(dir: string): Generator<string> {
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
@@ -204,11 +227,11 @@ describe("the SQL-gate bypass set (#5042, #5230)", () => {
     }
     expect(
       found.toSorted(),
-      "the set of places that can assert the SQL gate passed has changed. A new TEST harness is " +
-        "ordinarily fine — the real gate is whitelist-scoped and a test workspace has none — but a new " +
-        "PRODUCTION site is a second door onto an unvalidated statement reaching a customer's " +
-        "datasource, and it is the thing to argue rather than merge. Add it to KNOWN_BYPASSES with a " +
-        "reason, or remove the cast.",
+      "the set of places under packages/api/src, ee/src and packages/cli/src that can assert the SQL " +
+        "gate passed has changed. A new TEST harness is ordinarily fine — the real gate is " +
+        "whitelist-scoped and a test workspace has none — but a new PRODUCTION site is a second door " +
+        "onto an unvalidated statement reaching a customer's datasource, and it is the thing to argue " +
+        "rather than merge. Add it to KNOWN_BYPASSES with a reason, or remove the cast.",
     ).toEqual(KNOWN_BYPASSES.map((b) => b.file).toSorted());
   });
 
@@ -238,12 +261,34 @@ describe("the SQL-gate bypass set (#5042, #5230)", () => {
     expect(BYPASS_RE.test(seam)).toBe(true);
     const deps = `const d = { validateSnapshotSql: mint } as WarehouseProducer${"Deps"};`;
     expect(BYPASS_RE.test(deps)).toBe(true);
+    // The RUNNER type, the fifth name. Free today — the tree has zero assertions
+    // onto it — and it is the cheapest innocuous-looking uncaught mint, because its
+    // parameter IS the branded request.
+    const runner = `const run = ((r) => read(r)) as WarehouseSnapshot${"Runner"};`;
+    expect(BYPASS_RE.test(runner)).toBe(true);
+    // A DOUBLE assertion through `unknown`, on one line. A round-1 draft of the
+    // header listed this as escaping; it does not, and the control is here so the
+    // sentence cannot drift back.
+    const doubled = `const r = payload as unknown as Validated${"SnapshotRequest"};`;
+    expect(BYPASS_RE.test(doubled)).toBe(true);
     // And negative controls, so the matcher is not simply true of everything:
     // naming a TYPE is not asserting a pass.
     expect(BYPASS_RE.test(`let v: Snapshot${"SqlVerdict"};`)).toBe(false);
     expect(BYPASS_RE.test(`let r: Validated${"SnapshotRequest"};`)).toBe(false);
     expect(BYPASS_RE.test(`const f: SnapshotSql${"Validator"} = realGate;`)).toBe(false);
     expect(BYPASS_RE.test(`function run(d: WarehouseProducer${"Deps"}) {}`)).toBe(false);
+    // ⚠️ The two negatives above contain no `as` at all, so they are false for ANY
+    // matcher that requires the keyword — including one that has lost every name.
+    // They do not discriminate the arms they sit beside. This one does: a matched
+    // name with no `as` anywhere on the line, in a position no assertion can take.
+    expect(BYPASS_RE.test(`export type { SnapshotSql${"Validator"} };`)).toBe(false);
+    // ⚠️ And the honest cost, asserted rather than described: PROSE containing the
+    // word and a matched name on one line MATCHES. This is the quotation trap as a
+    // measurement — the guard cannot tell a sentence from an assertion, which is
+    // exactly why the header describes spellings instead of writing them out.
+    expect(
+      BYPASS_RE.test(`// as good a place as any to name SnapshotSql${"Validator"} in prose`),
+    ).toBe(true);
     // ⚠️ A NEGATIVE control of legitimate PROSE, not only of legitimate code. Every
     // positive above is hand-planted by the same author as the matcher, so they pass
     // by construction; this is the arm that catches an over-broad one. The sentence

--- a/packages/api/src/lib/brain/__tests__/warehouse-producer-logging.test.ts
+++ b/packages/api/src/lib/brain/__tests__/warehouse-producer-logging.test.ts
@@ -95,7 +95,10 @@ void mock.module("@atlas/api/lib/logger", () => {
 });
 
 type ProducerModule = typeof import("@atlas/api/lib/brain/warehouse-producer");
-type SnapshotSqlVerdict = import("@atlas/api/lib/brain/warehouse-producer").SnapshotSqlVerdict;
+type WarehouseSnapshotRequest =
+  import("@atlas/api/lib/brain/warehouse-producer").WarehouseSnapshotRequest;
+type ValidatedSnapshotRequest =
+  import("@atlas/api/lib/brain/warehouse-producer").ValidatedSnapshotRequest;
 type ReconcileModule = typeof import("@atlas/api/lib/brain/reconcile");
 
 let producer: ProducerModule;
@@ -157,8 +160,16 @@ function deps(over: Partial<Parameters<ProducerModule["runWarehouseProducer"]>[1
       has: () => true,
     }),
     loadEntity: async () => ACCOUNTS_YAML,
-    // Cast because the passing verdict is branded — see the unit suite's note.
-    validateSnapshotSql: async () => ({ valid: true }) as SnapshotSqlVerdict,
+    // Cast because the passing verdict carries a branded request — see the unit
+    // suite's note. It brands the request it was HANDED: a fresh object would trip
+    // the run loop's anti-replay identity check (#5230).
+    // `true as const`, because this literal is NOT contextually typed — `deps()`
+    // has no return annotation, so a bare `true` widens to `boolean` and the whole
+    // object stops satisfying the seam.
+    validateSnapshotSql: async (request: WarehouseSnapshotRequest) => ({
+      valid: true as const,
+      request: request as ValidatedSnapshotRequest,
+    }),
     runSnapshot: async () => [
       { [producer.SUBJECT_ALIAS]: "Acme Corp", [`${producer.DIMENSION_ALIAS_PREFIX}0`]: "active" },
     ],

--- a/packages/api/src/lib/brain/__tests__/warehouse-producer-logging.test.ts
+++ b/packages/api/src/lib/brain/__tests__/warehouse-producer-logging.test.ts
@@ -340,9 +340,10 @@ describe("warehouse producer logging", () => {
   });
 
   it("logs a gate/request mismatch at ERROR, naming what came BACK (#5230)", async () => {
-    // ⚠️ The only ERROR-level per-entity refusal in the run loop — every sibling is
-    // a WARN, and the neighbouring `snapshot-failed` case above asserts
-    // `messages(errors)` is empty. Without this case, demoting this line to `warn`
+    // ⚠️ One of TWO ERROR-level per-entity refusals — the transaction-rollback case
+    // directly above is the other, and it also files `snapshot-failed`. Every
+    // remaining sibling is a WARN, and the first case in this file asserts the error
+    // sink is empty for one of them. Without this case, demoting this line to `warn`
     // (or deleting it) is green, which is the demotion this file's header names as
     // the failure it exists to refuse.
     //

--- a/packages/api/src/lib/brain/__tests__/warehouse-producer-logging.test.ts
+++ b/packages/api/src/lib/brain/__tests__/warehouse-producer-logging.test.ts
@@ -339,6 +339,36 @@ describe("warehouse producer logging", () => {
     expect(payload.err).toBeInstanceOf(Error);
   });
 
+  it("logs a gate/request mismatch at ERROR, naming what came BACK (#5230)", async () => {
+    // ⚠️ The only ERROR-level per-entity refusal in the run loop — every sibling is
+    // a WARN, and the neighbouring `snapshot-failed` case above asserts
+    // `messages(errors)` is empty. Without this case, demoting this line to `warn`
+    // (or deleting it) is green, which is the demotion this file's header names as
+    // the failure it exists to refuse.
+    //
+    // The validator returns a token for a RECONSTRUCTED request: same fields, wrong
+    // object. That is the mismatch arm rather than the gate-threw one.
+    await run({
+      validateSnapshotSql: async (request: WarehouseSnapshotRequest) => ({
+        valid: true as const,
+        request: { ...request } as ValidatedSnapshotRequest,
+      }),
+    });
+
+    const payload = payloadOf(errors, "verdict for a different request");
+    expect(payload.entity).toBe("Accounts");
+    expect(payload.table).toBe("accounts");
+    // ⚠️ What CAME BACK, under its own keys. A payload carrying only the submitted
+    // entity cannot tell a same-workspace replay from a token minted against another
+    // tenant's statement, and the second is the one that has to be greppable.
+    expect(payload.returnedEntity).toBe("Accounts");
+    expect(payload.returnedWorkspaceId).toBe(WORKSPACE);
+    expect(payload.requestId).toBe("req-1");
+    // ABSENT from warn, not merely present in error — a demotion is how this line
+    // stops being an incident while still being "logged".
+    expect(messages(warns).filter((m) => m.includes("different request"))).toEqual([]);
+  });
+
   it("carries the request id and the trigger on every line, including the failures", async () => {
     // The failures that matter here return 200 — a refusal is a successful response
     // — so without this an operator holding one has workspace plus wall-clock and
@@ -351,7 +381,12 @@ describe("warehouse producer logging", () => {
     // ⚠️ The count assertion first. `for (const line of [...warns, ...infos])` over
     // two EMPTY sinks passes while proving nothing, which is the shape this file
     // exists to refuse.
-    const lines = [...warns, ...infos];
+    //
+    // ⚠️ `errors` is in the sweep too (#5230). It was omitted while the only ERROR
+    // line was the transaction failure; the gate/request mismatch made two, and the
+    // mismatch refusal is the one that TELLS the operator to quote the request id —
+    // so an error line without it is the one place the instruction is unfollowable.
+    const lines = [...warns, ...infos, ...errors];
     expect(lines.length).toBeGreaterThanOrEqual(2);
     for (const line of lines) {
       expect(line.payload).toMatchObject({

--- a/packages/api/src/lib/brain/__tests__/warehouse-producer-logging.test.ts
+++ b/packages/api/src/lib/brain/__tests__/warehouse-producer-logging.test.ts
@@ -346,23 +346,33 @@ describe("warehouse producer logging", () => {
     // (or deleting it) is green, which is the demotion this file's header names as
     // the failure it exists to refuse.
     //
-    // The validator returns a token for a RECONSTRUCTED request: same fields, wrong
-    // object. That is the mismatch arm rather than the gate-threw one.
+    // ⚠️ The token names ANOTHER TENANT and ANOTHER ENTITY, and both differences are
+    // load-bearing. With a plain `{ ...request }` the returned values equal the
+    // submitted ones, so a payload that logged the SUBMITTED entity under both keys
+    // passed — measured: replacing `validated.entity` with `entityPlan.entity.name`
+    // and `validated.workspaceId` with `workspaceId` left this suite green, which is
+    // precisely the defect these two keys were added to close.
     await run({
       validateSnapshotSql: async (request: WarehouseSnapshotRequest) => ({
         valid: true as const,
-        request: { ...request } as ValidatedSnapshotRequest,
+        request: {
+          ...request,
+          entity: "Impostor",
+          workspaceId: "ws-other-tenant",
+        } as ValidatedSnapshotRequest,
       }),
     });
 
     const payload = payloadOf(errors, "verdict for a different request");
     expect(payload.entity).toBe("Accounts");
+    // NOT shadowed by the returned one — the keys are separate for this reason.
+    expect(payload.workspaceId).toBe(WORKSPACE);
     expect(payload.table).toBe("accounts");
     // ⚠️ What CAME BACK, under its own keys. A payload carrying only the submitted
     // entity cannot tell a same-workspace replay from a token minted against another
     // tenant's statement, and the second is the one that has to be greppable.
-    expect(payload.returnedEntity).toBe("Accounts");
-    expect(payload.returnedWorkspaceId).toBe(WORKSPACE);
+    expect(payload.returnedEntity).toBe("Impostor");
+    expect(payload.returnedWorkspaceId).toBe("ws-other-tenant");
     expect(payload.requestId).toBe("req-1");
     // ABSENT from warn, not merely present in error — a demotion is how this line
     // stops being an incident while still being "logged".
@@ -378,16 +388,28 @@ describe("warehouse producer logging", () => {
         throw new Error("connection refused");
       },
     });
-    // ⚠️ The count assertion first. `for (const line of [...warns, ...infos])` over
-    // two EMPTY sinks passes while proving nothing, which is the shape this file
-    // exists to refuse.
+    // ⚠️ TWO runs, because the first emits no ERROR line at all. Adding `...errors`
+    // to the sweep without this was measured VACUOUS — `warns=1 infos=1 errors=0` —
+    // so the widening proved nothing and its own justification described a line the
+    // fixture never emitted. The mismatch arm is what populates the error sink, and
+    // it is mutually exclusive with a throwing runner on one entity.
+    await run({
+      validateSnapshotSql: async (request: WarehouseSnapshotRequest) => ({
+        valid: true as const,
+        request: { ...request } as ValidatedSnapshotRequest,
+      }),
+    });
+    // ⚠️ The count assertions first. `for (const line of [...warns, ...infos])` over
+    // EMPTY sinks passes while proving nothing, which is the shape this file exists
+    // to refuse — and the per-sink assertion is what stops `errors` sliding back to
+    // zero while the total stays satisfied by warns and infos.
     //
-    // ⚠️ `errors` is in the sweep too (#5230). It was omitted while the only ERROR
-    // line was the transaction failure; the gate/request mismatch made two, and the
-    // mismatch refusal is the one that TELLS the operator to quote the request id —
-    // so an error line without it is the one place the instruction is unfollowable.
+    // `errors` is in the sweep since #5230: the mismatch refusal is the one line
+    // that TELLS the operator to quote the request id, so an error line without it
+    // is the one place the instruction is unfollowable.
+    expect(errors.length).toBeGreaterThanOrEqual(1);
     const lines = [...warns, ...infos, ...errors];
-    expect(lines.length).toBeGreaterThanOrEqual(2);
+    expect(lines.length).toBeGreaterThanOrEqual(3);
     for (const line of lines) {
       expect(line.payload).toMatchObject({
         workspaceId: WORKSPACE,

--- a/packages/api/src/lib/brain/__tests__/warehouse-producer-mint.test.ts
+++ b/packages/api/src/lib/brain/__tests__/warehouse-producer-mint.test.ts
@@ -6,10 +6,10 @@
  * `runWarehouseProducer` refuses unless `verdict.request === request` — the
  * anti-replay check. The only production mint is `defaultValidateSnapshotSql`, and
  * nothing asserted that it brands the request it was HANDED rather than a copy of
- * it. That asymmetry is the dangerous kind: an innocuous edit there (`{ ...request }`,
- * a normalized field, a logging Proxy) compiles, keeps every existing suite green,
- * and in production refuses **every entity on every run** as an "Atlas wiring fault".
- * The producer silently stops emitting and the Atlas goes stale.
+ * it. Measured: replacing that with `{ ...request }` fails only this suite — the
+ * unit, logging and bypass suites stay green — while in production every entity is
+ * refused on every run as an "Atlas wiring fault". The producer silently stops
+ * emitting and the Atlas goes stale.
  *
  * The unit suite cannot cover it. Its real-gate block drives the shipped
  * `defaultValidateSnapshotSql` for real, but the gate's table check is
@@ -71,9 +71,12 @@ beforeAll(async () => {
 afterAll(() => {
   // ⚠️ `mock.module` is PROCESS-wide, not file-wide. `scripts/test-isolated.ts`
   // spawns per file so CI is unaffected, but `bun test <a> <b>` — the invocation
-  // CLAUDE.md permits for single files — shares one process, and a leaked REFUSING
-  // stub would make `warehouse-producer.test.ts`'s real-gate block pass vacuously.
-  // Resetting cannot uninstall the mock; it makes the leak benign instead.
+  // CLAUDE.md permits for single files — shares one process. Resetting cannot
+  // uninstall the mock. Since #5230 `warehouse-producer.test.ts`'s real-gate block
+  // carries a positive tripwire on the shipped gate's own wording, so a co-run REDS
+  // there rather than passing against this stub — measured, and its docstring says
+  // so. The reset only keeps the leaked state predictable; the red is that file's
+  // job, not this one's.
   nextResult = { valid: true };
   validateSqlCalls = [];
 });

--- a/packages/api/src/lib/brain/__tests__/warehouse-producer-mint.test.ts
+++ b/packages/api/src/lib/brain/__tests__/warehouse-producer-mint.test.ts
@@ -1,0 +1,106 @@
+/**
+ * The production mint's BY-REFERENCE contract (#5230).
+ *
+ * ## Why this needs its own file
+ *
+ * `runWarehouseProducer` refuses unless `verdict.request === request` — the
+ * anti-replay check. The only production mint is `defaultValidateSnapshotSql`, and
+ * nothing asserted that it brands the request it was HANDED rather than a copy of
+ * it. That asymmetry is the dangerous kind: an innocuous edit there (`{ ...request }`,
+ * a normalized field, a logging Proxy) compiles, keeps every existing suite green,
+ * and in production refuses **every entity on every run** as an "Atlas wiring fault".
+ * The producer silently stops emitting and the Atlas goes stale.
+ *
+ * The unit suite cannot cover it. Its real-gate block drives the shipped
+ * `defaultValidateSnapshotSql` for real, but the gate's table check is
+ * workspace-whitelist-scoped and a test workspace has none — so that block only ever
+ * reaches the REFUSING arm, and the refusing arm carries no request. The passing arm
+ * is only reachable with the gate itself stubbed, which means `mock.module`, which is
+ * process-wide and therefore cannot share a file with suites that want the real one.
+ *
+ * ⚠️ EVERY value export of `lib/tools/sql` is replaced below. `mock.module` swaps the
+ * whole module, so an export left out becomes `undefined` and the first unrelated
+ * consumer throws — which reads as a broken test rather than a missing mock.
+ */
+
+import { beforeAll, describe, expect, mock, test } from "bun:test";
+
+let validateSqlCalls: { sql: string; connectionId?: string; workspaceId?: string }[] = [];
+let nextResult: { valid: boolean; error?: string } = { valid: true };
+
+void mock.module("@atlas/api/lib/tools/sql", () => ({
+  MAX_SQL_LEN: 100_000,
+  extractClassification: () => undefined,
+  parserDatabase: () => "postgresql",
+  validateSQL: async (sql: string, connectionId?: string, workspaceId?: string) => {
+    validateSqlCalls.push({ sql, connectionId, workspaceId });
+    return nextResult;
+  },
+  buildSqlExecuteSpanAttrs: () => ({}),
+  runSqlPipelineEffect: () => {
+    throw new Error("not used by this suite");
+  },
+  runUserQueryPipeline: async () => {
+    throw new Error("not used by this suite");
+  },
+  executeSQL: {},
+}));
+
+type ProducerModule = typeof import("@atlas/api/lib/brain/warehouse-producer");
+type WarehouseSnapshotRequest =
+  import("@atlas/api/lib/brain/warehouse-producer").WarehouseSnapshotRequest;
+
+let producer: ProducerModule;
+
+beforeAll(async () => {
+  // DYNAMIC, after the mock is installed — a static import binds the real
+  // `validateSQL` at module-evaluation time and this suite would drive the shipped
+  // gate against a workspace with no whitelist, i.e. the refusing arm forever.
+  producer = await import("@atlas/api/lib/brain/warehouse-producer");
+});
+
+const REQUEST: WarehouseSnapshotRequest = {
+  workspaceId: "ws-5230-mint",
+  entity: "Accounts",
+  connectionId: undefined,
+  sql: "SELECT account_id AS atlas_brain_subject FROM accounts LIMIT 101",
+};
+
+describe("defaultValidateSnapshotSql", () => {
+  test("brands the request it was handed — BY REFERENCE, not a copy", async () => {
+    validateSqlCalls = [];
+    nextResult = { valid: true };
+
+    const verdict = await producer.defaultValidateSnapshotSql(REQUEST);
+
+    expect(verdict.valid).toBe(true);
+    if (!verdict.valid) throw new Error("the stubbed gate said yes; the mint refused");
+    // ⚠️ `toBe`, deliberately, and this is the whole point of the file. `toEqual`
+    // passes against `{ ...request }` — the edit that fail-closes production — so a
+    // deep-equality assertion here would certify exactly the defect it exists for.
+    // Upcast so the comparison is at the request type; the brand is compile-time.
+    const branded: WarehouseSnapshotRequest = verdict.request;
+    expect(branded).toBe(REQUEST);
+    // …and it validated THIS statement, not some other one. Without this the mint
+    // could ignore its argument entirely and still satisfy the line above.
+    expect(validateSqlCalls).toEqual([
+      { sql: REQUEST.sql, connectionId: undefined, workspaceId: REQUEST.workspaceId },
+    ]);
+  });
+
+  test("the refusing arm carries the gate's own reason and no request", async () => {
+    validateSqlCalls = [];
+    nextResult = { valid: false, error: 'Table "accounts" is not in this workspace\'s whitelist' };
+
+    const verdict = await producer.defaultValidateSnapshotSql(REQUEST);
+
+    expect(verdict.valid).toBe(false);
+    if (verdict.valid) throw new Error("the stubbed gate said no; the mint passed it");
+    // The gate's text, verbatim. Collapsing it to a generic string is what put a
+    // `?? "no reason given"` into the run loop once already.
+    expect(verdict.error).toBe('Table "accounts" is not in this workspace\'s whitelist');
+    // The refusing arm is deliberately unbranded — there is nothing to forge on it,
+    // and a `request` here would be a token for a statement that did NOT pass.
+    expect("request" in verdict).toBe(false);
+  });
+});

--- a/packages/api/src/lib/brain/__tests__/warehouse-producer-mint.test.ts
+++ b/packages/api/src/lib/brain/__tests__/warehouse-producer-mint.test.ts
@@ -15,15 +15,24 @@
  * `defaultValidateSnapshotSql` for real, but the gate's table check is
  * workspace-whitelist-scoped and a test workspace has none — so that block only ever
  * reaches the REFUSING arm, and the refusing arm carries no request. The passing arm
- * is only reachable with the gate itself stubbed, which means `mock.module`, which is
- * process-wide and therefore cannot share a file with suites that want the real one.
+ * is only reachable with the gate itself stubbed, which means `mock.module`, whose
+ * blast radius is the PROCESS rather than the file — so this suite must not share one
+ * with `warehouse-producer.test.ts`'s real-gate block, the very block whose docstring
+ * records that deleting the production gate used to leave every suite green. The
+ * isolated runner spawns per file, so CI is safe; a hand-run `bun test <a> <b>` is
+ * not, and the `afterAll` below is what makes a leak benign rather than silent.
  *
  * ⚠️ EVERY value export of `lib/tools/sql` is replaced below. `mock.module` swaps the
  * whole module, so an export left out becomes `undefined` and the first unrelated
  * consumer throws — which reads as a broken test rather than a missing mock.
+ *
+ * ⚠️ **What this file does NOT pin: the brand.** Retype the passing arm's `request`
+ * to the bare request type and every assertion here still compiles and passes. That
+ * half is carried by the `@ts-expect-error` rows in `warehouse-producer.test.ts`, and
+ * the two files can be edited independently — hence the pointer.
  */
 
-import { beforeAll, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, mock, test } from "bun:test";
 
 let validateSqlCalls: { sql: string; connectionId?: string; workspaceId?: string }[] = [];
 let nextResult: { valid: boolean; error?: string } = { valid: true };
@@ -59,10 +68,31 @@ beforeAll(async () => {
   producer = await import("@atlas/api/lib/brain/warehouse-producer");
 });
 
+afterAll(() => {
+  // ⚠️ `mock.module` is PROCESS-wide, not file-wide. `scripts/test-isolated.ts`
+  // spawns per file so CI is unaffected, but `bun test <a> <b>` — the invocation
+  // CLAUDE.md permits for single files — shares one process, and a leaked REFUSING
+  // stub would make `warehouse-producer.test.ts`'s real-gate block pass vacuously.
+  // Resetting cannot uninstall the mock; it makes the leak benign instead.
+  nextResult = { valid: true };
+  validateSqlCalls = [];
+});
+
+/**
+ * ⚠️ A NON-DEFAULT `connectionId`, and it is load-bearing.
+ *
+ * With `undefined` here, `toEqual` ignores the key and the "it validated THIS
+ * statement" assertion below is blind to the argument being dropped — measured:
+ * passing a literal `undefined` as `validateSQL`'s second argument left this suite
+ * green. That argument resolves the dialect the parser runs in (`tools/sql.ts` calls
+ * the wrong mode a security risk) and scopes the whitelist, while
+ * `defaultRunSnapshot` reads the row set from `connectionId ?? "default"` — so
+ * dropping it validates against one connection and reads from another.
+ */
 const REQUEST: WarehouseSnapshotRequest = {
   workspaceId: "ws-5230-mint",
   entity: "Accounts",
-  connectionId: undefined,
+  connectionId: "warehouse-replica",
   sql: "SELECT account_id AS atlas_brain_subject FROM accounts LIMIT 101",
 };
 
@@ -84,7 +114,7 @@ describe("defaultValidateSnapshotSql", () => {
     // …and it validated THIS statement, not some other one. Without this the mint
     // could ignore its argument entirely and still satisfy the line above.
     expect(validateSqlCalls).toEqual([
-      { sql: REQUEST.sql, connectionId: undefined, workspaceId: REQUEST.workspaceId },
+      { sql: REQUEST.sql, connectionId: "warehouse-replica", workspaceId: REQUEST.workspaceId },
     ]);
   });
 

--- a/packages/api/src/lib/brain/__tests__/warehouse-producer-pg.test.ts
+++ b/packages/api/src/lib/brain/__tests__/warehouse-producer-pg.test.ts
@@ -40,7 +40,7 @@ import {
   WAREHOUSE_PRODUCER,
   runWarehouseProducer,
   warehouseRowId,
-  type SnapshotSqlVerdict,
+  type ValidatedSnapshotRequest,
   type WarehouseProducerDeps,
 } from "@atlas/api/lib/brain/warehouse-producer";
 
@@ -146,10 +146,16 @@ describeIfPg("warehouse producer (real Postgres)", () => {
       // The SQL gate is workspace-whitelist-scoped and this schema has no
       // whitelist, so it is stubbed here and driven for real in the unit suite
       // (`what it builds is never rejected for its FORM`).
-      // The cast is required: `SnapshotSqlVerdict`'s passing arm is branded so an
-      // object literal cannot assert the gate passed, which makes every bypass in
-      // the tree greppable as `as SnapshotSqlVerdict`.
-      validateSnapshotSql: async () => ({ valid: true }) as SnapshotSqlVerdict,
+      // The cast is required: the passing verdict carries a branded
+      // `ValidatedSnapshotRequest`, so an object literal cannot assert the gate
+      // passed, which makes every bypass in the tree greppable.
+      //
+      // It brands the request it was HANDED — a freshly built one would be refused
+      // by the run loop's anti-replay identity check (#5230).
+      validateSnapshotSql: async (request) => ({
+        valid: true,
+        request: request as ValidatedSnapshotRequest,
+      }),
       runSnapshot: async () => rows,
       now: () => snapshotAt,
     };

--- a/packages/api/src/lib/brain/__tests__/warehouse-producer.test.ts
+++ b/packages/api/src/lib/brain/__tests__/warehouse-producer.test.ts
@@ -74,6 +74,7 @@ import {
   type WarehouseEntityLookup,
   type WarehouseEntityPlan,
   type WarehouseProducerDeps,
+  type SnapshotSqlValidator,
   type SnapshotSqlVerdict,
   type ValidatedSnapshotRequest,
   type WarehouseRowId,
@@ -1096,7 +1097,7 @@ describe("runWarehouseProducer", () => {
 
     let cached: SnapshotSqlVerdict | undefined;
     const report = await runWarehouseProducer(
-      { workspaceId: WORKSPACE, triggeredBy: "user-1" },
+      { workspaceId: WORKSPACE, triggeredBy: "user-1", requestId: "req-replay" },
       {
         ...h.deps,
         validateSnapshotSql: async (request) => {
@@ -1114,6 +1115,15 @@ describe("runWarehouseProducer", () => {
     // planner emits first is not this test's subject.
     expect(h.snapshots).toHaveLength(1);
     const ran = h.snapshots[0]?.entity;
+    // ⚠️ WHICH one ran, not merely that one did. `not.toBe(ran)` alone is satisfied
+    // by an INVERTED check (`===` instead of `!==`), which runs the wrong entity on
+    // the cached token and refuses the right one — the mutation this test is the
+    // subject of, and the one it could not see. The cached token is about the first
+    // request the gate was handed, so that entity is the one that may run.
+    expect(ran).toBe(h.validations[0]?.entity);
+    // …and the row counts differ (1 vs 2), so `created` says which entity's rows
+    // were read rather than only that reading happened.
+    expect(report.created).toBe(1);
     expect(refusalKeys(report.refusals)).toHaveLength(1);
     const refused = report.refusals[0];
     expect(refused?.entity).not.toBe(ran);
@@ -1123,9 +1133,9 @@ describe("runWarehouseProducer", () => {
     expect(refused?.reason).toBe("snapshot-failed");
     expect(refused?.message).not.toContain("Re-running will not change");
     expect(refused?.message).toContain("could not confirm");
-    // And the run still produced the entity the token WAS for — a guard that
-    // refused everything would satisfy every assertion above.
-    expect(report.created).toBeGreaterThan(0);
+    // The operator's only handle: the report carries no request id, so the refusal
+    // has to name it inline or the instruction to quote it is unfollowable.
+    expect(refused?.message).toContain("req-replay");
   });
 
   test("a verdict carrying a RECONSTRUCTED request is refused too (#5230)", async () => {
@@ -1156,6 +1166,46 @@ describe("runWarehouseProducer", () => {
 
     expect(h.snapshots).toEqual([]);
     expect(refusalKeys(report.refusals)).toEqual(["Copied.status:snapshot-failed"]);
+    // ⚠️ The MESSAGE, because `snapshot-failed` is shared by four arms — the gate
+    // throwing, the gate rejecting, the snapshot throwing, and this one — and only
+    // the message tells them apart. Without it this test passes on a run that
+    // refused for an entirely different reason.
+    expect(report.refusals[0]?.message).toContain("could not confirm");
+    expect(report.created).toBe(0);
+  });
+
+  test("a validator that MUTATES the request after validating is refused (#5230)", async () => {
+    // ⚠️ The residual the identity check reads as if it had closed. `readonly` is
+    // erased at runtime, so a validator can validate, rewrite `sql`, and hand back
+    // the SAME reference — identity passes and the datasource reads a statement the
+    // gate never saw. The request is frozen, so the write throws instead, onto the
+    // gate-threw arm. `Object.assign` rather than `request.sql = …`: the latter is a
+    // compile error against the `readonly` field, and a test that cannot be written
+    // is not evidence about runtime.
+    const h = harness({
+      pairs: [{ entity: "Mutated", dimension: "status", naming: false }],
+      entities: {
+        Mutated: entityYaml({ table: "mutated", primaryKey: "id", dimensions: ["id", "status"] }),
+      },
+      rows: { Mutated: [snapshotRow("Acme Corp", "active")] },
+    });
+
+    const report = await runWarehouseProducer(
+      { workspaceId: WORKSPACE, triggeredBy: "user-1" },
+      {
+        ...h.deps,
+        validateSnapshotSql: async (request) => {
+          Object.assign(request, { sql: "SELECT * FROM salaries" });
+          return { valid: true, request: request as ValidatedSnapshotRequest };
+        },
+      },
+    );
+
+    expect(h.snapshots).toEqual([]);
+    expect(refusalKeys(report.refusals)).toEqual(["Mutated.status:snapshot-failed"]);
+    // The TRANSIENT arm, and specifically the gate-threw one rather than the
+    // mismatch one — the write throws before a verdict exists.
+    expect(report.refusals[0]?.message).toContain("could not check the query");
     expect(report.created).toBe(0);
   });
 
@@ -1174,7 +1224,23 @@ describe("runWarehouseProducer", () => {
     };
     // @ts-expect-error a bare request has not passed the SQL gate, and the runner says so
     const call = () => runner(bare);
+    // ⚠️ Keep the guarded line MINIMAL. `@ts-expect-error` suppresses *any* error on
+    // its line, so a line that grows can start satisfying the directive for a reason
+    // that has nothing to do with the brand.
     expect(typeof call).toBe("function");
+
+    // The BRAND, not only the parameter — three more one-line claims, each measured
+    // against `bun run type` rather than reasoned about. Without these, deleting the
+    // brand from the verdict's passing arm would leave only the runner's parameter
+    // pinned, and the replay half of #5230 would go quiet.
+    // @ts-expect-error the passing verdict cannot be written as a literal carrying a bare request
+    const literal: SnapshotSqlVerdict = { valid: true, request: bare };
+    // @ts-expect-error a validator cannot return a token for a request the gate has not branded
+    const mint: SnapshotSqlValidator = async (r) => ({ valid: true, request: r });
+    // @ts-expect-error the runner cannot be narrowed to a function taking a bare request
+    const widened: (r: WarehouseSnapshotRequest) => Promise<readonly Record<string, unknown>[]> =
+      runner;
+    expect([literal, mint, widened].every((v) => v !== null)).toBe(true);
   });
 
   test("a validator that REJECTS is caught on the same arm", async () => {

--- a/packages/api/src/lib/brain/__tests__/warehouse-producer.test.ts
+++ b/packages/api/src/lib/brain/__tests__/warehouse-producer.test.ts
@@ -520,6 +520,13 @@ describe("buildSnapshotSql", () => {
    * actually reached (inside the hooks and restored after — the test-discipline
    * rule). And the assertions are UNCONDITIONAL, because an assertion inside
    * `if (!valid)` reports "pass" for exactly the case it was written to exclude.
+   *
+   * ⚠️ **This block REDS if you run it in the same `bun test` invocation as
+   * `warehouse-producer-mint.test.ts`, and that is the tripwire working.** That
+   * suite `mock.module`s `lib/tools/sql`, whose blast radius is the process, so the
+   * real gate is not what answers here. The isolated runner spawns per file, so CI
+   * and `bun run test` are unaffected; a hand-run of both files together is not, and
+   * the red is telling you this block measured a stub. Run them separately.
    */
   describe("against the product's real SQL gate", () => {
     let priorDatasourceUrl: string | undefined;
@@ -546,6 +553,12 @@ describe("buildSnapshotSql", () => {
       // The tripwire the first version lacked: the gate must have been REACHED.
       // "No valid datasource" means it returned before reading the statement.
       expect(reason(result)).not.toContain("No valid datasource");
+      // ⚠️ And a POSITIVE tripwire, which the negative one cannot supply: this is
+      // the SHIPPED gate's own wording. A negative assertion is satisfied by any
+      // stub that happens not to say that phrase, and `mock.module` is process-wide
+      // — so co-locating a suite that stubs `lib/tools/sql` in one `bun test`
+      // invocation made this whole block pass against the stub's message instead.
+      expect(reason(result)).toMatch(/allowed list|catalog\.yml/);
       // The whitelist is workspace-scoped and this workspace has none, so a
       // table-scoped rejection is the expected shape here. A FORM rejection would
       // reject in EVERY workspace — ADR-0039's dead producer.
@@ -1209,6 +1222,59 @@ describe("runWarehouseProducer", () => {
     expect(report.created).toBe(0);
   });
 
+  test("a verdict whose `request` ANSWERS DIFFERENTLY on each read is refused (#5230)", async () => {
+    // ⚠️ Identity across TWO PROPERTY ACCESSES is not identity. `validation` comes
+    // from the seam the check defends against, so `validation.request` is an
+    // expression the implementer controls: a getter answers the guard with the
+    // honest request and the runner with another object. Freezing the request closes
+    // mutation and leaves this open; only capturing the value once closes it.
+    //
+    // Worse than the mutation hole it sits beside: the substituted object carries its
+    // own `workspaceId`/`connectionId`, and `defaultRunSnapshot` selects the
+    // connection pool from those — a cross-tenant read, not merely a gate bypass.
+    const h = harness({
+      pairs: [{ entity: "Aliased", dimension: "status", naming: false }],
+      entities: {
+        Aliased: entityYaml({ table: "aliased", primaryKey: "id", dimensions: ["id", "status"] }),
+      },
+      rows: { Aliased: [snapshotRow("Acme Corp", "active")] },
+    });
+
+    let reads = 0;
+    const report = await runWarehouseProducer(
+      { workspaceId: WORKSPACE, triggeredBy: "user-1" },
+      {
+        ...h.deps,
+        validateSnapshotSql: async (request) => {
+          const other = { ...request, sql: "SELECT * FROM salaries" };
+          return {
+            valid: true,
+            get request() {
+              // First read: the honest object, so the guard passes. Every read after:
+              // a different statement.
+              return (reads++ === 0 ? request : other) as ValidatedSnapshotRequest;
+            },
+          };
+        },
+      },
+    );
+
+    // ⚠️ EXACTLY ONE read. Two would mean the guard's value and the runner's
+    // argument came from separate property accesses — the defect, even on a read
+    // that happens to return the same thing.
+    expect(reads).toBe(1);
+    // …and the statement that reached the runner is the one the gate approved, not
+    // the getter's second answer. This is the assertion that goes red without the
+    // capture: the run still succeeds, silently, on the wrong statement.
+    expect(h.snapshots).toHaveLength(1);
+    expect(h.snapshots[0]?.sql).not.toContain("salaries");
+    expect(h.snapshots[0]?.sql).toContain("aliased");
+    // A refusal here would be a DIFFERENT, weaker outcome — the honest request did
+    // pass the gate, so the entity is expected to produce.
+    expect(report.refusals).toEqual([]);
+    expect(report.created).toBe(1);
+  });
+
   test("the runner's parameter refuses an unvalidated request — ordering is a TYPE (#5230)", () => {
     // ⚠️ A COMPILE-TIME assertion, and `bun run type` is where it fails. `@ts-expect-error`
     // is an error when the line it guards has NO error, so widening
@@ -1240,7 +1306,11 @@ describe("runWarehouseProducer", () => {
     // @ts-expect-error the runner cannot be narrowed to a function taking a bare request
     const widened: (r: WarehouseSnapshotRequest) => Promise<readonly Record<string, unknown>[]> =
       runner;
-    expect([literal, mint, widened].every((v) => v !== null)).toBe(true);
+    // ⚠️ This asserts NOTHING about the brand, and saying so is the point. The three
+    // values are referenced so the unused-vars rule is satisfied; the CLAIM is each
+    // `@ts-expect-error` directive above, and `bun run type` is where it fails. An
+    // `every(v => v !== null)` here read like an assertion and had no reachable red.
+    expect([literal, mint, widened]).toHaveLength(3);
   });
 
   test("a validator that REJECTS is caught on the same arm", async () => {

--- a/packages/api/src/lib/brain/__tests__/warehouse-producer.test.ts
+++ b/packages/api/src/lib/brain/__tests__/warehouse-producer.test.ts
@@ -1180,9 +1180,10 @@ describe("runWarehouseProducer", () => {
     expect(h.snapshots).toEqual([]);
     expect(refusalKeys(report.refusals)).toEqual(["Copied.status:snapshot-failed"]);
     // ⚠️ The MESSAGE, because `snapshot-failed` is shared by four arms — the gate
-    // throwing, the gate rejecting, the snapshot throwing, and this one — and only
-    // the message tells them apart. Without it this test passes on a run that
-    // refused for an entirely different reason.
+    // throwing, the snapshot read throwing, a rolled-back transaction, and this one
+    // — and only the message tells them apart. (The gate REJECTING is
+    // `snapshot-rejected`, a different reason.) Without it this test passes on a run
+    // that refused for an entirely different reason.
     expect(report.refusals[0]?.message).toContain("could not confirm");
     expect(report.created).toBe(0);
   });

--- a/packages/api/src/lib/brain/__tests__/warehouse-producer.test.ts
+++ b/packages/api/src/lib/brain/__tests__/warehouse-producer.test.ts
@@ -75,8 +75,10 @@ import {
   type WarehouseEntityPlan,
   type WarehouseProducerDeps,
   type SnapshotSqlVerdict,
+  type ValidatedSnapshotRequest,
   type WarehouseRowId,
   type WarehouseSnapshotRequest,
+  type WarehouseSnapshotRunner,
 } from "@atlas/api/lib/brain/warehouse-producer";
 
 const WORKSPACE = "ws-5042";
@@ -883,13 +885,17 @@ function harness(options: {
         validations.push(request);
         return rejected.has(request.entity)
           ? { valid: false, error: `Table "${request.entity}" is not in the whitelist` }
-      // ⚠️ A CAST, and it has to be. `SnapshotSqlVerdict`'s passing arm is branded
-      // so no object literal can assert that the product's SQL gate said yes —
-      // which is the whole point, since an unbranded `{valid: true}` made the seam
-      // the same convention-enforced hole it replaced. The real gate is
-      // workspace-whitelist-scoped and this suite has no whitelist, so the bypass
-      // is deliberate, named here, and greppable as `as SnapshotSqlVerdict`.
-          : ({ valid: true } as SnapshotSqlVerdict);
+      // ⚠️ A CAST, and it has to be. The passing verdict carries a branded
+      // `ValidatedSnapshotRequest`, so no object literal can assert that the
+      // product's SQL gate said yes — which is the whole point, since an unbranded
+      // `{valid: true}` made the seam the same convention-enforced hole it
+      // replaced. The real gate is workspace-whitelist-scoped and this suite has no
+      // whitelist, so the bypass is deliberate, named here, and greppable.
+      //
+      // ⚠️ It brands THE REQUEST IT WAS HANDED, by reference. Minting a fresh object
+      // here would satisfy the type and be refused by the run loop's identity check
+      // (#5230) — which is the anti-replay guard, and it does not exempt harnesses.
+          : { valid: true, request: request as ValidatedSnapshotRequest };
       },
       runSnapshot: async (request) => {
         snapshots.push(request);
@@ -1044,7 +1050,10 @@ describe("runWarehouseProducer", () => {
         // that.
         validateSnapshotSql: (request) => {
           if (request.entity === "Throws") throw new Error("module init failed");
-          return Promise.resolve({ valid: true } as SnapshotSqlVerdict);
+          return Promise.resolve({
+            valid: true,
+            request: request as ValidatedSnapshotRequest,
+          });
         },
       },
     );
@@ -1054,6 +1063,118 @@ describe("runWarehouseProducer", () => {
     expect(report.refusals[0]?.message).not.toContain("Re-running will not change");
     // The positive control: one entity throwing costs one entity.
     expect(report.created).toBe(1);
+  });
+
+  test("a REPLAYED verdict cannot authorize a different statement (#5230)", async () => {
+    // ⚠️ THE SHAPE #5230 EXISTS FOR, and nothing in it is forged. The validator
+    // mints ONE genuine passing token — for the first request it is handed — and
+    // hands the same token back for every entity after that:
+    //
+    //   cached ??= await validate(FIRST_REQUEST)
+    //
+    // Under a verdict that only said "something passed", every later entity reached
+    // the datasource on a token about a statement it has nothing to do with. The
+    // verdict now carries the request it passed, and the run loop compares it by
+    // IDENTITY against what it submitted.
+    const h = harness({
+      pairs: [
+        { entity: "First", dimension: "status", naming: false },
+        { entity: "Second", dimension: "tier", naming: false },
+      ],
+      entities: {
+        First: entityYaml({ table: "first", primaryKey: "id", dimensions: ["id", "status"] }),
+        Second: entityYaml({ table: "second", primaryKey: "id", dimensions: ["id", "tier"] }),
+      },
+      // ⚠️ DIFFERENT row counts, so the two entities cannot be told apart by
+      // accident: an assertion that both ran and one that only the first did would
+      // otherwise read the same on `created`.
+      rows: {
+        First: [snapshotRow("Acme Corp", "gold")],
+        Second: [snapshotRow("Beta Ltd", "silver"), snapshotRow("Gamma Inc", "bronze")],
+      },
+    });
+
+    let cached: SnapshotSqlVerdict | undefined;
+    const report = await runWarehouseProducer(
+      { workspaceId: WORKSPACE, triggeredBy: "user-1" },
+      {
+        ...h.deps,
+        validateSnapshotSql: async (request) => {
+          h.validations.push(request);
+          return (cached ??= { valid: true, request: request as ValidatedSnapshotRequest });
+        },
+      },
+    );
+
+    // The gate was consulted for both — the replay is at the VERDICT, not the call.
+    expect(h.validations.map((v) => v.entity).toSorted()).toEqual(["First", "Second"]);
+
+    // Exactly one entity reached the runner: the one the cached token is actually
+    // about. Asserted relationally rather than by name, because which entity the
+    // planner emits first is not this test's subject.
+    expect(h.snapshots).toHaveLength(1);
+    const ran = h.snapshots[0]?.entity;
+    expect(refusalKeys(report.refusals)).toHaveLength(1);
+    const refused = report.refusals[0];
+    expect(refused?.entity).not.toBe(ran);
+    // TRANSIENT, not `snapshot-rejected`: the statement was never judged, so a
+    // message saying "re-running will not change this" would describe a check that
+    // did not happen.
+    expect(refused?.reason).toBe("snapshot-failed");
+    expect(refused?.message).not.toContain("Re-running will not change");
+    expect(refused?.message).toContain("could not confirm");
+    // And the run still produced the entity the token WAS for — a guard that
+    // refused everything would satisfy every assertion above.
+    expect(report.created).toBeGreaterThan(0);
+  });
+
+  test("a verdict carrying a RECONSTRUCTED request is refused too (#5230)", async () => {
+    // Identity, not field equality. A validator that returns a token for an object
+    // with the same fields is indistinguishable at the field level from one
+    // returning a token for a statement it rewrote — the gate's answer is about the
+    // object it was given, so a copy is refused. Without this the check could be
+    // weakened to a deep compare and the test above would stay green, since a
+    // CACHED token differs in fields as well as in identity.
+    const h = harness({
+      pairs: [{ entity: "Copied", dimension: "status", naming: false }],
+      entities: {
+        Copied: entityYaml({ table: "copied", primaryKey: "id", dimensions: ["id", "status"] }),
+      },
+      rows: { Copied: [snapshotRow("Acme Corp", "active")] },
+    });
+
+    const report = await runWarehouseProducer(
+      { workspaceId: WORKSPACE, triggeredBy: "user-1" },
+      {
+        ...h.deps,
+        validateSnapshotSql: async (request) => ({
+          valid: true,
+          request: { ...request } as ValidatedSnapshotRequest,
+        }),
+      },
+    );
+
+    expect(h.snapshots).toEqual([]);
+    expect(refusalKeys(report.refusals)).toEqual(["Copied.status:snapshot-failed"]);
+    expect(report.created).toBe(0);
+  });
+
+  test("the runner's parameter refuses an unvalidated request — ordering is a TYPE (#5230)", () => {
+    // ⚠️ A COMPILE-TIME assertion, and `bun run type` is where it fails. `@ts-expect-error`
+    // is an error when the line it guards has NO error, so widening
+    // `WarehouseSnapshotRunner` back to a bare request — or dropping the brand —
+    // reds the type gate rather than quietly restoring the hole this issue closed.
+    // Statement order was the only thing sequencing validate-then-run before #5230.
+    const runner: WarehouseSnapshotRunner = async () => [];
+    const bare: WarehouseSnapshotRequest = {
+      workspaceId: WORKSPACE,
+      entity: "Unvalidated",
+      connectionId: undefined,
+      sql: "SELECT 1",
+    };
+    // @ts-expect-error a bare request has not passed the SQL gate, and the runner says so
+    const call = () => runner(bare);
+    expect(typeof call).toBe("function");
   });
 
   test("a validator that REJECTS is caught on the same arm", async () => {

--- a/packages/api/src/lib/brain/warehouse-producer.ts
+++ b/packages/api/src/lib/brain/warehouse-producer.ts
@@ -657,7 +657,15 @@ export function buildSnapshotSql(plan: WarehouseEntityPlan, rowCap = WAREHOUSE_R
   return `SELECT ${columns.join(", ")} FROM ${plan.entity.table} LIMIT ${rowCap + 1}`;
 }
 
-/** What {@link WarehouseSnapshotRunner} is asked for. */
+/**
+ * What {@link WarehouseSnapshotRunner} is asked for.
+ *
+ * ⚠️ **Every field must stay a PRIMITIVE.** `runWarehouseProducer` freezes this
+ * object so a substituted validator cannot rewrite the statement after the gate
+ * approved it, and a shallow freeze is total only while nothing here is a reference.
+ * An object-typed field added later would leave the freeze looking intact and the
+ * guarantee gone.
+ */
 export interface WarehouseSnapshotRequest {
   readonly workspaceId: string;
   readonly entity: string;
@@ -1206,24 +1214,28 @@ export interface WarehouseRunContext {
  * ⚠️ **What the shape does and does not close, measured rather than asserted.**
  * REFUSED with no cast: an object literal, `as const`, `satisfies`, a spread of the
  * refusing arm, `unknown`, and the identity form of generic-inference laundering.
- * ACCEPTED: `as unknown as`, any `any`-typed wiring (`JSON.parse`, an untyped mock,
- * a dynamic `import()` of a plugin), a `Partial<T>`-shaped generic builder — and,
- * the one that matters, **an assertion onto the VALIDATOR seam type whose mint takes
- * a parameter.** The nullary spelling is refused; the one-parameter spelling is not,
- * because its return literal's `valid` widens to `boolean` and the discriminated-arm
- * check is skipped. That is the only useful spelling now that the passing arm must
- * carry a request, and such a validator hands back its OWN argument — so the run
- * loop's identity check waves it through. Two earlier drafts of this paragraph
- * asserted the opposite; both were comments stating a universal the type does not
- * deliver, which is why the seam names are now in the matcher rather than here.
+ * ACCEPTED by the compiler: `as unknown as`, any `any`-typed wiring (`JSON.parse`,
+ * an untyped mock, a dynamic `import()` of a plugin), a `Partial<T>`-shaped generic
+ * builder — and, the one that matters, **an assertion onto the VALIDATOR seam type,
+ * or onto this union, or onto the deps interface.**
  *
- * ⚠️ **FOUR names are in the bypass matcher, and none is redundant.**
- * {@link ValidatedSnapshotRequest} is what a mint ordinarily names, and this union
- * is a second door: `{ valid: true, request: <unvalidated> }` is *comparable* to it
- * — the `request` fields differ only by the brand — so a whole-verdict assertion
- * compiles just as a request assertion does. {@link SnapshotSqlValidator} and
- * {@link WarehouseProducerDeps} are the third and fourth, for the paragraph above.
- * `__tests__/warehouse-producer-bypass.test.ts` pins all four, which is the half a
+ * The mechanism, since two earlier drafts of this paragraph guessed it and both
+ * guesses were measurably wrong: **the brand only ADDS a property**, so
+ * `ValidatedSnapshotRequest` is assignable to {@link WarehouseSnapshotRequest}, and
+ * `as` succeeds whenever EITHER direction is comparable. The reverse direction
+ * carries every one of those spellings. The shapes that are refused are the ones
+ * where the reverse direction also fails — a NULLARY mint (a 1-parameter function
+ * type is not assignable to a 0-parameter one), or a literal with an excess
+ * property. Pinning `valid` with `as const` does NOT close it; that was the second
+ * wrong guess. Such a validator hands back its OWN argument, so the run loop's
+ * identity check waves it through — which is why the seam names are in the bypass
+ * matcher rather than described away here.
+ *
+ * ⚠️ **FIVE names are in the bypass matcher, and none is redundant.** This union,
+ * {@link ValidatedSnapshotRequest}, {@link SnapshotSqlValidator},
+ * {@link WarehouseProducerDeps} and {@link WarehouseSnapshotRunner} — every exported
+ * name an assertion can land on and reach this authority, for the reason above.
+ * `__tests__/warehouse-producer-bypass.test.ts` pins all five, which is the half a
  * grep can actually hold; what it cannot hold is stated there rather than here.
  *
  * ⚠️ **The type still cannot say WHICH statement passed — only the run loop can.**
@@ -1710,14 +1722,20 @@ export async function runWarehouseProducer(
 
   for (const entityPlan of plan.emit) {
     const sql = buildSnapshotSql(entityPlan, rowCap);
-    // ⚠️ FROZEN, and that is the other half of the identity check below. Identity
-    // proves the gate answered about THIS OBJECT; freezing is what makes "this
-    // object" and "this statement" the same claim. `readonly` is erased at runtime,
-    // so a substituted validator could validate, then `Object.assign(request, {sql})`
-    // and hand the same reference back — passing the identity check and reaching a
-    // customer's datasource with a statement the gate never saw. Frozen, that write
-    // throws under module strict mode and lands on the gate-threw arm below, which
-    // refuses transiently. Shallow is total here: every field is a primitive.
+    // ⚠️ FROZEN, one of three things the identity check below needs. Identity proves
+    // the gate answered about THIS OBJECT; freezing stops the object changing under
+    // it; capturing the returned request ONCE (below) stops a getter answering the
+    // guard and the runner differently. `readonly` is erased at runtime, so a
+    // substituted validator could validate, then `Object.assign(request, {sql})` and
+    // hand the same reference back — passing the check and reaching a customer's
+    // datasource with a statement the gate never saw.
+    //
+    // Frozen, that write fails CLOSED either way, and the two ways differ: an
+    // `Object.assign` throws whatever the caller's strictness and lands on the
+    // gate-threw arm below; a plain `request.sql = …` in a sloppy-mode caller
+    // silently no-ops, so the run proceeds with the statement the gate DID see.
+    // Shallow is total here: every field of {@link WarehouseSnapshotRequest} is a
+    // primitive, which is a property of that interface rather than of this line.
     const request: WarehouseSnapshotRequest = Object.freeze({
       workspaceId,
       entity: entityPlan.entity.name,
@@ -1790,7 +1808,18 @@ export async function runWarehouseProducer(
     // never judged, so "re-running will not change this" would be a claim about a
     // check that did not happen. It shares the arm with the gate THROWING for the
     // same reason — in both, the gate declined to answer about this entity.
-    if (validation.request !== request) {
+    // ⚠️ **READ ONCE, and this is the other half of freezing the request.**
+    // `validation` comes from the very seam this check defends against, so
+    // `validation.request` is an EXPRESSION the implementer controls: a getter or a
+    // Proxy answers the guard with the honest request and the runner with another
+    // object. Four separate reads — guard, two log fields, and the runner argument —
+    // proved nothing about the fourth. The swapped object also carries its own
+    // `workspaceId`/`connectionId`, and `defaultRunSnapshot` selects the pool from
+    // those, so the residual was a cross-tenant read rather than only a gate bypass.
+    // Freezing closes mutation; capturing closes aliasing; neither closes the other.
+    // `reconcile.ts` states the same rule for the same reason.
+    const validated = validation.request;
+    if (validated !== request) {
       log.error(
         {
           ...runLog,
@@ -1801,8 +1830,11 @@ export async function runWarehouseProducer(
           // token for the first entity) and a token minted against ANOTHER
           // WORKSPACE's statement log identically — and the second is the one that
           // has to be greppable the day it happens.
-          returnedEntity: validation.request.entity,
-          returnedWorkspaceId: validation.request.workspaceId,
+          //
+          // Bounded: both strings come from the seam rather than from the plan, and
+          // nothing else on this line is attacker-shaped.
+          returnedEntity: validated.entity.slice(0, 200),
+          returnedWorkspaceId: validated.workspaceId.slice(0, 200),
         },
         "Warehouse producer: the SQL gate returned a verdict for a different request — refusing rather than reading",
       );
@@ -1817,17 +1849,21 @@ export async function runWarehouseProducer(
           // to quote it had workspace plus wall-clock — exactly what
           // `WarehouseRunContext.requestId`'s docstring exists to prevent. Same
           // shape as the entity-edge failure message above.
-          `with the entity — if it repeats, report it with request id ${requestId ?? "(none)"}.`,
+          // `"unknown"`, matching `vocabulary-preview.ts` and
+          // `vocabulary-object-radius.ts`. Two spellings of the same placeholder in
+          // one subsystem means an operator grepping support tickets for one misses
+          // the other.
+          `with the entity — if it repeats, report it with request id ${requestId ?? "unknown"}.`,
       );
       continue;
     }
 
     let rows: readonly Record<string, unknown>[];
     try {
-      // `validation.request`, not `request`: the runner's input type admits only what
-      // the gate produced, and the identity check above has already established the
-      // two are the same object.
-      rows = await runSnapshot(validation.request);
+      // `validated`, the value the guard compared — NOT a fresh `validation.request`,
+      // which would be a second read of a property the seam controls. See the capture
+      // above.
+      rows = await runSnapshot(validated);
     } catch (err) {
       // The Error itself, not `.message`. `scrubErrSerializer` emits type, message,
       // stack AND pg's `code` with credentials already stripped — and `42P01` vs

--- a/packages/api/src/lib/brain/warehouse-producer.ts
+++ b/packages/api/src/lib/brain/warehouse-producer.ts
@@ -696,11 +696,10 @@ declare const validatedSnapshotSql: unique symbol;
  *   a new call site reaching the runner directly, compiled fine. Now the runner's
  *   only input is a value that cannot exist without the gate having produced it.
  *
- * The symbol is module-private and never exported, so the only ways to obtain one
- * are {@link defaultValidateSnapshotSql} or a cast naming this type (or
- * {@link SnapshotSqlVerdict}, whose passing arm is comparable to an object literal
- * carrying an unvalidated request). Both spellings are greppable, and
- * `__tests__/warehouse-producer-bypass.test.ts` pins the set.
+ * The symbol is module-private and never exported, so this type is minted by
+ * {@link defaultValidateSnapshotSql} or by an assertion. FIVE exported names can
+ * carry such an assertion — see {@link SnapshotSqlVerdict}'s note for why — and
+ * `__tests__/warehouse-producer-bypass.test.ts` pins all five.
  */
 export type ValidatedSnapshotRequest = WarehouseSnapshotRequest & {
   readonly [validatedSnapshotSql]: true;
@@ -1216,20 +1215,21 @@ export interface WarehouseRunContext {
  * refusing arm, `unknown`, and the identity form of generic-inference laundering.
  * ACCEPTED by the compiler: `as unknown as`, any `any`-typed wiring (`JSON.parse`,
  * an untyped mock, a dynamic `import()` of a plugin), a `Partial<T>`-shaped generic
- * builder — and, the one that matters, **an assertion onto the VALIDATOR seam type,
- * or onto this union, or onto the deps interface.**
+ * builder — and, the one that matters, **an assertion onto any of the five names the
+ * bypass matcher takes**: this union, {@link ValidatedSnapshotRequest},
+ * {@link SnapshotSqlValidator}, {@link WarehouseProducerDeps} or
+ * {@link WarehouseSnapshotRunner}.
  *
- * The mechanism, since two earlier drafts of this paragraph guessed it and both
- * guesses were measurably wrong: **the brand only ADDS a property**, so
+ * The mechanism, measured rather than reasoned — the two obvious explanations for it
+ * are both wrong: **the brand only ADDS a property**, so
  * `ValidatedSnapshotRequest` is assignable to {@link WarehouseSnapshotRequest}, and
  * `as` succeeds whenever EITHER direction is comparable. The reverse direction
- * carries every one of those spellings. The shapes that are refused are the ones
- * where the reverse direction also fails — a NULLARY mint (a 1-parameter function
- * type is not assignable to a 0-parameter one), or a literal with an excess
- * property. Pinning `valid` with `as const` does NOT close it; that was the second
- * wrong guess. Such a validator hands back its OWN argument, so the run loop's
- * identity check waves it through — which is why the seam names are in the bypass
- * matcher rather than described away here.
+ * carries every one of those spellings. Refused only where the reverse direction
+ * also fails — a NULLARY mint (a 1-parameter function type is not assignable to a
+ * 0-parameter one), or a literal with an excess property. Pinning `valid` with
+ * `as const` does NOT close it. Such a validator hands back its OWN argument, so the
+ * run loop's identity check waves it through — which is why the seam names are in
+ * the bypass matcher rather than described away here.
  *
  * ⚠️ **FIVE names are in the bypass matcher, and none is redundant.** This union,
  * {@link ValidatedSnapshotRequest}, {@link SnapshotSqlValidator},
@@ -1812,8 +1812,9 @@ export async function runWarehouseProducer(
     // `validation` comes from the very seam this check defends against, so
     // `validation.request` is an EXPRESSION the implementer controls: a getter or a
     // Proxy answers the guard with the honest request and the runner with another
-    // object. Four separate reads — guard, two log fields, and the runner argument —
-    // proved nothing about the fourth. The swapped object also carries its own
+    // object. Four read SITES across two paths — guard plus two log fields on the
+    // mismatch arm, guard plus the runner argument on the passing one — and a
+    // per-site read proves nothing about the next. The swapped object also carries its own
     // `workspaceId`/`connectionId`, and `defaultRunSnapshot` selects the pool from
     // those, so the residual was a cross-tenant read rather than only a gate bypass.
     // Freezing closes mutation; capturing closes aliasing; neither closes the other.

--- a/packages/api/src/lib/brain/warehouse-producer.ts
+++ b/packages/api/src/lib/brain/warehouse-producer.ts
@@ -705,6 +705,12 @@ export type ValidatedSnapshotRequest = WarehouseSnapshotRequest & {
  * site — here or in a future scheduler — can reach a datasource with a statement
  * the SELECT-only / single-statement / whitelist-scoped gate has not passed. The
  * ordering is a type, not a convention.
+ *
+ * ⚠️ **Every seam holding this must be a PROPERTY, never a method shorthand.**
+ * `WarehouseProducerDeps.runSnapshot` is a property today and has to stay one:
+ * method parameters are bivariant, so `interface S { run(r: WarehouseSnapshotRequest): … }`
+ * accepts this runner and then admits a bare request at the call site — measured,
+ * and it is the one way the parameter's guarantee can be re-opened without a cast.
  */
 export type WarehouseSnapshotRunner = (
   request: ValidatedSnapshotRequest,
@@ -1199,20 +1205,26 @@ export interface WarehouseRunContext {
  *
  * ⚠️ **What the shape does and does not close, measured rather than asserted.**
  * REFUSED with no cast: an object literal, `as const`, `satisfies`, a spread of the
- * refusing arm, `unknown`, generic-inference laundering — and, the useful one,
- * `(async () => ({valid: true, request: r})) as SnapshotSqlValidator`, which does
- * not compile either. ACCEPTED without a hit on either branded name: `as unknown
- * as`, and any `any`-typed wiring (`JSON.parse`, an untyped mock, a dynamic
- * `import()` of a plugin). So the bypass list is a cast naming
- * {@link ValidatedSnapshotRequest} or this type, plus `as unknown as`, plus `any` —
- * an earlier draft claimed the cast alone was the whole list, which was a comment
- * stating a universal the type does not deliver.
+ * refusing arm, `unknown`, and the identity form of generic-inference laundering.
+ * ACCEPTED: `as unknown as`, any `any`-typed wiring (`JSON.parse`, an untyped mock,
+ * a dynamic `import()` of a plugin), a `Partial<T>`-shaped generic builder — and,
+ * the one that matters, **an assertion onto the VALIDATOR seam type whose mint takes
+ * a parameter.** The nullary spelling is refused; the one-parameter spelling is not,
+ * because its return literal's `valid` widens to `boolean` and the discriminated-arm
+ * check is skipped. That is the only useful spelling now that the passing arm must
+ * carry a request, and such a validator hands back its OWN argument — so the run
+ * loop's identity check waves it through. Two earlier drafts of this paragraph
+ * asserted the opposite; both were comments stating a universal the type does not
+ * deliver, which is why the seam names are now in the matcher rather than here.
  *
- * ⚠️ **BOTH names are in the bypass matcher, and the second is not redundant.**
- * `{ valid: true, request: <unvalidated> }` is *comparable* to this union — the
- * `request` fields differ only by the brand — so a whole-verdict cast compiles just
- * as a request cast does. `__tests__/warehouse-producer-bypass.test.ts` pins both
- * spellings, which is the half a grep can actually hold.
+ * ⚠️ **FOUR names are in the bypass matcher, and none is redundant.**
+ * {@link ValidatedSnapshotRequest} is what a mint ordinarily names, and this union
+ * is a second door: `{ valid: true, request: <unvalidated> }` is *comparable* to it
+ * — the `request` fields differ only by the brand — so a whole-verdict assertion
+ * compiles just as a request assertion does. {@link SnapshotSqlValidator} and
+ * {@link WarehouseProducerDeps} are the third and fourth, for the paragraph above.
+ * `__tests__/warehouse-producer-bypass.test.ts` pins all four, which is the half a
+ * grep can actually hold; what it cannot hold is stated there rather than here.
  *
  * ⚠️ **The type still cannot say WHICH statement passed — only the run loop can.**
  * A validator is free to return a genuine token minted for some other request, and
@@ -1698,12 +1710,20 @@ export async function runWarehouseProducer(
 
   for (const entityPlan of plan.emit) {
     const sql = buildSnapshotSql(entityPlan, rowCap);
-    const request: WarehouseSnapshotRequest = {
+    // ⚠️ FROZEN, and that is the other half of the identity check below. Identity
+    // proves the gate answered about THIS OBJECT; freezing is what makes "this
+    // object" and "this statement" the same claim. `readonly` is erased at runtime,
+    // so a substituted validator could validate, then `Object.assign(request, {sql})`
+    // and hand the same reference back — passing the identity check and reaching a
+    // customer's datasource with a statement the gate never saw. Frozen, that write
+    // throws under module strict mode and lands on the gate-threw arm below, which
+    // refuses transiently. Shallow is total here: every field is a primitive.
+    const request: WarehouseSnapshotRequest = Object.freeze({
       workspaceId,
       entity: entityPlan.entity.name,
       connectionId: entityPlan.entity.connection ?? undefined,
       sql,
-    };
+    });
 
     // ⚠️ The gate runs HERE, before the seam — and since #5230 the TYPE says so
     // rather than this statement order. While the check lived inside
@@ -1772,7 +1792,18 @@ export async function runWarehouseProducer(
     // same reason — in both, the gate declined to answer about this entity.
     if (validation.request !== request) {
       log.error(
-        { ...runLog, entity: entityPlan.entity.name },
+        {
+          ...runLog,
+          entity: entityPlan.entity.name,
+          table: entityPlan.entity.table,
+          // ⚠️ What CAME BACK, under its OWN keys so `runLog`'s workspaceId is not
+          // shadowed. Without these, the replay this branch exists for (a cached
+          // token for the first entity) and a token minted against ANOTHER
+          // WORKSPACE's statement log identically — and the second is the one that
+          // has to be greppable the day it happens.
+          returnedEntity: validation.request.entity,
+          returnedWorkspaceId: validation.request.workspaceId,
+        },
         "Warehouse producer: the SQL gate returned a verdict for a different request — refusing rather than reading",
       );
       refuseEntity(
@@ -1781,7 +1812,12 @@ export async function runWarehouseProducer(
         `Atlas could not confirm its SQL gate checked the query it would run against ` +
           `"${entityPlan.entity.table}", so nothing was emitted for it this run. Nothing was ` +
           "invalidated and no window was stamped. This is an Atlas wiring fault rather than a problem " +
-          "with the entity — if it repeats, report it with this run's request id.",
+          // ⚠️ INTERPOLATED, not "this run's request id". The report carries no
+          // requestId field and no middleware echoes one back, so an operator told
+          // to quote it had workspace plus wall-clock — exactly what
+          // `WarehouseRunContext.requestId`'s docstring exists to prevent. Same
+          // shape as the entity-edge failure message above.
+          `with the entity — if it repeats, report it with request id ${requestId ?? "(none)"}.`,
       );
       continue;
     }

--- a/packages/api/src/lib/brain/warehouse-producer.ts
+++ b/packages/api/src/lib/brain/warehouse-producer.ts
@@ -666,9 +666,48 @@ export interface WarehouseSnapshotRequest {
   readonly sql: string;
 }
 
-/** Reads tier-1. The one seam in this module that touches a customer datasource. */
+declare const validatedSnapshotSql: unique symbol;
+
+/**
+ * A snapshot request THE GATE HAS SEEN AND PASSED — the token, and the statement
+ * it is a token for, as one value.
+ *
+ * ⚠️ **The brand is on the REQUEST rather than on a bare verdict, and that is the
+ * whole of #5230.** A verdict that merely says *"something passed"* leaves two
+ * doors open that no object literal has to walk through:
+ *
+ * - **Replay.** `cached ??= await validate(BENIGN_REQUEST)` mints one genuine
+ *   passing token and hands it back for every entity thereafter. Nothing is
+ *   forged; the token is simply about a different statement than the one about to
+ *   run. Carrying the request kills it, because {@link runWarehouseProducer}
+ *   compares what came back against what it sent and runs only what the gate
+ *   actually saw.
+ * - **Ordering.** While {@link WarehouseSnapshotRunner} took a bare
+ *   {@link WarehouseSnapshotRequest}, validate-then-run was enforced by STATEMENT
+ *   ORDER — the same convention the brand was introduced to replace. A reorder, or
+ *   a new call site reaching the runner directly, compiled fine. Now the runner's
+ *   only input is a value that cannot exist without the gate having produced it.
+ *
+ * The symbol is module-private and never exported, so the only ways to obtain one
+ * are {@link defaultValidateSnapshotSql} or a cast naming this type (or
+ * {@link SnapshotSqlVerdict}, whose passing arm is comparable to an object literal
+ * carrying an unvalidated request). Both spellings are greppable, and
+ * `__tests__/warehouse-producer-bypass.test.ts` pins the set.
+ */
+export type ValidatedSnapshotRequest = WarehouseSnapshotRequest & {
+  readonly [validatedSnapshotSql]: true;
+};
+
+/**
+ * Reads tier-1. The one seam in this module that touches a customer datasource.
+ *
+ * ⚠️ It takes a {@link ValidatedSnapshotRequest}, not a bare request, so no call
+ * site — here or in a future scheduler — can reach a datasource with a statement
+ * the SELECT-only / single-statement / whitelist-scoped gate has not passed. The
+ * ordering is a type, not a convention.
+ */
 export type WarehouseSnapshotRunner = (
-  request: WarehouseSnapshotRequest,
+  request: ValidatedSnapshotRequest,
 ) => Promise<readonly Record<string, unknown>[]>;
 
 /**
@@ -1139,10 +1178,8 @@ export interface WarehouseRunContext {
   readonly requestId?: string;
 }
 
-declare const snapshotSqlBrand: unique symbol;
-
 /**
- * The SQL gate's verdict — and the PASSING arm is branded.
+ * The SQL gate's verdict — and the PASSING arm carries the request it passed.
  *
  * ⚠️ **The brand is the guarantee; without it the seam is the defect it replaced.**
  * Moving `validateSQL` out of `defaultRunSnapshot` stopped a substituted RUNNER
@@ -1153,29 +1190,41 @@ declare const snapshotSqlBrand: unique symbol;
  * the repo's answer and cites where ignoring it cost a round (#5032): an unbranded
  * value is an unbranded door.
  *
- * A `valid: true` cannot be written as an object literal. It comes from
- * {@link defaultValidateSnapshotSql}, or from a cast — and a cast is greppable,
- * deliberate, and has to be argued for in review, which is exactly the difference
- * between an invariant enforced by the type and one enforced by convention.
+ * A `valid: true` cannot be written as an object literal, because it needs a
+ * {@link ValidatedSnapshotRequest} and that type's symbol is module-private. It
+ * comes from {@link defaultValidateSnapshotSql}, or from a cast — and a cast is
+ * greppable, deliberate, and has to be argued for in review, which is exactly the
+ * difference between an invariant enforced by the type and one enforced by
+ * convention.
  *
- * ⚠️ **What the brand does and does not close, measured rather than asserted.**
+ * ⚠️ **What the shape does and does not close, measured rather than asserted.**
  * REFUSED with no cast: an object literal, `as const`, `satisfies`, a spread of the
  * refusing arm, `unknown`, generic-inference laundering — and, the useful one,
- * `(async () => ({valid: true})) as SnapshotSqlValidator`, which does not compile
- * either. ACCEPTED without a `as SnapshotSqlVerdict` hit: `as unknown as`, and any
- * `any`-typed wiring (`JSON.parse`, an untyped mock, a dynamic `import()` of a
- * plugin). So the bypass list is `as SnapshotSqlVerdict` plus `as unknown as` plus
- * `any` — an earlier draft of this line claimed the first alone was the whole list,
- * which was a comment stating a universal the type does not deliver.
+ * `(async () => ({valid: true, request: r})) as SnapshotSqlValidator`, which does
+ * not compile either. ACCEPTED without a hit on either branded name: `as unknown
+ * as`, and any `any`-typed wiring (`JSON.parse`, an untyped mock, a dynamic
+ * `import()` of a plugin). So the bypass list is a cast naming
+ * {@link ValidatedSnapshotRequest} or this type, plus `as unknown as`, plus `any` —
+ * an earlier draft claimed the cast alone was the whole list, which was a comment
+ * stating a universal the type does not deliver.
  *
- * `__tests__/warehouse-producer-bypass.test.ts` pins the `as SnapshotSqlVerdict`
- * sites, which is the half a grep can actually hold.
+ * ⚠️ **BOTH names are in the bypass matcher, and the second is not redundant.**
+ * `{ valid: true, request: <unvalidated> }` is *comparable* to this union — the
+ * `request` fields differ only by the brand — so a whole-verdict cast compiles just
+ * as a request cast does. `__tests__/warehouse-producer-bypass.test.ts` pins both
+ * spellings, which is the half a grep can actually hold.
+ *
+ * ⚠️ **The type still cannot say WHICH statement passed — only the run loop can.**
+ * A validator is free to return a genuine token minted for some other request, and
+ * a cached one is exactly that. {@link runWarehouseProducer} therefore compares the
+ * returned request against the one it submitted and refuses on a mismatch; the
+ * type narrows the door, the identity check closes it.
  *
  * The REFUSING arm is deliberately unbranded: refusing more is always safe, so
  * there is no property to forge.
  */
 export type SnapshotSqlVerdict =
-  | { readonly valid: true; readonly [snapshotSqlBrand]: true }
+  | { readonly valid: true; readonly request: ValidatedSnapshotRequest }
   // ⚠️ `error` is REQUIRED. The wrapped `SQLValidationResult` makes it required on
   // its failing arm, so an optional here made the seam weaker than the thing it
   // wraps — and the run loop paid for it with a `?? "no reason given"` fallback, on
@@ -1656,11 +1705,13 @@ export async function runWarehouseProducer(
       sql,
     };
 
-    // ⚠️ The gate runs HERE, before the seam, and that placement is the guarantee.
-    // While it lived inside `defaultRunSnapshot`, any injected runner — a test
-    // harness today, a scheduler or self-hosted variant tomorrow — satisfied
-    // `WarehouseSnapshotRunner` while skipping the SELECT-only, single-statement,
-    // whitelist-scoped check entirely, and nothing in the type said otherwise. The
+    // ⚠️ The gate runs HERE, before the seam — and since #5230 the TYPE says so
+    // rather than this statement order. While the check lived inside
+    // `defaultRunSnapshot`, any injected runner — a test harness today, a scheduler
+    // or self-hosted variant tomorrow — satisfied `WarehouseSnapshotRunner` while
+    // skipping the SELECT-only, single-statement, whitelist-scoped check entirely.
+    // Moving it out fixed that but left the sequence itself a convention; the runner
+    // now takes only a `ValidatedSnapshotRequest`, so a reorder does not compile. The
     // statement is assembled from admin-authored `table:` and `sql:` expressions, so
     // it is exactly the input that check exists for.
     // `try`/`catch` rather than `.catch(…)`: a validator that throws SYNCHRONOUSLY
@@ -1706,9 +1757,41 @@ export async function runWarehouseProducer(
       continue;
     }
 
+    // ⚠️ **IDENTITY, not equality, and it is the anti-replay check.** The verdict
+    // now carries the request it passed, but nothing stops a validator from handing
+    // back a genuine token minted for a DIFFERENT statement — `cached ??= await
+    // validate(BENIGN_REQUEST)` compiles, forges nothing, and would otherwise let
+    // one benign statement authorize every entity in the run. Comparing object
+    // identity against what this iteration submitted is the narrowest possible
+    // acceptance: a re-serialized or reconstructed request is refused too, which is
+    // correct, because the gate's answer is about the object it was given.
+    //
+    // Transient (`snapshot-failed`), not `snapshot-rejected`: the statement was
+    // never judged, so "re-running will not change this" would be a claim about a
+    // check that did not happen. It shares the arm with the gate THROWING for the
+    // same reason — in both, the gate declined to answer about this entity.
+    if (validation.request !== request) {
+      log.error(
+        { ...runLog, entity: entityPlan.entity.name },
+        "Warehouse producer: the SQL gate returned a verdict for a different request — refusing rather than reading",
+      );
+      refuseEntity(
+        entityPlan,
+        "snapshot-failed",
+        `Atlas could not confirm its SQL gate checked the query it would run against ` +
+          `"${entityPlan.entity.table}", so nothing was emitted for it this run. Nothing was ` +
+          "invalidated and no window was stamped. This is an Atlas wiring fault rather than a problem " +
+          "with the entity — if it repeats, report it with this run's request id.",
+      );
+      continue;
+    }
+
     let rows: readonly Record<string, unknown>[];
     try {
-      rows = await runSnapshot(request);
+      // `validation.request`, not `request`: the runner's input type admits only what
+      // the gate produced, and the identity check above has already established the
+      // two are the same object.
+      rows = await runSnapshot(validation.request);
     } catch (err) {
       // The Error itself, not `.message`. `scrubErrSerializer` emits type, message,
       // stack AND pg's `code` with credentials already stripped — and `42P01` vs
@@ -2130,8 +2213,9 @@ async function defaultLoadEntity(
  * guarantee: while the validation lived inside the shipped runner, any substituted
  * runner satisfied the runner type while skipping the gate entirely, and nothing in
  * the type said otherwise. {@link runWarehouseProducer} now calls this before the
- * runner, so a replacement runner cannot reach a datasource with an unvalidated
- * statement.
+ * runner — and since #5230 the runner's parameter is a
+ * {@link ValidatedSnapshotRequest}, so a replacement runner cannot reach a
+ * datasource with an unvalidated statement even if the call order changes.
  *
  * Exported so a test can drive the REAL gate over a REAL built statement.
  *
@@ -2150,13 +2234,17 @@ export async function defaultValidateSnapshotSql(
 ): Promise<SnapshotSqlVerdict> {
   const { validateSQL } = await import("@atlas/api/lib/tools/sql");
   const result = await validateSQL(request.sql, request.connectionId, request.workspaceId);
-  // THE cast — the only `as SnapshotSqlVerdict` in production code, which is what
+  // THE cast — the only one in production code, which is what
   // `warehouse-producer-bypass.test.ts` pins. This is the single point where
   // "the product's SQL gate said yes" becomes a value the run will act on — see
-  // {@link SnapshotSqlVerdict} for why that has to be unforgeable by an object
+  // {@link ValidatedSnapshotRequest} for why that has to be unforgeable by an object
   // literal rather than merely documented.
+  //
+  // It brands THE REQUEST IT WAS GIVEN, by reference. Constructing a fresh object
+  // with the same fields would satisfy the type and fail the run loop's identity
+  // check, which is the anti-replay guard — the token has to be about this object.
   return result.valid
-    ? ({ valid: true } as SnapshotSqlVerdict)
+    ? { valid: true, request: request as ValidatedSnapshotRequest }
     : // `error` is required on both sides — `SQLValidationResult`'s failing arm and
       // this one — so there is nothing to conditionally spread.
       { valid: false, error: result.error };
@@ -2165,12 +2253,13 @@ export async function defaultValidateSnapshotSql(
 /**
  * The shipped snapshot runner — reads tier-1, and nothing else.
  *
- * It deliberately does NOT validate: the gate ran before it was called, and having
- * it here as well would put the product's one SQL invariant inside a substitutable
- * implementation. See {@link defaultValidateSnapshotSql}.
+ * It deliberately does NOT validate: the gate ran before it was called — its
+ * parameter type is the proof — and having it here as well would put the product's
+ * one SQL invariant inside a substitutable implementation. See
+ * {@link defaultValidateSnapshotSql}.
  */
 async function defaultRunSnapshot(
-  request: WarehouseSnapshotRequest,
+  request: ValidatedSnapshotRequest,
 ): Promise<readonly Record<string, unknown>[]> {
   const { connections } = await import("@atlas/api/lib/db/connection");
   const connection = connections.getForOrg(request.workspaceId, request.connectionId ?? "default");

--- a/packages/schemas/src/brain.ts
+++ b/packages/schemas/src/brain.ts
@@ -1639,8 +1639,13 @@ export const BrainEnrollmentNamingResponseSchema = z.strictObject({
  *     table is outside the whitelist or a `sql:` expression is malformed, and
  *     re-running changes nothing.
  *   - `snapshot-failed` — the run could not complete for this entity: the
- *     datasource read failed, the SQL gate threw rather than answering, or the
- *     entity's transaction rolled back. Nothing was stamped. Retryable, but not
+ *     datasource read failed, the SQL gate threw rather than answering, the
+ *     entity's transaction rolled back, or Atlas could not confirm the gate's
+ *     verdict was about the statement it was going to run (#5230). Nothing was
+ *     stamped. The last of the four is an Atlas wiring fault rather than an
+ *     environment one, and its message says so and carries the request id — the
+ *     other three ask the operator to look at their warehouse or their YAML, and
+ *     that one asks them to report it. Retryable, but not
  *     always usefully so — a dropped table fails the same way forever, and after a
  *     rolled-back transaction earlier entities have already COMMITTED, so that
  *     message tells the operator to drain the review queue before re-running. Split

--- a/packages/schemas/src/brain.ts
+++ b/packages/schemas/src/brain.ts
@@ -1643,9 +1643,10 @@ export const BrainEnrollmentNamingResponseSchema = z.strictObject({
  *     entity's transaction rolled back, or Atlas could not confirm the gate's
  *     verdict was about the statement it was going to run (#5230). Nothing was
  *     stamped. The last of the four is an Atlas wiring fault rather than an
- *     environment one, and its message says so and carries the request id — the
- *     other three ask the operator to look at their warehouse or their YAML, and
- *     that one asks them to report it. Retryable, but not
+ *     environment one, and its message says so and carries the request id. Of the
+ *     other three, two name a remedy — fix the entity YAML, or drain the review
+ *     queue before re-running — and the gate-throw arm names none, because its cause
+ *     is not visible from the wire. Retryable, but not
  *     always usefully so — a dropped table fails the same way forever, and after a
  *     rolled-back transaction earlier entities have already COMMITTED, so that
  *     message tells the operator to drain the review queue before re-running. Split


### PR DESCRIPTION
## What

The SQL gate's passing verdict was branded, so no object literal could assert that the product's SELECT-only / single-statement / whitelist-scoped check said yes. Two holes remained, and neither was a literal.

**Replay.** The verdict carried no linkage to the request it validated. This compiled clean, with no cast:

```ts
let cached: SnapshotSqlVerdict | undefined;
validateSnapshotSql: async (_req) => (cached ??= await defaultValidateSnapshotSql(BENIGN_REQUEST))
```

Nothing is forged — one benign statement is validated, and every entity thereafter reaches a customer's datasource on a genuine token about a statement it has nothing to do with.

**Ordering.** `WarehouseSnapshotRunner` took a bare `WarehouseSnapshotRequest`, so validate-then-run was enforced by **statement order** — exactly the convention the brand was introduced to replace. A reorder compiled, and so did a new call site reaching the runner directly.

## How

The brand moves onto the request:

```ts
declare const validatedSnapshotSql: unique symbol;
export type ValidatedSnapshotRequest = WarehouseSnapshotRequest & {
  readonly [validatedSnapshotSql]: true;
};

export type SnapshotSqlVerdict =
  | { readonly valid: true; readonly request: ValidatedSnapshotRequest }
  | { readonly valid: false; readonly error: string };

export type WarehouseSnapshotRunner = (
  request: ValidatedSnapshotRequest,
) => Promise<readonly Record<string, unknown>[]>;
```

The runner's only input is a value that cannot exist without the gate having produced it, so **ordering is a type**. The type cannot say *which* statement passed, so the run loop closes that half at runtime, and it takes **three** things rather than one — each of which the review rounds found the previous one did not cover:

1. **Identity** — the returned request must be the object submitted. Kills a cached or reconstructed token.
2. **`Object.freeze`** — `readonly` is erased, so a validator could validate, `Object.assign(request, {sql})`, and hand the same reference back. Frozen, that write fails closed.
3. **Read once** — `validation.request` is a property access on an object the *seam* produced, so a getter answers the guard with the honest request and the runner with another. The value is captured once and used everywhere.

(3) is the sharp one: the substituted object carries its own `workspaceId`/`connectionId`, and `defaultRunSnapshot` selects the connection pool from those — so the residual was a **cross-tenant read**, not merely a gate bypass.

A mismatch refuses as `snapshot-failed` (transient), **not** `snapshot-rejected`. The statement was never judged, so *"re-running will not change this"* would describe a check that did not happen.

## Review — the panel stopped at round 2 on the RATIO rule

| round | findings | new surface | defect-in-prior-fix |
|---|---|---|---|
| 1 | 12 | 12 | 0 |
| 2 | 19 | ~4 | **~15** |
| closing comment sweep | 6 + de-slop | — | 6 |

Round 2's findings were overwhelmingly defects inside round 1's own fixes, so the rounds ended there rather than at the 3-round cap: another round would have added work faster than it removed it. Every confirmed must-fix from both rounds is fixed here, and the closing round paid its costs — `comment-analyzer` ran on the final diff, and every named falsifier was built **and run**.

**The single recurring defect in this PR was a comment asserting something nobody had measured**, and it recurred in every round including the sweep — 3 in round 2, 6 in the sweep, several of them introduced by the fix for a previous one. Two were *inverted*, i.e. they told the next reader a guard was weaker than it is:

- *"the module names these types in prose, so the guard would keep matching even if its cast were removed."* Measured backwards — it matches on the cast's line alone, so deleting the cast reds the test.
- *"an indexed lookup of the runner's parameter escapes the scan."* The assertion form matches; only the annotation form escapes, and an annotation asserts nothing.

Two more were enumerations of one fact that disagreed with the *other* copy of it added in this same PR (`snapshot-failed`'s four arms; how many ERROR-level per-entity refusals exist). Every claim written in the closing commit was re-verified against the tree before pushing.

Both `fix-vs-finding` passes on round 1 returned **REPRODUCED**, and both were right:

- the freeze fix closed *mutation* and left *aliasing* open — finding (3) above;
- the comment rewritten to remove a false universal asserted two more.

**Three comment claims were measured false and corrected**, which is the pattern worth naming: a claim about what a compiler or a regex does is an experiment, and reasoning about it kept losing.

- *"an assertion onto the validator seam type is refused"* — false. The nullary mint is refused; the one-parameter mint compiles, and that is the only useful shape now that the passing arm carries a request. Such a validator hands back its own argument, so the identity check waves it through.
- *"…because `valid` widens to `boolean` and the arm check is skipped"* — false, four ways. The real mechanism: the brand only **adds** a property, so the branded request is assignable to the bare one and `as` succeeds whenever *either* direction is comparable. Pinning `valid` with `as const` does **not** close it — which is what made the wrong cause expensive: it mispredicts the fix.
- *"`as unknown as` gets through the bypass scan"* — false; on one line it matches. A control now pins it.

## Falsifiers — built, run, measured

Round 1:

| mutation | result |
|---|---|
| identity check removed | replay + reconstructed tests fail |
| identity → field compare | **reconstructed fails, replay passes** |
| runner param widened back | `bun run type` reds (`TS2578`) |
| mint returns `{ ...request }` | mint test fails |
| identity `!==` → `===` | replay test fails (it did **not** before round 2's pin) |
| seam names dropped from the matcher | positive control fails |
| `ee` root path off by one | root-existence **and** set tests fail |

Round 2:

| mutation | result |
|---|---|
| re-read `validation.request` at the runner | aliasing test fails (`reads: 2`) |
| `connectionId` dropped from the gate call | mint test fails |
| returned\* log keys ← submitted values | logging ERROR test fails |
| the sweep's second run removed | `errors.length >= 1` fails |
| fifth name dropped from the matcher | positive control fails |

The two anti-replay tests are independently falsifiable by construction: one pins that a token for another statement is refused, the other that a **field-equal copy** is refused too — so weakening identity to a deep compare cannot pass both.

## Acceptance criteria

- [x] `runSnapshot` cannot be called with a request the gate has not validated — enforced by the type, with a `@ts-expect-error` falsifier that reds `bun run type` if the parameter is widened
- [x] A cached or replayed verdict cannot authorize a different request — refused at runtime by identity, plus freeze and read-once for the two channels that made identity insufficient
- [x] The bypass allowlist still names every mint; the matcher takes **five** names and scans three roots, and its failure message now names the roots it actually scans
- [x] `SnapshotSqlVerdict`'s docstring no longer claims the gate is closed against literals but open on ordering
- [x] The three test harnesses mint a validated **request**, each with the same named, greppable cast

## Consciously left as follow-ups

Named rather than silently dropped:

- **SQL digests on the mismatch log**, to separate *same workspace, same entity, different statement* from a benign replay. Real gap; new machinery on a log line; the entity is refused either way.
- **Replacing the `as`-adjacency matcher with a whole-file name allowlist.** Strictly better closure — it kills the alias, angle-bracket and line-break escapes in one move — but it redefines an entry from "may bypass" to "may name", so a legitimate future annotator has to be listed.
- **A distinct arm for a frozen-write `TypeError`.** Declined rather than deferred: `instanceof TypeError` is not specific to a frozen write, so the discriminator would be a new false universal in the round that exists to remove three of them. The raw `err` is already in the payload.

## Notes

- #5042 shipped the brand this builds on. #5228's cadence trigger is the second call site that makes the ordering hole reachable unattended, which is why this lands first.
- No schema change: the mismatch reuses the existing `snapshot-failed` reason. Its wire docstring now enumerates four causes instead of three.
- `warehouse-producer-mint.test.ts` and `warehouse-producer.test.ts` must not share one `bun test` invocation — the former's `mock.module` is process-wide. The isolated runner spawns per file, so CI is unaffected, and a positive tripwire now makes the collision loud instead of silent.

Closes #5230
