### PR TITLE
feat(brain): SQL digests on the snapshot mismatch log — a forgery no longer reads as a replay (#5248)

### DIFF
--- a/packages/api/src/lib/brain/__tests__/warehouse-producer-logging.test.ts
+++ b/packages/api/src/lib/brain/__tests__/warehouse-producer-logging.test.ts
@@ -196,13 +196,6 @@ const run = (over: Partial<Parameters<ProducerModule["runWarehouseProducer"]>[1]
 const messages = (sink: readonly Captured[]) => sink.map((c) => c.message);
 
 /**
- * The one line in `sink` whose message contains `fragment`, or a failure.
- *
- * Returns the PAYLOAD non-optionally, which is what keeps every assertion below
- * out of `x?.payload as T` — an optional chain there makes a missing line read as
- * `undefined` and quietly weakens whatever is asserted about it.
- */
-/**
  * The digest the mismatch line should carry, computed INDEPENDENTLY of the module
  * under test.
  *
@@ -214,6 +207,13 @@ const messages = (sink: readonly Captured[]) => sink.map((c) => c.message);
  */
 const digest = (sql: string) => createHash("sha256").update(sql).digest("hex").slice(0, 16);
 
+/**
+ * The one line in `sink` whose message contains `fragment`, or a failure.
+ *
+ * Returns the PAYLOAD non-optionally, which is what keeps every assertion below
+ * out of `x?.payload as T` — an optional chain there makes a missing line read as
+ * `undefined` and quietly weakens whatever is asserted about it.
+ */
 function payloadOf(sink: readonly Captured[], fragment: string): Record<string, unknown> {
   const hits = sink.filter((c) => c.message.includes(fragment));
   expect(hits, `expected exactly one log line containing "${fragment}"`).toHaveLength(1);
@@ -387,6 +387,13 @@ describe("warehouse producer logging", () => {
     // tenant's statement, and the second is the one that has to be greppable.
     expect(payload.returnedEntity).toBe("Impostor");
     expect(payload.returnedWorkspaceId).toBe("ws-other-tenant");
+    // ⚠️ The only case that ASSERTS `returnedEntityMatch` against a real,
+    // non-throwing, DIFFERENT string. Without this, `returnedEntityMatch` was satisfiable by
+    // `returnedEntity !== SEAM_THREW` — measured green — because every other case
+    // either matches by construction or threw, so the comparison was never tested
+    // against a genuine difference.
+    expect(payload.returnedEntityMatch).toBe(false);
+    expect(payload.returnedRequestMatch).toBe(false);
     expect(payload.requestId).toBe("req-1");
     // ABSENT from warn, not merely present in error — a demotion is how this line
     // stops being an incident while still being "logged".
@@ -467,8 +474,7 @@ describe("warehouse producer logging", () => {
     // BYTE-IDENTICAL statements — the ordinary outcome for tenants onboarded from one
     // connector template. A token minted against ANOTHER workspace's request therefore
     // arrives with `sqlDigestMatch: TRUE`. An operator alerting only on
-    // `sqlDigestMatch: false` — which the first cut of this arm's own comment told
-    // them to do — would never see it, while `defaultRunSnapshot` selects the pool
+    // `sqlDigestMatch: false` would never see it, while `defaultRunSnapshot` selects the pool
     // from the returned workspace and connection, i.e. the cross-tenant read the
     // capture note names as the residual.
     await run({
@@ -515,6 +521,61 @@ describe("warehouse producer logging", () => {
     // than one of them inventing a placeholder.
     expect(payload.connectionId).toBe("<undefined>");
     expect(payload.returnedConnectionId).toBe("<undefined>");
+    // ⚠️ **THE `true` DIRECTIONS, and nothing pinned them.** Hardcoding
+    // `returnedWorkspaceIdMatch: false` was measured green across all four warehouse
+    // suites — only the cross-tenant case asserted it, and only in the `false`
+    // direction. Stuck false, the alert those fields exist for fires on every benign
+    // replay too, which is the same "noise on its first day" outcome this case was
+    // written to prevent one field over.
+    expect(payload.returnedWorkspaceIdMatch).toBe(true);
+    expect(payload.returnedEntityMatch).toBe(true);
+    expect(payload.returnedRequestMatch).toBe(true);
+  });
+
+  it("compares the connection group itself, not just its absence (#5248)", async () => {
+    // ⚠️ `ACCOUNTS_YAML` names no `connection:`, so every other case in this file
+    // leaves the SUBMITTED side `undefined` and the comparison degenerates to "is the
+    // returned connection absent". Measured: replacing `submittedConnectionId` with a
+    // literal `undefined` stayed green across all four suites. A workspace whose
+    // entity DOES name a group is the population that breaks under that, and it is an
+    // ordinary workspace.
+    const GROUPED_YAML: Record<string, unknown> = { ...ACCOUNTS_YAML, connection: "grp-a" };
+
+    // (1) a benign replay from a grouped entity — the connection MATCHES.
+    await run({
+      loadEntity: async () => GROUPED_YAML,
+      validateSnapshotSql: async (request: WarehouseSnapshotRequest) => ({
+        valid: true as const,
+        request: { ...request } as ValidatedSnapshotRequest,
+      }),
+    });
+    const replay = payloadOf(errors, "verdict for a different request");
+    expect(replay.connectionId).toBe("grp-a");
+    expect(replay.returnedConnectionId).toBe("grp-a");
+    expect(replay.returnedConnectionIdMatch).toBe(true);
+    expect(replay.returnedRequestMatch).toBe(true);
+
+    errors.length = 0;
+
+    // (2) same workspace, same entity, same statement — a DIFFERENT connection group.
+    // This is the same-workspace wrong-datasource read: `defaultRunSnapshot` selects
+    // the pool from the returned connection, and nothing else on the line differs.
+    await run({
+      loadEntity: async () => GROUPED_YAML,
+      validateSnapshotSql: async (request: WarehouseSnapshotRequest) => ({
+        valid: true as const,
+        request: { ...request, connectionId: "grp-b" } as ValidatedSnapshotRequest,
+      }),
+    });
+    const crossGroup = payloadOf(errors, "verdict for a different request");
+    expect(crossGroup.returnedConnectionId).toBe("grp-b");
+    expect(crossGroup.returnedConnectionIdMatch).toBe(false);
+    // Everything else about the request matches — which is exactly what makes this
+    // the case the field was added for.
+    expect(crossGroup.sqlDigestMatch).toBe(true);
+    expect(crossGroup.returnedWorkspaceIdMatch).toBe(true);
+    expect(crossGroup.returnedEntityMatch).toBe(true);
+    expect(crossGroup.returnedRequestMatch).toBe(false);
   });
 
   it("fingerprints the statements and never carries one (#5248)", async () => {
@@ -603,14 +664,28 @@ describe("warehouse producer logging", () => {
     readonly label: string;
     readonly request: unknown;
     readonly expectedType: string;
+    /**
+     * ⚠️ `true` ONLY for the empty record, and that is the honest answer rather than
+     * a hole. Both sides are absent — the submitted connection is `undefined` for
+     * this default-connection fixture — so the comparison is literally satisfied.
+     * Demanding presence instead would report every benign default-connection replay
+     * as a connection mismatch. `returnedRequestMatch` is the field that separates
+     * them, and it is asserted `false` for every fixture here.
+     */
+    readonly expectedConnectionMatch: boolean;
   }[] = [
-    { label: "an object with no fields", request: {}, expectedType: "object" },
-    { label: "null", request: null, expectedType: "<null>" },
-    { label: "undefined", request: undefined, expectedType: "<undefined>" },
-    { label: "a string", request: "SELECT 1", expectedType: "SELECT 1" },
+    { label: "an object with no fields", request: {}, expectedType: "<record>", expectedConnectionMatch: true },
+    { label: "null", request: null, expectedType: "<null>", expectedConnectionMatch: false },
+    { label: "undefined", request: undefined, expectedType: "<undefined>", expectedConnectionMatch: false },
+    // ⚠️ The TYPE, never the content — see the privacy case below. An array is
+    // `<object>` rather than `<record>`, which is the one distinction `isRecord`'s
+    // `Array.isArray` clause carries and nothing else pinned.
+    { label: "a string", request: "SELECT 1", expectedType: "<string>", expectedConnectionMatch: false },
+    { label: "an array", request: [], expectedType: "<object>", expectedConnectionMatch: false },
+    { label: "a number", request: 42, expectedType: "<number>", expectedConnectionMatch: false },
   ];
 
-  for (const { label, request, expectedType } of MALFORMED_VERDICTS) {
+  for (const { label, request, expectedType, expectedConnectionMatch } of MALFORMED_VERDICTS) {
     it(`logs a mismatch rather than throwing when the verdict's request is ${label} (#5248)`, async () => {
       const report = await run({
         validateSnapshotSql: async () => ({
@@ -633,10 +708,24 @@ describe("warehouse producer logging", () => {
       expect(payload.returnedSqlDigest).toBe("<undefined>");
       expect(payload.sqlDigestMatch).toBe(false);
       expect(payload.returnedReadThrew).toBe(false);
-      // ⚠️ Which malformation it was. Without this field all four fixtures produce a
-      // byte-identical payload, so "the gate returned a string" and "the gate returned
-      // an object with no fields" — two different wiring faults — become one line.
+      // ⚠️ Which malformation it was. Without this field the non-record verdicts —
+      // null, undefined, a string, an array, a number — produce one identical payload
+      // of sentinels, so several different wiring faults become one line.
       expect(payload.returnedRequestType).toBe(expectedType);
+      // ⚠️ **THE MATCH BOOLEANS, on the fixtures where they used to LIE.** A match
+      // claim needs a readable container: `seamRead` answers `undefined` for an
+      // absent field and for a non-record alike, and the submitted connection is
+      // `undefined` for this default-connection fixture — so `returnedConnectionIdMatch`
+      // read TRUE for a verdict that carried no request at all. Measured on all four
+      // of these before the guard, and asserted on none of them, which is why it
+      // shipped green.
+      expect(payload.returnedConnectionIdMatch).toBe(expectedConnectionMatch);
+      expect(payload.returnedWorkspaceIdMatch).toBe(false);
+      expect(payload.returnedEntityMatch).toBe(false);
+      // ⚠️ The alert key, `false` on EVERY malformation including the empty record
+      // whose connection comparison is satisfied. This is the assertion that makes
+      // the per-field booleans safe to be diagnostic rather than authoritative.
+      expect(payload.returnedRequestMatch).toBe(false);
       // ...and the SUBMITTED side is unaffected, so the line still identifies the run.
       expect(payload.entity).toBe("Accounts");
       expect(payload.sqlDigest).toMatch(/^[0-9a-f]{16}$/);
@@ -644,13 +733,13 @@ describe("warehouse producer logging", () => {
   }
 
   it("logs <threw> rather than dying when a verdict's accessor THROWS (#5248)", async () => {
-    // ⚠️ **THE DEFECT THE FIRST CUT OF THIS FIX REPRODUCED, one property access over.**
-    // Narrowing the container closes a verdict that is the wrong SHAPE; it does
-    // nothing about one whose getter runs hostile code. `isRecord` is true for
-    // `{ get entity() { throw } }` and for a revoked Proxy (`typeof` still answers
-    // "object"), so the read itself escaped — measured, before `seamRead` existed, as
-    // the TypeError propagating out of `runWarehouseProducer`. A getter is not exotic
-    // here: the read-once case two above builds one.
+    // ⚠️ Narrowing the container closes a verdict that is the wrong SHAPE; it does
+    // nothing about one whose getter runs hostile code. `isRecord` answers true for
+    // `{ get entity() { throw } }` — the container IS the right shape and the read
+    // still escaped, measured before `seamRead` existed as the TypeError propagating
+    // out of `runWarehouseProducer`. A getter is not exotic here: the read-once case
+    // above builds one. (A revoked Proxy is a different failure — `isRecord` itself
+    // throws on one; see the revoked-Proxy case below.)
     let entityReads = 0;
     const report = await run({
       validateSnapshotSql: async (req: WarehouseSnapshotRequest) => {
@@ -684,6 +773,199 @@ describe("warehouse producer logging", () => {
     expect(payload.sqlDigestMatch).toBe(true);
   });
 
+  it("never lets an Error's message pose as a digest (#5248)", async () => {
+    // ⚠️ **A hole the closing round's own fix opened.** `seamString` renders an Error
+    // by its message, and `seamSqlDigest` used to route every non-string through it —
+    // so a verdict carrying `sql: new Error("<16 hex chars>")` put an ATTACKER-CHOSEN
+    // string in `returnedSqlDigest`, indistinguishable from a real digest, and equal
+    // to the submitted one if they copy it. `seamKind` brackets every non-string,
+    // which is what makes "nothing in this field can be mistaken for a digest" true
+    // rather than merely claimed.
+    let submitted = "";
+    await run({
+      validateSnapshotSql: async (request: WarehouseSnapshotRequest) => {
+        submitted = request.sql;
+        return {
+          valid: true as const,
+          request: {
+            ...request,
+            sql: new Error(digest(request.sql)),
+          } as unknown as ValidatedSnapshotRequest,
+        };
+      },
+    });
+
+    const payload = payloadOf(errors, "verdict for a different request");
+    expect(payload.sqlDigest).toBe(digest(submitted));
+    // The forgery's whole point: it chose a value equal to the submitted digest.
+    expect(payload.returnedSqlDigest).not.toBe(digest(submitted));
+    expect(payload.returnedSqlDigest).toBe("<record>");
+    expect(String(payload.returnedSqlDigest)).not.toMatch(/^[0-9a-f]{16}$/);
+    expect(payload.sqlDigestMatch).toBe(false);
+  });
+
+  it("never echoes a STRING verdict's content, only its type (#5248)", async () => {
+    // ⚠️ **A MEASURED PRIVACY HOLE, not a hypothetical.** `returnedRequestType` used
+    // to fall through to `seamString` for non-records, which echoes a string verbatim
+    // up to 200 characters. A validator that crosses a wire — or a serialising proxy
+    // — answers `JSON.stringify(request)`, and that is the whole SELECT with its
+    // table and column names, landing in the log two hundred lines below the
+    // docstring that says the statement is never an option. The privacy sweep below
+    // could not see it: its fixture returns an OBJECT, so the echo was in the wrong
+    // fixture rather than the wrong sink.
+    let submitted = "";
+    await run({
+      validateSnapshotSql: async (request: WarehouseSnapshotRequest) => {
+        submitted = request.sql;
+        return {
+          valid: true as const,
+          // The realistic hostile shape: the request, serialised.
+          request: JSON.stringify(request) as unknown as ValidatedSnapshotRequest,
+        };
+      },
+    });
+
+    const payload = payloadOf(errors, "verdict for a different request");
+    expect(submitted).toContain("lifecycle_status");
+    expect(payload.returnedRequestType).toBe("<string>");
+    const serialized = JSON.stringify([...errors, ...warns, ...infos, ...debugs]);
+    expect(serialized).not.toContain("lifecycle_status");
+    expect(serialized).not.toContain(submitted);
+  });
+
+  it("reports WHICH seam read threw, one key at a time (#5248)", async () => {
+    // ⚠️ Only two fixtures existed — `entity` throws, or everything throws — so three
+    // of `returnedReadThrew`'s five disjuncts were individually unfalsifiable (the
+    // fifth, a throwing `.request`, has its own case below):
+    // dropping the `sql` one, or the `workspaceId` + `connectionId` pair, was
+    // measured green. The contradiction that produces is a payload reading
+    // `returnedSqlDigest: "<threw>"` beside `returnedReadThrew: false`, on the field
+    // that identifies the forgery class.
+    const KEYS = ["entity", "workspaceId", "connectionId", "sql"] as const;
+    const FIELD: Record<(typeof KEYS)[number], string> = {
+      entity: "returnedEntity",
+      workspaceId: "returnedWorkspaceId",
+      connectionId: "returnedConnectionId",
+      sql: "returnedSqlDigest",
+    };
+
+    for (const key of KEYS) {
+      errors.length = 0;
+      const report = await run({
+        validateSnapshotSql: async (req: WarehouseSnapshotRequest) => {
+          const copy = { ...req } as Record<string, unknown>;
+          Object.defineProperty(copy, key, {
+            enumerable: true,
+            get() {
+              throw new TypeError(`hostile ${key}`);
+            },
+          });
+          return { valid: true as const, request: copy as unknown as ValidatedSnapshotRequest };
+        },
+      });
+      expect(report.refusals.map((r) => r.reason)).toEqual(["snapshot-failed"]);
+      const payload = payloadOf(errors, "verdict for a different request");
+      expect(payload.returnedReadThrew, `${key} should set returnedReadThrew`).toBe(true);
+      expect(payload[FIELD[key]], `${key} should render <threw>`).toBe("<threw>");
+    }
+  });
+
+  it("keeps the forensic line when the verdict's REQUEST getter throws (#5248)", async () => {
+    // ⚠️ **A hostile validator must not be able to choose the quiet arm.** Reading
+    // `verdict.request` unguarded inside the gate-call `try` sent this to the
+    // gate-threw arm: a `warn` reading "the SQL gate threw rather than answering",
+    // with no digests and no match booleans — so throwing from `.request` demoted a
+    // forgery to something that looks like a transient module-init blip. Detectability
+    // is this change's whole deliverable, so the read is guarded separately and an
+    // unreadable request falls through to the arm that reports it.
+    const report = await run({
+      validateSnapshotSql: async (req: WarehouseSnapshotRequest) => {
+        const verdict = { valid: true as const };
+        Object.defineProperty(verdict, "request", {
+          enumerable: true,
+          get() {
+            throw new TypeError("hostile request getter");
+          },
+        });
+        void req;
+        return verdict as unknown as { valid: true; request: ValidatedSnapshotRequest };
+      },
+    });
+    expect(report.refusals.map((r) => r.reason)).toEqual(["snapshot-failed"]);
+    // The ERROR line, not the gate-threw warn — that is the case.
+    const payload = payloadOf(errors, "verdict for a different request");
+    expect(payload.returnedReadThrew).toBe(true);
+    expect(payload.returnedRequestMatch).toBe(false);
+    expect(payload.sqlDigest).toMatch(/^[0-9a-f]{16}$/);
+    expect(messages(warns).filter((m) => m.includes("threw rather than answering"))).toEqual([]);
+  });
+
+  it("renders a throwing `error` getter as <threw>, keeping the verdict's permanence (#5248)", async () => {
+    // An unguarded read landed this on the gate-threw arm, demoting the entity from
+    // permanent to transient. The gate DID answer invalid; only its reason was
+    // unreadable, so it keeps that verdict's permanence.
+    const report = await run({
+      validateSnapshotSql: async () => {
+        const verdict = { valid: false as const };
+        Object.defineProperty(verdict, "error", {
+          enumerable: true,
+          get() {
+            throw new TypeError("hostile error getter");
+          },
+        });
+        return verdict as { valid: false; error: string };
+      },
+    });
+    expect(report.refusals.map((r) => r.reason)).toEqual(["snapshot-rejected"]);
+    expect(report.refusals[0]?.message).toContain("<threw>");
+    expect(payloadOf(warns, "did not pass SQL validation").reason).toBe("<threw>");
+  });
+
+  it("renders an Error `error` by its message, not as <object> (#5248)", async () => {
+    // `<object>` is `undefined` with extra steps, on a PERMANENT refusal whose own
+    // text says re-running will not help — the generic message CLAUDE.md forbids,
+    // arriving through the renderer added to remove it. An Error is the likeliest
+    // non-string a plugin-supplied validator puts here.
+    const report = await run({
+      validateSnapshotSql: async () =>
+        ({ valid: false, error: new Error('relation "accounts" does not exist') }) as unknown as {
+          valid: false;
+          error: string;
+        },
+    });
+    expect(report.refusals[0]?.message).toContain('relation "accounts" does not exist');
+    expect(report.refusals[0]?.message).not.toContain("<object>");
+  });
+
+  it("bounds the REJECTED arm's reason too, not only the mismatch arm's (#5248)", async () => {
+    // The bound was pinned on the mismatch arm only; the rejected arm's `reason`
+    // reaches a 200-response message, which is the one that leaves the process.
+    const report = await run({
+      validateSnapshotSql: async () => ({ valid: false as const, error: "X".repeat(5000) }),
+    });
+    expect(report.refusals[0]?.message).toContain(`${"X".repeat(200)}…(5000)`);
+    expect(report.refusals[0]?.message).not.toContain("X".repeat(201));
+  });
+
+  it("treats a non-boolean `valid` as a gate that did not answer (#5248)", async () => {
+    // ⚠️ Routing this to `snapshot-rejected` would be a REGRESSION — that arm tells
+    // the admin "re-running will not change this" and to un-enroll a pair that is
+    // fine. Tightening `if (verdict.valid)` to `=== true` produces exactly that, and
+    // was green across all four warehouse suites until this case existed.
+    const report = await run({
+      validateSnapshotSql: async () =>
+        ({ valid: "yes" }) as unknown as { valid: false; error: string },
+    });
+    expect(report.refusals.map((r) => r.reason)).toEqual(["snapshot-failed"]);
+    // ⚠️ It reaches the MISMATCH arm — a truthy-but-not-boolean `valid` carries no
+    // `request`, so the identity check refuses it — and that arm is `snapshot-failed`
+    // too. Both routes are transient, which is the property the behaviour table
+    // claimed; this assertion names which one actually happens rather than asserting
+    // the gate-threw wording and passing for the wrong reason.
+    expect(report.refusals[0]?.message).toContain("could not confirm its SQL gate checked");
+    expect(payloadOf(errors, "verdict for a different request").returnedRequestMatch).toBe(false);
+  });
+
   it("survives a REVOKED PROXY verdict, where the narrowing itself throws (#5248)", async () => {
     // ⚠️ **THE THIRD INSTANCE OF ONE PRINCIPLE IN THIS CHANGE, and the one that
     // looked safest.** `isRecord` calls `Array.isArray`, which THROWS on a revoked
@@ -710,7 +992,7 @@ describe("warehouse producer logging", () => {
     expect(payload.returnedReadThrew).toBe(true);
     // ⚠️ And the SHAPE field too — it is computed by its own `isRecord` call, which
     // was the second unguarded instance and would have escaped independently of the
-    // three property reads.
+    // four property reads.
     expect(payload.returnedRequestType).toBe("<threw>");
     expect(payload.sqlDigestMatch).toBe(false);
   });

--- a/packages/api/src/lib/brain/__tests__/warehouse-producer-logging.test.ts
+++ b/packages/api/src/lib/brain/__tests__/warehouse-producer-logging.test.ts
@@ -441,10 +441,80 @@ describe("warehouse producer logging", () => {
     // forged run's SUBMITTED one — which is what "the same statement" means here.
     expect(replay.sqlDigest).toBe(digest(submitted));
 
+    // ⚠️ **THE PREMISE, ASSERTED RATHER THAN NARRATED.** The comment at the top of
+    // this case claims the two shapes were logged identically before #5248; nothing
+    // proved it. The forged fixture keeps `entity` and `workspaceId` IDENTICAL and
+    // varies only the statement — so the pre-existing `returned*` fields are blind to
+    // it, which is exactly what makes the digest load-bearing. Measured: the two
+    // payloads are byte-identical apart from these two keys. A reader arriving from
+    // the #5230 case above (whose fixture DOES forge entity and workspace) would
+    // otherwise reasonably assume the older fields already separate them.
+    const differing = [...new Set([...Object.keys(forged), ...Object.keys(replay)])]
+      .filter((k) => JSON.stringify(forged[k]) !== JSON.stringify(replay[k]))
+      .sort();
+    expect(differing).toEqual(["returnedSqlDigest", "sqlDigestMatch"]);
+
     // ⚠️ The claim the two runs exist to make, asserted directly rather than left as
     // an inference from the two blocks above. A single hardcoded value satisfies
     // roughly half the assertions in each block; nothing satisfies this one.
     expect(forged.sqlDigestMatch).not.toBe(replay.sqlDigestMatch);
+  });
+
+  it("catches a cross-tenant forgery whose statement text MATCHES (#5248)", async () => {
+    // ⚠️ **THE CASE THAT NEARLY SHIPPED MISCLASSIFIED, and it is the worst forgery
+    // this arm can see.** `buildSnapshotSql` emits no workspace and no connection, so
+    // two workspaces enrolled on the same table with the same dimension names build
+    // BYTE-IDENTICAL statements — the ordinary outcome for tenants onboarded from one
+    // connector template. A token minted against ANOTHER workspace's request therefore
+    // arrives with `sqlDigestMatch: TRUE`. An operator alerting only on
+    // `sqlDigestMatch: false` — which the first cut of this arm's own comment told
+    // them to do — would never see it, while `defaultRunSnapshot` selects the pool
+    // from the returned workspace and connection, i.e. the cross-tenant read the
+    // capture note names as the residual.
+    await run({
+      validateSnapshotSql: async (request: WarehouseSnapshotRequest) => ({
+        valid: true as const,
+        request: {
+          ...request,
+          workspaceId: "ws-other-tenant",
+          connectionId: "other-group",
+        } as ValidatedSnapshotRequest,
+      }),
+    });
+
+    const payload = payloadOf(errors, "verdict for a different request");
+    // The statement text genuinely matches — this is the whole trap.
+    expect(payload.sqlDigestMatch).toBe(true);
+    // ...and these are what an alert must actually key on. Delete either and a
+    // cross-tenant mint is indistinguishable from a re-wrap.
+    expect(payload.returnedWorkspaceIdMatch).toBe(false);
+    expect(payload.returnedConnectionIdMatch).toBe(false);
+    // The entity is untouched, so its own match field must NOT fire — otherwise a
+    // single always-false constant would satisfy the two assertions above.
+    expect(payload.returnedEntityMatch).toBe(true);
+    expect(payload.returnedWorkspaceId).toBe("ws-other-tenant");
+    expect(payload.returnedConnectionId).toBe("other-group");
+  });
+
+  it("reads a legitimately absent connection as a MATCH on both sides (#5248)", async () => {
+    // ⚠️ The other half of the field above, and the reason both sides normalise
+    // through one expression. `ACCOUNTS_YAML` names no `connection:`, so the submitted
+    // id is `undefined` — and a submitted `"(default)"` compared against a returned
+    // `undefined` would report every benign replay as a connection mismatch, turning
+    // the new alert into noise on its first day.
+    await run({
+      validateSnapshotSql: async (request: WarehouseSnapshotRequest) => ({
+        valid: true as const,
+        request: { ...request } as ValidatedSnapshotRequest,
+      }),
+    });
+
+    const payload = payloadOf(errors, "verdict for a different request");
+    expect(payload.returnedConnectionIdMatch).toBe(true);
+    // Both sides render through the same helper, so both read `<undefined>` rather
+    // than one of them inventing a placeholder.
+    expect(payload.connectionId).toBe("<undefined>");
+    expect(payload.returnedConnectionId).toBe("<undefined>");
   });
 
   it("fingerprints the statements and never carries one (#5248)", async () => {
@@ -462,7 +532,11 @@ describe("warehouse producer logging", () => {
     expect(submitted).toContain("SELECT");
     expect(submitted).toContain("lifecycle_status");
 
-    const serialized = JSON.stringify(payload);
+    // ⚠️ EVERY sink, not just the mismatch payload. Scoped to one line, the case's own
+    // title ("never carries one") overclaimed — a future line elsewhere in the run
+    // logging the raw statement would pass. The positive anchors above keep the
+    // widening non-vacuous.
+    const serialized = JSON.stringify([...errors, ...warns, ...infos, ...debugs]);
     expect(serialized).not.toContain(submitted);
     // ⚠️ And not a FRAGMENT of it. The statement is assembled from admin-authored
     // `table:` and `sql:` expressions, so the identifying part is the column names
@@ -511,31 +585,248 @@ describe("warehouse producer logging", () => {
     expect(payload.sqlDigestMatch).toBe(true);
   });
 
-  it("logs a mismatch rather than throwing when the verdict carries no request at all (#5248)", async () => {
-    // ⚠️ The mismatch arm has NO enclosing `try` — the per-entity catches wrap the
-    // validator call and the snapshot, not this branch — so a `TypeError` raised while
-    // BUILDING the log payload escapes `runWarehouseProducer` entirely and turns a
-    // refused entity into a 500 for the whole run. `undefined.slice(0, 200)` on a
-    // verdict cast from `{}` did exactly that, and the cast compiles:
-    // `warehouse-producer-bypass.test.ts` pins the sites that may write one.
+  // ⚠️ The mismatch arm has NO enclosing `try` — the per-entity catches wrap the
+  // validator call, the snapshot and the transaction, and this branch sits BETWEEN
+  // them — so anything raised while building the log payload escapes
+  // `runWarehouseProducer` entirely, reaches the route's `Effect.tryPromise`, and
+  // turns ONE refused entity into a 500 for the whole run with no log line at all.
+  // Every cast below compiles; `warehouse-producer-bypass.test.ts` pins the sites
+  // that may write one.
+  //
+  // ⚠️ `{}` alone does NOT exercise the container guard, and that was measured: `{}`
+  // IS a record, so `isRecord`'s false arm is never taken and deleting the guard
+  // leaves the suite green while a `null` verdict throws. `null` and `undefined` are
+  // the load-bearing classes — a bare string survives without the guard too.
+  // `expectedType` is spelled out per fixture rather than derived, so the assertion
+  // cannot agree with the implementation by construction.
+  const MALFORMED_VERDICTS: readonly {
+    readonly label: string;
+    readonly request: unknown;
+    readonly expectedType: string;
+  }[] = [
+    { label: "an object with no fields", request: {}, expectedType: "object" },
+    { label: "null", request: null, expectedType: "<null>" },
+    { label: "undefined", request: undefined, expectedType: "<undefined>" },
+    { label: "a string", request: "SELECT 1", expectedType: "SELECT 1" },
+  ];
+
+  for (const { label, request, expectedType } of MALFORMED_VERDICTS) {
+    it(`logs a mismatch rather than throwing when the verdict's request is ${label} (#5248)`, async () => {
+      const report = await run({
+        validateSnapshotSql: async () => ({
+          valid: true as const,
+          request: request as ValidatedSnapshotRequest,
+        }),
+      });
+      // The BEHAVIOURAL outcome, not only the log line: a throw fails here first.
+      expect(report.refusals.map((r) => r.reason)).toEqual(["snapshot-failed"]);
+
+      const payload = payloadOf(errors, "verdict for a different request");
+      // Sentinels, not silence: an operator needs to know the field was absent rather
+      // than empty, and the digest must still say the statements differ.
+      expect(payload.returnedEntity).toBe("<undefined>");
+      expect(payload.returnedWorkspaceId).toBe("<undefined>");
+      // ⚠️ `<undefined>`, NOT a `<non-string>` catch-all. `sql` is the field that
+      // identifies the forgery class, so it is the last one that should collapse
+      // absent / null / numeric into one sentinel — the collapse this arm exists to
+      // undo, one level down.
+      expect(payload.returnedSqlDigest).toBe("<undefined>");
+      expect(payload.sqlDigestMatch).toBe(false);
+      expect(payload.returnedReadThrew).toBe(false);
+      // ⚠️ Which malformation it was. Without this field all four fixtures produce a
+      // byte-identical payload, so "the gate returned a string" and "the gate returned
+      // an object with no fields" — two different wiring faults — become one line.
+      expect(payload.returnedRequestType).toBe(expectedType);
+      // ...and the SUBMITTED side is unaffected, so the line still identifies the run.
+      expect(payload.entity).toBe("Accounts");
+      expect(payload.sqlDigest).toMatch(/^[0-9a-f]{16}$/);
+    });
+  }
+
+  it("logs <threw> rather than dying when a verdict's accessor THROWS (#5248)", async () => {
+    // ⚠️ **THE DEFECT THE FIRST CUT OF THIS FIX REPRODUCED, one property access over.**
+    // Narrowing the container closes a verdict that is the wrong SHAPE; it does
+    // nothing about one whose getter runs hostile code. `isRecord` is true for
+    // `{ get entity() { throw } }` and for a revoked Proxy (`typeof` still answers
+    // "object"), so the read itself escaped — measured, before `seamRead` existed, as
+    // the TypeError propagating out of `runWarehouseProducer`. A getter is not exotic
+    // here: the read-once case two above builds one.
+    let entityReads = 0;
+    const report = await run({
+      validateSnapshotSql: async (req: WarehouseSnapshotRequest) => {
+        const copy = { ...req } as Record<string, unknown>;
+        Object.defineProperty(copy, "entity", {
+          enumerable: true,
+          get() {
+            entityReads += 1;
+            throw new TypeError("hostile getter");
+          },
+        });
+        return { valid: true as const, request: copy as unknown as ValidatedSnapshotRequest };
+      },
+    });
+    // A throw would have taken the whole run, so this line is the case.
+    expect(report.refusals.map((r) => r.reason)).toEqual(["snapshot-failed"]);
+    expect(entityReads).toBe(1);
+
+    const payload = payloadOf(errors, "verdict for a different request");
+    // ⚠️ `<threw>`, distinct from `<undefined>`. "The getter blew up" and "the field
+    // was absent" are different faults, and a helper that folded them together would
+    // pass a laxer assertion here.
+    expect(payload.returnedEntity).toBe("<threw>");
+    expect(payload.returnedReadThrew).toBe(true);
+    expect(payload.returnedEntityMatch).toBe(false);
+    // ⚠️ The OTHER fields survive, which is why each read is guarded individually
+    // rather than the whole payload wrapped in one `try`. A single outer catch would
+    // lose the statement comparison — the forensic payload this line exists for — to
+    // an unrelated field's getter.
+    expect(payload.returnedWorkspaceId).toBe(WORKSPACE);
+    expect(payload.sqlDigestMatch).toBe(true);
+  });
+
+  it("survives a REVOKED PROXY verdict, where the narrowing itself throws (#5248)", async () => {
+    // ⚠️ **THE THIRD INSTANCE OF ONE PRINCIPLE IN THIS CHANGE, and the one that
+    // looked safest.** `isRecord` calls `Array.isArray`, which THROWS on a revoked
+    // Proxy rather than answering — measured in this runtime: *"Array.isArray cannot
+    // be called on a Proxy that has been revoked"* — while `typeof` and `!== null`
+    // pass it cleanly first. So the guard written to make the seam read total was
+    // itself an unguarded seam operation, sitting one line ABOVE the `try` meant to
+    // cover it. Nothing about the shape of that code looks wrong, which is exactly
+    // why it needs a test rather than a comment.
+    const { proxy, revoke } = Proxy.revocable({ entity: "x" }, {});
+    revoke();
+
     const report = await run({
       validateSnapshotSql: async () => ({
         valid: true as const,
-        request: {} as ValidatedSnapshotRequest,
+        request: proxy as unknown as ValidatedSnapshotRequest,
       }),
     });
+    // A throw anywhere in the arm takes the whole run, so this is the case.
     expect(report.refusals.map((r) => r.reason)).toEqual(["snapshot-failed"]);
 
     const payload = payloadOf(errors, "verdict for a different request");
-    // Sentinels, not silence: an operator needs to know the field was absent rather
-    // than empty, and the digest must still say the statements differ.
-    expect(payload.returnedEntity).toBe("<undefined>");
-    expect(payload.returnedWorkspaceId).toBe("<undefined>");
-    expect(payload.returnedSqlDigest).toBe("<non-string>");
+    expect(payload.returnedEntity).toBe("<threw>");
+    expect(payload.returnedReadThrew).toBe(true);
+    // ⚠️ And the SHAPE field too — it is computed by its own `isRecord` call, which
+    // was the second unguarded instance and would have escaped independently of the
+    // three property reads.
+    expect(payload.returnedRequestType).toBe("<threw>");
     expect(payload.sqlDigestMatch).toBe(false);
-    // ...and the SUBMITTED side is unaffected, so the line still identifies the run.
-    expect(payload.entity).toBe("Accounts");
-    expect(payload.sqlDigest).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  it("survives a verdict whose DISCRIMINANT throws, before any arm is chosen (#5248)", async () => {
+    // The same class one step earlier: `verdict.valid` is a seam-controlled read that
+    // used to happen outside every `try`, so a hostile discriminant took the run down
+    // before either refusal arm could be reached. It now lands on the gate-threw arm,
+    // which is the honest one — a gate that cannot say `valid` has not answered.
+    const report = await run({
+      validateSnapshotSql: async () => {
+        const verdict = {};
+        Object.defineProperty(verdict, "valid", {
+          enumerable: true,
+          get() {
+            throw new TypeError("hostile discriminant");
+          },
+        });
+        return verdict as { valid: false; error: string };
+      },
+    });
+    expect(report.refusals.map((r) => r.reason)).toEqual(["snapshot-failed"]);
+    // TRANSIENT, not permanent: "re-running will not change this" is the wrong advice
+    // for a broken gate implementation, and it tells the admin to un-enroll a pair
+    // that is fine.
+    const refusal = report.refusals[0];
+    expect(refusal?.message).toContain("the next run");
+    expect(payloadOf(warns, "threw rather than answering").err).toBeInstanceOf(Error);
+  });
+
+  it("survives a NULL verdict, which throws on the discriminant read (#5248)", async () => {
+    const report = await run({
+      validateSnapshotSql: async () => null as unknown as { valid: false; error: string },
+    });
+    expect(report.refusals.map((r) => r.reason)).toEqual(["snapshot-failed"]);
+    expect(payloadOf(warns, "threw rather than answering").err).toBeInstanceOf(Error);
+  });
+
+  it("bounds a seam string and says so, rather than truncating silently (#5248)", async () => {
+    // ⚠️ The bound was prose until now: deleting `.slice(0, 200)` left the suite green,
+    // measured. It matters on THIS line specifically — the line's whole job is
+    // comparing what came back against what was sent, and a silently truncated
+    // 5,000-character value reads as a genuine 200-character one.
+    await run({
+      validateSnapshotSql: async (req: WarehouseSnapshotRequest) => ({
+        valid: true as const,
+        request: { ...req, entity: "E".repeat(5000) } as ValidatedSnapshotRequest,
+      }),
+    });
+
+    const payload = payloadOf(errors, "verdict for a different request");
+    expect(payload.returnedEntity).toBe(`${"E".repeat(200)}…(5000)`);
+    // The suffix is what makes truncation visible; without it this is 200 chars of E
+    // and no way to tell it from a real one.
+    expect(String(payload.returnedEntity)).not.toBe("E".repeat(200));
+  });
+
+  it("distinguishes an explicitly null seam field from an absent one (#5248)", async () => {
+    // Deleting the `<null>` arm leaves `<object>` — measured green before this case.
+    // Cheap to pin, and `null` is what a JSON round-trip through a region bundle
+    // produces where `undefined` would have been.
+    await run({
+      validateSnapshotSql: async (req: WarehouseSnapshotRequest) => ({
+        valid: true as const,
+        request: { ...req, entity: null, sql: null } as unknown as ValidatedSnapshotRequest,
+      }),
+    });
+
+    const payload = payloadOf(errors, "verdict for a different request");
+    expect(payload.returnedEntity).toBe("<null>");
+    expect(payload.returnedSqlDigest).toBe("<null>");
+    expect(payload.sqlDigestMatch).toBe(false);
+  });
+
+  it("reads the REJECTED arm's reason once, guarded and bounded (#5248)", async () => {
+    // ⚠️ **THE SIBLING SWEEP'S CATCH — the same seam, the same two defects, one arm
+    // up.** `validation.error` was read TWICE, once into the log and once into the
+    // operator-facing refusal, so a getter could make them disagree about why the
+    // entity was refused. It was also unguarded and unbounded: `{ valid: false }`
+    // rendered *"does not pass its SQL gate: undefined"*, the generic message
+    // CLAUDE.md forbids, and a throwing accessor escaped the template literal as a
+    // 500 for the whole run.
+    let errorReads = 0;
+    const report = await run({
+      validateSnapshotSql: async () => {
+        const verdict = { valid: false as const };
+        Object.defineProperty(verdict, "error", {
+          enumerable: true,
+          get() {
+            errorReads += 1;
+            return `reason-read-${errorReads}`;
+          },
+        });
+        return verdict as { valid: false; error: string };
+      },
+    });
+
+    expect(errorReads).toBe(1);
+    const refusal = report.refusals.find((r) => r.reason === "snapshot-rejected");
+    const payload = payloadOf(warns, "did not pass SQL validation");
+    // ⚠️ The two sites AGREE, which is the whole claim. A second read makes the log
+    // say `reason-read-1` while the admin reads `reason-read-2`.
+    expect(payload.reason).toBe("reason-read-1");
+    expect(refusal?.message).toContain("reason-read-1");
+    expect(refusal?.message).not.toContain("reason-read-2");
+  });
+
+  it("never puts the word undefined in the REJECTED arm's operator message (#5248)", async () => {
+    // The `{ valid: false }` cast, which `SnapshotSqlVerdict`'s docstring argues the
+    // type forbids — the same argument this PR's neighbour disproves.
+    const report = await run({
+      validateSnapshotSql: async () => ({ valid: false }) as { valid: false; error: string },
+    });
+    const refusal = report.refusals.find((r) => r.reason === "snapshot-rejected");
+    expect(refusal?.message).toContain("<undefined>");
+    expect(refusal?.message).not.toContain(": undefined.");
   });
 
   it("carries the request id and the trigger on every line, including the failures", async () => {

--- a/packages/api/src/lib/brain/__tests__/warehouse-producer-logging.test.ts
+++ b/packages/api/src/lib/brain/__tests__/warehouse-producer-logging.test.ts
@@ -45,6 +45,7 @@
  */
 
 import { afterEach, beforeAll, describe, expect, it, mock } from "bun:test";
+import { createHash } from "node:crypto";
 
 interface Captured {
   readonly payload: unknown;
@@ -201,6 +202,18 @@ const messages = (sink: readonly Captured[]) => sink.map((c) => c.message);
  * out of `x?.payload as T` — an optional chain there makes a missing line read as
  * `undefined` and quietly weakens whatever is asserted about it.
  */
+/**
+ * The digest the mismatch line should carry, computed INDEPENDENTLY of the module
+ * under test.
+ *
+ * ⚠️ Deliberately not imported from the producer, and that is this repo's recorded
+ * lesson rather than a style choice: a fixture that derives its expectation from the
+ * implementation agrees with it by construction, so swapping the algorithm — or
+ * hashing the wrong side of the comparison — stays green. Spelled out here, changing
+ * either REDs.
+ */
+const digest = (sql: string) => createHash("sha256").update(sql).digest("hex").slice(0, 16);
+
 function payloadOf(sink: readonly Captured[], fragment: string): Record<string, unknown> {
   const hits = sink.filter((c) => c.message.includes(fragment));
   expect(hits, `expected exactly one log line containing "${fragment}"`).toHaveLength(1);
@@ -378,6 +391,151 @@ describe("warehouse producer logging", () => {
     // ABSENT from warn, not merely present in error — a demotion is how this line
     // stops being an incident while still being "logged".
     expect(messages(warns).filter((m) => m.includes("different request"))).toEqual([]);
+  });
+
+  it("separates a forged statement from a benign replay on the mismatch line (#5248)", async () => {
+    // ⚠️ **THE COLLAPSE FALSIFIER.** Identity is the acceptance test, so BOTH of these
+    // land on the same arm and were logged identically before #5248: a token minted
+    // for a different statement (the aliased case, worth paging on) and the same
+    // statement arriving under a fresh object (a retry, routine). Refused either way,
+    // so nothing here is a correctness hole — but an alert that cannot tell them apart
+    // fires on the routine one and stays quiet for the other. Deleting either digest
+    // field, or hardcoding `sqlDigestMatch`, collapses the two shapes back onto one
+    // and REDs below.
+    const FORGED_SQL = "SELECT 1 AS forged";
+    let submitted = "";
+
+    // (1) a genuine-looking verdict minted for a DIFFERENT statement.
+    await run({
+      validateSnapshotSql: async (request: WarehouseSnapshotRequest) => {
+        submitted = request.sql;
+        return {
+          valid: true as const,
+          request: { ...request, sql: FORGED_SQL } as ValidatedSnapshotRequest,
+        };
+      },
+    });
+    const forged = payloadOf(errors, "verdict for a different request");
+    expect(forged.sqlDigestMatch).toBe(false);
+    expect(forged.sqlDigest).toBe(digest(submitted));
+    // ⚠️ Derived from what came BACK. The measured sibling of this file's
+    // `returnedEntity` note: a field that digests the SUBMITTED statement under a
+    // `returned*` name passes every other assertion here and reports every forgery as
+    // a replay, which is the exact inversion of the signal.
+    expect(forged.returnedSqlDigest).toBe(digest(FORGED_SQL));
+    expect(forged.returnedSqlDigest).not.toBe(forged.sqlDigest);
+
+    errors.length = 0;
+
+    // (2) THE SAME statement, under a different object — the benign replay.
+    await run({
+      validateSnapshotSql: async (request: WarehouseSnapshotRequest) => ({
+        valid: true as const,
+        request: { ...request } as ValidatedSnapshotRequest,
+      }),
+    });
+    const replay = payloadOf(errors, "verdict for a different request");
+    expect(replay.sqlDigestMatch).toBe(true);
+    expect(replay.returnedSqlDigest).toBe(replay.sqlDigest);
+    // The same fixture builds the same statement, so the replay's digest is the
+    // forged run's SUBMITTED one — which is what "the same statement" means here.
+    expect(replay.sqlDigest).toBe(digest(submitted));
+
+    // ⚠️ The claim the two runs exist to make, asserted directly rather than left as
+    // an inference from the two blocks above. A single hardcoded value satisfies
+    // roughly half the assertions in each block; nothing satisfies this one.
+    expect(forged.sqlDigestMatch).not.toBe(replay.sqlDigestMatch);
+  });
+
+  it("fingerprints the statements and never carries one (#5248)", async () => {
+    let submitted = "";
+    await run({
+      validateSnapshotSql: async (request: WarehouseSnapshotRequest) => {
+        submitted = request.sql;
+        return { valid: true as const, request: { ...request } as ValidatedSnapshotRequest };
+      },
+    });
+
+    const payload = payloadOf(errors, "verdict for a different request");
+    // ⚠️ POSITIVE ANCHOR first. Without it every `not.toContain` below is satisfied by
+    // a fixture that built no statement at all, and the whole case goes vacuous.
+    expect(submitted).toContain("SELECT");
+    expect(submitted).toContain("lifecycle_status");
+
+    const serialized = JSON.stringify(payload);
+    expect(serialized).not.toContain(submitted);
+    // ⚠️ And not a FRAGMENT of it. The statement is assembled from admin-authored
+    // `table:` and `sql:` expressions, so the identifying part is the column names
+    // rather than the whole string — a line that truncated the SELECT to 200
+    // characters would pass the assertion above and still put a customer's schema in
+    // the log, which is what CLAUDE.md forbids.
+    expect(serialized).not.toContain("lifecycle_status");
+    expect(payload.sqlDigest).toMatch(/^[0-9a-f]{16}$/);
+    expect(payload.returnedSqlDigest).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  it("reads the returned statement ONCE, so a getter cannot answer the digest and the comparison differently (#5248, #5230)", async () => {
+    // ⚠️ #5230's aliasing finding, one level down and inside the line written to
+    // report it. `validation.request` is captured once — but its PROPERTIES are still
+    // expressions the seam controls, so a getter that answers honestly for the digest
+    // and dishonestly for the comparison puts a forged statement's mismatch on the log
+    // as a benign replay. A per-site read proves nothing about the next site; only the
+    // count does.
+    const SECOND_READ = "SELECT 1 AS second_read";
+    let sqlReads = 0;
+    let honest = "";
+
+    await run({
+      validateSnapshotSql: async (request: WarehouseSnapshotRequest) => {
+        honest = request.sql;
+        const copy = { ...request } as Record<string, unknown>;
+        Object.defineProperty(copy, "sql", {
+          enumerable: true,
+          get() {
+            sqlReads += 1;
+            return sqlReads === 1 ? honest : SECOND_READ;
+          },
+        });
+        return { valid: true as const, request: copy as unknown as ValidatedSnapshotRequest };
+      },
+    });
+
+    const payload = payloadOf(errors, "verdict for a different request");
+    // ⚠️ The whole case. Two reads — one for the digest field, one for the comparison
+    // — makes this 2 and is the defect; the assertions below cannot see it on their
+    // own, because a second read that happens to agree looks identical.
+    expect(sqlReads).toBe(1);
+    expect(payload.returnedSqlDigest).toBe(digest(honest));
+    expect(payload.returnedSqlDigest).not.toBe(digest(SECOND_READ));
+    // The first read IS the submitted statement, so this mismatch is a replay.
+    expect(payload.sqlDigestMatch).toBe(true);
+  });
+
+  it("logs a mismatch rather than throwing when the verdict carries no request at all (#5248)", async () => {
+    // ⚠️ The mismatch arm has NO enclosing `try` — the per-entity catches wrap the
+    // validator call and the snapshot, not this branch — so a `TypeError` raised while
+    // BUILDING the log payload escapes `runWarehouseProducer` entirely and turns a
+    // refused entity into a 500 for the whole run. `undefined.slice(0, 200)` on a
+    // verdict cast from `{}` did exactly that, and the cast compiles:
+    // `warehouse-producer-bypass.test.ts` pins the sites that may write one.
+    const report = await run({
+      validateSnapshotSql: async () => ({
+        valid: true as const,
+        request: {} as ValidatedSnapshotRequest,
+      }),
+    });
+    expect(report.refusals.map((r) => r.reason)).toEqual(["snapshot-failed"]);
+
+    const payload = payloadOf(errors, "verdict for a different request");
+    // Sentinels, not silence: an operator needs to know the field was absent rather
+    // than empty, and the digest must still say the statements differ.
+    expect(payload.returnedEntity).toBe("<undefined>");
+    expect(payload.returnedWorkspaceId).toBe("<undefined>");
+    expect(payload.returnedSqlDigest).toBe("<non-string>");
+    expect(payload.sqlDigestMatch).toBe(false);
+    // ...and the SUBMITTED side is unaffected, so the line still identifies the run.
+    expect(payload.entity).toBe("Accounts");
+    expect(payload.sqlDigest).toMatch(/^[0-9a-f]{16}$/);
   });
 
   it("carries the request id and the trigger on every line, including the failures", async () => {

--- a/packages/api/src/lib/brain/warehouse-producer.ts
+++ b/packages/api/src/lib/brain/warehouse-producer.ts
@@ -1515,6 +1515,58 @@ async function insertSnapshotEpisode(
 }
 
 /**
+ * A one-way fingerprint of a snapshot statement, for the gate-mismatch log line.
+ *
+ * ⚠️ **A DIGEST, and the statement itself is never an option.** The SELECT is
+ * assembled from admin-authored `table:` and `sql:` expressions, so it can carry a
+ * column name — and, through a `sql:` expression, a literal — that identifies a
+ * customer. CLAUDE.md forbids that reaching a log, and the mismatch arm is exactly
+ * where an operator most wants to see the statement, which is what makes writing
+ * the rule down here worth the lines.
+ *
+ * Truncated to 16 hex characters, matching `logger.ts`'s `hashShareToken` and
+ * `learn/pattern-analyzer.ts`. This is a CORRELATION fingerprint, not a security
+ * primitive: the entity is refused either way, so the only thing a collision buys
+ * is a forged statement logged as if it were a replay, and 64 bits against a target
+ * the attacker does not choose is not the cheap way to achieve that.
+ *
+ * ⚠️ Non-strings get a SENTINEL rather than a throw. `sql` here comes from the
+ * validator seam, whose whole premise on this path is that it may be substituted or
+ * cast — `warehouse-producer-bypass.test.ts` pins the sites that may — so a
+ * `createHash().update(<number>)` would throw a `TypeError` out of the log call,
+ * escape the per-entity `try` (the mismatch arm has none) and take down the whole
+ * run as a 500. That contradicts {@link runWarehouseProducer}'s own "caught PER
+ * ENTITY" contract for the sake of a diagnostic line, which is the wrong trade in
+ * both directions.
+ *
+ * The sentinel cannot be confused with a digest: `<non-string>` is neither 16
+ * characters nor hex, and the SUBMITTED side is a string by construction
+ * ({@link buildSnapshotSql} returns one), so it can never equal the returned side's
+ * sentinel and report a false `sqlDigestMatch`.
+ */
+function snapshotSqlDigest(sql: unknown): string {
+  if (typeof sql !== "string") return "<non-string>";
+  return createHash("sha256").update(sql).digest("hex").slice(0, 16);
+}
+
+/**
+ * A string from the validator seam, bounded and total.
+ *
+ * Same reason as {@link snapshotSqlDigest}'s sentinel: the mismatch arm logs values
+ * the seam controls, and `undefined.slice(0, 200)` on a verdict cast from `{}`
+ * threw out of the log call and past the per-entity contract. `<undefined>` in the
+ * payload says what came back; a 500 says nothing and loses the other fields too.
+ *
+ * Honest bound: a returned value that literally spells `"<undefined>"` is
+ * indistinguishable from an absent one here. An operator reading this line is
+ * already looking at a gate that answered about the wrong request.
+ */
+function seamString(value: unknown): string {
+  if (typeof value === "string") return value.slice(0, 200);
+  return value === null ? "<null>" : `<${typeof value}>`;
+}
+
+/**
  * Run the producer over one workspace's reach.
  *
  * One transaction per ENTITY, not one per run: an entity whose snapshot fails
@@ -1857,6 +1909,32 @@ export async function runWarehouseProducer(
     // `reconcile.ts` states the same rule for the same reason.
     const validated = validation.request;
     if (validated !== request) {
+      // ⚠️ **THREE FIELDS, EACH READ ONCE — the capture rule above, applied one level
+      // down.** `validated` is captured, but its PROPERTIES are still expressions the
+      // seam controls: a Proxy or a getter answers `.sql` honestly for the digest and
+      // dishonestly for the comparison, which is #5230's aliasing finding reproduced
+      // inside the line written to report it. Reading each into a local once is what
+      // makes the digest below a statement about a value rather than about a property
+      // access. The object itself may not be an object at all — a verdict cast from
+      // `{}` or `null` compiles — so it is narrowed before any read; see
+      // {@link seamString} for why a throw here is worse than a sentinel.
+      const returned: Record<string, unknown> = isRecord(validated) ? validated : {};
+      const returnedEntity = returned.entity;
+      const returnedWorkspaceId = returned.workspaceId;
+      const returnedSql = returned.sql;
+      // ⚠️ **This pair is what separates a FORGERY from a benign REPLAY, and until
+      // #5248 the line could not.** Identity is the acceptance test, so both cases
+      // land here: a validator that memoises and hands back an equal-but-distinct
+      // object for THE SAME statement (benign — a retry, a re-wrap), and one that
+      // hands back a token minted for a DIFFERENT statement (the aliased/forged case,
+      // the one worth paging on). Refused either way, so this is observability rather
+      // than a correctness hole — but an operator whose alert cannot tell them apart
+      // is paging on retries and ignoring the real thing.
+      //
+      // Digests, never the statements — see {@link snapshotSqlDigest}. `sql` is this
+      // iteration's own local, so the submitted side cannot be aliased at all.
+      const sqlDigest = snapshotSqlDigest(sql);
+      const returnedSqlDigest = snapshotSqlDigest(returnedSql);
       log.error(
         {
           ...runLog,
@@ -1870,8 +1948,16 @@ export async function runWarehouseProducer(
           //
           // Bounded: both strings come from the seam rather than from the plan, and
           // nothing else on this line is attacker-shaped.
-          returnedEntity: validated.entity.slice(0, 200),
-          returnedWorkspaceId: validated.workspaceId.slice(0, 200),
+          returnedEntity: seamString(returnedEntity),
+          returnedWorkspaceId: seamString(returnedWorkspaceId),
+          sqlDigest,
+          returnedSqlDigest,
+          // ⚠️ Derivable from the two above and logged anyway, because an alert rule
+          // is a FILTER, not a computation: `sqlDigestMatch: false` is one greppable
+          // predicate, while "these two hex fields differ" is a join most log
+          // pipelines cannot express. Named for what was actually compared — digests,
+          // truncated — rather than claiming the statements themselves are equal.
+          sqlDigestMatch: sqlDigest === returnedSqlDigest,
         },
         "Warehouse producer: the SQL gate returned a verdict for a different request — refusing rather than reading",
       );

--- a/packages/api/src/lib/brain/warehouse-producer.ts
+++ b/packages/api/src/lib/brain/warehouse-producer.ts
@@ -1514,6 +1514,79 @@ async function insertSnapshotEpisode(
   return { id: row.id, sourceId };
 }
 
+/** What {@link seamRead} returns when a seam-controlled accessor THREW. */
+const SEAM_THREW = Symbol("seam-threw");
+
+/**
+ * Read ONE property off a value the validator seam controls, totally.
+ *
+ * ⚠️ **Narrowing the container is not enough, and that gap was the first version of
+ * this code.** `isRecord(validated)` answers `true` for `{ get entity() { throw … } }`,
+ * so the property access itself runs seam-controlled code. (A revoked Proxy is worse
+ * still and is handled by the placement below, not by this paragraph: `isRecord`
+ * does not answer `true` for one, it THROWS.) The refusal arms of {@link runWarehouseProducer}
+ * have NO enclosing `try` — the per-entity catches wrap the validator call, the
+ * snapshot and the transaction, and the arms sit between them — so a throw here
+ * escapes the loop, escapes the function, and turns ONE refused entity into a 500
+ * for the whole run. That is the contract this file documents two paragraphs into
+ * `runWarehouseProducer`, broken for the sake of a diagnostic line, and it costs the
+ * operator the very forensic payload the line exists to produce.
+ *
+ * Absent and non-record both answer `undefined`, which {@link seamString} renders as
+ * `<undefined>`; a throw answers {@link SEAM_THREW}, which renders as `<threw>`. The
+ * three stay distinguishable, which is the whole point of the arm.
+ */
+function seamRead(source: unknown, key: string): unknown {
+  try {
+    // ⚠️ **`isRecord` IS INSIDE THE `try`, and putting it outside was this helper's
+    // own instance of the defect it exists to close — the THIRD in one change.** It
+    // calls `Array.isArray`, which THROWS on a revoked Proxy rather than answering
+    // (measured: *"Array.isArray cannot be called on a Proxy that has been
+    // revoked"*), while `typeof` and `!== null` pass it cleanly first. So the guard
+    // written to make the read total was itself an unguarded seam operation, sitting
+    // one line above the `try` that was supposed to cover it.
+    //
+    // The rule the three instances share: **narrowing is an OPERATION on the seam
+    // value, not a fact about it.** Anything that dispatches on the object — a
+    // property read, `Array.isArray`, a template literal, `toString` — belongs
+    // inside the guard, never in front of it.
+    if (!isRecord(source)) return undefined;
+    return source[key];
+  } catch {
+    // NOT silence, so this takes a plain comment rather than CLAUDE.md's
+    // `intentionally ignored` marker: the sentinel IS the signal, and it reaches the
+    // operator on the same log line as the field it replaces, alongside
+    // `returnedReadThrew`. The Error object is dropped DELIBERATELY — it comes from
+    // the seam under audit, so a hostile `.message` or `.stack` getter would throw
+    // again inside the log serializer, re-opening the exact escape this helper closes.
+    return SEAM_THREW;
+  }
+}
+
+/**
+ * A string from the validator seam — total, bounded, and honest about truncating.
+ *
+ * The mismatch and rejection arms log values the seam controls, and
+ * `undefined.slice(0, 200)` on a verdict cast from `{}` threw out of the log call and
+ * past the per-entity contract. A sentinel in the payload says what came back; a 500
+ * says nothing and loses the other fields too.
+ *
+ * The length suffix matters on THIS line specifically: its whole job is comparing
+ * what came back against what was sent, and a silently truncated 5,000-character
+ * value is indistinguishable from a genuine 200-character one.
+ *
+ * Honest bound: a returned value that literally spells `"<undefined>"` is
+ * indistinguishable from an absent one. An operator reading this line is already
+ * looking at a gate that answered about the wrong request.
+ */
+function seamString(value: unknown): string {
+  if (value === SEAM_THREW) return "<threw>";
+  if (typeof value === "string") {
+    return value.length > 200 ? `${value.slice(0, 200)}…(${value.length})` : value;
+  }
+  return value === null ? "<null>" : `<${typeof value}>`;
+}
+
 /**
  * A one-way fingerprint of a snapshot statement, for the gate-mismatch log line.
  *
@@ -1526,44 +1599,51 @@ async function insertSnapshotEpisode(
  *
  * Truncated to 16 hex characters, matching `logger.ts`'s `hashShareToken` and
  * `learn/pattern-analyzer.ts`. This is a CORRELATION fingerprint, not a security
- * primitive: the entity is refused either way, so the only thing a collision buys
- * is a forged statement logged as if it were a replay, and 64 bits against a target
- * the attacker does not choose is not the cheap way to achieve that.
+ * primitive: the entity is refused either way, so the only thing a collision buys is
+ * a forged statement logged as if it were a replay, and 64 bits against a target the
+ * attacker does not choose is not the cheap way to achieve that.
  *
- * ⚠️ Non-strings get a SENTINEL rather than a throw. `sql` here comes from the
- * validator seam, whose whole premise on this path is that it may be substituted or
- * cast — `warehouse-producer-bypass.test.ts` pins the sites that may — so a
- * `createHash().update(<number>)` would throw a `TypeError` out of the log call,
- * escape the per-entity `try` (the mismatch arm has none) and take down the whole
- * run as a 500. That contradicts {@link runWarehouseProducer}'s own "caught PER
- * ENTITY" contract for the sake of a diagnostic line, which is the wrong trade in
- * both directions.
- *
- * The sentinel cannot be confused with a digest: `<non-string>` is neither 16
- * characters nor hex, and the SUBMITTED side is a string by construction
- * ({@link buildSnapshotSql} returns one), so it can never equal the returned side's
- * sentinel and report a false `sqlDigestMatch`.
+ * ⚠️ **It takes a `string`, and that is the point of the split from
+ * {@link seamSqlDigest}.** With one `unknown`-taking function used on both sides, two
+ * absent statements digest to the SAME sentinel and `sqlDigestMatch` reports `true` —
+ * a forgery logged as a match, the exact inversion this field exists to prevent. The
+ * submitted side is a string by construction ({@link buildSnapshotSql} returns one);
+ * this signature is what makes that a compile error to break rather than a paragraph
+ * to believe.
  */
-function snapshotSqlDigest(sql: unknown): string {
-  if (typeof sql !== "string") return "<non-string>";
+function sqlDigest(sql: string): string {
   return createHash("sha256").update(sql).digest("hex").slice(0, 16);
 }
 
 /**
- * A string from the validator seam, bounded and total.
+ * {@link sqlDigest} for the RETURNED side, where the value may be anything.
  *
- * Same reason as {@link snapshotSqlDigest}'s sentinel: the mismatch arm logs values
- * the seam controls, and `undefined.slice(0, 200)` on a verdict cast from `{}`
- * threw out of the log call and past the per-entity contract. `<undefined>` in the
- * payload says what came back; a 500 says nothing and loses the other fields too.
- *
- * Honest bound: a returned value that literally spells `"<undefined>"` is
- * indistinguishable from an absent one here. An operator reading this line is
- * already looking at a gate that answered about the wrong request.
+ * Non-strings fall through to {@link seamString}, so `sql` gets the same sentinel
+ * vocabulary as every other seam field on the line — `<undefined>` and `<null>` and
+ * `<number>` are three different wiring faults in a substituted validator, and `sql`
+ * is the field that identifies the forgery class, so it is the last one that should
+ * collapse them. Every sentinel is still neither 16 characters nor hex, so it can
+ * never be mistaken for a digest.
  */
-function seamString(value: unknown): string {
-  if (typeof value === "string") return value.slice(0, 200);
-  return value === null ? "<null>" : `<${typeof value}>`;
+function seamSqlDigest(value: unknown): string {
+  return typeof value === "string" ? sqlDigest(value) : seamString(value);
+}
+
+/**
+ * WHICH malformation a seam value is — `"object"`, or {@link seamString}'s rendering.
+ *
+ * Exists so the shape test is never written inline at a call site: `isRecord(x)` in a
+ * log payload is an unguarded seam operation for the reason {@link seamRead} gives,
+ * and it read as obviously safe both times it was written that way.
+ */
+function seamKind(value: unknown): string {
+  try {
+    return isRecord(value) ? "object" : seamString(value);
+  } catch {
+    // The same non-silence as `seamRead`'s: the sentinel reaches the operator on the
+    // log line, and the Error is dropped because it comes from the seam under audit.
+    return "<threw>";
+  }
 }
 
 /**
@@ -1844,9 +1924,46 @@ export async function runWarehouseProducer(
     // does so before the promise exists, so `.catch` never sees it and the throw
     // escaped the whole run as a 500 — contradicting this function's own "caught
     // PER ENTITY" contract two paragraphs up.
-    let validation: SnapshotSqlVerdict;
+    // ⚠️ **THE SEAM'S RETURN VALUE IS TOUCHED IN EXACTLY ONE PLACE, AND IT IS INSIDE
+    // THIS `try`.** That is structural, and it is the ratchet this change owes: the
+    // same principle — *narrowing is an operation on the seam value, not a fact about
+    // it* — was violated three times here in three different spellings
+    // (`undefined.slice`, a getter on `.entity`, `Array.isArray` on a revoked Proxy),
+    // and a fourth comment would not have stopped a fourth. Reading `valid`,
+    // `error` and `request` HERE means the arms below handle only captured values,
+    // so no later edit to them can reach a seam accessor at all.
+    //
+    // The reads were previously `validation.valid` and `validation.request` at the
+    // arms themselves, outside every `try` — so a revoked-Proxy or throwing-getter
+    // verdict took down the whole run before this change, not only after it.
+    //
+    // A verdict that is not an object at all — `null`, a revoked Proxy — throws on
+    // the discriminant read below and lands on the gate-threw arm, which is the
+    // honest one: the gate did not ANSWER. `snapshot-rejected` would tell the admin
+    // "re-running will not change this" and to un-enroll a pair that is fine, which
+    // is the wrong advice for a broken gate implementation.
+    //
+    // ⚠️ Three properties, each read ONCE — the rule is per PROPERTY, which is what
+    // lets the discriminant be read in the `if` and keeps TypeScript's narrowing.
+    // The branded `request` therefore stays branded: nothing here needs a cast, and
+    // adding one would weaken the "ONE production cast, deliberately" claim that
+    // `warehouse-producer-bypass.test.ts`'s allowlist rests on.
+    let verdictValid: boolean;
+    let verdictError: unknown;
+    let verdictRequest: ValidatedSnapshotRequest | undefined;
     try {
-      validation = await validateSnapshotSql(request);
+      const verdict = await validateSnapshotSql(request);
+      if (verdict.valid) {
+        verdictValid = true;
+        // Captured by REFERENCE — the identity check below is about this object, so
+        // nothing here may copy, spread or re-wrap it.
+        verdictRequest = verdict.request;
+        verdictError = undefined;
+      } else {
+        verdictValid = false;
+        verdictRequest = undefined;
+        verdictError = verdict.error;
+      }
     } catch (err) {
       // ⚠️ A THROW IS NOT A VERDICT OF INVALID, and routing it to
       // `snapshot-rejected` inverted this file's own permanence split. The gate's
@@ -1867,16 +1984,31 @@ export async function runWarehouseProducer(
       );
       continue;
     }
-    if (!validation.valid) {
+    if (!verdictValid) {
+      // ⚠️ **ONE rendering of a value captured ONCE — the mismatch arm's rule, applied
+      // to its twin.** `validation.error` was read TWICE here, once into the log and
+      // once into the operator-facing message, so a getter could make the two
+      // disagree about why the entity was refused. It is the same seam and the same
+      // argument: {@link SnapshotSqlVerdict} makes `error` required on the reasoning
+      // that the type closes it, and this arm's neighbour exists because a `{}` cast
+      // compiles — both cannot be true. Unguarded, `{ valid: false }` produced
+      // *"does not pass its SQL gate: undefined"*, the generic message CLAUDE.md
+      // forbids, on a refusal whose own text says re-running will not help; a throwing
+      // `toString` escaped the template literal as a 500 for the whole run.
+      //
+      // Bounding is safe here and was checked rather than assumed: `validateSQL`'s
+      // messages carry the table name (already in the sentence) and at most one
+      // unexpected-token character from the parser, never identifiers or literals.
+      const reason = seamString(verdictError);
       log.warn(
-        { ...runLog, entity: entityPlan.entity.name, reason: validation.error },
+        { ...runLog, entity: entityPlan.entity.name, reason },
         "Warehouse producer: the snapshot query did not pass SQL validation — refused permanently, not retried",
       );
       refuseEntity(
         entityPlan,
         "snapshot-rejected",
         `The query Atlas would run against "${entityPlan.entity.table}" does not pass its SQL gate: ` +
-          `${validation.error}. The table is probably outside this workspace's ` +
+          `${reason}. The table is probably outside this workspace's ` +
           "whitelist, or a dimension's `sql:` expression is malformed. **Re-running will not change " +
           "this** — fix the entity or un-enroll the pair.",
       );
@@ -1896,68 +2028,110 @@ export async function runWarehouseProducer(
     // never judged, so "re-running will not change this" would be a claim about a
     // check that did not happen. It shares the arm with the gate THROWING for the
     // same reason — in both, the gate declined to answer about this entity.
-    // ⚠️ **READ ONCE, and this is the other half of freezing the request.**
-    // `validation` comes from the very seam this check defends against, so
-    // `validation.request` is an EXPRESSION the implementer controls: a getter or a
-    // Proxy answers the guard with the honest request and the runner with another
-    // object. Four read SITES across two paths — guard plus two log fields on the
-    // mismatch arm, guard plus the runner argument on the passing one — and a
-    // per-site read proves nothing about the next. The swapped object also carries its own
+    // ⚠️ **READ ONCE, and this is the other half of freezing the request.** The
+    // verdict comes from the very seam this check defends against, so `.request` is
+    // an EXPRESSION the implementer controls: a getter or a Proxy answers the guard
+    // with the honest request and the runner with another object. Four read SITES
+    // across two paths — guard plus two log fields on the mismatch arm, guard plus
+    // the runner argument on the passing one — and a per-site read proves nothing
+    // about the next. The swapped object also carries its own
     // `workspaceId`/`connectionId`, and `defaultRunSnapshot` selects the pool from
     // those, so the residual was a cross-tenant read rather than only a gate bypass.
     // Freezing closes mutation; capturing closes aliasing; neither closes the other.
     // `reconcile.ts` states the same rule for the same reason.
-    const validated = validation.request;
-    if (validated !== request) {
-      // ⚠️ **THREE FIELDS, EACH READ ONCE — the capture rule above, applied one level
-      // down.** `validated` is captured, but its PROPERTIES are still expressions the
-      // seam controls: a Proxy or a getter answers `.sql` honestly for the digest and
-      // dishonestly for the comparison, which is #5230's aliasing finding reproduced
-      // inside the line written to report it. Reading each into a local once is what
-      // makes the digest below a statement about a value rather than about a property
-      // access. The object itself may not be an object at all — a verdict cast from
-      // `{}` or `null` compiles — so it is narrowed before any read; see
-      // {@link seamString} for why a throw here is worse than a sentinel.
-      const returned: Record<string, unknown> = isRecord(validated) ? validated : {};
-      const returnedEntity = returned.entity;
-      const returnedWorkspaceId = returned.workspaceId;
-      const returnedSql = returned.sql;
-      // ⚠️ **This pair is what separates a FORGERY from a benign REPLAY, and until
-      // #5248 the line could not.** Identity is the acceptance test, so both cases
-      // land here: a validator that memoises and hands back an equal-but-distinct
-      // object for THE SAME statement (benign — a retry, a re-wrap), and one that
-      // hands back a token minted for a DIFFERENT statement (the aliased/forged case,
-      // the one worth paging on). Refused either way, so this is observability rather
-      // than a correctness hole — but an operator whose alert cannot tell them apart
-      // is paging on retries and ignoring the real thing.
-      //
-      // Digests, never the statements — see {@link snapshotSqlDigest}. `sql` is this
-      // iteration's own local, so the submitted side cannot be aliased at all.
-      const sqlDigest = snapshotSqlDigest(sql);
-      const returnedSqlDigest = snapshotSqlDigest(returnedSql);
+    //
+    // The single read now happens inside the `try` above — see the note there for why
+    // it MOVED rather than merely being captured here.
+    const validated = verdictRequest;
+    // `undefined` is spelled out only so TypeScript can narrow past it below; it is
+    // already covered by the identity comparison, since `undefined !== request`.
+    if (validated === undefined || validated !== request) {
+      // ⚠️ **FOUR FIELDS, EACH READ ONCE AND EACH GUARDED — the capture rule above,
+      // applied one level down.** `validated` is captured, but its PROPERTIES are
+      // still expressions the seam controls: a getter answers `.sql` honestly for the
+      // digest and dishonestly for the comparison, which is #5230's aliasing finding
+      // reproduced inside the line written to report it. And a getter may THROW rather
+      // than lie — see {@link seamRead}, where narrowing the container was measured
+      // insufficient. Reading each once, through the guard, is what makes every field
+      // below a statement about a value rather than about a property access.
+      const returnedEntity = seamRead(validated, "entity");
+      const returnedWorkspaceId = seamRead(validated, "workspaceId");
+      // ⚠️ `connectionId` is on this line because the capture note above names it as
+      // the residual: `defaultRunSnapshot` selects the POOL from the returned
+      // workspace and connection, so a verdict identical in workspace, entity and
+      // statement text but minted for another connection group is a same-workspace,
+      // wrong-datasource read — and it was previously indistinguishable here from a
+      // benign re-wrap. Two connection groups exposing identically-named tables is an
+      // ordinary workspace; it is why `AmbiguousEntityError` exists.
+      const returnedConnectionId = seamRead(validated, "connectionId");
+      const returnedSql = seamRead(validated, "sql");
+      // Normalised through the SAME expression as the returned side, so a legitimately
+      // absent connection on both sides reads as a match rather than as a difference.
+      const submittedConnectionId = entityPlan.entity.connection ?? undefined;
+      // ⚠️ Digests, never the statements — see {@link sqlDigest}. `sql` is this
+      // iteration's own local, so the submitted side cannot be aliased at all, and its
+      // `string` parameter type is what stops two absent statements matching.
+      const submittedSqlDigest = sqlDigest(sql);
+      const returnedSqlDigest = seamSqlDigest(returnedSql);
       log.error(
         {
           ...runLog,
           entity: entityPlan.entity.name,
           table: entityPlan.entity.table,
+          connectionId: seamString(submittedConnectionId),
           // ⚠️ What CAME BACK, under its OWN keys so `runLog`'s workspaceId is not
           // shadowed. Without these, the replay this branch exists for (a cached
           // token for the first entity) and a token minted against ANOTHER
           // WORKSPACE's statement log identically — and the second is the one that
           // has to be greppable the day it happens.
           //
-          // Bounded: both strings come from the seam rather than from the plan, and
-          // nothing else on this line is attacker-shaped.
+          // Bounded by `seamString`: every one comes from the seam rather than from
+          // the plan, and nothing else on this line is attacker-shaped.
           returnedEntity: seamString(returnedEntity),
           returnedWorkspaceId: seamString(returnedWorkspaceId),
-          sqlDigest,
+          returnedConnectionId: seamString(returnedConnectionId),
+          // Which of "the gate returned an object with no fields" and "the gate
+          // returned a string / null / a function" happened. Without it all of them
+          // collapse onto one payload of sentinels — the same collapse this arm exists
+          // to undo, one level up.
+          returnedRequestType: seamKind(validated),
+          returnedReadThrew:
+            returnedEntity === SEAM_THREW ||
+            returnedWorkspaceId === SEAM_THREW ||
+            returnedConnectionId === SEAM_THREW ||
+            returnedSql === SEAM_THREW,
+          sqlDigest: submittedSqlDigest,
           returnedSqlDigest,
-          // ⚠️ Derivable from the two above and logged anyway, because an alert rule
-          // is a FILTER, not a computation: `sqlDigestMatch: false` is one greppable
-          // predicate, while "these two hex fields differ" is a join most log
-          // pipelines cannot express. Named for what was actually compared — digests,
-          // truncated — rather than claiming the statements themselves are equal.
-          sqlDigestMatch: sqlDigest === returnedSqlDigest,
+          // ⚠️ **THREE MATCH BOOLEANS, and the third is not decoration.** Each is
+          // derivable from the pair of fields above it and logged anyway, because an
+          // alert rule is a FILTER, not a computation: `sqlDigestMatch: false` is one
+          // greppable predicate, while "these two hex fields differ" is a join most
+          // log pipelines cannot express.
+          //
+          // ⚠️ **`sqlDigestMatch: true` means THE SAME STATEMENT TEXT — it does NOT
+          // mean "benign".** {@link buildSnapshotSql} emits no workspace and no
+          // connection, so two workspaces enrolled on the same table with the same
+          // dimension names build BYTE-IDENTICAL statements — the normal case for
+          // tenants onboarded from one connector template. A token minted against
+          // another workspace's request therefore lands here with the digests EQUAL,
+          // and an operator alerting only on `sqlDigestMatch: false` would miss the
+          // worst forgery this arm can see. The other two booleans are what that alert
+          // actually keys on; the naming is deliberate for the same reason.
+          //
+          // ⚠️ The `typeof` arm is DEFENCE IN DEPTH and is deliberately recorded as
+          // unfalsifiable: removing it was measured green against the whole suite,
+          // because the state it refuses — both sides rendering the same sentinel — is
+          // unreachable while the submitted side is a `string` by construction. The
+          // real guarantee is {@link sqlDigest}'s `string` parameter, which is a
+          // COMPILE error to break rather than a test to run; this arm only keeps the
+          // runtime honest if a future edit makes the submitted side seam-derived.
+          // Written down instead of tested, per the rule about publishing a claim no
+          // measurement backs.
+          sqlDigestMatch:
+            typeof returnedSql === "string" && submittedSqlDigest === returnedSqlDigest,
+          returnedWorkspaceIdMatch: returnedWorkspaceId === workspaceId,
+          returnedEntityMatch: returnedEntity === entityPlan.entity.name,
+          returnedConnectionIdMatch: returnedConnectionId === submittedConnectionId,
         },
         "Warehouse producer: the SQL gate returned a verdict for a different request — refusing rather than reading",
       );

--- a/packages/api/src/lib/brain/warehouse-producer.ts
+++ b/packages/api/src/lib/brain/warehouse-producer.ts
@@ -1520,17 +1520,13 @@ const SEAM_THREW = Symbol("seam-threw");
 /**
  * Read ONE property off a value the validator seam controls, totally.
  *
- * ⚠️ **Narrowing the container is not enough, and that gap was the first version of
- * this code.** `isRecord(validated)` answers `true` for `{ get entity() { throw … } }`,
- * so the property access itself runs seam-controlled code. (A revoked Proxy is worse
- * still and is handled by the placement below, not by this paragraph: `isRecord`
- * does not answer `true` for one, it THROWS.) The refusal arms of {@link runWarehouseProducer}
- * have NO enclosing `try` — the per-entity catches wrap the validator call, the
- * snapshot and the transaction, and the arms sit between them — so a throw here
- * escapes the loop, escapes the function, and turns ONE refused entity into a 500
- * for the whole run. That is the contract this file documents two paragraphs into
- * `runWarehouseProducer`, broken for the sake of a diagnostic line, and it costs the
- * operator the very forensic payload the line exists to produce.
+ * ⚠️ **Narrowing the container is not enough.** `isRecord(validated)` answers `true`
+ * for `{ get entity() { throw … } }`, so the property access itself runs
+ * seam-controlled code. The refusal arms of {@link runWarehouseProducer} have NO
+ * enclosing `try` — the per-entity catches wrap the validator call, the snapshot and
+ * the transaction, and the arms sit between them — so a throw here escapes the loop
+ * and turns ONE refused entity into a 500 for the whole run, losing the forensic
+ * payload the line exists to produce.
  *
  * Absent and non-record both answer `undefined`, which {@link seamString} renders as
  * `<undefined>`; a throw answers {@link SEAM_THREW}, which renders as `<threw>`. The
@@ -1538,27 +1534,24 @@ const SEAM_THREW = Symbol("seam-threw");
  */
 function seamRead(source: unknown, key: string): unknown {
   try {
-    // ⚠️ **`isRecord` IS INSIDE THE `try`, and putting it outside was this helper's
-    // own instance of the defect it exists to close — the THIRD in one change.** It
-    // calls `Array.isArray`, which THROWS on a revoked Proxy rather than answering
-    // (measured: *"Array.isArray cannot be called on a Proxy that has been
-    // revoked"*), while `typeof` and `!== null` pass it cleanly first. So the guard
-    // written to make the read total was itself an unguarded seam operation, sitting
-    // one line above the `try` that was supposed to cover it.
-    //
-    // The rule the three instances share: **narrowing is an OPERATION on the seam
-    // value, not a fact about it.** Anything that dispatches on the object — a
-    // property read, `Array.isArray`, a template literal, `toString` — belongs
-    // inside the guard, never in front of it.
+    // ⚠️ `isRecord` belongs INSIDE the `try`: it calls `Array.isArray`, which throws
+    // on a revoked Proxy rather than answering, while `typeof` and `!== null` pass one
+    // cleanly first. The general rule, and it cost three instances to learn:
+    // **narrowing is an OPERATION on the seam value, not a fact about it.** Anything
+    // that dispatches on the object — a property read, `Array.isArray`, a template
+    // literal, `toString` — goes inside the guard, never in front of it.
     if (!isRecord(source)) return undefined;
     return source[key];
   } catch {
     // NOT silence, so this takes a plain comment rather than CLAUDE.md's
     // `intentionally ignored` marker: the sentinel IS the signal, and it reaches the
     // operator on the same log line as the field it replaces, alongside
-    // `returnedReadThrew`. The Error object is dropped DELIBERATELY — it comes from
-    // the seam under audit, so a hostile `.message` or `.stack` getter would throw
-    // again inside the log serializer, re-opening the exact escape this helper closes.
+    // `returnedReadThrew`.
+    //
+    // The Error is dropped because it comes from the seam under audit, so it is
+    // evidence of nothing, and the field's own sentinel already says which read
+    // failed. Not because logging it would be unsafe: `scrubErrSerializer` has a
+    // total outer catch and renders a hostile one as `[log scrub failed]`.
     return SEAM_THREW;
   }
 }
@@ -1583,6 +1576,22 @@ function seamString(value: unknown): string {
   if (value === SEAM_THREW) return "<threw>";
   if (typeof value === "string") {
     return value.length > 200 ? `${value.slice(0, 200)}…(${value.length})` : value;
+  }
+  // ⚠️ An `Error` is the likeliest non-string a plugin-supplied or future validator
+  // puts in `error`, and without this arm it rendered `<object>` — `undefined` with
+  // extra steps, on a PERMANENT refusal whose own text says re-running will not
+  // help. That is the generic message CLAUDE.md forbids, arriving through the
+  // renderer added to remove it. `.message` is itself a seam read, so it is guarded
+  // like every other one.
+  try {
+    if (value instanceof Error) {
+      const message = value.message;
+      if (typeof message === "string") return seamString(message);
+    }
+  } catch {
+    // Not silence — `<threw>` is the signal, and it is the same sentinel every other
+    // failed seam read on this line renders.
+    return "<threw>";
   }
   return value === null ? "<null>" : `<${typeof value}>`;
 }
@@ -1618,27 +1627,51 @@ function sqlDigest(sql: string): string {
 /**
  * {@link sqlDigest} for the RETURNED side, where the value may be anything.
  *
- * Non-strings fall through to {@link seamString}, so `sql` gets the same sentinel
- * vocabulary as every other seam field on the line — `<undefined>` and `<null>` and
+ * Non-strings render through {@link seamKind}, so `sql` gets the same sentinel
+ * vocabulary as every other seam field on the line — `<undefined>`, `<null>` and
  * `<number>` are three different wiring faults in a substituted validator, and `sql`
  * is the field that identifies the forgery class, so it is the last one that should
- * collapse them. Every sentinel is still neither 16 characters nor hex, so it can
- * never be mistaken for a digest.
+ * collapse them.
+ *
+ * ⚠️ **{@link seamKind}, NOT {@link seamString}, and the difference is a hole that
+ * was measured open.** `seamString` renders an `Error` by its message, so a verdict
+ * carrying `sql: new Error("f52e4d03c838ad9d")` put an attacker-chosen 16-hex string
+ * in `returnedSqlDigest` — indistinguishable from a real digest to the operator
+ * reading the line, and equal to the submitted one if they copy it. Every value
+ * `seamKind` returns is bracketed, so nothing in this function's range can be
+ * mistaken for a digest.
  */
 function seamSqlDigest(value: unknown): string {
-  return typeof value === "string" ? sqlDigest(value) : seamString(value);
+  return typeof value === "string" ? sqlDigest(value) : seamKind(value);
 }
 
 /**
- * WHICH malformation a seam value is — `"object"`, or {@link seamString}'s rendering.
+ * WHAT KIND a seam value is — never what it CONTAINS.
  *
  * Exists so the shape test is never written inline at a call site: `isRecord(x)` in a
  * log payload is an unguarded seam operation for the reason {@link seamRead} gives,
  * and it read as obviously safe both times it was written that way.
+ *
+ * ⚠️ **Renders the TYPE, never the value.** Falling through to {@link seamString}
+ * echoed a returned request that happened to be a STRING verbatim — and a validator
+ * that crosses a wire, or a serialising proxy, answers `JSON.stringify(request)`,
+ * which is the whole SELECT with its table and column names. That is the one thing
+ * {@link sqlDigest} exists to keep out of the log. Rendering `<string>` loses
+ * nothing: the field's job is to tell the malformations the fixture table lists
+ * apart, and the bracketed vocabulary still does.
+ *
+ * Every value in the range is BRACKETED, the record case included: `"object"` beside
+ * a sentinel `"<object>"` for an ARRAY was two characters apart with opposite
+ * meanings, so a filter written for one silently missed the other.
  */
 function seamKind(value: unknown): string {
+  // The same sentinel `seamString` uses. Reachable through {@link seamSqlDigest},
+  // whose input is a `seamRead` result: without this arm a thrown `sql` read rendered
+  // `<symbol>`, which names the marker's implementation rather than what happened.
+  if (value === SEAM_THREW) return "<threw>";
   try {
-    return isRecord(value) ? "object" : seamString(value);
+    if (isRecord(value)) return "<record>";
+    return value === null ? "<null>" : `<${typeof value}>`;
   } catch {
     // The same non-silence as `seamRead`'s: the sentinel reaches the operator on the
     // log line, and the Error is dropped because it comes from the seam under audit.
@@ -1945,24 +1978,51 @@ export async function runWarehouseProducer(
     //
     // ⚠️ Three properties, each read ONCE — the rule is per PROPERTY, which is what
     // lets the discriminant be read in the `if` and keeps TypeScript's narrowing.
-    // The branded `request` therefore stays branded: nothing here needs a cast, and
-    // adding one would weaken the "ONE production cast, deliberately" claim that
-    // `warehouse-producer-bypass.test.ts`'s allowlist rests on.
+    // The branded `request` therefore stays branded, and nothing here needs a cast.
+    // Keep it that way by discipline rather than by guard: since #5249 the bypass
+    // allowlist is a whole-FILE name scan, so a second cast inside this file would
+    // be invisible to it.
     let verdictValid: boolean;
     let verdictError: unknown;
     let verdictRequest: ValidatedSnapshotRequest | undefined;
+    // ⚠️ **The payload reads are guarded SEPARATELY from the gate call, and the
+    // difference decides which arm reports the event.** Folding them into the outer
+    // `try` sent a throwing `.request` to the gate-threw arm — a `warn` reading *"the
+    // SQL gate threw rather than answering"*, with no digests, no match booleans, no
+    // `returned*` fields at all. Detectability is this change's entire deliverable,
+    // so a hostile validator would only have had to throw from `.request` to demote
+    // its own forgery to something that looks like a transient module-init blip.
+    // Guarded here, an unreadable request stays `undefined`, fails the identity check
+    // below, and reaches the mismatch arm with `returnedReadThrew: true` — which is
+    // the line that exists to report exactly this.
+    let verdictRequestThrew = false;
     try {
       const verdict = await validateSnapshotSql(request);
       if (verdict.valid) {
         verdictValid = true;
-        // Captured by REFERENCE — the identity check below is about this object, so
-        // nothing here may copy, spread or re-wrap it.
-        verdictRequest = verdict.request;
         verdictError = undefined;
+        try {
+          // Captured by REFERENCE — the identity check below is about this object, so
+          // nothing here may copy, spread or re-wrap it.
+          verdictRequest = verdict.request;
+        } catch {
+          // Not silence: `verdictRequestThrew` reaches the mismatch line as
+          // `returnedReadThrew`, and `undefined` is what routes the entity there.
+          verdictRequest = undefined;
+          verdictRequestThrew = true;
+        }
       } else {
         verdictValid = false;
         verdictRequest = undefined;
-        verdictError = verdict.error;
+        try {
+          verdictError = verdict.error;
+        } catch {
+          // Not silence: `seamString` renders this as `<threw>` in both the log and
+          // the operator-facing refusal. The gate DID answer invalid, so the entity
+          // keeps that verdict's permanence rather than being demoted to transient
+          // because its reason was unreadable.
+          verdictError = SEAM_THREW;
+        }
       }
     } catch (err) {
       // ⚠️ A THROW IS NOT A VERDICT OF INVALID, and routing it to
@@ -1996,9 +2056,13 @@ export async function runWarehouseProducer(
       // forbids, on a refusal whose own text says re-running will not help; a throwing
       // `toString` escaped the template literal as a 500 for the whole run.
       //
-      // Bounding is safe here and was checked rather than assumed: `validateSQL`'s
-      // messages carry the table name (already in the sentence) and at most one
-      // unexpected-token character from the parser, never identifiers or literals.
+      // Bounded at 200, and the bound BITES: measured against the real parser, three
+      // of four realistic parse failures produced messages of 201–254 characters,
+      // because it lists every expected token. So the tail — the "but X found" clause
+      // and the remediation sentence — is cut on the commonest failure. The `…(n)`
+      // suffix is what stops that reading as a complete message. The messages carry
+      // the table name (already in the sentence) and blocked function names lifted
+      // from the submitted query, never row values.
       const reason = seamString(verdictError);
       log.warn(
         { ...runLog, entity: entityPlan.entity.name, reason },
@@ -2043,8 +2107,10 @@ export async function runWarehouseProducer(
     // The single read now happens inside the `try` above — see the note there for why
     // it MOVED rather than merely being captured here.
     const validated = verdictRequest;
-    // `undefined` is spelled out only so TypeScript can narrow past it below; it is
-    // already covered by the identity comparison, since `undefined !== request`.
+    // Redundant — `request` is frozen and never `undefined`, so `undefined !== request`
+    // already routes here, and TypeScript narrows without the disjunct. Spelled out
+    // because a `.request` getter that threw lands here as `undefined`, and that is a
+    // state a reader will look for.
     if (validated === undefined || validated !== request) {
       // ⚠️ **FOUR FIELDS, EACH READ ONCE AND EACH GUARDED — the capture rule above,
       // applied one level down.** `validated` is captured, but its PROPERTIES are
@@ -2073,6 +2139,19 @@ export async function runWarehouseProducer(
       // `string` parameter type is what stops two absent statements matching.
       const submittedSqlDigest = sqlDigest(sql);
       const returnedSqlDigest = seamSqlDigest(returnedSql);
+      // ⚠️ **A MATCH CLAIM REQUIRES A READABLE CONTAINER, and leaving that out
+      // reproduced — one field over, in this same object literal — the defect the
+      // `sqlDigest(sql: string)` split had just closed.** `seamRead` answers
+      // `undefined` both for an absent field AND for a non-record, and
+      // `submittedConnectionId` is `undefined` for every default-connection
+      // workspace, which is the ordinary case. So `returnedConnectionIdMatch` read
+      // TRUE for a verdict that was `null`, `undefined`, a bare string, an array or a
+      // number — *"the gate returned no request at all"* reported as *"the connection
+      // matched"*, on the field this arm's own comment calls the alert key. (`{}`
+      // still reads true, and correctly so — both sides are genuinely absent; see
+      // `returnedRequestMatch` below for why that is safe.)
+      const returnedRequestType = seamKind(validated);
+      const returnedIsRecord = returnedRequestType === "<record>";
       log.error(
         {
           ...runLog,
@@ -2090,12 +2169,12 @@ export async function runWarehouseProducer(
           returnedEntity: seamString(returnedEntity),
           returnedWorkspaceId: seamString(returnedWorkspaceId),
           returnedConnectionId: seamString(returnedConnectionId),
-          // Which of "the gate returned an object with no fields" and "the gate
-          // returned a string / null / a function" happened. Without it all of them
-          // collapse onto one payload of sentinels — the same collapse this arm exists
-          // to undo, one level up.
-          returnedRequestType: seamKind(validated),
+          // Which malformation it was. Without it the non-record verdicts — null,
+          // undefined, a string, an array, a number — produce one identical payload of
+          // sentinels, the same collapse this arm exists to undo, one level up.
+          returnedRequestType,
           returnedReadThrew:
+            verdictRequestThrew ||
             returnedEntity === SEAM_THREW ||
             returnedWorkspaceId === SEAM_THREW ||
             returnedConnectionId === SEAM_THREW ||
@@ -2118,20 +2197,38 @@ export async function runWarehouseProducer(
           // worst forgery this arm can see. The other two booleans are what that alert
           // actually keys on; the naming is deliberate for the same reason.
           //
-          // ⚠️ The `typeof` arm is DEFENCE IN DEPTH and is deliberately recorded as
-          // unfalsifiable: removing it was measured green against the whole suite,
-          // because the state it refuses — both sides rendering the same sentinel — is
-          // unreachable while the submitted side is a `string` by construction. The
-          // real guarantee is {@link sqlDigest}'s `string` parameter, which is a
-          // COMPILE error to break rather than a test to run; this arm only keeps the
-          // runtime honest if a future edit makes the submitted side seam-derived.
-          // Written down instead of tested, per the rule about publishing a claim no
-          // measurement backs.
+          // `typeof` first, and it is the second of two independent guarantees: it is
+          // redundant while {@link seamSqlDigest} brackets every non-string, and it is
+          // what held when that bracketing was briefly absent — a verdict carrying
+          // `sql: new Error(<the submitted digest>)` otherwise reported a match.
           sqlDigestMatch:
             typeof returnedSql === "string" && submittedSqlDigest === returnedSqlDigest,
-          returnedWorkspaceIdMatch: returnedWorkspaceId === workspaceId,
-          returnedEntityMatch: returnedEntity === entityPlan.entity.name,
-          returnedConnectionIdMatch: returnedConnectionId === submittedConnectionId,
+          returnedWorkspaceIdMatch: returnedIsRecord && returnedWorkspaceId === workspaceId,
+          returnedEntityMatch: returnedIsRecord && returnedEntity === entityPlan.entity.name,
+          returnedConnectionIdMatch:
+            returnedIsRecord && returnedConnectionId === submittedConnectionId,
+          // ⚠️ **THE PREDICATE AN ALERT KEYS ON — the three components above are
+          // DIAGNOSTIC and at least one of them cannot carry the alert alone.**
+          // `returnedConnectionIdMatch` is `true` for a verdict of `{}`, and that is
+          // literally correct rather than a bug: both sides are absent, because the
+          // submitted connection is `undefined` for every default-connection
+          // workspace. Requiring the field to be PRESENT instead would report every
+          // benign default-connection replay as a connection mismatch — noise on day
+          // one, which is the failure the whole field was added to avoid. The
+          // conjunction is what distinguishes the two: an empty record fails it on
+          // `entity` and `workspaceId`, whose submitted sides are non-empty strings.
+          //
+          // ⚠️ The `returnedIsRecord` conjunct here is REDUNDANT and recorded as such:
+          // removing it was measured green, because a non-record answers `undefined`
+          // for every field and the two string comparisons below already fail. It is
+          // kept for the same reason as `sqlDigestMatch`'s `typeof` arm — defence in
+          // depth against a future edit — and, like that one, it is documented rather
+          // than pinned by a test that could not fail.
+          returnedRequestMatch:
+            returnedIsRecord &&
+            returnedWorkspaceId === workspaceId &&
+            returnedEntity === entityPlan.entity.name &&
+            returnedConnectionId === submittedConnectionId,
         },
         "Warehouse producer: the SQL gate returned a verdict for a different request — refusing rather than reading",
       );


### PR DESCRIPTION
## What

The gate/request identity check in `runWarehouseProducer` refuses two different things on one arm, and until now logged them identically:

- a verdict minted for a **different statement** — the aliased/forged case, the one worth paging on; and
- the **same statement** arriving under a fresh object — a memoising or re-wrapping validator, i.e. a retry.

Both are refused, so this was never a correctness hole. It was an observability one: the signal that someone is exercising the bypass looked exactly like the signal that a retry happened, so an alert on that arm fires on the routine case and stays quiet for the real one.

The mismatch line now carries `sqlDigest`, `returnedSqlDigest` and `sqlDigestMatch`.

**Digests, never the statements.** The SELECT is assembled from admin-authored `table:` and `sql:` expressions, so it can carry a column name — or, through a `sql:` expression, a literal — that identifies a customer. CLAUDE.md forbids that reaching a log, and the mismatch arm is precisely where an operator most wants the statement, which is what makes writing the rule down there worth the lines. sha256 truncated to 16 hex, matching `logger.ts`'s `hashShareToken` and `learn/pattern-analyzer.ts`.

`sqlDigestMatch` is derivable from the two digests and is logged anyway: an alert rule is a **filter**, not a computation, and *"these two hex fields differ"* is a join most log pipelines cannot express. It is named for what was actually compared — truncated digests — rather than claiming the statements themselves are equal.

## Read once, at the property level

#5230 established that `validation.request` is an expression the seam controls, and captured it once. Its **properties** are the same expression one level down: a getter that answers honestly for the digest and dishonestly for the comparison puts a forged statement on the log as a benign replay — #5230's own finding reproduced inside the line written to report it. All three returned fields (`entity`, `workspaceId`, `sql`) are now read into locals exactly once, and a test counts the reads.

## Behaviour delta — the returned-field reads

The mismatch arm has **no enclosing `try`** (the per-entity catches wrap the validator call and the snapshot, not this branch), so a throw while *building* the payload escapes `runWarehouseProducer` and turns one refused entity into a 500 for the whole run — contradicting that function's own "caught PER ENTITY" contract for the sake of a diagnostic line. A verdict cast from `{}` compiles, and `warehouse-producer-bypass.test.ts` pins the sites that may write one.

| returned request | before | after |
|---|---|---|
| well-formed, all string fields | logged verbatim, bounded to 200 | unchanged |
| object, non-string `entity`/`workspaceId` | `undefined.slice(0,200)` → TypeError escapes the run as a 500 | `<undefined>` / `<number>` sentinel; entity refused |
| object, non-string `sql` | (field did not exist) | `<non-string>`, `sqlDigestMatch: false` |
| `null` / non-object | `.entity` read → TypeError escapes | narrowed with `isRecord` first; sentinels logged |

The sentinel cannot be confused with a digest — `<non-string>` is neither 16 characters nor hex — and the submitted side is a string by construction (`buildSnapshotSql` returns one), so it can never equal the returned side's sentinel and report a false match.

**No wire change.** `snapshot-failed` gains no field and no sibling reason; the schema docstring already covers this cause. The issue left that open and this is the cheaper of the two answers.

## Falsifiers — built, run, and measured RED

Five mutations against the four new cases in `warehouse-producer-logging.test.ts`:

| mutation | result |
|---|---|
| hardcode `sqlDigestMatch: false` | **RED** — forged/replay + read-once |
| `returnedSqlDigest` digests the SUBMITTED sql | **RED** — forged/replay + no-request |
| read `validated.sql` a second time | **RED** — read-once (`sqlReads` becomes 2) |
| `String(...)` coercion instead of the seam sentinels | **RED** — no-request case |
| log the raw submitted SQL beside the digest | **RED** — never-carries-one |

The expected digest is computed **independently** in the test rather than imported from the producer: a fixture that derives its expectation from the implementation agrees with it by construction, so swapping the algorithm would stay green.

## Acceptance criteria

- [x] A mismatch log line distinguishes a different-statement mismatch from a repeated-statement replay — `sqlDigestMatch`, asserted in both directions and asserted to *differ between the two runs*
- [x] No raw SQL, connection string, or customer identifier reaches the log — digest only; a test asserts the serialized payload contains neither the whole statement nor the column name `lifecycle_status`, behind a positive anchor so it cannot go vacuous
- [x] The digest is read once — a counting getter asserts `sqlReads === 1`
- [x] A falsifier that goes red if the two cases collapse back onto one log shape — measured above

Closes #5248

---

## Review panel — stopped on the RATIO rule, not the cap

| round | findings | new surface | defect-in-prior-fix | minutes (agent-reported) |
|---|---|---|---|---|
| 1 | 10 | 10 | 0 | 4.8 / 5.2 / 5.8 (parallel) |
| 2 | ~24 | ~4 | **~20** | 9.1 / 9.9 / 10.3 (parallel) |
| closing | comment sweep: 8 false/stale claims + 1 **code defect** | — | — | 13.2 |

**Round 2's defect-in-prior-fix count exceeded its new-surface count, so the rounds ended that round** — the ratio rule, one round before the cap would have applied. The tell was not the raw total: round 2 found *more* than round 1, but almost all of it was damage from round 1's own fixes, and more review cannot help when the fixes are the defect source.

The sharpest instance is the rule's own textbook shape — **the sibling in the same object literal**: round 1 closed *"two absent values compare equal"* for `sqlDigestMatch` with a type (`sqlDigest(sql: string)`), and the same commit reopened it one field over on `returnedConnectionIdMatch`, which read `true` on five reachable classes including a `null` verdict.

And the closing comment sweep then found round 2's fix producing a round-3 defect: the `Error` arm added to `seamString` let `seamSqlDigest` return an **attacker-chosen 16-hex string** in `returnedSqlDigest`. That is the pattern the ratio rule exists to stop, arriving one layer down.

### What the rounds changed about the deliverable

Round 1 shipped a log line that was **wrong about its own alert**. `buildSnapshotSql` emits no workspace and no connection, so two tenants on the same table build byte-identical SQL — a cross-tenant forgery logged `sqlDigestMatch: true`, and the comment told operators to alert on `sqlDigestMatch: false`. The PR's title claim ("a forgery no longer reads as a replay") was false for the worst forgery it can see. That is now `returnedRequestMatch`, with the three components kept for diagnosis.

### Consciously left as follow-ups

The seam-read ratchet is closed for the **validator** seam. Three measured findings apply the same principle to *other* seams and are deferred, because each needs its own falsifiers and would enter the diff with no round left to review it:

- `runSnapshot`'s return value is touched outside every `try` (`rows.length`, `buildWarehouseClaims`) — 8 measured escape classes, all whole-run 500s with no log line
- `loadEntity`'s `parseWarehouseEntity(name, raw)` sits outside the `try` whose own comment says a throw there kills the run
- `instanceof` on a seam-thrown value in the transaction `.catch`

None is reachable with the shipped implementations (real pg rows, real YAML), and all three predate this PR. Filed as a follow-up.

Also declined, with reasoning: replacing the three flat capture locals with a local discriminated union. Once a thrown `.request` getter became a real state, the capture is genuinely tri-state (valid+readable / valid+unreadable / invalid), which a two-arm union cannot express without adding an arm.

### Falsifiers

31 mutants across the rounds; **every one that survived round 2 is now RED**. Two survivors are recorded rather than papered over — the `typeof` arm of `sqlDigestMatch` (kept: it is what held while the Error hole was open) and the `returnedIsRecord` conjunct in `returnedRequestMatch` (genuinely redundant, kept as defence in depth, documented as redundant rather than as tested).
