### PR TITLE
fix(brain): carry the seam-read ratchet past the validator — runSnapshot, loadEntity and the transaction catch (#5257)

### DIFF
--- a/packages/api/src/lib/brain/__tests__/warehouse-producer-logging.test.ts
+++ b/packages/api/src/lib/brain/__tests__/warehouse-producer-logging.test.ts
@@ -1160,12 +1160,15 @@ describe("warehouse producer logging", () => {
  * seams of the same loop — the snapshot runner's return value, the entity loader's
  * return value, and the value `withTransaction` rejects with.
  *
- * ⚠️ **Every case here was measured RED against the unfixed producer**, by restoring
- * the pre-fix file from a backup and re-running this suite — not reasoned about.
- * Reasoning has been wrong on this principle three times in this file's history, and
- * a `runWarehouseProducer` that REJECTS is the failure: one refused entity becomes a
- * 500 for the whole run, with no log line at all, which is why every case below
- * asserts a resolved report AND a log line rather than only the first.
+ * Falsifiers here were measured against the unfixed producer by restoring it from a
+ * backup and re-running — not reasoned about. **Not every case is one:** several are
+ * counter-cases or pins that were GREEN before the fix and are killed instead by a
+ * targeted mutation of it, and each says so at its own site. Reasoning has been wrong
+ * on this principle repeatedly in this file's history.
+ *
+ * A `runWarehouseProducer` that REJECTS is the failure this describe exists for: one
+ * refused entity becoming a 500 for the whole run, with no log line at all. That is
+ * why the cases assert a resolved report AND a log line rather than only the first.
  */
 describe("warehouse producer seam reads past the validator (#5257)", () => {
   /**
@@ -1265,9 +1268,7 @@ describe("warehouse producer seam reads past the validator (#5257)", () => {
       // ⚠️ **A PIN, not a falsifier, and saying so is the honest half.** Measured
       // GREEN against the unfixed producer: a revoked Proxy is trapped by the `await`
       // inside the existing `try`, so this case survived by luck rather than by
-      // design. It stays because the fix's own `Array.isArray` is an operation on the
-      // seam value and would throw here — correct only because it sits inside the
-      // `try`. No local mutation of the fix REDs it, which is the shape of "covered by
+      // design. No local mutation of the fix REDs it, which is the shape of "covered by
       // construction" worth recording rather than dressing up as a measurement.
       //
       // ⚠️ The first draft of this comment justified that with *"every consumption of
@@ -1335,6 +1336,33 @@ describe("warehouse producer seam reads past the validator (#5257)", () => {
 
       const report = await run({ rowCap: 5, runSnapshot: returning(lying) });
       expect(report.entities.map((e) => e.rows)).toEqual([0]);
+      // ⚠️ The same premise pin as the case above, and without it this one is INERT:
+      // with only two reads the trap never fires, so a plain `[]` satisfies the
+      // assertion and the Proxy proves nothing.
+      expect(reads).toBe(2);
+    });
+
+    it("refuses a snapshot whose `length` is not a usable count", async () => {
+      // ⚠️ Making the cap check and the report the same number does not make that
+      // number VALID. `NaN > rowCap` is false, so a trap answering `NaN` sailed past
+      // the cap into `WarehouseEntityOutcome.rows`, where the run report's schema
+      // requires a non-negative int — so one bad `length` blanked the ENTIRE run
+      // report, every other entity's outcome included. Bigger blast radius than the
+      // entity it came from, which is why it is refused at the read.
+      for (const bad of [Number.NaN, -1, 1.5, Number.POSITIVE_INFINITY]) {
+        warns.length = 0;
+        const hostile = new Proxy([] as Record<string, unknown>[], {
+          get(target, key, receiver) {
+            if (key === "length") return bad;
+            return Reflect.get(target, key, receiver);
+          },
+        });
+        const report = await run({ runSnapshot: returning(hostile) });
+        expect(report.refusals.map((r) => r.reason)).toEqual(["snapshot-failed"]);
+        expect(report.entities).toEqual([]);
+        // Blamed on Atlas, not the entity — the shape phase, not the read.
+        expect(payloadOf(warns, "snapshot failed").phase).toBe("shape");
+      }
     });
 
     it("survives a NULL row inside a well-formed array", async () => {
@@ -1365,7 +1393,13 @@ describe("warehouse producer seam reads past the validator (#5257)", () => {
       const report = await run({ runSnapshot: returning([hostileRow]) });
       expect(report.refusals.map((r) => r.reason)).toEqual(["snapshot-failed"]);
       expect(report.entities).toEqual([]);
-      expect(payloadOf(warns, "snapshot failed").entity).toBe("Accounts");
+      // ⚠️ `phase: "claims"` — the ONLY signal separating "the seam answered a bad
+      // shape" from "our own claim builder is defective", which is the stated cost of
+      // widening the `try`. Nothing else asserts it, so deleting the assignment was
+      // green until this line.
+      const payload = payloadOf(warns, "snapshot failed");
+      expect(payload.entity).toBe("Accounts");
+      expect(payload.phase).toBe("claims");
       expect(messages(errors)).toEqual([]);
     });
 
@@ -1426,8 +1460,13 @@ describe("warehouse producer seam reads past the validator (#5257)", () => {
           throw new Error("relation does not exist");
         },
       });
-      expect(read.refusals[0]?.message).toContain("Fix the entity YAML");
-      expect(read.refusals[0]?.message).not.toContain("This is an Atlas fault");
+      // ⚠️ It points at the LOG rather than asserting the cause. `phase: "run"` covers
+      // more than the datasource read — `defaultRunSnapshot` imports a module and looks
+      // up a pool first — so naming "a table or column that no longer exists" as THE
+      // cause was unfollowable for the Atlas-side half of its own arm.
+      expect(read.refusals[0]?.message).toContain("a table or a dimension's column");
+      expect(read.refusals[0]?.message).toContain("The server log for this run names what");
+      expect(read.refusals[0]?.message).not.toContain("This is an Atlas fault rather than a problem");
       expect(payloadOf(warns, "snapshot failed").phase).toBe("run");
     });
 
@@ -1518,17 +1557,35 @@ describe("warehouse producer seam reads past the validator (#5257)", () => {
       expect(warns.filter((c) => c.message.includes("YAML could not be read"))).toEqual([]);
     });
 
-    it("routes a non-record loader answer to `no-table`, silently", async () => {
-      // A loader answering a string or an array does not THROW — `parseWarehouseEntity`
-      // reads no `table:` off it and returns null — so it lands on the third arm, whose
-      // remedy is already right. Pinned because the wire cannot tell these three apart
-      // (all are `entity-unreadable`) and only the log can, which is this file's whole
-      // subject: this one is deliberately NOT logged, and that asymmetry should be a
-      // decision rather than an accident.
-      const report = await run({ loadEntity: async () => "yaml" as unknown as Record<string, unknown> });
+    it("blames ATLAS when the loader answers something that is not a record", async () => {
+      // ⚠️ **This case previously PINNED THE DEFECT.** A loader answering a string or an
+      // array does not throw — `nonEmptyString(raw.table)` just answers `undefined` — so
+      // it fell through to the `no-table` arm and told the admin *"its YAML declares no
+      // `table:` … Fix the entity YAML"*, with ZERO log lines. That is the same
+      // misdirection the `unreadable-shape` split removed, one arm over, and the
+      // quietest instance of it: the other two arms at least warn.
+      for (const answer of ["yaml", 42, [], true]) {
+        warns.length = 0;
+        const report = await run({
+          loadEntity: async () => answer as unknown as Record<string, unknown>,
+        });
+
+        expect(report.refusals.map((r) => r.reason)).toEqual(["entity-unreadable"]);
+        expect(report.refusals[0]?.message).toContain("This is an Atlas fault");
+        expect(report.refusals[0]?.message).not.toContain("declares no `table:`");
+        expect(payloadOf(warns, "not an entity record").entity).toBe("Accounts");
+      }
+    });
+
+    it("keeps the genuine `no-table` arm silent for a record that simply omits it", async () => {
+      // The counter-case: a real entity record with no `table:` is an ordinary YAML
+      // mistake whose remedy is already right, and it stays SILENT by design. Without
+      // this, the shape guard above could be widened to swallow the genuine case too.
+      const report = await run({ loadEntity: async () => ({ dimensions: [] }) });
 
       expect(report.refusals.map((r) => r.reason)).toEqual(["entity-unreadable"]);
       expect(report.refusals[0]?.message).toContain("declares no `table:`");
+      expect(warns.filter((c) => c.message.includes("not an entity record"))).toEqual([]);
       expect(warns.filter((c) => c.message.includes("YAML could not be read"))).toEqual([]);
       expect(warns.filter((c) => c.message.includes("entity lookup failed"))).toEqual([]);
     });
@@ -1621,6 +1678,40 @@ describe("warehouse producer seam reads past the validator (#5257)", () => {
       expect(report.refusals.map((r) => r.reason)).toEqual(["snapshot-failed"]);
       expect(report.entities).toEqual([]);
       expect(report.created).toBe(0);
+      // ⚠️ Recorded: this fixture's runner never invokes the callback, so post-fix the
+      // hostile getter is read ZERO times and this lands on the same arm as the
+      // `undefined` case below. It still kills a `resolved ?? producedOutcome`
+      // weakening, but the genuinely distinct class — a runner that RUNS the callback
+      // and then resolves something else — is the next case, not this one.
+      expect(payloadOf(errors, "resolved without running").entity).toBe("Accounts");
+    });
+
+    it("ignores a plausible outcome the runner resolves AFTER running the callback", async () => {
+      // ⚠️ The distinct class the case above does not reach: the callback runs and
+      // commits, and the seam then resolves its OWN object. Nothing about that object
+      // is hostile — it is exactly the shape we build — so only reading the closure
+      // local tells the two apart. `created: 99` is deliberately not a number this run
+      // can produce, so a fix that trusted the returned value would report it.
+      const report = await run({
+        withTransaction: (async (fn: (tx: TestTx) => Promise<unknown>) => {
+          await store().runner(fn);
+          return { entity: "Accounts", rows: 7, candidates: 7, created: 99 };
+        }) as never,
+      });
+      expect(report.created).toBe(1);
+      expect(report.entities.map((e) => ({ entity: e.entity, rows: e.rows }))).toEqual([
+        { entity: "Accounts", rows: 1 },
+      ]);
+      expect(report.refusals).toEqual([]);
+    });
+
+    it("treats a plain non-thenable return as work never done", async () => {
+      // The sibling of the revoked-Proxy return: `.catch` is simply UNDEFINED on a
+      // number, so the old form died with `x.catch is not a function` outside every
+      // guard. It is the shape a naive substituted runner actually has.
+      const report = await run({ withTransaction: (() => 5) as never });
+      expect(report.refusals.map((r) => r.reason)).toEqual(["snapshot-failed"]);
+      expect(report.refusals[0]?.message).toContain("either of its exits");
     });
 
     it("cannot escape on the RETURNED value either, before it is ever awaited", async () => {
@@ -1658,8 +1749,96 @@ describe("warehouse producer seam reads past the validator (#5257)", () => {
       // this report exists to remove.
       const report = await run({ withTransaction: async () => undefined as never });
       expect(report.refusals.map((r) => r.reason)).toEqual(["snapshot-failed"]);
-      expect(report.refusals[0]?.message).toContain("returned without doing the work");
+      expect(report.refusals[0]?.message).toContain("either of its exits");
+      // ⚠️ It must NOT claim a clean rollback. The callback may have run and committed
+      // an episode before a swallowed throw — only the final assignment is known not to
+      // have happened — so the sibling abort arm's "nothing at all was recorded"
+      // guarantee does not travel here.
+      expect(report.refusals[0]?.message).toContain("cannot confirm what");
+      expect(report.refusals[0]?.message).not.toContain("nothing at all was recorded");
       expect(payloadOf(errors, "resolved without running").entity).toBe("Accounts");
+    });
+
+    it("resets its per-entity state — an entity AFTER a failed one still commits", async () => {
+      // ⚠️ **`producedOutcome` and `transactionAborted` are new mutable state this fix
+      // introduced, and every other case puts the FAILING entity last** — so neither
+      // flag is ever observed being reset. Hoisting either declaration out of the loop
+      // body, the classic refactor, is green without this case and produces exactly the
+      // silence this module argues against:
+      //   - `transactionAborted` hoisted → every entity after an abort hits `continue`
+      //     and vanishes from BOTH lists: no facts, and no refusal naming it.
+      //   - `producedOutcome` hoisted → the next entity pushes the PREVIOUS entity's
+      //     outcome, double-counting `created` in the operator report.
+      let calls = 0;
+      const report = await run({
+        loadReach: async () => ({
+          pairs: [
+            { entity: "A", dimension: "status", naming: false },
+            { entity: "B", dimension: "tier", naming: false },
+            { entity: "C", dimension: "band", naming: false },
+          ],
+          entities: ["A", "B", "C"],
+          namingDimension: new Map<string, string>(),
+          has: () => true,
+        }),
+        loadEntity: async (_workspaceId: string, name: string) => ({
+          table: `t_${name.toLowerCase()}`,
+          dimensions: [
+            { name: `${name.toLowerCase()}_id`, sql: "id", primary_key: true },
+            { name: name === "A" ? "status" : name === "B" ? "tier" : "band", sql: "col" },
+          ],
+        }),
+        withTransaction: async <T,>(fn: (tx: TestTx) => Promise<T>): Promise<T> => {
+          // B is the MIDDLE entity, which is the whole point.
+          if (++calls === 2) throw new Error("40001 serialization failure");
+          return store().runner(fn);
+        },
+      });
+
+      // A and C both committed; only B is refused — and B is named, not dropped.
+      expect(report.entities.map((e) => e.entity)).toEqual(["A", "C"]);
+      expect(report.refusals.map((r) => `${r.entity}:${r.reason}`)).toEqual([
+        "B:snapshot-failed",
+      ]);
+      expect(report.created).toBe(2);
+      // ⚠️ And the error line proves the "earlier entities had already committed" story
+      // end to end: A is in the list, C is not, because C had not run yet.
+      expect(payloadOf(errors, "transaction failed").committedEntities).toEqual(["A"]);
+    });
+
+    it("does not carry one entity's outcome onto the next", async () => {
+      // The `producedOutcome` half of the case above, isolated: B's runner resolves
+      // without ever invoking the callback. A hoisted `producedOutcome` would push A's
+      // outcome a second time under B's turn.
+      let calls = 0;
+      const report = await run({
+        loadReach: async () => ({
+          pairs: [
+            { entity: "A", dimension: "status", naming: false },
+            { entity: "B", dimension: "tier", naming: false },
+          ],
+          entities: ["A", "B"],
+          namingDimension: new Map<string, string>(),
+          has: () => true,
+        }),
+        loadEntity: async (_workspaceId: string, name: string) => ({
+          table: `t_${name.toLowerCase()}`,
+          dimensions: [
+            { name: `${name.toLowerCase()}_id`, sql: "id", primary_key: true },
+            { name: name === "A" ? "status" : "tier", sql: "col" },
+          ],
+        }),
+        withTransaction: (async (fn: (tx: TestTx) => Promise<unknown>) => {
+          if (++calls === 2) return undefined;
+          return store().runner(fn);
+        }) as never,
+      });
+
+      expect(report.entities.map((e) => e.entity)).toEqual(["A"]);
+      expect(report.created).toBe(1);
+      expect(report.refusals.map((r) => `${r.entity}:${r.reason}`)).toEqual([
+        "B:snapshot-failed",
+      ]);
     });
 
     it("still lets this module's OWN contract defect stay fatal", async () => {

--- a/packages/api/src/lib/brain/__tests__/warehouse-producer-logging.test.ts
+++ b/packages/api/src/lib/brain/__tests__/warehouse-producer-logging.test.ts
@@ -1623,6 +1623,33 @@ describe("warehouse producer seam reads past the validator (#5257)", () => {
       expect(report.created).toBe(0);
     });
 
+    it("cannot escape on the RETURNED value either, before it is ever awaited", async () => {
+      // ⚠️ **The third read on this one seam, and the one a `.catch(…)` chain cannot
+      // guard — because `.catch` is itself a property access on the returned value.**
+      // A runner handing back a revoked Proxy threw at the `.catch` lookup, outside
+      // every `try`, after earlier entities had committed. `await` inside a `try/catch`
+      // has no such read: the revoked Proxy throws on the `.then` lookup instead, where
+      // it is caught.
+      const { proxy, revoke } = Proxy.revocable({}, {});
+      revoke();
+
+      const report = await run({ withTransaction: (() => proxy) as never });
+      expect(report.refusals.map((r) => r.reason)).toEqual(["snapshot-failed"]);
+      expect(report.entities).toEqual([]);
+
+      // ⚠️ A REAL Error, and `contractCheckThrew: false` — asserted because the first
+      // draft of this case guessed `true` and was measured wrong. What reaches the
+      // catch is the `TypeError` the runtime raises for the `.then` lookup on a revoked
+      // Proxy, NOT the Proxy itself, so the classification never touches a hostile
+      // value here. The distinction matters: it is why this case does not duplicate the
+      // revoked-Proxy REJECTION case above, which does hand one straight to
+      // `instanceof`.
+      const payload = payloadOf(errors, "transaction failed");
+      expect(payload.err).toBeInstanceOf(Error);
+      expect(payload.contractCheckThrew).toBe(false);
+      expect(payload.errKind).toBe("<record>");
+    });
+
     it("refuses when the runner resolves WITHOUT running the entity's work", async () => {
       // The same class with no hostility at all: a substituted runner that simply
       // forgets to invoke the callback resolves `undefined`, which passed both

--- a/packages/api/src/lib/brain/__tests__/warehouse-producer-logging.test.ts
+++ b/packages/api/src/lib/brain/__tests__/warehouse-producer-logging.test.ts
@@ -1151,3 +1151,257 @@ describe("warehouse producer logging", () => {
     }
   });
 });
+
+/**
+ * The seam-read ratchet, applied past the validator (#5257).
+ *
+ * #5248 closed one class for `validateSnapshotSql`: *narrowing is an OPERATION on
+ * the seam value, not a fact about it.* These are the same principle on the SIBLING
+ * seams of the same loop — the snapshot runner's return value, the entity loader's
+ * return value, and the value `withTransaction` rejects with.
+ *
+ * ⚠️ **Every case here was measured RED against the unfixed producer**, by restoring
+ * the pre-fix file from a backup and re-running this suite — not reasoned about.
+ * Reasoning has been wrong on this principle three times in this file's history, and
+ * a `runWarehouseProducer` that REJECTS is the failure: one refused entity becomes a
+ * 500 for the whole run, with no log line at all, which is why every case below
+ * asserts a resolved report AND a log line rather than only the first.
+ */
+describe("warehouse producer seam reads past the validator (#5257)", () => {
+  /**
+   * A snapshot runner returning `value`, with the seam's return type asserted away.
+   *
+   * The whole point of these cases is a runner that does NOT honour its declared
+   * return type — a substituted implementation, a plugin, a wire — so the assertion
+   * is the fixture, not a shortcut around one.
+   */
+  const returning = (value: unknown) => async () =>
+    value as readonly Record<string, unknown>[];
+
+  describe("the snapshot runner's return value", () => {
+    // ⚠️ The rendered kinds are DELIBERATELY not all distinct — two records render
+    // `<record>` — but the shapes are, and each one escaped through a different
+    // expression before the fix: `.length` on `null`, a `length` GETTER, and
+    // `valueOf` during the `>` comparison. Collapsing them into one case would let a
+    // guard that closes only the first stay green.
+    const nonArrays: readonly { readonly label: string; readonly kind: string; readonly make: () => unknown }[] = [
+      { label: "null", kind: "<null>", make: () => null },
+      { label: "undefined", kind: "<undefined>", make: () => undefined },
+      { label: "a string", kind: "<string>", make: () => "rows" },
+      {
+        label: "an object whose `length` getter throws",
+        kind: "<record>",
+        make: () => {
+          const hostile = {};
+          Object.defineProperty(hostile, "length", {
+            enumerable: true,
+            get() {
+              throw new TypeError("hostile length getter");
+            },
+          });
+          return hostile;
+        },
+      },
+      {
+        label: "an object whose `length` coerces by throwing",
+        kind: "<record>",
+        make: () => ({
+          length: {
+            valueOf() {
+              throw new TypeError("hostile length valueOf");
+            },
+          },
+        }),
+      },
+    ];
+
+    for (const { label, kind, make } of nonArrays) {
+      it(`refuses ONE entity when the runner answers ${label}, rather than 500ing the run`, async () => {
+        const report = await run({ runSnapshot: returning(make()) });
+
+        // Resolved at all — the pre-fix producer REJECTED here, so this line is the
+        // falsifier and the payload assertions below are the diagnosis.
+        expect(report.refusals.map((r) => r.reason)).toEqual(["snapshot-failed"]);
+        expect(report.entities).toEqual([]);
+
+        const payload = payloadOf(warns, "snapshot failed");
+        expect(payload.entity).toBe("Accounts");
+        // ⚠️ The message NAMES what came back. Without it the five shapes above
+        // produce one identical line, which is the collapse `seamKind` exists to
+        // undo — and an operator cannot tell a runner returning `null` from one
+        // returning a hostile object.
+        expect(payload.err).toBeInstanceOf(Error);
+        expect((payload.err as Error).message).toContain(kind);
+        // A shape fault is not an incident for the whole run.
+        expect(messages(errors)).toEqual([]);
+      });
+    }
+
+    it("survives an array whose `Symbol.iterator` throws", async () => {
+      // ⚠️ `Array.isArray` answers TRUE here and `.length` is honest, so the shape
+      // check alone does not save this one — the claim builder's `for…of` is where it
+      // throws, which is why the whole consumption of the returned rows moved inside
+      // the `try` rather than only the length read.
+      const rows: Record<string, unknown>[] = [
+        { [producer.SUBJECT_ALIAS]: "Acme Corp", [`${producer.DIMENSION_ALIAS_PREFIX}0`]: "active" },
+      ];
+      Object.defineProperty(rows, Symbol.iterator, {
+        get() {
+          throw new TypeError("hostile iterator");
+        },
+      });
+
+      const report = await run({ runSnapshot: returning(rows) });
+      expect(report.refusals.map((r) => r.reason)).toEqual(["snapshot-failed"]);
+      expect(payloadOf(warns, "snapshot failed").entity).toBe("Accounts");
+    });
+
+    it("survives a REVOKED PROXY array, where `Array.isArray` itself throws", async () => {
+      // ⚠️ **A PIN, not a falsifier, and saying so is the honest half.** Measured
+      // GREEN against the unfixed producer: a revoked Proxy is trapped by the `await`
+      // inside the existing `try`, so this case survived by luck rather than by
+      // design. It stays because the fix's own `Array.isArray` is an operation on the
+      // seam value and would throw here — correct only because it sits inside the
+      // `try`. No local mutation of the fix REDs it (every consumption of the returned
+      // rows is now guarded, so the case is caught whichever expression throws first),
+      // which is precisely the shape of "covered by construction" worth recording
+      // rather than dressing up as a measurement.
+      const { proxy, revoke } = Proxy.revocable([{ [producer.SUBJECT_ALIAS]: "Acme Corp" }], {});
+      revoke();
+
+      const report = await run({ runSnapshot: returning(proxy) });
+      expect(report.refusals.map((r) => r.reason)).toEqual(["snapshot-failed"]);
+      expect(payloadOf(warns, "snapshot failed").entity).toBe("Accounts");
+    });
+
+    it("survives a NULL row inside a well-formed array", async () => {
+      // ⚠️ A hostile CELL is IN scope, and this case plus the next are what make that
+      // sentence in the producer a claim rather than a hope. Two rows, not one, so a
+      // fix that merely dropped the bad row would still have to explain the survivor.
+      const report = await run({
+        runSnapshot: returning([
+          { [producer.SUBJECT_ALIAS]: "Acme Corp", [`${producer.DIMENSION_ALIAS_PREFIX}0`]: "active" },
+          null,
+        ]),
+      });
+      expect(report.refusals.map((r) => r.reason)).toEqual(["snapshot-failed"]);
+      expect(payloadOf(warns, "snapshot failed").entity).toBe("Accounts");
+    });
+
+    it("survives a row whose subject getter throws", async () => {
+      const hostileRow = {};
+      Object.defineProperty(hostileRow, producer.SUBJECT_ALIAS, {
+        enumerable: true,
+        get() {
+          throw new TypeError("hostile subject getter");
+        },
+      });
+
+      const report = await run({ runSnapshot: returning([hostileRow]) });
+      expect(report.refusals.map((r) => r.reason)).toEqual(["snapshot-failed"]);
+      expect(payloadOf(warns, "snapshot failed").entity).toBe("Accounts");
+    });
+
+    it("still refuses an over-cap snapshot under its OWN reason, not `snapshot-failed`", async () => {
+      // ⚠️ The shape check moved the cap read inside the `try`, and a `try` that
+      // swallowed the cap arm would relabel a routine, well-diagnosed refusal as a
+      // failed snapshot — advice that sends an admin to check their warehouse instead
+      // of their enrollment. Measured: deleting the `row-cap` arm and letting the
+      // catch handle it passes every OTHER case in this describe.
+      const report = await run({
+        rowCap: 1,
+        runSnapshot: returning([
+          { [producer.SUBJECT_ALIAS]: "Acme Corp", [`${producer.DIMENSION_ALIAS_PREFIX}0`]: "active" },
+          { [producer.SUBJECT_ALIAS]: "Globex", [`${producer.DIMENSION_ALIAS_PREFIX}0`]: "churned" },
+        ]),
+      });
+      expect(report.refusals.map((r) => r.reason)).toEqual(["row-cap-exceeded"]);
+      expect(payloadOf(warns, "exceeds the row cap").rowCap).toBe(1);
+      expect(warns.filter((c) => c.message.includes("snapshot failed"))).toEqual([]);
+    });
+  });
+
+  describe("the entity loader's return value", () => {
+    it("refuses ONE entity whose YAML shape throws, leaving its neighbour's run intact", async () => {
+      // ⚠️ TWO enrolled entities, and the second one is the whole assertion. The
+      // parse sat outside the `try` whose own comment says an uncaught throw *"rejects
+      // the whole `Promise.all`, killing the run for every unrelated enrolled
+      // entity"* — so a one-entity fixture would prove only that the run resolved,
+      // never that the unrelated entity survived.
+      const hostileYaml: Record<string, unknown> = {};
+      Object.defineProperty(hostileYaml, "table", {
+        enumerable: true,
+        get() {
+          throw new TypeError("hostile table getter");
+        },
+      });
+
+      const report = await run({
+        loadReach: async () => ({
+          pairs: [
+            { entity: "Accounts", dimension: "status", naming: false },
+            { entity: "Hostile", dimension: "status", naming: false },
+          ],
+          entities: ["Accounts", "Hostile"],
+          namingDimension: new Map<string, string>(),
+          has: () => true,
+        }),
+        loadEntity: async (_workspaceId: string, name: string) =>
+          name === "Hostile" ? hostileYaml : ACCOUNTS_YAML,
+      });
+
+      // The hostile one is refused under the arm that already had the right cause.
+      expect(report.refusals.map((r) => `${r.entity}:${r.reason}`)).toEqual([
+        "Hostile:entity-unreadable",
+      ]);
+      // ⚠️ And the UNRELATED entity still produced its outcome. Asserting only the
+      // refusal above would stay green for a fix that refused every entity in the
+      // run, which is the 500 wearing a different hat.
+      expect(report.entities.map((e) => e.entity)).toEqual(["Accounts"]);
+      expect(payloadOf(warns, "entity lookup failed").entity).toBe("Hostile");
+    });
+
+    it("keeps `not-published` distinct from a throwing shape", async () => {
+      // The arm the move must not swallow: `null` is an ordinary unpublished entity
+      // and gets `entity-not-published`, not the loader's failure arm. Without this,
+      // folding the null check into the catch passes the case above.
+      const report = await run({ loadEntity: async () => null });
+      expect(report.refusals.map((r) => r.reason)).toEqual(["entity-not-published"]);
+      expect(warns.filter((c) => c.message.includes("entity lookup failed"))).toEqual([]);
+    });
+  });
+
+  describe("the value the transaction rejects with", () => {
+    it("cannot escape the `instanceof` in the transaction handler", async () => {
+      // ⚠️ `err instanceof WarehouseProducerContractError` walks the prototype chain,
+      // so it is an operation on a value the transaction seam chose. Measured before
+      // the fix: a revoked Proxy escaped `runWarehouseProducer` with ZERO log lines,
+      // out of the handler written to stop precisely that.
+      const { proxy, revoke } = Proxy.revocable({}, {});
+      revoke();
+
+      const report = await run({
+        withTransaction: async () => {
+          throw proxy;
+        },
+      });
+      expect(report.refusals.map((r) => r.reason)).toEqual(["snapshot-failed"]);
+      expect(payloadOf(errors, "transaction failed").committedEntities).toEqual([]);
+    });
+
+    it("still lets this module's OWN contract defect stay fatal", async () => {
+      // ⚠️ **The anti-constant falsifier, and without it the guard is satisfiable by
+      // `() => false`.** Every other case in this describe wants the classification
+      // to answer "not a contract error"; only this one wants a `true`, and it is the
+      // one that keeps the fatal/operational split from collapsing into "nothing is
+      // ever fatal".
+      await expect(
+        run({
+          withTransaction: async () => {
+            throw new producer.WarehouseProducerContractError("RETURNING clause and reader disagree");
+          },
+        }),
+      ).rejects.toThrow("RETURNING clause and reader disagree");
+    });
+  });
+});

--- a/packages/api/src/lib/brain/__tests__/warehouse-producer-logging.test.ts
+++ b/packages/api/src/lib/brain/__tests__/warehouse-producer-logging.test.ts
@@ -1178,6 +1178,9 @@ describe("warehouse producer seam reads past the validator (#5257)", () => {
   const returning = (value: unknown) => async () =>
     value as readonly Record<string, unknown>[];
 
+  /** The `tx` shape {@link store}'s runner hands its callback. */
+  type TestTx = { query: (sql: string, params?: unknown[]) => Promise<{ rows: readonly unknown[] }> };
+
   describe("the snapshot runner's return value", () => {
     // ⚠️ The rendered kinds are DELIBERATELY not all distinct — two records render
     // `<record>` — but the shapes are, and each one escaped through a different
@@ -1253,7 +1256,9 @@ describe("warehouse producer seam reads past the validator (#5257)", () => {
 
       const report = await run({ runSnapshot: returning(rows) });
       expect(report.refusals.map((r) => r.reason)).toEqual(["snapshot-failed"]);
+      expect(report.entities).toEqual([]);
       expect(payloadOf(warns, "snapshot failed").entity).toBe("Accounts");
+      expect(messages(errors)).toEqual([]);
     });
 
     it("survives a REVOKED PROXY array, where `Array.isArray` itself throws", async () => {
@@ -1262,16 +1267,74 @@ describe("warehouse producer seam reads past the validator (#5257)", () => {
       // inside the existing `try`, so this case survived by luck rather than by
       // design. It stays because the fix's own `Array.isArray` is an operation on the
       // seam value and would throw here — correct only because it sits inside the
-      // `try`. No local mutation of the fix REDs it (every consumption of the returned
-      // rows is now guarded, so the case is caught whichever expression throws first),
-      // which is precisely the shape of "covered by construction" worth recording
-      // rather than dressing up as a measurement.
+      // `try`. No local mutation of the fix REDs it, which is the shape of "covered by
+      // construction" worth recording rather than dressing up as a measurement.
+      //
+      // ⚠️ The first draft of this comment justified that with *"every consumption of
+      // the returned rows is now guarded"*, which was FALSE when written: the
+      // no-candidates arm read `rows.length` outside every `try`. The case below is
+      // the falsifier for it. A pin's justification is a claim like any other.
       const { proxy, revoke } = Proxy.revocable([{ [producer.SUBJECT_ALIAS]: "Acme Corp" }], {});
       revoke();
 
       const report = await run({ runSnapshot: returning(proxy) });
       expect(report.refusals.map((r) => r.reason)).toEqual(["snapshot-failed"]);
+      expect(report.entities).toEqual([]);
       expect(payloadOf(warns, "snapshot failed").entity).toBe("Accounts");
+      expect(messages(errors)).toEqual([]);
+    });
+
+    it("survives an array that answers `length` and THEN throws, after the claims are built", async () => {
+      // ⚠️ **THE ROUND-1 FIX'S OWN DEFECT, ONE STATEMENT OVER.** `Array.isArray`
+      // answers TRUE for a Proxy over an array, so the shape check passes and `length`
+      // stays under the seam's control for every later read. The first fix guarded the
+      // cap read and the claim build, then handed the array back out and read
+      // `rows.length` again in the no-candidates arm, where nothing encloses it.
+      //
+      // ⚠️ **The threshold is MEASURED, and the premise is asserted below rather than
+      // assumed.** Against the round-1 code an empty returned array took THREE
+      // `length` reads — cap check, the `for…of` iterator, and the no-candidates arm —
+      // and a trap throwing from #3 gave `REJECTED: hostile length read #3`: the
+      // whole-run 500 with no log line, from inside the fix written to stop it.
+      // Against this code there are TWO, both inside the `try`, so #3 never happens.
+      let reads = 0;
+      const counted = new Proxy([] as Record<string, unknown>[], {
+        get(target, key, receiver) {
+          if (key === "length" && ++reads >= 3) throw new TypeError(`hostile length read #${reads}`);
+          return Reflect.get(target, key, receiver);
+        },
+      });
+
+      const report = await run({ runSnapshot: returning(counted) });
+
+      // The behavioural claim: the run RESOLVED. Pre-fix it rejected.
+      expect(report.refusals).toEqual([]);
+      expect(report.entities.map((e) => e.rows)).toEqual([0]);
+      // ⚠️ And the premise, pinned. Without this the case goes vacuous the day an
+      // internal read is added — the trap would stop firing for a reason that has
+      // nothing to do with the guard, and a green test would prove nothing.
+      expect(reads).toBe(2);
+    });
+
+    it("reports the row count the CAP accepted, not a later answer", async () => {
+      // ⚠️ The same seam, lying rather than throwing — the half a `try` cannot catch.
+      // A trap that answers honestly for the cap check and inflates afterwards made
+      // the report say 999,999 rows for an entity the cap had just accepted. Reading
+      // `length` once, beside the comparison, makes the two the same number by
+      // construction.
+      // Read #3 for the same measured reason as the case above — reads #1 and #2 are
+      // the cap check and the `for…of`, and an inflated answer to EITHER would make
+      // the claim builder iterate a million absent rows rather than test the report.
+      let reads = 0;
+      const lying = new Proxy([] as Record<string, unknown>[], {
+        get(target, key, receiver) {
+          if (key === "length" && ++reads >= 3) return 999_999;
+          return Reflect.get(target, key, receiver);
+        },
+      });
+
+      const report = await run({ rowCap: 5, runSnapshot: returning(lying) });
+      expect(report.entities.map((e) => e.rows)).toEqual([0]);
     });
 
     it("survives a NULL row inside a well-formed array", async () => {
@@ -1285,10 +1348,12 @@ describe("warehouse producer seam reads past the validator (#5257)", () => {
         ]),
       });
       expect(report.refusals.map((r) => r.reason)).toEqual(["snapshot-failed"]);
+      expect(report.entities).toEqual([]);
       expect(payloadOf(warns, "snapshot failed").entity).toBe("Accounts");
+      expect(messages(errors)).toEqual([]);
     });
 
-    it("survives a row whose subject getter throws", async () => {
+    it("survives a row whose SUBJECT getter throws", async () => {
       const hostileRow = {};
       Object.defineProperty(hostileRow, producer.SUBJECT_ALIAS, {
         enumerable: true,
@@ -1299,7 +1364,71 @@ describe("warehouse producer seam reads past the validator (#5257)", () => {
 
       const report = await run({ runSnapshot: returning([hostileRow]) });
       expect(report.refusals.map((r) => r.reason)).toEqual(["snapshot-failed"]);
+      expect(report.entities).toEqual([]);
       expect(payloadOf(warns, "snapshot failed").entity).toBe("Accounts");
+      expect(messages(errors)).toEqual([]);
+    });
+
+    it("survives a row whose DIMENSION cell getter throws", async () => {
+      // ⚠️ A DIFFERENT expression from the subject case above — `row[SUBJECT_ALIAS]`
+      // and `row[DIMENSION_ALIAS_PREFIX + i]` are separate reads behind separate
+      // branches, and the subject one runs first. A row with a valid subject and a
+      // hostile dimension reaches the second read only, so this is the case that
+      // proves the guard covers the per-dimension loop rather than just the key.
+      const hostileRow: Record<string, unknown> = { [producer.SUBJECT_ALIAS]: "Acme Corp" };
+      Object.defineProperty(hostileRow, `${producer.DIMENSION_ALIAS_PREFIX}0`, {
+        enumerable: true,
+        get() {
+          throw new TypeError("hostile dimension getter");
+        },
+      });
+
+      const report = await run({ runSnapshot: returning([hostileRow]) });
+      expect(report.refusals.map((r) => r.reason)).toEqual(["snapshot-failed"]);
+      expect(report.entities).toEqual([]);
+      expect(payloadOf(warns, "snapshot failed").entity).toBe("Accounts");
+    });
+
+    it("does NOT refuse a primitive row — it stays an unidentified row (#5257 scope)", async () => {
+      // ⚠️ **The boundary of "a hostile CELL is IN scope", pinned because the first
+      // draft of that comment overstated it.** A row that is a primitive answers
+      // `undefined` for every alias instead of THROWING, so nothing reaches the guard
+      // and the pre-existing unidentified-row counter takes it. Measured identical
+      // before and after the fix — `rows: 1, unidentifiedRows: 1`, no refusal.
+      //
+      // Whether an unreadable ROW should cost a refusal is a real question and a
+      // different one; #5257 deliberately does not move it. This case is what makes
+      // that a recorded decision rather than an unnoticed gap, and it REDs the day
+      // someone changes it silently.
+      const report = await run({ runSnapshot: returning([42, "x"]) });
+      expect(report.refusals).toEqual([]);
+      expect(report.entities.map((e) => ({ rows: e.rows, unidentified: e.unidentifiedRows }))).toEqual([
+        { rows: 2, unidentified: 2 },
+      ]);
+    });
+
+    it("blames ATLAS, not the entity, when the fault is the runner's shape", async () => {
+      // ⚠️ Widening the `try` made two Atlas-side faults reachable on an arm whose
+      // message says "usually a table or a dimension's column that no longer exists.
+      // Fix the entity YAML" — advice that sends an admin to edit a correct entity.
+      // The `phase` split is what keeps the sentence honest, and this is its falsifier:
+      // collapsing the ternary back to one message passes every other case here.
+      const shape = await run({ runSnapshot: returning(null) });
+      expect(shape.refusals[0]?.message).toContain("This is an Atlas fault");
+      expect(shape.refusals[0]?.message).toContain("req-1");
+      expect(shape.refusals[0]?.message).not.toContain("Fix the entity YAML");
+      expect(payloadOf(warns, "snapshot failed").phase).toBe("shape");
+
+      warns.length = 0;
+      // And the datasource read keeps the entity-facing advice it always had.
+      const read = await run({
+        runSnapshot: async () => {
+          throw new Error("relation does not exist");
+        },
+      });
+      expect(read.refusals[0]?.message).toContain("Fix the entity YAML");
+      expect(read.refusals[0]?.message).not.toContain("This is an Atlas fault");
+      expect(payloadOf(warns, "snapshot failed").phase).toBe("run");
     });
 
     it("still refuses an over-cap snapshot under its OWN reason, not `snapshot-failed`", async () => {
@@ -1350,15 +1479,58 @@ describe("warehouse producer seam reads past the validator (#5257)", () => {
           name === "Hostile" ? hostileYaml : ACCOUNTS_YAML,
       });
 
-      // The hostile one is refused under the arm that already had the right cause.
+      // The hostile one is refused, and the message is the PERMANENT one: the lookup
+      // succeeded, so `load-threw`'s "audit your connection groups / wait and retry"
+      // would be advice this admin can follow forever.
       expect(report.refusals.map((r) => `${r.entity}:${r.reason}`)).toEqual([
         "Hostile:entity-unreadable",
       ]);
-      // ⚠️ And the UNRELATED entity still produced its outcome. Asserting only the
-      // refusal above would stay green for a fix that refused every entity in the
-      // run, which is the 500 wearing a different hat.
+      expect(report.refusals[0]?.message).toContain("fix the entity YAML");
+      // ⚠️ And the UNRELATED entity still produced its outcome — with a POSITIVE
+      // CONTROL on what it produced. `entities` containing "Accounts" is satisfied by
+      // an entity that ran and emitted nothing, so without `created` this stays green
+      // for a fix that leaves the neighbour reachable but broken.
       expect(report.entities.map((e) => e.entity)).toEqual(["Accounts"]);
-      expect(payloadOf(warns, "entity lookup failed").entity).toBe("Hostile");
+      expect(report.created).toBe(1);
+      // ⚠️ Its OWN message, not the loader's. Asserted as absent from the loader's
+      // line too, because sharing one arm is exactly what this split undid.
+      expect(payloadOf(warns, "YAML could not be read").entity).toBe("Hostile");
+      expect(warns.filter((c) => c.message.includes("entity lookup failed"))).toEqual([]);
+    });
+
+    it("keeps a THROWING loader distinct from an unreadable SHAPE", async () => {
+      // ⚠️ The counter-case for the split above, and without it the two arms can be
+      // folded back together and every other case here stays green. A loader that
+      // THREW says nothing about whether the entity is fixable — the ambiguous-name
+      // and transient-blip causes are both live — so its prose points at the server
+      // log, not at the YAML.
+      const report = await run({
+        loadEntity: async () => {
+          throw new Error("connect ECONNREFUSED");
+        },
+      });
+
+      expect(report.refusals.map((r) => r.reason)).toEqual(["entity-unreadable"]);
+      expect(report.refusals[0]?.message).toContain("connection group");
+      // And NOT the permanent remedy — the two arms must not converge on one sentence.
+      expect(report.refusals[0]?.message).not.toContain("fix the entity YAML");
+      expect(payloadOf(warns, "entity lookup failed").err).toBeInstanceOf(Error);
+      expect(warns.filter((c) => c.message.includes("YAML could not be read"))).toEqual([]);
+    });
+
+    it("routes a non-record loader answer to `no-table`, silently", async () => {
+      // A loader answering a string or an array does not THROW — `parseWarehouseEntity`
+      // reads no `table:` off it and returns null — so it lands on the third arm, whose
+      // remedy is already right. Pinned because the wire cannot tell these three apart
+      // (all are `entity-unreadable`) and only the log can, which is this file's whole
+      // subject: this one is deliberately NOT logged, and that asymmetry should be a
+      // decision rather than an accident.
+      const report = await run({ loadEntity: async () => "yaml" as unknown as Record<string, unknown> });
+
+      expect(report.refusals.map((r) => r.reason)).toEqual(["entity-unreadable"]);
+      expect(report.refusals[0]?.message).toContain("declares no `table:`");
+      expect(warns.filter((c) => c.message.includes("YAML could not be read"))).toEqual([]);
+      expect(warns.filter((c) => c.message.includes("entity lookup failed"))).toEqual([]);
     });
 
     it("keeps `not-published` distinct from a throwing shape", async () => {
@@ -1380,13 +1552,87 @@ describe("warehouse producer seam reads past the validator (#5257)", () => {
       const { proxy, revoke } = Proxy.revocable({}, {});
       revoke();
 
+      // ⚠️ TWO enrolled entities, the first committing, so `committedEntities` is
+      // asserted against a NON-EMPTY list. With the one-entity fixture the pre-existing
+      // case uses, `toEqual([])` is true by construction and cannot tell a correct
+      // payload from a hardcoded one — and this key exists precisely to be the only
+      // record that earlier entities had already filed drafts.
+      let calls = 0;
       const report = await run({
-        withTransaction: async () => {
+        loadReach: async () => ({
+          pairs: [
+            { entity: "Accounts", dimension: "status", naming: false },
+            { entity: "Second", dimension: "tier", naming: false },
+          ],
+          entities: ["Accounts", "Second"],
+          namingDimension: new Map<string, string>(),
+          has: () => true,
+        }),
+        // ⚠️ Distinct DIMENSION NAMES, not just distinct tables. One dimension name
+        // owned by two entities is `ambiguous-dimension`, and the plan refuses both
+        // before a transaction is ever opened — which would make this case green for
+        // a reason that has nothing to do with the transaction seam.
+        loadEntity: async (_workspaceId: string, name: string) =>
+          name === "Second"
+            ? {
+                table: "contacts",
+                dimensions: [
+                  { name: "contact_id", sql: "contact_id", primary_key: true },
+                  { name: "tier", sql: "tier" },
+                ],
+              }
+            : ACCOUNTS_YAML,
+        withTransaction: async <T,>(fn: (tx: TestTx) => Promise<T>): Promise<T> => {
+          if (++calls === 1) return store().runner(fn);
           throw proxy;
         },
       });
+      expect(report.refusals.map((r) => `${r.entity}:${r.reason}`)).toEqual([
+        "Second:snapshot-failed",
+      ]);
+
+      const payload = payloadOf(errors, "transaction failed");
+      expect(payload.committedEntities).toEqual(["Accounts"]);
+      expect(payload.committedCreated).toBe(1);
+      // ⚠️ The two fields that survive a hostile value. `scrubErrSerializer` renders
+      // one as `[log scrub failed]`, so without these the operator's entire diagnosis
+      // is that string — and `contractCheckThrew` is the bit a bare boolean swallowed.
+      expect(payload.errKind).toBe("<threw>");
+      expect(payload.contractCheckThrew).toBe(true);
+    });
+
+    it("cannot escape on the value the transaction RESOLVES with", async () => {
+      // ⚠️ **THE MIRROR HALF, and the round-1 fix hardened only the rejection.**
+      // `withTransaction`'s `T` is inferred from OUR callback, so the declared type is
+      // a claim about a substitutable seam rather than a fact about it — nothing
+      // checked that the resolved value was the object the callback built. Measured
+      // against the round-1 code: an outcome with a throwing `created` getter rejected
+      // the whole run from `outcomes.reduce(…)`, AFTER every entity had committed,
+      // with no log line naming the entity.
+      const hostileOutcome = {};
+      Object.defineProperty(hostileOutcome, "created", {
+        enumerable: true,
+        get() {
+          throw new TypeError("hostile outcome getter");
+        },
+      });
+
+      const report = await run({ withTransaction: async () => hostileOutcome as never });
       expect(report.refusals.map((r) => r.reason)).toEqual(["snapshot-failed"]);
-      expect(payloadOf(errors, "transaction failed").committedEntities).toEqual([]);
+      expect(report.entities).toEqual([]);
+      expect(report.created).toBe(0);
+    });
+
+    it("refuses when the runner resolves WITHOUT running the entity's work", async () => {
+      // The same class with no hostility at all: a substituted runner that simply
+      // forgets to invoke the callback resolves `undefined`, which passed both
+      // identity checks and reached `o.created`. It is now its own refusal, because
+      // dropping the entity from both lists reads as "never enrolled" — the silence
+      // this report exists to remove.
+      const report = await run({ withTransaction: async () => undefined as never });
+      expect(report.refusals.map((r) => r.reason)).toEqual(["snapshot-failed"]);
+      expect(report.refusals[0]?.message).toContain("returned without doing the work");
+      expect(payloadOf(errors, "resolved without running").entity).toBe("Accounts");
     });
 
     it("still lets this module's OWN contract defect stay fatal", async () => {

--- a/packages/api/src/lib/brain/warehouse-producer.ts
+++ b/packages/api/src/lib/brain/warehouse-producer.ts
@@ -271,11 +271,13 @@ export type WarehouseEntityLookup =
   | { readonly kind: "found"; readonly entity: WarehouseEntity }
   | { readonly kind: "not-published" }
   /**
-   * `cause` beside `why`, and the split earns its two lines. `why` is the sentence
-   * the operator reads; `cause` is what the plan, a test, and any future consumer
-   * branch on — without it, asserting WHICH cause fired means matching prose, and
-   * the refusal could not withhold the driver's text on one arm while keeping it on
-   * the other.
+   * `cause` beside `why`. `why` is the sentence the operator reads.
+   *
+   * ⚠️ **No production code branches on `cause` today** — {@link planWarehouseEmission}
+   * reads only `why` and folds all three into one `entity-unreadable` refusal. It is
+   * carried so a consumer CAN branch without matching prose, and so a test can assert
+   * which cause fired; the earlier wording here claimed a live branch that has never
+   * existed.
    */
   | {
       readonly kind: "unreadable";
@@ -1692,7 +1694,7 @@ function seamKind(value: unknown): string {
  *
  * ⚠️ **`instanceof` walks the prototype chain, so it is an OPERATION on a value a
  * seam chose — {@link seamRead}'s rule, arriving at the one site written to keep a
- * seam's failure from taking the run down.** The transaction `.catch` classifies
+ * seam's failure from taking the run down.** The transaction catch classifies
  * whatever `withTransaction` rejected with, and a revoked Proxy there threw out of
  * the classification itself: measured escaping `runWarehouseProducer` with ZERO log
  * lines, from inside the handler whose entire purpose is turning a failed
@@ -1813,6 +1815,34 @@ export async function runWarehouseProducer(
       }
       if (raw === null) {
         entityShapes.set(name, { kind: "not-published" });
+        return;
+      }
+      // ⚠️ **A NON-RECORD ANSWER IS AN ATLAS FAULT, AND WITHOUT THIS IT WAS THE
+      // QUIETEST ARM IN THE FILE** (#5257 review, round 2). `parseWarehouseEntity`
+      // reads `raw.table` through `nonEmptyString`, which answers `undefined` for a
+      // string, a number or an array rather than throwing — so a loader returning
+      // `"yaml"` or `[]` sailed past the parse guard, landed on the `no-table` arm,
+      // and told the admin *"its YAML declares no `table:` … Fix the entity YAML"*
+      // with ZERO log lines. That is the misdirection the `unreadable-shape` split was
+      // written to remove, surviving one arm over, and worse: the other two arms at
+      // least `warn`.
+      //
+      // `defaultLoadEntity` casts its column to a record unchecked, and this module is
+      // documented as callable with a YAML record read from disk, so the shape is a
+      // claim rather than a fact.
+      if (!isRecord(raw)) {
+        log.warn(
+          { ...runLog, entity: name, loaderAnswered: seamKind(raw) },
+          "Warehouse producer: the entity loader answered something that is not an entity record — its pairs are refused, the rest of the run continues",
+        );
+        entityShapes.set(name, {
+          kind: "unreadable",
+          cause: "unreadable-shape",
+          why:
+            "Atlas could not read the stored entity — its loader answered something that is not an " +
+            "entity record. This is an Atlas fault rather than a problem with the entity; the server " +
+            "log for this run carries the reason.",
+        });
         return;
       }
       // ⚠️ **THE PARSE IS GUARDED, AND IT GETS ITS OWN ARM RATHER THAN SHARING
@@ -1966,8 +1996,11 @@ export async function runWarehouseProducer(
       entityEdgesFailed =
         "The entity-edge pass failed part-way. Any edge it had already proposed is committed — " +
         "the alias-producer log line for this run carries those counts — and every fact and store " +
+        // `"unknown"`, matching every other placeholder in this file. Two spellings of
+        // one placeholder means an operator grepping support tickets for one misses
+        // the other — the rule the snapshot arm already states, applied to the outlier.
         `entry is committed too. Re-running is safe. The server log for request ${
-          requestId ?? "(none)"
+          requestId ?? "unknown"
         } carries the reason.`;
       // `err` raw, so pino's serializer emits the stack — for a pool or lock
       // failure the stack is the actionable half, and the per-entity catch
@@ -2205,11 +2238,10 @@ export async function runWarehouseProducer(
       // than lie — see {@link seamRead}, where narrowing the container was measured
       // insufficient. Reading each once, through the guard, is what makes every field
       // below a statement about a value rather than about a property access.
-      // ⚠️ **RE-TYPED TO `unknown` FOR THIS ARM (#5257).** `validated` is a
-      // `ValidatedSnapshotRequest`, so the compiler ACTIVELY ENCOURAGES
-      // `validated.table.slice(0, 200)` here — it typechecks, it looks like every
-      // other field, and it is the exact shape that recurred three times through
-      // #5256's rounds. Reading through `seam` makes that expression a compile error.
+      // ⚠️ **RE-TYPED TO `unknown` FOR THIS ARM (#5257).** Reading every field through
+      // `seam` is what keeps this arm's growth going through the guard: the shape that
+      // recurred three times through #5256's rounds was a direct property read off the
+      // typed request.
       //
       // ⚠️ **What it does NOT do, stated because the first draft of this comment
       // claimed otherwise:** the typed binding is still in scope, so a future edit can
@@ -2358,7 +2390,7 @@ export async function runWarehouseProducer(
      * ⚠️ **The row-cap read and the claim build used to sit between the snapshot
      * `catch` and the transaction `.catch`, where nothing encloses them.**
      * {@link WarehouseSnapshotRunner} is one of the five names
-     * `warehouse-producer-bypass.test.ts` pins as castable, so its return value is a
+     * `warehouse-producer-bypass.test.ts` guards, so its return value is a
      * seam value under exactly the threat model #5248 spent its rounds on for the
      * validator — and `rows.length` is an operation on it, not a fact about it.
      *
@@ -2379,17 +2411,14 @@ export async function runWarehouseProducer(
      * - **A revoked-Proxy array survived**, but only because `await` happened to trap
      *   it inside the `try` that was already here.
      *
-     * ⚠️ **A cell whose READ THROWS is in scope; a primitive row is not, and the
-     * difference is measured rather than intended.** {@link buildWarehouseClaims}
-     * iterates the array and reads `row[SUBJECT_ALIAS]` and each dimension alias off
-     * it, so a `null` row or a throwing cell getter throws inside this `try` and the
-     * entity is refused. A row that is a PRIMITIVE answers `undefined` for every alias
-     * instead of throwing — measured, `[42]` and `["x"]` both still report
-     * `rows: 1, unidentifiedRows: 1` — so it lands in the pre-existing
-     * unidentified-row counter and no refusal is raised. That is unchanged behaviour
-     * and arguably wrong, but it is a different question (what an unreadable ROW
-     * should cost) from the one this guard answers (a throw must not take the run),
-     * and #5257 deliberately does not move it.
+     * ⚠️ **What is in scope is a read that THROWS, and the boundary is measured.**
+     * {@link buildWarehouseClaims} reads `row[SUBJECT_ALIAS]` and each dimension alias,
+     * so a throwing cell getter throws inside this `try` and the entity is refused.
+     * Measured over row shapes: only `null` and `undefined` rows throw. An array, a
+     * `Date`, a function and a primitive all answer `undefined` for every alias and
+     * report `rows: 1, unidentifiedRows: 1` — unchanged by this fix, and left alone
+     * deliberately: what an unreadable ROW should cost is a different question from
+     * the one this guard answers.
      *
      * **Stated cost:** a genuine defect in this module's own pure claim-building now
      * reports as a failed snapshot — logged at `warn` with the Error, never swallowed,
@@ -2427,17 +2456,27 @@ export async function runWarehouseProducer(
           readonly rowCount: number;
           readonly claims: WarehouseClaims;
         }
-      | { readonly kind: "row-cap" };
+      /**
+       * ⚠️ It carries the count too. The cap arm used to log only `rowCap`, so an
+       * operator learned "more than 1000" and could not tell 1,001 from 1.4M — the
+       * difference between narrowing an enrollment and abandoning the table. The
+       * number was read and validated inside the guard already, so this is free.
+       *
+       * Honest bound: {@link buildSnapshotSql} emits `LIMIT rowCap + 1`, so against a
+       * well-behaved runner this is always exactly `rowCap + 1` and says only "at
+       * least". It is worth carrying anyway, because a substituted runner ignores the
+       * LIMIT and then the real number is the whole story.
+       */
+      | { readonly kind: "row-cap"; readonly rowCount: number };
     /**
      * WHICH of the three things inside the `try` failed (#5257 review).
      *
      * ⚠️ **The refusal below tells the admin to fix their entity YAML, and for two of
      * these three that is the wrong person to send.** `run` is the datasource read —
      * a dropped table or a renamed column, the admin's to fix. `shape` and `claims`
-     * are Atlas faults: a substituted runner answering something that is not an array,
-     * or a defect in this module's own claim builder. Widening the `try` is what made
-     * those two reachable here, so the message has to widen with it or the guard buys
-     * detectability at the cost of misdirection.
+     * are Atlas faults. Widening the `try` is what made them reachable here, so the
+     * message has to widen with it or the guard buys detectability at the cost of
+     * misdirection.
      */
     let phase: "run" | "shape" | "claims" = "run";
     try {
@@ -2469,21 +2508,36 @@ export async function runWarehouseProducer(
       // ⚠️ ONE read of `length`, and every later use is of THIS number. See the
       // `rowCount` field above for the two measurements that forced it.
       const rowCount = rows.length;
+      // ⚠️ **A SEAM-CONTROLLED NUMBER, VALIDATED — and the cap check is not the
+      // validation** (#5257 review, round 2). `length` on a Proxy over an array is
+      // whatever its trap returns: `NaN > rowCap` is FALSE, so `NaN` flows straight
+      // past the cap into the report, where `BrainWarehouseRunReportSchema` requires a
+      // non-negative int. One bad `length` therefore blanks the WHOLE run report —
+      // every entity's outcome and every refusal replaced by `reportComplete: false` —
+      // which is a much larger blast radius than the entity it came from.
+      if (!Number.isSafeInteger(rowCount) || rowCount < 0) {
+        // The VALUE when it is a number — `NaN`, `-1` and `1.5` are three different
+        // wiring faults and `<number>` collapses them. A number cannot carry customer
+        // data, so interpolating it is safe here in a way `sql` never is. TypeScript
+        // believes `length` is a `number`; the trap is why the arm exists anyway.
+        const shown = typeof rowCount === "number" ? String(rowCount) : seamKind(rowCount);
+        throw new TypeError(`the snapshot runner's array reported a length of ${shown}`);
+      }
+      // The cap comparison stays under `shape`.
+      const overCap = rowCount > rowCap;
       phase = "claims";
       snapshot =
-        rowCount > rowCap
-          ? { kind: "row-cap" }
+        overCap
+          ? { kind: "row-cap", rowCount }
           : {
               kind: "rows",
               rowCount,
               claims: buildWarehouseClaims({
                 workspaceId,
                 plan: entityPlan,
-                // The one assertion, and it is checked by the guard around it rather
-                // than by the type: a row that is not a record throws on the first cell
-                // read, inside this `try`, and is refused. A row that is a PRIMITIVE
-                // and does not throw is counted into `unidentifiedRows` instead — see
-                // the scope note above.
+                // The one assertion. The element shape is unchecked; what makes it
+                // survivable is that every read of it happens inside this `try`. What a
+                // non-record row COSTS is in the scope note above, measured.
                 rows: rows as readonly Record<string, unknown>[],
                 snapshotAt,
               }),
@@ -2518,8 +2572,16 @@ export async function runWarehouseProducer(
               // column exists — so a dropped table or a renamed column throws HERE, on
               // every run, forever. "The next run retries the pair" was true and useless;
               // an operator seeing it repeat needs to know the cause may be permanent.
-              "If it fails the same way on every run the cause is permanent — usually a table or a " +
-              "dimension's column that no longer exists. Fix the entity YAML, or un-enroll the pair."
+              // ⚠️ It no longer ASSERTS the cause, and the reason is that `phase: "run"`
+              // covers more than the datasource read: `defaultRunSnapshot` dynamically
+              // imports the connection module and looks up a pool BEFORE any query
+              // runs, so a module-init failure or a missing pool lands here too. Those
+              // are Atlas faults, and "fix the entity YAML" is unfollowable for them —
+              // the same misattribution the gate-threw arm was split out to avoid.
+              "If it fails the same way on every run the cause is permanent — most often a table or a " +
+              "dimension's column that no longer exists. The server log for this run names what " +
+              "actually failed; if it is a connection or module failure, that is an Atlas fault rather " +
+              "than an entity one."
           : // ⚠️ The ATLAS-fault register, borrowed verbatim from the gate-mismatch arm
             // above, because these two arms now describe the same kind of event: Atlas
             // read the entity fine and then could not process what came back. Sending
@@ -2536,7 +2598,7 @@ export async function runWarehouseProducer(
     if (snapshot.kind === "row-cap") {
       // ⚠️ REFUSED, not truncated — see WAREHOUSE_ROW_CAP.
       log.warn(
-        { ...runLog, entity: entityPlan.entity.name, rowCap },
+        { ...runLog, entity: entityPlan.entity.name, rowCap, rowCount: snapshot.rowCount },
         "Warehouse producer: entity exceeds the row cap — refused rather than emitting a truncated snapshot",
       );
       refuseEntity(
@@ -2636,7 +2698,7 @@ export async function runWarehouseProducer(
      * This entity's outcome, taken from a CLOSURE LOCAL rather than from what
      * `withTransaction` resolved with (#5257 review).
      *
-     * ⚠️ **The `.catch` below hardens the value the transaction seam REJECTS with;
+     * ⚠️ **The catch below hardens the value the transaction seam REJECTS with;
      * this is the half it resolves with, and leaving it unguarded made the handler
      * READ as though the seam were closed.** `ReconcileTransactionRunner` is
      * `<T>(fn) => Promise<T>` with `T` inferred from our own callback — a claim about
@@ -2665,144 +2727,144 @@ export async function runWarehouseProducer(
     // already reports.
     try {
       await withTransaction(async (tx) => {
-      const episode = await insertSnapshotEpisode(tx, {
-        workspaceId,
-        entity: entityPlan.entity.name,
-        sql,
-        snapshotAt,
-      });
-      if (episode === null) {
-        // The identical snapshot instant is already recorded, so its facts are
-        // too. Re-reconciling against a second episode id would attach a fresh
-        // evidence pointer to claims that already have one.
-        log.info(
-          { ...runLog, entity: entityPlan.entity.name, snapshotAt: snapshotAt.toISOString() },
-          "Warehouse producer: this snapshot instant is already recorded — skipping the entity",
-        );
-        producedOutcome = null;
-        return;
-      }
-
-      const report = await reconcileFacts(
-        {
-          episode: {
-            id: episode.id,
-            workspaceId,
-            source: WAREHOUSE_SOURCE,
-            sourceId: episode.sourceId,
-            sourceActor: WAREHOUSE_PRODUCER_PRINCIPAL,
-            occurredAt: snapshotAt,
-            visibleTo: [ORG_PRINCIPAL],
-          },
-          candidates: claims.candidates,
-          producer: WAREHOUSE_PRODUCER,
-          // The pass that produced these claims ran at the snapshot instant. Not
-          // null: a warehouse claim is derived from a reading, unlike an authored
-          // one, and `extracted_at` is what records that a pass happened.
-          extractedAt: snapshotAt,
-          sourcePrincipal: WAREHOUSE_PRODUCER_PRINCIPAL,
-          resolveEntity: warehouseEntityResolver(claims.subjectIds),
-          vocabulary,
-        },
-        { withTransaction: (fn) => fn(tx), now: () => snapshotAt },
-      );
-
-      // The entity store, INSIDE this entity's transaction (#5043), so the
-      // entries and the facts they describe commit or roll back together. An
-      // entity whose transaction fails leaves its previous entries intact, which
-      // is the honest state: nothing was read, so nothing is known to have
-      // changed.
-      //
-      // Unconditional, including when `entityEntries` is empty — the DELETE half
-      // is what clears the store after a human un-names a dimension. Skipping it
-      // on an empty list would leave every prior entry resolving under a name
-      // nobody named any more.
-      await writeEntityEntries(tx, {
-        workspaceId,
-        entity: entityPlan.entity.name,
-        entries: claims.entityEntries,
-        snapshotAt,
-      });
-
-      // The authoritative half of `single` — `pending`, one entry per predicate,
-      // and a refusal here is the ordinary case rather than an error: the first
-      // run raises it and every later one is `already-decided`, which is also how
-      // a human's `rejected` stays rejected.
-      const proposed: string[] = [];
-      for (const dim of entityPlan.dimensions) {
-        // Addressed by SURFACE, deliberately: `keys-not-on-the-wire.test.ts`
-        // refuses to see a slot key named outside the modules allowlisted for
-        // naming a column they cannot address a row without naming, and the
-        // alternative — allowlisting this file — would switch off that guard's
-        // SELECT arm here too. `cardinality.ts` derives the key and never
-        // returns it.
-        const result = await proposePredicateCardinalityForSurface(tx, workspaceId, {
-          predicateSurface: dim.name,
-          cardinality: "single",
-          sourceClass: WAREHOUSE_CARDINALITY_SOURCE,
-          proposedBy: WAREHOUSE_PRODUCER,
-          predicateAlias: vocabulary.predicate,
-        });
-        if (result.ok) {
-          proposed.push(dim.name);
-          continue;
-        }
-        // ⚠️ THREE arms. `cardinality.ts`'s correction-event proposer splits only
-        // two ways (`already-decided` at `debug`, everything else at `warn`), and
-        // that is not enough here. `already-decided` is genuinely routine — it is
-        // what makes a re-run a no-op and what makes a human's `rejected` stick.
-        // `degenerate-key` is reachable from real data (a dimension whose norm
-        // collapses to nothing) and means this predicate will never get a `single`
-        // entry, so the machinery this producer exists to wake up stays dormant for
-        // it — that is neither routine nor drift. The remaining two are unreachable
-        // from THIS call site (the cardinality is a literal and the producer id is a
-        // const), which is why reaching one means the call site drifted.
-        //
-        // `result.message` travels too: `cardinality.ts` puts the operator-facing
-        // text there.
-        const line = {
-          ...runLog,
+        const episode = await insertSnapshotEpisode(tx, {
+          workspaceId,
           entity: entityPlan.entity.name,
-          dimension: dim.name,
-          refusal: result.refusal,
-          detail: result.message,
-        };
-        if (result.refusal === "already-decided") {
-          log.debug(line, "Warehouse producer: predicate cardinality already adjudicated, no proposal");
-        } else if (result.refusal === "degenerate-key") {
-          log.warn(
-            line,
-            "Warehouse producer: this dimension's name normalizes away to nothing, so it can never carry a `single` cardinality entry — supersession stays dormant for it",
+          sql,
+          snapshotAt,
+        });
+        if (episode === null) {
+          // The identical snapshot instant is already recorded, so its facts are
+          // too. Re-reconciling against a second episode id would attach a fresh
+          // evidence pointer to claims that already have one.
+          log.info(
+            { ...runLog, entity: entityPlan.entity.name, snapshotAt: snapshotAt.toISOString() },
+            "Warehouse producer: this snapshot instant is already recorded — skipping the entity",
           );
-        } else {
-          log.warn(line, "Warehouse producer: cardinality proposal refused unexpectedly — this call site drifted");
+          producedOutcome = null;
+          return;
         }
-      }
 
-      // ⚠️ One expression, not a ternary on `episodeBlocked`. When an episode is
-      // blocked wholesale, `reconcile.ts` sets `blocked[reason] = candidates.length`
-      // with every other reason at zero — so the sum ALREADY equals
-      // `claims.candidates.length` and the ternary's two arms were the same number.
-      // A branch that looks like it compensates for a contract violation, but does
-      // not, costs the next reader a trip into `reconcile.ts` to discover it is
-      // dead.
-      const blocked = Object.values(report.blocked).reduce((sum, n) => sum + n, 0);
-      producedOutcome = {
-        entity: entityPlan.entity.name,
-        rows: rowCount,
-        candidates: claims.candidates.length,
-        created: report.created,
-        corroborated: report.corroborated,
-        blocked,
-        comparable: report.comparable,
-        unidentifiedRows: claims.unidentifiedRows,
-        collidingSubjectRows: claims.collidingSubjectRows,
-        unsurfaceableCells: claims.unsurfaceableCells,
-        unsurfaceableKeyRows: claims.unsurfaceableKeyRows,
-        cardinalityProposed: proposed,
-        entitiesStored: claims.entityEntries.length,
-        unnamedRows: claims.unnamedRows,
-      } satisfies WarehouseEntityOutcome;
+        const report = await reconcileFacts(
+          {
+            episode: {
+              id: episode.id,
+              workspaceId,
+              source: WAREHOUSE_SOURCE,
+              sourceId: episode.sourceId,
+              sourceActor: WAREHOUSE_PRODUCER_PRINCIPAL,
+              occurredAt: snapshotAt,
+              visibleTo: [ORG_PRINCIPAL],
+            },
+            candidates: claims.candidates,
+            producer: WAREHOUSE_PRODUCER,
+            // The pass that produced these claims ran at the snapshot instant. Not
+            // null: a warehouse claim is derived from a reading, unlike an authored
+            // one, and `extracted_at` is what records that a pass happened.
+            extractedAt: snapshotAt,
+            sourcePrincipal: WAREHOUSE_PRODUCER_PRINCIPAL,
+            resolveEntity: warehouseEntityResolver(claims.subjectIds),
+            vocabulary,
+          },
+          { withTransaction: (fn) => fn(tx), now: () => snapshotAt },
+        );
+
+        // The entity store, INSIDE this entity's transaction (#5043), so the
+        // entries and the facts they describe commit or roll back together. An
+        // entity whose transaction fails leaves its previous entries intact, which
+        // is the honest state: nothing was read, so nothing is known to have
+        // changed.
+        //
+        // Unconditional, including when `entityEntries` is empty — the DELETE half
+        // is what clears the store after a human un-names a dimension. Skipping it
+        // on an empty list would leave every prior entry resolving under a name
+        // nobody named any more.
+        await writeEntityEntries(tx, {
+          workspaceId,
+          entity: entityPlan.entity.name,
+          entries: claims.entityEntries,
+          snapshotAt,
+        });
+
+        // The authoritative half of `single` — `pending`, one entry per predicate,
+        // and a refusal here is the ordinary case rather than an error: the first
+        // run raises it and every later one is `already-decided`, which is also how
+        // a human's `rejected` stays rejected.
+        const proposed: string[] = [];
+        for (const dim of entityPlan.dimensions) {
+          // Addressed by SURFACE, deliberately: `keys-not-on-the-wire.test.ts`
+          // refuses to see a slot key named outside the modules allowlisted for
+          // naming a column they cannot address a row without naming, and the
+          // alternative — allowlisting this file — would switch off that guard's
+          // SELECT arm here too. `cardinality.ts` derives the key and never
+          // returns it.
+          const result = await proposePredicateCardinalityForSurface(tx, workspaceId, {
+            predicateSurface: dim.name,
+            cardinality: "single",
+            sourceClass: WAREHOUSE_CARDINALITY_SOURCE,
+            proposedBy: WAREHOUSE_PRODUCER,
+            predicateAlias: vocabulary.predicate,
+          });
+          if (result.ok) {
+            proposed.push(dim.name);
+            continue;
+          }
+          // ⚠️ THREE arms. `cardinality.ts`'s correction-event proposer splits only
+          // two ways (`already-decided` at `debug`, everything else at `warn`), and
+          // that is not enough here. `already-decided` is genuinely routine — it is
+          // what makes a re-run a no-op and what makes a human's `rejected` stick.
+          // `degenerate-key` is reachable from real data (a dimension whose norm
+          // collapses to nothing) and means this predicate will never get a `single`
+          // entry, so the machinery this producer exists to wake up stays dormant for
+          // it — that is neither routine nor drift. The remaining two are unreachable
+          // from THIS call site (the cardinality is a literal and the producer id is a
+          // const), which is why reaching one means the call site drifted.
+          //
+          // `result.message` travels too: `cardinality.ts` puts the operator-facing
+          // text there.
+          const line = {
+            ...runLog,
+            entity: entityPlan.entity.name,
+            dimension: dim.name,
+            refusal: result.refusal,
+            detail: result.message,
+          };
+          if (result.refusal === "already-decided") {
+            log.debug(line, "Warehouse producer: predicate cardinality already adjudicated, no proposal");
+          } else if (result.refusal === "degenerate-key") {
+            log.warn(
+              line,
+              "Warehouse producer: this dimension's name normalizes away to nothing, so it can never carry a `single` cardinality entry — supersession stays dormant for it",
+            );
+          } else {
+            log.warn(line, "Warehouse producer: cardinality proposal refused unexpectedly — this call site drifted");
+          }
+        }
+
+        // ⚠️ One expression, not a ternary on `episodeBlocked`. When an episode is
+        // blocked wholesale, `reconcile.ts` sets `blocked[reason] = candidates.length`
+        // with every other reason at zero — so the sum ALREADY equals
+        // `claims.candidates.length` and the ternary's two arms were the same number.
+        // A branch that looks like it compensates for a contract violation, but does
+        // not, costs the next reader a trip into `reconcile.ts` to discover it is
+        // dead.
+        const blocked = Object.values(report.blocked).reduce((sum, n) => sum + n, 0);
+        producedOutcome = {
+          entity: entityPlan.entity.name,
+          rows: rowCount,
+          candidates: claims.candidates.length,
+          created: report.created,
+          corroborated: report.corroborated,
+          blocked,
+          comparable: report.comparable,
+          unidentifiedRows: claims.unidentifiedRows,
+          collidingSubjectRows: claims.collidingSubjectRows,
+          unsurfaceableCells: claims.unsurfaceableCells,
+          unsurfaceableKeyRows: claims.unsurfaceableKeyRows,
+          cardinalityProposed: proposed,
+          entitiesStored: claims.entityEntries.length,
+          unnamedRows: claims.unnamedRows,
+        } satisfies WarehouseEntityOutcome;
       });
     } catch (err: unknown) {
       // A defect in this module's own contract stays FATAL — see
@@ -2812,7 +2874,27 @@ export async function runWarehouseProducer(
       // the prototype chain of a value `withTransaction` chose — a revoked Proxy threw
       // out of this very line and escaped the run with no log at all (#5257).
       const contract = seamContractCheck(err);
-      if (contract.isContract) throw err;
+      if (contract.isContract) {
+        // ⚠️ Logged BEFORE the re-throw. This is the only path that aborts a run
+        // mid-way, and it was the one path with no line from this module: `runEffect`
+        // logs the message and a requestId, but it knows nothing about which entities
+        // already committed — the facts the OPERATIONAL sibling below calls essential,
+        // for the same reason. The more serious incident had the thinner record.
+        log.error(
+          {
+            ...runLog,
+            entity: entityPlan.entity.name,
+            committedEntities: outcomes.map((o) => o.entity),
+            committedCreated: outcomes.reduce((sum, o) => sum + o.created, 0),
+            err,
+          },
+          "Warehouse producer: this module's own contract broke — the run is aborted; earlier entities had already committed and their drafts are filed",
+        );
+        throw err;
+      }
+      // Set before the reporting below, so the flag that carries "this transaction
+      // aborted" is written by the statement that knows it.
+      transactionAborted = true;
       // ⚠️ **REFUSED PER ENTITY, NOT RE-THROWN — and this reverses an earlier
       // decision in this file rather than extending it.**
       //
@@ -2834,8 +2916,8 @@ export async function runWarehouseProducer(
           entity: entityPlan.entity.name,
           committedEntities: outcomes.map((o) => o.entity),
           committedCreated: outcomes.reduce((sum, o) => sum + o.created, 0),
-          // ⚠️ These two are the ONLY fields that say anything when the rejected value
-          // is hostile: `scrubErrSerializer` renders one as `[log scrub failed]`,
+          // ⚠️ These two are the only fields that say anything ABOUT THE REJECTED VALUE
+          // when it is hostile: `scrubErrSerializer` renders it as `[log scrub failed]`,
           // measured. `errKind` is bracketed like every other seam sentinel on this
           // file's log lines, and `contractCheckThrew` is the bit the classification
           // would otherwise have swallowed — see {@link seamContractCheck}.
@@ -2845,7 +2927,6 @@ export async function runWarehouseProducer(
         },
         "Warehouse producer: a transaction failed and rolled back — its entity produced nothing; earlier entities had already committed",
       );
-      transactionAborted = true;
       refuseEntity(
         entityPlan,
         "snapshot-failed",
@@ -2863,27 +2944,34 @@ export async function runWarehouseProducer(
     const outcome = producedOutcome;
 
     if (outcome === undefined) {
-      // ⚠️ The transaction seam RESOLVED without our callback reaching either of its
-      // exits — a substituted runner that never invoked it, or one that swallowed a
-      // throw and resolved anyway. Reported rather than assumed away: nothing was
-      // committed for this entity, and silently omitting it is the "never enrolled"
-      // silence the arm below refuses. It is an Atlas fault, so it takes the same
-      // register as the shape arm above rather than the entity-YAML advice.
+      // ⚠️ The transaction seam RESOLVED without our callback reaching either exit — a
+      // runner that never invoked it, or one that swallowed a throw and resolved
+      // anyway. Reported rather than assumed away: silently omitting the entity is the
+      // "never enrolled" silence the arm below refuses.
+      //
+      // ⚠️ **It does NOT claim nothing was written, and the first draft did.** In the
+      // swallowed-throw case the callback ran: `insertSnapshotEpisode` may have
+      // committed and drafts may be filed, with only the final assignment unreached.
+      // The sibling arm above can promise a clean rollback because the real runner
+      // ROLLBACKs; that guarantee does not travel here. Asserting the clean case in a
+      // catch is the same false-claim class this file closes one closure up.
       log.error(
         {
           ...runLog,
           entity: entityPlan.entity.name,
           committedEntities: outcomes.map((o) => o.entity),
+          committedCreated: outcomes.reduce((sum, o) => sum + o.created, 0),
         },
-        "Warehouse producer: the transaction runner resolved without running this entity's work — nothing was committed for it",
+        "Warehouse producer: the transaction runner resolved without running this entity's work — what, if anything, it wrote is unknown",
       );
       refuseEntity(
         entityPlan,
         "snapshot-failed",
         `Atlas could not write "${entityPlan.entity.table}"'s claims: its transaction returned without ` +
-          "doing the work, so nothing at all was recorded for it — no episode, no drafts, no proposals. " +
-          "This is an Atlas fault rather than a problem with the entity — if it repeats, report it with " +
-          `request id ${requestId ?? "unknown"}.`,
+          "our work reaching either of its exits, so Atlas cannot confirm what — if anything — was " +
+          "recorded for it. Check the review queue for partial drafts before re-running; entities " +
+          "earlier in this run DID commit, so a blind re-run re-files their drafts. This is an Atlas " +
+          `fault rather than a problem with the entity — if it repeats, report it with request id ${requestId ?? "unknown"}.`,
       );
       continue;
     }

--- a/packages/api/src/lib/brain/warehouse-producer.ts
+++ b/packages/api/src/lib/brain/warehouse-producer.ts
@@ -1680,6 +1680,37 @@ function seamKind(value: unknown): string {
 }
 
 /**
+ * `err instanceof WarehouseProducerContractError`, made total (#5257).
+ *
+ * ⚠️ **`instanceof` walks the prototype chain, so it is an OPERATION on a value a
+ * seam chose — {@link seamRead}'s rule, arriving at the one site written to keep a
+ * seam's failure from taking the run down.** The transaction `.catch` classifies
+ * whatever `withTransaction` rejected with, and a revoked Proxy there threw out of
+ * the classification itself: measured escaping `runWarehouseProducer` with ZERO log
+ * lines, from inside the handler whose entire purpose is turning a failed
+ * transaction into one refused entity plus an `error` line naming what had already
+ * committed.
+ *
+ * ⚠️ **`false` on a throw, and the direction is the safe one rather than a
+ * fallback CLAUDE.md forbids.** `false` routes the value to the per-entity refusal,
+ * which LOGS it at `error` and accounts for every pair — so nothing is swallowed.
+ * `true` would re-throw, which is the 500-for-the-whole-run this arm exists to
+ * prevent, chosen on the strength of a prototype walk that just failed. A hostile
+ * value cannot be one of this module's own contract defects anyway: the sole
+ * {@link WarehouseProducerContractError} in this file is constructed at its throw
+ * expression, so a value that defeats `instanceof` did not come from there.
+ */
+function seamIsContractError(err: unknown): boolean {
+  try {
+    return err instanceof WarehouseProducerContractError;
+  } catch {
+    // Not silence — the caller logs `err` on the very next statement. See above for
+    // why the answer is `false` rather than a re-throw.
+    return false;
+  }
+}
+
+/**
  * Run the producer over one workspace's reach.
  *
  * One transaction per ENTITY, not one per run: an entity whose snapshot fails
@@ -1732,9 +1763,27 @@ export async function runWarehouseProducer(
       // rejects the whole `Promise.all`, killing the run for every unrelated
       // enrolled entity and returning a 500 in place of the report whose entire job
       // is explaining why a pair produced nothing.
-      let raw: Record<string, unknown> | null;
+      let entity: WarehouseEntity | null;
       try {
-        raw = await loadEntity(workspaceId, name);
+        const raw = await loadEntity(workspaceId, name);
+        if (raw === null) {
+          entityShapes.set(name, { kind: "not-published" });
+          return;
+        }
+        // ⚠️ **PARSING IS INSIDE THE `try`, and the move is the whole of this site's
+        // fix (#5257).** {@link parseWarehouseEntity} does `raw.table`,
+        // `Object.entries(raw.dimensions)` and `isRecord` — every one an operation on
+        // a value THIS seam returned, per {@link seamRead}'s rule. Outside, a
+        // `{ get table() { throw } }` entity rejected the `Promise.all` and produced
+        // the exact 500 the catch below is written to prevent, measured; inside, it
+        // lands on the `load-threw` arm, which is already the right refusal — the
+        // lookup did not yield a readable entity, and its `why` says the server log
+        // carries the reason.
+        //
+        // `raw === null` is an identity comparison rather than a read, so it is total
+        // on any value; it stays here so the `not-published` arm keeps its own shape
+        // instead of being folded into `load-threw`.
+        entity = parseWarehouseEntity(name, raw);
       } catch (err) {
         log.warn(
           { ...runLog, entity: name, err },
@@ -1757,11 +1806,6 @@ export async function runWarehouseProducer(
         });
         return;
       }
-      if (raw === null) {
-        entityShapes.set(name, { kind: "not-published" });
-        return;
-      }
-      const entity = parseWarehouseEntity(name, raw);
       entityShapes.set(
         name,
         entity === null
@@ -2120,8 +2164,16 @@ export async function runWarehouseProducer(
       // than lie — see {@link seamRead}, where narrowing the container was measured
       // insufficient. Reading each once, through the guard, is what makes every field
       // below a statement about a value rather than about a property access.
-      const returnedEntity = seamRead(validated, "entity");
-      const returnedWorkspaceId = seamRead(validated, "workspaceId");
+      // ⚠️ **RE-TYPED TO `unknown` FOR THIS ARM, and the widening is a guard rather
+      // than a tidy-up (#5257).** `validated` is a `ValidatedSnapshotRequest`, so the
+      // compiler ACTIVELY ENCOURAGES `validated.table.slice(0, 200)` on this line — it
+      // typechecks, it looks like every other field, and it is the exact shape that
+      // recurred three times through #5256's rounds. Through `seam`, an unguarded read
+      // of a future field is a compile error instead of a review catch; every read
+      // below has to go through {@link seamRead} or {@link seamKind}.
+      const seam: unknown = validated;
+      const returnedEntity = seamRead(seam, "entity");
+      const returnedWorkspaceId = seamRead(seam, "workspaceId");
       // ⚠️ `connectionId` is on this line because the capture note above names it as
       // the residual: `defaultRunSnapshot` selects the POOL from the returned
       // workspace and connection, so a verdict identical in workspace, entity and
@@ -2129,8 +2181,8 @@ export async function runWarehouseProducer(
       // wrong-datasource read — and it was previously indistinguishable here from a
       // benign re-wrap. Two connection groups exposing identically-named tables is an
       // ordinary workspace; it is why `AmbiguousEntityError` exists.
-      const returnedConnectionId = seamRead(validated, "connectionId");
-      const returnedSql = seamRead(validated, "sql");
+      const returnedConnectionId = seamRead(seam, "connectionId");
+      const returnedSql = seamRead(seam, "sql");
       // Normalised through the SAME expression as the returned side, so a legitimately
       // absent connection on both sides reads as a match rather than as a difference.
       const submittedConnectionId = entityPlan.entity.connection ?? undefined;
@@ -2150,7 +2202,7 @@ export async function runWarehouseProducer(
       // matched"*, on the field this arm's own comment calls the alert key. (`{}`
       // still reads true, and correctly so — both sides are genuinely absent; see
       // `returnedRequestMatch` below for why that is safe.)
-      const returnedRequestType = seamKind(validated);
+      const returnedRequestType = seamKind(seam);
       const returnedIsRecord = returnedRequestType === "<record>";
       log.error(
         {
@@ -2252,13 +2304,91 @@ export async function runWarehouseProducer(
       continue;
     }
 
-    let rows: readonly Record<string, unknown>[];
+    /**
+     * Everything derived from the snapshot runner's return value, decided INSIDE the
+     * `try` below (#5257).
+     *
+     * ⚠️ **The row-cap read and the claim build used to sit between the snapshot
+     * `catch` and the transaction `.catch`, where nothing encloses them.**
+     * {@link WarehouseSnapshotRunner} is one of the five names
+     * `warehouse-producer-bypass.test.ts` pins as castable, so its return value is a
+     * seam value under exactly the threat model #5248 spent its rounds on for the
+     * validator — and `rows.length` is an operation on it, not a fact about it. NINE
+     * shapes were run against the unfixed producer; EIGHT escaped it as a whole-run
+     * 500 with no log line at all — `null`, `undefined`, a bare string, a throwing
+     * `length` getter, a `length` whose `valueOf` throws, a hostile `Symbol.iterator`,
+     * a `null` row, and a row with a throwing `atlas_brain_subject` getter. The ninth,
+     * a revoked-Proxy array, survived — but only because `await` happened to trap it
+     * inside the `try` that was already here.
+     *
+     * ⚠️ **A hostile CELL is IN scope, deliberately, and this sentence exists because
+     * silence here read as "already handled".** {@link buildWarehouseClaims} iterates
+     * the array and reads `row[SUBJECT_ALIAS]` and each dimension alias off it, so a
+     * `null` row or a throwing cell getter is the same class one level down and gets
+     * the same answer: this entity is refused, the run continues. **Stated cost:** a
+     * genuine defect in this module's own pure claim-building now reports as a failed
+     * snapshot — logged at `warn` with the Error, never swallowed, but wearing the
+     * wrong label. That is the cheaper of the two mistakes, because the alternative is
+     * one hostile cell taking down a run in which earlier entities have committed.
+     *
+     * ⚠️ **NOT in scope: an iterator that never ends.** A `Symbol.iterator` yielding
+     * forever hangs inside the `for…of` the claim builder runs, and no `try` catches a
+     * hang. The row cap cannot help: `length` is a separate property, so an array
+     * reporting `0` can still iterate forever. That is a liveness problem wanting a
+     * timeout, not a shape problem wanting a guard — and leaving it unsaid here is the
+     * "already handled" silence this comment exists to remove.
+     *
+     * Two arms rather than a bare `rows`, because the cap is a REFUSAL with its own
+     * reason (`row-cap-exceeded`, not `snapshot-failed`) and its own operator message,
+     * and folding it into the catch would relabel it.
+     */
+    let snapshot:
+      | {
+          readonly kind: "rows";
+          readonly rows: readonly Record<string, unknown>[];
+          readonly claims: WarehouseClaims;
+        }
+      | { readonly kind: "row-cap" };
     try {
       // `validated`, the value the guard compared — NOT a fresh `validation.request`,
       // which would be a second read of a property the seam controls. See the capture
       // above.
-      rows = await runSnapshot(validated);
+      const returned: unknown = await runSnapshot(validated);
+      // ⚠️ **`Array.isArray` FIRST, and it is inside the `try` for the revoked-Proxy
+      // reason {@link seamRead} states: it THROWS on one rather than answering.** That
+      // throw is wanted here — it lands on the refusal arm below instead of taking the
+      // run — but it is only safe because it is guarded, which is the property the
+      // three previous instances of this class all lacked. It also buys the diagnosis:
+      // `{ length: 5 }` would otherwise pass the cap check and die as *"not iterable"*
+      // deep inside the claim builder, and `seamKind` names what actually came back.
+      if (!Array.isArray(returned)) {
+        throw new TypeError(
+          `the snapshot runner answered ${seamKind(returned)} rather than an array of rows`,
+        );
+      }
+      const rows: readonly Record<string, unknown>[] = returned;
+      snapshot =
+        rows.length > rowCap
+          ? { kind: "row-cap" }
+          : {
+              kind: "rows",
+              rows,
+              claims: buildWarehouseClaims({
+                workspaceId,
+                plan: entityPlan,
+                rows,
+                snapshotAt,
+              }),
+            };
     } catch (err) {
+      // ⚠️ **No {@link WarehouseProducerContractError} re-throw here, unlike the
+      // transaction handler below, and the asymmetry is deliberate rather than an
+      // omission.** This module raises that error in exactly one place —
+      // {@link insertSnapshotEpisode}, which runs INSIDE the transaction — so a
+      // re-throw on this arm would be unreachable machinery that also converted a
+      // seam throwing one into a whole-run 500. Everything reachable here is a seam
+      // failure or a hostile row, and one refused entity is the proportionate answer.
+      //
       // The Error itself, not `.message`. `scrubErrSerializer` emits type, message,
       // stack AND pg's `code` with credentials already stripped — and `42P01` vs
       // `ECONNREFUSED` is the difference between "fix your YAML" and "your warehouse
@@ -2285,7 +2415,7 @@ export async function runWarehouseProducer(
       continue;
     }
 
-    if (rows.length > rowCap) {
+    if (snapshot.kind === "row-cap") {
       // ⚠️ REFUSED, not truncated — see WAREHOUSE_ROW_CAP.
       log.warn(
         { ...runLog, entity: entityPlan.entity.name, rowCap },
@@ -2301,12 +2431,7 @@ export async function runWarehouseProducer(
       continue;
     }
 
-    const claims = buildWarehouseClaims({
-      workspaceId,
-      plan: entityPlan,
-      rows,
-      snapshotAt,
-    });
+    const { rows, claims } = snapshot;
 
     if (claims.unsurfaceableCells > 0) {
       // An enrollment mistake rather than an empty column — see `isAbsentCell`. It
@@ -2527,7 +2652,10 @@ export async function runWarehouseProducer(
       // A defect in this module's own contract stays FATAL — see
       // `WarehouseProducerContractError`. Everything below is for OPERATIONAL
       // failures, where refusing one entity is the proportionate answer.
-      if (err instanceof WarehouseProducerContractError) throw err;
+      // ⚠️ Through {@link seamIsContractError}, because a bare `instanceof` here walks
+      // the prototype chain of a value `withTransaction` chose — a revoked Proxy threw
+      // out of this very line and escaped the run with no log at all (#5257).
+      if (seamIsContractError(err)) throw err;
       // ⚠️ **REFUSED PER ENTITY, NOT RE-THROWN — and this reverses an earlier
       // decision in this file rather than extending it.**
       //

--- a/packages/api/src/lib/brain/warehouse-producer.ts
+++ b/packages/api/src/lib/brain/warehouse-producer.ts
@@ -279,7 +279,15 @@ export type WarehouseEntityLookup =
    */
   | {
       readonly kind: "unreadable";
-      readonly cause: "load-threw" | "no-table";
+      /**
+       * ⚠️ `unreadable-shape` is NOT a spelling of `load-threw`, and merging them was
+       * measured wrong (#5257). The loader SUCCEEDED and handed back a record this
+       * producer cannot parse — permanent, with a concrete remedy — while
+       * `load-threw`'s prose offers an ambiguous-name audit and a retry, neither of
+       * which can ever help. Same `kind` on the wire, different sentence and different
+       * thing to branch on, which is what this field is for.
+       */
+      readonly cause: "load-threw" | "unreadable-shape" | "no-table";
       readonly why: string;
     };
 
@@ -1699,14 +1707,29 @@ function seamKind(value: unknown): string {
  * value cannot be one of this module's own contract defects anyway: the sole
  * {@link WarehouseProducerContractError} in this file is constructed at its throw
  * expression, so a value that defeats `instanceof` did not come from there.
+ *
+ * ⚠️ **`threw` travels beside the answer, and dropping it was a measured hole.** This
+ * file spends paragraphs keeping "the read THREW" apart from "the read did not
+ * match" — {@link SEAM_THREW}, `<threw>`, `returnedReadThrew` — and a bare `boolean`
+ * collapsed *the classification itself failed* into *not a contract error*. Measured
+ * against the REAL logger rather than the suite's mock, the resulting line said only
+ * `err: "[log scrub failed]"`: it named neither what came back nor that the check had
+ * failed, which is the generic message CLAUDE.md forbids, on the incident line.
+ *
+ * ⚠️ **Not a type predicate, and that is a decision rather than an oversight.** There
+ * is exactly ONE call site, and it re-throws the value as `unknown`, so a predicate
+ * narrows nothing anybody uses — and a predicate cannot also carry `threw`, which is
+ * the half with a measurement behind it. Split it if a second call site ever wants
+ * the error's fields.
  */
-function seamIsContractError(err: unknown): boolean {
+function seamContractCheck(err: unknown): { readonly isContract: boolean; readonly threw: boolean } {
   try {
-    return err instanceof WarehouseProducerContractError;
+    return { isContract: err instanceof WarehouseProducerContractError, threw: false };
   } catch {
-    // Not silence — the caller logs `err` on the very next statement. See above for
-    // why the answer is `false` rather than a re-throw.
-    return false;
+    // Not silence — `contractCheckThrew` reaches the operator on the error line the
+    // caller emits next. See above for why the answer is `false` rather than a
+    // re-throw.
+    return { isContract: false, threw: true };
   }
 }
 
@@ -1763,27 +1786,9 @@ export async function runWarehouseProducer(
       // rejects the whole `Promise.all`, killing the run for every unrelated
       // enrolled entity and returning a 500 in place of the report whose entire job
       // is explaining why a pair produced nothing.
-      let entity: WarehouseEntity | null;
+      let raw: Record<string, unknown> | null;
       try {
-        const raw = await loadEntity(workspaceId, name);
-        if (raw === null) {
-          entityShapes.set(name, { kind: "not-published" });
-          return;
-        }
-        // ⚠️ **PARSING IS INSIDE THE `try`, and the move is the whole of this site's
-        // fix (#5257).** {@link parseWarehouseEntity} does `raw.table`,
-        // `Object.entries(raw.dimensions)` and `isRecord` — every one an operation on
-        // a value THIS seam returned, per {@link seamRead}'s rule. Outside, a
-        // `{ get table() { throw } }` entity rejected the `Promise.all` and produced
-        // the exact 500 the catch below is written to prevent, measured; inside, it
-        // lands on the `load-threw` arm, which is already the right refusal — the
-        // lookup did not yield a readable entity, and its `why` says the server log
-        // carries the reason.
-        //
-        // `raw === null` is an identity comparison rather than a read, so it is total
-        // on any value; it stays here so the `not-published` arm keeps its own shape
-        // instead of being folded into `load-threw`.
-        entity = parseWarehouseEntity(name, raw);
+        raw = await loadEntity(workspaceId, name);
       } catch (err) {
         log.warn(
           { ...runLog, entity: name, err },
@@ -1803,6 +1808,42 @@ export async function runWarehouseProducer(
             "looking it up failed. A name that resolves in more than one connection group is one " +
             "cause — enrollment stores no group, so this surface cannot tell the two apart — but the " +
             "lookup can also fail transiently. The server log for this run carries the reason.",
+        });
+        return;
+      }
+      if (raw === null) {
+        entityShapes.set(name, { kind: "not-published" });
+        return;
+      }
+      // ⚠️ **THE PARSE IS GUARDED, AND IT GETS ITS OWN ARM RATHER THAN SHARING
+      // `load-threw`'s (#5257).** {@link parseWarehouseEntity} does `raw.table`,
+      // `Object.entries(raw.dimensions)` and `isRecord` — every one an operation on a
+      // value this seam returned, per {@link seamRead}'s rule, and unguarded a
+      // `{ get table() { throw } }` entity rejected the whole `Promise.all`: the exact
+      // 500 the catch above exists to prevent, measured.
+      //
+      // ⚠️ **A SEPARATE `try`, and folding it into the one above was the first
+      // draft's mistake.** `load-threw`'s `why` enumerates two causes — an ambiguous
+      // name and a transient lookup failure — and BOTH are wrong here: the lookup
+      // SUCCEEDED, and a malformed record fails identically on every run until someone
+      // edits the YAML. Sharing the arm would have handed the admin "audit your
+      // connection groups" and "wait and retry" for a permanent fault with a concrete
+      // remedy, which is the misdirection that arm's own comment says it removed.
+      let entity: WarehouseEntity | null;
+      try {
+        entity = parseWarehouseEntity(name, raw);
+      } catch (err) {
+        log.warn(
+          { ...runLog, entity: name, err },
+          "Warehouse producer: the entity's YAML could not be read — its pairs are refused, the rest of the run continues",
+        );
+        entityShapes.set(name, {
+          kind: "unreadable",
+          cause: "unreadable-shape",
+          why:
+            "its stored YAML could not be read — a field of it threw or is not the shape this producer " +
+            "parses. This does not change between runs: fix the entity YAML, or un-enroll the pair. The " +
+            "server log for this run carries the reason.",
         });
         return;
       }
@@ -2164,13 +2205,19 @@ export async function runWarehouseProducer(
       // than lie — see {@link seamRead}, where narrowing the container was measured
       // insufficient. Reading each once, through the guard, is what makes every field
       // below a statement about a value rather than about a property access.
-      // ⚠️ **RE-TYPED TO `unknown` FOR THIS ARM, and the widening is a guard rather
-      // than a tidy-up (#5257).** `validated` is a `ValidatedSnapshotRequest`, so the
-      // compiler ACTIVELY ENCOURAGES `validated.table.slice(0, 200)` on this line — it
-      // typechecks, it looks like every other field, and it is the exact shape that
-      // recurred three times through #5256's rounds. Through `seam`, an unguarded read
-      // of a future field is a compile error instead of a review catch; every read
-      // below has to go through {@link seamRead} or {@link seamKind}.
+      // ⚠️ **RE-TYPED TO `unknown` FOR THIS ARM (#5257).** `validated` is a
+      // `ValidatedSnapshotRequest`, so the compiler ACTIVELY ENCOURAGES
+      // `validated.table.slice(0, 200)` here — it typechecks, it looks like every
+      // other field, and it is the exact shape that recurred three times through
+      // #5256's rounds. Reading through `seam` makes that expression a compile error.
+      //
+      // ⚠️ **What it does NOT do, stated because the first draft of this comment
+      // claimed otherwise:** the typed binding is still in scope, so a future edit can
+      // simply reach for `validated` and typecheck. This buys "a read written through
+      // `seam` cannot skip the guard", not "no unguarded read is possible" — review is
+      // still the backstop. Making it structural means lifting the arm into its own
+      // function so the typed binding is not in scope at all; that is real machinery
+      // and deliberately not in this slice.
       const seam: unknown = validated;
       const returnedEntity = seamRead(seam, "entity");
       const returnedWorkspaceId = seamRead(seam, "workspaceId");
@@ -2313,23 +2360,43 @@ export async function runWarehouseProducer(
      * {@link WarehouseSnapshotRunner} is one of the five names
      * `warehouse-producer-bypass.test.ts` pins as castable, so its return value is a
      * seam value under exactly the threat model #5248 spent its rounds on for the
-     * validator — and `rows.length` is an operation on it, not a fact about it. NINE
-     * shapes were run against the unfixed producer; EIGHT escaped it as a whole-run
-     * 500 with no log line at all — `null`, `undefined`, a bare string, a throwing
-     * `length` getter, a `length` whose `valueOf` throws, a hostile `Symbol.iterator`,
-     * a `null` row, and a row with a throwing `atlas_brain_subject` getter. The ninth,
-     * a revoked-Proxy array, survived — but only because `await` happened to trap it
-     * inside the `try` that was already here.
+     * validator — and `rows.length` is an operation on it, not a fact about it.
      *
-     * ⚠️ **A hostile CELL is IN scope, deliberately, and this sentence exists because
-     * silence here read as "already handled".** {@link buildWarehouseClaims} iterates
-     * the array and reads `row[SUBJECT_ALIAS]` and each dimension alias off it, so a
-     * `null` row or a throwing cell getter is the same class one level down and gets
-     * the same answer: this entity is refused, the run continues. **Stated cost:** a
-     * genuine defect in this module's own pure claim-building now reports as a failed
-     * snapshot — logged at `warn` with the Error, never swallowed, but wearing the
-     * wrong label. That is the cheaper of the two mistakes, because the alternative is
-     * one hostile cell taking down a run in which earlier entities have committed.
+     * Nine shapes were run against the unfixed producer, and they split three ways
+     * rather than the one way the first draft of this comment claimed:
+     *
+     * - **SEVEN escaped as a whole-run 500 with no log line at all** — `null`,
+     *   `undefined`, a throwing `length` getter, a `length` whose `valueOf` throws, a
+     *   hostile `Symbol.iterator`, a `null` row, and a row with a throwing
+     *   `atlas_brain_subject` getter.
+     * - **A bare STRING did not 500 — it produced a phantom entity outcome**, and this
+     *   correction is the point of writing the split out. `"rows".length` is 4, which
+     *   is under the cap, and the claim builder iterates a string's CHARACTERS without
+     *   throwing: measured `rows: 4, candidates: 0, unidentifiedRows: 4`, no refusal,
+     *   no 500. An entity reported as read-and-empty when nothing was read is the
+     *   silence this module exists to remove, so it is the worse outcome of the two,
+     *   and it is the one a 500-shaped description would have hidden.
+     * - **A revoked-Proxy array survived**, but only because `await` happened to trap
+     *   it inside the `try` that was already here.
+     *
+     * ⚠️ **A cell whose READ THROWS is in scope; a primitive row is not, and the
+     * difference is measured rather than intended.** {@link buildWarehouseClaims}
+     * iterates the array and reads `row[SUBJECT_ALIAS]` and each dimension alias off
+     * it, so a `null` row or a throwing cell getter throws inside this `try` and the
+     * entity is refused. A row that is a PRIMITIVE answers `undefined` for every alias
+     * instead of throwing — measured, `[42]` and `["x"]` both still report
+     * `rows: 1, unidentifiedRows: 1` — so it lands in the pre-existing
+     * unidentified-row counter and no refusal is raised. That is unchanged behaviour
+     * and arguably wrong, but it is a different question (what an unreadable ROW
+     * should cost) from the one this guard answers (a throw must not take the run),
+     * and #5257 deliberately does not move it.
+     *
+     * **Stated cost:** a genuine defect in this module's own pure claim-building now
+     * reports as a failed snapshot — logged at `warn` with the Error, never swallowed,
+     * but wearing the wrong label. That is the cheaper of the two mistakes, because
+     * the alternative is one hostile cell taking down a run in which earlier entities
+     * have committed. The `phase` field below is what keeps the operator-facing
+     * message honest about whose fault it was.
      *
      * ⚠️ **NOT in scope: an iterator that never ends.** A `Symbol.iterator` yielding
      * forever hangs inside the `for…of` the claim builder runs, and no `try` catches a
@@ -2345,15 +2412,40 @@ export async function runWarehouseProducer(
     let snapshot:
       | {
           readonly kind: "rows";
-          readonly rows: readonly Record<string, unknown>[];
+          /**
+           * ⚠️ **THE COUNT, NOT THE ARRAY, and carrying the array was this fix
+           * reproducing its own defect one statement over** (#5257 review). The rows
+           * are needed only by {@link buildWarehouseClaims}, which now runs inside the
+           * `try`; letting them out meant `rows.length` was read again in the
+           * no-candidates arm, where nothing encloses it. Measured: a Proxy over an
+           * array — `Array.isArray` answers TRUE for one — whose `length` trap throws
+           * on a LATER read passed the cap check and then rejected the whole run with
+           * no log line, and a trap that merely LIES reported 999,999 rows for an
+           * entity the cap had just accepted. One read, inside the guard, is what makes
+           * the cap check and the reported count the same number by construction.
+           */
+          readonly rowCount: number;
           readonly claims: WarehouseClaims;
         }
       | { readonly kind: "row-cap" };
+    /**
+     * WHICH of the three things inside the `try` failed (#5257 review).
+     *
+     * ⚠️ **The refusal below tells the admin to fix their entity YAML, and for two of
+     * these three that is the wrong person to send.** `run` is the datasource read —
+     * a dropped table or a renamed column, the admin's to fix. `shape` and `claims`
+     * are Atlas faults: a substituted runner answering something that is not an array,
+     * or a defect in this module's own claim builder. Widening the `try` is what made
+     * those two reachable here, so the message has to widen with it or the guard buys
+     * detectability at the cost of misdirection.
+     */
+    let phase: "run" | "shape" | "claims" = "run";
     try {
       // `validated`, the value the guard compared — NOT a fresh `validation.request`,
       // which would be a second read of a property the seam controls. See the capture
       // above.
       const returned: unknown = await runSnapshot(validated);
+      phase = "shape";
       // ⚠️ **`Array.isArray` FIRST, and it is inside the `try` for the revoked-Proxy
       // reason {@link seamRead} states: it THROWS on one rather than answering.** That
       // throw is wanted here — it lands on the refusal arm below instead of taking the
@@ -2366,17 +2458,33 @@ export async function runWarehouseProducer(
           `the snapshot runner answered ${seamKind(returned)} rather than an array of rows`,
         );
       }
-      const rows: readonly Record<string, unknown>[] = returned;
+      // ⚠️ `readonly unknown[]`, not `readonly Record<string, unknown>[]`, and the
+      // difference is honesty rather than pedantry. After `Array.isArray` on an
+      // `unknown`, TypeScript infers `any[]` — verified against this repo's own
+      // checker, where `const t: string = returned[0]` then compiles — so annotating
+      // the element type here would launder an unchecked `any` into a claim about
+      // every row, at the one site whose entire premise is not trusting this seam. The
+      // element shape is asserted ONCE, visibly, where it is actually needed.
+      const rows: readonly unknown[] = returned;
+      // ⚠️ ONE read of `length`, and every later use is of THIS number. See the
+      // `rowCount` field above for the two measurements that forced it.
+      const rowCount = rows.length;
+      phase = "claims";
       snapshot =
-        rows.length > rowCap
+        rowCount > rowCap
           ? { kind: "row-cap" }
           : {
               kind: "rows",
-              rows,
+              rowCount,
               claims: buildWarehouseClaims({
                 workspaceId,
                 plan: entityPlan,
-                rows,
+                // The one assertion, and it is checked by the guard around it rather
+                // than by the type: a row that is not a record throws on the first cell
+                // read, inside this `try`, and is refused. A row that is a PRIMITIVE
+                // and does not throw is counted into `unidentifiedRows` instead — see
+                // the scope note above.
+                rows: rows as readonly Record<string, unknown>[],
                 snapshotAt,
               }),
             };
@@ -2395,22 +2503,32 @@ export async function runWarehouseProducer(
       // is down". This log line is the only place that survives, because the
       // refusal below deliberately keeps the driver's text off the wire.
       log.warn(
-        { ...runLog, entity: entityPlan.entity.name, table: entityPlan.entity.table, err },
+        { ...runLog, entity: entityPlan.entity.name, table: entityPlan.entity.table, phase, err },
         "Warehouse producer: snapshot failed — the entity's pairs produced nothing this run",
       );
       refuseEntity(
         entityPlan,
         "snapshot-failed",
-        `Reading "${entityPlan.entity.table}" failed, so nothing was emitted for it this run. ` +
-          "Nothing was invalidated and no window was stamped; the next run tries again. " +
-          // ⚠️ The message no longer PROMISES that retrying will work, and the
-          // difference is not cosmetic. The SQL gate checks SELECT-only,
-          // single-statement and the whitelist — it does NOT check that the table or
-          // column exists — so a dropped table or a renamed column throws HERE, on
-          // every run, forever. "The next run retries the pair" was true and useless;
-          // an operator seeing it repeat needs to know the cause may be permanent.
-          "If it fails the same way on every run the cause is permanent — usually a table or a " +
-          "dimension's column that no longer exists. Fix the entity YAML, or un-enroll the pair.",
+        phase === "run"
+          ? `Reading "${entityPlan.entity.table}" failed, so nothing was emitted for it this run. ` +
+              "Nothing was invalidated and no window was stamped; the next run tries again. " +
+              // ⚠️ The message no longer PROMISES that retrying will work, and the
+              // difference is not cosmetic. The SQL gate checks SELECT-only,
+              // single-statement and the whitelist — it does NOT check that the table or
+              // column exists — so a dropped table or a renamed column throws HERE, on
+              // every run, forever. "The next run retries the pair" was true and useless;
+              // an operator seeing it repeat needs to know the cause may be permanent.
+              "If it fails the same way on every run the cause is permanent — usually a table or a " +
+              "dimension's column that no longer exists. Fix the entity YAML, or un-enroll the pair."
+          : // ⚠️ The ATLAS-fault register, borrowed verbatim from the gate-mismatch arm
+            // above, because these two arms now describe the same kind of event: Atlas
+            // read the entity fine and then could not process what came back. Sending
+            // this admin to "fix the entity YAML" is advice they can follow forever
+            // without anything changing.
+            `Atlas read "${entityPlan.entity.table}" but could not process the result, so nothing was ` +
+              "emitted for it this run. Nothing was invalidated and no window was stamped. This is an " +
+              "Atlas fault rather than a problem with the entity — if it repeats, report it with request " +
+              `id ${requestId ?? "unknown"}.`,
       );
       continue;
     }
@@ -2431,7 +2549,11 @@ export async function runWarehouseProducer(
       continue;
     }
 
-    const { rows, claims } = snapshot;
+    // ⚠️ No `rows` here, and its absence is the fix (#5257 review): the array the
+    // snapshot seam returned does not survive the `try`, so no later line can read a
+    // property off it. `rowCount` was read once, inside the guard, beside the cap
+    // comparison it has to agree with.
+    const { rowCount, claims } = snapshot;
 
     if (claims.unsurfaceableCells > 0) {
       // An enrollment mistake rather than an empty column — see `isAbsentCell`. It
@@ -2489,7 +2611,7 @@ export async function runWarehouseProducer(
       // reached must not look alike.
       outcomes.push({
         entity: entityPlan.entity.name,
-        rows: rows.length,
+        rows: rowCount,
         candidates: 0,
         created: 0,
         corroborated: 0,
@@ -2510,7 +2632,30 @@ export async function runWarehouseProducer(
       continue;
     }
 
-    const outcome = await withTransaction(async (tx) => {
+    /**
+     * This entity's outcome, taken from a CLOSURE LOCAL rather than from what
+     * `withTransaction` resolved with (#5257 review).
+     *
+     * ⚠️ **The `.catch` below hardens the value the transaction seam REJECTS with;
+     * this is the half it resolves with, and leaving it unguarded made the handler
+     * READ as though the seam were closed.** `ReconcileTransactionRunner` is
+     * `<T>(fn) => Promise<T>` with `T` inferred from our own callback — a claim about
+     * a substitutable seam, not a fact about it. Nothing checked that the resolved
+     * value was the object the callback built, or that the callback ran at all, and
+     * `outcome === "aborted"` / `outcome === null` are identity comparisons that let
+     * everything else through to `outcomes.push`. Measured: a runner resolving an
+     * object with a throwing `created` getter rejected the whole run from
+     * `outcomes.reduce(…)`, AFTER every entity had committed and with no log line
+     * naming the entity; a runner that simply forgets to `return` resolves `undefined`
+     * and does the same.
+     *
+     * `undefined` therefore means something a seam cannot fake: our callback never
+     * reached either of its exits. Reading the local makes "this outcome came from us"
+     * a scope fact instead of a type annotation.
+     */
+    let producedOutcome: WarehouseEntityOutcome | null | undefined;
+    let transactionAborted = false;
+    await withTransaction(async (tx) => {
       const episode = await insertSnapshotEpisode(tx, {
         workspaceId,
         entity: entityPlan.entity.name,
@@ -2525,7 +2670,8 @@ export async function runWarehouseProducer(
           { ...runLog, entity: entityPlan.entity.name, snapshotAt: snapshotAt.toISOString() },
           "Warehouse producer: this snapshot instant is already recorded — skipping the entity",
         );
-        return null;
+        producedOutcome = null;
+        return;
       }
 
       const report = await reconcileFacts(
@@ -2632,9 +2778,9 @@ export async function runWarehouseProducer(
       // not, costs the next reader a trip into `reconcile.ts` to discover it is
       // dead.
       const blocked = Object.values(report.blocked).reduce((sum, n) => sum + n, 0);
-      return {
+      producedOutcome = {
         entity: entityPlan.entity.name,
-        rows: rows.length,
+        rows: rowCount,
         candidates: claims.candidates.length,
         created: report.created,
         corroborated: report.corroborated,
@@ -2652,10 +2798,11 @@ export async function runWarehouseProducer(
       // A defect in this module's own contract stays FATAL — see
       // `WarehouseProducerContractError`. Everything below is for OPERATIONAL
       // failures, where refusing one entity is the proportionate answer.
-      // ⚠️ Through {@link seamIsContractError}, because a bare `instanceof` here walks
+      // ⚠️ Through {@link seamContractCheck}, because a bare `instanceof` here walks
       // the prototype chain of a value `withTransaction` chose — a revoked Proxy threw
       // out of this very line and escaped the run with no log at all (#5257).
-      if (seamIsContractError(err)) throw err;
+      const contract = seamContractCheck(err);
+      if (contract.isContract) throw err;
       // ⚠️ **REFUSED PER ENTITY, NOT RE-THROWN — and this reverses an earlier
       // decision in this file rather than extending it.**
       //
@@ -2677,10 +2824,18 @@ export async function runWarehouseProducer(
           entity: entityPlan.entity.name,
           committedEntities: outcomes.map((o) => o.entity),
           committedCreated: outcomes.reduce((sum, o) => sum + o.created, 0),
+          // ⚠️ These two are the ONLY fields that say anything when the rejected value
+          // is hostile: `scrubErrSerializer` renders one as `[log scrub failed]`,
+          // measured. `errKind` is bracketed like every other seam sentinel on this
+          // file's log lines, and `contractCheckThrew` is the bit the classification
+          // would otherwise have swallowed — see {@link seamContractCheck}.
+          errKind: seamKind(err),
+          contractCheckThrew: contract.threw,
           err,
         },
         "Warehouse producer: a transaction failed and rolled back — its entity produced nothing; earlier entities had already committed",
       );
+      transactionAborted = true;
       refuseEntity(
         entityPlan,
         "snapshot-failed",
@@ -2689,10 +2844,39 @@ export async function runWarehouseProducer(
           "in this run DID commit, so a blind re-run re-files their drafts: drain the review queue " +
           "first, then re-run.",
       );
-      return "aborted" as const;
     });
 
-    if (outcome === "aborted") continue;
+    if (transactionAborted) continue;
+
+    // Copied to a `const` before any branch reads it, so the three arms below cannot
+    // disagree about what the callback produced.
+    const outcome = producedOutcome;
+
+    if (outcome === undefined) {
+      // ⚠️ The transaction seam RESOLVED without our callback reaching either of its
+      // exits — a substituted runner that never invoked it, or one that swallowed a
+      // throw and resolved anyway. Reported rather than assumed away: nothing was
+      // committed for this entity, and silently omitting it is the "never enrolled"
+      // silence the arm below refuses. It is an Atlas fault, so it takes the same
+      // register as the shape arm above rather than the entity-YAML advice.
+      log.error(
+        {
+          ...runLog,
+          entity: entityPlan.entity.name,
+          committedEntities: outcomes.map((o) => o.entity),
+        },
+        "Warehouse producer: the transaction runner resolved without running this entity's work — nothing was committed for it",
+      );
+      refuseEntity(
+        entityPlan,
+        "snapshot-failed",
+        `Atlas could not write "${entityPlan.entity.table}"'s claims: its transaction returned without ` +
+          "doing the work, so nothing at all was recorded for it — no episode, no drafts, no proposals. " +
+          "This is an Atlas fault rather than a problem with the entity — if it repeats, report it with " +
+          `request id ${requestId ?? "unknown"}.`,
+      );
+      continue;
+    }
 
     if (outcome === null) {
       // The entity is reported rather than omitted. An entity that vanishes from

--- a/packages/api/src/lib/brain/warehouse-producer.ts
+++ b/packages/api/src/lib/brain/warehouse-producer.ts
@@ -2655,7 +2655,16 @@ export async function runWarehouseProducer(
      */
     let producedOutcome: WarehouseEntityOutcome | null | undefined;
     let transactionAborted = false;
-    await withTransaction(async (tx) => {
+    // ⚠️ **`try`/`catch`, NOT `.catch(…)` on the returned value, and the difference is
+    // the last unguarded read on this seam** (#5257 review, round 2). `.catch` is
+    // itself a property access on whatever `withTransaction` returned: a non-thenable
+    // or a revoked Proxy threw THERE, outside every guard, after earlier entities had
+    // committed. `await` inside a `try` has no such read — a revoked Proxy throws on
+    // the `.then` lookup and lands in the catch, and a plain non-promise simply
+    // resolves to itself and leaves `producedOutcome` undefined, which the arm below
+    // already reports.
+    try {
+      await withTransaction(async (tx) => {
       const episode = await insertSnapshotEpisode(tx, {
         workspaceId,
         entity: entityPlan.entity.name,
@@ -2794,7 +2803,8 @@ export async function runWarehouseProducer(
         entitiesStored: claims.entityEntries.length,
         unnamedRows: claims.unnamedRows,
       } satisfies WarehouseEntityOutcome;
-    }).catch((err: unknown) => {
+      });
+    } catch (err: unknown) {
       // A defect in this module's own contract stays FATAL — see
       // `WarehouseProducerContractError`. Everything below is for OPERATIONAL
       // failures, where refusing one entity is the proportionate answer.
@@ -2844,7 +2854,7 @@ export async function runWarehouseProducer(
           "in this run DID commit, so a blind re-run re-files their drafts: drain the review queue " +
           "first, then re-run.",
       );
-    });
+    }
 
     if (transactionAborted) continue;
 


### PR DESCRIPTION
Carries #5248's seam-read ratchet — *narrowing is an OPERATION on the seam value, not a fact about it* — past the validator to the three sibling seams in the same loop of `runWarehouseProducer`. Those refusal arms have no enclosing `try`, so a throw turns ONE refused entity into a 500 for the whole run, with no log line at all.

Not reachable with the shipped implementations (real pg rows, real YAML, real `pg` rejections) — hardening of a stated invariant, not a live incident.

## What changed

**1. `runSnapshot`'s return value.** The cap read and `buildWarehouseClaims` move inside the `try`, behind an `Array.isArray` check that is itself inside it. The local union carries a **`rowCount` read once**, not the array — so nothing after the guard can touch the seam's value. The count is also *validated*: `NaN > rowCap` is false, and a `NaN` reaching the report blanks the **entire** run report, because the wire schema requires a non-negative int.

**2. `loadEntity`.** `parseWarehouseEntity` moves inside a guard with its own `unreadable-shape` cause, separate from `load-threw` — the lookup *succeeded*, so "audit your connection groups / wait and retry" is unfollowable. A loader answering a **non-record** (a string, a number, an array) previously fell through to `no-table` and said *"its YAML declares no `table:` … Fix the entity YAML"* with **zero log lines**; it is now an Atlas fault with a warn.

**3. The transaction seam, all three of its surfaces.** The value it *rejects* with (`instanceof` via a total `seamContractCheck`), the value it *resolves* with (read from a closure local — `undefined` means our callback never ran, which a seam cannot fake), and the value it *returns* (`try`/`catch` instead of `.catch`, because `.catch` is itself a property read on it).

Plus `const seam: unknown` in the mismatch arm, and `phase` so the operator-facing message blames Atlas rather than the entity YAML for an Atlas-side fault.

## Decisions the issue asked to be stated, not left silent

- **A cell whose read THROWS is in scope.** Measured over row shapes: only `null` and `undefined` rows throw; an array, a `Date`, a function and a primitive all answer `undefined` for every alias and land in the pre-existing `unidentifiedRows`. Unchanged and left alone deliberately — what an unreadable *row* should cost is a different question.
- **A non-terminating iterator is OUT of scope.** No `try` catches a hang, and `length` is a separate property from the iterator. A liveness problem wanting a timeout.
- **Stated cost:** a genuine defect in our own claim builder now reports as a failed snapshot — logged with the Error, never swallowed, but wearing the wrong label. Cheaper than one hostile cell taking down a run in which earlier entities have committed.

## Review panel — the curve, and why it stopped

| round | findings | new surface | defect-in-prior-fix |
|---|---|---|---|
| 1 | 14 | 14 | 0 |
| 2 | ~28 | ~7 | **~15** |

**Stopped on the ratio rule, not the 3-round cap.** Round 2's defect-in-prior-fix count exceeded its new-surface count and the total rose — the signal that the fixes were manufacturing the next round's work faster than they removed it. Round 2 was therefore the closing round: every confirmed must-fix is in, the comment sweep ran on this diff, and every falsifier is built and measured.

Round 1 found two HIGH defects that were **this fix reproducing its own defect one statement over** — the array escaping the `try`, and the transaction seam's *resolve* half left open beside the *reject* half I had just hardened. A `fix-vs-finding` pass then returned CLEAN but named its own boundary (`.catch` is a property read too), which is the third commit.

**Residue — consciously deferred, not dropped:** collapsing `producedOutcome` + `transactionAborted` into one discriminated union (the illegal pair is unreachable by statement order today); a three-state union for `seamContractCheck`; widening `buildWarehouseClaims`'s exported signature (carries a behaviour delta — `null` rows would stop being a refusal); lifting the gate-mismatch arm into its own function so the typed binding leaves scope.

## AC-5 — measured RED, never reasoned

Every falsifier was run against the **unfixed** code, restored from a backup (never `git checkout`, which would revert the fix too).

- **Round 1:** 10 cases RED against `main`'s producer — `null` / `undefined` / a bare string / a throwing `length` getter / a `length` whose `valueOf` throws; a hostile `Symbol.iterator`; a `null` row; a throwing subject getter; a throwing entity-YAML `table` getter; a revoked Proxy thrown by `withTransaction`.
- **Round 2:** 7 cases RED against round 1's commit, including the two HIGH defects. The `length`-read premise was measured, not assumed: **3 reads under round 1** (the third outside the `try`), **2 now** (both inside) — and the test asserts `reads === 2` so the premise cannot go stale silently.
- **Closing round:** 5 more RED against round 2b.
- **Green-by-design cases each killed by their own mutation:** the `unreadable-shape` split (both fold directions, each killed by its own case); the `row-cap` arm; the `not-published` arm; `seamContractCheck` forced never-contract; `phase = "claims"` deleted; the per-entity state hoisted out of the loop (kills both multi-entity cases and nothing else); trusting the seam's returned value.
- **One case is a PIN, labelled as one in the test:** the revoked-Proxy *array*. It was GREEN before the fix — `await` traps it inside the pre-existing `try` — and no mutation of the fix REDs it. Recorded as covered-by-construction rather than dressed up as a measurement.

## Comment claims measured false and CUT

Eight across the three rounds, every one written by an earlier round of this branch — the documented failure mode where a rewrite introduces fresh false claims. They are deletions, not more careful assertions:

- *"EIGHT escaped as a whole-run 500"* — **seven** did. A bare string produced a **phantom entity outcome** (`rows: 4`, no refusal), which is the worse failure and the one the wrong count hid.
- *"a hostile CELL … is refused"* — only one whose read throws.
- *"every consumption of the returned rows is now guarded"* — false when written; the no-candidates arm was the counter-example.
- *"`undefined` is NOT this case"* — `isRecord(undefined)` is false, so it is.
- *"`validated.table.slice(0, 200)` … it typechecks"* — verified with this repo's tsc: no `table` on that type, and the binding is possibly-undefined.
- *"`rowCount > rowCap` can itself throw"* — the validation above rejects it first; `Number.isSafeInteger` does not coerce.
- Two stale `.catch` references to a construct this branch had already replaced, and one "sibling arm below" that is above.

## Gates

`--affected` 12/12 · `tsgo --noEmit` · `lint` · `lint:type-aware` all clean. No mutation spec targets `warehouse-producer`, so `mutation-tables` is undisturbed.

Closes #5257
