### PR TITLE
refactor(brain): whole-file name allowlist for the SQL-gate bypass set (#5249)

### DIFF
--- a/packages/api/src/lib/brain/__tests__/warehouse-producer-bypass.test.ts
+++ b/packages/api/src/lib/brain/__tests__/warehouse-producer-bypass.test.ts
@@ -18,13 +18,12 @@
  * That is #5249's change and it is a real widening: before, an entry meant *"this
  * line may cast"*; now it means *"this file may say the word"*.
  *
- * The consequence is that a module which only ANNOTATES — `let v: <a guarded name>`,
- * a re-export, an import — has to be listed too, even though an annotation asserts
- * nothing and is safe. The allowlist therefore grows for reasons that are not
- * bypasses, and a flat list would quietly stop distinguishing the two. So it does not
- * stay flat: every entry carries a {@link AllowlistKind}, and the count of each is
- * asserted below. A reviewer reading the list can still see *"four bypasses, zero
- * annotations"* rather than *"five files, unknown mix"*.
+ * The consequence is that a module which only ANNOTATES — an annotation, a
+ * re-export, an import — has to be listed too, even though it asserts nothing and is
+ * safe. The allowlist therefore grows for reasons that are not bypasses, and a flat
+ * list would quietly stop distinguishing the two. So it does not stay flat: every
+ * entry carries a {@link AllowlistKind}, the count of each is asserted, and every
+ * entry claiming `"bypass"` is CHECKED against the tree rather than believed.
  *
  * **When you add an entry, pick the kind honestly.** `"bypass"` is the one that has
  * to be argued: a production module minting a passing verdict is a second door onto
@@ -80,18 +79,28 @@
  * appears in this file's source, so it needs no entry, and **a real assertion written
  * into this file would still spell a name contiguously and would still RED.**
  *
- * ⚠️ **Assembly introduces its own silent-failure mode, and it is the dangerous
- * kind: a rename makes the guard VACUOUS rather than red.** If someone renames the
- * VERDICT union, the fragments stop matching anything, the scan finds nothing, and
- * the allowlist assertion fails loudly only because the four real files stop matching
- * too — but a rename of a name with no instances (the runner, today) would go green
- * forever. That is why the first test below reads `warehouse-producer.ts` and asserts
- * every assembled name is really exported there.
+ * ⚠️ **Assembly collapses the matcher and its fixtures onto ONE array, and that is a
+ * vacuity risk the first draft of #5249 shipped.** Before, the regex literal spelled
+ * the five contiguously while each control assembled its own — two independent
+ * spellings that had to agree. Deriving both from `GUARDED_NAMES` removed that
+ * independence, and it was measured: **deleting three of the five names left the
+ * whole suite green**, including the RUNNER arm that has no instances in the tree and
+ * is the cheapest innocuous-looking uncaught mint. Fixtures that agree by
+ * construction (#5000, #5068), one layer up.
  *
- * ⚠️ This paragraph names the types by ROLE rather than spelling them, and that is
- * the rule for every comment added to this file from now on. The first draft of
- * #5249's header spelled one — the suite RED-ed on its own file, immediately, which
- * is the guard working.
+ * Three different mechanisms hold three different failures, and none subsumes
+ * another — say which is which before touching any of them:
+ *
+ * - **DELETION** — a name leaving the array. Closed at COMPILE time: the array is a
+ *   fixed-arity tuple, so dropping an element is a type error, and the runtime length
+ *   assertion below is the same claim where a reader will look for it.
+ * - **RENAME / TYPO** — a fragment that no longer spells a real export. Closed at
+ *   RUNTIME by reading `warehouse-producer.ts`; the compiler cannot see inside a
+ *   concatenation, so nothing else can close this.
+ * - **A SIXTH branded type being exported and nobody adding it here** — OPEN, and
+ *   deliberately: deriving the set from the module needs a tagging convention in
+ *   production source. Tracked as a follow-up rather than improvised in a review
+ *   round. A green run does not claim the five are still the whole set.
  *
  * ## What this does NOT prove
  *
@@ -105,9 +114,20 @@
  * type without naming it — `any`-typed wiring, a `Partial<T>`-shaped generic builder,
  * or an indexed-access lookup routed through a VALUE rather than the type
  * (`Parameters<typeof someRunner>[0]`). Those need no assertion and name nothing; the
- * negative controls below pin that limit rather than leave it to prose. The list is
- * not exhaustive and cannot be — read a green run as *"no new file names one"*,
- * nothing more.
+ * negative controls below pin that limit rather than leave it to prose.
+ *
+ * ⚠️ **The scanned roots are three, and they are NOT every root a mint could live
+ * in.** {@link ROOTS} says which, and says plainly which sibling directories are
+ * knowingly unscanned. Read a green run as *"no new file under those three roots
+ * names one"*, nothing more.
+ *
+ * ⚠️ **`--affected` will not select this file for the event it exists to catch.** The
+ * affected-test runner keys on quoted module specifiers, and a brand-new mint at
+ * `lib/brain/<new-file>.ts` is named in no string here — nor is anything under
+ * `ee/src` or `packages/cli/src`, which are outside this package entirely. So the
+ * local pre-flight is blind to a new mint and only full CI catches it. This is the
+ * repo's known glob-scanning-guard-is-`--affected`-blind pattern; do not read a green
+ * pre-flight as covering it.
  *
  * It also does not pin the ANTI-REPLAY half. A mint listed below hands back a token
  * for the request it was given; a mint that hands back a token for some OTHER request
@@ -121,34 +141,55 @@
 import { describe, expect, test } from "bun:test";
 import { existsSync, readFileSync, readdirSync } from "fs";
 import { join } from "path";
+import { fileURLToPath } from "url";
 
 // `src/`, from `src/lib/brain/__tests__/`. Resolved off `import.meta.url` rather
 // than `process.cwd()`: the isolated runner and a bare `bun test` disagree about
 // the working directory, and a cwd-relative root would silently scan nothing under
-// one of them.
-const SRC_ROOT = new URL("../../../", import.meta.url).pathname;
+// one of them. `fileURLToPath`, not `.pathname` — the latter stays percent-encoded,
+// so a checkout path containing a space resolves to a directory that does not exist.
+const SRC_ROOT = fileURLToPath(new URL("../../../", import.meta.url));
 
 /**
- * Every root that can hold a mint — three of them, not decoration.
+ * The roots this guard scans, with a floor on how much each must yield.
  *
- * ⚠️ All five guarded names are EXPORTED, and both `ee/` and `packages/cli/` import
- * `@atlas/api/*` freely: only the api→ee direction is gated. A scan of this package
- * alone proved a claim strictly narrower than the one the failure message made, so a
- * mint added under either would sit outside the enumeration while the guard stayed
- * green. `packages/cli/` is the concrete case: it already imports
- * `@atlas/api/lib/db/*` and `@atlas/api/lib/semantic/*`, so an `atlas brain produce`
- * command is a plausible sixth site.
+ * ⚠️ **These are the three roots with brain-adjacent imports today. They are NOT
+ * "every root a mint could live in", and an earlier draft of this comment claimed
+ * they were.** All five guarded names are EXPORTED and nothing gates who imports
+ * `@atlas/api/*` — only the api→ee direction is gated — so the same argument that
+ * put `ee/src` and `packages/cli/src` here applies verbatim to directories that are
+ * knowingly unscanned: every `plugins/<name>/src` (a dozen of which import
+ * `@atlas/api` today), `packages/cli/bin`, `packages/cli/lib`,
+ * `packages/api/scripts`, and `packages/mcp/src`. None names a guarded type today —
+ * verified by repo-wide grep —
+ * so the gap is latent, not live. Widening the scan to cover them needs glob
+ * expansion and is tracked as a follow-up.
  *
  * ⚠️ **The roots are NAMED in the failure message too.** An enumeration is only as
- * honest as its scope, and a previous message asserted a tree-wide claim over one
- * directory. If a root is added here, add it there.
+ * honest as its scope. If a root is added here, add it there.
+ *
+ * ⚠️ **`minFiles` exists because root EXISTENCE is not root CORRECTNESS.** Repointing
+ * a root at a subdirectory that also exists — `ee/src/lib` for `ee/src` — passed
+ * every other assertion in this file, because `ee/` and `cli/` contribute zero
+ * matches and a narrower scan of them is invisible. The floors are set near half of
+ * today's counts (1966 / 108 / 75), so ordinary churn does not red them and gross
+ * narrowing does.
  */
-const ROOTS: readonly { readonly dir: string; readonly label: string }[] = [
-  { dir: SRC_ROOT, label: "" },
-  { dir: new URL("../../../../../../ee/src/", import.meta.url).pathname, label: "ee/src/" },
+const ROOTS: readonly {
+  readonly dir: string;
+  readonly label: string;
+  readonly minFiles: number;
+}[] = [
+  { dir: SRC_ROOT, label: "", minFiles: 1000 },
   {
-    dir: new URL("../../../../../cli/src/", import.meta.url).pathname,
+    dir: fileURLToPath(new URL("../../../../../../ee/src/", import.meta.url)),
+    label: "ee/src/",
+    minFiles: 50,
+  },
+  {
+    dir: fileURLToPath(new URL("../../../../../cli/src/", import.meta.url)),
     label: "packages/cli/src/",
+    minFiles: 30,
   },
 ];
 
@@ -162,9 +203,13 @@ const DEFINING_MODULE = join(SRC_ROOT, "lib/brain/warehouse-producer.ts");
  * The five guarded names, ASSEMBLED so no contiguous spelling appears in this file.
  * See the header: writing them whole would put this file into its own result set.
  *
- * The split points are arbitrary and only have to prevent a contiguous literal.
+ * ⚠️ **The TUPLE type is the fix for a measured silent failure, not decoration.**
+ * As `readonly string[]` this array could lose an element with the entire suite
+ * green — matcher and fixtures both derive from it, so they shrank together. A
+ * fixed-arity tuple makes a deletion a COMPILE error, which is the only place it can
+ * be caught cheaply: no runtime assertion can see a name that was never there.
  */
-const GUARDED_NAMES: readonly string[] = [
+const GUARDED_NAMES: readonly [string, string, string, string, string] = [
   "Validated" + "SnapshotRequest",
   "Snapshot" + "SqlVerdict",
   "SnapshotSql" + "Validator",
@@ -178,16 +223,27 @@ const GUARDED_NAMES: readonly string[] = [
  * No keyword, no line discipline, no character class — the widening is the whole
  * change, and it is what closes the alias, angle-bracket and line-break spellings in
  * one move rather than three.
+ *
+ * ⚠️ The fragments are interpolated UNESCAPED, and that coupling is load-bearing
+ * rather than sloppy: a name containing a regex metacharacter would fail to match
+ * here AND fail to match in the export check below, so the export check reds instead
+ * of this one going quietly vacuous.
  */
 const NAME_RE = new RegExp(`\\b(?:${GUARDED_NAMES.join("|")})\\b`);
 
 /**
- * The matcher #5249 REPLACED, kept only so the behaviour delta is executable.
+ * The matcher #5249 replaced. It does NOT scan the tree — but it is not dead code
+ * either, and an earlier draft that treated it as dead shipped a vacuous test.
  *
- * ⚠️ This is not live — nothing scans the tree with it. It exists so the test below
- * can assert, on each escape spelling, that the old matcher MISSED it and the new one
- * CATCHES it. A delta described in prose drifts; a delta that runs cannot. Built from
- * the same assembled fragments, for the same self-match reason as {@link NAME_RE}.
+ * Two live uses: the behaviour delta below asserts it MISSES each escape spelling
+ * (with a positive anchor, so a matcher that missed *everything* could not satisfy
+ * it), and the `kind: "bypass"` check asserts every file claiming to bypass actually
+ * contains an assertion form. That second use restores a property #5249 otherwise
+ * removed — under the old matcher, deleting a cast without deleting its entry RED-ed
+ * the suite; under a name scan it would not.
+ *
+ * Built from the same assembled fragments, for the same self-match reason as
+ * {@link NAME_RE}.
  */
 const LEGACY_AS_ADJACENT_RE = new RegExp(
   `\\bas\\b[^;=\\n]*\\b(?:${GUARDED_NAMES.join("|")})\\b`,
@@ -195,7 +251,7 @@ const LEGACY_AS_ADJACENT_RE = new RegExp(
 
 /** What an allowlist entry certifies. See the header — the distinction is the cost of #5249. */
 type AllowlistKind =
-  /** The file mints or asserts a passing verdict. This is the one to argue. */
+  /** The file mints or asserts a passing verdict. This is the one to argue, and it is CHECKED. */
   | "bypass"
   /** The file only names the type — annotation, import, re-export. Safe, still visible. */
   | "annotation";
@@ -231,14 +287,17 @@ const NAME_ALLOWLIST: readonly {
   {
     file: "lib/brain/__tests__/warehouse-producer-pg.test.ts",
     kind: "bypass",
-    why: "the -pg harness, for the same reason; its subject is the storage layer, not the gate",
+    why: "the -pg harness, same whitelist reason; its subject is the storage layer, not the gate",
   },
   {
     file: "lib/brain/__tests__/warehouse-producer-logging.test.ts",
     kind: "bypass",
-    why: "the logging harness, for the same reason",
+    why: "the logging harness, same whitelist reason; its subject is the emitted log line",
   },
 ];
+
+/** Kinds are counted, not merely declared — see the test that pins this. */
+const EXPECTED_BY_KIND: Record<AllowlistKind, number> = { bypass: 4, annotation: 0 };
 
 function* walk(dir: string): Generator<string> {
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
@@ -246,22 +305,53 @@ function* walk(dir: string): Generator<string> {
     if (entry.isDirectory()) {
       if (entry.name === "node_modules" || entry.name === "dist") continue;
       yield* walk(full);
-    } else if (entry.name.endsWith(".ts") || entry.name.endsWith(".tsx")) {
+    } else if (/\.(?:ts|tsx|mts|cts)$/.test(entry.name)) {
+      // `.mts`/`.cts` are included though the roots contain none today: the cost is
+      // one alternative, and a module extension the scan cannot see is exactly the
+      // silent narrowing this file is built to refuse.
       yield full;
     }
   }
 }
 
+/** Strip line and block comments, so a guard cannot be satisfied by prose about it. */
+function withoutComments(source: string): string {
+  return source
+    .split("\n")
+    .filter((line) => {
+      const t = line.trimStart();
+      return !t.startsWith("//") && !t.startsWith("*") && !t.startsWith("/*");
+    })
+    .join("\n");
+}
+
 describe("the SQL-gate name allowlist (#5042, #5230, #5249)", () => {
   test("every assembled name is really exported — a rename must RED, not go vacuous", () => {
-    // ⚠️ The one test that assembly makes mandatory. Fragments cannot be checked by
-    // the compiler, so nothing but this read connects them to the real exports.
-    // Without it, renaming a guarded type with no instances in the tree leaves a
-    // matcher that can never match and a suite that is green forever.
-    const source = readFileSync(DEFINING_MODULE, "utf8");
+    // ⚠️ The one test that assembly makes mandatory. Fragments are invisible to the
+    // compiler, so nothing but this read connects them to the real exports. It closes
+    // RENAME and TYPO; it cannot close DELETION (the tuple type does that) and does
+    // not claim to.
+    expect(
+      existsSync(DEFINING_MODULE),
+      `the defining module moved: ${DEFINING_MODULE}. Update DEFINING_MODULE — a bare ` +
+        `ENOENT below would be this assertion's job done badly.`,
+    ).toBe(true);
+    // Belt and braces on the tuple: the same claim, where a reader looks for it.
+    expect(GUARDED_NAMES.length, "a guarded name left the array; the scan silently narrowed").toBe(
+      5,
+    );
+
+    // ⚠️ Comments are stripped and the pattern is line-ANCHORED. Unanchored, a
+    // `// export type <name> was renamed in #9999` note satisfied this check — the
+    // exact vacuity the test exists to refuse, satisfied by prose describing the
+    // rename. Measured.
+    const source = withoutComments(readFileSync(DEFINING_MODULE, "utf8"));
     for (const name of GUARDED_NAMES) {
+      const declared = new RegExp(`^export (?:declare )?(?:type|interface|class) ${name}\\b`, "m");
+      // A barrel re-export is a legal refactor for a 2,300-line module and must not RED.
+      const reExported = new RegExp(`^export (?:type )?\\{[^}]*\\b${name}\\b`, "m");
       expect(
-        new RegExp(`export (?:type|interface) ${name}\\b`).test(source),
+        declared.test(source) || reExported.test(source),
         `${name} is no longer exported from lib/brain/warehouse-producer.ts. If it was ` +
           `renamed, update GUARDED_NAMES — the assembled fragments are invisible to the ` +
           `compiler, so a stale one silently matches nothing.`,
@@ -269,14 +359,18 @@ describe("the SQL-gate name allowlist (#5042, #5230, #5249)", () => {
     }
   });
 
-  test("every scanned root exists — a moved path must RED, not shrink the scan", () => {
+  test("every scanned root exists AND still yields its floor — narrowing must RED", () => {
     // ⚠️ Asserted rather than filtered. `existsSync`-and-skip would turn a renamed
-    // directory into a silently smaller scan that still passes, which is the exact
-    // failure the two-root change was made to close.
-    for (const { dir, label } of ROOTS) {
-      expect(existsSync(dir), `scan root missing: ${label || "packages/api/src/"} (${dir})`).toBe(
-        true,
-      );
+    // directory into a silently smaller scan that still passes. The floor is the same
+    // discipline one level down: a root repointed at a real subdirectory exists, and
+    // without a volume check its narrowing is invisible.
+    for (const { dir, label, minFiles } of ROOTS) {
+      const name = label || "packages/api/src/";
+      expect(existsSync(dir), `scan root missing: ${name} (${dir})`).toBe(true);
+      expect(
+        [...walk(dir)].length,
+        `scan root ${name} yielded fewer than ${minFiles} files — repointed at a subdirectory?`,
+      ).toBeGreaterThan(minFiles);
     }
   });
 
@@ -305,12 +399,42 @@ describe("the SQL-gate name allowlist (#5042, #5230, #5249)", () => {
     // ⚠️ The number, not just the field. #5249 widened what an entry means, and the
     // failure mode it introduces is a real mint added as `kind: "annotation"` because
     // that is the quieter word. Pinning the count makes adding a bypass a visible edit
-    // to this line, with the reviewer's attention on it.
-    const byKind = { bypass: 0, annotation: 0 };
+    // to a line a reviewer is looking at.
+    const byKind: Record<AllowlistKind, number> = { bypass: 0, annotation: 0 };
     for (const entry of NAME_ALLOWLIST) byKind[entry.kind]++;
-    expect(byKind).toEqual({ bypass: 4, annotation: 0 });
-    // Every entry says why, and the reason is not the empty string.
+    expect(byKind).toEqual(EXPECTED_BY_KIND);
+  });
+
+  test("every kind:'bypass' entry really contains an assertion — the claim is checked, not believed", () => {
+    // ⚠️ This restores a property #5249 removed. Under the old line-keyed matcher,
+    // deleting a cast while leaving its entry RED-ed the suite; a name scan cannot see
+    // that, so an entry could over-claim forever. Non-vacuous today: all four match.
+    //
+    // Honest limit, stated because the arm is one-directional: this uses the LEGACY
+    // matcher, so a bypass written in one of the escape forms would read as an
+    // annotation here. It does not make `kind` sound; it makes the common case
+    // falsifiable and restores the deleted-cast-REDs property.
+    const bypasses = NAME_ALLOWLIST.filter((e) => e.kind === "bypass");
+    expect(bypasses.length, "no bypass entries — this test would be vacuous").toBeGreaterThan(0);
+    for (const entry of bypasses) {
+      expect(
+        LEGACY_AS_ADJACENT_RE.test(readFileSync(join(SRC_ROOT, entry.file), "utf8")),
+        `${entry.file} is listed kind "bypass" but contains no assertion form. If its cast ` +
+          `was removed, demote it to "annotation" (and move the count); do not leave a stale ` +
+          `over-claim in the list.`,
+      ).toBe(true);
+    }
+  });
+
+  test("every entry states a distinct reason", () => {
+    // Split from the count assertion above: a failing count used to mean this loop
+    // never ran. Two entries sharing a reason verbatim is the copy-paste this list
+    // trends toward, and the reason is the only thing a reviewer actually reads.
     for (const entry of NAME_ALLOWLIST) expect(entry.why.length).toBeGreaterThan(20);
+    expect(
+      new Set(NAME_ALLOWLIST.map((e) => e.why)).size,
+      "two entries share a reason verbatim — say what is different about them",
+    ).toBe(NAME_ALLOWLIST.length);
   });
 
   test("the escapes #5249 closed: old matcher MISSES each, new matcher CATCHES each", () => {
@@ -321,6 +445,14 @@ describe("the SQL-gate name allowlist (#5042, #5230, #5249)", () => {
     // ASSEMBLED, never written whole — a contiguous name here would put this file into
     // its own result set, which is the trap the header describes.
     const V = "Snapshot" + "SqlVerdict";
+    // ⚠️ The POSITIVE anchor, and it is what makes the misses below mean anything.
+    // Without it, replacing the legacy matcher with one that matches NOTHING satisfied
+    // every `should MISS` assertion and the suite stayed green — a delta test proving
+    // only that the new matcher works. Measured.
+    expect(
+      LEGACY_AS_ADJACENT_RE.test(`const v = x as ${V};`),
+      "the legacy matcher must still catch the one-line form, or the misses below are vacuous",
+    ).toBe(true);
     const escapes: readonly { readonly label: string; readonly src: string }[] = [
       {
         label: "a local type alias, then the assertion through the alias",
@@ -346,28 +478,36 @@ describe("the SQL-gate name allowlist (#5042, #5230, #5249)", () => {
   });
 
   test("the positive control: the matcher finds every name it is shown", () => {
-    // Without this, an over-narrow matcher reports an empty set forever and the
-    // allowlist test above passes by finding nothing — the shape a guard test fails
-    // in silently. One arm per name, so losing a single alternative REDS.
+    // ⚠️ Read this for what it is: it proves the word boundaries hold in BOTH the
+    // assertion and the annotation context, for each name. It CANNOT detect a name
+    // leaving GUARDED_NAMES — matcher and loop derive from the same array, so they
+    // shrink together. The tuple type closes that; an earlier draft claimed this loop
+    // did, and that claim was measured false.
     for (const name of GUARDED_NAMES) {
-      expect(NAME_RE.test(`const v = x as ${name};`), `lost the arm for ${name}`).toBe(true);
+      expect(NAME_RE.test(`const v = x as ${name};`), `boundary failed for ${name}`).toBe(true);
       // ⚠️ And the whole point of #5249: the same name with no assertion at all.
       expect(NAME_RE.test(`let v: ${name};`), `annotation form missed for ${name}`).toBe(true);
     }
   });
 
   test("the negative controls: what a name scan still cannot see", () => {
-    // ⚠️ These are the residual holes, pinned as assertions so the header's "what this
-    // does NOT prove" section cannot drift away from the truth. Each names none of the
-    // five, so each reaches the branded type — or claims to — without spelling it.
+    // ⚠️ These three are the residual holes, pinned as assertions so the header's
+    // "what this does NOT prove" section cannot drift away from the truth. Each
+    // reaches the branded type — or claims to — without spelling it.
+    //
+    // ⚠️ They do NOT discriminate the matcher: containing none of the five, they are
+    // false for ANY matcher, including one that lost every alternative. The two
+    // boundary controls below are the ones that kill mutants.
     expect(NAME_RE.test(`const d: any = { validateSnapshotSql: mint };`)).toBe(false);
     expect(NAME_RE.test(`type V = Parameters<typeof runProducerSnapshot>[0];`)).toBe(false);
     expect(NAME_RE.test(`const v = buildPartial({ valid: true, request: r });`)).toBe(false);
-    // ⚠️ A DISCRIMINATING negative, not merely an absent one. A near-miss identifier
-    // that CONTAINS a guarded name as a prefix must not match — otherwise `\b` has
-    // been dropped and the matcher is a substring test, which would drag in every
-    // sibling type and make the allowlist unmaintainable.
+    // ⚠️ DISCRIMINATING negatives, one per boundary. A near-miss identifier must not
+    // match — otherwise a `\b` has been dropped and the matcher is a substring test,
+    // which would drag in every sibling type and make the allowlist unmaintainable.
+    // Both directions, because they fail independently: dropping the TRAILING `\b`
+    // and dropping the LEADING one are different mutations and each needs its own arm.
     expect(NAME_RE.test(`let v: Snapshot${"SqlVerdict"}ish;`)).toBe(false);
+    expect(NAME_RE.test(`type Pre${"Validated"}SnapshotRequest = never;`)).toBe(false);
     // The real sibling type this scan must stay clear of: the UNvalidated request is
     // named all over the producer and is not one of the five.
     expect(NAME_RE.test(`function run(r: WarehouseSnapshot${"Request"}) {}`)).toBe(false);

--- a/packages/api/src/lib/brain/__tests__/warehouse-producer-bypass.test.ts
+++ b/packages/api/src/lib/brain/__tests__/warehouse-producer-bypass.test.ts
@@ -61,9 +61,11 @@
  * assertion succeeds whenever EITHER direction is comparable — the reverse direction
  * carries every seam name. Refused only where the reverse direction also fails: a
  * NULLARY mint (a 1-parameter function type is not assignable to a 0-parameter one),
- * or a literal with an excess property. Such a validator returns its own argument, so
- * the run loop's identity check waves it through: the gate never ran and nothing
- * downstream can tell.
+ * or a literal with an excess property. `as const` on `valid` does not close it.
+ * Measured against the repo's own checker, because the two obvious explanations for
+ * this were both wrong. The identity mint that survives — one returning its own
+ * argument — is waved through by the run loop's identity check: the gate never ran
+ * and nothing downstream can tell.
  *
  * ## The names are ASSEMBLED, and that is load-bearing twice
  *
@@ -84,12 +86,13 @@
  * the five contiguously while each control assembled its own — two independent
  * spellings that had to agree. Deriving both from `GUARDED_NAMES` removed that
  * independence, and it was measured: **deleting three of the five names left the
- * whole suite green**, including the RUNNER arm that has no instances in the tree and
- * is the cheapest innocuous-looking uncaught mint. Fixtures that agree by
- * construction (#5000, #5068), one layer up.
+ * whole suite green**, including the RUNNER arm — every file that names it is already
+ * listed and also names another guarded type, so losing the arm changes no result,
+ * and no unlisted file names it, which makes it the cheapest innocuous-looking
+ * uncaught mint. Fixtures that agree by construction (#5000, #5068), one layer up.
  *
- * Three different mechanisms hold three different failures, and none subsumes
- * another — say which is which before touching any of them:
+ * Three failures are closed by four mechanisms, none subsuming another, and a fourth
+ * failure is open — say which is which before touching any of them:
  *
  * - **DELETION** — a name leaving the array. Closed at COMPILE time by the fixed-arity
  *   tuple (`bun run type`) and at RUNTIME by the length assertion (`bun test`, which
@@ -115,8 +118,8 @@
  * spread of the refusing arm, `unknown`, and the identity form of generic-inference
  * laundering are all REFUSED by the COMPILER.
  *
- * ⚠️ **What this scan holds is exactly: no unlisted file under the scanned roots
- * SPELLS one of the five names.** What still escapes is everything that reaches the
+ * ⚠️ **What this scan holds is exactly: no unlisted TypeScript file under the scanned
+ * roots SPELLS one of the five names.** What still escapes is everything that reaches the
  * type without naming it — `any`-typed wiring, a `Partial<T>`-shaped generic builder,
  * or an indexed-access lookup routed through a VALUE rather than the type
  * (`Parameters<typeof someRunner>[0]`). Those need no assertion and name nothing; the
@@ -129,8 +132,10 @@
  *
  * ⚠️ **`--affected` will not select this file for the event it exists to catch.** The
  * affected-test runner keys on quoted module specifiers, and a brand-new mint at
- * `lib/brain/<new-file>.ts` is named in no string here — nor is anything under
- * `ee/src` or `packages/cli/src`, which are outside this package entirely. So the
+ * `lib/brain/<new-file>.ts` is named in no string here. The two sentinel strings DO
+ * name files under `ee/src` and `packages/cli/src`, but the runner needs its token
+ * immediately before the closing quote and `"validate.ts"` ends in `.ts`, so they
+ * select nothing either — and those roots are outside this package regardless. So the
  * local pre-flight is blind to a new mint and only full CI catches it. This is the
  * repo's known glob-scanning-guard-is-`--affected`-blind pattern; do not read a green
  * pre-flight as covering it.
@@ -164,12 +169,11 @@ const SRC_ROOT = fileURLToPath(new URL("../../../", import.meta.url));
  * they were.** All five guarded names are EXPORTED and nothing gates who imports
  * `@atlas/api/*` — only the api→ee direction is gated — so the same argument that
  * put `ee/src` and `packages/cli/src` here applies verbatim to directories that are
- * knowingly unscanned: every `plugins/<name>/src` (a dozen of which import
- * `@atlas/api` today), `packages/cli/bin`, `packages/cli/lib`,
- * `packages/api/scripts`, and `packages/mcp/src`. None names a guarded type today —
- * verified by repo-wide grep —
- * so the gap is latent, not live. Widening the scan to cover them needs glob
- * expansion and is tracked as a follow-up.
+ * knowingly unscanned: every `plugins/<name>/src` (24 of the 25 import `@atlas/api`
+ * today), `packages/cli/bin`, `packages/cli/lib`, `packages/api/scripts`, and
+ * `packages/mcp/src`. None names a guarded type today, verified by repo-wide grep, so
+ * the gap is latent rather than live. Widening the scan needs glob expansion and is
+ * tracked as a follow-up.
  *
  * ⚠️ **The roots are NAMED in the failure message too.** An enumeration is only as
  * honest as its scope. If a root is added here, add it there.
@@ -179,16 +183,22 @@ const SRC_ROOT = fileURLToPath(new URL("../../../", import.meta.url));
  * roughly half of each root's file count and verified one root. That is the wrong
  * calibration: the number that matters is the size of the largest CHILD directory,
  * because repointing a root at its own child is the edit in question. Measured —
- * `packages/api/src` -> `src/lib` is 1613 files against a floor of 1000, and
+ * `packages/api/src` -> `src/lib` is 1612 files against a floor of 1000, and
  * `packages/cli/src` -> `src/__tests__` is 35 against 30. Both stayed GREEN. Only the
  * `ee` root, the one that had been checked, RED-ed.
  *
  * So the floor is no longer the mechanism, it is the backstop. **`sentinel` is the
  * mechanism**: a file that must be REACHED by the walk, which answers "is this the
- * right directory" directly instead of inferring it from a count. It also catches
- * narrowing introduced INSIDE `walk` — a skipped directory or a tightened extension
- * test — which no root-level floor can see. Each sentinel is a uniquely-pathed file
- * under its root, so a repoint cannot accidentally satisfy it.
+ * right directory" directly instead of inferring it from a count. Each sentinel is a
+ * uniquely-pathed file under its root, so a repoint cannot accidentally satisfy it.
+ *
+ * ⚠️ **The sentinel catches a `walk` narrowing only when that narrowing drops the
+ * sentinel's OWN path, and an earlier draft of this paragraph claimed more.**
+ * Measured: skipping `brain` leaves 1,789 files — clears the 1,000 floor, but REDs
+ * the sentinel. Skipping `src/api` leaves 1,651 — clears the floor AND still reaches
+ * the sentinel, so both mechanisms miss it. Tightening the extension test to `.ts`
+ * drops nothing at all, since no root holds a `.tsx`, `.mts` or `.cts` today. A scan
+ * narrowed away from the sentinel's path is not covered here.
  *
  * The floors stay because they catch a different thing: a scan that still reaches the
  * sentinel while losing most of the tree.
@@ -275,7 +285,8 @@ const NAME_RE = new RegExp(`\\b(?:${GUARDED_NAMES.join("|")})\\b`);
 
 /**
  * The matcher #5249 replaced. It does NOT scan the tree — but it is not dead code
- * either, and an earlier draft that treated it as dead shipped a vacuous test.
+ * either, and an earlier draft's only use of it carried no positive anchor, so a
+ * matcher that matched NOTHING satisfied every "should MISS" assertion.
  *
  * Two live uses: the behaviour delta below asserts it MISSES each escape spelling
  * (with a positive anchor, so a matcher that missed *everything* could not satisfy
@@ -349,7 +360,7 @@ function* walk(dir: string): Generator<string> {
       yield* walk(full);
     } else if (/\.(?:ts|tsx|mts|cts)$/.test(entry.name)) {
       // `.mts`/`.cts` are included though the roots contain none today: the cost is
-      // one alternative, and a module extension the scan cannot see is exactly the
+      // two alternatives, and a module extension the scan cannot see is exactly the
       // silent narrowing this file is built to refuse.
       yield full;
     }
@@ -397,7 +408,7 @@ function withoutComments(source: string): string {
 function isExported(source: string, name: string): boolean {
   const stripped = withoutComments(source);
   const declared = new RegExp(`^export (?:declare )?(?:type|interface|class) ${name}\\b`, "m");
-  // A barrel re-export is a legal refactor for a 2,300-line module and must not RED.
+  // A barrel re-export is a legal refactor for a 2,378-line module and must not RED.
   // ⚠️ The negative lookahead matters: `export type { X as V2 }` means X is NO LONGER
   // exported under that spelling, which is precisely the rename this check exists to
   // catch — without it the widening swallowed its own subject.
@@ -419,15 +430,16 @@ describe("the SQL-gate name allowlist (#5042, #5230, #5249)", () => {
     // ⚠️ Under `bun test` the tuple contributes NOTHING — the runner strips types
     // without checking them, so this assertion is the only live mechanism here and
     // the tuple is the only one in `bun run type`. Two gates, two mechanisms, neither
-    // redundant. This is not belt and braces.
+    // redundant.
     expect(GUARDED_NAMES.length, "a guarded name left the array; the scan silently narrowed").toBe(
       5,
     );
     // ⚠️ ARITY IS NOT IDENTITY, and the gap was measured. Substituting one name for a
     // COPY of another keeps the length at 5, keeps both spellings real exports, and
     // shrinks the positive-control loop along with the matcher — the whole suite
-    // stayed GREEN while `NAME_RE` silently lost an alternative. The runner arm, which
-    // has no instances in the tree, is exactly the one a copy-paste clobbers.
+    // stayed GREEN while `NAME_RE` silently lost an alternative. The runner arm has no
+    // assertion onto it anywhere and no unlisted file naming it, so it is the one a
+    // copy-paste clobbers unnoticed.
     expect(
       new Set(GUARDED_NAMES).size,
       "two fragments assemble the same name — an arm left the matcher without shortening it",
@@ -480,8 +492,9 @@ describe("the SQL-gate name allowlist (#5042, #5230, #5249)", () => {
       const files = [...walk(dir)];
       // ⚠️ The sentinel, not the floor, is what answers "is this the right directory".
       // Two of the three floors were measured passable by repointing a root at its own
-      // largest child; a reached-file check cannot be satisfied that way, and it also
-      // catches narrowing introduced inside `walk` itself.
+      // largest child; a reached-file check cannot be satisfied that way. It also
+      // catches a `walk` narrowing that drops the sentinel's own directory — but only
+      // that one; a narrowing elsewhere clears both this and the floor.
       expect(
         files,
         `scan root ${name} no longer reaches ${sentinel} — repointed, or did walk() narrow?`,
@@ -580,8 +593,8 @@ describe("the SQL-gate name allowlist (#5042, #5230, #5249)", () => {
 
   test("the escapes #5249 closed: old matcher MISSES each, new matcher CATCHES each", () => {
     // ⚠️ The behaviour delta, executed rather than described. Each spelling below was
-    // also compiled against the repo's own checker while #5249 was written — all three
-    // typecheck, which is what made them escapes rather than curiosities.
+    // also compiled against the repo's own checker while #5249 was written — each of
+    // the four typechecks, which is what made them escapes rather than curiosities.
     //
     // ASSEMBLED, never written whole — a contiguous name here would put this file into
     // its own result set, which is the trap the header describes.

--- a/packages/api/src/lib/brain/__tests__/warehouse-producer-bypass.test.ts
+++ b/packages/api/src/lib/brain/__tests__/warehouse-producer-bypass.test.ts
@@ -91,12 +91,18 @@
  * Three different mechanisms hold three different failures, and none subsumes
  * another — say which is which before touching any of them:
  *
- * - **DELETION** — a name leaving the array. Closed at COMPILE time: the array is a
- *   fixed-arity tuple, so dropping an element is a type error, and the runtime length
- *   assertion below is the same claim where a reader will look for it.
+ * - **DELETION** — a name leaving the array. Closed at COMPILE time by the fixed-arity
+ *   tuple (`bun run type`) and at RUNTIME by the length assertion (`bun test`, which
+ *   strips types without checking them, so neither mechanism is redundant).
+ * - **SUBSTITUTION** — one name replaced by a COPY of another. Arity is unchanged and
+ *   both spellings are real exports, so neither mechanism above sees it, and the
+ *   positive-control loop shrinks along with the matcher. Closed by the DISTINCTNESS
+ *   assertion. This is listed separately because an earlier draft treated deletion as
+ *   the whole class and measured green under substitution.
  * - **RENAME / TYPO** — a fragment that no longer spells a real export. Closed at
  *   RUNTIME by reading `warehouse-producer.ts`; the compiler cannot see inside a
- *   concatenation, so nothing else can close this.
+ *   concatenation, so nothing else can close this. The reading machinery has its own
+ *   fixture block, because a checker with no falsifier is how its blind spots ship.
  * - **A SIXTH branded type being exported and nobody adding it here** — OPEN, and
  *   deliberately: deriving the set from the module needs a tagging convention in
  *   production source. Tracked as a follow-up rather than improvised in a review
@@ -168,30 +174,66 @@ const SRC_ROOT = fileURLToPath(new URL("../../../", import.meta.url));
  * ⚠️ **The roots are NAMED in the failure message too.** An enumeration is only as
  * honest as its scope. If a root is added here, add it there.
  *
- * ⚠️ **`minFiles` exists because root EXISTENCE is not root CORRECTNESS.** Repointing
- * a root at a subdirectory that also exists — `ee/src/lib` for `ee/src` — passed
- * every other assertion in this file, because `ee/` and `cli/` contribute zero
- * matches and a narrower scan of them is invisible. The floors are set near half of
- * today's counts (1966 / 108 / 75), so ordinary churn does not red them and gross
- * narrowing does.
+ * ⚠️ **Root EXISTENCE is not root CORRECTNESS, and a VOLUME floor is only a proxy
+ * for it — a proxy that was measured insufficient.** A first attempt set floors at
+ * roughly half of each root's file count and verified one root. That is the wrong
+ * calibration: the number that matters is the size of the largest CHILD directory,
+ * because repointing a root at its own child is the edit in question. Measured —
+ * `packages/api/src` -> `src/lib` is 1613 files against a floor of 1000, and
+ * `packages/cli/src` -> `src/__tests__` is 35 against 30. Both stayed GREEN. Only the
+ * `ee` root, the one that had been checked, RED-ed.
+ *
+ * So the floor is no longer the mechanism, it is the backstop. **`sentinel` is the
+ * mechanism**: a file that must be REACHED by the walk, which answers "is this the
+ * right directory" directly instead of inferring it from a count. It also catches
+ * narrowing introduced INSIDE `walk` — a skipped directory or a tightened extension
+ * test — which no root-level floor can see. Each sentinel is a uniquely-pathed file
+ * under its root, so a repoint cannot accidentally satisfy it.
+ *
+ * The floors stay because they catch a different thing: a scan that still reaches the
+ * sentinel while losing most of the tree.
+ *
+ * ⚠️ **The TUPLE type is the same fix as {@link GUARDED_NAMES}', and it is here
+ * because the first attempt at that fix reproduced the defect one array over.**
+ * Pinning a root's `dir` catches NARROWING it; nothing caught DELETING the entry,
+ * because every assertion about a root is driven by this same list — so removing an
+ * element removed the scan and its own checks together, and `ee/src` and
+ * `packages/cli/src` contribute zero matches, so the allowlist test could not notice
+ * either. Fixed arity makes a deletion a compile error.
  */
-const ROOTS: readonly {
+type ScanRoot = {
   readonly dir: string;
   readonly label: string;
   readonly minFiles: number;
-}[] = [
-  { dir: SRC_ROOT, label: "", minFiles: 1000 },
+  /** Root-relative path that MUST be reached — the direct answer to "right directory?". */
+  readonly sentinel: string;
+};
+const ROOTS: readonly [ScanRoot, ScanRoot, ScanRoot] = [
+  {
+    dir: SRC_ROOT,
+    label: "",
+    minFiles: 1000,
+    sentinel: "lib/brain/warehouse-producer.ts",
+  },
   {
     dir: fileURLToPath(new URL("../../../../../../ee/src/", import.meta.url)),
     label: "ee/src/",
     minFiles: 50,
+    sentinel: "deploy-mode.ts",
   },
   {
     dir: fileURLToPath(new URL("../../../../../cli/src/", import.meta.url)),
     label: "packages/cli/src/",
     minFiles: 30,
+    sentinel: "validate.ts",
   },
 ];
+
+/** Resolve an allowlist entry to an absolute path via its root's label, never assuming the api root. */
+function resolveEntry(file: string): string {
+  const root = ROOTS.find((r) => r.label !== "" && file.startsWith(r.label));
+  return root ? join(root.dir, file.slice(root.label.length)) : join(SRC_ROOT, file);
+}
 
 /**
  * The module that defines all five names — read, not imported, so the assembled
@@ -314,15 +356,53 @@ function* walk(dir: string): Generator<string> {
   }
 }
 
-/** Strip line and block comments, so a guard cannot be satisfied by prose about it. */
+/**
+ * Strip block and line comments, so a guard cannot be satisfied by prose about itself.
+ *
+ * ⚠️ **Block comments are removed as REGIONS, not by looking at how each line
+ * starts, and the difference was measured.** A line-shape filter (drop lines whose
+ * trimmed start is `//`, `*` or `/*`) leaves the BODY of an ordinary block comment
+ * intact, because continuation lines are only conventionally prefixed with `*` —
+ * nothing enforces it, and "toggle block comment" over a declaration produces none.
+ * So this stayed GREEN:
+ *
+ *     /* <a guarded declaration, commented out during a rename>
+ *
+ * which is the same vacuity the line filter was written to close, one comment syntax
+ * over — a guard satisfied by prose describing the very rename it exists to catch.
+ *
+ * Honest bound: a STRING LITERAL whose content begins a line with `export type <a
+ * guarded name>` still satisfies the caller's pattern. Not constructible against
+ * today's module, and the fixtures below pin the shapes that are.
+ */
 function withoutComments(source: string): string {
   return source
+    .replace(/\/\*[\s\S]*?\*\//g, "")
     .split("\n")
-    .filter((line) => {
-      const t = line.trimStart();
-      return !t.startsWith("//") && !t.startsWith("*") && !t.startsWith("/*");
-    })
+    .filter((line) => !line.trimStart().startsWith("//"))
     .join("\n");
+}
+
+/**
+ * Is `name` exported from `source`? Hoisted out of the test so it can be DRIVEN BY
+ * FIXTURES rather than only by the real module.
+ *
+ * ⚠️ **Hoisting is the fix for a measured hole: the machinery that closes the
+ * rename check had no falsifier of its own.** Replacing {@link withoutComments} with
+ * the identity function, or dropping the `^`/`m` anchor, each left the whole suite
+ * GREEN — so the previous round's fix was protected by nothing and its blind spot
+ * (block comments) shipped undetected. The fixture block below is what makes both
+ * deletions RED.
+ */
+function isExported(source: string, name: string): boolean {
+  const stripped = withoutComments(source);
+  const declared = new RegExp(`^export (?:declare )?(?:type|interface|class) ${name}\\b`, "m");
+  // A barrel re-export is a legal refactor for a 2,300-line module and must not RED.
+  // ⚠️ The negative lookahead matters: `export type { X as V2 }` means X is NO LONGER
+  // exported under that spelling, which is precisely the rename this check exists to
+  // catch — without it the widening swallowed its own subject.
+  const reExported = new RegExp(`^export (?:type )?\\{[^}]*\\b${name}\\b(?!\\s+as\\b)`, "m");
+  return declared.test(stripped) || reExported.test(stripped);
 }
 
 describe("the SQL-gate name allowlist (#5042, #5230, #5249)", () => {
@@ -336,22 +416,27 @@ describe("the SQL-gate name allowlist (#5042, #5230, #5249)", () => {
       `the defining module moved: ${DEFINING_MODULE}. Update DEFINING_MODULE — a bare ` +
         `ENOENT below would be this assertion's job done badly.`,
     ).toBe(true);
-    // Belt and braces on the tuple: the same claim, where a reader looks for it.
+    // ⚠️ Under `bun test` the tuple contributes NOTHING — the runner strips types
+    // without checking them, so this assertion is the only live mechanism here and
+    // the tuple is the only one in `bun run type`. Two gates, two mechanisms, neither
+    // redundant. This is not belt and braces.
     expect(GUARDED_NAMES.length, "a guarded name left the array; the scan silently narrowed").toBe(
       5,
     );
+    // ⚠️ ARITY IS NOT IDENTITY, and the gap was measured. Substituting one name for a
+    // COPY of another keeps the length at 5, keeps both spellings real exports, and
+    // shrinks the positive-control loop along with the matcher — the whole suite
+    // stayed GREEN while `NAME_RE` silently lost an alternative. The runner arm, which
+    // has no instances in the tree, is exactly the one a copy-paste clobbers.
+    expect(
+      new Set(GUARDED_NAMES).size,
+      "two fragments assemble the same name — an arm left the matcher without shortening it",
+    ).toBe(GUARDED_NAMES.length);
 
-    // ⚠️ Comments are stripped and the pattern is line-ANCHORED. Unanchored, a
-    // `// export type <name> was renamed in #9999` note satisfied this check — the
-    // exact vacuity the test exists to refuse, satisfied by prose describing the
-    // rename. Measured.
-    const source = withoutComments(readFileSync(DEFINING_MODULE, "utf8"));
+    const source = readFileSync(DEFINING_MODULE, "utf8");
     for (const name of GUARDED_NAMES) {
-      const declared = new RegExp(`^export (?:declare )?(?:type|interface|class) ${name}\\b`, "m");
-      // A barrel re-export is a legal refactor for a 2,300-line module and must not RED.
-      const reExported = new RegExp(`^export (?:type )?\\{[^}]*\\b${name}\\b`, "m");
       expect(
-        declared.test(source) || reExported.test(source),
+        isExported(source, name),
         `${name} is no longer exported from lib/brain/warehouse-producer.ts. If it was ` +
           `renamed, update GUARDED_NAMES — the assembled fragments are invisible to the ` +
           `compiler, so a stale one silently matches nothing.`,
@@ -359,17 +444,53 @@ describe("the SQL-gate name allowlist (#5042, #5230, #5249)", () => {
     }
   });
 
-  test("every scanned root exists AND still yields its floor — narrowing must RED", () => {
+  test("the export check itself: prose must not satisfy it, a legal refactor must not RED it", () => {
+    // ⚠️ This block exists because the machinery above had NO falsifier. Replacing
+    // `withoutComments` with the identity function, or dropping its line anchor, each
+    // left the suite green — so the rename check was protected by nothing, and that is
+    // how the block-comment hole below shipped in the first place.
+    const N = "SnapshotSql" + "Validator";
+    // The real shape, which must pass.
+    expect(isExported(`export type ${N} = (r: R) => V;`, N)).toBe(true);
+    // A barrel re-export is legal and must pass, including multi-line.
+    expect(isExported(`export type {\n  Other,\n  ${N},\n} from "./split";`, N)).toBe(true);
+    // ⚠️ ...but a re-export that RENAMES it away is the rename, not an export of it.
+    expect(isExported(`export type { ${N} as ${N}V2 } from "./split";`, N)).toBe(false);
+    // Prose must not satisfy it — the line form the previous round closed...
+    expect(isExported(`// export type ${N} = ... renamed in #9999`, N)).toBe(false);
+    // ...the JSDoc form...
+    expect(isExported(`/**\n * export type ${N} = (r: R) => V;\n */`, N)).toBe(false);
+    // ...and the plain BLOCK form, whose body lines carry no `*` prefix. This is the
+    // one a line-shape filter misses, and it is what "comment out the old declaration
+    // during a rename" actually produces.
+    expect(isExported(`/*\nexport type ${N} = (r: R) => V;\n*/`, N)).toBe(false);
+    // A block comment opened mid-line, same reason.
+    expect(isExported(`export type ${N}V2 = X; /* was:\nexport type ${N} = Y;\n*/`, N)).toBe(false);
+    // The anchor: an indented match is not a top-level export.
+    expect(isExported(`  export type ${N} = X;`, N)).toBe(false);
+  });
+
+  test("every scanned root exists, reaches its sentinel, and still yields its floor", () => {
     // ⚠️ Asserted rather than filtered. `existsSync`-and-skip would turn a renamed
-    // directory into a silently smaller scan that still passes. The floor is the same
-    // discipline one level down: a root repointed at a real subdirectory exists, and
-    // without a volume check its narrowing is invisible.
-    for (const { dir, label, minFiles } of ROOTS) {
+    // directory into a silently smaller scan that still passes.
+    expect(ROOTS.length, "a root left the list; the scan silently stopped covering it").toBe(3);
+    for (const { dir, label, minFiles, sentinel } of ROOTS) {
       const name = label || "packages/api/src/";
       expect(existsSync(dir), `scan root missing: ${name} (${dir})`).toBe(true);
+      const files = [...walk(dir)];
+      // ⚠️ The sentinel, not the floor, is what answers "is this the right directory".
+      // Two of the three floors were measured passable by repointing a root at its own
+      // largest child; a reached-file check cannot be satisfied that way, and it also
+      // catches narrowing introduced inside `walk` itself.
       expect(
-        [...walk(dir)].length,
-        `scan root ${name} yielded fewer than ${minFiles} files — repointed at a subdirectory?`,
+        files,
+        `scan root ${name} no longer reaches ${sentinel} — repointed, or did walk() narrow?`,
+      ).toContain(join(dir, sentinel));
+      expect(
+        files.length,
+        `scan root ${name} yielded fewer than ${minFiles} files. Either it was repointed at a ` +
+          `subdirectory, or the package genuinely shrank — establish which before lowering ` +
+          `this floor; the sentinel above distinguishes them.`,
       ).toBeGreaterThan(minFiles);
     }
   });
@@ -395,34 +516,54 @@ describe("the SQL-gate name allowlist (#5042, #5230, #5249)", () => {
     ).toEqual(NAME_ALLOWLIST.map((b) => b.file).toSorted());
   });
 
-  test("the allowlist's kinds are counted, so a bypass cannot arrive dressed as an annotation", () => {
-    // ⚠️ The number, not just the field. #5249 widened what an entry means, and the
-    // failure mode it introduces is a real mint added as `kind: "annotation"` because
-    // that is the quieter word. Pinning the count makes adding a bypass a visible edit
-    // to a line a reviewer is looking at.
+  test("the allowlist's kinds are counted, so adding a bypass is a visible edit", () => {
+    // ⚠️ The NAME of this test used to promise that a bypass "cannot arrive dressed as
+    // an annotation". Counting cannot give that: a mislabeller edits the entry and the
+    // expected count in one hunk, and both are green. What counting DOES give is that
+    // the edit is visible to a reviewer — which is worth having, and is all this
+    // claims. The property the old name promised is held by the two checks below.
     const byKind: Record<AllowlistKind, number> = { bypass: 0, annotation: 0 };
     for (const entry of NAME_ALLOWLIST) byKind[entry.kind]++;
     expect(byKind).toEqual(EXPECTED_BY_KIND);
   });
 
-  test("every kind:'bypass' entry really contains an assertion — the claim is checked, not believed", () => {
-    // ⚠️ This restores a property #5249 removed. Under the old line-keyed matcher,
-    // deleting a cast while leaving its entry RED-ed the suite; a name scan cannot see
-    // that, so an entry could over-claim forever. Non-vacuous today: all four match.
+  test("every kind is CHECKED against the tree, in both directions", () => {
+    // ⚠️ The bypass arm restores a property #5249 removed: under the old line-keyed
+    // matcher, deleting a cast while leaving its entry RED-ed the suite; a name scan
+    // cannot see that, so an entry could over-claim forever.
     //
-    // Honest limit, stated because the arm is one-directional: this uses the LEGACY
-    // matcher, so a bypass written in one of the escape forms would read as an
-    // annotation here. It does not make `kind` sound; it makes the common case
-    // falsifiable and restores the deleted-cast-REDs property.
+    // ⚠️ The annotation arm is the one the header's own threat model asks for — "a
+    // real mint added as kind:'annotation' because that is the quieter word" — and it
+    // was missing, so that exact edit passed everything. It is VACUOUS TODAY (zero
+    // annotations) and load-bearing the moment the first one lands, which is the case
+    // #5249's widening was written to invite. Do not delete it as dead.
+    //
+    // ⚠️ Both read through `withoutComments`. Reading raw source reproduced, in the
+    // check added to fix it, the same prose vacuity the export check above was fixed
+    // for: a comment narrating a cast satisfied the bypass arm after the cast itself
+    // was gone.
+    //
+    // Honest limit: this uses the LEGACY matcher, so a bypass written in one of the
+    // escape spellings reads as an annotation. It does not make `kind` sound; it makes
+    // the common case falsifiable in both directions.
     const bypasses = NAME_ALLOWLIST.filter((e) => e.kind === "bypass");
-    expect(bypasses.length, "no bypass entries — this test would be vacuous").toBeGreaterThan(0);
+    expect(bypasses.length, "no bypass entries — the arm below would be vacuous").toBeGreaterThan(
+      0,
+    );
     for (const entry of bypasses) {
       expect(
-        LEGACY_AS_ADJACENT_RE.test(readFileSync(join(SRC_ROOT, entry.file), "utf8")),
+        LEGACY_AS_ADJACENT_RE.test(withoutComments(readFileSync(resolveEntry(entry.file), "utf8"))),
         `${entry.file} is listed kind "bypass" but contains no assertion form. If its cast ` +
           `was removed, demote it to "annotation" (and move the count); do not leave a stale ` +
           `over-claim in the list.`,
       ).toBe(true);
+    }
+    for (const entry of NAME_ALLOWLIST.filter((e) => e.kind === "annotation")) {
+      expect(
+        LEGACY_AS_ADJACENT_RE.test(withoutComments(readFileSync(resolveEntry(entry.file), "utf8"))),
+        `${entry.file} is listed kind "annotation" but contains an assertion form — it is a ` +
+          `bypass. Argue it as one rather than filing it under the quieter word.`,
+      ).toBe(false);
     }
   });
 
@@ -481,8 +622,9 @@ describe("the SQL-gate name allowlist (#5042, #5230, #5249)", () => {
     // ⚠️ Read this for what it is: it proves the word boundaries hold in BOTH the
     // assertion and the annotation context, for each name. It CANNOT detect a name
     // leaving GUARDED_NAMES — matcher and loop derive from the same array, so they
-    // shrink together. The tuple type closes that; an earlier draft claimed this loop
-    // did, and that claim was measured false.
+    // shrink together. An earlier draft claimed this loop did, and that was measured
+    // false. Deletion is closed by the tuple and the length assert; SUBSTITUTION by
+    // the distinctness assert — two different mechanisms, neither of them this loop.
     for (const name of GUARDED_NAMES) {
       expect(NAME_RE.test(`const v = x as ${name};`), `boundary failed for ${name}`).toBe(true);
       // ⚠️ And the whole point of #5249: the same name with no assertion at all.

--- a/packages/api/src/lib/brain/__tests__/warehouse-producer-bypass.test.ts
+++ b/packages/api/src/lib/brain/__tests__/warehouse-producer-bypass.test.ts
@@ -1,5 +1,6 @@
 /**
- * The SQL-gate bypass set (#5042, re-pointed at #5230's spelling).
+ * The SQL-gate name allowlist (#5042, re-pointed at #5230's spelling, widened to
+ * whole-file name occurrence by #5249).
  *
  * ## WHY THIS FILE EXISTS
  *
@@ -10,43 +11,87 @@
  * grepping for the assertion is the whole list of places the gate is bypassed. An
  * assertion is greppable; nothing fails when a fifth one appears.
  *
+ * ## WHAT AN ENTRY MEANS — read this before adding one
+ *
+ * **An entry names a file that may MENTION a guarded name. It does not certify that
+ * the file bypasses anything, and it no longer certifies that the file asserts.**
+ * That is #5249's change and it is a real widening: before, an entry meant *"this
+ * line may cast"*; now it means *"this file may say the word"*.
+ *
+ * The consequence is that a module which only ANNOTATES — `let v: <a guarded name>`,
+ * a re-export, an import — has to be listed too, even though an annotation asserts
+ * nothing and is safe. The allowlist therefore grows for reasons that are not
+ * bypasses, and a flat list would quietly stop distinguishing the two. So it does not
+ * stay flat: every entry carries a {@link AllowlistKind}, and the count of each is
+ * asserted below. A reviewer reading the list can still see *"four bypasses, zero
+ * annotations"* rather than *"five files, unknown mix"*.
+ *
+ * **When you add an entry, pick the kind honestly.** `"bypass"` is the one that has
+ * to be argued: a production module minting a passing verdict is a second door onto
+ * an unvalidated statement reaching a customer's datasource. `"annotation"` is
+ * ordinarily fine and still has to be visible.
+ *
+ * ## WHY WHOLE-FILE, and what it bought
+ *
+ * The previous matcher keyed on the cast's own line — the keyword and a guarded name
+ * on one physical line. Three spellings walked past it, **all three measured against
+ * the repo's own checker (they compile) and against both matchers (the old one misses
+ * each, this one catches each)**. The measurement is not described here, it is
+ * executed: see the delta table in the "escapes closed by #5249" test below, which
+ * runs {@link LEGACY_AS_ADJACENT_RE} beside {@link NAME_RE} on each spelling.
+ *
+ * - a local type ALIAS, then the assertion through the alias
+ * - the ANGLE-BRACKET assertion form
+ * - a LINE BREAK between the keyword and the name
+ *
+ * A fourth, listed as a live escape by the previous header, is closed by the same
+ * move: an import that renames a guarded type OUT to another local name still spells
+ * the guarded name at the import site.
+ *
  * ## FIVE names, because #5230 moved the brand onto the REQUEST
  *
- * The passing verdict now carries the request it validated, and that request is
- * what is branded — which is how replay (a cached token for some other statement)
- * and ordering (a runner reachable with an unvalidated request) got closed. A bypass
- * can therefore be spelled five ways, and {@link BYPASS_RE} matches all of them: an
- * assertion naming the branded REQUEST type (what a mint ordinarily writes), the
- * VERDICT union, the VALIDATOR seam type, the DEPS interface that holds it, or the
- * RUNNER type whose parameter is the branded request.
+ * The passing verdict carries the request it validated, and that request is what is
+ * branded — which is how replay (a cached token for some other statement) and
+ * ordering (a runner reachable with an unvalidated request) got closed. A bypass can
+ * be spelled five ways: the branded REQUEST type, the VERDICT union, the VALIDATOR
+ * seam type, the DEPS interface that holds it, or the RUNNER type whose parameter is
+ * the branded request.
  *
- * ⚠️ **All five have to be matched, and the reason is one property of the brand.**
- * It only ADDS a field, so a branded request is assignable to a bare one, and `as`
- * succeeds whenever EITHER direction is comparable — the reverse direction carries
- * every seam name. Refused only where the reverse direction also fails: a NULLARY
- * mint (a 1-parameter function type is not assignable to a 0-parameter one), or a
- * literal with an excess property. `as const` on `valid` does not close it. Measured
- * against the repo's own checker, because the two obvious explanations for this were
- * both wrong. Such a validator returns its own argument, so the run loop's identity
- * check waves it through: the gate never ran and nothing downstream can tell.
+ * ⚠️ **All five have to be listed, and the reason is one property of the brand.** It
+ * only ADDS a field, so a branded request is assignable to a bare one, and the
+ * assertion succeeds whenever EITHER direction is comparable — the reverse direction
+ * carries every seam name. Refused only where the reverse direction also fails: a
+ * NULLARY mint (a 1-parameter function type is not assignable to a 0-parameter one),
+ * or a literal with an excess property. Such a validator returns its own argument, so
+ * the run loop's identity check waves it through: the gate never ran and nothing
+ * downstream can tell.
  *
- * ⚠️ **The pattern is not written out in this file's prose, and that is the point
- * rather than fastidiousness.** A lexical guard cannot tell a quotation from an
- * assertion, so a docstring spelling the forbidden cast puts the guard's own file
- * in its own result set — which it did, on the first run. The repo's answer is
- * reword, never exempt: an exemption is a hole shaped exactly like the thing being
- * guarded, and the next real instance gets written inside it. The exact spelling
- * lives in {@link BYPASS_RE} below, where a reader can still see it and the scan
- * cannot trip over it.
+ * ## The names are ASSEMBLED, and that is load-bearing twice
  *
- * ## What a new entry means
+ * A lexical guard cannot tell a quotation from an assertion. Under the old
+ * line-keyed matcher this file stayed out of its own result set by describing
+ * spellings in prose instead of writing them; under a whole-file name scan that is no
+ * longer enough, because **the matcher's own definition would spell all five names
+ * and put this file into its own results.** Measured: it does.
  *
- * Not automatically a bug. A suite that must bypass the real gate has a legitimate
- * reason — the gate's table check is workspace-whitelist-scoped, and a test schema
- * has no whitelist — which is why three of the four sites are test harnesses. What
- * it must not be is INVISIBLE: a production module minting a passing verdict is a
- * second door onto an unvalidated statement reaching a customer's datasource, and
- * that is the event that has to be argued rather than merged.
+ * The repo's answer is reword, never exempt — an exemption is a hole shaped exactly
+ * like the thing being guarded. So {@link GUARDED_NAMES} assembles each name from
+ * fragments and {@link NAME_RE} is built at runtime. No contiguous guarded name
+ * appears in this file's source, so it needs no entry, and **a real assertion written
+ * into this file would still spell a name contiguously and would still RED.**
+ *
+ * ⚠️ **Assembly introduces its own silent-failure mode, and it is the dangerous
+ * kind: a rename makes the guard VACUOUS rather than red.** If someone renames the
+ * VERDICT union, the fragments stop matching anything, the scan finds nothing, and
+ * the allowlist assertion fails loudly only because the four real files stop matching
+ * too — but a rename of a name with no instances (the runner, today) would go green
+ * forever. That is why the first test below reads `warehouse-producer.ts` and asserts
+ * every assembled name is really exported there.
+ *
+ * ⚠️ This paragraph names the types by ROLE rather than spelling them, and that is
+ * the rule for every comment added to this file from now on. The first draft of
+ * #5249's header spelled one — the suite RED-ed on its own file, immediately, which
+ * is the guard working.
  *
  * ## What this does NOT prove
  *
@@ -55,22 +100,19 @@
  * spread of the refusing arm, `unknown`, and the identity form of generic-inference
  * laundering are all REFUSED by the COMPILER.
  *
- * ⚠️ **What this scan holds is a different question, and conflating the two is how
- * this header has been wrong twice.** What it holds is exactly: *an assertion that
- * puts the keyword and one of the five names on ONE PHYSICAL LINE.* So it DOES catch
- * a double assertion through `unknown` written on one line. What genuinely escapes:
- * an angle-bracket assertion; a local type alias (including one aliasing an indexed
- * lookup of the runner's parameter); an import that renames one of these types OUT
- * to another local name; a line break between keyword and name, since the character
- * class below bars a newline; and `any`-typed wiring or a `Partial<T>`-shaped
- * generic builder, which need no assertion at all. The list is not exhaustive and
- * cannot be — read a green run as *"no new file names one"*, nothing more.
+ * ⚠️ **What this scan holds is exactly: no unlisted file under the scanned roots
+ * SPELLS one of the five names.** What still escapes is everything that reaches the
+ * type without naming it — `any`-typed wiring, a `Partial<T>`-shaped generic builder,
+ * or an indexed-access lookup routed through a VALUE rather than the type
+ * (`Parameters<typeof someRunner>[0]`). Those need no assertion and name nothing; the
+ * negative controls below pin that limit rather than leave it to prose. The list is
+ * not exhaustive and cannot be — read a green run as *"no new file names one"*,
+ * nothing more.
  *
  * It also does not pin the ANTI-REPLAY half. A mint listed below hands back a token
- * for the request it was given; a mint that hands back a token for some OTHER
- * request is a source-identical line this scan cannot tell apart, and it is the run
- * loop's identity check that refuses it. `warehouse-producer.test.ts` drives that
- * refusal.
+ * for the request it was given; a mint that hands back a token for some OTHER request
+ * is a source-identical line this scan cannot tell apart, and it is the run loop's
+ * identity check that refuses it. `warehouse-producer.test.ts` drives that refusal.
  *
  * A source-text test, and it says so: it proves what the tree CONTAINS, never what
  * runs.
@@ -89,17 +131,16 @@ const SRC_ROOT = new URL("../../../", import.meta.url).pathname;
 /**
  * Every root that can hold a mint — three of them, not decoration.
  *
- * ⚠️ All five matched names are EXPORTED, and both `ee/` and `packages/cli/` import
+ * ⚠️ All five guarded names are EXPORTED, and both `ee/` and `packages/cli/` import
  * `@atlas/api/*` freely: only the api→ee direction is gated. A scan of this package
  * alone proved a claim strictly narrower than the one the failure message made, so a
  * mint added under either would sit outside the enumeration while the guard stayed
- * green — the same silent-empty shape {@link BYPASS_RE}'s own note is written to
- * prevent, one axis over. `packages/cli/` is the concrete case: it already imports
+ * green. `packages/cli/` is the concrete case: it already imports
  * `@atlas/api/lib/db/*` and `@atlas/api/lib/semantic/*`, so an `atlas brain produce`
  * command is a plausible sixth site.
  *
  * ⚠️ **The roots are NAMED in the failure message too.** An enumeration is only as
- * honest as its scope, and the previous message asserted a tree-wide claim over one
+ * honest as its scope, and a previous message asserted a tree-wide claim over one
  * directory. If a root is added here, add it there.
  */
 const ROOTS: readonly { readonly dir: string; readonly label: string }[] = [
@@ -112,72 +153,92 @@ const ROOTS: readonly { readonly dir: string; readonly label: string }[] = [
 ];
 
 /**
- * Every site that MAY ASSERT one of the guarded names, with why.
+ * The module that defines all five names — read, not imported, so the assembled
+ * fragments can be checked against the real exports.
+ */
+const DEFINING_MODULE = join(SRC_ROOT, "lib/brain/warehouse-producer.ts");
+
+/**
+ * The five guarded names, ASSEMBLED so no contiguous spelling appears in this file.
+ * See the header: writing them whole would put this file into its own result set.
  *
- * ⚠️ "May assert", not "does bypass" — and the difference is real now that five
- * names are matched. A deps assertion carrying no `validateSnapshotSql`, or a
- * validator assertion returning only the refusing arm, bypasses nothing and still
- * belongs here. An entry is a place to LOOK, not a finding.
+ * The split points are arbitrary and only have to prevent a contiguous literal.
+ */
+const GUARDED_NAMES: readonly string[] = [
+  "Validated" + "SnapshotRequest",
+  "Snapshot" + "SqlVerdict",
+  "SnapshotSql" + "Validator",
+  "WarehouseProducer" + "Deps",
+  "WarehouseSnapshot" + "Runner",
+];
+
+/**
+ * #5249's matcher: does the file MENTION a guarded name at all?
+ *
+ * No keyword, no line discipline, no character class — the widening is the whole
+ * change, and it is what closes the alias, angle-bracket and line-break spellings in
+ * one move rather than three.
+ */
+const NAME_RE = new RegExp(`\\b(?:${GUARDED_NAMES.join("|")})\\b`);
+
+/**
+ * The matcher #5249 REPLACED, kept only so the behaviour delta is executable.
+ *
+ * ⚠️ This is not live — nothing scans the tree with it. It exists so the test below
+ * can assert, on each escape spelling, that the old matcher MISSED it and the new one
+ * CATCHES it. A delta described in prose drifts; a delta that runs cannot. Built from
+ * the same assembled fragments, for the same self-match reason as {@link NAME_RE}.
+ */
+const LEGACY_AS_ADJACENT_RE = new RegExp(
+  `\\bas\\b[^;=\\n]*\\b(?:${GUARDED_NAMES.join("|")})\\b`,
+);
+
+/** What an allowlist entry certifies. See the header — the distinction is the cost of #5249. */
+type AllowlistKind =
+  /** The file mints or asserts a passing verdict. This is the one to argue. */
+  | "bypass"
+  /** The file only names the type — annotation, import, re-export. Safe, still visible. */
+  | "annotation";
+
+/**
+ * Every file that MAY NAME one of the guarded types, with which kind and why.
+ *
+ * ⚠️ "May name", not "does bypass" — see the header. An entry is a place to LOOK,
+ * not a finding.
  *
  * ⚠️ ONE production entry, deliberately. It is the single point where the product's
- * gate answering yes becomes a value the run will act on. Measured: the module
- * matches on that cast's line alone — no prose line in it puts the keyword and a
- * matched name together — so deleting the cast without deleting this entry REDS the
- * test. Deleting both together is silent; an entry is a claim about the tree, not a
- * lock on the file.
+ * gate answering yes becomes a value the run will act on.
+ *
+ * ⚠️ This file is deliberately ABSENT, and that is not an exemption. It names none
+ * of the five contiguously — {@link GUARDED_NAMES} assembles them — so the scan does
+ * not find it. A real assertion written here would spell a name and would RED.
  */
-const KNOWN_BYPASSES: readonly { file: string; why: string }[] = [
+const NAME_ALLOWLIST: readonly {
+  readonly file: string;
+  readonly kind: AllowlistKind;
+  readonly why: string;
+}[] = [
   {
     file: "lib/brain/warehouse-producer.ts",
-    why: "the production mint — `defaultValidateSnapshotSql`, wrapping the real `validateSQL`",
+    kind: "bypass",
+    why: "the production mint — `defaultValidateSnapshotSql`, wrapping the real `validateSQL`; also where all five names are DEFINED",
   },
   {
     file: "lib/brain/__tests__/warehouse-producer.test.ts",
+    kind: "bypass",
     why: "the unit harness: no whitelist exists in a test workspace, so the real gate refuses every table",
   },
   {
     file: "lib/brain/__tests__/warehouse-producer-pg.test.ts",
+    kind: "bypass",
     why: "the -pg harness, for the same reason; its subject is the storage layer, not the gate",
   },
   {
     file: "lib/brain/__tests__/warehouse-producer-logging.test.ts",
+    kind: "bypass",
     why: "the logging harness, for the same reason",
   },
 ];
-
-/**
- * The cast that asserts a pass, however it is spelled.
- *
- * ⚠️ **`[^;=\n]*` between the keyword and the name, not `\s+`, and the difference
- * was measured rather than reasoned.** The first version required them adjacent, so
- * a QUALIFIED reference — the `as` keyword followed by an inline `import(…)` type
- * and only then the name, which is what a file that has not imported the type
- * writes — walked straight past it. A guard that reports an empty set is
- * indistinguishable from one with nothing to find, which is the way this kind of
- * test fails silently. (The spelling is not written out here for the header's
- * reason; the second positive control below constructs it.)
- *
- * The class excludes `;`, `=` and a newline so the match stays inside one type
- * position rather than spanning statements. The regex is also the canonical
- * spelling of the pattern: writing it out in prose would put this file into its own
- * result set, which is why the header describes it instead.
- *
- * ⚠️ **FIVE alternatives (#5230), and the header says why each is load-bearing.**
- * Only the first has instances in the tree today; the other four are pinned by the
- * planted controls below, which is deliberate — a matcher whose arms are exercised
- * only by real instances loses the arm the moment the tree stops containing one, and
- * these four exist precisely for the mint nobody has written yet.
- *
- * ⚠️ A single-line import that renames some OTHER binding INTO one of these names
- * matches — a false positive rather than a hole, since it fails loudly and the fix
- * is to rename the local. An import that renames one of these types OUT to a
- * different local name does NOT match, and that direction is a real escape, listed
- * with the others in the header. Neither spelling is written out here: writing one
- * put THIS FILE into its own result set on the first run, which is the quotation
- * trap arriving exactly where the header says it does.
- */
-const BYPASS_RE =
-  /\bas\b[^;=\n]*\b(?:ValidatedSnapshotRequest|SnapshotSqlVerdict|SnapshotSqlValidator|WarehouseProducerDeps|WarehouseSnapshotRunner)\b/;
 
 function* walk(dir: string): Generator<string> {
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
@@ -191,7 +252,23 @@ function* walk(dir: string): Generator<string> {
   }
 }
 
-describe("the SQL-gate bypass set (#5042, #5230)", () => {
+describe("the SQL-gate name allowlist (#5042, #5230, #5249)", () => {
+  test("every assembled name is really exported — a rename must RED, not go vacuous", () => {
+    // ⚠️ The one test that assembly makes mandatory. Fragments cannot be checked by
+    // the compiler, so nothing but this read connects them to the real exports.
+    // Without it, renaming a guarded type with no instances in the tree leaves a
+    // matcher that can never match and a suite that is green forever.
+    const source = readFileSync(DEFINING_MODULE, "utf8");
+    for (const name of GUARDED_NAMES) {
+      expect(
+        new RegExp(`export (?:type|interface) ${name}\\b`).test(source),
+        `${name} is no longer exported from lib/brain/warehouse-producer.ts. If it was ` +
+          `renamed, update GUARDED_NAMES — the assembled fragments are invisible to the ` +
+          `compiler, so a stale one silently matches nothing.`,
+      ).toBe(true);
+    }
+  });
+
   test("every scanned root exists — a moved path must RED, not shrink the scan", () => {
     // ⚠️ Asserted rather than filtered. `existsSync`-and-skip would turn a renamed
     // directory into a silently smaller scan that still passes, which is the exact
@@ -203,85 +280,102 @@ describe("the SQL-gate bypass set (#5042, #5230)", () => {
     }
   });
 
-  test("exactly the known sites assert a passing SQL verdict", () => {
+  test("exactly the allowlisted files name a guarded type", () => {
     const found: string[] = [];
     for (const { dir, label } of ROOTS) {
       for (const file of walk(dir)) {
-        if (BYPASS_RE.test(readFileSync(file, "utf8"))) {
+        if (NAME_RE.test(readFileSync(file, "utf8"))) {
           found.push(label + file.slice(dir.length));
         }
       }
     }
     expect(
       found.toSorted(),
-      "the set of places under packages/api/src, ee/src and packages/cli/src that can assert the SQL " +
-        "gate passed has changed. A new TEST harness is ordinarily fine — the real gate is " +
-        "whitelist-scoped and a test workspace has none — but a new PRODUCTION site is a second door " +
-        "onto an unvalidated statement reaching a customer's datasource, and it is the thing to argue " +
-        "rather than merge. Add it to KNOWN_BYPASSES with a reason, or remove the cast.",
-    ).toEqual(KNOWN_BYPASSES.map((b) => b.file).toSorted());
+      "the set of files under packages/api/src, ee/src and packages/cli/src that NAME one of " +
+        "the five guarded SQL-gate types has changed. Since #5249 an entry means 'may name', " +
+        "not 'may cast' — so a file that merely ANNOTATES one of these types lands here too, " +
+        "and that is expected: add it to NAME_ALLOWLIST with kind 'annotation'. A new " +
+        "PRODUCTION site that MINTS a passing verdict is kind 'bypass', and it is a second " +
+        "door onto an unvalidated statement reaching a customer's datasource — the thing to " +
+        "argue rather than merge.",
+    ).toEqual(NAME_ALLOWLIST.map((b) => b.file).toSorted());
   });
 
-  test("the positive control: the matcher finds a cast it is shown", () => {
-    // Without this, an over-narrow regex reports an empty set forever and the test
-    // above passes by finding nothing — the shape a guard test fails in silently.
-    // ASSEMBLED, never written whole — see the header. A literal here would put this
-    // file back in its own result set.
-    const planted = `const v = ({ valid: true, request: r }) as Snapshot${"SqlVerdict"};`;
-    expect(BYPASS_RE.test(planted)).toBe(true);
-    // The QUALIFIED spelling, which the first version of this matcher missed — a
-    // file that has not imported the type writes it this way.
-    const qualified = `const v = x as import("./warehouse-producer").Snapshot${"SqlVerdict"};`;
-    expect(BYPASS_RE.test(qualified)).toBe(true);
-    // #5230's spelling — the one the four sites listed ABOVE actually use. Without
-    // this arm the matcher could lose the request alternative entirely and every
-    // assertion here would still pass on the verdict one.
-    const branded = `const v = { valid: true, request: r as Validated${"SnapshotRequest"} };`;
-    expect(BYPASS_RE.test(branded)).toBe(true);
-    const brandedQualified = `const v = r as import("./warehouse-producer").Validated${"SnapshotRequest"};`;
-    expect(BYPASS_RE.test(brandedQualified)).toBe(true);
-    // The SEAM spellings, and these two are the reason the header's claim changed.
-    // A mint asserted onto the validator type — with a PARAMETER, which is the only
-    // useful shape — compiles, so the matcher has to see it. The tree contains no
-    // instance, so these controls are the arms' only coverage.
-    const seam = `const v = (async (r) => ({ valid: true, request: r })) as SnapshotSql${"Validator"};`;
-    expect(BYPASS_RE.test(seam)).toBe(true);
-    const deps = `const d = { validateSnapshotSql: mint } as WarehouseProducer${"Deps"};`;
-    expect(BYPASS_RE.test(deps)).toBe(true);
-    // The RUNNER type, the fifth name. Free today — the tree has zero assertions
-    // onto it — and it is the cheapest innocuous-looking uncaught mint, because its
-    // parameter IS the branded request.
-    const runner = `const run = ((r) => read(r)) as WarehouseSnapshot${"Runner"};`;
-    expect(BYPASS_RE.test(runner)).toBe(true);
-    // A DOUBLE assertion through `unknown`, on one line. A round-1 draft of the
-    // header listed this as escaping; it does not, and the control is here so the
-    // sentence cannot drift back.
-    const doubled = `const r = payload as unknown as Validated${"SnapshotRequest"};`;
-    expect(BYPASS_RE.test(doubled)).toBe(true);
-    // And negative controls, so the matcher is not simply true of everything:
-    // naming a TYPE is not asserting a pass.
-    expect(BYPASS_RE.test(`let v: Snapshot${"SqlVerdict"};`)).toBe(false);
-    expect(BYPASS_RE.test(`let r: Validated${"SnapshotRequest"};`)).toBe(false);
-    expect(BYPASS_RE.test(`const f: SnapshotSql${"Validator"} = realGate;`)).toBe(false);
-    expect(BYPASS_RE.test(`function run(d: WarehouseProducer${"Deps"}) {}`)).toBe(false);
-    // ⚠️ The two negatives above contain no `as` at all, so they are false for ANY
-    // matcher that requires the keyword — including one that has lost every name.
-    // They do not discriminate the arms they sit beside. This one does: a matched
-    // name with no `as` anywhere on the line, in a position no assertion can take.
-    expect(BYPASS_RE.test(`export type { SnapshotSql${"Validator"} };`)).toBe(false);
-    // ⚠️ And the honest cost, asserted rather than described: PROSE containing the
-    // word and a matched name on one line MATCHES. This is the quotation trap as a
-    // measurement — the guard cannot tell a sentence from an assertion, which is
-    // exactly why the header describes spellings instead of writing them out.
-    expect(
-      BYPASS_RE.test(`// as good a place as any to name SnapshotSql${"Validator"} in prose`),
-    ).toBe(true);
-    // ⚠️ A NEGATIVE control of legitimate PROSE, not only of legitimate code. Every
-    // positive above is hand-planted by the same author as the matcher, so they pass
-    // by construction; this is the arm that catches an over-broad one. The sentence
-    // below is the shape a docstring in this module actually writes.
-    expect(
-      BYPASS_RE.test(`// the runner is reachable only as a consequence of the gate passing`),
-    ).toBe(false);
+  test("the allowlist's kinds are counted, so a bypass cannot arrive dressed as an annotation", () => {
+    // ⚠️ The number, not just the field. #5249 widened what an entry means, and the
+    // failure mode it introduces is a real mint added as `kind: "annotation"` because
+    // that is the quieter word. Pinning the count makes adding a bypass a visible edit
+    // to this line, with the reviewer's attention on it.
+    const byKind = { bypass: 0, annotation: 0 };
+    for (const entry of NAME_ALLOWLIST) byKind[entry.kind]++;
+    expect(byKind).toEqual({ bypass: 4, annotation: 0 });
+    // Every entry says why, and the reason is not the empty string.
+    for (const entry of NAME_ALLOWLIST) expect(entry.why.length).toBeGreaterThan(20);
+  });
+
+  test("the escapes #5249 closed: old matcher MISSES each, new matcher CATCHES each", () => {
+    // ⚠️ The behaviour delta, executed rather than described. Each spelling below was
+    // also compiled against the repo's own checker while #5249 was written — all three
+    // typecheck, which is what made them escapes rather than curiosities.
+    //
+    // ASSEMBLED, never written whole — a contiguous name here would put this file into
+    // its own result set, which is the trap the header describes.
+    const V = "Snapshot" + "SqlVerdict";
+    const escapes: readonly { readonly label: string; readonly src: string }[] = [
+      {
+        label: "a local type alias, then the assertion through the alias",
+        src: `type V = ${V};\nconst v = ({ valid: true, request: r }) as V;`,
+      },
+      {
+        label: "the angle-bracket assertion form",
+        src: `const v = <${V}>({ valid: true, request: r });`,
+      },
+      {
+        label: "a line break between the keyword and the name",
+        src: `const v = ({ valid: true, request: r }) as\n  ${V};`,
+      },
+      {
+        label: "an import renaming a guarded type OUT to another local name",
+        src: `import type { ${V} as Ok } from "./warehouse-producer";`,
+      },
+    ];
+    for (const { label, src } of escapes) {
+      expect(LEGACY_AS_ADJACENT_RE.test(src), `legacy matcher should MISS: ${label}`).toBe(false);
+      expect(NAME_RE.test(src), `#5249 matcher should CATCH: ${label}`).toBe(true);
+    }
+  });
+
+  test("the positive control: the matcher finds every name it is shown", () => {
+    // Without this, an over-narrow matcher reports an empty set forever and the
+    // allowlist test above passes by finding nothing — the shape a guard test fails
+    // in silently. One arm per name, so losing a single alternative REDS.
+    for (const name of GUARDED_NAMES) {
+      expect(NAME_RE.test(`const v = x as ${name};`), `lost the arm for ${name}`).toBe(true);
+      // ⚠️ And the whole point of #5249: the same name with no assertion at all.
+      expect(NAME_RE.test(`let v: ${name};`), `annotation form missed for ${name}`).toBe(true);
+    }
+  });
+
+  test("the negative controls: what a name scan still cannot see", () => {
+    // ⚠️ These are the residual holes, pinned as assertions so the header's "what this
+    // does NOT prove" section cannot drift away from the truth. Each names none of the
+    // five, so each reaches the branded type — or claims to — without spelling it.
+    expect(NAME_RE.test(`const d: any = { validateSnapshotSql: mint };`)).toBe(false);
+    expect(NAME_RE.test(`type V = Parameters<typeof runProducerSnapshot>[0];`)).toBe(false);
+    expect(NAME_RE.test(`const v = buildPartial({ valid: true, request: r });`)).toBe(false);
+    // ⚠️ A DISCRIMINATING negative, not merely an absent one. A near-miss identifier
+    // that CONTAINS a guarded name as a prefix must not match — otherwise `\b` has
+    // been dropped and the matcher is a substring test, which would drag in every
+    // sibling type and make the allowlist unmaintainable.
+    expect(NAME_RE.test(`let v: Snapshot${"SqlVerdict"}ish;`)).toBe(false);
+    // The real sibling type this scan must stay clear of: the UNvalidated request is
+    // named all over the producer and is not one of the five.
+    expect(NAME_RE.test(`function run(r: WarehouseSnapshot${"Request"}) {}`)).toBe(false);
+    // ⚠️ And the honest cost of the widening, asserted rather than described: PROSE
+    // naming a guarded type now matches, where the old matcher needed the keyword too.
+    // This is the quotation trap as a measurement — it is why the names above are
+    // assembled, and why "reword, never exempt" is the only way to add a comment here
+    // that mentions one.
+    expect(NAME_RE.test(`// see Snapshot${"SqlVerdict"} for the passing arm`)).toBe(true);
   });
 });


### PR DESCRIPTION
Replaces the `as`-adjacency bypass matcher in `warehouse-producer-bypass.test.ts` with a whole-file name allowlist.

## The escapes

The old matcher keyed on the cast's own physical line. Three spellings compile and walk straight past it, and a fourth the previous header listed as a live escape is closed by the same move:

| spelling | legacy matcher | this matcher |
|---|---|---|
| local type alias, asserted through | misses | catches |
| angle-bracket assertion form | misses | catches |
| line break between keyword and name | misses | catches |
| import renaming a guarded type *out* to a local name | misses | catches |

That table is not prose — the replaced matcher is kept in the file, unused, so the delta **runs** as a test, with a positive anchor so a matcher that missed *everything* cannot satisfy it.

## What an entry means now — this is a real widening

An entry used to mean *"this line may cast"*. It now means *"this file may say the word"*. A module that only **annotates** has to be listed too, so the allowlist will grow for reasons that are not bypasses.

The issue asked whether that is acceptable or whether the categories need separating. **Separated:** every entry carries `kind: "bypass" | "annotation"`, the counts are pinned, and **both kinds are checked against the tree** rather than believed. Today the tree has zero annotation-only sites, so the list is unchanged at four files.

## Review curve — the rounds stopped on the ratio rule, not the cap

| round | findings | new surface | defect-in-prior-fix | agent wall-clock (parallel) |
|---|---|---|---|---|
| 1 | ~15 | ~15 | 0 | ~6.0 min |
| 2 | ~12 | ~2 | ~10 | ~10.3 min |
| comment sweep | 2 must-fix, 7 should-fix | — | — | ~9.4 min |

**Round 2 was almost entirely defects inside round 1's own fixes, so the rounds closed there** — per `/review-panel`, that ratio means another round manufactures more work than it removes. Everything confirmed is fixed; nothing was carried out of the loop unfixed. Minutes are the reviewers' own reported durations, not end-to-end session time.

The round-2 pattern was one mistake repeated: **each round-1 fix closed the reported instance and left the class open.**

| round-1 fix | class it left open (measured GREEN) |
|---|---|
| tuple pins arity | **substitution** — swap a name for a copy of another; arity still 5, matcher silently loses an arm |
| strip `//` comments | **`/* */` bodies** — continuation lines carry `*` only by convention |
| check `kind:"bypass"` | **`"annotation"` never checked** — the quieter word a mislabeller reaches for |
| `minFiles` floors | **only the one root I measured** — api (1612 vs 1000) and cli (35 vs 30) both passed a repoint |

Two findings are worth calling out because they are about the review itself:

- **The machinery that closed round 1 had no falsifier.** Replacing `withoutComments` with the identity function, or dropping the `^` anchor, each left the suite green — which is exactly how the block-comment hole shipped. The predicate is now hoisted to `isExported()` and driven by fixtures.
- **`fix-vs-finding` returned REPRODUCED.** I pinned `GUARDED_NAMES`' arity and left the adjacent `ROOTS` array with the identical defect — its floor test iterated the very list it validated, so deleting a root removed the scan *and* its own assertions. Same treatment applied.

## The self-match problem, and why this file has no entry

Under a name scan the matcher's own definition would spell all five names and land this file in its own result set. Measured: the first draft did, and the suite RED-ed on its own file on the first run. Per *reword, never exempt* there is no exemption — `GUARDED_NAMES` assembles each name from fragments. A genuine cast written here still spells a name contiguously and still REDs; that claim is executed by a falsifier, not asserted.

## Measured, not reasoned

#5234 shipped nine false claims about this matcher, two inverted. This PR's own comment sweep then caught two more, one of them inverted in the same dangerous direction — a sentinel paragraph claiming to catch `walk` narrowings it does not catch. Both were re-measured and rewritten to their real range.

**Seventeen falsifiers built and run across three commits, every one measured green beforehand:**

| round | mutation | result |
|---|---|---|
| 1 | matcher reverted to line-adjacency | RED |
| 1 | an assembled name detached from its export | RED |
| 1 | a mint relabelled `kind:"annotation"` | RED |
| 1 | word boundaries dropped | RED |
| 1 | a contiguous name planted in this file | RED |
| 1 | an allowlisted file removed | RED |
| 2 | delete `Validator` / `Deps` / `Runner` | RED ×3 |
| 3 | substitution (runner → duplicate of verdict) | RED |
| 3 | substitution **+ a real unlisted mint using the dropped arm** | RED |
| 3 | `withoutComments` → identity | RED |
| 3 | drop the `^`/`m` anchor | RED |
| 3 | drop the `(?!\s+as)` lookahead | RED |
| 3 | rename behind a plain block comment | RED |
| 3 | repoint api root at `src/lib` | RED |
| 3 | repoint cli root at `src/__tests__` | RED |
| 3 | delete the `ee` root from `ROOTS` | RED |
| 3 | a real mint filed as `kind:"annotation"` | RED |

Tuple deletion additionally verified as `TS2322`. All three escape forms confirmed to compile, with the compile probe itself falsified by a planted error to prove it was being checked. Mutated files restored byte-identical from backups; no stray fixtures left behind.

## Gates

`--affected` (1/1), `lint`, `type`, `lint:type-aware` all clean; remote CI green on the head SHA.

⚠️ **`check-mutation-tables.sh --affected` SKIPPED rather than passed locally** — `TEST_DATABASE_URL` unset, and it exits 0 either way, so it verified nothing. No mutation spec anchors on this suite (grep-checked; consistent with #5229, which exists because the producer has no spec yet). Remote CI runs it against a real Postgres and is green.

## Deliberately not done

The set-completeness direction — a **sixth** branded type exported and never added here — stays open. Closing it needs a tagging convention in production source, which is new machinery; per `/review-panel` Step 5a that defaults to a follow-up rather than being improvised in a review round. Same for widening the scanned roots beyond the three (`plugins/<name>/src`, `cli/bin`, `cli/lib`, `api/scripts`, `mcp/src` are knowingly unscanned; none names a guarded type today). Both are filed as #5255, and the header states the gap rather than hiding it.

## Acceptance criteria

- [x] Alias, angle-bracket and line-break escapes each caught, one falsifier each, measured red before and green after
- [x] Allowlist semantics stated in the fixture header: what an entry permits, and what a reader must do when adding one
- [x] Legitimate annotation sites handled deliberately — separated by `kind`, checked in both directions, with the choice argued
- [x] Every comment asserting compiler or regex behaviour was executed — twice over, after the sweep found two that were not

Closes #5249
