### PR TITLE
sec(settings): the security-audit line masks a secret setting's value (#5180)

### DIFF
--- a/packages/api/src/lib/__tests__/settings-audit-log.test.ts
+++ b/packages/api/src/lib/__tests__/settings-audit-log.test.ts
@@ -6,8 +6,8 @@
  * cannot see that line at all: with 150 pure-function assertions green,
  * `log.warn({ ...line, value }, …)` — issue #5180 verbatim, plaintext straight
  * back into the log stream — passed the entire suite. So did dropping the
- * definition (masking every value, which silently destroys the "do not mask
- * everything" control), and so did deleting the audit emission outright.
+ * definition (withholding every value, which silently destroys the "do not
+ * withhold everything" control), and so did deleting the audit outright.
  *
  * A SEPARATE FILE, deliberately. `settings.test.ts` avoids `mock.module` on
  * purpose — it injects the pool via `_resetPool(mockPool)` — and a module mock
@@ -15,19 +15,40 @@
  * of its tests behind a fake logger. The isolated runner gives each file its
  * own module registry, which is what makes this split free.
  *
- * The assertions compare the EMITTED object against
+ * Most assertions compare the EMITTED object against
  * `securitySensitiveAuditLine`'s own output rather than a hand-written literal.
- * That is the point: a literal on both sides would agree by construction with
- * whatever the emitter did, while equality-with-the-builder pins exactly the
- * property under test — the payload is passed through, with nothing added,
- * nothing dropped and nothing swapped.
+ * That is the point: a literal on both sides would restate the payload and pass
+ * whether or not the emitter used the builder at all, while
+ * equality-with-the-builder pins exactly the property under test — the payload
+ * is passed through, with nothing added, dropped or swapped.
+ *
+ * ⚠️ That comparison has one blind spot, and the last block in this file exists
+ * for it: both sides are built from the same inputs, so an edit that changes
+ * what the emitter FEEDS the builder is invisible whenever the hand-written
+ * input coincides with the mutated one. `undefined` is the value every
+ * dropped-argument mutation produces, which is why `orgId` is driven with a
+ * real workspace here rather than left to default.
  */
 import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
+// Type-only, so it does not pull the module in ahead of the logger mock below.
+import type { SecuritySensitiveAuditInput } from "@atlas/api/lib/settings";
 
-type LogCall = [Record<string, unknown>, string];
+/**
+ * `[first-arg, message]`. The first argument is `unknown`, not an object:
+ * `settings.ts` also calls `log.warn("isSaasModeForGuard: …")` with a bare
+ * string, so typing it as a record would be a claim the stub cannot keep.
+ */
+type LogCall = [unknown, string | undefined];
 
 const warnCalls: LogCall[] = [];
 const infoCalls: LogCall[] = [];
+/**
+ * Recorded, not discarded. A stub that no-ops `error`/`fatal` cannot assert
+ * "and nothing went wrong" — so the natural future edit
+ * `try { emit(line) } catch (err) { log.error(…) }`, an audit swallowed by a
+ * catch that logs, would leave every test here green.
+ */
+const errorCalls: LogCall[] = [];
 
 // ⚠️ ALL exports, per the repo's partial-mock rule: a `mock.module` factory
 // REPLACES the module, so any export omitted here becomes undefined for every
@@ -37,16 +58,20 @@ const infoCalls: LogCall[] = [];
 // deadlocks bun's module registry.
 await mock.module("@atlas/api/lib/logger", () => {
   const stub = {
-    warn: (obj: Record<string, unknown>, msg: string) => {
+    warn: (obj: unknown, msg?: string) => {
       warnCalls.push([obj, msg]);
     },
-    info: (obj: Record<string, unknown>, msg: string) => {
+    info: (obj: unknown, msg?: string) => {
       infoCalls.push([obj, msg]);
     },
-    error: () => {},
+    error: (obj: unknown, msg?: string) => {
+      errorCalls.push([obj, msg]);
+    },
+    fatal: (obj: unknown, msg?: string) => {
+      errorCalls.push([obj, msg]);
+    },
     debug: () => {},
     trace: () => {},
-    fatal: () => {},
     child: () => stub,
     level: "info",
   };
@@ -59,7 +84,10 @@ await mock.module("@atlas/api/lib/logger", () => {
     scrubLogFormatter: (obj: unknown) => obj,
     getLogger: () => stub,
     createLogger: () => stub,
-    hashShareToken: (token: string) => token,
+    // Visibly NOT the token: returning the input would invert a security
+    // helper inside a test file about not disclosing secrets, and would let a
+    // caller that forgot to hash look correct here.
+    hashShareToken: (token: string) => `stub-hash-of-${token.length}-chars`,
     setLogLevel: () => true,
   };
 });
@@ -96,42 +124,92 @@ describe("auditSecuritySensitiveChange — what reaches the log stream (#5180)",
   beforeEach(() => {
     warnCalls.length = 0;
     infoCalls.length = 0;
+    errorCalls.length = 0;
     process.env.DATABASE_URL = "postgresql://test:test@localhost:5432/test";
     _resetPool(mockPool);
     _resetSettingsCache();
   });
 
   afterEach(() => {
+    // Nothing in this file should provoke an error-level line. If one appears,
+    // the most likely cause is an audit swallowed by a catch that logs.
+    expect(errorCalls).toEqual([]);
     _resetPool(null);
     _resetSettingsCache();
     if (origDatabaseUrl === undefined) delete process.env.DATABASE_URL;
     else process.env.DATABASE_URL = origDatabaseUrl;
   });
 
-  /** The single security-audit line, or a failure if there is not exactly one. */
-  function auditLine(): Record<string, unknown> {
-    const lines = warnCalls.filter(([obj]) => obj.event === "security_setting.changed");
-    expect(lines).toHaveLength(1);
-    return lines[0]![0];
+  /** The one security-audit call, as `[payload, message]`. */
+  function auditCall(): [Record<string, unknown>, string | undefined] {
+    const lines = warnCalls.filter(
+      (call): call is [Record<string, unknown>, string | undefined] =>
+        typeof call[0] === "object" &&
+        call[0] !== null &&
+        (call[0] as Record<string, unknown>).event === "security_setting.changed",
+    );
+    const [first] = lines;
+    // Thrown rather than asserted so the failure names the real problem, and so
+    // no `!` is needed below — `toHaveLength` would satisfy a reader but not
+    // the compiler.
+    if (lines.length !== 1 || first === undefined) {
+      throw new Error(`expected exactly one security-audit line, got ${lines.length}`);
+    }
+    return first;
   }
 
-  // ⚠️ THE ONE ASSERTION THAT SEES THE LEAK. `log.warn({ ...line, value }, …)`
-  // is a one-keystroke edit at the call site and reintroduces #5180; nothing in
-  // `settings.test.ts` goes red for it, because the builder it tests is still
-  // returning the right thing. Equality with the builder's output is what
-  // catches it: an extra `value` field makes the emitted object unequal.
-  it("emits exactly the builder's payload — nothing added, dropped or swapped", async () => {
+  /** The single security-audit payload. */
+  function auditLine(): Record<string, unknown> {
+    return auditCall()[0];
+  }
+
+  /**
+   * The payload the builder produces for these inputs, as a plain record so it
+   * compares against the emitted one without a cast. Throws on `null`, which
+   * would mean the key stopped being sensitive — a different bug, and one the
+   * caller should not discover as a confusing equality failure.
+   */
+  function builtLine(input: SecuritySensitiveAuditInput): Record<string, unknown> {
+    const line = securitySensitiveAuditLine(input);
+    if (!line) throw new Error(`builder returned null for sensitive key ${input.key}`);
+    return { ...line };
+  }
+
+  // ⚠️ THIS ASSERTION DOES NOT SEE THE PLAINTEXT LEAK — see the
+  // `secret: true` block below, which does. `value` is a DECLARED field of the
+  // payload, so `log.warn({ ...line, value }, …)` overwrites it rather than
+  // adding a key, and while every shipped sensitive key is non-secret the raw
+  // and redacted values are equal, so both sides of this comparison move
+  // together.
+  //
+  // What this assertion does close is everything that changes WHAT is emitted:
+  // a dropped or swapped field, a wrong actor or org, a definition that is not
+  // the key's own. Equality against the builder's own output rather than a
+  // literal is deliberate — a literal here would restate the payload and pass
+  // whether or not the emitter used the builder at all.
+  it("emits exactly the builder's payload — nothing dropped or swapped", async () => {
     await setSetting(RPM, "0", "user_1");
     expect(auditLine()).toEqual(
-      securitySensitiveAuditLine({
+      builtLine({
         key: RPM,
         definition: getSettingDefinition(RPM),
         action: "set",
         value: "0",
         actorId: "user_1",
         orgId: undefined,
-      }) as unknown as Record<string, unknown>,
+      }),
     );
+  });
+
+  it("records the message, and the message does not carry the value", async () => {
+    // A template literal is a leak channel no type can close: `${line.value}`
+    // and `${rawValue}` are both just strings there. Nothing else in this file
+    // looks at the message at all, so without this the emitter could append
+    // the secret to the text and stay green.
+    await setSetting(SOURCES, "warehouse_key,extractor", "user_1");
+    const [, msg] = auditCall();
+    expect(msg).toBe(`Security-sensitive setting changed at runtime: ${SOURCES}`);
+    expect(msg).not.toContain("warehouse_key,extractor");
   });
 
   it("passes the key's OWN definition, so a non-secret value stays verbatim", async () => {
@@ -152,15 +230,34 @@ describe("auditSecuritySensitiveChange — what reaches the log stream (#5180)",
   it("audits a CLEAR through deleteSetting", async () => {
     await deleteSetting(RPM, "user_2");
     expect(auditLine()).toEqual(
-      securitySensitiveAuditLine({
+      builtLine({
         key: RPM,
         definition: getSettingDefinition(RPM),
         action: "clear",
         value: undefined,
         actorId: "user_2",
         orgId: undefined,
-      }) as unknown as Record<string, unknown>,
+      }),
     );
+  });
+
+  // ⚠️ `orgId` was `undefined` on both sides of every assertion above, which is
+  // the value a dropped-argument mutation produces — so the emitter could have
+  // stopped passing it and nothing would have moved. Two of the four sensitive
+  // keys are workspace-scoped, so this is the field that answers "whose control
+  // moved", on exactly the keys where that is the question.
+  it("records the org for a workspace-scoped key", async () => {
+    await setSetting(SOURCES, "warehouse_key", "user_1", "org_9");
+    expect(auditLine().orgId).toBe("org_9");
+  });
+
+  it("records NO org for a platform-scoped key, even when one was passed", async () => {
+    // `setSetting` collapses `orgId` to undefined for a platform-scoped key,
+    // because the write is global. Logging the caller's `orgId` instead would
+    // claim a blast radius of one workspace for a change that hit every
+    // workspace — a misattribution in the line that exists for the incident.
+    await setSetting(RPM, "0", "user_1", "org_9");
+    expect(auditLine().orgId).toBeUndefined();
   });
 
   // Deleting the emission entirely was the third survivor. These two are what
@@ -168,14 +265,94 @@ describe("auditSecuritySensitiveChange — what reaches the log stream (#5180)",
   // line, a non-sensitive one must not.
   it("emits NO security-audit line for a non-sensitive key", async () => {
     await setSetting(PLAIN, "500", "user_1");
-    expect(warnCalls.filter(([obj]) => obj.event === "security_setting.changed")).toHaveLength(0);
+    expect(
+      warnCalls.filter(
+        ([obj]) =>
+          typeof obj === "object" &&
+          obj !== null &&
+          (obj as Record<string, unknown>).event === "security_setting.changed",
+      ),
+    ).toHaveLength(0);
     // The generic settings-change info log still fires, so this is a statement
     // about the AUDIT line specifically, not about the write being skipped.
-    expect(infoCalls.some(([obj]) => obj.key === PLAIN)).toBe(true);
+    expect(
+      infoCalls.some(
+        ([obj]) =>
+          typeof obj === "object" &&
+          obj !== null &&
+          (obj as Record<string, unknown>).key === PLAIN,
+      ),
+    ).toBe(true);
   });
 
   it("carries the actor through, so the line can answer WHO", async () => {
     await setSetting(RPM, "0", "operator_9");
     expect(auditLine().actorId).toBe("operator_9");
+  });
+
+  // ⚠️ THE BLOCK THAT SEES THE PLAINTEXT LEAK, and the reason the rest of this
+  // file cannot.
+  //
+  // Everything above compares two payloads that move together, because no
+  // shipped sensitive key is `secret: true` — so redacted equals raw on every
+  // input the emitter can reach, and the leak edit is a no-op. Two drafts of
+  // this file concluded from that "no assertion can catch it" and reached for a
+  // type instead. That conclusion was wrong, and the error is worth naming: it
+  // treated a fact about the REGISTRY's current contents as a fact about what
+  // is observable.
+  //
+  // `getSettingDefinition` returns the object `SETTINGS_MAP` holds. Flipping
+  // `secret` on it for the duration of one test makes redacted and raw differ
+  // on a fully reachable input, and the leak becomes an ordinary assertion —
+  // which also catches the two edits the brand cannot see: inlining `log.warn`
+  // back into the caller, and fabricating a `{ key, secret: false }` definition
+  // at the call site.
+  //
+  // Scoped and restored. Never at top level, and the isolated runner gives this
+  // file its own module registry, so the flip cannot reach another file.
+  describe("a sensitive key that IS secret — #5180's actual subject", () => {
+    const SECRET_WRITTEN = "sk-ant-api03-SUPERSECRET-payload";
+    let restore: (() => void) | undefined;
+
+    beforeEach(() => {
+      const def = getSettingDefinition(RPM) as { secret?: boolean } | undefined;
+      if (!def) throw new Error(`no registry definition for ${RPM}`);
+      const prev = def.secret;
+      def.secret = true;
+      restore = () => {
+        if (prev === undefined) delete def.secret;
+        else def.secret = prev;
+      };
+    });
+
+    afterEach(() => {
+      restore?.();
+      restore = undefined;
+      // The flip must not outlive the test, or every assertion in the blocks
+      // above silently changes meaning.
+      expect(getSettingDefinition(RPM)?.secret).not.toBe(true);
+    });
+
+    it("withholds the plaintext from the log stream, not merely from the builder", async () => {
+      await setSetting(RPM, SECRET_WRITTEN, "user_1");
+      const [line, msg] = auditCall();
+      expect(line.value).toBe("[withheld:secret-setting]");
+      expect(line.valueMasked).toBe(true);
+      expect(line.maskReason).toBe("secret");
+      // The WHOLE record, payload and message: a secret that lands in a sibling
+      // field or gets appended to the text is the same breach.
+      expect(JSON.stringify(line)).not.toContain("SUPERSECRET");
+      expect(msg).not.toContain("SUPERSECRET");
+    });
+
+    it("still classifies from the written value while withholding it", async () => {
+      // `"0"` is the fixture that can tell the two apart: withheld it is
+      // unparseable, raw it is the documented disabled sentinel. A redact-early
+      // emitter would report the abuse control as still on.
+      await setSetting(RPM, "0", "user_1");
+      const line = auditLine();
+      expect(line.disablesControl).toBe(true);
+      expect(line.value).toBe("[withheld:secret-setting]");
+    });
   });
 });

--- a/packages/api/src/lib/__tests__/settings-audit-log.test.ts
+++ b/packages/api/src/lib/__tests__/settings-audit-log.test.ts
@@ -1,0 +1,181 @@
+/**
+ * #5180 — what the security-audit line actually EMITS.
+ *
+ * `settings.test.ts` pins the payload builder. This file pins the one line that
+ * consumes it, and it exists because review measured that the builder's tests
+ * cannot see that line at all: with 150 pure-function assertions green,
+ * `log.warn({ ...line, value }, …)` — issue #5180 verbatim, plaintext straight
+ * back into the log stream — passed the entire suite. So did dropping the
+ * definition (masking every value, which silently destroys the "do not mask
+ * everything" control), and so did deleting the audit emission outright.
+ *
+ * A SEPARATE FILE, deliberately. `settings.test.ts` avoids `mock.module` on
+ * purpose — it injects the pool via `_resetPool(mockPool)` — and a module mock
+ * applies to a whole file, so installing a logger mock there would put all 150
+ * of its tests behind a fake logger. The isolated runner gives each file its
+ * own module registry, which is what makes this split free.
+ *
+ * The assertions compare the EMITTED object against
+ * `securitySensitiveAuditLine`'s own output rather than a hand-written literal.
+ * That is the point: a literal on both sides would agree by construction with
+ * whatever the emitter did, while equality-with-the-builder pins exactly the
+ * property under test — the payload is passed through, with nothing added,
+ * nothing dropped and nothing swapped.
+ */
+import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
+
+type LogCall = [Record<string, unknown>, string];
+
+const warnCalls: LogCall[] = [];
+const infoCalls: LogCall[] = [];
+
+// ⚠️ ALL exports, per the repo's partial-mock rule: a `mock.module` factory
+// REPLACES the module, so any export omitted here becomes undefined for every
+// importer in this file — including `settings.ts`'s transitive dependencies.
+// Awaited, not fire-and-forget, so the mock is installed before the dynamic
+// imports below resolve. The FACTORY stays synchronous — an async factory
+// deadlocks bun's module registry.
+await mock.module("@atlas/api/lib/logger", () => {
+  const stub = {
+    warn: (obj: Record<string, unknown>, msg: string) => {
+      warnCalls.push([obj, msg]);
+    },
+    info: (obj: Record<string, unknown>, msg: string) => {
+      infoCalls.push([obj, msg]);
+    },
+    error: () => {},
+    debug: () => {},
+    trace: () => {},
+    fatal: () => {},
+    child: () => stub,
+    level: "info",
+  };
+  return {
+    ACTOR_KINDS: ["human", "agent", "mcp", "scheduler", "api_key"] as const,
+    withRequestContext: <T>(_ctx: unknown, fn: () => T): T => fn(),
+    getRequestContext: () => undefined,
+    redactPaths: [] as string[],
+    scrubErrSerializer: (value: unknown) => value,
+    scrubLogFormatter: (obj: unknown) => obj,
+    getLogger: () => stub,
+    createLogger: () => stub,
+    hashShareToken: (token: string) => token,
+    setLogLevel: () => true,
+  };
+});
+
+const { _resetPool } = await import("@atlas/api/lib/db/internal");
+const {
+  setSetting,
+  deleteSetting,
+  securitySensitiveAuditLine,
+  getSettingDefinition,
+  _resetSettingsCache,
+} = await import("@atlas/api/lib/settings");
+type InternalPool = Parameters<typeof _resetPool>[0];
+
+const mockPool = {
+  query: async () => ({ rows: [] }),
+  async connect() {
+    return { query: async () => ({ rows: [] }), release() {} };
+  },
+  end: async () => {},
+  on: () => {},
+} as unknown as NonNullable<InternalPool>;
+
+/** A sensitive key with no `secret` flag — the verbatim control. */
+const RPM = "ATLAS_TRIAL_IP_RATE_LIMIT_RPM";
+/** Sensitive, and its value must never be logged verbatim once it is secret. */
+const SOURCES = "ATLAS_BRAIN_ALIAS_AUTO_APPROVE_SOURCES";
+/** Not sensitive — must produce no audit line at all. */
+const PLAIN = "ATLAS_ROW_LIMIT";
+
+const origDatabaseUrl = process.env.DATABASE_URL;
+
+describe("auditSecuritySensitiveChange — what reaches the log stream (#5180)", () => {
+  beforeEach(() => {
+    warnCalls.length = 0;
+    infoCalls.length = 0;
+    process.env.DATABASE_URL = "postgresql://test:test@localhost:5432/test";
+    _resetPool(mockPool);
+    _resetSettingsCache();
+  });
+
+  afterEach(() => {
+    _resetPool(null);
+    _resetSettingsCache();
+    if (origDatabaseUrl === undefined) delete process.env.DATABASE_URL;
+    else process.env.DATABASE_URL = origDatabaseUrl;
+  });
+
+  /** The single security-audit line, or a failure if there is not exactly one. */
+  function auditLine(): Record<string, unknown> {
+    const lines = warnCalls.filter(([obj]) => obj.event === "security_setting.changed");
+    expect(lines).toHaveLength(1);
+    return lines[0]![0];
+  }
+
+  // ⚠️ THE ONE ASSERTION THAT SEES THE LEAK. `log.warn({ ...line, value }, …)`
+  // is a one-keystroke edit at the call site and reintroduces #5180; nothing in
+  // `settings.test.ts` goes red for it, because the builder it tests is still
+  // returning the right thing. Equality with the builder's output is what
+  // catches it: an extra `value` field makes the emitted object unequal.
+  it("emits exactly the builder's payload — nothing added, dropped or swapped", async () => {
+    await setSetting(RPM, "0", "user_1");
+    expect(auditLine()).toEqual(
+      securitySensitiveAuditLine({
+        key: RPM,
+        definition: getSettingDefinition(RPM),
+        action: "set",
+        value: "0",
+        actorId: "user_1",
+        orgId: undefined,
+      }) as unknown as Record<string, unknown>,
+    );
+  });
+
+  it("passes the key's OWN definition, so a non-secret value stays verbatim", async () => {
+    // The sibling mutation: `definition: undefined` at the call site fails
+    // closed and withholds EVERY value, which looks correct — `valueMasked` is
+    // true and the value is a placeholder — while quietly destroying the
+    // control that the issue's second acceptance criterion exists to protect.
+    // Only an assertion downstream of the real call site can tell.
+    await setSetting(SOURCES, "warehouse_key,extractor", "user_1");
+    const line = auditLine();
+    expect(line.value).toBe("warehouse_key,extractor");
+    expect(line.valueMasked).toBe(false);
+    expect(line.maskReason).toBeUndefined();
+    // The flags still travel: a widened source list is the event itself.
+    expect(line.widensAuthority).toBe(true);
+  });
+
+  it("audits a CLEAR through deleteSetting", async () => {
+    await deleteSetting(RPM, "user_2");
+    expect(auditLine()).toEqual(
+      securitySensitiveAuditLine({
+        key: RPM,
+        definition: getSettingDefinition(RPM),
+        action: "clear",
+        value: undefined,
+        actorId: "user_2",
+        orgId: undefined,
+      }) as unknown as Record<string, unknown>,
+    );
+  });
+
+  // Deleting the emission entirely was the third survivor. These two are what
+  // make its absence visible in each direction: a sensitive key must produce a
+  // line, a non-sensitive one must not.
+  it("emits NO security-audit line for a non-sensitive key", async () => {
+    await setSetting(PLAIN, "500", "user_1");
+    expect(warnCalls.filter(([obj]) => obj.event === "security_setting.changed")).toHaveLength(0);
+    // The generic settings-change info log still fires, so this is a statement
+    // about the AUDIT line specifically, not about the write being skipped.
+    expect(infoCalls.some(([obj]) => obj.key === PLAIN)).toBe(true);
+  });
+
+  it("carries the actor through, so the line can answer WHO", async () => {
+    await setSetting(RPM, "0", "operator_9");
+    expect(auditLine().actorId).toBe("operator_9");
+  });
+});

--- a/packages/api/src/lib/__tests__/settings.test.ts
+++ b/packages/api/src/lib/__tests__/settings.test.ts
@@ -19,9 +19,13 @@ import {
   HOT_RELOADED_KEYS,
   isHotReloadedKey,
   securitySensitiveAuditFields,
+  securitySensitiveAuditLine,
+  redactAuditValue,
   settingsCacheEverLoaded,
   SECURITY_SENSITIVE_KEYS,
   type SecuritySensitiveKey,
+  type SecuritySensitiveAuditInput,
+  type SettingDefinition,
   _resetSettingsCache,
 } from "../settings";
 import { ANSWER_STYLE_NAMES, isAnswerStyle } from "../answer-styles";
@@ -1234,8 +1238,9 @@ describe("securitySensitiveAuditFields (#3797)", () => {
   // `parseRpm` returns the shipped DEFAULT on a non-finite value, so `"off"`
   // leaves the limiter running at 5rpm — nothing was disabled, and flagging it
   // trains an incident responder to discount the one signal that says an abuse
-  // control went away. The raw value still rides in the log line, so a garbled
-  // write is not invisible; it is just not a *disable*.
+  // control went away. The written value still rides in the log line — these
+  // keys carry no `secret` flag, so #5180's redaction leaves them verbatim —
+  // and a garbled write is therefore not invisible; it is just not a *disable*.
   it("does NOT flag disablesControl on a non-finite value — the reader keeps the default", () => {
     expect(securitySensitiveAuditFields("ATLAS_TRIAL_IP_RATE_LIMIT_RPM", "set", "off")).toEqual({
       disablesControl: false,
@@ -1500,6 +1505,235 @@ describe("securitySensitiveAuditFields — alias auto-approve authority (#5161)"
       widensAuthority: false,
     });
   });
+});
+
+// #5180 — the security-audit line used to put the WRITTEN VALUE into the log
+// stream verbatim. Harmless for today's four members (two RPM limits, a source
+// list, a confidence bar — none carries `secret`), and filed anyway because
+// #5178 made joining the set a two-line, compile-checked change that never
+// requires touching, or reading, the logging line. The next `secret: true` key
+// to join would have written its plaintext to the logs.
+//
+// The redaction is a pure function of the DEFINITION, so it is tested here
+// against real registry entries without DB or logger plumbing — the same
+// treatment `securitySensitiveAuditFields` gets above.
+describe("audit value redaction (#5180)", () => {
+  const RPM: SecuritySensitiveKey = "ATLAS_TRIAL_IP_RATE_LIMIT_RPM";
+  const SOURCES: SecuritySensitiveKey = "ATLAS_BRAIN_ALIAS_AUTO_APPROVE_SOURCES";
+
+  // Real registry definitions, not synthetic literals: a hand-written pair
+  // would agree with whatever the test wanted, and the pairing this fix
+  // protects is the one the registry actually ships.
+  const SECRET_DEF = getSettingDefinition("ANTHROPIC_API_KEY");
+  const PLAIN_DEF = getSettingDefinition(RPM);
+
+  it("the two fixtures differ on the only axis under test", () => {
+    // Both are live registry entries, so a registry edit could quietly make
+    // them agree — at which point every assertion below would pass whatever
+    // `redactAuditValue` did with them.
+    expect(SECRET_DEF?.secret).toBe(true);
+    expect(PLAIN_DEF?.secret).not.toBe(true);
+  });
+
+  it("masks a secret definition's value — plaintext absent, not merely different", () => {
+    const written = "sk-ant-api03-SUPERSECRET-payload";
+    const { value, masked } = redactAuditValue(SECRET_DEF, written);
+    expect(masked).toBe(true);
+    expect(value).not.toBe(written);
+    expect(value).not.toContain("SUPERSECRET");
+    expect(value).toBe("sk-a••••load");
+  });
+
+  it("masks a short secret to a fixed run, revealing no characters at all", () => {
+    // `maskSecret`'s <= 8 arm. Asserted separately because the long arm above
+    // reveals eight characters by design, and a secret short enough to be
+    // reconstructed from its ends must not fall through to it.
+    expect(redactAuditValue(SECRET_DEF, "hunter22")).toEqual({
+      value: "••••••••",
+      masked: true,
+    });
+  });
+
+  // ⚠️ THE CONTROL. The fix must not be "mask everything": the written value is
+  // what tells an incident responder WHICH WAY a control moved, and an audit
+  // line that redacts a rate limit has thrown away its own subject.
+  it("leaves a non-secret definition's value verbatim", () => {
+    expect(redactAuditValue(PLAIN_DEF, "0")).toEqual({ value: "0", masked: false });
+    expect(redactAuditValue(getSettingDefinition(SOURCES), "warehouse_key,extractor")).toEqual({
+      value: "warehouse_key,extractor",
+      masked: false,
+    });
+  });
+
+  it("fails closed on an unknown definition", () => {
+    // "We could not tell whether this is a secret" is not a licence to print.
+    expect(redactAuditValue(undefined, "mystery-value-here")).toEqual({
+      value: "myst••••here",
+      masked: true,
+    });
+  });
+
+  it("a clear carries no value and is not reported as masked", () => {
+    // `masked: true` here would be a lie in the audit's own metadata — nothing
+    // was withheld, there was nothing to withhold.
+    expect(redactAuditValue(SECRET_DEF, undefined)).toEqual({ value: undefined, masked: false });
+    expect(redactAuditValue(PLAIN_DEF, undefined)).toEqual({ value: undefined, masked: false });
+  });
+
+  it("an empty write to a secret key masks to undefined — `action` marks the clear", () => {
+    // `maskSecret("")` is undefined: there is nothing in "" to reveal. The
+    // set/clear distinction survives because it lives in `action`, not in
+    // whether `value` is present.
+    expect(redactAuditValue(SECRET_DEF, "")).toEqual({ value: undefined, masked: true });
+    expect(redactAuditValue(PLAIN_DEF, "")).toEqual({ value: "", masked: false });
+  });
+});
+
+describe("securitySensitiveAuditLine (#5180)", () => {
+  const RPM: SecuritySensitiveKey = "ATLAS_TRIAL_IP_RATE_LIMIT_RPM";
+
+  /** `key`'s real registry entry, with `secret` forced either way. */
+  function definitionWithSecret(key: string, secret: boolean): SettingDefinition {
+    const def = getSettingDefinition(key);
+    if (!def) throw new Error(`no registry definition for ${key}`);
+    return { ...def, secret };
+  }
+
+  function lineFor(overrides: Partial<SecuritySensitiveAuditInput> = {}) {
+    return securitySensitiveAuditLine({
+      key: RPM,
+      definition: getSettingDefinition(RPM),
+      action: "set",
+      value: "0",
+      actorId: "user_1",
+      orgId: "org_1",
+      ...overrides,
+    });
+  }
+
+  it("returns null for a non-sensitive key — no audit line at all", () => {
+    expect(lineFor({ key: "ATLAS_ROW_LIMIT", definition: getSettingDefinition("ATLAS_ROW_LIMIT") }))
+      .toBeNull();
+  });
+
+  it("is the whole logged payload, redaction included", () => {
+    // Asserted as the FULL object rather than a `toMatchObject`: the defect
+    // being fixed was an extra field in this payload, so a partial match is
+    // exactly the assertion that could not have caught it.
+    expect(lineFor()).toEqual({
+      key: RPM,
+      action: "set",
+      value: "0",
+      valueMasked: false,
+      disablesControl: true,
+      widensAuthority: false,
+      actorId: "user_1",
+      orgId: "org_1",
+      event: "security_setting.changed",
+    });
+  });
+
+  it("carries the actor and org through unchanged, and undefined when absent", () => {
+    expect(lineFor({ action: "clear", value: undefined, actorId: undefined, orgId: undefined }))
+      .toEqual({
+        key: RPM,
+        action: "clear",
+        value: undefined,
+        valueMasked: false,
+        disablesControl: false,
+        widensAuthority: false,
+        actorId: undefined,
+        orgId: undefined,
+        event: "security_setting.changed",
+      });
+  });
+
+  // ⚠️ THE ROW THE WHOLE ISSUE IS ABOUT, and it is only reachable because
+  // `definition` is a parameter. None of today's four sensitive keys is
+  // `secret: true`, so with the registry lookup inlined in the builder, the
+  // masked and unmasked values coincided on EVERY reachable input — mutating
+  // the builder to log the raw value, or to hardcode `valueMasked: false`,
+  // passed the entire suite. Both mutations now go red here.
+  it("masks the value when the definition says secret, and says so in the payload", () => {
+    const line = lineFor({
+      definition: definitionWithSecret(RPM, true),
+      value: "sk-ant-api03-SUPERSECRET-payload",
+    });
+    expect(line?.value).toBe("sk-a••••load");
+    expect(line?.value).not.toContain("SUPERSECRET");
+    expect(line?.valueMasked).toBe(true);
+  });
+
+  // ⚠️ REDACTION MUST NOT BLIND THE CLASSIFICATION. The obvious way to close a
+  // plaintext leak is to mask early and let everything downstream read the
+  // masked string — which silently turns every rule into a no-op, because a
+  // masked value parses as nothing. The flags are the reason this line exists;
+  // losing them to protect the value would be a worse audit than the leak.
+  //
+  // `"0"` is the fixture that can see it: masked it is `••••••••`, which
+  // `Number` reads as NaN → "the reader kept its default" → disablesControl
+  // false. Raw, it is the documented disabled sentinel → true. A longer secret
+  // masks to something equally unparseable, so the two agree and the test
+  // cannot fail — which is exactly what the first draft of this assertion did.
+  it("decides the flags from the WRITTEN value even when the payload is masked", () => {
+    const line = lineFor({ definition: definitionWithSecret(RPM, true), value: "0" });
+    expect(line?.disablesControl).toBe(true);
+    expect(line?.valueMasked).toBe(true);
+    expect(line?.value).toBe("••••••••");
+  });
+
+  // The control, at the payload level: the fix must not be "mask everything".
+  it("leaves the value verbatim when the definition is not secret", () => {
+    const line = lineFor({
+      definition: definitionWithSecret(RPM, false),
+      value: "sk-ant-api03-SUPERSECRET-payload",
+    });
+    expect(line?.value).toBe("sk-ant-api03-SUPERSECRET-payload");
+    expect(line?.valueMasked).toBe(false);
+  });
+
+  it("fails closed when the definition belongs to a DIFFERENT key", () => {
+    // A non-secret definition, so a builder that trusted the mismatched
+    // argument would log verbatim. It tells us nothing about RPM, so the
+    // masked branch is the only honest one.
+    const line = lineFor({
+      definition: definitionWithSecret("ATLAS_ROW_LIMIT", false),
+      value: "mystery-value-here",
+    });
+    expect(line?.value).toBe("myst••••here");
+    expect(line?.valueMasked).toBe(true);
+  });
+
+  it("fails closed when there is no definition at all", () => {
+    const line = lineFor({ definition: undefined, value: "mystery-value-here" });
+    expect(line?.value).toBe("myst••••here");
+    expect(line?.valueMasked).toBe(true);
+  });
+
+  // The general claim over the real set, so it stays live as the set grows
+  // rather than needing someone to remember it. Today every member is
+  // non-secret, so this is the verbatim control; the day a `secret: true` key
+  // joins SECURITY_SENSITIVE_KEYS it becomes the masking assertion with no
+  // edit here, which is the future this issue exists to cover.
+  it.each([...SECURITY_SENSITIVE_KEYS])(
+    "%s redacts exactly as its own registry definition dictates",
+    (key) => {
+      const written = "audit-probe-0123456789";
+      const def = getSettingDefinition(key);
+      const line = securitySensitiveAuditLine({
+        key,
+        definition: def,
+        action: "set",
+        value: written,
+        actorId: undefined,
+        orgId: undefined,
+      });
+      const isSecret = def?.secret === true;
+      expect(line).not.toBeNull();
+      expect(line?.valueMasked).toBe(isSecret);
+      expect(line?.value).toBe(isSecret ? "audi••••6789" : written);
+    },
+  );
 });
 
 // #5162 — the signal the alias authority path fails closed on. These live in

--- a/packages/api/src/lib/__tests__/settings.test.ts
+++ b/packages/api/src/lib/__tests__/settings.test.ts
@@ -26,6 +26,7 @@ import {
   type SecuritySensitiveKey,
   type SecuritySensitiveAuditInput,
   type SettingDefinition,
+  type AuditedValue,
   _resetSettingsCache,
 } from "../settings";
 import { ANSWER_STYLE_NAMES, isAnswerStyle } from "../answer-styles";
@@ -1517,6 +1518,13 @@ describe("securitySensitiveAuditFields — alias auto-approve authority (#5161)"
 // The redaction is a pure function of the DEFINITION, so it is tested here
 // against real registry entries without DB or logger plumbing — the same
 // treatment `securitySensitiveAuditFields` gets above.
+/**
+ * Build an expected `AuditedValue`. Tests have to name the strings they expect,
+ * and `AuditedValue` is branded precisely so production code cannot — this cast
+ * is the test's side of that trade, and it is the only one in the file.
+ */
+const audited = (value: string): AuditedValue => value as AuditedValue;
+
 describe("audit value redaction (#5180)", () => {
   const RPM: SecuritySensitiveKey = "ATLAS_TRIAL_IP_RATE_LIMIT_RPM";
   const SOURCES: SecuritySensitiveKey = "ATLAS_BRAIN_ALIAS_AUTO_APPROVE_SOURCES";
@@ -1535,57 +1543,89 @@ describe("audit value redaction (#5180)", () => {
     expect(PLAIN_DEF?.secret).not.toBe(true);
   });
 
-  it("masks a secret definition's value — plaintext absent, not merely different", () => {
-    const written = "sk-ant-api03-SUPERSECRET-payload";
-    const { value, masked } = redactAuditValue(SECRET_DEF, written);
+  // ⚠️ NO CHARACTERS SURVIVE, AT ANY LENGTH. The audit path deliberately does
+  // NOT reuse `maskSecret`, whose `first4••••last4` long arm is a recognition
+  // affordance for one admin looking at their own key on their own settings
+  // page. A log stream is retained, exported and broadly readable, and that
+  // mask leaks 8 of 9 characters of a short secret into it. These fixtures
+  // straddle the boundary the display mask cares about (8 / 9 / 32 chars) to
+  // pin that the audit path has no such boundary left.
+  it.each([
+    ["sk-ant-api03-SUPERSECRET-payload", 32],
+    ["abcdefghi", 9],
+    ["hunter22", 8],
+    ["   ", 3],
+    ["x", 1],
+  ])("withholds a secret's value entirely — %p (%p chars)", (written) => {
+    const { value, masked, maskReason } = redactAuditValue(SECRET_DEF, written);
     expect(masked).toBe(true);
-    expect(value).not.toBe(written);
+    expect(maskReason).toBe("secret");
+    expect(value).toBe(audited("[redacted]"));
+    // Not merely "different from the input" — no fragment of it survives.
+    for (const ch of new Set(written.replace(/[a-z[\]]/g, ""))) {
+      expect(value).not.toContain(ch);
+    }
     expect(value).not.toContain("SUPERSECRET");
-    expect(value).toBe("sk-a••••load");
-  });
-
-  it("masks a short secret to a fixed run, revealing no characters at all", () => {
-    // `maskSecret`'s <= 8 arm. Asserted separately because the long arm above
-    // reveals eight characters by design, and a secret short enough to be
-    // reconstructed from its ends must not fall through to it.
-    expect(redactAuditValue(SECRET_DEF, "hunter22")).toEqual({
-      value: "••••••••",
-      masked: true,
-    });
   });
 
   // ⚠️ THE CONTROL. The fix must not be "mask everything": the written value is
   // what tells an incident responder WHICH WAY a control moved, and an audit
   // line that redacts a rate limit has thrown away its own subject.
   it("leaves a non-secret definition's value verbatim", () => {
-    expect(redactAuditValue(PLAIN_DEF, "0")).toEqual({ value: "0", masked: false });
-    expect(redactAuditValue(getSettingDefinition(SOURCES), "warehouse_key,extractor")).toEqual({
-      value: "warehouse_key,extractor",
+    expect(redactAuditValue(PLAIN_DEF, "0")).toEqual({
+      value: audited("0"),
       masked: false,
+      maskReason: undefined,
+    });
+    expect(redactAuditValue(getSettingDefinition(SOURCES), "warehouse_key,extractor")).toEqual({
+      value: audited("warehouse_key,extractor"),
+      masked: false,
+      maskReason: undefined,
     });
   });
 
-  it("fails closed on an unknown definition", () => {
+  it("fails closed on an unknown definition, and says WHY", () => {
     // "We could not tell whether this is a secret" is not a licence to print.
+    // The reason is separate from the routine one because a sensitive key with
+    // no registry entry is drift — reported as a plain masked write it would be
+    // indistinguishable from the healthy case, and the backstop would fire
+    // silently.
     expect(redactAuditValue(undefined, "mystery-value-here")).toEqual({
-      value: "myst••••here",
+      value: audited("[redacted]"),
       masked: true,
+      maskReason: "unknown_definition",
     });
   });
 
   it("a clear carries no value and is not reported as masked", () => {
     // `masked: true` here would be a lie in the audit's own metadata — nothing
     // was withheld, there was nothing to withhold.
-    expect(redactAuditValue(SECRET_DEF, undefined)).toEqual({ value: undefined, masked: false });
-    expect(redactAuditValue(PLAIN_DEF, undefined)).toEqual({ value: undefined, masked: false });
+    expect(redactAuditValue(SECRET_DEF, undefined)).toEqual({
+      value: undefined,
+      masked: false,
+      maskReason: undefined,
+    });
+    expect(redactAuditValue(PLAIN_DEF, undefined)).toEqual({
+      value: undefined,
+      masked: false,
+      maskReason: undefined,
+    });
   });
 
-  it("an empty write to a secret key masks to undefined — `action` marks the clear", () => {
-    // `maskSecret("")` is undefined: there is nothing in "" to reveal. The
-    // set/clear distinction survives because it lives in `action`, not in
-    // whether `value` is present.
-    expect(redactAuditValue(SECRET_DEF, "")).toEqual({ value: undefined, masked: true });
-    expect(redactAuditValue(PLAIN_DEF, "")).toEqual({ value: "", masked: false });
+  it("an empty write to a secret key yields undefined — `action` marks the clear", () => {
+    // There is nothing in "" to withhold, and emitting the placeholder would
+    // imply content that does not exist. The set/clear distinction survives
+    // because it lives in `action`, not in whether `value` is present.
+    expect(redactAuditValue(SECRET_DEF, "")).toEqual({
+      value: undefined,
+      masked: true,
+      maskReason: "secret",
+    });
+    expect(redactAuditValue(PLAIN_DEF, "")).toEqual({
+      value: audited(""),
+      masked: false,
+      maskReason: undefined,
+    });
   });
 });
 
@@ -1604,7 +1644,7 @@ describe("securitySensitiveAuditLine (#5180)", () => {
       key: RPM,
       definition: getSettingDefinition(RPM),
       action: "set",
-      value: "0",
+      value: audited("0"),
       actorId: "user_1",
       orgId: "org_1",
       ...overrides,
@@ -1623,8 +1663,9 @@ describe("securitySensitiveAuditLine (#5180)", () => {
     expect(lineFor()).toEqual({
       key: RPM,
       action: "set",
-      value: "0",
+      value: audited("0"),
       valueMasked: false,
+      maskReason: undefined,
       disablesControl: true,
       widensAuthority: false,
       actorId: "user_1",
@@ -1640,12 +1681,39 @@ describe("securitySensitiveAuditLine (#5180)", () => {
         action: "clear",
         value: undefined,
         valueMasked: false,
+        maskReason: undefined,
         disablesControl: false,
         widensAuthority: false,
         actorId: undefined,
         orgId: undefined,
         event: "security_setting.changed",
       });
+  });
+
+  // Credential rotation on a sensitive key: the exact scenario the "a
+  // `secret: true` key IS allowed in the set" rationale rests on, and the one
+  // combination the payload builder never saw in a test. Nothing is withheld
+  // because a clear carries no value — the audit's whole content here is that
+  // the override went away, and that survives redaction intact.
+  it("audits a CLEAR on a secret key with nothing withheld", () => {
+    expect(
+      lineFor({
+        definition: definitionWithSecret(RPM, true),
+        action: "clear",
+        value: undefined,
+      }),
+    ).toEqual({
+      key: RPM,
+      action: "clear",
+      value: undefined,
+      valueMasked: false,
+      maskReason: undefined,
+      disablesControl: false,
+      widensAuthority: false,
+      actorId: "user_1",
+      orgId: "org_1",
+      event: "security_setting.changed",
+    });
   });
 
   // ⚠️ THE ROW THE WHOLE ISSUE IS ABOUT, and it is only reachable because
@@ -1659,9 +1727,10 @@ describe("securitySensitiveAuditLine (#5180)", () => {
       definition: definitionWithSecret(RPM, true),
       value: "sk-ant-api03-SUPERSECRET-payload",
     });
-    expect(line?.value).toBe("sk-a••••load");
+    expect(line?.value).toBe(audited("[redacted]"));
     expect(line?.value).not.toContain("SUPERSECRET");
     expect(line?.valueMasked).toBe(true);
+    expect(line?.maskReason).toBe("secret");
   });
 
   // ⚠️ REDACTION MUST NOT BLIND THE CLASSIFICATION. The obvious way to close a
@@ -1670,16 +1739,17 @@ describe("securitySensitiveAuditLine (#5180)", () => {
   // masked value parses as nothing. The flags are the reason this line exists;
   // losing them to protect the value would be a worse audit than the leak.
   //
-  // `"0"` is the fixture that can see it: masked it is `••••••••`, which
-  // `Number` reads as NaN → "the reader kept its default" → disablesControl
-  // false. Raw, it is the documented disabled sentinel → true. A longer secret
-  // masks to something equally unparseable, so the two agree and the test
-  // cannot fail — which is exactly what the first draft of this assertion did.
+  // `"0"` is the fixture that can see it: withheld it becomes `[redacted]`,
+  // which `Number` reads as NaN → "the reader kept its default" →
+  // disablesControl false. Raw, it is the documented disabled sentinel → true.
+  // ANY other secret redacts to that same unparseable placeholder, so masked
+  // and raw agree and the test cannot fail — which is exactly what the first
+  // draft of this assertion did, with a 32-char key on both sides.
   it("decides the flags from the WRITTEN value even when the payload is masked", () => {
     const line = lineFor({ definition: definitionWithSecret(RPM, true), value: "0" });
     expect(line?.disablesControl).toBe(true);
     expect(line?.valueMasked).toBe(true);
-    expect(line?.value).toBe("••••••••");
+    expect(line?.value).toBe(audited("[redacted]"));
   });
 
   // The control, at the payload level: the fix must not be "mask everything".
@@ -1688,7 +1758,7 @@ describe("securitySensitiveAuditLine (#5180)", () => {
       definition: definitionWithSecret(RPM, false),
       value: "sk-ant-api03-SUPERSECRET-payload",
     });
-    expect(line?.value).toBe("sk-ant-api03-SUPERSECRET-payload");
+    expect(line?.value).toBe(audited("sk-ant-api03-SUPERSECRET-payload"));
     expect(line?.valueMasked).toBe(false);
   });
 
@@ -1700,14 +1770,18 @@ describe("securitySensitiveAuditLine (#5180)", () => {
       definition: definitionWithSecret("ATLAS_ROW_LIMIT", false),
       value: "mystery-value-here",
     });
-    expect(line?.value).toBe("myst••••here");
+    expect(line?.value).toBe(audited("[redacted]"));
     expect(line?.valueMasked).toBe(true);
+    // Reported as drift, not as a routine masked write — the mismatch is a
+    // caller bug, and an anomaly that logs like the healthy case is silent.
+    expect(line?.maskReason).toBe("unknown_definition");
   });
 
   it("fails closed when there is no definition at all", () => {
     const line = lineFor({ definition: undefined, value: "mystery-value-here" });
-    expect(line?.value).toBe("myst••••here");
+    expect(line?.value).toBe(audited("[redacted]"));
     expect(line?.valueMasked).toBe(true);
+    expect(line?.maskReason).toBe("unknown_definition");
   });
 
   // The general claim over the real set, so it stays live as the set grows
@@ -1715,11 +1789,19 @@ describe("securitySensitiveAuditLine (#5180)", () => {
   // non-secret, so this is the verbatim control; the day a `secret: true` key
   // joins SECURITY_SENSITIVE_KEYS it becomes the masking assertion with no
   // edit here, which is the future this issue exists to cover.
+  //
+  // ⚠️ The registry lookup is asserted BEFORE it is used. Written as
+  // `def?.secret === true`, a key renamed out of the registry collapses into
+  // "not secret", so the row would demand the value verbatim while
+  // `redactAuditValue` correctly fails closed — going red with a message that
+  // accuses the redaction of a bug that is actually a rename. The assertion
+  // below names the real cause; `:1327` owns the claim itself.
   it.each([...SECURITY_SENSITIVE_KEYS])(
     "%s redacts exactly as its own registry definition dictates",
     (key) => {
       const written = "audit-probe-0123456789";
       const def = getSettingDefinition(key);
+      expect(def).toBeDefined();
       const line = securitySensitiveAuditLine({
         key,
         definition: def,
@@ -1728,10 +1810,10 @@ describe("securitySensitiveAuditLine (#5180)", () => {
         actorId: undefined,
         orgId: undefined,
       });
-      const isSecret = def?.secret === true;
+      const withheld = def === undefined || def.secret === true;
       expect(line).not.toBeNull();
-      expect(line?.valueMasked).toBe(isSecret);
-      expect(line?.value).toBe(isSecret ? "audi••••6789" : written);
+      expect(line?.valueMasked).toBe(withheld);
+      expect(line?.value).toBe(audited(withheld ? "[redacted]" : written));
     },
   );
 });

--- a/packages/api/src/lib/__tests__/settings.test.ts
+++ b/packages/api/src/lib/__tests__/settings.test.ts
@@ -1550,22 +1550,31 @@ describe("audit value redaction (#5180)", () => {
   // mask leaks 8 of 9 characters of a short secret into it. These fixtures
   // straddle the boundary the display mask cares about (8 / 9 / 32 chars) to
   // pin that the audit path has no such boundary left.
-  it.each([
-    ["sk-ant-api03-SUPERSECRET-payload", 32],
-    ["abcdefghi", 9],
-    ["hunter22", 8],
-    ["   ", 3],
-    ["x", 1],
-  ])("withholds a secret's value entirely — %p (%p chars)", (written) => {
+  /** Straddles the boundary the display mask cared about: 32 / 9 / 8 / 3 / 1. */
+  const SECRET_LENGTHS = ["sk-ant-api03-SUPERSECRET-payload", "abcdefghi", "hunter22", "   ", "x"];
+
+  it.each(SECRET_LENGTHS)("withholds a secret's value entirely — %p", (written) => {
     const { value, masked, maskReason } = redactAuditValue(SECRET_DEF, written);
     expect(masked).toBe(true);
     expect(maskReason).toBe("secret");
-    expect(value).toBe(audited("[redacted]"));
-    // Not merely "different from the input" — no fragment of it survives.
-    for (const ch of new Set(written.replace(/[a-z[\]]/g, ""))) {
-      expect(value).not.toContain(ch);
-    }
-    expect(value).not.toContain("SUPERSECRET");
+    expect(value).toBe(audited("[withheld:secret-setting]"));
+  });
+
+  // ⚠️ THE CLAIM THAT ACTUALLY BITES, and the first draft of it could not fail.
+  // That draft asserted, per row, that no character of the input survived —
+  // but it stripped lowercase letters before comparing, so for `"abcdefghi"`
+  // and `"x"` it iterated ZERO times and asserted nothing at all. The property
+  // worth pinning is stronger and uniform: the output does not depend on the
+  // input. `maskSecret` produces five DIFFERENT strings for these five values,
+  // two of them revealing eight characters, so it goes red here.
+  it("produces one identical placeholder for every secret, whatever its length", () => {
+    const outputs = new Set(SECRET_LENGTHS.map((w) => redactAuditValue(SECRET_DEF, w).value));
+    expect(outputs.size).toBe(1);
+    expect([...outputs][0]).toBe(audited("[withheld:secret-setting]"));
+    // And the distinctive one, named directly rather than derived.
+    expect(redactAuditValue(SECRET_DEF, "sk-ant-api03-SUPERSECRET-payload").value).not.toContain(
+      "SUPERSECRET",
+    );
   });
 
   // ⚠️ THE CONTROL. The fix must not be "mask everything": the written value is
@@ -1591,7 +1600,7 @@ describe("audit value redaction (#5180)", () => {
     // indistinguishable from the healthy case, and the backstop would fire
     // silently.
     expect(redactAuditValue(undefined, "mystery-value-here")).toEqual({
-      value: audited("[redacted]"),
+      value: audited("[withheld:secret-setting]"),
       masked: true,
       maskReason: "unknown_definition",
     });
@@ -1612,12 +1621,15 @@ describe("audit value redaction (#5180)", () => {
     });
   });
 
-  it("an empty write to a secret key yields undefined — `action` marks the clear", () => {
-    // There is nothing in "" to withhold, and emitting the placeholder would
-    // imply content that does not exist. The set/clear distinction survives
-    // because it lives in `action`, not in whether `value` is present.
+  // ⚠️ THE EMPTY SECRET IS WITHHELD LIKE ANY OTHER, and the earlier draft that
+  // returned `undefined` here was a one-bit oracle. Every other secret reads
+  // `[withheld:secret-setting]`, so a lone `undefined` singled the empty one
+  // out — and for the empty secret, "its length is zero" IS the secret. The
+  // set/clear distinction it was protecting lives in `action`, which is where
+  // it always was.
+  it("withholds an empty write to a secret key like any other value", () => {
     expect(redactAuditValue(SECRET_DEF, "")).toEqual({
-      value: undefined,
+      value: audited("[withheld:secret-setting]"),
       masked: true,
       maskReason: "secret",
     });
@@ -1727,7 +1739,7 @@ describe("securitySensitiveAuditLine (#5180)", () => {
       definition: definitionWithSecret(RPM, true),
       value: "sk-ant-api03-SUPERSECRET-payload",
     });
-    expect(line?.value).toBe(audited("[redacted]"));
+    expect(line?.value).toBe(audited("[withheld:secret-setting]"));
     expect(line?.value).not.toContain("SUPERSECRET");
     expect(line?.valueMasked).toBe(true);
     expect(line?.maskReason).toBe("secret");
@@ -1749,7 +1761,7 @@ describe("securitySensitiveAuditLine (#5180)", () => {
     const line = lineFor({ definition: definitionWithSecret(RPM, true), value: "0" });
     expect(line?.disablesControl).toBe(true);
     expect(line?.valueMasked).toBe(true);
-    expect(line?.value).toBe(audited("[redacted]"));
+    expect(line?.value).toBe(audited("[withheld:secret-setting]"));
   });
 
   // The control, at the payload level: the fix must not be "mask everything".
@@ -1770,16 +1782,19 @@ describe("securitySensitiveAuditLine (#5180)", () => {
       definition: definitionWithSecret("ATLAS_ROW_LIMIT", false),
       value: "mystery-value-here",
     });
-    expect(line?.value).toBe(audited("[redacted]"));
+    expect(line?.value).toBe(audited("[withheld:secret-setting]"));
     expect(line?.valueMasked).toBe(true);
-    // Reported as drift, not as a routine masked write — the mismatch is a
-    // caller bug, and an anomaly that logs like the healthy case is silent.
-    expect(line?.maskReason).toBe("unknown_definition");
+    // ⚠️ `definition_mismatch`, NOT `unknown_definition`. Both withhold, but
+    // they route an operator to different places: drift means grep the
+    // registry, mismatch means the key is present and the CALLER is wrong.
+    // Reporting a caller bug as drift gets the alert closed as a false
+    // positive against a registry that looks fine.
+    expect(line?.maskReason).toBe("definition_mismatch");
   });
 
   it("fails closed when there is no definition at all", () => {
     const line = lineFor({ definition: undefined, value: "mystery-value-here" });
-    expect(line?.value).toBe(audited("[redacted]"));
+    expect(line?.value).toBe(audited("[withheld:secret-setting]"));
     expect(line?.valueMasked).toBe(true);
     expect(line?.maskReason).toBe("unknown_definition");
   });
@@ -1813,7 +1828,7 @@ describe("securitySensitiveAuditLine (#5180)", () => {
       const withheld = def === undefined || def.secret === true;
       expect(line).not.toBeNull();
       expect(line?.valueMasked).toBe(withheld);
-      expect(line?.value).toBe(audited(withheld ? "[redacted]" : written));
+      expect(line?.value).toBe(audited(withheld ? "[withheld:secret-setting]" : written));
     },
   );
 });

--- a/packages/api/src/lib/settings.ts
+++ b/packages/api/src/lib/settings.ts
@@ -2472,14 +2472,23 @@ export async function setSetting(key: string, value: string, userId?: string, or
   // Bust live cache so next read picks up the new value immediately
   _liveCache.clear();
 
+  // #3797 — louder audit trail when a runtime-mutable abuse control is changed
+  // (especially disabled via the documented `0` sentinel), so weakening it is
+  // traceable during an incident rather than buried in settings-change noise.
+  //
+  // ⚠️ BEFORE the side effect, not after. The row is committed and both caches
+  // are updated by this point, so the security-relevant change is already live;
+  // a side-effect handler that throws would otherwise take the audit down with
+  // it and leave a landed change with no record. The audit needs nothing the
+  // side effect produces, so the ordering is free. No handler throws today —
+  // the only one catches internally — which makes this cheap insurance rather
+  // than a live fix.
+  auditSecuritySensitiveChange(key, "set", value, userId, effectiveOrgId);
+
   // Apply runtime side effects for hot-reloadable settings
   applySettingSideEffect(key, value);
 
   log.info({ key, orgId: effectiveOrgId, actorId: userId }, "Setting override saved");
-  // #3797 — louder audit trail when a runtime-mutable abuse control is changed
-  // (especially disabled via the documented `0` sentinel), so weakening it is
-  // traceable during an incident rather than buried in settings-change noise.
-  auditSecuritySensitiveChange(key, "set", value, userId, effectiveOrgId);
 }
 
 /**
@@ -2518,6 +2527,12 @@ export async function deleteSetting(key: string, userId?: string, orgId?: string
   // Bust live cache so next read picks up the reverted value
   _liveCache.clear();
 
+  // #3797 — clearing an abuse-control override reverts it to env/default,
+  // which is itself a security-relevant change; audit it too. Before the side
+  // effect for the same reason as `setSetting`: the delete has committed, so
+  // the audit must not be reachable-only-if the revert succeeds.
+  auditSecuritySensitiveChange(key, "clear", undefined, userId, effectiveOrgId);
+
   // Apply runtime side effects (e.g., revert log level to env var / default)
   const revertedValue = getSetting(key, effectiveOrgId);
   if (revertedValue !== undefined) {
@@ -2525,9 +2540,6 @@ export async function deleteSetting(key: string, userId?: string, orgId?: string
   }
 
   log.info({ key, orgId: effectiveOrgId, actorId: userId }, "Setting override removed");
-  // #3797 — clearing an abuse-control override reverts it to env/default,
-  // which is itself a security-relevant change; audit it too.
-  auditSecuritySensitiveChange(key, "clear", undefined, userId, effectiveOrgId);
 }
 
 /**
@@ -3035,12 +3047,40 @@ export function securitySensitiveAuditFields(
  * A truncated digest was considered and rejected: it correlates rotations
  * nicely, but a short or low-entropy secret is brute-forceable from one, which
  * adds a disclosure channel rather than removing one. So does a length marker,
- * for less benefit.
+ * for less benefit — and the empty string is withheld the same way as any
+ * other value for exactly that reason: `value: undefined` where every other
+ * secret reads `[withheld…]` would be a one-bit oracle on the secret's
+ * content, which for the empty secret discloses it completely.
+ *
+ * ⚠️ Deliberately not any of the three placeholders it sits near, and one of
+ * them is a trap rather than a style choice:
+ * - `plugins/secrets.ts`'s `MASKED_PLACEHOLDER` (`••••••••`) is a
+ *   ROUND-TRIPPING sentinel — `restoreMaskedSecrets` reads it back as "keep the
+ *   stored value". Sharing it would make an audit line's contents meaningful to
+ *   a settings writer, which is the opposite of what a redaction is for.
+ * - pino's own default censor is `[Redacted]`, written into this same stream by
+ *   `redact: redactPaths` for any field named `apiKey`/`token`/`secret`/…. A
+ *   placeholder differing from it by one capital letter, meaning something
+ *   else, is a trap for anyone grepping the stream.
+ * - `maskSecret`'s `••••••••`, per the whole argument above.
+ *
+ * Self-describing, so a reader of the stream knows which mechanism withheld it
+ * and does not have to guess. Kept module-private so a second sink with a
+ * different audience cannot adopt it without deciding, here, that the trade
+ * still holds.
  */
-const REDACTED_AUDIT_VALUE = "[redacted]";
+const REDACTED_AUDIT_VALUE = "[withheld:secret-setting]";
 
-/** Why {@link redactAuditValue} withheld a value. */
-export type AuditMaskReason = "secret" | "unknown_definition";
+/**
+ * Why {@link redactAuditValue} withheld a value.
+ *
+ * Three arms rather than two, because collapsing the latter two mislabels an
+ * alert. `"unknown_definition"` reads as *registry drift* and sends an operator
+ * to grep `SETTINGS_REGISTRY`; for a definition that belongs to a DIFFERENT key
+ * the entry is right there and the bug is at the call site. Reported as drift,
+ * that alert is closed as a false positive.
+ */
+export type AuditMaskReason = "secret" | "unknown_definition" | "definition_mismatch";
 
 declare const auditedValueBrand: unique symbol;
 
@@ -3065,6 +3105,28 @@ declare const auditedValueBrand: unique symbol;
  * the parameter — and the escalation the review loop asks for once a principle
  * has been argued twice: stop restating it in prose and make the state
  * unrepresentable.
+ *
+ * ⚠️ **WHAT THE BRAND DOES NOT CLOSE**, stated because a brand invites exactly
+ * the wrong confidence, and both survivors were measured rather than guessed:
+ *
+ * - **A leak that never mentions the seam.** `log.warn` types its first
+ *   parameter as `<T extends object>`, inferring `T` from the literal, so
+ *   `log.warn({ ...line, value: raw }, …)` type-checks clean. The brand bites
+ *   only where something is *expected* to carry it — hence
+ *   {@link warnAuditLine}. Inline `log.warn` back and the fence is gone.
+ * - **A dishonest `definition`.** The brand fences the OUTPUT of the decision;
+ *   the INPUT is an ordinary structural value, so `{ …, secret: false }` at the
+ *   call site reaches the verbatim arm with no cast.
+ *
+ * Both are closed by the registry-flip test in `settings-audit-log.test.ts`,
+ * which makes redacted and raw differ on a reachable input. The brand and that
+ * test cover disjoint edits and neither is redundant: the type catches the
+ * seam-preserving spelling on a day nobody runs the suite, the test catches the
+ * seam-removing one, which is the cheaper edit.
+ *
+ * The brand asserts "this went through the decision" — NOT "this is safe to
+ * disclose". On the non-secret arm it carries the written value verbatim, by
+ * design, so a second sink must not read it as a clearance.
  */
 export type AuditedValue = string & { readonly [auditedValueBrand]: true };
 
@@ -3082,9 +3144,17 @@ export interface RedactedAuditValue {
  *
  * Takes the DEFINITION rather than the key on purpose: the decision genuinely
  * depends on `def.secret`, and passing `undefined` explicitly is what makes the
- * fail-closed contract legible — and testable — at the call site. Narrowed to
- * the two fields actually read, so the audit path does not acquire a dependency
- * on the whole mutable registry record.
+ * fail-closed contract legible — and testable — at the call site.
+ *
+ * ⚠️ It takes the WHOLE `SettingDefinition`, and an earlier draft narrowing it
+ * to `Pick<…, "key" | "secret">` was measured to be a net loss. The narrowing
+ * looked like good hygiene, but the only thing standing between this function
+ * and a fabricated definition is how tedious one is to write: against the full
+ * record a fake needs seven required fields and reads as a deliberate act,
+ * while `{ key, secret: false }` reads as tidying — and `secret` is optional in
+ * the `Pick`, so even `{ key }` lands in the verbatim arm. The registry-flip
+ * test in `settings-audit-log.test.ts` is what actually closes that class; this
+ * signature just declines to make it cheap.
  *
  * ⚠️ FAIL CLOSED ON AN UNKNOWN DEFINITION. A key with no registry entry cannot
  * be *shown* to be non-secret, and "we could not tell" is not a licence to
@@ -3093,19 +3163,19 @@ export interface RedactedAuditValue {
  * a backstop against a rename rather than a live path — which is exactly why it
  * must not be the permissive one.
  *
- * ⚠️ It reports `maskReason` rather than a bare boolean because those two arms
- * are not the same event. `"secret"` is routine. `"unknown_definition"` means a
- * sensitive key has drifted out of the registry (or a caller passed the wrong
- * definition) — an anomaly that, reported as a plain masked write, would be
- * indistinguishable from the healthy case and so would fire silently.
+ * ⚠️ It reports a `maskReason` rather than a bare boolean because the arms are
+ * not the same event, and they route an operator to different places. See
+ * {@link AuditMaskReason}.
  *
- * The empty string yields `undefined`: there is nothing in `""` to withhold,
- * and emitting the placeholder would imply content that does not exist. No
- * audit information is lost, because `action` — not the presence of `value` —
- * is what distinguishes a `set` from a `clear`.
+ * The empty string is withheld like any other value. An earlier draft returned
+ * `undefined` for it — "nothing in `""` to withhold" — which was true about the
+ * string and wrong about the stream: every other secret reads
+ * `[withheld:secret-setting]`, so `undefined` singled the empty one out and
+ * disclosed it exactly. Uniformity is the property; `action` carries set-vs-
+ * clear, which is the distinction that was worth keeping.
  */
 export function redactAuditValue(
-  def: Pick<SettingDefinition, "key" | "secret"> | undefined,
+  def: SettingDefinition | undefined,
   value: string | undefined,
 ): RedactedAuditValue {
   // The sole minting site for {@link AuditedValue}. Every `as` below is a
@@ -3119,11 +3189,7 @@ export function redactAuditValue(
     return { value: audited(REDACTED_AUDIT_VALUE), masked: true, maskReason: "unknown_definition" };
   }
   if (def.secret === true) {
-    return {
-      value: value === "" ? undefined : audited(REDACTED_AUDIT_VALUE),
-      masked: true,
-      maskReason: "secret",
-    };
+    return { value: audited(REDACTED_AUDIT_VALUE), masked: true, maskReason: "secret" };
   }
   return { value: audited(value), masked: false, maskReason: undefined };
 }
@@ -3161,14 +3227,12 @@ export interface SecuritySensitiveAuditInput {
   /**
    * `key`'s registry entry, or `undefined` when it has none.
    *
-   * Passed in rather than looked up so the redaction is reachable from a test.
-   * None of today's four sensitive keys is `secret: true` — that is the whole
-   * premise of #5180 — so with the lookup inlined here, mutating this function
-   * to log the RAW value survived the entire suite: every reachable input made
-   * the masked and unmasked values identical. A parameter is the only thing
-   * that makes the branch this function exists for observable.
+   * Passed in rather than looked up so the builder stays a pure function of its
+   * inputs and the secret arm is reachable from a unit test without touching
+   * the registry. The WHOLE definition, not a `Pick` of the two fields read —
+   * see {@link redactAuditValue} for why narrowing it was a net loss.
    */
-  readonly definition: Pick<SettingDefinition, "key" | "secret"> | undefined;
+  readonly definition: SettingDefinition | undefined;
   readonly action: SettingAuditAction;
   readonly value: string | undefined;
   readonly actorId: string | undefined;
@@ -3207,8 +3271,24 @@ export interface SecuritySensitiveAuditInput {
  * earlier draft of this comment claimed the emitter "has no raw `value` in
  * scope to reach for"; `value` is its third parameter, so reaching for it is
  * one keystroke, and `log.warn({ ...line, value }, …)` reintroduced #5180 with
- * the whole suite green. What closes it is the emission test in
- * `settings-audit-log.test.ts`, not the arrangement of this function.
+ * the whole suite green.
+ *
+ * It takes BOTH halves to close, and this comment has now been wrong in both
+ * directions, so the split is worth stating exactly:
+ *
+ * - {@link AuditedValue} plus {@link warnAuditLine} close every spelling that
+ *   still routes through {@link emitSecuritySensitiveAudit}.
+ * - The registry-flip test in `settings-audit-log.test.ts` closes the spelling
+ *   that inlines `log.warn` back here — which no type can see, because
+ *   `log.warn`'s first parameter is untyped.
+ *
+ * Neither closes it alone. The second draft of this comment credited the test
+ * alone (it could not see the leak: `value` is a declared field, so the edit
+ * overwrites rather than adds, and raw equals redacted for every key shipping
+ * today). The third credited the type alone, and missed that removing the seam
+ * removes the type. The test only became possible once it stopped assuming the
+ * registry was fixed: flipping a definition to `secret: true` for one test
+ * makes raw and redacted differ on a fully reachable input.
  */
 export function securitySensitiveAuditLine(
   input: SecuritySensitiveAuditInput,
@@ -3217,17 +3297,24 @@ export function securitySensitiveAuditLine(
   const fields = securitySensitiveAuditFields(key, action, value);
   if (!fields) return null;
   // A definition belonging to some OTHER key tells us nothing about this one,
-  // so it is discarded rather than trusted — `redactAuditValue` then fails
-  // closed on the `undefined`. The two arguments are independent, which makes
-  // the mismatch representable; this is where it stops being dangerous.
-  const definition = input.definition?.key === key ? input.definition : undefined;
-  const redacted = redactAuditValue(definition, value);
+  // so it is discarded rather than trusted, and `redactAuditValue` fails closed
+  // on the `undefined`.
+  //
+  // ⚠️ This closes "someone else's definition". It structurally CANNOT close
+  // "this key's definition, lying about `secret`" — a fabricated
+  // `{ key, secret: false }` passes the check and reaches the verbatim arm. The
+  // registry-flip test in `settings-audit-log.test.ts` is what covers that, by
+  // making redacted and raw differ on a reachable input.
+  const mismatched = input.definition !== undefined && input.definition.key !== key;
+  const redacted = redactAuditValue(mismatched ? undefined : input.definition, value);
   return {
     key,
     action,
     value: redacted.value,
     valueMasked: redacted.masked,
-    maskReason: redacted.maskReason,
+    // A mismatch is a caller bug, not registry drift; reporting it as drift
+    // sends the operator to grep a registry where the key is present and fine.
+    maskReason: mismatched ? "definition_mismatch" : redacted.maskReason,
     disablesControl: fields.disablesControl,
     widensAuthority: fields.widensAuthority,
     actorId,
@@ -3269,16 +3356,36 @@ function auditSecuritySensitiveChange(
 }
 
 /**
+ * `log.warn`, narrowed to this one payload shape.
+ *
+ * ⚠️ **The narrowing is what gives {@link AuditedValue} teeth, and calling
+ * `log.warn` directly does not.** Pino types its log functions as
+ * `<T extends object>(obj: T, …)`, so `T` is INFERRED from whatever literal you
+ * hand it: there is no target type, no excess-property check, and no branded-
+ * field check. Measured — `log.warn({ ...line, value: raw }, …)` type-checks
+ * clean, while the same object assigned into a `SecuritySensitiveAuditLine`
+ * position is `TS2322`. A brand only bites where something is expected to have
+ * it. This alias creates that expectation.
+ */
+const warnAuditLine: (line: SecuritySensitiveAuditLine, msg: string) => void = (line, msg) => {
+  log.warn(line, msg);
+};
+
+/**
  * Write one built audit line to the log stream.
  *
- * ⚠️ Takes the payload and nothing else, deliberately. The raw written value is
- * not a parameter, is not in scope, and could not be assigned into `line.value`
- * if it were — that field is branded. This function is the whole reason the
- * brand has teeth; inlining it back into the caller returns `log.warn`'s
- * untyped first argument to the code path and with it the silent edit #5180 is.
+ * ⚠️ Takes the payload and nothing else, deliberately, and emits through
+ * {@link warnAuditLine} rather than `log.warn`. Both halves are load-bearing:
+ * the parameter list keeps the raw value out of scope, and the typed alias
+ * makes putting it back a compile error rather than a silent no-op.
+ *
+ * The message is built from `line`, never from the caller's arguments — a
+ * template literal is a leak channel no type can close, so the only defence
+ * there is that the raw value is not reachable from here. `settings-audit-log.
+ * test.ts` asserts the message text and that it does not contain the value.
  */
 function emitSecuritySensitiveAudit(line: SecuritySensitiveAuditLine): void {
-  log.warn(
+  warnAuditLine(
     line,
     `Security-sensitive setting ${line.action === "clear" ? "override cleared" : "changed"} at runtime: ${line.key}`,
   );

--- a/packages/api/src/lib/settings.ts
+++ b/packages/api/src/lib/settings.ts
@@ -2816,8 +2816,11 @@ function isSaasImmutableKey(key: string): key is SaasImmutableKey {
  *
  * Adding a family means adding a rule in {@link SECURITY_SENSITIVE_RULES}; the
  * table below IS the key set, so there is no way to join one without the other.
+ * A member marked `secret: true` in the registry is fine — the audit line masks
+ * its value rather than refusing the key (#5180); see
+ * {@link securitySensitiveAuditLine} for why that call went the way it did.
  */
-/** The structured fields {@link auditSecuritySensitiveChange} logs. */
+/** The rule-derived flags carried by {@link SecuritySensitiveAuditLine}. */
 export interface SecuritySensitiveAudit {
   readonly disablesControl: boolean;
   readonly widensAuthority: boolean;
@@ -3000,6 +3003,129 @@ export function securitySensitiveAuditFields(
 }
 
 /**
+ * The written value as an audit line may record it (#5180), plus whether it was
+ * redacted on the way.
+ *
+ * Takes the DEFINITION rather than the key on purpose: the decision genuinely
+ * depends on `def.secret`, and passing `undefined` explicitly is what makes the
+ * fail-closed contract legible — and testable — at the call site.
+ *
+ * ⚠️ FAIL CLOSED ON AN UNKNOWN DEFINITION. A key with no registry entry cannot
+ * be *shown* to be non-secret, and "we could not tell" is not a licence to
+ * print. `settings.test.ts` pins every member of {@link SECURITY_SENSITIVE_KEYS}
+ * to a registry entry, so through {@link securitySensitiveAuditLine} this arm is
+ * a backstop against a rename rather than a live path — which is exactly why it
+ * must not be the permissive one.
+ *
+ * The empty string masks to `undefined`, per {@link maskSecret}'s own contract:
+ * there is nothing in `""` to reveal. No audit information is lost, because
+ * `action` — not the presence of `value` — is what distinguishes a `set` from a
+ * `clear`.
+ */
+export function redactAuditValue(
+  def: SettingDefinition | undefined,
+  value: string | undefined,
+): { value: string | undefined; masked: boolean } {
+  if (value === undefined) return { value: undefined, masked: false };
+  if (def === undefined || def.secret === true) {
+    return { value: maskSecret(value), masked: true };
+  }
+  return { value, masked: false };
+}
+
+/** The full structured payload {@link auditSecuritySensitiveChange} logs. */
+export interface SecuritySensitiveAuditLine extends SecuritySensitiveAudit {
+  readonly key: string;
+  readonly action: "set" | "clear";
+  /**
+   * The written value — verbatim, or {@link maskSecret}-masked when the
+   * registry definition carries `secret: true`. Read it together with
+   * `valueMasked`: without that flag a masked `••••••••` is indistinguishable
+   * from a setting whose literal value is `••••••••`.
+   */
+  readonly value: string | undefined;
+  /** Whether `value` was redacted rather than recorded verbatim (#5180). */
+  readonly valueMasked: boolean;
+  readonly actorId: string | undefined;
+  readonly orgId: string | undefined;
+  readonly event: "security_setting.changed";
+}
+
+/** Everything {@link securitySensitiveAuditLine} needs to build one line. */
+export interface SecuritySensitiveAuditInput {
+  readonly key: string;
+  /**
+   * `key`'s registry entry, or `undefined` when it has none.
+   *
+   * Passed in rather than looked up so the redaction is reachable from a test.
+   * None of today's four sensitive keys is `secret: true` — that is the whole
+   * premise of #5180 — so with the lookup inlined here, mutating this function
+   * to log the RAW value survived the entire suite: every reachable input made
+   * the masked and unmasked values identical. A parameter is the only thing
+   * that makes the branch this function exists for observable.
+   */
+  readonly definition: SettingDefinition | undefined;
+  readonly action: "set" | "clear";
+  readonly value: string | undefined;
+  readonly actorId: string | undefined;
+  readonly orgId: string | undefined;
+}
+
+/**
+ * The exact payload the security-audit `log.warn` line carries, or `null` when
+ * `key` is not sensitive (no audit). Pure, and exported so the redaction is
+ * testable against the *logged object* rather than against a helper the log
+ * line is merely trusted to call.
+ *
+ * ⚠️ **A `secret: true` key IS allowed in {@link SECURITY_SENSITIVE_KEYS}; its
+ * value is masked instead (#5180).** The alternative — refusing the
+ * combination outright — was considered and rejected on three counts:
+ *
+ * 1. "Audit the change, never the content" is a legitimate pairing, not a
+ *    contradiction. Rotating a credential that gates an abuse control is
+ *    precisely the event an audit trail exists to record; refusing membership
+ *    would make that rotation emit *nothing*, which is strictly worse than a
+ *    line with a masked value.
+ * 2. It is not expressible where it would have to be. `secret` lives on
+ *    {@link SettingDefinition} inside a `SettingDefinition[]`, not on a
+ *    literal-typed const, so `Record<SecuritySensitiveKey, …>` cannot see it —
+ *    enforcement would be a runtime boot guard, trading a masked log line for a
+ *    refusal to boot on a defect the mask already closes.
+ * 3. Masking here reuses the convention {@link resolvePlatformTier} and
+ *    {@link getSettingsForAdmin} already apply, so the display paths agree
+ *    rather than each inventing a policy.
+ *
+ * The payload is built here in full — including `key` and `action` — so that
+ * {@link auditSecuritySensitiveChange} has no raw `value` in scope to reach
+ * for. Adding a sensitive key stays the two-line, compile-checked change #5178
+ * made it, and cannot reintroduce plaintext by not touching this file.
+ */
+export function securitySensitiveAuditLine(
+  input: SecuritySensitiveAuditInput,
+): SecuritySensitiveAuditLine | null {
+  const { key, action, value, actorId, orgId } = input;
+  const fields = securitySensitiveAuditFields(key, action, value);
+  if (!fields) return null;
+  // A definition belonging to some OTHER key tells us nothing about this one,
+  // so it is discarded rather than trusted — `redactAuditValue` then fails
+  // closed on the `undefined`. The two arguments are independent, which makes
+  // the mismatch representable; this is where it stops being dangerous.
+  const definition = input.definition?.key === key ? input.definition : undefined;
+  const redacted = redactAuditValue(definition, value);
+  return {
+    key,
+    action,
+    value: redacted.value,
+    valueMasked: redacted.masked,
+    disablesControl: fields.disablesControl,
+    widensAuthority: fields.widensAuthority,
+    actorId,
+    orgId,
+    event: "security_setting.changed",
+  };
+}
+
+/**
  * Emit a security-audit `log.warn` when a {@link SECURITY_SENSITIVE_KEYS}
  * setting is changed or cleared at runtime. `action` is `set` (a new value
  * persisted) or `clear` (override deleted → reverts to env/default). A no-op
@@ -3012,19 +3138,17 @@ function auditSecuritySensitiveChange(
   actorId: string | undefined,
   orgId: string | undefined,
 ): void {
-  const fields = securitySensitiveAuditFields(key, action, value);
-  if (!fields) return;
+  const line = securitySensitiveAuditLine({
+    key,
+    definition: getSettingDefinition(key),
+    action,
+    value,
+    actorId,
+    orgId,
+  });
+  if (!line) return;
   log.warn(
-    {
-      key,
-      action,
-      value,
-      disablesControl: fields.disablesControl,
-      widensAuthority: fields.widensAuthority,
-      actorId,
-      orgId,
-      event: "security_setting.changed",
-    },
+    line,
     `Security-sensitive setting ${action === "clear" ? "override cleared" : "changed"} at runtime: ${key}`,
   );
 }

--- a/packages/api/src/lib/settings.ts
+++ b/packages/api/src/lib/settings.ts
@@ -2816,10 +2816,15 @@ function isSaasImmutableKey(key: string): key is SaasImmutableKey {
  *
  * Adding a family means adding a rule in {@link SECURITY_SENSITIVE_RULES}; the
  * table below IS the key set, so there is no way to join one without the other.
- * A member marked `secret: true` in the registry is fine — the audit line masks
- * its value rather than refusing the key (#5180); see
- * {@link securitySensitiveAuditLine} for why that call went the way it did.
  */
+/**
+ * What a settings write did: persisted a value, or removed the override and
+ * reverted to the next tier. One definition rather than five inline copies —
+ * the audit rule, the flag decision, the payload, the builder input and the
+ * emitter all have to agree, and a third action would otherwise drift.
+ */
+export type SettingAuditAction = "set" | "clear";
+
 /** The rule-derived flags carried by {@link SecuritySensitiveAuditLine}. */
 export interface SecuritySensitiveAudit {
   readonly disablesControl: boolean;
@@ -2828,7 +2833,7 @@ export interface SecuritySensitiveAudit {
 
 /** How one sensitive key decides its audit flags from a written value. */
 type SecuritySensitiveRule = (
-  action: "set" | "clear",
+  action: SettingAuditAction,
   value: string | undefined,
 ) => SecuritySensitiveAudit;
 
@@ -2947,6 +2952,13 @@ const aliasThresholdRule: SecuritySensitiveRule = (action, value) => {
  * compile error, and a typo in a key name a compile error rather than a silent
  * fall-through. This is #5161's own defect class one level up: a claim whose
  * subject was enlarged without re-checking the predicate riding on it.
+ *
+ * ⚠️ **A key marked `secret: true` in the registry may join this list.** Its
+ * value is withheld from the audit line rather than the key being refused
+ * (#5180) — {@link securitySensitiveAuditLine} carries why that call went the
+ * way it did. Nothing else about adding a key changes: you do not need to touch
+ * the logging path, which is the property that made this defect worth closing
+ * before it had a subject.
  */
 const SECURITY_SENSITIVE_KEYS_LITERAL = [
   "ATLAS_TRIAL_IP_RATE_LIMIT_RPM",
@@ -2995,7 +3007,7 @@ function isSecuritySensitiveKey(key: string): key is SecuritySensitiveKey {
  */
 export function securitySensitiveAuditFields(
   key: string,
-  action: "set" | "clear",
+  action: SettingAuditAction,
   value: string | undefined,
 ): SecuritySensitiveAudit | null {
   if (!isSecuritySensitiveKey(key)) return null;
@@ -3003,12 +3015,76 @@ export function securitySensitiveAuditFields(
 }
 
 /**
- * The written value as an audit line may record it (#5180), plus whether it was
- * redacted on the way.
+ * What an audit line records in place of a value it must not disclose.
+ *
+ * ⚠️ **Deliberately NOT {@link maskSecret}, and that divergence is the point.**
+ * `maskSecret` emits `first4••••last4` as a *recognition* affordance: one
+ * authenticated platform admin, looking at their own key on their own settings
+ * page, needs to tell which credential is installed. A `log.warn` has neither
+ * property — the stream is retained, exported, and readable by anyone with log
+ * access, in SaaS potentially a third party — and the display mask's reveal
+ * rate is calamitous at the short end: `"hunter2!!"` becomes `hunt••••r2!!`,
+ * which is eight of nine characters. Inheriting a UX threshold into a security
+ * sink imports a trade nobody made there.
+ *
+ * The audit's subject is *which control moved, and which way*. For a
+ * secret-valued key that is not derivable from the characters anyway, so
+ * withholding all of them costs the audit nothing. `key`, `action` and the two
+ * rule flags carry the whole signal; `valueMasked` says the value was withheld.
+ *
+ * A truncated digest was considered and rejected: it correlates rotations
+ * nicely, but a short or low-entropy secret is brute-forceable from one, which
+ * adds a disclosure channel rather than removing one. So does a length marker,
+ * for less benefit.
+ */
+const REDACTED_AUDIT_VALUE = "[redacted]";
+
+/** Why {@link redactAuditValue} withheld a value. */
+export type AuditMaskReason = "secret" | "unknown_definition";
+
+declare const auditedValueBrand: unique symbol;
+
+/**
+ * A string that has been through {@link redactAuditValue} — the ONLY thing an
+ * audit line may carry in its `value` field.
+ *
+ * ⚠️ **The brand is the guard, and it is here because nothing else could be.**
+ * Review measured that `log.warn({ ...line, value }, …)` at the emitter —
+ * issue #5180 verbatim, plaintext back in the log stream — passed all 154
+ * tests. Not because the tests were weak: no sensitive key is `secret: true`
+ * today, so the redacted value and the raw value are *identical on every
+ * reachable input*, and the edit is a behavioural no-op until the day it is a
+ * breach. An assertion cannot see a difference that does not yet exist.
+ *
+ * So the check is a type rather than a test: {@link emitSecuritySensitiveAudit}
+ * takes a {@link SecuritySensitiveAuditLine}, whose `value` is branded, and a
+ * raw `string` is not assignable to it. That one-keystroke edit is now a
+ * compile error, on the day it is harmless and on the day it is not.
+ *
+ * This is the repo's own rule applied to itself — brand the OUTPUT, not just
+ * the parameter — and the escalation the review loop asks for once a principle
+ * has been argued twice: stop restating it in prose and make the state
+ * unrepresentable.
+ */
+export type AuditedValue = string & { readonly [auditedValueBrand]: true };
+
+/** {@link redactAuditValue}'s decision: what to log, and why. */
+export interface RedactedAuditValue {
+  readonly value: AuditedValue | undefined;
+  readonly masked: boolean;
+  /** `undefined` exactly when `masked` is false. */
+  readonly maskReason: AuditMaskReason | undefined;
+}
+
+/**
+ * The written value as an audit line may record it (#5180), plus whether — and
+ * why — it was withheld.
  *
  * Takes the DEFINITION rather than the key on purpose: the decision genuinely
  * depends on `def.secret`, and passing `undefined` explicitly is what makes the
- * fail-closed contract legible — and testable — at the call site.
+ * fail-closed contract legible — and testable — at the call site. Narrowed to
+ * the two fields actually read, so the audit path does not acquire a dependency
+ * on the whole mutable registry record.
  *
  * ⚠️ FAIL CLOSED ON AN UNKNOWN DEFINITION. A key with no registry entry cannot
  * be *shown* to be non-secret, and "we could not tell" is not a licence to
@@ -3017,35 +3093,63 @@ export function securitySensitiveAuditFields(
  * a backstop against a rename rather than a live path — which is exactly why it
  * must not be the permissive one.
  *
- * The empty string masks to `undefined`, per {@link maskSecret}'s own contract:
- * there is nothing in `""` to reveal. No audit information is lost, because
- * `action` — not the presence of `value` — is what distinguishes a `set` from a
- * `clear`.
+ * ⚠️ It reports `maskReason` rather than a bare boolean because those two arms
+ * are not the same event. `"secret"` is routine. `"unknown_definition"` means a
+ * sensitive key has drifted out of the registry (or a caller passed the wrong
+ * definition) — an anomaly that, reported as a plain masked write, would be
+ * indistinguishable from the healthy case and so would fire silently.
+ *
+ * The empty string yields `undefined`: there is nothing in `""` to withhold,
+ * and emitting the placeholder would imply content that does not exist. No
+ * audit information is lost, because `action` — not the presence of `value` —
+ * is what distinguishes a `set` from a `clear`.
  */
 export function redactAuditValue(
-  def: SettingDefinition | undefined,
+  def: Pick<SettingDefinition, "key" | "secret"> | undefined,
   value: string | undefined,
-): { value: string | undefined; masked: boolean } {
-  if (value === undefined) return { value: undefined, masked: false };
-  if (def === undefined || def.secret === true) {
-    return { value: maskSecret(value), masked: true };
+): RedactedAuditValue {
+  // The sole minting site for {@link AuditedValue}. Every `as` below is a
+  // string that has just been through the decision above it — that is what the
+  // brand asserts, and keeping the casts in one function is what keeps the
+  // assertion true.
+  const audited = (v: string): AuditedValue => v as AuditedValue;
+
+  if (value === undefined) return { value: undefined, masked: false, maskReason: undefined };
+  if (def === undefined) {
+    return { value: audited(REDACTED_AUDIT_VALUE), masked: true, maskReason: "unknown_definition" };
   }
-  return { value, masked: false };
+  if (def.secret === true) {
+    return {
+      value: value === "" ? undefined : audited(REDACTED_AUDIT_VALUE),
+      masked: true,
+      maskReason: "secret",
+    };
+  }
+  return { value: audited(value), masked: false, maskReason: undefined };
 }
 
 /** The full structured payload {@link auditSecuritySensitiveChange} logs. */
 export interface SecuritySensitiveAuditLine extends SecuritySensitiveAudit {
   readonly key: string;
-  readonly action: "set" | "clear";
+  readonly action: SettingAuditAction;
   /**
-   * The written value — verbatim, or {@link maskSecret}-masked when the
-   * registry definition carries `secret: true`. Read it together with
-   * `valueMasked`: without that flag a masked `••••••••` is indistinguishable
-   * from a setting whose literal value is `••••••••`.
+   * The written value — verbatim, or replaced by {@link REDACTED_AUDIT_VALUE}
+   * when the registry definition carries `secret: true`. Read it together with
+   * `valueMasked`: without that flag a placeholder is indistinguishable from a
+   * setting whose literal value happens to be that string.
+   *
+   * Branded, so only {@link redactAuditValue} can produce one — see
+   * {@link AuditedValue} for why a type and not a test.
    */
-  readonly value: string | undefined;
-  /** Whether `value` was redacted rather than recorded verbatim (#5180). */
+  readonly value: AuditedValue | undefined;
+  /** Whether `value` was withheld rather than recorded verbatim (#5180). */
   readonly valueMasked: boolean;
+  /**
+   * Why it was withheld. `"unknown_definition"` is the one worth alerting on —
+   * it means a sensitive key has no registry entry, which is drift rather than
+   * a routine masked write.
+   */
+  readonly maskReason: AuditMaskReason | undefined;
   readonly actorId: string | undefined;
   readonly orgId: string | undefined;
   readonly event: "security_setting.changed";
@@ -3064,8 +3168,8 @@ export interface SecuritySensitiveAuditInput {
    * the masked and unmasked values identical. A parameter is the only thing
    * that makes the branch this function exists for observable.
    */
-  readonly definition: SettingDefinition | undefined;
-  readonly action: "set" | "clear";
+  readonly definition: Pick<SettingDefinition, "key" | "secret"> | undefined;
+  readonly action: SettingAuditAction;
   readonly value: string | undefined;
   readonly actorId: string | undefined;
   readonly orgId: string | undefined;
@@ -3073,9 +3177,9 @@ export interface SecuritySensitiveAuditInput {
 
 /**
  * The exact payload the security-audit `log.warn` line carries, or `null` when
- * `key` is not sensitive (no audit). Pure, and exported so the redaction is
- * testable against the *logged object* rather than against a helper the log
- * line is merely trusted to call.
+ * `key` is not sensitive (no audit). Pure, and exported so that
+ * `settings-audit-log.test.ts` can assert the *emitted* object equals this
+ * builder's output — pinning the pass-through itself, not just the payload.
  *
  * ⚠️ **A `secret: true` key IS allowed in {@link SECURITY_SENSITIVE_KEYS}; its
  * value is masked instead (#5180).** The alternative — refusing the
@@ -3091,14 +3195,20 @@ export interface SecuritySensitiveAuditInput {
  *    literal-typed const, so `Record<SecuritySensitiveKey, …>` cannot see it —
  *    enforcement would be a runtime boot guard, trading a masked log line for a
  *    refusal to boot on a defect the mask already closes.
- * 3. Masking here reuses the convention {@link resolvePlatformTier} and
- *    {@link getSettingsForAdmin} already apply, so the display paths agree
- *    rather than each inventing a policy.
+ * 3. The audit still records the *event* — who, when, which key, and which way
+ *    the two rule flags moved. Only the characters go, and for a secret-valued
+ *    key those were never the audit's subject. See {@link REDACTED_AUDIT_VALUE}
+ *    for why this path does NOT reuse the display mask.
  *
- * The payload is built here in full — including `key` and `action` — so that
- * {@link auditSecuritySensitiveChange} has no raw `value` in scope to reach
- * for. Adding a sensitive key stays the two-line, compile-checked change #5178
- * made it, and cannot reintroduce plaintext by not touching this file.
+ * The payload is built here in full — including `key` and `action` — so the
+ * emitter has nothing left to assemble and no reason to name `value` again.
+ *
+ * ⚠️ That is a shape, not a guarantee, and the distinction was measured. An
+ * earlier draft of this comment claimed the emitter "has no raw `value` in
+ * scope to reach for"; `value` is its third parameter, so reaching for it is
+ * one keystroke, and `log.warn({ ...line, value }, …)` reintroduced #5180 with
+ * the whole suite green. What closes it is the emission test in
+ * `settings-audit-log.test.ts`, not the arrangement of this function.
  */
 export function securitySensitiveAuditLine(
   input: SecuritySensitiveAuditInput,
@@ -3117,6 +3227,7 @@ export function securitySensitiveAuditLine(
     action,
     value: redacted.value,
     valueMasked: redacted.masked,
+    maskReason: redacted.maskReason,
     disablesControl: fields.disablesControl,
     widensAuthority: fields.widensAuthority,
     actorId,
@@ -3130,10 +3241,17 @@ export function securitySensitiveAuditLine(
  * setting is changed or cleared at runtime. `action` is `set` (a new value
  * persisted) or `clear` (override deleted → reverts to env/default). A no-op
  * for non-sensitive keys.
+ *
+ * ⚠️ It emits through {@link emitSecuritySensitiveAudit} rather than calling
+ * `log.warn` directly, and the indirection is load-bearing: `log.warn` takes
+ * an untyped object, so `log.warn({ ...line, value }, …)` — #5180 verbatim —
+ * has no target type to be checked against and compiles. Routed through a
+ * parameter typed {@link SecuritySensitiveAuditLine}, the same edit fails to
+ * type-check, because `value` there is an {@link AuditedValue}.
  */
 function auditSecuritySensitiveChange(
   key: string,
-  action: "set" | "clear",
+  action: SettingAuditAction,
   value: string | undefined,
   actorId: string | undefined,
   orgId: string | undefined,
@@ -3147,9 +3265,22 @@ function auditSecuritySensitiveChange(
     orgId,
   });
   if (!line) return;
+  emitSecuritySensitiveAudit(line);
+}
+
+/**
+ * Write one built audit line to the log stream.
+ *
+ * ⚠️ Takes the payload and nothing else, deliberately. The raw written value is
+ * not a parameter, is not in scope, and could not be assigned into `line.value`
+ * if it were — that field is branded. This function is the whole reason the
+ * brand has teeth; inlining it back into the caller returns `log.warn`'s
+ * untyped first argument to the code path and with it the silent edit #5180 is.
+ */
+function emitSecuritySensitiveAudit(line: SecuritySensitiveAuditLine): void {
   log.warn(
     line,
-    `Security-sensitive setting ${action === "clear" ? "override cleared" : "changed"} at runtime: ${key}`,
+    `Security-sensitive setting ${line.action === "clear" ? "override cleared" : "changed"} at runtime: ${line.key}`,
   );
 }
 


### PR DESCRIPTION
## What

`auditSecuritySensitiveChange` put the written setting value straight into the structured log. Safe for the four current members of `SECURITY_SENSITIVE_KEYS` — two RPM limits, a source list, a confidence bar, none of them `secret` — and worth closing because #5178 made joining that set a two-line, compile-checked change that never requires touching, or reading, the logging line. The next `secret: true` key to join would have written its plaintext to the log stream.

Confirmed the logger cannot save you: `redactPaths` (`logger.ts`) covers *named* credential fields (`apiKey`, `clientSecret`, …); nothing matches a top-level `value`.

## Behaviour delta — `redactAuditValue(def, value)`

| input class | before | after |
|---|---|---|
| non-secret def, `"0"` | logs `"0"` | logs `"0"`, `valueMasked: false` |
| `secret: true`, `"sk-ant-…-payload"` (32) | **logs plaintext** | `[withheld:secret-setting]` |
| `secret: true`, `"hunter2!!"` (9) | **logs plaintext** | `[withheld:secret-setting]` |
| `secret: true`, `"hunter22"` (8) | **logs plaintext** | `[withheld:secret-setting]` |
| `secret: true`, `""` | **logs `""`** | `[withheld:secret-setting]` |
| def belonging to a DIFFERENT key | n/a (looked up) | withheld, `maskReason: "definition_mismatch"` |
| no def at all | **logs plaintext** | withheld, `maskReason: "unknown_definition"` |
| `action: "clear"` | logs `undefined` | logs `undefined`, `valueMasked: false` |

Every changed row moves toward less disclosure. `disablesControl` / `widensAuthority` are still decided from the **written** value — redacting the payload must not blind the audit's own classification, which is the reason the line exists.

## The mask is deliberately NOT `maskSecret` — AC-1 overridden, on purpose

AC-1 asked for `maskSecret` reuse. Two reviewers independently measured why that is wrong here: `maskSecret` emits `first4••••last4` as a *recognition affordance* for one admin looking at their own key in the UI. A log stream is retained, exported and broadly readable, and that mask leaks **8 of 9 characters** of a short secret (`"hunter2!!"` → `hunt••••r2!!`).

AC-1's purpose was "don't invent a divergent policy". The measurement showed the display policy *is* the wrong policy for a log sink, so the deviation serves the AC's intent. A truncated digest was rejected (a short secret is brute-forceable from one — a new disclosure channel). `[withheld:secret-setting]` is self-describing and collides with neither pino's default `[Redacted]` censor nor `plugins/secrets.ts`'s `MASKED_PLACEHOLDER`, which is a **round-tripping sentinel** that `restoreMaskedSecrets` reads back as "keep the stored value".

## AC-3 — a `secret: true` key MAY join the set

Decided rather than assumed, and written into the source:

1. **"Audit the change, never the content" is a legitimate pairing.** Rotating a credential that gates an abuse control is exactly what an audit trail is for; refusing membership makes that rotation emit *nothing*.
2. **Refusal is not expressible where it would have to be** — `secret` lives on `SettingDefinition` inside a `SettingDefinition[]`, so `Record<SecuritySensitiveKey, …>` cannot see it. Enforcement would be a boot guard: a refusal to boot in place of a withheld log line.
3. The audit still records who, when, which key, and which way both flags moved. Only the characters go.

## The part worth reading: the round-1 premise was FALSE

Round 1 concluded *"no runtime assertion can catch the leak, so the check must be a type"* — because no shipped sensitive key is `secret: true`, so redacted == raw on every reachable input and `log.warn({ ...line, value }, …)` is a behavioural no-op.

That is a fact about the **registry's current contents**, not about what is observable. `getSettingDefinition` returns the live `SETTINGS_MAP` object; flipping `secret` for the duration of one test makes redacted and raw differ on a fully reachable input, and the leak becomes an ordinary assertion. Measured:

| edit | `settings.test` | `settings-audit-log.test` | `tsgo` |
|---|---|---|---|
| inline `log.warn` back, spreading raw value | 0 | **3** | 0 |
| fabricate `{ key, secret: false }` at the caller | 0 | **2** | 0 |
| `emit({ ...line, value })` through the seam | 0 | 2 | **1** |
| `warnAuditLine({ ...line, value })` | 0 | 5 | **1** |

Neither of the first two is visible to any type; neither survives the test. So both halves ship, covering disjoint edits:

- **`AuditedValue`** (a branded string minted only in `redactAuditValue`) + **`warnAuditLine`** (a typed alias — pino types `log.warn`'s first parameter as `<T extends object>` and *infers* `T`, so calling it directly checks nothing) close every seam-preserving spelling at compile time.
- **The registry-flip block** closes the two that remove or bypass the seam.

## One comment, wrong three times

1. *"the emitter has no raw `value` in scope to reach for"* — it was parameter 3.
2. *"the emission test closes the leak"* — measured false; `value` is a declared field, so the edit overwrites rather than adds and both sides of the equality move together.
3. *"what closes that is `AuditedValue` — a TYPE"* — inlining `log.warn` removes the seam and the type with it.

It now states the split explicitly, and `AuditedValue` carries the "WHAT THIS DOES NOT CLOSE" paragraph its neighbours have.

## Also fixed

- **`Pick<SettingDefinition, "key" | "secret">` reverted** to the full record. Round 1's hygiene, measured a net loss: `secret` is optional in the `Pick`, so `{ key }` alone reaches the verbatim arm, and `{ key, secret: false }` reads as tidying where a seven-field fake reads as deliberate.
- **The empty secret is withheld like any other value.** `undefined` for `""` was a one-bit oracle — and for the empty secret, its length *is* the secret. It also contradicted the constant's own "no length marker" argument two paragraphs above.
- **The audit is emitted BEFORE `applySettingSideEffect`** in both writers. The round-1 deferral ("wants a logger seam, new machinery") described the cost of *testing* it, not of *fixing* it — the audit needs nothing the side effect produces.
- **`orgId` pinned both directions.** It was `undefined` on both sides of every assertion — the value a dropped-argument mutation produces — while two of the four sensitive keys are workspace-scoped. Logging the raw `orgId` instead of `effectiveOrgId` would claim a blast radius of one workspace for a global change.
- **The message is asserted, and asserted not to contain the value** — a template literal is a leak channel no type can close.
- **`error`/`fatal` recorded and asserted empty** — a stub that no-ops them cannot see an audit swallowed by a catch that logs.
- `maskReason: "definition_mismatch"` as a third arm; a caller bug reported as registry drift gets closed as a false positive.
- Smaller: `hashShareToken` stub no longer returns its input; `LogCall` no longer claims the first argument is an object; the `!` and two double casts are gone; `SettingAuditAction` extracted; the #5180 note moved onto `SECURITY_SENSITIVE_KEYS_LITERAL` out of a JSDoc-dead block.

## A falsifier of mine that could not fail

The five-length `it.each` asserted per row that no character of the input survived — but stripped lowercase before comparing, so for `"abcdefghi"` and `"x"` it iterated **zero** times. Replaced by the uniformity property: all five lengths produce one identical placeholder, which goes red on `maskSecret`'s five distinct outputs.

## Panel — 2 rounds, stopped on the RATIO rule

| round | findings | new surface | defect-in-prior-fix |
|---|---|---|---|
| 1 | ~12 | ~12 | 0 |
| 2 | ~22 | ~5 | **~17** |

Round 2's defect-in-prior-fix count exceeds its new-surface count, so the rounds ended there rather than at the 3-round cap: when the majority of a round's findings are defects the previous round's fixes introduced, another round adds work faster than it removes it. Every confirmed must-fix is fixed; the comment sweep ran on this diff.

`fix-vs-finding`, in fresh context, per must-fix:
- *mask reuse across audiences* → **CLEAN** (checked `REDACTED_AUDIT_VALUE`, `redactAuditValue`, `AuditedValue`, `maskReason`, `emitSecuritySensitiveAudit`; noted `redactAuditValue`'s sink-generic name as a latent invitation, not an instance).
- *a guard whose outcomes coincide on every input* → **REPRODUCED**, and that is what surfaced the false "the emission test closes it" claim. Fixed in this round.

## Deferred, with reasons

- **`ATLAS_LOG_LEVEL` is runtime-mutable, un-audited, and can silence this very line** (`warn` < `error`). A genuine audit-evasion shape and the best new-surface find of the round — but adding it to `SECURITY_SENSITIVE_KEYS` means a new rule, new tests and a change to the audited set. Follow-up.
- `admin.ts` writes the raw value into `admin_action_log` and echoes it in the response. Out of this PR's surface, and gated today by a 403 on `def.secret` — defence-in-depth, not a live leak.
- `@ts-expect-error` rows proving the brand *rejects* raw strings. Nice-to-have.

## Falsifiers — 16 mutations, all dead (165 tests, 0 fail; baseline `tsgo` 0 errors)

| mutation | `settings.test` | `audit-log.test` | `tsgo` |
|---|---|---|---|
| inline `log.warn` back, raw value | 0 | 3 | 0 |
| fabricate a non-secret definition | 0 | 2 | 0 |
| `emit({ ...line, value })` | 0 | 2 | 1 |
| `warnAuditLine({ ...line, value })` | 0 | 5 | 1 |
| never withhold | 9 | 2 | 0 |
| fail OPEN on an unknown definition | 3 | 0 | 1 |
| withhold everything | 8 | 1 | 0 |
| mismatch reported as drift | 1 | 0 | 0 |
| trust a mismatched definition | 1 | 0 | 0 |
| flags from the WITHHELD value | 1 | 1 | 0 |
| placeholder reverts to the display mask | 12 | 2 | 0 |
| `valueMasked` hardcoded false | 4 | 1 | 0 |
| message appends the value | 0 | 1 | 0 |
| audit never emitted | 0 | 9 | 0 |
| `orgId` dropped at both call sites | 0 | 1 | 0 |
| raw `orgId` instead of `effectiveOrgId` | 0 | 1 | 0 |

## Scope

`packages/api/src/lib/settings.ts` and its tests only. No route, schema, or migration touched. No mutation spec targets `settings.ts` or counts either test file (checked against every `file:` in `scripts/mutations/*.mutations.ts`), so `mutation-tables` is unaffected.

## Verification

- `bun test settings.test.ts settings-audit-log.test.ts` — 165 pass, 0 fail
- `bun run scripts/test-isolated.ts --affected` — 103 files, 103 pass, 0 fail
- `bun run lint` / `bun run type` / `bun run lint:type-aware` — 0 errors each
- `scripts/check-test-discipline.sh` — passed, no new offenders

Closes #5180
