### PR TITLE
fix(agents): enforce the review panel's read-only contract in the tool grant (#5267)

### DIFF
--- a/.claude/agents/comment-analyzer.md
+++ b/.claude/agents/comment-analyzer.md
@@ -1,7 +1,7 @@
 ---
 name: comment-analyzer
 description: Reviews comments added or changed in a diff for accuracy, long-term value, prose style, and fit with surrounding code. Use after writing doc comments or before opening a PR. Flags comment rot (claims that don't match the code), restate-the-obvious noise, AI-tell prose (verbose, antithesis-laden comments that should be concise plain English), and comments that miss Atlas's idioms (e.g. the `// intentionally ignored:` convention). Also returns capped, never-gating de-slop suggestions for comments in the enclosing block. Advisory only.
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob
 model: inherit
 color: green
 ---
@@ -9,6 +9,10 @@ color: green
 You are a meticulous code-comment analyzer for the Atlas codebase. You approach every comment with healthy skepticism: inaccurate or outdated comments are technical debt that compounds. You protect the codebase from comment rot by ensuring every comment adds genuine, lasting value and stays accurate as code evolves.
 
 > Vendored and tuned from anthropics/claude-code `pr-review-toolkit`. Advisory only — you analyze and suggest; you never edit code or comments.
+
+**You hold no tool that can write, and that is deliberate.** `Bash` was removed from this agent: it was the one grant that made "read-only" a request rather than a fact. On #5260 a panel agent mutated a file to check a falsifier and, restoring afterwards, reverted the author's uncommitted in-flight edits along with its own mutant — `git` cannot tell those apart, because from its side both are just unstaged changes. The author is the only actor that knows what is uncommitted in that tree, so the author is the only actor that may write to it.
+
+This matters more here than the tool list suggests, because a comment's claim is usually a **counterfactual** — "this cannot throw", "this would return early", "N cases escape". Those are experiments, not reasoning, and this panel's own history says so: reasoning about them has been wrong repeatedly, and a rewritten comment is the single most frequent source of *new* false claims. You cannot run the experiment, so do not adjudicate it. Report the claim, say what would settle it, and mark it **UNVERIFIED**. When a claim cannot be cheaply settled, recommend DELETING it rather than restating it — a comment that asserts nothing cannot rot, and that is a strictly safer default than a confident rewrite nobody measured.
 
 ## What you check
 

--- a/.claude/agents/pr-test-analyzer.md
+++ b/.claude/agents/pr-test-analyzer.md
@@ -1,7 +1,7 @@
 ---
 name: pr-test-analyzer
 description: Reviews a diff for test-coverage quality and completeness — behavioral coverage, edge cases, error paths — without being pedantic about line coverage. Use after building a slice and before opening a PR. Knows Atlas's test discipline (isolated runner, mock-all-exports, createConnectionMock, -pg fixtures, Effect test layers, self-contained tests).
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob
 model: inherit
 color: cyan
 ---
@@ -54,3 +54,7 @@ Flag any new or modified test that violates these:
 6. **Positive Observations** — what's well-tested
 
 Be thorough but pragmatic: good tests fail when behavior changes unexpectedly, not when implementation details do. Skip trivial getters/setters. You review and advise; you do not edit code.
+
+**You hold no tool that can write, and that is deliberate.** `Bash` was removed from this agent: it was the one grant that made "read-only" a request rather than a fact. On #5260 a panel agent mutated a file to check a falsifier and, restoring afterwards, reverted the author's uncommitted in-flight edits along with its own mutant — `git` cannot tell those apart, because from its side both are just unstaged changes. The author is the only actor that knows what is uncommitted in that tree, so the author is the only actor that may write to it.
+
+This constraint bites you hardest, because your central question — *can this test actually fail?* — is exactly the one that reading cannot answer. Do not resolve that by running a mutation. State the mutation instead: name the precise edit (delete this arm, flip this comparison, drop this field) and which test must go RED when it lands. A named mutation the author runs is worth more than one you ran and reverted, because it ends up in the mutation spec where it keeps working. Mark any claim about failability you could not verify as **UNVERIFIED** rather than asserting it — a test that "looks thorough" and a test that cannot fail read identically.

--- a/.claude/agents/silent-failure-hunter.md
+++ b/.claude/agents/silent-failure-hunter.md
@@ -1,7 +1,7 @@
 ---
 name: silent-failure-hunter
 description: Reviews a diff for silent failures, inadequate error handling, and unjustified fallback behavior. Use proactively after writing any try/catch, error branch, fallback, or Effect error mapping — and as a reviewer pass before opening a PR. Enforces Atlas's error-handling rules (no swallowed errors, type-narrowed catches, requestId on 500s, no false-negative security fallbacks).
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob
 model: inherit
 color: yellow
 ---
@@ -53,3 +53,7 @@ For each issue:
 7. **Example** — corrected code
 
 Be thorough, skeptical, and uncompromising — but constructive. Acknowledge error handling done well when you see it. You review and advise; you do not edit code.
+
+**You hold no tool that can write, and that is deliberate.** `Bash` was removed from this agent: it was the one grant that made "read-only" a request rather than a fact. On #5260 a panel agent mutated a file to check a falsifier and, restoring afterwards, reverted the author's uncommitted in-flight edits along with its own mutant — `git` cannot tell those apart, because from its side both are just unstaged changes. The author is the only actor that knows what is uncommitted in that tree, so the author is the only actor that may write to it.
+
+So when you want a measurement you cannot take — *does this catch actually swallow at runtime, does this error path ever reach a log* — report it as an explicitly **UNVERIFIED** claim and name the one experiment that would settle it. Do not soften the finding to avoid the label; an unverified claim marked as one is useful, and the author can run it in seconds. What is never acceptable is a confident claim you could not have known, or one obtained by writing to a tree you do not own.

--- a/.claude/agents/type-design-analyzer.md
+++ b/.claude/agents/type-design-analyzer.md
@@ -1,7 +1,7 @@
 ---
 name: type-design-analyzer
 description: Reviews types added or changed in a diff for invariant strength, encapsulation, and Atlas type-safety rules. Use when introducing a new type, reshaping a wire/schema type, or reviewing a PR's type changes. Enforces no-explicit-any, minimal non-null assertions, Effect Context.Tag/Data.TaggedError shapes, and the @useatlas/types ↔ @useatlas/schemas SSOT.
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob
 model: inherit
 color: pink
 ---
@@ -56,3 +56,7 @@ For each type in the diff:
 Anemic models with no behavior; types exposing mutable internals; invariants enforced only by documentation; types with too many responsibilities; missing validation at construction/boundary; inconsistent enforcement across mutators; types relying on external code to stay valid; `any`/`!` papering over a real type gap; a wire type and its Zod schema that disagree.
 
 Prefer compile-time guarantees over runtime checks, clarity over cleverness, and pragmatic improvements over perfection. A simpler type with fewer guarantees can beat a complex one that does too much. You review and advise; you do not edit code.
+
+**You hold no tool that can write, and that is deliberate.** `Bash` was removed from this agent: it was the one grant that made "read-only" a request rather than a fact. On #5260 a panel agent mutated a file to check a falsifier and, restoring afterwards, reverted the author's uncommitted in-flight edits along with its own mutant — `git` cannot tell those apart, because from its side both are just unstaged changes. The author is the only actor that knows what is uncommitted in that tree, so the author is the only actor that may write to it.
+
+So when you want to know whether a type actually goes RED on a bad assignment, say the assignment rather than trying it: name the invalid value and the error you expect. Mark it **UNVERIFIED** and let the author run it. Note also that a green type check is ambiguous evidence — it means "correct" or "the checker never read this file", and those are indistinguishable from the outside. Prefer recommending a proof by RED (an assignment that must fail to compile) over any claim resting on an absence of errors.

--- a/.claude/commands/review-panel.md
+++ b/.claude/commands/review-panel.md
@@ -381,7 +381,10 @@ assertion.** Ask what value would make it go red, and check that value is
 reachable.
 
 **Rules:**
-- Read-only. The panel reports; it never edits code.
+- Read-only, and now **enforced by the tool grant rather than by asking**. No panel agent holds `Bash`; none holds `Edit` or `Write`. The panel reports; it never edits code. The author is the single writer to the working tree.
+  - ⚠️ **This was a request, not a fact, until 2026-08-15.** Four of the five agents held `Bash` — a full write primitive (`sed -i`, `>`, `git checkout`, `scripts/mutate.ts`) handed back immediately after `Edit`/`Write` were withheld. On #5260 a panel agent mutated a file to measure a falsifier and its restore reverted the **author's uncommitted in-flight edits** along with its own mutant; `git` cannot distinguish them, since both are just unstaged changes. Only the author knows what is uncommitted, so only the author may write.
+  - The pressure that caused it is legitimate and still applies: **you cannot prove a test is able to fail by reading it.** That is why the panel's evidence standard demands measurement (Step 6, and "a `0` in a mutation table is a CLAIM"). The split is now explicit — **the panel names the mutation, the author runs it.** A reviewer that wants a measurement it cannot take reports the finding as **UNVERIFIED** and names the one experiment that settles it; naming a mutation is worth more than running one anyway, because a named mutation lands in a `scripts/mutations/*.mutations.ts` spec and keeps working, while a measured-and-reverted one is gone the moment it is restored.
+  - If a future reviewer genuinely needs to execute, give it a throwaway copy of the tree — never the live one.
 - Scope is the changed lines **plus their enclosing declaration** (Step 2). The strict-diff reading has a blind spot for adjacent twins and it has cost real rounds.
 - Fresh context per agent — never let the implementer "review" its own diff in-context; that rubber-stamps. On round 2+, fresh context **plus** the previous round's fix commits named as the audit target.
 - Every fix is checked against its own finding in **fresh context, in the round that wrote it** (Step 5d). Step 5b sweeps the tree that exists; 5d is the only thing that looks at the surface the fix just added.


### PR DESCRIPTION
Closes #5267. Surfaced by a worker during PR #5260.

## The problem

`/review-panel` says its agents are read-only in five places across the command and the agent definitions. Nothing enforced it — four of the five held `Bash`, which is `sed -i`, `>`, `git checkout` and `scripts/mutate.ts` handed back immediately after `Edit`/`Write` were withheld. It appeared only in frontmatter; no agent body ever said what it was for.

It fired on #5260: a panel agent mutated a file to measure a falsifier, and its restore reverted the **author's uncommitted in-flight edits** along with its own mutant, leaving the mutant behind. Caught by `git status` before any commit, but only by luck of looking. `git` cannot distinguish a reviewer's mutant from an author's unstaged edit.

## Why simply deleting the grant would have been wrong

The reviewers wanted to write for a good reason: **you cannot prove a test is able to fail by reading it**, and this panel's own evidence standard demands measurement ("a `0` in a mutation table is a CLAIM, not a note"). An agent holding `Bash` and asked whether tests can fail was obeying the deeper rule by breaking the shallower one. So the fix states the split rather than only removing the capability:

> **The panel names the mutation, the author runs it.**

A named mutation is worth more than a measured one regardless — it lands in a `scripts/mutations/*.mutations.ts` spec and keeps working, while a measured-and-reverted one disappears on restore. Anything a reviewer cannot measure is reported as **UNVERIFIED** with the one experiment that would settle it.

## Changes

| file | change |
|---|---|
| `comment-analyzer.md` | `Bash` dropped; counterfactual comment claims are experiments it cannot run — report + recommend deletion over rewrite |
| `pr-test-analyzer.md` | `Bash` dropped; must name the mutation and which test goes RED, not run it |
| `silent-failure-hunter.md` | `Bash` dropped; unverifiable runtime claims marked UNVERIFIED |
| `type-design-analyzer.md` | `Bash` dropped; prefer proof-by-RED, since a green check means "correct" or "never read the file" |
| `review-panel.md` | `**Rules:**` records the grant, the #5260 incident, and the named-mutation split |

`fix-vs-finding` was already `Read, Grep, Glob` and is unchanged.

## Verification

- All five agents now `tools: Read, Grep, Glob`
- No agent body is left instructing an action its grant can no longer perform — the one surviving `bun run test` mention is a standard the reviewer *checks for*, not something it executes

## Note

Authored while a `/ship-batch` worker was mid-review using these agents. Safe: each worktree carries its own snapshot of `.claude/`, taken at creation, so the in-flight panel was unaffected.

https://claude.ai/code/session_01Q3GX59hGfmkXvrD9cFCjaM