### PR TITLE
fix(db,settings): a blocked catalog row stops reporting as preserved, and the settings audit row stops carrying plaintext (#5266, #5270, #5262)

### DIFF
--- a/packages/api/src/api/__tests__/admin-settings.test.ts
+++ b/packages/api/src/api/__tests__/admin-settings.test.ts
@@ -47,6 +47,22 @@ void mock.module("@atlas/api/lib/audit", () => ({
   causeToError: (cause: unknown) => (cause instanceof Error ? cause : new Error(String(cause))),
 }));
 
+/**
+ * #5270/#5262 — the settings write path no longer builds its own audit entry;
+ * it hands the definition and the raw value to `auditSettingsWrite`, which
+ * redacts, stamps `scope` and awaits the row. The ENTRY's shape is pinned in
+ * `lib/audit/__tests__/settings-write.test.ts`; what belongs here is what the
+ * ROUTE passes — in particular that `platformTier` tracks the row the write
+ * actually landed on, which is #4669's claim restated at the new seam.
+ */
+const mockAuditSettingsWrite: Mock<(entry: Record<string, unknown>) => Promise<void>> = mock(
+  async () => {},
+);
+
+void mock.module("@atlas/api/lib/audit/settings-write", () => ({
+  auditSettingsWrite: mockAuditSettingsWrite,
+}));
+
 // --- Test-specific overrides ---
 
 let mockConfigOverride: Record<string, unknown> | null = null;
@@ -225,6 +241,7 @@ describe("admin settings routes", () => {
     mockSetSetting.mockClear();
     mockDeleteSetting.mockClear();
     mockLogAdminAction.mockClear();
+    mockAuditSettingsWrite.mockClear();
     mockIsSaasModeForGuard.mockClear();
     mockIsSaasModeForGuard.mockImplementation(saasGuardDefaultImpl);
   });
@@ -672,8 +689,8 @@ describe("admin settings routes", () => {
       expect(mockDeleteSetting).toHaveBeenCalledWith("ATLAS_ROW_LIMIT", "ws-admin-1", "org-1");
       // #4669 — DELETE's audit annotation is a separate copy of PUT's;
       // pin its workspace arm too.
-      expect(mockLogAdminAction).toHaveBeenCalledWith(
-        expect.objectContaining({ metadata: expect.objectContaining({ tier: "workspace" }) }),
+      expect(mockAuditSettingsWrite).toHaveBeenCalledWith(
+        expect.objectContaining({ platformTier: false }),
       );
     });
 
@@ -1198,8 +1215,8 @@ describe("admin settings routes", () => {
       // explicit tier targets the global row → orgId undefined.
       expect(mockSetSetting).toHaveBeenCalledWith("ATLAS_AGENT_AUTH_ENABLED", "true", "platform-admin-1", undefined);
       // Audit trail records the row the write actually landed on.
-      expect(mockLogAdminAction).toHaveBeenCalledWith(
-        expect.objectContaining({ metadata: expect.objectContaining({ tier: "platform" }) }),
+      expect(mockAuditSettingsWrite).toHaveBeenCalledWith(
+        expect.objectContaining({ platformTier: true }),
       );
     });
 
@@ -1211,8 +1228,8 @@ describe("admin settings routes", () => {
       expect(res.status).toBe(200);
       expect(mockDeleteSetting).toHaveBeenCalledTimes(1);
       expect(mockDeleteSetting).toHaveBeenCalledWith("ATLAS_AGENT_AUTH_ENABLED", "platform-admin-1", undefined);
-      expect(mockLogAdminAction).toHaveBeenCalledWith(
-        expect.objectContaining({ metadata: expect.objectContaining({ tier: "platform" }) }),
+      expect(mockAuditSettingsWrite).toHaveBeenCalledWith(
+        expect.objectContaining({ platformTier: true }),
       );
     });
 
@@ -1333,8 +1350,8 @@ describe("admin settings routes", () => {
       expect(res.status).toBe(200);
       expect(mockSetSetting).toHaveBeenCalledWith("ATLAS_AGENT_AUTH_ENABLED", "false", "ws-admin-1", "org-1");
       // Audit trail labels the workspace-row write accordingly.
-      expect(mockLogAdminAction).toHaveBeenCalledWith(
-        expect.objectContaining({ metadata: expect.objectContaining({ tier: "workspace" }) }),
+      expect(mockAuditSettingsWrite).toHaveBeenCalledWith(
+        expect.objectContaining({ platformTier: false }),
       );
     });
 
@@ -1359,6 +1376,81 @@ describe("admin settings routes", () => {
       // The router's shared validationHook defaultHook → 422 Unprocessable Entity.
       expect(res.status).toBe(422);
       expect(mockSetSetting).not.toHaveBeenCalled();
+    });
+  });
+
+  // ─── the audit row is awaited (#5262) ──────────────────────────
+
+  describe("an audit row that cannot be committed (#5262)", () => {
+    // The residual #5262 is actually about: `logAdminAction` dropped the row
+    // with a `log.warn` when the internal-DB circuit breaker was open, and a
+    // raised `ATLAS_LOG_LEVEL` — itself runtime-mutable — then ate the warn.
+    // Awaiting the row turns a silently unrecorded config change into a
+    // response the admin sees.
+    const auditDown = () => {
+      mockAuditSettingsWrite.mockImplementationOnce(() =>
+        Promise.reject(new Error("circuit breaker open")),
+      );
+    };
+
+    it("PUT 500s when the audit row is rejected", async () => {
+      auditDown();
+      const res = await request("/api/v1/admin/settings/ATLAS_ROW_LIMIT", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ value: "500" }),
+      });
+      expect(res.status).toBe(500);
+      const body = (await res.json()) as { error: string; message: string; requestId: string };
+      expect(body.error).toBe("audit_not_committed");
+      // ⚠️ THE MESSAGE'S CLAIM, not just its presence. The write already
+      // landed and the cache is already updated, so a body implying the
+      // change did not apply would send the admin to re-check the wrong
+      // thing. It has to say the setting DID change and is unaudited.
+      expect(body.message).toContain("already in effect");
+      expect(body.message).toContain("unaudited");
+      expect(body.requestId).toBeTruthy();
+    });
+
+    it("⭐ and the write really did land — the 500 is about the record, not the write", async () => {
+      // Without this, a handler that rolled the setting back on audit failure
+      // would satisfy the status assertion above while doing something
+      // completely different, and the message would then be a lie.
+      auditDown();
+      await request("/api/v1/admin/settings/ATLAS_ROW_LIMIT", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ value: "500" }),
+      });
+      expect(mockSetSetting).toHaveBeenCalledTimes(1);
+      // The submitted value, not a rollback to anything else.
+      expect(mockSetSetting).toHaveBeenCalledWith(
+        "ATLAS_ROW_LIMIT",
+        "500",
+        expect.any(String),
+        undefined,
+      );
+    });
+
+    it("DELETE 500s the same way — the clear path is a write too", async () => {
+      auditDown();
+      const res = await request("/api/v1/admin/settings/ATLAS_ROW_LIMIT", { method: "DELETE" });
+      expect(res.status).toBe(500);
+      const body = (await res.json()) as { error: string; message: string };
+      expect(body.error).toBe("audit_not_committed");
+      expect(body.message).toContain("reset to its default");
+      expect(mockDeleteSetting).toHaveBeenCalledTimes(1);
+    });
+
+    it("stays 200 when the audit row commits — the arm that must NOT fail", async () => {
+      // The other half of the claim: a route that 500'd unconditionally would
+      // pass all three tests above.
+      const res = await request("/api/v1/admin/settings/ATLAS_ROW_LIMIT", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ value: "500" }),
+      });
+      expect(res.status).toBe(200);
     });
   });
 

--- a/packages/api/src/api/__tests__/admin-settings.test.ts
+++ b/packages/api/src/api/__tests__/admin-settings.test.ts
@@ -1412,10 +1412,13 @@ describe("admin settings routes", () => {
     // seam-preserving edits the module docstring says the brand does not
     // close.
 
-    it("⭐ PUT passes the full entry — key, definition, value, action, tier", async () => {
+    it("⭐ PUT passes the full entry — key, definition, value, action, tier, ip", async () => {
+      // ⚠️ `x-forwarded-for` is SENT here. Round 1 asserted `ipAddress: null`,
+      // which is also what a route that stopped reading the headers produces
+      // — accidental equality, in the describe written to close exactly that.
       const res = await request("/api/v1/admin/settings/ATLAS_ROW_LIMIT", {
         method: "PUT",
-        headers: { "Content-Type": "application/json" },
+        headers: { "Content-Type": "application/json", "x-forwarded-for": "203.0.113.7" },
         body: JSON.stringify({ value: "500" }),
       });
       expect(res.status).toBe(200);
@@ -1428,7 +1431,7 @@ describe("admin settings routes", () => {
         value: "500",
         action: "update",
         platformTier: expect.any(Boolean),
-        ipAddress: null,
+        ipAddress: "203.0.113.7",
       });
     });
 
@@ -1483,14 +1486,60 @@ describe("admin settings routes", () => {
       expect(mockAuditSettingsWrite).not.toHaveBeenCalled();
       expect(mockSetSetting).not.toHaveBeenCalled();
     });
+
+    it("DELETE's secret gate also stops short of the seam", async () => {
+      // The mirror half — the PUT twin above had this and DELETE did not.
+      const res = await request("/api/v1/admin/settings/ANTHROPIC_API_KEY", {
+        method: "DELETE",
+      });
+      expect(res.status).toBe(403);
+      expect(mockAuditSettingsWrite).not.toHaveBeenCalled();
+      expect(mockDeleteSetting).not.toHaveBeenCalled();
+    });
+
+    it("⭐ an EMPTY activeOrganizationId is a platform-tier write, not a workspace one", async () => {
+      // ⚠️ The one input class where `!effectiveOrgId` and `=== undefined`
+      // disagree, and the reason the delta table at the call sites exists.
+      // `activeOrganizationId` is typed `string | undefined`, so `""` is in
+      // the type; `setSetting` treats it as the GLOBAL row (its own checks
+      // are truthiness), so the audit row must say platform. Under
+      // `=== undefined` this lands `platformTier: false` → `scope:
+      // "workspace"` → back onto the org-scoped read API this PR exists to
+      // keep it off. Round 1 wrote the table and shipped no test for it.
+      mocks.mockAuthenticateRequest.mockImplementationOnce(() =>
+        Promise.resolve({
+          authenticated: true,
+          mode: "better-auth",
+          user: {
+            id: "ws-admin-1",
+            mode: "better-auth",
+            label: "Admin",
+            role: "admin",
+            activeOrganizationId: "",
+          },
+        }),
+      );
+      const res = await request("/api/v1/admin/settings/ATLAS_ROW_LIMIT", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ value: "500" }),
+      });
+      expect(res.status).toBe(200);
+      expect(mockAuditSettingsWrite).toHaveBeenCalledWith(
+        expect.objectContaining({ platformTier: true }),
+      );
+    });
   });
 
   // ─── the audit row is awaited (#5262) ──────────────────────────
 
   describe("an audit row that cannot be committed (#5262)", () => {
-    // The residual #5262 is actually about: `logAdminAction` dropped the row
-    // with a `log.warn` when the internal-DB circuit breaker was open, and a
-    // raised `ATLAS_LOG_LEVEL` — itself runtime-mutable — then ate the warn.
+    // The residual #5262 is actually about: `logAdminAction` DROPS the row
+    // when the internal-DB circuit breaker is open, and past that breaker it
+    // emits nothing at any level — only an anonymous counter. The mechanism
+    // is stated once, in `lib/audit/settings-write.ts`'s header; this comment
+    // deliberately does not restate it, because round 1 corrected the header
+    // and left three restatements of the retracted version behind.
     // Awaiting the row turns a silently unrecorded config change into a
     // response the admin sees.
     const auditDown = () => {

--- a/packages/api/src/api/__tests__/admin-settings.test.ts
+++ b/packages/api/src/api/__tests__/admin-settings.test.ts
@@ -213,6 +213,19 @@ void mock.module("@atlas/api/lib/settings", () => ({
   isHotReloadedKey: mock(() => false),
   SECURITY_SENSITIVE_KEYS: new Set<string>(),
   securitySensitiveAuditFields: mock(() => undefined),
+  // #5270 — newly load-bearing: `lib/audit/settings-write.ts` resolves
+  // `redactAuditValue` from this module. A partial mock replaces the WHOLE
+  // module, so the moment anything in admin.ts's import graph reaches it,
+  // the omission surfaces as `undefined is not a function` several files from
+  // the cause. `securitySensitiveAuditLine` and `settingsCacheEverLoaded`
+  // were already missing; added for the same reason.
+  redactAuditValue: mock((_def: unknown, value: string | undefined) => ({
+    value,
+    masked: false,
+    maskReason: undefined,
+  })),
+  securitySensitiveAuditLine: mock(() => undefined),
+  settingsCacheEverLoaded: mock(() => true),
 }));
 
 // --- Import the app AFTER mocks ---
@@ -1379,6 +1392,99 @@ describe("admin settings routes", () => {
     });
   });
 
+  // ─── what the route hands the audit seam (#5270) ───────────────
+
+  describe("the route→seam audit contract (#5270)", () => {
+    // ⚠️ EVERY OTHER ASSERTION ON THIS SEAM IS `objectContaining({
+    // platformTier })`, which leaves `key`, `definition`, `value` and
+    // `action` unobserved. That matters because `definition` and `value` are
+    // the two inputs the redaction decision is made from, and both are
+    // type-legal to break in one word:
+    //
+    //   `definition: def` → `definition: undefined`
+    //        every write records `[withheld:secret-setting]` /
+    //        `unknown_definition` — the audit trail's usefulness is gone
+    //   `value` → `value: ""`
+    //        every write records an empty value
+    //
+    // Neither is a brand violation (the value still goes through
+    // `redactAuditValue`), so the type cannot see either. These are the
+    // seam-preserving edits the module docstring says the brand does not
+    // close.
+
+    it("⭐ PUT passes the full entry — key, definition, value, action, tier", async () => {
+      const res = await request("/api/v1/admin/settings/ATLAS_ROW_LIMIT", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ value: "500" }),
+      });
+      expect(res.status).toBe(200);
+      expect(mockAuditSettingsWrite).toHaveBeenCalledWith({
+        key: "ATLAS_ROW_LIMIT",
+        // The REAL definition for THIS key — not `undefined`, and not another
+        // key's entry (which the seam now withholds on; see
+        // `lib/audit/__tests__/settings-write.test.ts`).
+        definition: expect.objectContaining({ key: "ATLAS_ROW_LIMIT" }),
+        value: "500",
+        action: "update",
+        platformTier: expect.any(Boolean),
+        ipAddress: null,
+      });
+    });
+
+    it("⭐ DELETE passes action reset_to_default and NO value", async () => {
+      // The untested mirror half. `metadata.action` is the ONLY thing
+      // separating the two verbs in `admin_action_log` — `ADMIN_ACTIONS
+      // .settings` has a single member, so PUT and DELETE both file
+      // `settings.update`. Flipping this to "update" made every DELETE
+      // indistinguishable from a PUT with nothing red.
+      const res = await request("/api/v1/admin/settings/ATLAS_ROW_LIMIT", { method: "DELETE" });
+      expect(res.status).toBe(200);
+      expect(mockAuditSettingsWrite).toHaveBeenCalledWith({
+        key: "ATLAS_ROW_LIMIT",
+        definition: expect.objectContaining({ key: "ATLAS_ROW_LIMIT" }),
+        value: undefined,
+        action: "reset_to_default",
+        platformTier: expect.any(Boolean),
+        ipAddress: null,
+      });
+    });
+
+    it("⭐ neither verb writes a SECOND row through the fire-and-forget sink", async () => {
+      // Re-adding the old `logAdminAction({ …, metadata: { key, value, tier }
+      // })` next to the new call would restore the unredacted, workspace-
+      // scoped durable row while every other test stayed green. `mockLog
+      // AdminAction` was declared and cleared but never asserted on.
+      await request("/api/v1/admin/settings/ATLAS_ROW_LIMIT", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ value: "500" }),
+      });
+      await request("/api/v1/admin/settings/ATLAS_ROW_LIMIT", { method: "DELETE" });
+      expect(mockLogAdminAction).not.toHaveBeenCalled();
+    });
+
+    it("does NOT reach the seam at all when the secret-key gate 403s", async () => {
+      // ⚠️ THE REACHABILITY PREMISE, which had no test. `admin.ts` 403s a
+      // `secret: true` key before the write, which is why the seam's
+      // redaction is defense-in-depth rather than the live control #5270
+      // claimed. Pinning the gate here means that if it is ever relaxed — to
+      // let platform admins rotate a key from the UI, say — this test is what
+      // says the redaction has just become load-bearing.
+      // Uses the registry fixture's real `secret: true` entry rather than a
+      // hand-built definition — a fixture written for this test could agree
+      // with it by construction.
+      const res = await request("/api/v1/admin/settings/ANTHROPIC_API_KEY", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ value: "sk-ant-live-secret" }),
+      });
+      expect(res.status).toBe(403);
+      expect(mockAuditSettingsWrite).not.toHaveBeenCalled();
+      expect(mockSetSetting).not.toHaveBeenCalled();
+    });
+  });
+
   // ─── the audit row is awaited (#5262) ──────────────────────────
 
   describe("an audit row that cannot be committed (#5262)", () => {
@@ -1430,16 +1536,29 @@ describe("admin settings routes", () => {
         expect.any(String),
         undefined,
       );
+      // ⚠️ THE NEGATIVE, because the natural rollback is the OTHER verb.
+      // `toHaveBeenCalledTimes(1)` on setSetting catches a rollback written
+      // as a second `setSetting`; it cannot see `deleteSetting(key, …)` in
+      // the audit catch — which would make "already in effect" a lie while
+      // every assertion above stayed green.
+      expect(mockDeleteSetting).not.toHaveBeenCalled();
     });
 
     it("DELETE 500s the same way — the clear path is a write too", async () => {
       auditDown();
       const res = await request("/api/v1/admin/settings/ATLAS_ROW_LIMIT", { method: "DELETE" });
       expect(res.status).toBe(500);
-      const body = (await res.json()) as { error: string; message: string };
+      const body = (await res.json()) as { error: string; message: string; requestId: string };
       expect(body.error).toBe("audit_not_committed");
       expect(body.message).toContain("reset to its default");
+      expect(body.message).toContain("already in effect");
+      // The PUT twin asserts this; the DELETE one did not. Every 500 in this
+      // repo carries a requestId for log correlation, and this one more than
+      // most — it is the ONLY handle on a config change that was not audited.
+      expect(body.requestId).toBeTruthy();
       expect(mockDeleteSetting).toHaveBeenCalledTimes(1);
+      // The mirror of the PUT negative: no rollback via the other verb.
+      expect(mockSetSetting).not.toHaveBeenCalled();
     });
 
     it("stays 200 when the audit row commits — the arm that must NOT fail", async () => {

--- a/packages/api/src/api/routes/admin-prompts.ts
+++ b/packages/api/src/api/routes/admin-prompts.ts
@@ -42,9 +42,9 @@ const log = createLogger("admin-prompts");
  * name 500s instead. The existing tests cannot see it: they set `err.code`
  * directly on a hand-built rejection, a fixture agreeing with the assumption.
  * Surfaced by the #5271 review panel and NOT fixed there — it is pre-existing,
- * needs a `-pg` harness to settle, and changing two routes' error
- * classification is machinery this PR has no round left to review. Tracked in
- * #5272.
+ * needs a `-pg` harness to settle, and changing four call sites' error
+ * classification (two routes, two stores) is machinery this PR has no round
+ * left to review. Tracked in #5272.
  */
 function isUniqueViolation(err: unknown): boolean {
   return asUniqueViolation(err) !== undefined;

--- a/packages/api/src/api/routes/admin-prompts.ts
+++ b/packages/api/src/api/routes/admin-prompts.ts
@@ -10,7 +10,7 @@ import { Effect } from "effect";
 import type { Context as HonoContext } from "hono";
 import { createRoute, z } from "@hono/zod-openapi";
 import { createLogger } from "@atlas/api/lib/logger";
-import { PG_UNIQUE_VIOLATION } from "@atlas/api/lib/db/pg-errors";
+import { asUniqueViolation } from "@atlas/api/lib/db/pg-errors";
 import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
 import { runEffect } from "@atlas/api/lib/effect/hono";
 import { RequestContext, AuthContext } from "@atlas/api/lib/effect/services";
@@ -31,9 +31,23 @@ const log = createLogger("admin-prompts");
  * in the same workspace can't share a case-insensitive name. We translate the
  * violation into a typed result so create/rename routes can return a 409
  * instead of leaking a generic 500.
+ *
+ * ⚠️ **READS A FLAT TOP-LEVEL `code`, AND THIS ROUTE WRITES THROUGH
+ * `internalQuery`, WHICH MAY NOT PRODUCE ONE.** Once the Layer has booted,
+ * `internalQuery` goes through `Effect.runPromise(_sqlClient.unsafe(…))`
+ * (`db/internal.ts:768-773`), which rejects with a `FiberFailure` wrapping
+ * `SqlError` wrapping the pg `DatabaseError` — no top-level `code`. That is
+ * the shape `integrations/install/routing-id-conflict.ts` walks the `.cause`
+ * chain for. If it holds here, this 409 is dead in production and a duplicate
+ * name 500s instead. The existing tests cannot see it: they set `err.code`
+ * directly on a hand-built rejection, a fixture agreeing with the assumption.
+ * Surfaced by the #5271 review panel and NOT fixed there — it is pre-existing,
+ * needs a `-pg` harness to settle, and changing two routes' error
+ * classification is machinery this PR has no round left to review. Tracked in
+ * #5272.
  */
 function isUniqueViolation(err: unknown): boolean {
-  return (err as { code?: string } | null | undefined)?.code === PG_UNIQUE_VIOLATION;
+  return asUniqueViolation(err) !== undefined;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/api/src/api/routes/admin-prompts.ts
+++ b/packages/api/src/api/routes/admin-prompts.ts
@@ -10,6 +10,7 @@ import { Effect } from "effect";
 import type { Context as HonoContext } from "hono";
 import { createRoute, z } from "@hono/zod-openapi";
 import { createLogger } from "@atlas/api/lib/logger";
+import { PG_UNIQUE_VIOLATION } from "@atlas/api/lib/db/pg-errors";
 import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
 import { runEffect } from "@atlas/api/lib/effect/hono";
 import { RequestContext, AuthContext } from "@atlas/api/lib/effect/services";
@@ -25,14 +26,12 @@ import {
 const log = createLogger("admin-prompts");
 
 /**
- * SQLSTATE 23505 = unique_violation. The `prompt_collections_org_name_uniq`
- * index introduced in migration 0054 (#2169) collapses `COALESCE(org_id, '')`
- * + `lower(name)`, so two collections in the same workspace can't share a
- * case-insensitive name. We translate the violation into a typed result so
- * create/rename routes can return a 409 instead of leaking a generic 500.
+ * The `prompt_collections_org_name_uniq` index introduced in migration 0054
+ * (#2169) collapses `COALESCE(org_id, '')` + `lower(name)`, so two collections
+ * in the same workspace can't share a case-insensitive name. We translate the
+ * violation into a typed result so create/rename routes can return a 409
+ * instead of leaking a generic 500.
  */
-const PG_UNIQUE_VIOLATION = "23505";
-
 function isUniqueViolation(err: unknown): boolean {
   return (err as { code?: string } | null | undefined)?.code === PG_UNIQUE_VIOLATION;
 }

--- a/packages/api/src/api/routes/admin.ts
+++ b/packages/api/src/api/routes/admin.ts
@@ -3684,9 +3684,14 @@ function settingsAuditFailureBody(
   key: string,
   requestId: string,
   verb: string,
+  actorId: string | undefined,
 ): { error: string; message: string; requestId: string } {
+  // ⚠️ `actorId` is on this line because the row that would have carried it is
+  // the thing that was just lost. This log.error is the closest surviving
+  // record of an unaudited configuration change, and without the actor it
+  // takes a join on `requestId` against the earlier info line to answer "who".
   log.error(
-    { err: err instanceof Error ? err.message : String(err), requestId, key },
+    { err: err instanceof Error ? err.message : String(err), requestId, key, actorId },
     "Settings write succeeded but its admin_action_log row could not be committed",
   );
   return {
@@ -3843,11 +3848,26 @@ admin.openapi(updateSettingRoute, async (c) => runHandler(c, "save setting", asy
       definition: def,
       value,
       action: "update",
-      platformTier: effectiveOrgId === undefined,
+      // ⚠️ `!effectiveOrgId`, NOT `=== undefined`. #4669's `tier` metadata has
+      // always been `effectiveOrgId ? "workspace" : "platform"`, and this
+      // value now drives the row's `scope` column as well — so the two
+      // spellings disagree on exactly one input class:
+      //
+      //                     old tier    `=== undefined`   `!effectiveOrgId`
+      //   undefined         platform    platform          platform
+      //   "org-1"           workspace   workspace         workspace
+      //   ""                platform    WORKSPACE  ←      platform
+      //
+      // `activeOrganizationId` is typed `string | undefined`, so `""` is in
+      // the type. The changed row moves a GLOBAL-row write back onto the
+      // org-scoped `/admin/admin-actions` read API — the precise exposure
+      // this PR exists to close — so it is the non-conservative direction and
+      // the truthiness spelling is the one that preserves #4669's semantics.
+      platformTier: !effectiveOrgId,
       ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
     });
   } catch (err) {
-    return c.json(settingsAuditFailureBody(err, key, requestId, "updated"), 500);
+    return c.json(settingsAuditFailureBody(err, key, requestId, "updated", authResult.user?.id), 500);
   }
 
   return c.json({ success: true, key, value }, 200);
@@ -3938,11 +3958,26 @@ admin.openapi(deleteSettingRoute, async (c) => runHandler(c, "delete setting", a
       definition: def,
       value: undefined,
       action: "reset_to_default",
-      platformTier: effectiveOrgId === undefined,
+      // ⚠️ `!effectiveOrgId`, NOT `=== undefined`. #4669's `tier` metadata has
+      // always been `effectiveOrgId ? "workspace" : "platform"`, and this
+      // value now drives the row's `scope` column as well — so the two
+      // spellings disagree on exactly one input class:
+      //
+      //                     old tier    `=== undefined`   `!effectiveOrgId`
+      //   undefined         platform    platform          platform
+      //   "org-1"           workspace   workspace         workspace
+      //   ""                platform    WORKSPACE  ←      platform
+      //
+      // `activeOrganizationId` is typed `string | undefined`, so `""` is in
+      // the type. The changed row moves a GLOBAL-row write back onto the
+      // org-scoped `/admin/admin-actions` read API — the precise exposure
+      // this PR exists to close — so it is the non-conservative direction and
+      // the truthiness spelling is the one that preserves #4669's semantics.
+      platformTier: !effectiveOrgId,
       ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
     });
   } catch (err) {
-    return c.json(settingsAuditFailureBody(err, key, requestId, "reset to its default"), 500);
+    return c.json(settingsAuditFailureBody(err, key, requestId, "reset to its default", authResult.user?.id), 500);
   }
 
   return c.json({ success: true, key }, 200);

--- a/packages/api/src/api/routes/admin.ts
+++ b/packages/api/src/api/routes/admin.ts
@@ -3848,10 +3848,10 @@ admin.openapi(updateSettingRoute, async (c) => runHandler(c, "save setting", asy
       definition: def,
       value,
       action: "update",
-      // ⚠️ `!effectiveOrgId`, NOT `=== undefined`. #4669's `tier` metadata has
-      // always been `effectiveOrgId ? "workspace" : "platform"`, and this
-      // value now drives the row's `scope` column as well — so the two
-      // spellings disagree on exactly one input class:
+      // ⚠️ `!effectiveOrgId`, NOT `=== undefined`. #4669's `tier` metadata is
+      // `effectiveOrgId ? "workspace" : "platform"`, and this value now
+      // drives the row's `scope` column as well — so the two spellings
+      // disagree on exactly one input class:
       //
       //                     old tier    `=== undefined`   `!effectiveOrgId`
       //   undefined         platform    platform          platform
@@ -3859,10 +3859,17 @@ admin.openapi(updateSettingRoute, async (c) => runHandler(c, "save setting", asy
       //   ""                platform    WORKSPACE  ←      platform
       //
       // `activeOrganizationId` is typed `string | undefined`, so `""` is in
-      // the type. The changed row moves a GLOBAL-row write back onto the
-      // org-scoped `/admin/admin-actions` read API — the precise exposure
-      // this PR exists to close — so it is the non-conservative direction and
-      // the truthiness spelling is the one that preserves #4669's semantics.
+      // the type, and `setSetting`'s own checks are truthiness — so it writes
+      // the GLOBAL row. Under `=== undefined` that write would be filed as a
+      // WORKSPACE action, which is the audit-correctness defect this PR
+      // closes; the truthiness spelling preserves #4669's semantics exactly.
+      //
+      // ⚠️ It is NOT additionally a disclosure, and an earlier draft of this
+      // table said it was. `requireOrgContext` 400s on a falsy orgId
+      // (`admin-router.ts`), so no session can ever query an `org_id = ''`
+      // row through `/admin/admin-actions`. The row would be misfiled, not
+      // readable. Correct fix, wrong stated reason — worth recording, since
+      // the reason is what a later reader checks.
       platformTier: !effectiveOrgId,
       ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
     });
@@ -3958,21 +3965,8 @@ admin.openapi(deleteSettingRoute, async (c) => runHandler(c, "delete setting", a
       definition: def,
       value: undefined,
       action: "reset_to_default",
-      // ⚠️ `!effectiveOrgId`, NOT `=== undefined`. #4669's `tier` metadata has
-      // always been `effectiveOrgId ? "workspace" : "platform"`, and this
-      // value now drives the row's `scope` column as well — so the two
-      // spellings disagree on exactly one input class:
-      //
-      //                     old tier    `=== undefined`   `!effectiveOrgId`
-      //   undefined         platform    platform          platform
-      //   "org-1"           workspace   workspace         workspace
-      //   ""                platform    WORKSPACE  ←      platform
-      //
-      // `activeOrganizationId` is typed `string | undefined`, so `""` is in
-      // the type. The changed row moves a GLOBAL-row write back onto the
-      // org-scoped `/admin/admin-actions` read API — the precise exposure
-      // this PR exists to close — so it is the non-conservative direction and
-      // the truthiness spelling is the one that preserves #4669's semantics.
+      // `!effectiveOrgId`, not `=== undefined` — same as PUT; see the table
+      // at the PUT handler for the input class where the two disagree.
       platformTier: !effectiveOrgId,
       ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
     });

--- a/packages/api/src/api/routes/admin.ts
+++ b/packages/api/src/api/routes/admin.ts
@@ -19,6 +19,7 @@ import type { AuthResult, AuthenticatedResult } from "@atlas/api/lib/auth/types"
 import { authenticateRequest } from "@atlas/api/lib/auth/middleware";
 import { invalidatePasswordGate } from "@atlas/api/lib/auth/password-gate";
 import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
+import { auditSettingsWrite } from "@atlas/api/lib/audit/settings-write";
 import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
 import { connections } from "@atlas/api/lib/db/connection";
 import {
@@ -3666,6 +3667,35 @@ admin.openapi(getSettingsRoute, async (c) => runHandler(c, "list settings", asyn
   return c.json({ settings, manageable, deployMode, regionApiUrl }, 200);
 }));
 
+/**
+ * The 500 both settings verbs return when their audit row cannot be committed
+ * (#5262).
+ *
+ * ⚠️ IT SAYS THE WRITE LANDED. `auditSettingsWrite` runs AFTER `setSetting` /
+ * `deleteSetting` have succeeded and the in-process cache has already been
+ * updated, so the setting really did change — a generic "something went wrong"
+ * here would tell an admin the opposite of what happened and invite a retry
+ * that double-applies nothing but also never gets recorded. The actionable
+ * part is the reconciliation, not a retry: the change is live and the log does
+ * not have it.
+ */
+function settingsAuditFailureBody(
+  err: unknown,
+  key: string,
+  requestId: string,
+  verb: string,
+): { error: string; message: string; requestId: string } {
+  log.error(
+    { err: err instanceof Error ? err.message : String(err), requestId, key },
+    "Settings write succeeded but its admin_action_log row could not be committed",
+  );
+  return {
+    error: "audit_not_committed",
+    message: `"${key}" was ${verb}, and the change is already in effect — but the admin action-log entry recording it could not be written, so this change is currently unaudited. Check the internal database's health, then re-apply the setting to produce a logged entry.`,
+    requestId,
+  };
+}
+
 admin.openapi(updateSettingRoute, async (c) => runHandler(c, "save setting", async () => {
 
   const { key } = c.req.valid("param");
@@ -3802,16 +3832,23 @@ admin.openapi(updateSettingRoute, async (c) => runHandler(c, "save setting", asy
   }
   log.info({ requestId, key, orgId: effectiveOrgId, actorId: authResult.user?.id }, "Setting override saved via admin API");
 
-  logAdminAction({
-    actionType: ADMIN_ACTIONS.settings.update,
-    targetType: "settings",
-    targetId: key,
-    ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
-    // #4669 — record which tier the write landed on (global row vs the
-    // session workspace's row) so platform-tier flips are distinguishable
-    // in the audit trail.
-    metadata: { key, value, tier: effectiveOrgId ? "workspace" : "platform" },
-  });
+  // #5270/#5262 — the whole entry is built inside `auditSettingsWrite`: it
+  // redacts a `secret: true` value, stamps `scope` from the tier (#4669's
+  // metadata annotation now drives the row's scope column too), and AWAITS
+  // the row. Handing it the definition and the raw value rather than a
+  // metadata object is what makes re-inlining the plaintext a type error.
+  try {
+    await auditSettingsWrite({
+      key,
+      definition: def,
+      value,
+      action: "update",
+      platformTier: effectiveOrgId === undefined,
+      ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
+    });
+  } catch (err) {
+    return c.json(settingsAuditFailureBody(err, key, requestId, "updated"), 500);
+  }
 
   return c.json({ success: true, key, value }, 200);
 }));
@@ -3892,14 +3929,21 @@ admin.openapi(deleteSettingRoute, async (c) => runHandler(c, "delete setting", a
   }
   log.info({ requestId, key, orgId: effectiveOrgId, actorId: authResult.user?.id }, "Setting override removed via admin API");
 
-  logAdminAction({
-    actionType: ADMIN_ACTIONS.settings.update,
-    targetType: "settings",
-    targetId: key,
-    ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
-    // #4669 — same tier annotation as PUT (see there).
-    metadata: { key, action: "reset_to_default", tier: effectiveOrgId ? "workspace" : "platform" },
-  });
+  // #5270/#5262 — same seam as PUT. `value: undefined` is the clear path and
+  // records no value field: what it reverted TO is the env/default, which is
+  // exactly as secret as the override was.
+  try {
+    await auditSettingsWrite({
+      key,
+      definition: def,
+      value: undefined,
+      action: "reset_to_default",
+      platformTier: effectiveOrgId === undefined,
+      ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
+    });
+  } catch (err) {
+    return c.json(settingsAuditFailureBody(err, key, requestId, "reset to its default"), 500);
+  }
 
   return c.json({ success: true, key }, 200);
 }));

--- a/packages/api/src/api/routes/sub-processor-subscriptions.ts
+++ b/packages/api/src/api/routes/sub-processor-subscriptions.ts
@@ -24,6 +24,7 @@ import { AuthContext, RequestContext } from "@atlas/api/lib/effect/services";
 import { hasInternalDB } from "@atlas/api/lib/db/internal";
 import { isSafeExternalUrl } from "@atlas/api/lib/sandbox/validate";
 import { createLogger } from "@atlas/api/lib/logger";
+import { PG_UNIQUE_VIOLATION } from "@atlas/api/lib/db/pg-errors";
 import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
 import { createSubscription } from "@atlas/api/lib/sub-processor-publisher";
 
@@ -36,8 +37,6 @@ import { standardAuth, requestContext, type AuthEnv } from "./middleware";
 import { validationHook } from "./validation-hook";
 
 const log = createLogger("sub-processor-subscriptions");
-
-const PG_UNIQUE_VIOLATION = "23505";
 
 const CreateSubscriptionBodySchema = z.object({
   url: z

--- a/packages/api/src/api/routes/sub-processor-subscriptions.ts
+++ b/packages/api/src/api/routes/sub-processor-subscriptions.ts
@@ -24,7 +24,7 @@ import { AuthContext, RequestContext } from "@atlas/api/lib/effect/services";
 import { hasInternalDB } from "@atlas/api/lib/db/internal";
 import { isSafeExternalUrl } from "@atlas/api/lib/sandbox/validate";
 import { createLogger } from "@atlas/api/lib/logger";
-import { PG_UNIQUE_VIOLATION } from "@atlas/api/lib/db/pg-errors";
+import { asUniqueViolation } from "@atlas/api/lib/db/pg-errors";
 import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
 import { createSubscription } from "@atlas/api/lib/sub-processor-publisher";
 
@@ -146,9 +146,17 @@ router.openapi(createSubscriptionRoute, async (c) => {
           // Match by SQLSTATE, not error message — the message is locale-
           // and pg-version dependent. Same precedent as
           // packages/api/src/lib/starter-prompts/favorite-store.ts and
-          // packages/api/src/lib/suggestions/approval-store.ts.
-          const code = (err as { code?: string } | undefined)?.code;
-          if (code === PG_UNIQUE_VIOLATION) {
+          // packages/api/src/lib/suggestions/approval-store.ts (both of which
+          // now import the shared constant from `db/pg-errors.ts`).
+          //
+          // ⚠️ FLAT `code`, and this path writes through `internalQuery`,
+          // which wraps the driver error under `.cause` once the Layer has
+          // booted — so this `duplicate` arm may be dead in production and a
+          // duplicate URL may 500 instead. Same hazard as
+          // `admin-prompts.ts`'s `isUniqueViolation`; see the note there.
+          // Pre-existing, surfaced by the #5271 review panel, tracked in
+          // #5272.
+          if (asUniqueViolation(err) !== undefined) {
             return { kind: "duplicate" };
           }
           throw err instanceof Error ? err : new Error(String(err));

--- a/packages/api/src/lib/audit/__tests__/settings-write.test.ts
+++ b/packages/api/src/lib/audit/__tests__/settings-write.test.ts
@@ -8,7 +8,8 @@
  *  2. a platform-tier write is stamped `scope: "platform"`, so it stays off
  *     the org-scoped `/admin/admin-actions` read API
  *  3. the row is AWAITED — a rejection propagates to the caller instead of
- *     being dropped with a `log.warn` the operator may have silenced
+ *     being dropped silently (the mechanism is in `settings-write.ts`'s
+ *     header; #5262's stated one was measured false)
  *
  * ⚠️ CLAIM 1 NEEDS A REGISTRY KEY THAT IS ACTUALLY `secret: true`, and it
  * needs redacted and raw to DIFFER on it. This is the trap #5180 documented:
@@ -19,7 +20,7 @@
  * not the placeholder.
  */
 
-import { describe, expect, it, mock, beforeEach } from "bun:test";
+import { describe, expect, it, mock, beforeEach, afterEach } from "bun:test";
 
 interface AwaitedEntry {
   readonly actionType: string;
@@ -50,6 +51,46 @@ void mock.module("@atlas/api/lib/audit/admin", () => ({
   },
 }));
 
+/**
+ * ⚠️ ONE SINK CARRYING THE LEVEL, for the same reason the seeder collision
+ * suite has one: a per-level array cannot see a `log.warn` demoted to
+ * `log.info`, and the mismatch guard's ENTIRE operator-visible signal is its
+ * level. Mock-all-exports per the repo rule.
+ */
+interface LoggedCall {
+  readonly level: "info" | "warn" | "error" | "debug";
+  readonly payload: unknown;
+  readonly message: string;
+}
+const logged: LoggedCall[] = [];
+const record =
+  (level: LoggedCall["level"]) =>
+  (payload: unknown, message?: string): void => {
+    logged.push({
+      level,
+      payload,
+      message: typeof payload === "string" ? payload : (message ?? ""),
+    });
+  };
+const stubLogger = {
+  info: record("info"),
+  warn: record("warn"),
+  error: record("error"),
+  debug: record("debug"),
+};
+void mock.module("@atlas/api/lib/logger", () => ({
+  ACTOR_KINDS: ["human", "agent", "mcp", "scheduler", "api_key"] as const,
+  createLogger: () => stubLogger,
+  getLogger: () => stubLogger,
+  getRequestContext: () => undefined,
+  withRequestContext: <T,>(_ctx: unknown, fn: () => T): T => fn(),
+  redactPaths: [] as string[],
+  scrubErrSerializer: (value: unknown) => value,
+  scrubLogFormatter: (obj: unknown) => obj,
+  hashShareToken: () => "",
+  setLogLevel: () => false,
+}));
+
 const { auditSettingsWrite } = await import("@atlas/api/lib/audit/settings-write");
 const { getSettingDefinition } = await import("@atlas/api/lib/settings");
 
@@ -58,17 +99,37 @@ const SECRET_DEF = getSettingDefinition("RESEND_API_KEY");
 /** A real non-secret entry, so the verbatim arm is exercised against the registry too. */
 const PLAIN_DEF = getSettingDefinition("ATLAS_MODEL");
 
-const SECRET_VALUE = "re_live_51H8xQ2eZvKYlo2C_not_a_placeholder";
+// ⚠️ Deliberately NOT a real provider prefix. `re_live_…` is Resend's live-key
+// shape and GitHub push protection scans for it — a fabricated value that trips
+// a secret scanner costs a CI round for nothing.
+const SECRET_VALUE = "resend_fake_51H8xQ2eZvKYlo2C_not_a_placeholder";
 const WITHHELD = "[withheld:secret-setting]";
 
 const lastAwaited = (): AwaitedEntry => awaited[awaited.length - 1]!;
 const meta = (): Record<string, unknown> => lastAwaited().metadata ?? {};
 
+let savedDbUrl: string | undefined;
+
 describe("auditSettingsWrite", () => {
   beforeEach(() => {
     awaited.length = 0;
     fireAndForget.length = 0;
+    logged.length = 0;
     awaitRejectsWith = undefined;
+    // ⚠️ `auditSettingsWrite` returns EARLY without a row when
+    // `hasInternalDB()` is false, and that is a pure
+    // `!!process.env.DATABASE_URL` read. Unit runs have no DATABASE_URL, so
+    // without this every test in this file exercises the no-DB arm and
+    // asserts against an entry that was never recorded — which is exactly
+    // what happened when the guard was added. Set per-test and restored in
+    // `afterEach`, never at module scope (the repo's self-containment rule).
+    savedDbUrl = process.env.DATABASE_URL;
+    process.env.DATABASE_URL = "postgresql://unit-test/not-connected";
+  });
+
+  afterEach(() => {
+    if (savedDbUrl === undefined) delete process.env.DATABASE_URL;
+    else process.env.DATABASE_URL = savedDbUrl;
   });
 
   it("the fixture is sound — the registry entries this file relies on are what it claims", () => {
@@ -163,6 +224,70 @@ describe("auditSettingsWrite", () => {
       // unable to produce it.
       expect(meta().maskReason).toBe("definition_mismatch");
       expect(JSON.stringify(lastAwaited())).not.toContain(SECRET_VALUE);
+    });
+
+    it("⭐ WARNS on a mismatch — the event is not left to one JSONB field", async () => {
+      // Round 1 recorded the mismatch only in `metadata.maskReason`: one field
+      // of one audit row, which nothing alerts on and nobody greps. A
+      // definition that does not belong to its key is a PROGRAMMER bug —
+      // registry drift, an alias resolver, a `def` reused across keys in a
+      // loop — and detecting it while saying nothing is the swallow this
+      // module's header is about.
+      await auditSettingsWrite({
+        key: "RESEND_API_KEY",
+        definition: PLAIN_DEF,
+        value: SECRET_VALUE,
+        action: "update",
+        platformTier: true,
+        ipAddress: null,
+      });
+      const warns = logged.filter((c) => c.level === "warn");
+      expect(warns).toHaveLength(1);
+      expect(warns[0]?.payload).toMatchObject({
+        key: "RESEND_API_KEY",
+        definitionKey: "ATLAS_MODEL",
+        maskReason: "definition_mismatch",
+      });
+      // The message must say it is a CALLER bug, not a data condition — the
+      // remedy is different and the operator reads the message.
+      expect(warns[0]?.message).toContain("caller bug");
+      // ⚠️ And the warn must not carry the value it just withheld.
+      expect(JSON.stringify(warns[0])).not.toContain(SECRET_VALUE);
+    });
+
+    it("⭐ WARNS on a mismatch even on reset_to_default, where there is no value to mark", async () => {
+      // The arm round 1's fix could not reach at all: with `value: undefined`
+      // the whole metadata block is skipped, so `mismatched` was computed,
+      // found true, and DISCARDED. A clear filed against the wrong registry
+      // entry was indistinguishable from a correct one.
+      await auditSettingsWrite({
+        key: "RESEND_API_KEY",
+        definition: PLAIN_DEF,
+        action: "reset_to_default",
+        platformTier: true,
+        ipAddress: null,
+      });
+      const warns = logged.filter((c) => c.level === "warn");
+      expect(warns).toHaveLength(1);
+      expect(warns[0]?.payload).toMatchObject({ action: "reset_to_default" });
+      // No value field exists to carry `maskReason`, which is precisely why
+      // the log line has to.
+      expect("value" in meta()).toBe(false);
+      expect("maskReason" in meta()).toBe(false);
+    });
+
+    it("does NOT warn when the definition matches — the discriminating half", async () => {
+      // A guard that warned unconditionally would pass both tests above and
+      // fill the stream with noise on every settings write.
+      await auditSettingsWrite({
+        key: "ATLAS_MODEL",
+        definition: PLAIN_DEF,
+        value: "claude-opus-5",
+        action: "update",
+        platformTier: true,
+        ipAddress: null,
+      });
+      expect(logged.filter((c) => c.level === "warn")).toHaveLength(0);
     });
 
     it("a definition whose key MATCHES is still used — the guard is not a blanket withhold", async () => {
@@ -274,10 +399,42 @@ describe("auditSettingsWrite", () => {
       expect(fireAndForget).toHaveLength(0);
     });
 
+    it("⭐ says NOT PERSISTED rather than COMMITTED when there is no internal DB", async () => {
+      // `logAdminActionAwait` resolves without inserting when the internal DB
+      // is absent, so the post-commit line would otherwise announce a row
+      // that was never written. Unreachable through today's two callers
+      // (both 404 first), but the header invites three more writers to adopt
+      // this seam, and a log line confidently naming a nonexistent row is
+      // worse than no line.
+      // ⚠️ `hasInternalDB()` is a pure `!!process.env.DATABASE_URL` read, so
+      // this needs no module mock — which matters, because a PARTIAL
+      // `mock.module("@atlas/api/lib/db/internal")` replaces every one of its
+      // exports and breaks `lib/settings.ts`'s `internalQuery` import several
+      // files away from the cause. Measured: that is exactly what happened on
+      // the first draft of this test.
+      delete process.env.DATABASE_URL;
+      await auditSettingsWrite({
+        key: "ATLAS_MODEL",
+        definition: PLAIN_DEF,
+        value: "claude-opus-5",
+        action: "update",
+        platformTier: true,
+        ipAddress: null,
+      });
+      expect(awaited).toHaveLength(0);
+      const warns = logged.filter((c) => c.level === "warn");
+      expect(warns).toHaveLength(1);
+      expect(warns[0]?.message).toContain("NOT persisted");
+      expect(logged.filter((c) => c.message.includes("COMMITTED"))).toHaveLength(0);
+    });
+
     it("⭐ propagates a rejection instead of swallowing it", async () => {
       // The whole point of the await: when the row cannot be committed the
-      // caller has to find out. `logAdminAction` would have dropped this with
-      // a `log.warn` — which a raised ATLAS_LOG_LEVEL then eats.
+      // caller has to find out. `logAdminAction` drops it instead — and past
+      // an open circuit breaker it does so with NO log line at any level
+      // (`db/internal.ts`), leaving only an anonymous counter. See the
+      // module header; do not restate the mechanism here, restatements are
+      // what went stale last round.
       awaitRejectsWith = new Error("circuit breaker open");
       await expect(
         auditSettingsWrite({

--- a/packages/api/src/lib/audit/__tests__/settings-write.test.ts
+++ b/packages/api/src/lib/audit/__tests__/settings-write.test.ts
@@ -77,6 +77,13 @@ describe("auditSettingsWrite", () => {
     // would make claim 1 pass for the wrong reason.
     expect(SECRET_DEF?.secret).toBe(true);
     expect(SECRET_DEF?.scope).toBe("platform");
+    // ⚠️ `toBeDefined` FIRST. `expect(PLAIN_DEF?.secret).toBeFalsy()` passes
+    // when `PLAIN_DEF` is `undefined` — the optional chain yields `undefined`,
+    // which is falsy — so a renamed registry key would make this file assert
+    // against a missing definition and every "verbatim arm" test below would
+    // pass through the fail-closed arm instead. That is the exact
+    // passes-for-the-wrong-reason class this block exists to prevent.
+    expect(PLAIN_DEF).toBeDefined();
     expect(PLAIN_DEF?.secret).toBeFalsy();
   });
 
@@ -130,6 +137,47 @@ describe("auditSettingsWrite", () => {
       expect(meta().value).toBe(WITHHELD);
       expect(meta().maskReason).toBe("unknown_definition");
       expect(JSON.stringify(lastAwaited())).not.toContain(SECRET_VALUE);
+    });
+
+    it("⭐ withholds when the definition belongs to a DIFFERENT key", async () => {
+      // The cheap defeat of the brand, and this module shipped without the
+      // guard its #5180 sibling has. The brand fences the OUTPUT of the
+      // redaction decision; corrupting its INPUT needs no cast. A real
+      // definition for the wrong key is far easier to produce than the
+      // fabricated one #5180 reasoned about — an alias or rename resolver
+      // hands you one.
+      await auditSettingsWrite({
+        key: "RESEND_API_KEY",
+        definition: PLAIN_DEF, // ATLAS_MODEL's entry: secret: false
+        value: SECRET_VALUE,
+        action: "update",
+        platformTier: true,
+        ipAddress: null,
+      });
+      expect(meta().value).toBe(WITHHELD);
+      expect(meta().valueMasked).toBe(true);
+      // ⚠️ The REASON, not just the withholding. "registry drift" and "the
+      // call site passed the wrong entry" send an operator to different
+      // places — which is why `AuditMaskReason` has three arms and not two.
+      // This module advertised `definition_mismatch` in its type while being
+      // unable to produce it.
+      expect(meta().maskReason).toBe("definition_mismatch");
+      expect(JSON.stringify(lastAwaited())).not.toContain(SECRET_VALUE);
+    });
+
+    it("a definition whose key MATCHES is still used — the guard is not a blanket withhold", async () => {
+      // The discriminating half. A guard that discarded every definition
+      // would pass the test above and withhold every value in the product.
+      await auditSettingsWrite({
+        key: "ATLAS_MODEL",
+        definition: PLAIN_DEF,
+        value: "claude-opus-5",
+        action: "update",
+        platformTier: true,
+        ipAddress: null,
+      });
+      expect(meta().value).toBe("claude-opus-5");
+      expect(meta().maskReason).toBeUndefined();
     });
 
     it("withholds the EMPTY secret like any other — no one-bit oracle", async () => {

--- a/packages/api/src/lib/audit/__tests__/settings-write.test.ts
+++ b/packages/api/src/lib/audit/__tests__/settings-write.test.ts
@@ -1,0 +1,264 @@
+/**
+ * #5270 / #5262 — the settings-write audit seam.
+ *
+ * Three claims, and they fail in different places, so they are asserted
+ * separately rather than through one "the entry looks right" check:
+ *
+ *  1. a `secret: true` value never reaches `admin_action_log.metadata`
+ *  2. a platform-tier write is stamped `scope: "platform"`, so it stays off
+ *     the org-scoped `/admin/admin-actions` read API
+ *  3. the row is AWAITED — a rejection propagates to the caller instead of
+ *     being dropped with a `log.warn` the operator may have silenced
+ *
+ * ⚠️ CLAIM 1 NEEDS A REGISTRY KEY THAT IS ACTUALLY `secret: true`, and it
+ * needs redacted and raw to DIFFER on it. This is the trap #5180 documented:
+ * for a key whose value is not secret, the redacted and raw strings are
+ * identical, so an assertion comparing them passes under a fix and under its
+ * removal alike. Every claim-1 test below therefore drives a real
+ * `secret: true` definition (`RESEND_API_KEY`) with a value that is visibly
+ * not the placeholder.
+ */
+
+import { describe, expect, it, mock, beforeEach } from "bun:test";
+
+interface AwaitedEntry {
+  readonly actionType: string;
+  readonly targetType: string;
+  readonly targetId: string;
+  readonly scope?: string;
+  readonly metadata?: Record<string, unknown>;
+  readonly ipAddress?: string | null;
+}
+
+const awaited: AwaitedEntry[] = [];
+const fireAndForget: AwaitedEntry[] = [];
+let awaitRejectsWith: Error | undefined;
+
+/**
+ * ⚠️ BOTH SINKS, kept apart on purpose. A single "was the audit called" array
+ * cannot see `logAdminActionAwait` swapped back to `logAdminAction` — which is
+ * exactly defect (3), and which no assertion on the metadata would notice
+ * because the entry is byte-identical either way.
+ */
+void mock.module("@atlas/api/lib/audit/admin", () => ({
+  logAdminAction: (entry: AwaitedEntry) => {
+    fireAndForget.push(entry);
+  },
+  logAdminActionAwait: async (entry: AwaitedEntry) => {
+    awaited.push(entry);
+    if (awaitRejectsWith) throw awaitRejectsWith;
+  },
+}));
+
+const { auditSettingsWrite } = await import("@atlas/api/lib/audit/settings-write");
+const { getSettingDefinition } = await import("@atlas/api/lib/settings");
+
+/** A real `secret: true`, `scope: "platform"` registry entry. */
+const SECRET_DEF = getSettingDefinition("RESEND_API_KEY");
+/** A real non-secret entry, so the verbatim arm is exercised against the registry too. */
+const PLAIN_DEF = getSettingDefinition("ATLAS_MODEL");
+
+const SECRET_VALUE = "re_live_51H8xQ2eZvKYlo2C_not_a_placeholder";
+const WITHHELD = "[withheld:secret-setting]";
+
+const lastAwaited = (): AwaitedEntry => awaited[awaited.length - 1]!;
+const meta = (): Record<string, unknown> => lastAwaited().metadata ?? {};
+
+describe("auditSettingsWrite", () => {
+  beforeEach(() => {
+    awaited.length = 0;
+    fireAndForget.length = 0;
+    awaitRejectsWith = undefined;
+  });
+
+  it("the fixture is sound — the registry entries this file relies on are what it claims", () => {
+    // Without this the whole suite could be asserting against `undefined`
+    // definitions, which land in `redactAuditValue`'s fail-closed arm and
+    // would make claim 1 pass for the wrong reason.
+    expect(SECRET_DEF?.secret).toBe(true);
+    expect(SECRET_DEF?.scope).toBe("platform");
+    expect(PLAIN_DEF?.secret).toBeFalsy();
+  });
+
+  describe("1 — the value", () => {
+    it("⭐ withholds a `secret: true` value instead of recording it verbatim", async () => {
+      await auditSettingsWrite({
+        key: "RESEND_API_KEY",
+        definition: SECRET_DEF,
+        value: SECRET_VALUE,
+        action: "update",
+        platformTier: true,
+        ipAddress: null,
+      });
+
+      expect(meta().value).toBe(WITHHELD);
+      expect(meta().valueMasked).toBe(true);
+      expect(meta().maskReason).toBe("secret");
+      // ⚠️ THE NEGATIVE TOO, and not only on `metadata.value`: the whole
+      // serialized entry, because a future field ("previousValue",
+      // "diff", …) that carried the plaintext would satisfy the assertion
+      // above and still be the breach.
+      expect(JSON.stringify(lastAwaited())).not.toContain(SECRET_VALUE);
+    });
+
+    it("records a non-secret value verbatim — the arm that must NOT be withheld", async () => {
+      // The other half of the claim. A module that withheld unconditionally
+      // would pass the test above and destroy the audit trail's usefulness.
+      await auditSettingsWrite({
+        key: "ATLAS_MODEL",
+        definition: PLAIN_DEF,
+        value: "claude-opus-5",
+        action: "update",
+        platformTier: true,
+        ipAddress: null,
+      });
+      expect(meta().value).toBe("claude-opus-5");
+      expect(meta().valueMasked).toBe(false);
+      expect(meta().maskReason).toBeUndefined();
+    });
+
+    it("fails closed on a key with no registry definition", async () => {
+      // "We could not tell whether it is secret" is not a licence to print.
+      await auditSettingsWrite({
+        key: "ATLAS_SOMETHING_RENAMED",
+        definition: undefined,
+        value: SECRET_VALUE,
+        action: "update",
+        platformTier: true,
+        ipAddress: null,
+      });
+      expect(meta().value).toBe(WITHHELD);
+      expect(meta().maskReason).toBe("unknown_definition");
+      expect(JSON.stringify(lastAwaited())).not.toContain(SECRET_VALUE);
+    });
+
+    it("withholds the EMPTY secret like any other — no one-bit oracle", async () => {
+      // `value: undefined` where every other secret reads `[withheld…]` would
+      // disclose the empty secret exactly. `action` carries set-vs-clear.
+      await auditSettingsWrite({
+        key: "RESEND_API_KEY",
+        definition: SECRET_DEF,
+        value: "",
+        action: "update",
+        platformTier: true,
+        ipAddress: null,
+      });
+      expect(meta().value).toBe(WITHHELD);
+      expect(meta().valueMasked).toBe(true);
+    });
+
+    it("the reset_to_default path carries NO value field at all", async () => {
+      await auditSettingsWrite({
+        key: "RESEND_API_KEY",
+        definition: SECRET_DEF,
+        value: undefined,
+        action: "reset_to_default",
+        platformTier: true,
+        ipAddress: null,
+      });
+      expect(meta().action).toBe("reset_to_default");
+      expect("value" in meta()).toBe(false);
+      expect("valueMasked" in meta()).toBe(false);
+    });
+  });
+
+  describe("2 — the scope", () => {
+    it("⭐ stamps a platform-tier write `scope: \"platform\"`", async () => {
+      // The default is "workspace" for any non-systemActor write, which put
+      // these rows on the org-scoped `/admin/admin-actions` read API. The
+      // entry must say platform EXPLICITLY, not rely on the default.
+      await auditSettingsWrite({
+        key: "RESEND_API_KEY",
+        definition: SECRET_DEF,
+        value: SECRET_VALUE,
+        action: "update",
+        platformTier: true,
+        ipAddress: null,
+      });
+      expect(lastAwaited().scope).toBe("platform");
+      expect(meta().tier).toBe("platform");
+    });
+
+    it("leaves a workspace-tier write `scope: \"workspace\"`", async () => {
+      // The discriminating half: a module that hardcoded "platform" would
+      // hide genuine workspace settings activity from the workspace's own
+      // audit view, which is a different bug in the opposite direction.
+      await auditSettingsWrite({
+        key: "ATLAS_MODEL",
+        definition: PLAIN_DEF,
+        value: "claude-opus-5",
+        action: "update",
+        platformTier: false,
+        ipAddress: null,
+      });
+      expect(lastAwaited().scope).toBe("workspace");
+      expect(meta().tier).toBe("workspace");
+    });
+
+    it("scope and tier agree — one fact, not two that can drift", async () => {
+      for (const platformTier of [true, false]) {
+        await auditSettingsWrite({
+          key: "ATLAS_MODEL",
+          definition: PLAIN_DEF,
+          value: "x",
+          action: "update",
+          platformTier,
+          ipAddress: null,
+        });
+        expect(lastAwaited().scope).toBe(meta().tier as string);
+      }
+    });
+  });
+
+  describe("3 — the await", () => {
+    it("⭐ uses the AWAITING variant, never fire-and-forget", async () => {
+      await auditSettingsWrite({
+        key: "ATLAS_MODEL",
+        definition: PLAIN_DEF,
+        value: "claude-opus-5",
+        action: "update",
+        platformTier: true,
+        ipAddress: null,
+      });
+      expect(awaited).toHaveLength(1);
+      // ⚠️ Different lengths (1 vs 0), so the two sinks cannot be swapped
+      // without a count disagreeing.
+      expect(fireAndForget).toHaveLength(0);
+    });
+
+    it("⭐ propagates a rejection instead of swallowing it", async () => {
+      // The whole point of the await: when the row cannot be committed the
+      // caller has to find out. `logAdminAction` would have dropped this with
+      // a `log.warn` — which a raised ATLAS_LOG_LEVEL then eats.
+      awaitRejectsWith = new Error("circuit breaker open");
+      await expect(
+        auditSettingsWrite({
+          key: "ATLAS_MODEL",
+          definition: PLAIN_DEF,
+          value: "claude-opus-5",
+          action: "update",
+          platformTier: true,
+          ipAddress: null,
+        }),
+      ).rejects.toThrow(/circuit breaker open/);
+    });
+  });
+
+  it("carries the action type, target and IP the forensic queries pivot on", async () => {
+    await auditSettingsWrite({
+      key: "ATLAS_MODEL",
+      definition: PLAIN_DEF,
+      value: "claude-opus-5",
+      action: "update",
+      platformTier: false,
+      ipAddress: "203.0.113.7",
+    });
+    expect(lastAwaited()).toMatchObject({
+      actionType: "settings.update",
+      targetType: "settings",
+      targetId: "ATLAS_MODEL",
+      ipAddress: "203.0.113.7",
+    });
+    expect(meta().key).toBe("ATLAS_MODEL");
+  });
+});

--- a/packages/api/src/lib/audit/admin.ts
+++ b/packages/api/src/lib/audit/admin.ts
@@ -5,8 +5,8 @@
  * admin_action_log table (when DATABASE_URL is set). Fire-and-forget DB
  * writes — two layers of protection:
  *
- * 1. internalExecute() returns a promise whose rejections are swallowed
- *    (async errors — the .catch prevents unhandled rejection crashes).
+ * 1. internalExecute() returns void and handles its own async rejections
+ *    internally (its `.catch` prevents unhandled rejection crashes).
  * 2. The surrounding try/catch covers synchronous throws from getInternalDB()
  *    (e.g. pool not initialized).
  *

--- a/packages/api/src/lib/audit/settings-write.ts
+++ b/packages/api/src/lib/audit/settings-write.ts
@@ -1,0 +1,173 @@
+/**
+ * The one seam through which a settings write reaches `admin_action_log`
+ * (#5270, #5262).
+ *
+ * ⚠️ **THREE DEFECTS SHARED ONE CALL SITE**, and each is only half-closed by
+ * fixing the others, which is why they land together:
+ *
+ * 1. **The value was recorded verbatim.** `PUT /admin/settings/{key}` passed
+ *    `metadata: { key, value, tier }` with the raw string, so writing any of
+ *    the seven `secret: true` registry keys — `RESEND_API_KEY`,
+ *    `ANTHROPIC_API_KEY`, `DATABASE_URL`, `ATLAS_DATASOURCE_URL`, … — put the
+ *    plaintext credential in a DB row. Two of the three surfaces that show a
+ *    settings value already withhold it: the read path masks
+ *    (`getSettingsForAdmin` → `maskSecret`), and #5180 redacted the
+ *    `security_setting.changed` log line. This one, the DURABLE surface, did
+ *    neither. `redactPaths` does not cover it either: pino redacts on FIELD
+ *    NAME (`apiKey`, `clientSecret`, `serverToken`, …) and this field is
+ *    called `value`, nested under `metadata`, so the pino line leaked too.
+ *
+ * 2. **The row was stamped `scope: "workspace"`.** `resolveEntry` defaults
+ *    scope to `"workspace"` for any non-`systemActor` write, and neither
+ *    settings call site passed one — unlike `admin-abuse.ts`,
+ *    `admin-connections.ts`, `admin-marketplace.ts` and
+ *    `admin-operator-integrations.ts`, which all pass `scope: "platform"`
+ *    explicitly. All seven secret keys are `scope: "platform"` in the
+ *    registry, so a platform-tier write was filed as a workspace action —
+ *    and `GET /admin/admin-actions` selects
+ *    `WHERE org_id = $1 AND scope = 'workspace'` and returns `metadata`
+ *    verbatim, with a CSV export beside it. That router is
+ *    `createAdminRouter()`, i.e. `adminAuth` only, while the write required
+ *    `admin:settings`. An admin who could not write the setting could read
+ *    back what another admin wrote. Redacting (1) without fixing this leaves
+ *    platform actions on the workspace read API; fixing this without (1)
+ *    leaves plaintext in the table and the log stream.
+ *
+ * 3. **The audit row was fire-and-forget.** `logAdminAction` drops the row
+ *    with a `log.warn` when the internal-DB circuit breaker is open — and
+ *    `ATLAS_LOG_LEVEL` is runtime-mutable, hot-reloading through
+ *    `SETTING_SIDE_EFFECTS`, so an operator who raised it to `error` also
+ *    silences that warn. `logAdminActionAwait` exists for exactly this shape;
+ *    its own docstring names the audit-retention surface, "where a
+ *    fire-and-forget gap during a circuit-breaker open would let an attacker
+ *    shrink retention with no record". A settings write is the same surface.
+ *
+ * ⚠️ **WHY THE WHOLE ENTRY IS BUILT HERE rather than at the route.** The
+ * redaction is not something a call site can be trusted to remember: #5180
+ * measured that re-inlining `log.warn({ ...line, value })` passed all 154
+ * tests, because no sensitive key is `secret: true` today and redacted equals
+ * raw on every currently-reachable input. The brand is the guard — and a brand
+ * only bites where something is EXPECTED to carry it. `AdminActionEntry`'s
+ * `metadata` is `Record<string, unknown>`, so a route that builds its own
+ * object gets no help at all. Hence: the route hands over the definition and
+ * the raw value, and never touches `metadata`. There is no spelling of the
+ * call site that reintroduces (1) without deleting this module.
+ *
+ * ⚠️ **WHAT THIS DOES NOT CLOSE**, stated because the fence invites the wrong
+ * confidence: a caller that goes back to `logAdminAction` directly with a
+ * hand-built metadata object bypasses everything here, and no type can see
+ * that. `__tests__/settings-write.test.ts` flips a registry definition to
+ * `secret: true` to make redacted and raw differ on a reachable input, which
+ * is what catches the seam-REMOVING edit; the brand catches the
+ * seam-preserving one. Neither is redundant.
+ */
+
+import { createLogger } from "@atlas/api/lib/logger";
+import { logAdminActionAwait } from "@atlas/api/lib/audit/admin";
+import { ADMIN_ACTIONS } from "@atlas/api/lib/audit/actions";
+import {
+  redactAuditValue,
+  type AuditedValue,
+  type AuditMaskReason,
+  type SettingDefinition,
+} from "@atlas/api/lib/settings";
+
+const log = createLogger("audit.settings-write");
+
+/**
+ * Which verb produced the row. `reset_to_default` is the DELETE path, which
+ * clears an override rather than writing one — it carries no value, and must
+ * not acquire one: "the value it reverted to" is the env/default, which is
+ * exactly as secret as the override was.
+ */
+export type SettingsWriteAction = "update" | "reset_to_default";
+
+/**
+ * The metadata shape that reaches `admin_action_log.metadata`.
+ *
+ * ⚠️ `value` is {@link AuditedValue}, not `string`. That is the compile-time
+ * half of defect (1) above: the only way to obtain one is
+ * {@link redactAuditValue}, so `value: rawValue` here is a type error on the
+ * day it is harmless and on the day it is a breach.
+ */
+type SettingsAuditMetadata = {
+  readonly key: string;
+  readonly tier: "workspace" | "platform";
+  readonly action?: "reset_to_default";
+  readonly value?: AuditedValue;
+  /** Present whenever a value is; `true` means the characters were withheld. */
+  readonly valueMasked?: boolean;
+  /** Present only when `valueMasked` is true. */
+  readonly maskReason?: AuditMaskReason;
+};
+
+export interface SettingsAuditWrite {
+  readonly key: string;
+  /**
+   * The registry definition, or `undefined` when the key has no entry.
+   * Passed rather than looked up here so the fail-closed arm of
+   * {@link redactAuditValue} — "we could not tell, so withhold" — stays
+   * reachable and testable from the call site.
+   */
+  readonly definition: SettingDefinition | undefined;
+  /** The raw written value; `undefined` on the `reset_to_default` path. */
+  readonly value: string | undefined;
+  readonly action: SettingsWriteAction;
+  /**
+   * True when the write targeted the GLOBAL row rather than a workspace's.
+   * The route computes this as `effectiveOrgId === undefined`, which is the
+   * same condition it already annotates as `tier` in the metadata — one fact,
+   * now driving both the metadata field and the row's `scope` column.
+   */
+  readonly platformTier: boolean;
+  readonly ipAddress: string | null;
+}
+
+/**
+ * Record a settings write in `admin_action_log`, awaiting the row.
+ *
+ * ⚠️ **IT REJECTS WHEN THE ROW CANNOT BE COMMITTED, and the caller must not
+ * swallow that.** This is a deliberate availability trade: a settings write
+ * whose audit row is lost is an unrecorded change to runtime configuration,
+ * which is the thing the log exists to prevent. The caller surfaces it as an
+ * explicit 500 saying the setting DID change but was not recorded — a generic
+ * "something failed" would be worse than silence, because it implies the write
+ * did not land.
+ *
+ * ⚠️ Applied to EVERY settings write, not only the security-sensitive keys.
+ * A conditional await would need a second classification of "which keys
+ * matter", and a second classification is a second thing that drifts from the
+ * first — the exact failure mode `SECURITY_SENSITIVE_KEYS` vs
+ * `SAAS_IMMUTABLE_KEYS` vs `secret: true` already presents three times over.
+ */
+export async function auditSettingsWrite(entry: SettingsAuditWrite): Promise<void> {
+  const redacted = redactAuditValue(entry.definition, entry.value);
+  const tier = entry.platformTier ? "platform" : "workspace";
+
+  const metadata: SettingsAuditMetadata = {
+    key: entry.key,
+    tier,
+    ...(entry.action === "reset_to_default" ? { action: "reset_to_default" as const } : {}),
+    ...(redacted.value !== undefined
+      ? {
+          value: redacted.value,
+          valueMasked: redacted.masked,
+          ...(redacted.maskReason !== undefined ? { maskReason: redacted.maskReason } : {}),
+        }
+      : {}),
+  };
+
+  await logAdminActionAwait({
+    actionType: ADMIN_ACTIONS.settings.update,
+    targetType: "settings",
+    targetId: entry.key,
+    // ⚠️ EXPLICIT, because the default is wrong here. `resolveEntry` defaults
+    // to "workspace" for any non-systemActor write, which put platform-tier
+    // settings rows on the org-scoped `/admin/admin-actions` read API.
+    scope: tier,
+    metadata,
+    ipAddress: entry.ipAddress,
+  });
+
+  log.debug({ key: entry.key, tier, action: entry.action }, "Settings write audited");
+}

--- a/packages/api/src/lib/audit/settings-write.ts
+++ b/packages/api/src/lib/audit/settings-write.ts
@@ -1,65 +1,86 @@
 /**
- * The one seam through which a settings write reaches `admin_action_log`
- * (#5270, #5262).
+ * The seam through which the `PUT`/`DELETE /admin/settings/{key}` verbs reach
+ * `admin_action_log` (#5270, #5262).
  *
- * ⚠️ **THREE DEFECTS SHARED ONE CALL SITE**, and each is only half-closed by
- * fixing the others, which is why they land together:
+ * ⚠️ **NOT "the one seam for settings writes" — three other writers exist and
+ * none of them routes through here.** `platform-demo.ts` files its own
+ * `settings.update` with the fire-and-forget `logAdminAction` (it does pass
+ * `scope: "platform"`, so only defect 3 below applies to it);
+ * `onboarding.ts:943` writes `ATLAS_DEMO_INDUSTRY`; `admin-sandbox.ts:542`
+ * clears `ATLAS_SANDBOX_BACKEND` with no audit row at all. They are outside
+ * this PR, and naming them here is the point — the next reader must not take
+ * "the seam" to mean coverage nobody built.
  *
- * 1. **The value was recorded verbatim.** `PUT /admin/settings/{key}` passed
- *    `metadata: { key, value, tier }` with the raw string, so writing any of
- *    the seven `secret: true` registry keys — `RESEND_API_KEY`,
- *    `ANTHROPIC_API_KEY`, `DATABASE_URL`, `ATLAS_DATASOURCE_URL`, … — put the
- *    plaintext credential in a DB row. Two of the three surfaces that show a
- *    settings value already withhold it: the read path masks
- *    (`getSettingsForAdmin` → `maskSecret`), and #5180 redacted the
- *    `security_setting.changed` log line. This one, the DURABLE surface, did
- *    neither. `redactPaths` does not cover it either: pino redacts on FIELD
- *    NAME (`apiKey`, `clientSecret`, `serverToken`, …) and this field is
- *    called `value`, nested under `metadata`, so the pino line leaked too.
+ * ⚠️ **THREE DEFECTS SHARED ONE CALL SITE. ONE WAS LIVE; TWO WERE NOT WHAT
+ * THE ISSUES SAID THEY WERE.** Both stated mechanisms were checked and both
+ * were wrong — recorded here rather than quietly corrected, because a fix
+ * resting on a false rationale is one verification away from being deleted:
  *
- * 2. **The row was stamped `scope: "workspace"`.** `resolveEntry` defaults
- *    scope to `"workspace"` for any non-`systemActor` write, and neither
- *    settings call site passed one — unlike `admin-abuse.ts`,
- *    `admin-connections.ts`, `admin-marketplace.ts` and
- *    `admin-operator-integrations.ts`, which all pass `scope: "platform"`
- *    explicitly. All seven secret keys are `scope: "platform"` in the
- *    registry, so a platform-tier write was filed as a workspace action —
- *    and `GET /admin/admin-actions` selects
- *    `WHERE org_id = $1 AND scope = 'workspace'` and returns `metadata`
- *    verbatim, with a CSV export beside it. That router is
- *    `createAdminRouter()`, i.e. `adminAuth` only, while the write required
- *    `admin:settings`. An admin who could not write the setting could read
- *    back what another admin wrote. Redacting (1) without fixing this leaves
- *    platform actions on the workspace read API; fixing this without (1)
- *    leaves plaintext in the table and the log stream.
+ * 1. **The value was recorded verbatim — but a `secret: true` value cannot
+ *    reach it.** `metadata: { key, value, tier }` carried the raw string, and
+ *    #5270 claimed that put the seven `secret: true` credentials in a DB row.
+ *    It does not: `admin.ts:3720` (PUT) and `:3876` (DELETE) both 403 a
+ *    `secret: true` key *before* the write, and that guard is on `main`
+ *    already — there was no window. So `redactAuditValue`'s `secret` arm and
+ *    its `undefined`-definition fail-closed arm are BOTH route-unreachable
+ *    today, and every production entry takes the verbatim arm.
  *
- * 3. **The audit row was fire-and-forget.** `logAdminAction` drops the row
- *    with a `log.warn` when the internal-DB circuit breaker is open — and
- *    `ATLAS_LOG_LEVEL` is runtime-mutable, hot-reloading through
- *    `SETTING_SIDE_EFFECTS`, so an operator who raised it to `error` also
- *    silences that warn. `logAdminActionAwait` exists for exactly this shape;
- *    its own docstring names the audit-retention surface, "where a
- *    fire-and-forget gap during a circuit-breaker open would let an attacker
- *    shrink retention with no record". A settings write is the same surface.
+ *    The redaction is kept as defense in depth, and the honest claim is
+ *    narrow: the 403 is the primary control, this is what remains if someone
+ *    deletes it or adds a second settings writer. `redactPaths` would not
+ *    catch that case — pino redacts on FIELD NAME (`apiKey`, `clientSecret`,
+ *    `serverToken`, …) and this field is called `value`, nested under
+ *    `metadata` — so there is no backstop underneath.
+ *
+ * 2. **The row was stamped `scope: "workspace"` — this one was live.**
+ *    `resolveEntry` defaults scope to `"workspace"` for any non-`systemActor`
+ *    write, and neither settings call site passed one, unlike
+ *    `admin-abuse.ts`, `admin-connections.ts`, `admin-marketplace.ts` and
+ *    `admin-operator-integrations.ts`. So a PLATFORM-tier write was filed as
+ *    a workspace action and landed on `GET /admin/admin-actions`, which
+ *    selects `WHERE org_id = $1 AND scope = 'workspace'` and returns
+ *    `metadata` verbatim with a CSV export beside it. The values involved are
+ *    non-secret registry settings (the secret ones are 403'd per 1), so this
+ *    is an audit-correctness bug plus minor disclosure of platform
+ *    configuration to workspace admins — not a credential leak.
+ *
+ * 3. **The audit row was fire-and-forget — and the drop is SILENT, which is
+ *    a stronger reason than the one #5262 gave.** #5262 argued a raised
+ *    `ATLAS_LOG_LEVEL` silences the drop's `log.warn`. There is no such warn.
+ *    Once the internal-DB circuit breaker is open, `internalExecute`
+ *    (`db/internal.ts:874-879`) increments `_droppedCount` and returns with
+ *    NO log line at any level — the only trace is an anonymous count on a
+ *    later recovery line, naming no key, actor or value. Before the breaker
+ *    opens, the drop logs at `error` (`:889-898`), which `ATLAS_LOG_LEVEL`
+ *    does not silence, and which names no key either. Either way the settings
+ *    change is unrecorded and unattributable, so `logAdminActionAwait` is the
+ *    right instrument — for the reason its own docstring gives about the
+ *    audit-retention surface, not for the reason #5262 gave.
  *
  * ⚠️ **WHY THE WHOLE ENTRY IS BUILT HERE rather than at the route.** The
  * redaction is not something a call site can be trusted to remember: #5180
  * measured that re-inlining `log.warn({ ...line, value })` passed all 154
- * tests, because no sensitive key is `secret: true` today and redacted equals
- * raw on every currently-reachable input. The brand is the guard — and a brand
- * only bites where something is EXPECTED to carry it. `AdminActionEntry`'s
- * `metadata` is `Record<string, unknown>`, so a route that builds its own
- * object gets no help at all. Hence: the route hands over the definition and
- * the raw value, and never touches `metadata`. There is no spelling of the
- * call site that reintroduces (1) without deleting this module.
+ * tests, because redacted equals raw on every currently-reachable input. The
+ * brand is the guard — and a brand only bites where something is EXPECTED to
+ * carry it. `AdminActionEntry`'s `metadata` is `Record<string, unknown>`, so a
+ * route that builds its own object gets no help at all. Hence: the route hands
+ * over the definition and the raw value, and never touches `metadata`.
  *
  * ⚠️ **WHAT THIS DOES NOT CLOSE**, stated because the fence invites the wrong
- * confidence: a caller that goes back to `logAdminAction` directly with a
- * hand-built metadata object bypasses everything here, and no type can see
- * that. `__tests__/settings-write.test.ts` flips a registry definition to
- * `secret: true` to make redacted and raw differ on a reachable input, which
- * is what catches the seam-REMOVING edit; the brand catches the
- * seam-preserving one. Neither is redundant.
+ * confidence, and every item below was MEASURED rather than reasoned about:
+ *
+ * - **A caller that goes back to `logAdminAction` with a hand-built metadata
+ *   object** bypasses everything here, and no type can see it.
+ * - **A property arriving via a SPREAD.** `...(cond ? { previousValue: raw }
+ *   : {})` compiles clean against this annotation — excess-property checking
+ *   does not apply through a spread — while the direct spelling
+ *   `previousValue: raw` is a type error. Verified by compiling both. The
+ *   spread form is caught only by `settings-write.test.ts`'s whole-entry
+ *   `JSON.stringify` negative assertion, which is why that assertion is on
+ *   the serialized entry rather than on `metadata.value`.
+ * - **A definition belonging to a DIFFERENT key** — closed below by the
+ *   `mismatched` check, which this module was missing until review caught
+ *   that its #5180 sibling has one and it did not.
  */
 
 import { createLogger } from "@atlas/api/lib/logger";
@@ -101,18 +122,17 @@ type SettingsAuditMetadata = {
   readonly maskReason?: AuditMaskReason;
 };
 
-export interface SettingsAuditWrite {
+interface SettingsAuditCommon {
   readonly key: string;
   /**
    * The registry definition, or `undefined` when the key has no entry.
+   *
    * Passed rather than looked up here so the fail-closed arm of
-   * {@link redactAuditValue} — "we could not tell, so withhold" — stays
-   * reachable and testable from the call site.
+   * {@link redactAuditValue} is reachable from a test. It is NOT reachable
+   * from either live route: `admin.ts` 400s an unknown key before the write,
+   * so through production callers this is always a real entry for `key`.
    */
   readonly definition: SettingDefinition | undefined;
-  /** The raw written value; `undefined` on the `reset_to_default` path. */
-  readonly value: string | undefined;
-  readonly action: SettingsWriteAction;
   /**
    * True when the write targeted the GLOBAL row rather than a workspace's.
    * The route computes this as `effectiveOrgId === undefined`, which is the
@@ -122,6 +142,26 @@ export interface SettingsAuditWrite {
   readonly platformTier: boolean;
   readonly ipAddress: string | null;
 }
+
+/**
+ * ⚠️ A UNION, so the docstring's rule about `reset_to_default` is the TYPE
+ * rather than prose. `{ action: "reset_to_default", value: "s3cret" }` was
+ * previously well-typed and produced a reset row carrying a value — exactly
+ * what {@link SettingsWriteAction} forbids in words. Its mirror,
+ * `{ action: "update", value: undefined }`, produced an update row with no
+ * value and no discriminator, indistinguishable from a bare key/tier row.
+ * Both are now compile errors.
+ *
+ * This matters more than a normal illegal-state cleanup because
+ * `metadata.action` is the ONLY thing separating the two verbs in
+ * `admin_action_log`: `ADMIN_ACTIONS.settings` has a single member, so both
+ * PUT and DELETE file `settings.update`.
+ */
+export type SettingsAuditWrite = SettingsAuditCommon &
+  (
+    | { readonly action: "update"; readonly value: string }
+    | { readonly action: "reset_to_default"; readonly value?: undefined }
+  );
 
 /**
  * Record a settings write in `admin_action_log`, awaiting the row.
@@ -141,7 +181,22 @@ export interface SettingsAuditWrite {
  * `SAAS_IMMUTABLE_KEYS` vs `secret: true` already presents three times over.
  */
 export async function auditSettingsWrite(entry: SettingsAuditWrite): Promise<void> {
-  const redacted = redactAuditValue(entry.definition, entry.value);
+  // ⚠️ A DEFINITION BELONGING TO A DIFFERENT KEY IS NOT EVIDENCE ABOUT THIS
+  // ONE. `securitySensitiveAuditLine` (settings.ts) has carried this check
+  // since #5180 and this module shipped without it — the brand fences the
+  // OUTPUT of the redaction decision, so corrupting its INPUT costs no cast
+  // and trips nothing. `auditSettingsWrite({ key: "RESEND_API_KEY",
+  // definition: <ATLAS_MODEL's entry>, value: rawKey })` would otherwise
+  // compile, run, and record the credential verbatim.
+  //
+  // Discarding the definition routes to `redactAuditValue`'s fail-closed arm,
+  // which is the conservative direction: an unrecognised pairing withholds.
+  // `maskReason` then says WHICH event it was, because "registry drift" and
+  // "the call site passed the wrong entry" send an operator to different
+  // places — the distinction `AuditMaskReason` exists to draw, and which this
+  // module advertised in its type while being unable to produce it.
+  const mismatched = entry.definition !== undefined && entry.definition.key !== entry.key;
+  const redacted = redactAuditValue(mismatched ? undefined : entry.definition, entry.value);
   const tier = entry.platformTier ? "platform" : "workspace";
 
   const metadata: SettingsAuditMetadata = {
@@ -152,7 +207,9 @@ export async function auditSettingsWrite(entry: SettingsAuditWrite): Promise<voi
       ? {
           value: redacted.value,
           valueMasked: redacted.masked,
-          ...(redacted.maskReason !== undefined ? { maskReason: redacted.maskReason } : {}),
+          ...(redacted.maskReason !== undefined || mismatched
+            ? { maskReason: mismatched ? ("definition_mismatch" as const) : redacted.maskReason }
+            : {}),
         }
       : {}),
   };
@@ -169,5 +226,13 @@ export async function auditSettingsWrite(entry: SettingsAuditWrite): Promise<voi
     ipAddress: entry.ipAddress,
   });
 
-  log.debug({ key: entry.key, tier, action: entry.action }, "Settings write audited");
+  // ⚠️ `info`, and AFTER the await, because it is the only line that can say
+  // the row COMMITTED. `logAdminActionAwait` calls `emitPino` BEFORE its
+  // INSERT, so the stream already carries a routine `admin_action` line at
+  // info for a row that may never land — nothing in it says "pending". At
+  // `debug` (where this started) it is off in every production deploy and
+  // duplicates fields the pre-commit line already has; at `info` it is the
+  // difference an operator greps for between a committed row and an
+  // emitted-then-lost one.
+  log.info({ key: entry.key, tier, action: entry.action }, "Settings write audit row COMMITTED");
 }

--- a/packages/api/src/lib/audit/settings-write.ts
+++ b/packages/api/src/lib/audit/settings-write.ts
@@ -6,8 +6,8 @@
  * none of them routes through here.** `platform-demo.ts` files its own
  * `settings.update` with the fire-and-forget `logAdminAction` (it does pass
  * `scope: "platform"`, so only defect 3 below applies to it);
- * `onboarding.ts:943` writes `ATLAS_DEMO_INDUSTRY`; `admin-sandbox.ts:542`
- * clears `ATLAS_SANDBOX_BACKEND` with no audit row at all. They are outside
+ * `onboarding.ts` writes `ATLAS_DEMO_INDUSTRY`; `admin-sandbox.ts` clears
+ * `ATLAS_SANDBOX_BACKEND` with no audit row at all. They are outside
  * this PR, and naming them here is the point — the next reader must not take
  * "the seam" to mean coverage nobody built.
  *
@@ -19,11 +19,20 @@
  * 1. **The value was recorded verbatim — but a `secret: true` value cannot
  *    reach it.** `metadata: { key, value, tier }` carried the raw string, and
  *    #5270 claimed that put the seven `secret: true` credentials in a DB row.
- *    It does not: `admin.ts:3720` (PUT) and `:3876` (DELETE) both 403 a
- *    `secret: true` key *before* the write, and that guard is on `main`
- *    already — there was no window. So `redactAuditValue`'s `secret` arm and
- *    its `undefined`-definition fail-closed arm are BOTH route-unreachable
- *    today, and every production entry takes the verbatim arm.
+ *    It does not: both verbs in `api/routes/admin.ts` 403 a `secret: true`
+ *    key *before* the write — grep the guard by its copy, `"Secret settings
+ *    cannot be modified from the UI."`, which appears once per verb — and
+ *    that guard is on `main` already, so there was no window. So
+ *    `redactAuditValue`'s `secret` arm and its `undefined`-definition
+ *    fail-closed arm are BOTH route-unreachable today, and every production
+ *    entry takes the verbatim arm.
+ *
+ *    ⚠️ Cited by MESSAGE rather than by line, deliberately. The first draft of
+ *    this block pinned `admin.ts:3720`/`:3876` and both were stale within the
+ *    same round — the line numbers moved when this PR's own helper was added
+ *    forty lines above them. A citation that rots is worse than none, because
+ *    the next reader checks it, finds unrelated code, and stops trusting the
+ *    paragraph that was right.
  *
  *    The redaction is kept as defense in depth, and the honest claim is
  *    narrow: the 403 is the primary control, this is what remains if someone

--- a/packages/api/src/lib/audit/settings-write.ts
+++ b/packages/api/src/lib/audit/settings-write.ts
@@ -6,8 +6,8 @@
  * none of them routes through here.** `platform-demo.ts` files its own
  * `settings.update` with the fire-and-forget `logAdminAction` (it does pass
  * `scope: "platform"`, so only defect 3 below applies to it);
- * `onboarding.ts` writes `ATLAS_DEMO_INDUSTRY`; `admin-sandbox.ts` clears
- * `ATLAS_SANDBOX_BACKEND` with no audit row at all. They are outside
+ * `onboarding.ts` writes `ATLAS_DEMO_INDUSTRY` and `admin-sandbox.ts` clears
+ * `ATLAS_SANDBOX_BACKEND`; neither files an audit row. They are outside
  * this PR, and naming them here is the point — the next reader must not take
  * "the seam" to mean coverage nobody built.
  *
@@ -60,23 +60,28 @@
  *    (`db/internal.ts:874-879`) increments `_droppedCount` and returns with
  *    NO log line at any level — the only trace is an anonymous count on a
  *    later recovery line, naming no key, actor or value. Before the breaker
- *    opens, the drop logs at `error` (`:889-898`), which `ATLAS_LOG_LEVEL`
- *    does not silence, and which names no key either. Either way the settings
- *    change is unrecorded and unattributable, so `logAdminActionAwait` is the
+ *    opens, the drop logs at `error` (`:889-898`), which names no key — and
+ *    which only `fatal` silences, a level that is itself in
+ *    `ATLAS_LOG_LEVEL`'s own option list, so even that trace is
+ *    operator-revocable — so #5262's instinct was not baseless; it named the
+ *    wrong line and the wrong branch. Either way the settings change is
+ *    unrecorded and unattributable, so
+ *    `logAdminActionAwait` is the
  *    right instrument — for the reason its own docstring gives about the
  *    audit-retention surface, not for the reason #5262 gave.
  *
  * ⚠️ **WHY THE WHOLE ENTRY IS BUILT HERE rather than at the route.** The
  * redaction is not something a call site can be trusted to remember: #5180
- * measured that re-inlining `log.warn({ ...line, value })` passed all 154
- * tests, because redacted equals raw on every currently-reachable input. The
+ * measured that re-inlining `log.warn({ ...line, value })` passed the whole
+ * suite, because redacted equals raw on every currently-reachable input. The
  * brand is the guard — and a brand only bites where something is EXPECTED to
  * carry it. `AdminActionEntry`'s `metadata` is `Record<string, unknown>`, so a
  * route that builds its own object gets no help at all. Hence: the route hands
  * over the definition and the raw value, and never touches `metadata`.
  *
  * ⚠️ **WHAT THIS DOES NOT CLOSE**, stated because the fence invites the wrong
- * confidence, and every item below was MEASURED rather than reasoned about:
+ * confidence. The spread case below was measured by compiling both spellings;
+ * the other two are stated from the type system's rules:
  *
  * - **A caller that goes back to `logAdminAction` with a hand-built metadata
  *   object** bypasses everything here, and no type can see it.
@@ -94,6 +99,7 @@
 
 import { createLogger } from "@atlas/api/lib/logger";
 import { logAdminActionAwait } from "@atlas/api/lib/audit/admin";
+import { hasInternalDB } from "@atlas/api/lib/db/internal";
 import { ADMIN_ACTIONS } from "@atlas/api/lib/audit/actions";
 import {
   redactAuditValue,
@@ -144,9 +150,11 @@ interface SettingsAuditCommon {
   readonly definition: SettingDefinition | undefined;
   /**
    * True when the write targeted the GLOBAL row rather than a workspace's.
-   * The route computes this as `effectiveOrgId === undefined`, which is the
-   * same condition it already annotates as `tier` in the metadata — one fact,
-   * now driving both the metadata field and the row's `scope` column.
+   * The route computes this as `!effectiveOrgId` — the truthiness spelling,
+   * not `=== undefined`; see the ⚠️ table at the PUT call site in `admin.ts`
+   * for the input class where the two disagree. It is the same condition the
+   * route already annotates as `tier` in the metadata, so one fact now drives
+   * both the metadata field and the row's `scope` column.
    */
   readonly platformTier: boolean;
   readonly ipAddress: string | null;
@@ -191,8 +199,8 @@ export type SettingsAuditWrite = SettingsAuditCommon &
  */
 export async function auditSettingsWrite(entry: SettingsAuditWrite): Promise<void> {
   // ⚠️ A DEFINITION BELONGING TO A DIFFERENT KEY IS NOT EVIDENCE ABOUT THIS
-  // ONE. `securitySensitiveAuditLine` (settings.ts) has carried this check
-  // since #5180 and this module shipped without it — the brand fences the
+  // ONE. `securitySensitiveAuditLine` (settings.ts) carries this check and
+  // this module shipped without it — the brand fences the
   // OUTPUT of the redaction decision, so corrupting its INPUT costs no cast
   // and trips nothing. `auditSettingsWrite({ key: "RESEND_API_KEY",
   // definition: <ATLAS_MODEL's entry>, value: rawKey })` would otherwise
@@ -208,6 +216,31 @@ export async function auditSettingsWrite(entry: SettingsAuditWrite): Promise<voi
   const redacted = redactAuditValue(mismatched ? undefined : entry.definition, entry.value);
   const tier = entry.platformTier ? "platform" : "workspace";
 
+  // ⚠️ EMITTED UNCONDITIONALLY, AND NOT VIA `maskReason`. The first draft of
+  // this guard recorded the mismatch ONLY in `metadata.maskReason` — one
+  // JSONB field of one audit row, which nobody greps and nothing alerts on.
+  // Worse, on the `reset_to_default` path there is no value, so the whole
+  // metadata block below is skipped and `mismatched` was computed, found
+  // true, and then DISCARDED: a clear against the wrong registry entry was
+  // indistinguishable from a correct one.
+  //
+  // A definition that does not belong to its key is a programmer bug —
+  // registry drift after a rename, an alias resolver handing back the old
+  // entry, a call site reusing one `def` across keys in a loop. Detecting it
+  // and saying nothing is the swallow this module's own header is about. The
+  // #5180 sibling emits its whole line at `warn` for the same reason.
+  if (mismatched) {
+    log.warn(
+      {
+        key: entry.key,
+        definitionKey: entry.definition?.key,
+        action: entry.action,
+        maskReason: "definition_mismatch",
+      },
+      "Settings audit: the definition passed does not belong to this key — value withheld and the audit row records maskReason=definition_mismatch. This is a caller bug: check for registry drift after a rename, or a call site resolving the definition for a different key.",
+    );
+  }
+
   const metadata: SettingsAuditMetadata = {
     key: entry.key,
     tier,
@@ -216,12 +249,32 @@ export async function auditSettingsWrite(entry: SettingsAuditWrite): Promise<voi
       ? {
           value: redacted.value,
           valueMasked: redacted.masked,
-          ...(redacted.maskReason !== undefined || mismatched
+          // `mismatched` needs no disjunct here: it forces the
+          // `undefined`-definition arm, which always sets a `maskReason` when
+          // a value exists — so `redacted.maskReason !== undefined` is
+          // already true whenever this spread is reached.
+          ...(redacted.maskReason !== undefined
             ? { maskReason: mismatched ? ("definition_mismatch" as const) : redacted.maskReason }
             : {}),
         }
       : {}),
   };
+
+  // ⚠️ `logAdminActionAwait` RESOLVES WITHOUT INSERTING when there is no
+  // internal DB (`audit/admin.ts`), so the COMMITTED line below would
+  // otherwise assert a row that was never written. Both current callers check
+  // `hasInternalDB()` and 404 first, making this unreachable today — but this
+  // module's header invites three other settings writers to adopt the seam,
+  // and "true by caller precondition" is not a property this function should
+  // rely on when the failure is a log line confidently naming a row that does
+  // not exist.
+  if (!hasInternalDB()) {
+    log.warn(
+      { key: entry.key, tier, action: entry.action },
+      "Settings write audit row NOT persisted — no internal database configured. The pino line is the only trail for this configuration change.",
+    );
+    return;
+  }
 
   await logAdminActionAwait({
     actionType: ADMIN_ACTIONS.settings.update,

--- a/packages/api/src/lib/db/__tests__/builtin-datasource-catalog-seed-pg.test.ts
+++ b/packages/api/src/lib/db/__tests__/builtin-datasource-catalog-seed-pg.test.ts
@@ -1,0 +1,285 @@
+/**
+ * Real-Postgres tests for the built-in Datasource catalog seed's conflict
+ * target and outcome accounting (#5266).
+ *
+ * ⚠️ WHAT ONLY REAL POSTGRES CAN SAY HERE. Half the fix is which conflict
+ * target the INSERT names, and the difference between the two spellings is
+ * something the DATABASE decides:
+ *
+ *   - `ON CONFLICT DO NOTHING`      — a slug held under a foreign id is
+ *                                    swallowed. Zero rows, no error, and the
+ *                                    pass reported the row as PRESERVED. That
+ *                                    is #5266.
+ *   - `ON CONFLICT (id) DO NOTHING` — the same collision raises 23505, which
+ *                                    the seeder reports and steps over.
+ *
+ * A mocked pool cannot demonstrate either: it returns whatever the fixture
+ * says. `seed-builtin-datasource-catalog-collision.test.ts` covers what the
+ * seeder DOES with the rejection; this file covers that the rejection happens
+ * at all — and that the old spelling would not have produced one, so the
+ * change is load-bearing rather than decorative.
+ *
+ * Skipped cleanly when `TEST_DATABASE_URL` is unset. CI's api-tests workflow
+ * provides the Postgres service.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "bun:test";
+import { Pool } from "pg";
+import {
+  BUILTIN_DATASOURCE_CATALOG_ROWS,
+  seedBuiltinDatasourceCatalog,
+  type BuiltinDatasourceCatalogSeedDb,
+} from "@atlas/api/lib/db/seed-builtin-datasource-catalog";
+
+const TEST_DB_URL = process.env.TEST_DATABASE_URL;
+const describeIfPg = TEST_DB_URL ? describe : describe.skip;
+
+const PG_TIMEOUT_MS = 30_000;
+
+const SQUATTER_ID = "catalog:operator-made-this";
+/** 4th of nine — neither first nor last, so a loop that stops early fails. */
+const SQUATTED = BUILTIN_DATASOURCE_CATALOG_ROWS.find((r) => r.slug === "clickhouse")!;
+const ALL_SLUGS = BUILTIN_DATASOURCE_CATALOG_ROWS.map((r) => r.slug);
+
+describeIfPg("built-in Datasource catalog seed against real Postgres (#5266)", () => {
+  let pool: Pool;
+  let db: BuiltinDatasourceCatalogSeedDb;
+  const schemaName = `dsseed_${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
+
+  beforeAll(async () => {
+    // `search_path` baked into the connection, `public` deliberately absent —
+    // this file runs unqualified `TRUNCATE plugin_catalog`, and a developer's
+    // `TEST_DATABASE_URL` points at their dev database.
+    pool = new Pool({
+      connectionString: TEST_DB_URL,
+      options: `-c search_path="${schemaName}"`,
+    });
+    await pool.query(`CREATE SCHEMA IF NOT EXISTS "${schemaName}"`);
+    const { rows } = await pool.query<{ s: string }>(`SELECT current_schema() AS s`);
+    expect(rows[0]?.s).toBe(schemaName);
+
+    // The columns the seeder's INSERT names, with the two constraints the
+    // conflict target is about: `id` PRIMARY KEY and `slug` UNIQUE. Without
+    // the UNIQUE on slug this whole file would pass with either spelling.
+    //
+    // ⚠️ THE FOUR CHECKs ARE COPIED FROM `schema.ts` DELIBERATELY — a fixture
+    // looser than production cannot fail where production would.
+    await pool.query(`
+      CREATE TABLE plugin_catalog (
+        id                    TEXT PRIMARY KEY,
+        name                  TEXT NOT NULL,
+        slug                  TEXT NOT NULL UNIQUE,
+        description           TEXT,
+        type                  TEXT NOT NULL,
+        install_model         TEXT NOT NULL,
+        pillar                TEXT NOT NULL,
+        implementation_status TEXT NOT NULL,
+        auto_install          BOOLEAN NOT NULL,
+        min_plan              TEXT NOT NULL,
+        enabled               BOOLEAN NOT NULL,
+        saas_eligible         BOOLEAN NOT NULL,
+        config_schema         JSONB,
+        created_at            TIMESTAMPTZ NOT NULL DEFAULT now(),
+        updated_at            TIMESTAMPTZ NOT NULL DEFAULT now(),
+        CONSTRAINT chk_plugin_catalog_type
+          CHECK (type IN ('datasource', 'context', 'interaction', 'action', 'sandbox', 'chat', 'integration')),
+        CONSTRAINT chk_plugin_catalog_install_model
+          CHECK (install_model IN ('oauth', 'form', 'static-bot', 'oauth-datasource')),
+        CONSTRAINT chk_plugin_catalog_pillar
+          CHECK (pillar IN ('datasource', 'chat', 'action', 'knowledge')),
+        CONSTRAINT chk_plugin_catalog_implementation_status
+          CHECK (implementation_status IN ('available', 'coming_soon'))
+      )
+    `);
+
+    db = {
+      async query<T = unknown>(sql: string, params?: unknown[]) {
+        const result = await pool.query(sql, params);
+        return { rows: result.rows as T[] };
+      },
+    };
+  }, PG_TIMEOUT_MS);
+
+  afterAll(async () => {
+    if (!pool) return;
+    await pool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+    await pool.end();
+  }, PG_TIMEOUT_MS);
+
+  beforeEach(async () => {
+    await pool.query(`TRUNCATE plugin_catalog`);
+  }, PG_TIMEOUT_MS);
+
+  /**
+   * An operator-created row squatting a built-in slug under its own id — the
+   * production-reachable shape #5266 is about. `slug` is settable only at
+   * create (`lib/integrations/catalog-crud.ts` has no `slug` in its update
+   * builder), so it takes a row created before the built-in was ever seeded.
+   */
+  async function insertSquatter(): Promise<void> {
+    await pool.query(
+      `INSERT INTO plugin_catalog
+         (id, name, slug, type, install_model, pillar, implementation_status,
+          auto_install, min_plan, enabled, saas_eligible)
+       VALUES ($1, 'Our own warehouse card', $2, 'datasource', 'form', 'datasource',
+               'available', false, 'starter', true, true)`,
+      [SQUATTER_ID, SQUATTED.slug],
+    );
+  }
+
+  const slugsInCatalog = async (): Promise<string[]> => {
+    const { rows } = await pool.query<{ slug: string }>(
+      `SELECT slug FROM plugin_catalog WHERE id LIKE 'catalog:%' ORDER BY slug`,
+    );
+    return rows.map((r) => r.slug);
+  };
+
+  it("seeds every row on an empty catalog", async () => {
+    const result = await seedBuiltinDatasourceCatalog(db);
+    expect(result.insertedSlugs).toEqual(ALL_SLUGS);
+    expect(result.preservedSlugs).toEqual([]);
+    expect(result.blockedSlugs).toEqual([]);
+    expect(await slugsInCatalog()).toEqual([...ALL_SLUGS].sort());
+  }, PG_TIMEOUT_MS);
+
+  it("is a no-op on a second pass — everything preserved, nothing blocked", async () => {
+    await seedBuiltinDatasourceCatalog(db);
+    const second = await seedBuiltinDatasourceCatalog(db);
+    expect(second.insertedSlugs).toEqual([]);
+    expect(second.preservedSlugs).toEqual(ALL_SLUGS);
+    expect(second.blockedSlugs).toEqual([]);
+  }, PG_TIMEOUT_MS);
+
+  it("⭐ raises 23505 rather than silently no-op'ing when a foreign id holds the slug", async () => {
+    // The behaviour the fix depends on, asserted directly against Postgres
+    // rather than inferred from the seeder's catch.
+    await insertSquatter();
+    let raised: { code?: unknown; constraint?: unknown; detail?: unknown } | undefined;
+    try {
+      await pool.query(
+        `INSERT INTO plugin_catalog
+           (id, name, slug, type, install_model, pillar, implementation_status,
+            auto_install, min_plan, enabled, saas_eligible)
+         VALUES ($1, 'x', $2, 'datasource', 'form', 'datasource', 'available',
+                 false, 'starter', true, true)
+         ON CONFLICT (id) DO NOTHING`,
+        [SQUATTED.id, SQUATTED.slug],
+      );
+    } catch (err) {
+      raised = err as { code?: unknown; constraint?: unknown; detail?: unknown };
+    }
+    expect(raised?.code).toBe("23505");
+    // ⚠️ THE SHAPE TOO, not only the code. The mocked collision suite asserts a
+    // warn payload carrying `constraint: "plugin_catalog_slug_key"` and
+    // `detail: "Key (slug)=(…) already exists."` — both hand-written in that
+    // file's own fixture, so it is agreeing with itself. These two lines are
+    // where those strings are checked against Postgres.
+    expect(raised?.constraint).toBe("plugin_catalog_slug_key");
+    expect(String(raised?.detail)).toContain(`Key (slug)=(${SQUATTED.slug})`);
+  }, PG_TIMEOUT_MS);
+
+  it("⭐ and the UNQUALIFIED target swallows exactly that collision — the defect, measured", async () => {
+    // The counterfactual, run rather than reasoned about. If this ever starts
+    // raising, the qualified target is no longer buying anything and #5266's
+    // whole argument needs re-reading.
+    await insertSquatter();
+    const { rows } = await pool.query(
+      `INSERT INTO plugin_catalog
+         (id, name, slug, type, install_model, pillar, implementation_status,
+          auto_install, min_plan, enabled, saas_eligible)
+       VALUES ($1, 'x', $2, 'datasource', 'form', 'datasource', 'available',
+               false, 'starter', true, true)
+       ON CONFLICT DO NOTHING
+       RETURNING slug`,
+      [SQUATTED.id, SQUATTED.slug],
+    );
+    // No error, no row — and the canonical id was never created. Under the old
+    // subtraction this empty result is precisely what got counted as preserved.
+    expect(rows).toHaveLength(0);
+    const { rows: canonical } = await pool.query(`SELECT id FROM plugin_catalog WHERE id = $1`, [
+      SQUATTED.id,
+    ]);
+    expect(canonical).toHaveLength(0);
+  }, PG_TIMEOUT_MS);
+
+  it("⭐ reports the squatted row as blocked, NOT as preserved, and seeds all the others", async () => {
+    await insertSquatter();
+    const result = await seedBuiltinDatasourceCatalog(db);
+
+    expect(result.blockedSlugs).toEqual([SQUATTED.slug]);
+    // ⚠️ THE WHOLE POINT OF #5266. The old derivation put this slug in
+    // `preservedSlugs` — telling the caller a row the catalog does not have is
+    // fine. `preservedSlugs` is empty here because nothing legitimately
+    // pre-existed: 8 inserted, 0 preserved, 1 blocked, three different sizes.
+    expect(result.preservedSlugs).toEqual([]);
+    expect(result.insertedSlugs).toEqual(ALL_SLUGS.filter((s) => s !== SQUATTED.slug));
+    expect(result.insertedSlugs).toHaveLength(ALL_SLUGS.length - 1);
+
+    // And the catalog agrees: the canonical id was never created.
+    const { rows } = await pool.query<{ id: string }>(
+      `SELECT id FROM plugin_catalog WHERE id = $1`,
+      [SQUATTED.id],
+    );
+    expect(rows).toHaveLength(0);
+    // ⚠️ THE ID SET, NOT A COUNT. "8 built-ins + the squatter" and "all 9
+    // built-ins, squatter clobbered" are both 9 rows, so a count cannot tell
+    // apart the world where the seeder lost this contest from the world where
+    // it won it — and the seeder is supposed to lose.
+    const { rows: present } = await pool.query<{ id: string }>(
+      `SELECT id FROM plugin_catalog ORDER BY id`,
+    );
+    expect(present.map((r) => r.id)).toEqual(
+      [
+        SQUATTER_ID,
+        ...BUILTIN_DATASOURCE_CATALOG_ROWS.filter((r) => r.slug !== SQUATTED.slug).map((r) => r.id),
+      ].sort(),
+    );
+  }, PG_TIMEOUT_MS);
+
+  it("⭐ keeps a genuinely preserved row apart from a blocked one in the same pass", async () => {
+    // The discriminating case: `postgres` legitimately exists under its
+    // canonical id (preserved), `clickhouse` is squatted (blocked). Under the
+    // old subtraction both were "not inserted" and reported identically.
+    await insertSquatter();
+    const canonical = BUILTIN_DATASOURCE_CATALOG_ROWS.find((r) => r.slug === "postgres")!;
+    await pool.query(
+      `INSERT INTO plugin_catalog
+         (id, name, slug, type, install_model, pillar, implementation_status,
+          auto_install, min_plan, enabled, saas_eligible)
+       VALUES ($1, 'Pre-existing', $2, 'datasource', 'form', 'datasource',
+               'available', false, 'starter', true, true)`,
+      [canonical.id, canonical.slug],
+    );
+
+    const result = await seedBuiltinDatasourceCatalog(db);
+    expect(result.preservedSlugs).toEqual(["postgres"]);
+    expect(result.blockedSlugs).toEqual([SQUATTED.slug]);
+    expect(result.insertedSlugs).toHaveLength(ALL_SLUGS.length - 2);
+  }, PG_TIMEOUT_MS);
+
+  it("does not clobber the squatter's own row", async () => {
+    // The seeder must lose this contest, not win it: the operator's row is the
+    // one that legitimately holds the slug.
+    await insertSquatter();
+    await seedBuiltinDatasourceCatalog(db);
+    const { rows } = await pool.query<{ name: string }>(
+      `SELECT name FROM plugin_catalog WHERE id = $1`,
+      [SQUATTER_ID],
+    );
+    expect(rows[0]?.name).toBe("Our own warehouse card");
+  }, PG_TIMEOUT_MS);
+
+  it("stays blocked, and stays out of preserved, on a re-boot", async () => {
+    await insertSquatter();
+    await seedBuiltinDatasourceCatalog(db);
+    const second = await seedBuiltinDatasourceCatalog(db);
+    // Everything else is present now, so nothing is inserted — but the blocked
+    // row is still blocked, and still must not drift into `preservedSlugs`.
+    // A second pass is exactly where the old subtraction looked most innocent:
+    // every slug "preserved", nothing inserted, no error.
+    expect(second.insertedSlugs).toEqual([]);
+    expect(second.blockedSlugs).toEqual([SQUATTED.slug]);
+    expect(second.preservedSlugs).toEqual(ALL_SLUGS.filter((s) => s !== SQUATTED.slug));
+    expect(second.preservedSlugs).not.toContain(SQUATTED.slug);
+  }, PG_TIMEOUT_MS);
+});

--- a/packages/api/src/lib/db/__tests__/pg-errors.test.ts
+++ b/packages/api/src/lib/db/__tests__/pg-errors.test.ts
@@ -10,8 +10,8 @@
  *
  * Prose is not a checked condition. This file makes it one — in particular the
  * wrapped case, which is the arm the header uses to justify NOT unifying the
- * two classifiers, and which #5272 is open against for two routes that read
- * the flat shape on a wrapped path.
+ * two classifiers, and which #5272 is open against for the four call sites
+ * (two routes, two stores) that read the flat shape on a wrapped path.
  */
 
 import { describe, expect, it } from "bun:test";
@@ -50,7 +50,7 @@ describe("asUniqueViolation", () => {
   });
 
   it("classifies a 23505 carrying no diagnostics — both fields undefined, not absent", () => {
-    // Both consumers read `.constraint` immediately after the guard; an
+    // Both seeders read `.constraint` immediately after the guard; an
     // unguarded read on a driver that omits them would throw INSIDE the catch,
     // turning a reported collision into an aborted pass.
     const got = asUniqueViolation(violation());

--- a/packages/api/src/lib/db/__tests__/pg-errors.test.ts
+++ b/packages/api/src/lib/db/__tests__/pg-errors.test.ts
@@ -1,0 +1,97 @@
+/**
+ * #5266 — `lib/db/pg-errors.ts`, the shared SQLSTATE classification.
+ *
+ * The module's header makes a contract claim that decides whether every
+ * consumer's recovery works: *"Reads a TOP-LEVEL `code` only. An
+ * `@effect/sql`-backed client wraps the driver error under `.cause`, so every
+ * collision would arrive here unclassified."* That is the whole reason
+ * `routing-id-conflict.ts` keeps a separate `.cause` walk instead of adopting
+ * this helper.
+ *
+ * Prose is not a checked condition. This file makes it one — in particular the
+ * wrapped case, which is the arm the header uses to justify NOT unifying the
+ * two classifiers, and which #5272 is open against for two routes that read
+ * the flat shape on a wrapped path.
+ */
+
+import { describe, expect, it } from "bun:test";
+import {
+  asUniqueViolation,
+  PG_UNIQUE_VIOLATION,
+  PG_PLUGIN_CATALOG_SLUG_CONSTRAINT,
+} from "@atlas/api/lib/db/pg-errors";
+
+describe("PG constants", () => {
+  it("pins the SQLSTATE and the constraint name", () => {
+    // ⚠️ Literals, not a re-derivation. `plugin_catalog_slug_key` is Postgres's
+    // auto-generated name for `slug TEXT NOT NULL UNIQUE` in migration 0014 —
+    // a migration that renamed it to `uq_plugin_catalog_slug` would silently
+    // route every collision down both seeders' rethrow arm.
+    expect(PG_UNIQUE_VIOLATION).toBe("23505");
+    expect(PG_PLUGIN_CATALOG_SLUG_CONSTRAINT).toBe("plugin_catalog_slug_key");
+  });
+});
+
+describe("asUniqueViolation", () => {
+  const violation = (extra: Record<string, unknown> = {}) =>
+    Object.assign(new Error("duplicate key value violates unique constraint"), {
+      code: "23505",
+      ...extra,
+    });
+
+  it("classifies a flat 23505 and returns its diagnostics", () => {
+    const got = asUniqueViolation(
+      violation({ constraint: "plugin_catalog_slug_key", detail: "Key (slug)=(x) already exists." }),
+    );
+    expect(got).toEqual({
+      constraint: "plugin_catalog_slug_key",
+      detail: "Key (slug)=(x) already exists.",
+    });
+  });
+
+  it("classifies a 23505 carrying no diagnostics — both fields undefined, not absent", () => {
+    // Both consumers read `.constraint` immediately after the guard; an
+    // unguarded read on a driver that omits them would throw INSIDE the catch,
+    // turning a reported collision into an aborted pass.
+    const got = asUniqueViolation(violation());
+    expect(got).toEqual({ constraint: undefined, detail: undefined });
+  });
+
+  it("⭐ returns undefined for a `.cause`-WRAPPED 23505 — the header's load-bearing claim", () => {
+    // This is why `routing-id-conflict.ts` walks the chain instead of calling
+    // this helper, and why #5272 exists. If this ever starts returning a
+    // value, the two classifiers have converged and that module's "do not
+    // simplify the two into one helper" argument needs re-reading.
+    const wrapped = Object.assign(new Error("SqlError"), { cause: violation() });
+    expect(asUniqueViolation(wrapped)).toBeUndefined();
+  });
+
+  it("returns undefined for a different SQLSTATE, however similar the message", () => {
+    // Message-keyed classification is the failure this reads the CODE to
+    // avoid: demoting a real outage to a benign collision.
+    const impostor = Object.assign(
+      new Error("duplicate key value violates unique constraint"),
+      { code: "XX000" },
+    );
+    expect(asUniqueViolation(impostor)).toBeUndefined();
+  });
+
+  it("returns undefined for an error with no code at all", () => {
+    expect(asUniqueViolation(new Error("connection terminated"))).toBeUndefined();
+  });
+
+  it("returns undefined for non-objects — the type-narrowing rule, not a cast", () => {
+    // `err.code` on a thrown string is `undefined`; reading it unguarded is
+    // what CLAUDE.md's narrowing rule forbids.
+    for (const notAnObject of ["23505", 23505, null, undefined, true]) {
+      expect(asUniqueViolation(notAnObject)).toBeUndefined();
+    }
+  });
+
+  it("ignores a non-string constraint rather than passing it through", () => {
+    // A driver returning a numeric oid would otherwise reach a consumer that
+    // compares it against a constraint NAME and silently never match.
+    const got = asUniqueViolation(violation({ constraint: 1234, detail: 5678 }));
+    expect(got).toEqual({ constraint: undefined, detail: undefined });
+  });
+});

--- a/packages/api/src/lib/db/__tests__/seed-builtin-datasource-catalog-collision.test.ts
+++ b/packages/api/src/lib/db/__tests__/seed-builtin-datasource-catalog-collision.test.ts
@@ -1,0 +1,310 @@
+/**
+ * #5266 — the foreign-id slug collision path of the built-in Datasource
+ * catalog seed.
+ *
+ * A row already holding one of the built-in slugs under a DIFFERENT id makes
+ * the insert raise `23505` instead of silently no-op'ing (that is what
+ * qualifying the conflict target to `(id)` buys). This file covers what the
+ * seeder does with that: warn naming the row, keep going, and report the slug
+ * as BLOCKED — rather than counting it as preserved, which is the sharper half
+ * of this defect and the thing that made it worse than #5239's sibling.
+ *
+ * ⚠️ SEPARATE FILE BECAUSE OF THE LOGGER MOCK. `createLogger(...)` is called at
+ * module evaluation, so `mock.module("@atlas/api/lib/logger")` only reaches it
+ * when the seeder is imported AFTER the mock — which rules out the static
+ * imports `seed-builtin-datasource-catalog.test.ts` relies on. Everything here
+ * therefore goes through a top-level `await import`.
+ *
+ * ⚠️ AND THE MOCK PROVES ONLY HALF OF IT. The rejections below are shaped by
+ * hand, so this file cannot show that Postgres raises `23505` for this
+ * situation at all — a fixture agreeing with the code by construction. That
+ * half is `builtin-datasource-catalog-seed-pg.test.ts`, against real Postgres.
+ */
+
+import { describe, expect, it, beforeEach, mock } from "bun:test";
+
+interface LoggedCall {
+  readonly level: "info" | "warn" | "error" | "debug";
+  readonly payload: unknown;
+  readonly message: string;
+}
+
+/**
+ * ⚠️ ONE SINK, AND IT CARRIES THE LEVEL. A per-level array (or a helper that
+ * pushes only the message) cannot see `log.warn` demoted back to `log.info`,
+ * which is precisely the claim the first two tests make — the seeder must stop
+ * reporting a pass that wrote nothing as a plain success.
+ */
+const logged: LoggedCall[] = [];
+const record =
+  (level: LoggedCall["level"]) =>
+  (payload: unknown, message?: string): void => {
+    logged.push({
+      level,
+      payload,
+      message: typeof payload === "string" ? payload : (message ?? ""),
+    });
+  };
+
+/**
+ * ⚠️ MOCK-ALL-EXPORTS, per the repo's testing rule. Only `createLogger` is
+ * needed today, but a partial `mock.module` replaces the whole module: the
+ * moment anything in this file's import graph resolves `getLogger()` at import
+ * time, a partial mock turns into `undefined is not a function` several files
+ * away from the cause.
+ */
+const stubLogger = {
+  info: record("info"),
+  warn: record("warn"),
+  error: record("error"),
+  debug: record("debug"),
+};
+
+void mock.module("@atlas/api/lib/logger", () => ({
+  ACTOR_KINDS: ["human", "agent", "mcp", "scheduler", "api_key"] as const,
+  createLogger: () => stubLogger,
+  getLogger: () => stubLogger,
+  getRequestContext: () => undefined,
+  withRequestContext: <T,>(_ctx: unknown, fn: () => T): T => fn(),
+  redactPaths: [] as string[],
+  scrubErrSerializer: (value: unknown) => value,
+  scrubLogFormatter: (obj: unknown) => obj,
+  hashShareToken: () => "",
+  setLogLevel: () => false,
+}));
+
+const { seedBuiltinDatasourceCatalog, BUILTIN_DATASOURCE_CATALOG_ROWS } = await import(
+  "@atlas/api/lib/db/seed-builtin-datasource-catalog"
+);
+
+type SeedDb = Parameters<typeof seedBuiltinDatasourceCatalog>[0];
+
+/** A `pg` `DatabaseError` as the driver hands one back: untyped extra fields. */
+const uniqueViolation = (slug: string): Error =>
+  Object.assign(
+    new Error(`duplicate key value violates unique constraint "plugin_catalog_slug_key"`),
+    {
+      code: "23505",
+      constraint: "plugin_catalog_slug_key",
+      detail: `Key (slug)=(${slug}) already exists.`,
+    },
+  );
+
+/**
+ * A DB whose insert rejects for `blocked`, returns an empty RETURNING set for
+ * `existing` (the preserved path), and inserts everything else.
+ *
+ * The slug is read off the bound parameters rather than the SQL, so a seeder
+ * that reordered its `VALUES` would not quietly reject a different row than
+ * the test asked for.
+ */
+const dbBlocking = (
+  blocked: ReadonlySet<string>,
+  reject: (slug: string) => unknown = uniqueViolation,
+  existing: ReadonlySet<string> = new Set(),
+): { db: SeedDb; attempted: string[] } => {
+  const attempted: string[] = [];
+  const db: SeedDb = {
+    async query<T = unknown>(_sql: string, params?: unknown[]) {
+      const slug = String(params?.[2]);
+      attempted.push(slug);
+      if (blocked.has(slug)) throw reject(slug);
+      return { rows: (existing.has(slug) ? [] : [{ slug }]) as T[] };
+    },
+  };
+  return { db, attempted };
+};
+
+const ALL_SLUGS = BUILTIN_DATASOURCE_CATALOG_ROWS.map((r) => r.slug);
+const rowFor = (slug: string) => BUILTIN_DATASOURCE_CATALOG_ROWS.find((r) => r.slug === slug)!;
+
+// 4th and 7th of nine — neither first nor last, so a loop that stopped at the
+// first collision and one that dropped only the tail both fail here.
+const CLICKHOUSE = "clickhouse";
+const SALESFORCE = "salesforce";
+
+describe("seedBuiltinDatasourceCatalog — a slug held under a foreign id (#5266)", () => {
+  beforeEach(() => {
+    logged.length = 0;
+  });
+
+  it("⭐ reports the blocked row as BLOCKED and never as preserved", async () => {
+    // #5266's actual subject. Before the fix `preservedSlugs` was derived by
+    // subtraction — every expected slug minus the inserted ones — so a row the
+    // seeder could not write was positively asserted to be present and fine.
+    const { db } = dbBlocking(new Set([CLICKHOUSE]));
+    const result = await seedBuiltinDatasourceCatalog(db);
+
+    expect(result.blockedSlugs).toEqual([CLICKHOUSE]);
+    expect(result.preservedSlugs).not.toContain(CLICKHOUSE);
+    expect(result.insertedSlugs).not.toContain(CLICKHOUSE);
+    // ⚠️ The three lists have DIFFERENT sizes here — 8 inserted, 0 preserved,
+    // 1 blocked — so no two of them can be swapped without a count
+    // disagreeing. With `{1, 1}` the assertion would hold under the swap.
+    expect(result.insertedSlugs).toHaveLength(ALL_SLUGS.length - 1);
+    expect(result.preservedSlugs).toHaveLength(0);
+  });
+
+  it("⭐ keeps blocked and preserved apart when BOTH outcomes occur in one pass", async () => {
+    // The discriminating case, and the one the old subtraction could not
+    // express at all: `postgres` genuinely already exists (empty RETURNING,
+    // no error) while `clickhouse` is squatted (23505). Under the old
+    // derivation both landed in `preservedSlugs` and were indistinguishable.
+    const { db } = dbBlocking(new Set([CLICKHOUSE]), uniqueViolation, new Set(["postgres"]));
+    const result = await seedBuiltinDatasourceCatalog(db);
+
+    expect(result.preservedSlugs).toEqual(["postgres"]);
+    expect(result.blockedSlugs).toEqual([CLICKHOUSE]);
+    expect(result.insertedSlugs).toHaveLength(ALL_SLUGS.length - 2);
+    // The partition holds: every expected slug lands in exactly one list.
+    const all = [...result.insertedSlugs, ...result.preservedSlugs, ...result.blockedSlugs];
+    expect([...all].sort()).toEqual([...ALL_SLUGS].sort());
+    expect(new Set(all).size).toBe(all.length);
+  });
+
+  it("warns naming the blocked row, and the warning is not a success log", async () => {
+    const { db } = dbBlocking(new Set([CLICKHOUSE]));
+    await seedBuiltinDatasourceCatalog(db);
+
+    const perRow = logged.filter(
+      (c) =>
+        c.level === "warn" &&
+        typeof c.payload === "object" &&
+        c.payload !== null &&
+        (c.payload as { slug?: unknown }).slug === CLICKHOUSE,
+    );
+    expect(perRow).toHaveLength(1);
+    // The row is named by BOTH of its identifiers: the slug is what collided,
+    // the canonical id is what an operator has to go look at.
+    expect(perRow[0]?.payload).toMatchObject({
+      id: rowFor(CLICKHOUSE).id,
+      slug: CLICKHOUSE,
+      constraint: "plugin_catalog_slug_key",
+      detail: `Key (slug)=(${CLICKHOUSE}) already exists.`,
+      err: 'duplicate key value violates unique constraint "plugin_catalog_slug_key"',
+    });
+    // ⚠️ THE MESSAGE, not only the payload — the operator's entire remedy lives
+    // there and nothing else asserts on it. It must name the constraint and
+    // condition the lookup on it rather than prescribing a slug query outright.
+    expect(perRow[0]?.message).toContain("constraint");
+    expect(perRow[0]?.message).toContain("plugin_catalog WHERE slug");
+    // No `info` may claim the pass simply completed.
+    expect(logged.filter((c) => c.level === "info")).toHaveLength(0);
+    const summary = logged.filter((c) => c.level === "warn" && c.message.includes("BLOCKED"));
+    expect(summary).toHaveLength(1);
+  });
+
+  it("logs the plain success `info` — and no warning — when nothing is blocked", async () => {
+    // The other half of the level claim. Without this, a seeder that warned
+    // unconditionally would pass the case above.
+    const { db } = dbBlocking(new Set());
+    await seedBuiltinDatasourceCatalog(db);
+    expect(logged.filter((c) => c.level === "warn")).toHaveLength(0);
+    expect(logged.filter((c) => c.level === "info")).toHaveLength(1);
+  });
+
+  it("seeds every remaining row — one collision does not abort the loop", async () => {
+    const { db, attempted } = dbBlocking(new Set([CLICKHOUSE, SALESFORCE]));
+    const result = await seedBuiltinDatasourceCatalog(db);
+
+    expect(attempted).toEqual(ALL_SLUGS);
+    expect(result.blockedSlugs).toEqual([CLICKHOUSE, SALESFORCE]);
+    expect(result.insertedSlugs).toEqual(
+      ALL_SLUGS.filter((s) => s !== CLICKHOUSE && s !== SALESFORCE),
+    );
+    expect(result.insertedSlugs).toHaveLength(ALL_SLUGS.length - 2);
+  });
+
+  it("still propagates a non-unique-violation failure instead of warning past it", async () => {
+    // The guard on the guard. A catch that treated every rejection as a benign
+    // collision would demote a real outage — a dropped table, a dead pool — to
+    // a warning and report a seeded catalog.
+    const { db } = dbBlocking(new Set([CLICKHOUSE]), () =>
+      Object.assign(new Error('relation "plugin_catalog" does not exist'), { code: "42P01" }),
+    );
+    await expect(seedBuiltinDatasourceCatalog(db)).rejects.toThrow(/does not exist/);
+    expect(logged.filter((c) => c.level === "warn")).toHaveLength(0);
+  });
+
+  it("propagates a rejection that is not an object at all", async () => {
+    // `err.code` on a thrown string is `undefined`, and reading it unguarded is
+    // the CLAUDE.md type-narrowing rule this catch has to honour.
+    const { db } = dbBlocking(new Set([CLICKHOUSE]), (slug) => `pool exploded seeding ${slug}`);
+    await expect(seedBuiltinDatasourceCatalog(db)).rejects.toThrow();
+  });
+
+  it("classifies on the SQLSTATE code, not on the message", async () => {
+    // A message-keyed catch would classify this as a collision and warn past a
+    // failure that is nothing of the sort.
+    const { db } = dbBlocking(new Set([CLICKHOUSE]), () =>
+      Object.assign(new Error("duplicate key value violates unique constraint"), {
+        code: "XX000",
+      }),
+    );
+    await expect(seedBuiltinDatasourceCatalog(db)).rejects.toThrow(/duplicate key/);
+    expect(logged.filter((c) => c.level === "warn")).toHaveLength(0);
+  });
+
+  it("⭐ rethrows a 23505 that NAMES a different unique index", async () => {
+    // The hedge made structural. The warning admits it cannot know WHICH unique
+    // value collided — but `blockedSlugs` is a list of SLUGS, so filing a
+    // future `UNIQUE (name)` violation there would send an operator to rename
+    // the row holding a slug that is not the problem.
+    const { db } = dbBlocking(new Set([CLICKHOUSE]), () =>
+      Object.assign(new Error("duplicate key value violates unique constraint"), {
+        code: "23505",
+        constraint: "plugin_catalog_name_key",
+      }),
+    );
+    await expect(seedBuiltinDatasourceCatalog(db)).rejects.toThrow(/duplicate key/);
+    expect(
+      logged.filter(
+        (c) => c.level === "warn" && (c.payload as { slug?: unknown }).slug === CLICKHOUSE,
+      ),
+    ).toHaveLength(0);
+  });
+
+  it("⭐ logs the PARTIAL blocked list before aborting on an unrelated failure", async () => {
+    // `blockedSlugs` does not survive a throw: the boot wrapper turns it into
+    // `{ kind: "error" }` and the Layer reports `blockedSlugs: []`. So a pass
+    // that blocked clickhouse (4th) and then hit a dead table on salesforce
+    // (7th) would report NOTHING blocked — the same overloading #5266 exists
+    // to remove, one arm over. The abort has to say what it already knew.
+    const { db } = dbBlocking(new Set([CLICKHOUSE, SALESFORCE]), (slug) =>
+      slug === CLICKHOUSE
+        ? uniqueViolation(slug)
+        : Object.assign(new Error('relation "plugin_catalog" does not exist'), { code: "42P01" }),
+    );
+    await expect(seedBuiltinDatasourceCatalog(db)).rejects.toThrow(/does not exist/);
+
+    const abort = logged.find((c) => c.level === "warn" && c.message.includes("ABORTING"));
+    expect(abort).toBeDefined();
+    expect(abort?.payload).toMatchObject({
+      blockedSlugs: [CLICKHOUSE],
+      abortingAt: rowFor(SALESFORCE).id,
+    });
+    // And it says the list is partial — an operator reading it must not take
+    // one blocked slug for the whole story.
+    expect(abort?.message).toContain("PARTIAL");
+  });
+
+  it("tolerates a 23505 carrying no constraint or detail fields", async () => {
+    // Not every driver populates them, and an unguarded read would throw
+    // inside the catch — turning a reported collision into an aborted pass.
+    const { db } = dbBlocking(new Set([CLICKHOUSE]), () =>
+      Object.assign(new Error("duplicate key"), { code: "23505" }),
+    );
+    const result = await seedBuiltinDatasourceCatalog(db);
+    expect(result.blockedSlugs).toEqual([CLICKHOUSE]);
+    const perRow = logged.find(
+      (c) => c.level === "warn" && (c.payload as { slug?: unknown }).slug === CLICKHOUSE,
+    );
+    // Both diagnostics absent — and the raw message is the ONLY thing left
+    // saying what happened, which is why it is on the payload.
+    expect(perRow?.payload).toMatchObject({
+      constraint: undefined,
+      detail: undefined,
+      err: "duplicate key",
+    });
+  });
+});

--- a/packages/api/src/lib/db/__tests__/seed-builtin-datasource-catalog.test.ts
+++ b/packages/api/src/lib/db/__tests__/seed-builtin-datasource-catalog.test.ts
@@ -16,7 +16,7 @@
  *     test.ts` covers that the rejection happens at all.
  *
  *  2. `BUILTIN_DATASOURCE_CATALOG_ROWS` — the in-process source of truth.
- *     Asserts content-level invariants: all eight slugs, only
+ *     Asserts content-level invariants: all nine slugs, only
  *     `demo-postgres` is auto_install, every catalog slug is recognised
  *     by the resolver, every secret field is flagged.
  *
@@ -452,8 +452,12 @@ describe("runBuiltinDatasourceCatalogSeedBoot (discriminated outcomes)", () => {
     // with a comment saying the same thing; #5266 did not carry it over, and
     // the review panel found the gap.
     //
-    // One blocked, one preserved, seven inserted — three DIFFERENT sizes, so
-    // no two of the lists can be swapped without a count disagreeing.
+    // ⚠️ One blocked, one preserved, seven inserted — blocked and preserved
+    // are the SAME size, so a count-only assertion could not tell a
+    // blocked↔preserved swap apart. That is why the two assertions below are
+    // `toEqual` on CONTENTS, not lengths. (The sibling collision suite gets
+    // three genuinely different sizes and says so; round 1 copied that
+    // comment into the one case where its own counterexample applies.)
     hasInternalDBReturns = true;
     mockQuery.mockImplementation((_sql, params) => {
       const slug = String((params ?? [])[2]);

--- a/packages/api/src/lib/db/__tests__/seed-builtin-datasource-catalog.test.ts
+++ b/packages/api/src/lib/db/__tests__/seed-builtin-datasource-catalog.test.ts
@@ -444,6 +444,45 @@ describe("runBuiltinDatasourceCatalogSeedBoot (discriminated outcomes)", () => {
     }
   });
 
+  it("⭐ forwards NON-EMPTY blockedSlugs and preservedSlugs across the boot seam", async () => {
+    // ⚠️ THE TEST ABOVE ASSERTS BOTH FIELDS ARE `[]`, WHICH IS THE VALUE A
+    // BROKEN FORWARD PRODUCES. `blockedSlugs: []` / `preservedSlugs: []`
+    // hardcoded in the boot wrapper passes it — measured. The knowledge
+    // sibling has this exact test (`seed-builtin-knowledge-catalog.test.ts`)
+    // with a comment saying the same thing; #5266 did not carry it over, and
+    // the review panel found the gap.
+    //
+    // One blocked, one preserved, seven inserted — three DIFFERENT sizes, so
+    // no two of the lists can be swapped without a count disagreeing.
+    hasInternalDBReturns = true;
+    mockQuery.mockImplementation((_sql, params) => {
+      const slug = String((params ?? [])[2]);
+      if (slug === "clickhouse") {
+        return Promise.reject(
+          Object.assign(new Error("duplicate key value violates unique constraint"), {
+            code: "23505",
+            constraint: "plugin_catalog_slug_key",
+            detail: `Key (slug)=(${slug}) already exists.`,
+          }),
+        );
+      }
+      // Empty RETURNING = the row already existed under its canonical id.
+      if (slug === "postgres") return Promise.resolve({ rows: [] });
+      return Promise.resolve({ rows: [{ slug }] });
+    });
+
+    const { runBuiltinDatasourceCatalogSeedBoot } = await import(
+      "@atlas/api/lib/db/seed-builtin-datasource-catalog"
+    );
+    const result = await runBuiltinDatasourceCatalogSeedBoot();
+    expect(result.kind).toBe("seeded");
+    if (result.kind === "seeded") {
+      expect(result.blockedSlugs).toEqual(["clickhouse"]);
+      expect(result.preservedSlugs).toEqual(["postgres"]);
+      expect(result.insertedSlugs).toHaveLength(7);
+    }
+  });
+
   it("returns `{ kind: 'error' }` when the pool query throws", async () => {
     hasInternalDBReturns = true;
     mockQuery.mockImplementation(() =>

--- a/packages/api/src/lib/db/__tests__/seed-builtin-datasource-catalog.test.ts
+++ b/packages/api/src/lib/db/__tests__/seed-builtin-datasource-catalog.test.ts
@@ -4,9 +4,16 @@
  * Two surfaces under test:
  *
  *  1. `seedBuiltinDatasourceCatalog(db)` — the runtime seeder. Asserts
- *     the eight rows are inserted with `ON CONFLICT DO NOTHING` semantics
- *     and that the result accounting (inserted vs preserved) tracks the
- *     RETURNING row set.
+ *     the nine rows are inserted with `ON CONFLICT (id) DO NOTHING`
+ *     semantics and that the result accounting partitions the expected
+ *     slugs across inserted / preserved / blocked (#5266).
+ *
+ *     ⚠️ THE BLOCKED OUTCOME IS NOT HERE, and cannot be: this file's mock
+ *     pool returns whatever the fixture says, so it can no more raise a
+ *     real 23505 than it can prove Postgres would.
+ *     `seed-builtin-datasource-catalog-collision.test.ts` covers what the
+ *     seeder DOES with a rejection; `builtin-datasource-catalog-seed-pg.
+ *     test.ts` covers that the rejection happens at all.
  *
  *  2. `BUILTIN_DATASOURCE_CATALOG_ROWS` — the in-process source of truth.
  *     Asserts content-level invariants: all eight slugs, only
@@ -36,6 +43,16 @@ interface CapturedQuery {
   params: unknown[];
 }
 
+/**
+ * Per-row mock pool (#5266 — the seeder issues one statement per row now).
+ *
+ * `conflictWith` names slugs whose row already exists under its canonical id:
+ * the `ON CONFLICT (id) DO NOTHING` path, which returns zero rows and no
+ * error. That is the PRESERVED outcome, and it is deliberately not the same
+ * thing as the BLOCKED outcome — a foreign id holding the slug raises 23505
+ * instead, which this mock cannot express and
+ * `seed-builtin-datasource-catalog-collision.test.ts` covers.
+ */
 const captureDb = (
   conflictWith: ReadonlyArray<string> = [],
 ): { db: BuiltinDatasourceCatalogSeedDb; captured: CapturedQuery[] } => {
@@ -43,11 +60,11 @@ const captureDb = (
   const db: BuiltinDatasourceCatalogSeedDb = {
     async query<T = unknown>(sql: string, params?: unknown[]) {
       captured.push({ sql, params: params ?? [] });
-      // Simulate ON CONFLICT DO NOTHING ... RETURNING slug:
-      // return slugs that did NOT conflict (i.e. that actually inserted).
-      const allSlugs = BUILTIN_DATASOURCE_CATALOG_ROWS.map((r) => r.slug);
-      const inserted = allSlugs.filter((s) => !conflictWith.includes(s));
-      return { rows: inserted.map((slug) => ({ slug })) as T[] };
+      // The seeder binds (id, name, slug, …) — slug is the third param.
+      const slug = String((params ?? [])[2]);
+      return {
+        rows: (conflictWith.includes(slug) ? [] : [{ slug }]) as T[],
+      };
     },
   };
   return { db, captured };
@@ -144,35 +161,39 @@ describe("BUILTIN_DATASOURCE_CATALOG_ROWS", () => {
 });
 
 describe("seedBuiltinDatasourceCatalog (idempotent boot seed)", () => {
-  it("issues a single bulk INSERT covering all eight rows", async () => {
+  it("issues one INSERT per row, with the conflict target QUALIFIED on id (#5266)", async () => {
     const { db, captured } = captureDb();
     await seedBuiltinDatasourceCatalog(db);
-    expect(captured).toHaveLength(1);
-    expect(captured[0]!.sql).toContain("INSERT INTO plugin_catalog");
-    // Unqualified ON CONFLICT DO NOTHING covers both the slug unique
-    // index AND the id PK — see seed module's JSDoc for the edge case
-    // (operator-edited row with a clashing `catalog:<slug>` id).
-    expect(captured[0]!.sql).toContain("ON CONFLICT DO NOTHING");
-    expect(captured[0]!.sql).not.toContain("ON CONFLICT (slug)");
-    expect(captured[0]!.sql).toContain("RETURNING slug");
+    // One statement per row — the shape that makes per-row recovery
+    // expressible at all. A bulk INSERT rejects the whole batch on the first
+    // 23505, so it cannot report WHICH row is missing.
+    expect(captured).toHaveLength(BUILTIN_DATASOURCE_CATALOG_ROWS.length);
+    for (const q of captured) {
+      expect(q.sql).toContain("INSERT INTO plugin_catalog");
+      // ⚠️ Qualified on `(id)`. The unqualified spelling ALSO covers the slug
+      // unique index, which is exactly the defect: it swallows a slug held
+      // under a foreign id instead of raising 23505.
+      expect(q.sql).toContain("ON CONFLICT (id) DO NOTHING");
+      expect(q.sql).not.toMatch(/ON CONFLICT\s+DO NOTHING/);
+      expect(q.sql).not.toContain("ON CONFLICT (slug)");
+      expect(q.sql).toContain("RETURNING slug");
+    }
   });
 
   it("emits 8 params per row (id, name, slug, description, install_model, auto_install, saas_eligible, config_schema)", async () => {
     const { db, captured } = captureDb();
     await seedBuiltinDatasourceCatalog(db);
-    // 9 rows × 8 params per row = 72 bound params total.
-    expect(captured[0]!.params).toHaveLength(9 * 8);
+    for (const q of captured) expect(q.params).toHaveLength(8);
   });
 
   it("binds saas_eligible per row — DuckDB false, every other row true (#3301)", async () => {
     const { db, captured } = captureDb();
     await seedBuiltinDatasourceCatalog(db);
-    // Each row's 7th param (index 6, 14, 22, …) is the saas_eligible boolean,
+    // Each statement's 7th param (index 6) is the saas_eligible boolean,
     // bound rather than a SQL literal so DuckDB lands `false` on a fresh DB.
     for (let i = 0; i < BUILTIN_DATASOURCE_CATALOG_ROWS.length; i++) {
       const row = BUILTIN_DATASOURCE_CATALOG_ROWS[i]!;
-      const param = captured[0]!.params[i * 8 + 6];
-      expect(param).toBe(row.slug === "duckdb" ? false : true);
+      expect(captured[i]!.params[6]).toBe(row.slug === "duckdb" ? false : true);
     }
   });
 
@@ -183,15 +204,19 @@ describe("seedBuiltinDatasourceCatalog (idempotent boot seed)", () => {
       [...BUILTIN_DATASOURCE_CATALOG_SLUGS].sort(),
     );
     expect(result.preservedSlugs).toHaveLength(0);
+    expect(result.blockedSlugs).toHaveLength(0);
   });
 
-  it("reports preserved slugs when rows already exist (ON CONFLICT DO NOTHING path)", async () => {
+  it("reports preserved slugs when rows already exist (ON CONFLICT (id) DO NOTHING path)", async () => {
     const { db } = captureDb(["postgres", "demo-postgres"]);
     const result = await seedBuiltinDatasourceCatalog(db);
     const preserved: string[] = [...result.preservedSlugs];
     expect(preserved.sort()).toEqual(["demo-postgres", "postgres"]);
     expect(result.insertedSlugs).toHaveLength(7);
     expect(result.insertedSlugs).not.toContain("postgres");
+    // Preserved is now a POSITIVE observation (the empty RETURNING set), not
+    // "everything that isn't inserted" — so nothing blocked can leak in here.
+    expect(result.blockedSlugs).toHaveLength(0);
   });
 
   it("reports all preserved on a fully-populated catalog (true idempotent re-boot)", async () => {
@@ -201,14 +226,27 @@ describe("seedBuiltinDatasourceCatalog (idempotent boot seed)", () => {
     expect([...result.preservedSlugs].sort()).toEqual(
       [...BUILTIN_DATASOURCE_CATALOG_SLUGS].sort(),
     );
+    expect(result.blockedSlugs).toHaveLength(0);
+  });
+
+  it("partitions the expected slugs across the three outcome lists", async () => {
+    // ⚠️ The invariant #5266 is about, stated as a partition rather than as
+    // three separate counts: every expected slug appears exactly once. The old
+    // derivation (`all minus inserted`) satisfied "covers everything" while
+    // putting blocked rows in the wrong bucket.
+    const { db } = captureDb(["postgres"]);
+    const result = await seedBuiltinDatasourceCatalog(db);
+    const all = [...result.insertedSlugs, ...result.preservedSlugs, ...result.blockedSlugs];
+    expect(all.sort()).toEqual([...BUILTIN_DATASOURCE_CATALOG_SLUGS].sort());
+    expect(new Set(all).size).toBe(all.length);
   });
 
   it("serializes config_schema as JSON in the bound params (matches ::jsonb cast in SQL)", async () => {
     const { db, captured } = captureDb();
     await seedBuiltinDatasourceCatalog(db);
-    // Each row's 8th param (index 7, 15, 23, …) is the JSON-serialized configSchema.
+    // Each statement's 8th param (index 7) is the JSON-serialized configSchema.
     for (let i = 0; i < BUILTIN_DATASOURCE_CATALOG_ROWS.length; i++) {
-      const param = captured[0]!.params[i * 8 + 7];
+      const param = captured[i]!.params[7];
       expect(typeof param).toBe("string");
       const parsed = JSON.parse(param as string);
       expect(parsed).toEqual(BUILTIN_DATASOURCE_CATALOG_ROWS[i]!.configSchema);
@@ -389,12 +427,10 @@ describe("runBuiltinDatasourceCatalogSeedBoot (discriminated outcomes)", () => {
 
   it("returns `{ kind: 'seeded' }` on a successful seed", async () => {
     hasInternalDBReturns = true;
-    // Simulate every row inserted (no conflicts) — match the bulk INSERT
-    // RETURNING contract.
-    mockQuery.mockImplementation(() =>
-      Promise.resolve({
-        rows: BUILTIN_DATASOURCE_CATALOG_ROWS.map((r) => ({ slug: r.slug })),
-      }),
+    // Simulate every row inserted (no conflicts) — one statement per row,
+    // each returning its own slug, matching the per-row RETURNING contract.
+    mockQuery.mockImplementation((_sql, params) =>
+      Promise.resolve({ rows: [{ slug: String((params ?? [])[2]) }] }),
     );
     const { runBuiltinDatasourceCatalogSeedBoot } = await import(
       "@atlas/api/lib/db/seed-builtin-datasource-catalog"
@@ -404,6 +440,7 @@ describe("runBuiltinDatasourceCatalogSeedBoot (discriminated outcomes)", () => {
     if (result.kind === "seeded") {
       expect(result.insertedSlugs).toHaveLength(9);
       expect(result.preservedSlugs).toHaveLength(0);
+      expect(result.blockedSlugs).toHaveLength(0);
     }
   });
 

--- a/packages/api/src/lib/db/internal.ts
+++ b/packages/api/src/lib/db/internal.ts
@@ -945,8 +945,10 @@ export function _hasRecoveryFiber(): boolean {
  * breaker. Read this *before* enqueueing a security-control audit row
  * (e.g. a rate-limit denial) so the call site can light up a
  * differentiated metric + `log.error` on drop. The fire-and-forget
- * `internalExecute` only logs an aggregate "Internal DB circuit breaker
- * open" once on open and a per-write debug line; without an exposed
+ * `internalExecute` logs an aggregate "Internal DB circuit breaker open"
+ * once on open, plus a per-write `log.error` that is SUPPRESSED for as long
+ * as the circuit stays open — so past that point a dropped row leaves no
+ * per-row trace at any level, only `_droppedCount`. Without an exposed
  * predicate, security-control callers can't tell their row was dropped
  * (#2183 item 3).
  */

--- a/packages/api/src/lib/db/pg-errors.ts
+++ b/packages/api/src/lib/db/pg-errors.ts
@@ -1,0 +1,63 @@
+/**
+ * Postgres error classification shared across the write paths that recover
+ * from a specific SQLSTATE rather than failing the whole pass.
+ *
+ * `PG_UNIQUE_VIOLATION` had FOUR independent definitions when this module was
+ * written (#5266) — `seed-builtin-knowledge-catalog.ts`, `admin-prompts.ts`,
+ * `sub-processor-subscriptions.ts` and `routing-id-conflict.ts` — the fourth
+ * added by #5260 while fixing the very defect class this module serves. Four
+ * spellings of one constant is four chances for one of them to drift to a
+ * SQLSTATE that means something else, and nothing would catch it: each site's
+ * tests pin its own copy.
+ *
+ * ⚠️ **Only the CONSTANT is universal; the classification around it is not.**
+ * `asUniqueViolation` below reads a FLAT `code`, which is right for the `pg`
+ * driver and wrong for `@effect/sql` — that wrapper moves the driver error
+ * under `.cause`, which is why `routing-id-conflict.ts` walks the chain
+ * instead. It imports the constant and keeps its own walk. Do not "simplify"
+ * the two into one helper: a chain walk applied to the seeders would classify
+ * a wrapped violation from an unrelated layer as a benign collision, and a
+ * flat read applied to the Effect path would classify every real collision as
+ * an unhandled throw.
+ */
+
+/** Postgres SQLSTATE for `unique_violation`. */
+export const PG_UNIQUE_VIOLATION = "23505";
+
+/**
+ * The diagnostic fields of a flat `23505`, or `undefined` for any other
+ * rejection.
+ *
+ * `pg` rejects with a `DatabaseError` carrying untyped `code`/`constraint`/
+ * `detail`, so this narrows rather than casts. It reads the CODE and not the
+ * message: matching on prose would classify an unrelated failure whose message
+ * happened to say "duplicate key" as a benign collision, and demoting a real
+ * outage to a warning is the failure this classification exists to avoid.
+ *
+ * ⚠️ Reads a TOP-LEVEL `code` only. An `@effect/sql`-backed client wraps the
+ * driver error under `.cause`, so every collision would arrive here
+ * unclassified — worse than no recovery, because the caller's catch would then
+ * treat a routine squatted slug as a hard failure. Both seeders pass a raw
+ * `Pool`; see their seam preconditions.
+ */
+export function asUniqueViolation(
+  err: unknown,
+): { readonly constraint?: string; readonly detail?: string } | undefined {
+  if (typeof err !== "object" || err === null) return undefined;
+  if (!("code" in err) || err.code !== PG_UNIQUE_VIOLATION) return undefined;
+  const constraint = "constraint" in err && typeof err.constraint === "string" ? err.constraint : undefined;
+  const detail = "detail" in err && typeof err.detail === "string" ? err.detail : undefined;
+  return { constraint, detail };
+}
+
+/**
+ * The one NAMED unique constraint the two `plugin_catalog` seeders' recovery
+ * models (`0014_plugin_marketplace.sql`; mirrored in `db/schema.ts`).
+ *
+ * `plugin_catalog` has two unique constraints today — PK `id`, consumed by the
+ * conflict target, and this one — so a 23505 reaching either seeder's catch is
+ * almost certainly a slug collision. Naming it turns that inference into a
+ * condition the code checks; an UNNAMED 23505 is still accepted, under the
+ * hedge each seeder's warning carries.
+ */
+export const PG_PLUGIN_CATALOG_SLUG_CONSTRAINT = "plugin_catalog_slug_key";

--- a/packages/api/src/lib/db/pg-errors.ts
+++ b/packages/api/src/lib/db/pg-errors.ts
@@ -2,13 +2,22 @@
  * Postgres error classification shared across the write paths that recover
  * from a specific SQLSTATE rather than failing the whole pass.
  *
- * `PG_UNIQUE_VIOLATION` had FOUR independent definitions when this module was
+ * `PG_UNIQUE_VIOLATION` had SIX independent definitions when this module was
  * written (#5266) — `seed-builtin-knowledge-catalog.ts`, `admin-prompts.ts`,
- * `sub-processor-subscriptions.ts` and `routing-id-conflict.ts` — the fourth
- * added by #5260 while fixing the very defect class this module serves. Four
- * spellings of one constant is four chances for one of them to drift to a
- * SQLSTATE that means something else, and nothing would catch it: each site's
- * tests pin its own copy.
+ * `sub-processor-subscriptions.ts`, `routing-id-conflict.ts`,
+ * `starter-prompts/favorite-store.ts` and `suggestions/approval-store.ts` —
+ * one of them added by #5260 while fixing the very defect class this module
+ * serves. Six spellings of one constant is six chances for one of them to
+ * drift to a SQLSTATE that means something else, and nothing would catch it:
+ * each site's tests pin its own copy.
+ *
+ * ⚠️ The first draft of this header said FOUR, because the sweep that produced
+ * it grepped for the declaration and stopped at the sites the issue named. The
+ * two it missed are cited BY PATH inside `sub-processor-subscriptions.ts` as
+ * its own precedent — i.e. they were reachable from a file the same commit was
+ * editing. A census in a header is a claim like any other; this one is now
+ * `grep -rn '= "23505"'` over `packages/api/src` and `ee/`, which returns this
+ * line and nothing else.
  *
  * ⚠️ **Only the CONSTANT is universal; the classification around it is not.**
  * `asUniqueViolation` below reads a FLAT `code`, which is right for the `pg`

--- a/packages/api/src/lib/db/pg-errors.ts
+++ b/packages/api/src/lib/db/pg-errors.ts
@@ -16,8 +16,10 @@
  * two it missed are cited BY PATH inside `sub-processor-subscriptions.ts` as
  * its own precedent — i.e. they were reachable from a file the same commit was
  * editing. A census in a header is a claim like any other; this one is now
- * `grep -rn '= "23505"'` over `packages/api/src` and `ee/`, which returns this
- * line and nothing else.
+ * `grep -rn 'const .* = "23505"'` over `packages/api/src` and `ee/`, which
+ * returns two lines: the declaration below, and this line quoting the recipe.
+ * (Constrained to DECLARATIONS on purpose — the unconstrained pattern also
+ * matches seven test fixtures that build a rejection by hand.)
  *
  * ⚠️ **Only the CONSTANT is universal; the classification around it is not.**
  * `asUniqueViolation` below reads a FLAT `code`, which is right for the `pg`
@@ -28,6 +30,14 @@
  * a wrapped violation from an unrelated layer as a benign collision, and a
  * flat read applied to the Effect path would classify every real collision as
  * an unhandled throw.
+ *
+ * ⚠️ FOUR of the six consumers are on exactly that Effect path today:
+ * `admin-prompts.ts`, `sub-processor-subscriptions.ts`,
+ * `starter-prompts/favorite-store.ts` and `suggestions/approval-store.ts` all
+ * read this flat classification off an `internalQuery` result, where the shape
+ * may be wrapped. Tracked in #5272; each site carries the same note. Do not
+ * read "flat is right for the `pg` driver" as "flat is right at every call
+ * site" — only the two seeders pass a raw `Pool`.
  */
 
 /** Postgres SQLSTATE for `unique_violation`. */
@@ -61,7 +71,10 @@ export function asUniqueViolation(
 
 /**
  * The one NAMED unique constraint the two `plugin_catalog` seeders' recovery
- * models (`0014_plugin_marketplace.sql`; mirrored in `db/schema.ts`).
+ * models. Postgres DERIVES this name from `slug TEXT NOT NULL UNIQUE` in
+ * `0014_plugin_marketplace.sql` — the literal string appears in neither the
+ * migration nor `db/schema.ts`, so grepping for it finds only this module and
+ * its tests.
  *
  * `plugin_catalog` has two unique constraints today — PK `id`, consumed by the
  * conflict target, and this one — so a 23505 reaching either seeder's catch is

--- a/packages/api/src/lib/db/seed-builtin-datasource-catalog.ts
+++ b/packages/api/src/lib/db/seed-builtin-datasource-catalog.ts
@@ -21,9 +21,11 @@
  *     existing rows; this seed deliberately leaves them alone — once
  *     a built-in row exists, an operator who edited its `name` or
  *     `description` via SQL keeps that edit.
- *   - Rows seed sequentially. A `23505` naming the slug index is recorded
- *     in `blockedSlugs` and the pass carries on; a `23505` naming any
- *     OTHER constraint, and every other error, propagates.
+ *   - Rows seed sequentially. A `23505` that names the slug index — OR
+ *     names no constraint at all, which is the hedge the recovery's own
+ *     warning carries — is recorded in `blockedSlugs` and the pass carries
+ *     on; a `23505` naming any OTHER constraint, and every other error,
+ *     propagates.
  *   - A seed-time failure logs at error and the API keeps booting —
  *     pre-existing rows answer admin-UI reads.
  *
@@ -488,7 +490,9 @@ export interface BuiltinDatasourceCatalogSeedResult {
  * Rows seed SEQUENTIALLY, one statement each, mirroring the knowledge seeder
  * (#5239/#5260). `RETURNING slug` reports whether each row was inserted vs
  * preserved; a slug held under a foreign id raises `23505`, is recorded in
- * `blockedSlugs` and does not stop the pass; any other failure propagates.
+ * `blockedSlugs` and does not stop the pass. A `23505` naming a DIFFERENT
+ * constraint, and every other failure, propagates — an UNNAMED one is
+ * accepted into the recovery, under the hedge the warning carries.
  *
  * ⚠️ **Per-row, not the bulk INSERT this used to issue — the shape IS the
  * fix.** A single statement cannot report per-row outcomes: one `23505`

--- a/packages/api/src/lib/db/seed-builtin-datasource-catalog.ts
+++ b/packages/api/src/lib/db/seed-builtin-datasource-catalog.ts
@@ -13,15 +13,28 @@
  *   > in `atlas.config.ts` — they ship with Atlas.
  *
  * Idempotency:
- *   - Uses unqualified `ON CONFLICT DO NOTHING` (covers both the `slug`
- *     unique index AND the `id` primary key) so re-running on a populated
- *     catalog is a no-op. The atlas.config.ts catalog seeder
+ *   - Uses `ON CONFLICT (id) DO NOTHING` — the target is QUALIFIED on the
+ *     primary key, so re-running on a populated catalog is a no-op while a
+ *     slug held under a FOREIGN id still raises `23505` rather than
+ *     silently no-op'ing (#5266). The atlas.config.ts catalog seeder
  *     (`integrations/catalog-seeder.ts`) updates mutable fields on
  *     existing rows; this seed deliberately leaves them alone — once
  *     a built-in row exists, an operator who edited its `name` or
  *     `description` via SQL keeps that edit.
+ *   - Rows seed sequentially. A `23505` naming the slug index is recorded
+ *     in `blockedSlugs` and the pass carries on; a `23505` naming any
+ *     OTHER constraint, and every other error, propagates.
  *   - A seed-time failure logs at error and the API keeps booting —
  *     pre-existing rows answer admin-UI reads.
+ *
+ * ⚠️ **A BLOCKED ROW IS NOT A PRESERVED ROW, and this seeder used to say it
+ * was.** Before #5266 the target was unqualified, so a squatted slug was
+ * swallowed as a no-op — and `preservedSlugs` was derived by SUBTRACTION
+ * (every expected slug minus the inserted ones), which put the blocked row in
+ * the same bucket as a row that genuinely already existed. The caller was told
+ * a row it does not have is fine. That is strictly worse than #5239's sibling
+ * defect on the knowledge seeder, which merely omitted the row from an
+ * ambiguous count rather than positively asserting its presence.
  *
  * These rows are live: they surface as catalog entries in admin-UI listings
  * (integrations marketplace `pillar = 'datasource'` cards), and form-install
@@ -39,6 +52,10 @@ import {
 } from "@atlas/api/lib/db/datasource-pool-resolver";
 import type { ConfigSchemaField } from "@atlas/api/lib/plugins/registry";
 import { assertOperatorCatalogWrite } from "@atlas/api/lib/plugins/catalog-provenance";
+import {
+  asUniqueViolation,
+  PG_PLUGIN_CATALOG_SLUG_CONSTRAINT,
+} from "@atlas/api/lib/db/pg-errors";
 
 const log = createLogger("db.seed-builtin-datasource-catalog");
 
@@ -416,26 +433,74 @@ export interface BuiltinDatasourceCatalogSeedDb {
   query<T = unknown>(sql: string, params?: unknown[]): Promise<{ rows: T[] }>;
 }
 
+/**
+ * ⚠️ TWO PRECONDITIONS ON THE SEAM ABOVE, both load-bearing for the #5266
+ * recovery below, and neither expressible in the type. Identical to the
+ * knowledge seeder's — one mechanism, two catalogs.
+ *
+ * 1. **It must autocommit.** The loop recovers from a per-row `23505` by
+ *    logging and continuing. Inside an open transaction the first one poisons
+ *    it, so every remaining INSERT fails `25P02` — not `23505`, so it rethrows
+ *    and aborts the pass with `current transaction is aborted`, and the
+ *    header's "carries on to the remaining rows" becomes false. The one
+ *    production caller passes a `Pool` (see
+ *    `runBuiltinDatasourceCatalogSeedBoot`), where each statement is its own
+ *    transaction.
+ * 2. **It must surface pg errors FLAT.** `asUniqueViolation` reads a top-level
+ *    `code`. `@effect/sql` wraps the driver error and moves it under `.cause`
+ *    (`lib/integrations/install/routing-id-conflict.ts` walks the chain for
+ *    exactly that reason), so an Effect-backed client would make every
+ *    collision an unclassified throw — worse than before #5266, not better.
+ */
+
 export interface BuiltinDatasourceCatalogSeedResult {
-  /** Slugs whose `ON CONFLICT DO NOTHING` ran an insert (row didn't exist). */
+  /** Slugs whose `ON CONFLICT (id) DO NOTHING` ran an insert (row didn't exist). */
   readonly insertedSlugs: ReadonlyArray<BuiltinDatasourceCatalogSlug>;
-  /** Slugs whose row already existed (the conflict path). */
+  /**
+   * Slugs whose row already existed under its canonical id (the conflict
+   * path).
+   *
+   * ⚠️ "Already existed", NOT "already correct". The seed is insert-only and
+   * never reads the row back, so its CONTENT is unobserved — an operator who
+   * rewrote a built-in row through `catalog-crud.ts` lands in this same
+   * bucket, which is the whole reason a field change takes a migration.
+   *
+   * ⚠️ It is now DISJOINT from {@link blockedSlugs}, and that is the whole
+   * point of #5266. It is no longer *everything that was not inserted*: a row
+   * a foreign-id collision blocked is absent from the catalog and belongs in
+   * `blockedSlugs`, not here. The three lists partition the expected slugs.
+   */
   readonly preservedSlugs: ReadonlyArray<BuiltinDatasourceCatalogSlug>;
+  /**
+   * The slugs a `23505` blocked — a DIFFERENT catalog row already holds the
+   * slug under a different id, so the built-in row does not exist under its
+   * canonical id and this pass could not create it (#5266).
+   *
+   * Same name and same meaning as the knowledge seeder's field (#5239): one
+   * concept, two catalogs.
+   */
+  readonly blockedSlugs: ReadonlyArray<BuiltinDatasourceCatalogSlug>;
 }
 
 /**
  * Idempotently seed the nine built-in Datasource catalog rows.
  *
- * Bulk INSERT keeps the seed cheap (single statement vs nine) and lets
- * the result set (`RETURNING slug`) report which rows actually inserted
- * vs which were preserved. Unqualified `ON CONFLICT DO NOTHING` covers
- * both the `slug` unique index AND the `id` primary key — so a stray
- * operator-edited row with one of our canonical `catalog:<slug>` ids
- * under a different slug doesn't crash the boot pass.
+ * Rows seed SEQUENTIALLY, one statement each, mirroring the knowledge seeder
+ * (#5239/#5260). `RETURNING slug` reports whether each row was inserted vs
+ * preserved; a slug held under a foreign id raises `23505`, is recorded in
+ * `blockedSlugs` and does not stop the pass; any other failure propagates.
  *
- * The bulk shape mirrors migration 0093's VALUES block exactly —
- * keeping them aligned is checked by the
- * `migration-and-seed-stay-aligned` test.
+ * ⚠️ **Per-row, not the bulk INSERT this used to issue — the shape IS the
+ * fix.** A single statement cannot report per-row outcomes: one `23505`
+ * rejects the whole batch, so recovering row-by-row is only expressible as
+ * row-by-row statements. Nine statements at boot is the price of being able
+ * to say WHICH row is missing, and the old bulk form paid for its cheapness
+ * by reporting the blocked row as present (#5266).
+ *
+ * The VALUES shape still mirrors migration 0093's block per row — keeping
+ * them aligned is checked by the `migration-and-seed-stay-aligned` test,
+ * which reads the migration SQL and this module's row table, not the
+ * statement count.
  */
 export async function seedBuiltinDatasourceCatalog(
   db: BuiltinDatasourceCatalogSeedDb,
@@ -453,63 +518,128 @@ export async function seedBuiltinDatasourceCatalog(
     }
   }
 
-  // Parameterised bulk INSERT — each row contributes 8 placeholders
-  // (id, name, slug, description, install_model, auto_install,
-  // saas_eligible, config_schema). The remaining 7 columns are SQL
-  // literals (`'datasource'` for type and pillar, `'available'` for
-  // status, `'starter'` for min_plan, one `true` for enabled, and two
-  // `NOW()` timestamps). `saas_eligible` is bound per row (#3301) so
-  // DuckDB lands `false` on a fresh DB; existing DBs are converged by
-  // migration 0124. Column order matches migration 0093's VALUES block —
-  // drift is checked by `__tests__/seed-builtin-datasource-catalog.test.ts`'s
-  // `migration-and-seed-stay-aligned` suite.
-  const placeholders: string[] = [];
-  const params: unknown[] = [];
-  let p = 0;
-  for (const row of BUILTIN_DATASOURCE_CATALOG_ROWS) {
-    const placeholder = `($${++p}, $${++p}, $${++p}, $${++p}, 'datasource', $${++p}, 'datasource', 'available', $${++p}, 'starter', true, $${++p}, $${++p}::jsonb, NOW(), NOW())`;
-    placeholders.push(placeholder);
-    params.push(
-      row.id,
-      row.name,
-      row.slug,
-      row.description,
-      row.installModel,
-      row.autoInstall,
-      row.saasEligible,
-      JSON.stringify(row.configSchema),
-    );
-  }
-
   // Operator-curated-only gate (#4174/#4099): rows here ship inside Atlas.
   assertOperatorCatalogWrite("builtin-datasource-seed");
-  const { rows } = await db.query<{ slug: BuiltinDatasourceCatalogSlug }>(
-    `INSERT INTO plugin_catalog
-       (id, name, slug, description, type, install_model, pillar,
-        implementation_status, auto_install, min_plan, enabled, saas_eligible,
-        config_schema, created_at, updated_at)
-     VALUES ${placeholders.join(", ")}
-     ON CONFLICT DO NOTHING
-     RETURNING slug`,
-    params,
-  );
 
-  const insertedSlugs = rows.map((r) => r.slug);
-  const insertedSet = new Set<string>(insertedSlugs);
-  const preservedSlugs = BUILTIN_DATASOURCE_CATALOG_ROWS.map((r) => r.slug).filter(
-    (slug) => !insertedSet.has(slug),
-  );
+  const insertedSlugs: BuiltinDatasourceCatalogSlug[] = [];
+  const blockedSlugs: BuiltinDatasourceCatalogSlug[] = [];
+  const preservedSlugs: BuiltinDatasourceCatalogSlug[] = [];
 
-  log.info(
-    {
-      insertedCount: insertedSlugs.length,
-      preservedCount: preservedSlugs.length,
-      insertedSlugs,
-    },
-    "Built-in Datasource catalog seed complete",
-  );
+  for (const row of BUILTIN_DATASOURCE_CATALOG_ROWS) {
+    let returned: { slug: BuiltinDatasourceCatalogSlug }[];
+    try {
+      // Each row binds 8 params (id, name, slug, description, install_model,
+      // auto_install, saas_eligible, config_schema). The remaining 7 columns
+      // are SQL literals (`'datasource'` for type and pillar, `'available'`
+      // for status, `'starter'` for min_plan, one `true` for enabled, and two
+      // `NOW()` timestamps). `saas_eligible` is bound per row (#3301) so
+      // DuckDB lands `false` on a fresh DB; existing DBs are converged by
+      // migration 0124. Column order matches migration 0093's VALUES block —
+      // drift is checked by
+      // `__tests__/seed-builtin-datasource-catalog.test.ts`'s
+      // `migration-and-seed-stay-aligned` suite.
+      const { rows } = await db.query<{ slug: BuiltinDatasourceCatalogSlug }>(
+        `INSERT INTO plugin_catalog
+           (id, name, slug, description, type, install_model, pillar,
+            implementation_status, auto_install, min_plan, enabled, saas_eligible,
+            config_schema, created_at, updated_at)
+         VALUES ($1, $2, $3, $4, 'datasource', $5, 'datasource', 'available', $6,
+                 'starter', true, $7, $8::jsonb, NOW(), NOW())
+         ON CONFLICT (id) DO NOTHING
+         RETURNING slug`,
+        [
+          row.id,
+          row.name,
+          row.slug,
+          row.description,
+          row.installModel,
+          row.autoInstall,
+          row.saasEligible,
+          JSON.stringify(row.configSchema),
+        ],
+      );
+      returned = rows;
+    } catch (err) {
+      const collision = asUniqueViolation(err);
+      // ⚠️ RETHROW COVERS TWO CASES, and the second one is the hedge made
+      // structural. Anything that is not a unique violation is a real failure
+      // (as before #5266) — and a 23505 that NAMES a constraint other than
+      // the slug index is not the squatter this recovery models either.
+      // Recording that as a blocked SLUG would file a future `UNIQUE (name)`
+      // violation under "go rename the row holding this slug", which is a
+      // hedged message next to unhedged data; the data loses. An unnamed
+      // 23505 still lands in the recovery below, where the message's hedge
+      // covers it.
+      const modelled =
+        collision !== undefined &&
+        (collision.constraint === undefined ||
+          collision.constraint === PG_PLUGIN_CATALOG_SLUG_CONSTRAINT);
+      if (!modelled) {
+        // ⚠️ `blockedSlugs` DOES NOT SURVIVE THIS THROW. The boot wrapper
+        // turns it into `{ kind: "error" }` and the Layer reports
+        // `blockedSlugs: []`, so a pass that blocked row 2 and then hit a
+        // dead pool on row 6 would otherwise report nothing blocked at all —
+        // the same overloading #5266 exists to remove, one arm over. Emit
+        // the partial list here or it is lost.
+        if (blockedSlugs.length > 0) {
+          log.warn(
+            { blockedSlugs, insertedSlugs, abortingAt: row.id },
+            "Built-in Datasource catalog seed ABORTING with rows already blocked — this list is PARTIAL (the pass stopped early) and is NOT carried on the boot result, which will report an error with no blocked slugs",
+          );
+        }
+        throw err;
+      }
+      blockedSlugs.push(row.slug);
+      log.warn(
+        {
+          id: row.id,
+          slug: row.slug,
+          constraint: collision.constraint,
+          detail: collision.detail,
+          // ⚠️ The raw message, because `constraint` and `detail` are both
+          // OPTIONAL — a driver that populates neither would otherwise leave
+          // the operator a warning with no evidence of WHAT collided. Safe to
+          // log: every unique value on `plugin_catalog` is a slug or a
+          // catalog id, neither of which is a secret.
+          err: err instanceof Error ? err.message : String(err),
+        },
+        // Hedged in the diagnosis AND in the remedy: `plugin_catalog` has
+        // exactly two unique constraints today — PK `id` (consumed by the
+        // conflict target) and UNIQUE `slug` — so a 23505 arriving here is
+        // almost certainly a slug collision. That is an inference from the
+        // current schema, not something this catch verified, so the lookup
+        // instruction is conditioned on what `constraint` actually says.
+        "Built-in Datasource catalog row NOT seeded — a unique violation means another catalog row already holds one of this row's unique values under a different id, so the row does not exist under its canonical id: the datasource will not appear in the integrations marketplace, and form-install handlers reading its config_schema will correctly find nothing. WHICH value collided is in `constraint`/`detail`, or in `err` when the driver omits them. If `constraint` is `plugin_catalog_slug_key` (the only non-primary-key unique index on this table today), find the holder with `SELECT id, name FROM plugin_catalog WHERE slug = '<slug>'`; if it names anything else, look up the column that constraint covers instead. Then rename or remove that row.",
+      );
+      continue;
+    }
+    // `RETURNING slug` yields a row only when the INSERT actually ran. An
+    // empty result is the `ON CONFLICT (id) DO NOTHING` path — the row
+    // already exists under its canonical id, which is the ONLY thing
+    // "preserved" now means.
+    if (returned.length > 0) insertedSlugs.push(row.slug);
+    else preservedSlugs.push(row.slug);
+  }
 
-  return { insertedSlugs, preservedSlugs };
+  const summary = {
+    insertedCount: insertedSlugs.length,
+    preservedCount: preservedSlugs.length,
+    blockedCount: blockedSlugs.length,
+    insertedSlugs,
+    blockedSlugs,
+  };
+  if (blockedSlugs.length > 0) {
+    // Not `info`: the pass finished, but the catalog is missing rows it was
+    // asked to seed. Reporting that as completion is #5266's defect.
+    log.warn(
+      summary,
+      "Built-in Datasource catalog seed finished with BLOCKED rows — see the per-row warnings above",
+    );
+  } else {
+    log.info(summary, "Built-in Datasource catalog seed complete");
+  }
+
+  return { insertedSlugs, preservedSlugs, blockedSlugs };
 }
 
 /**
@@ -528,6 +658,13 @@ export type BuiltinDatasourceCatalogSeedBootResult =
       readonly kind: "seeded";
       readonly insertedSlugs: ReadonlyArray<BuiltinDatasourceCatalogSlug>;
       readonly preservedSlugs: ReadonlyArray<BuiltinDatasourceCatalogSlug>;
+      /**
+       * Rows a foreign-id slug collision blocked (#5266). `seeded` with a
+       * non-empty `blockedSlugs` is a real state — the pass ran, and the
+       * catalog is missing rows it was asked to seed — so `kind` alone no
+       * longer partitions the outcomes; this field does.
+       */
+      readonly blockedSlugs: ReadonlyArray<BuiltinDatasourceCatalogSlug>;
     }
   | { readonly kind: "error"; readonly message: string };
 
@@ -565,6 +702,7 @@ export async function runBuiltinDatasourceCatalogSeedBoot(): Promise<BuiltinData
       kind: "seeded",
       insertedSlugs: result.insertedSlugs,
       preservedSlugs: result.preservedSlugs,
+      blockedSlugs: result.blockedSlugs,
     };
   } catch (err) {
     const normalized = err instanceof Error ? err : new Error(String(err));

--- a/packages/api/src/lib/db/seed-builtin-knowledge-catalog.ts
+++ b/packages/api/src/lib/db/seed-builtin-knowledge-catalog.ts
@@ -118,6 +118,10 @@ import {
 } from "@atlas/api/lib/brain/ingest/outlook/config";
 import type { ConfigSchemaField } from "@atlas/api/lib/plugins/registry";
 import { assertOperatorCatalogWrite } from "@atlas/api/lib/plugins/catalog-provenance";
+import {
+  asUniqueViolation,
+  PG_PLUGIN_CATALOG_SLUG_CONSTRAINT,
+} from "@atlas/api/lib/db/pg-errors";
 
 const log = createLogger("db.seed-builtin-knowledge-catalog");
 
@@ -948,40 +952,6 @@ export interface BuiltinKnowledgeCatalogSeedResult {
   readonly blockedSlugs: ReadonlyArray<string>;
 }
 
-/** Postgres `unique_violation` (23505). */
-const PG_UNIQUE_VIOLATION = "23505";
-
-/**
- * The one NAMED unique constraint this seeder's recovery models
- * (`0014_plugin_marketplace.sql`; mirrored in `db/schema.ts`).
- *
- * `plugin_catalog` has two unique constraints today — PK `id`, consumed by the
- * conflict target, and this one — so a 23505 reaching the catch is almost
- * certainly a slug collision. Naming it turns that inference into a condition
- * the code checks; an UNNAMED 23505 is still accepted, under the same hedge the
- * warning carries.
- */
-const PG_SLUG_CONSTRAINT = "plugin_catalog_slug_key";
-
-/**
- * The diagnostic fields of a `23505`, or `undefined` for any other rejection.
- *
- * `pg` rejects with a `DatabaseError` carrying untyped `code`/`constraint`/
- * `detail`, so this narrows rather than casts. It reads the CODE and not the
- * message: matching on prose would classify an unrelated failure whose message
- * happened to say "duplicate key" as a benign collision, and demoting a real
- * outage to a warning is the failure this catch exists to avoid.
- */
-function asUniqueViolation(
-  err: unknown,
-): { readonly constraint?: string; readonly detail?: string } | undefined {
-  if (typeof err !== "object" || err === null) return undefined;
-  if (!("code" in err) || err.code !== PG_UNIQUE_VIOLATION) return undefined;
-  const constraint = "constraint" in err && typeof err.constraint === "string" ? err.constraint : undefined;
-  const detail = "detail" in err && typeof err.detail === "string" ? err.detail : undefined;
-  return { constraint, detail };
-}
-
 /**
  * Idempotently seed every row in `BUILTIN_KNOWLEDGE_CATALOG_ROWS`.
  *
@@ -1045,7 +1015,8 @@ export async function seedBuiltinKnowledgeCatalog(
       // the recovery below, where the message's hedge covers it.
       const modelled =
         collision !== undefined &&
-        (collision.constraint === undefined || collision.constraint === PG_SLUG_CONSTRAINT);
+        (collision.constraint === undefined ||
+          collision.constraint === PG_PLUGIN_CATALOG_SLUG_CONSTRAINT);
       if (!modelled) {
         // ⚠️ `blockedSlugs` DOES NOT SURVIVE THIS THROW. The boot wrapper turns
         // it into `{ kind: "error" }` and the Layer reports `blockedSlugs: []`,

--- a/packages/api/src/lib/db/seed-builtin-knowledge-catalog.ts
+++ b/packages/api/src/lib/db/seed-builtin-knowledge-catalog.ts
@@ -107,8 +107,6 @@ import { FRONT_CATALOG_ID, FRONT_SLUG } from "@atlas/api/lib/knowledge/front/con
 import { HELPSCOUT_CATALOG_ID, HELPSCOUT_SLUG } from "@atlas/api/lib/knowledge/helpscout/config";
 import { FRESHDESK_CATALOG_ID, FRESHDESK_SLUG } from "@atlas/api/lib/knowledge/freshdesk/config";
 import {
-} from "@atlas/api/lib/brain/ingest/slack/config";
-import {
   ZOOM_TRANSCRIPTS_CATALOG_ID,
   ZOOM_TRANSCRIPTS_SLUG,
 } from "@atlas/api/lib/brain/ingest/zoom/config";
@@ -963,13 +961,13 @@ export interface BuiltinKnowledgeCatalogSeedResult {
  * header), and any other hard failure aborts the pass and propagates (the boot
  * wrapper logs and continues booting).
  *
- * ⚠️ The sibling built-in DATASOURCE seed (`seed-builtin-datasource-catalog.ts`)
- * still inserts with an unqualified `ON CONFLICT DO NOTHING` and so still has
- * the swallow described in this file's header. #5239 scoped itself to the
- * knowledge catalog; the class is the same one file over — and worse there,
- * because that seeder derives `preservedSlugs` as *all minus inserted* and its
- * docstring calls them rows that "already existed". A blocked row is therefore
- * positively REPORTED as present, where this seeder merely omitted it.
+ * The sibling built-in DATASOURCE seed (`seed-builtin-datasource-catalog.ts`)
+ * carried the same defect and was fixed in #5266 — worse there, because it
+ * derived `preservedSlugs` as *all minus inserted*, so a blocked row was
+ * positively REPORTED as present where this seeder merely omitted it. Both
+ * now qualify the conflict target and report `blockedSlugs` as its own
+ * outcome; they share `asUniqueViolation` and the SQLSTATE constants from
+ * `db/pg-errors.ts`.
  */
 export async function seedBuiltinKnowledgeCatalog(
   db: BuiltinKnowledgeCatalogSeedDb,

--- a/packages/api/src/lib/effect/__tests__/layers.test.ts
+++ b/packages/api/src/lib/effect/__tests__/layers.test.ts
@@ -1433,6 +1433,7 @@ describe("ImplementationStatusOverrideLive", () => {
     Layer.succeed(BuiltinDatasourceCatalogSeed, {
       insertedSlugs: [],
       preservedSlugs: [],
+      blockedSlugs: [],
       outcome: "seeded" as const,
     }),
   );

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -918,10 +918,12 @@ export class BuiltinDatasourceCatalogSeed extends Context.Tag(
 )<BuiltinDatasourceCatalogSeed, BuiltinDatasourceCatalogSeedShape>() {}
 
 /**
- * Idempotent boot-time seed of the eight built-in Datasource catalog
+ * Idempotent boot-time seed of the nine built-in Datasource catalog
  * rows. Per ADR-0007 these are code-seeded (not declared in
  * `atlas.config.ts`) and re-asserted on every boot via
- * `ON CONFLICT (slug) DO NOTHING`.
+ * `ON CONFLICT (id) DO NOTHING` — qualified on the primary key since
+ * #5266, so a slug held under a foreign id raises `23505` and is
+ * reported in `blockedSlugs` rather than being swallowed.
  *
  * Depends on `Migration` so the `pillar` / `implementation_status` /
  * `auto_install` columns added by migration 0092 exist before the
@@ -985,10 +987,17 @@ export const BuiltinDatasourceCatalogSeedLive: Layer.Layer<
             // `runBuiltinDatasourceCatalogSeedBoot` already logged at
             // error; surface the message to health consumers via the
             // documented `outcome: "error"` contract.
+            //
+            // ⚠️ SCRUBBED, like the `catchAll` arm below and like the
+            // knowledge sibling. A `pg` connect failure carries
+            // `scheme://user:pass@host` in `message`, and the field is
+            // DOCUMENTED as scrubbed — one field with two producers must not
+            // have two guarantees. #5239 fixed exactly this asymmetry one
+            // Layer over; it was still live here.
             return {
               ...zeroCounts,
               outcome: "error",
-              error: result.message,
+              error: errorMessage(new Error(result.message)),
             } satisfies BuiltinDatasourceCatalogSeedShape;
         }
       },

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -867,7 +867,7 @@ export const CatalogSeedLive: Layer.Layer<
 /**
  * Discriminated outcome of the boot-time built-in Datasource catalog
  * seed. Distinct from {@link CatalogSeedOutcome} because the built-in
- * seed is code-driven (eight fixed rows) while the atlas.config.ts
+ * seed is code-driven (nine fixed rows) while the atlas.config.ts
  * seed is operator-driven. Per ADR-0007, the built-in seed runs in
  * addition to the atlas.config.ts seed, not instead of it.
  *
@@ -933,7 +933,7 @@ export class BuiltinDatasourceCatalogSeed extends Context.Tag(
  * the `connections` table; nothing consumes these rows yet. Slice 6
  * (#2744) pivots `ConnectionRegistry` to read from
  * `workspace_plugins WHERE pillar = 'datasource'`, at which point the
- * eight rows seeded here become live install targets.
+ * nine rows seeded here become live install targets.
  *
  * Non-fatal: the boot wrapper swallows errors and logs at error so a
  * failed seed leaves pre-existing rows authoritative.

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -872,7 +872,9 @@ export const CatalogSeedLive: Layer.Layer<
  * addition to the atlas.config.ts seed, not instead of it.
  *
  * - `skipped-gate`  — InternalDB or Migration upstream not satisfied
- * - `seeded`        — seed ran (preservedSlugs may include all eight on re-boot)
+ * - `seeded`        — seed ran (preservedSlugs may include all nine on re-boot).
+ *                     Read `blockedSlugs` before treating this as a complete
+ *                     catalog: the pass can finish having written nothing (#5266)
  * - `error`         — the boot wrapper or its dynamic import threw;
  *                     pre-existing rows answer admin-UI reads
  */
@@ -885,10 +887,27 @@ export interface BuiltinDatasourceCatalogSeedShape {
   /** Slugs whose row was newly inserted this boot. */
   readonly insertedSlugs: ReadonlyArray<string>;
   /**
-   * Slugs whose row already existed and was preserved (ON CONFLICT DO
-   * NOTHING). Re-boots on a healthy DB land every built-in slug here.
+   * Slugs whose row already existed under its canonical id and was preserved
+   * (the `ON CONFLICT (id) DO NOTHING` path). Re-boots on a healthy DB land
+   * every built-in slug here.
+   *
+   * ⚠️ Disjoint from {@link blockedSlugs} since #5266. It used to be derived
+   * as *every expected slug minus the inserted ones*, which reported a row a
+   * foreign-id collision had blocked as preserved — the caller was told a row
+   * the catalog does not have is fine.
    */
   readonly preservedSlugs: ReadonlyArray<string>;
+  /**
+   * Built-in slugs a foreign-id collision blocked (#5266) — the catalog is
+   * missing these rows and a re-boot will not fix it.
+   *
+   * `[]` on `skipped-gate` means nothing ran. `[]` on `error` means
+   * **unknown**, NOT "none": a throw mid-loop abandons the list the seeder had
+   * accumulated, so a pass that blocked one row and then hit a dead pool
+   * reports `[]` here. The seeder logs the partial list before rethrowing
+   * precisely because it cannot survive this field.
+   */
+  readonly blockedSlugs: ReadonlyArray<string>;
   readonly outcome: BuiltinDatasourceCatalogSeedOutcome;
   /** Scrubbed error message when `outcome === "error"`. */
   readonly error?: string;
@@ -929,6 +948,7 @@ export const BuiltinDatasourceCatalogSeedLive: Layer.Layer<
     const zeroCounts = {
       insertedSlugs: [] as ReadonlyArray<string>,
       preservedSlugs: [] as ReadonlyArray<string>,
+      blockedSlugs: [] as ReadonlyArray<string>,
     };
 
     if (!db.available || !migration.migrated) {
@@ -958,6 +978,7 @@ export const BuiltinDatasourceCatalogSeedLive: Layer.Layer<
             return {
               insertedSlugs: result.insertedSlugs,
               preservedSlugs: result.preservedSlugs,
+              blockedSlugs: result.blockedSlugs,
               outcome: "seeded",
             } satisfies BuiltinDatasourceCatalogSeedShape;
           case "error":

--- a/packages/api/src/lib/integrations/install/routing-id-conflict.ts
+++ b/packages/api/src/lib/integrations/install/routing-id-conflict.ts
@@ -22,7 +22,14 @@
  * index (the `workspace_plugins_id_unique` id index, the singleton index)
  * is a genuinely different failure and must NOT be relabelled as a
  * cross-workspace routing conflict.
+ *
+ * ⚠️ The SQLSTATE constant is shared (#5266); the classification around it is
+ * NOT. `pg-errors.ts`'s `asUniqueViolation` reads a FLAT top-level `code`,
+ * which is wrong on this path — see the chain-walk rationale on
+ * {@link isRoutingIdUniqueViolation}.
  */
+
+import { PG_UNIQUE_VIOLATION } from "@atlas/api/lib/db/pg-errors";
 
 /**
  * Name of the partial unique index created by migration 0120 and mirrored
@@ -30,9 +37,6 @@
  * `unique_violation` error when a concurrent install loses the race.
  */
 export const CHAT_ROUTING_ID_UNIQUE_INDEX = "workspace_plugins_chat_routing_id_unique";
-
-/** Postgres SQLSTATE for `unique_violation`. */
-const PG_UNIQUE_VIOLATION = "23505";
 
 /**
  * Max `.cause` links to follow. The pg error is at most a couple of links

--- a/packages/api/src/lib/starter-prompts/favorite-store.ts
+++ b/packages/api/src/lib/starter-prompts/favorite-store.ts
@@ -16,6 +16,7 @@ import {
   hasInternalDB,
   internalQuery,
 } from "@atlas/api/lib/db/internal";
+import { PG_UNIQUE_VIOLATION } from "@atlas/api/lib/db/pg-errors";
 
 const log = createLogger("favorite-store");
 
@@ -26,8 +27,6 @@ const log = createLogger("favorite-store");
  * keeps the empty-state grid readable.
  */
 export const FAVORITE_TEXT_MAX_LENGTH = 2000;
-
-const PG_UNIQUE_VIOLATION = "23505";
 
 export interface FavoritePromptRow {
   readonly id: string;

--- a/packages/api/src/lib/starter-prompts/favorite-store.ts
+++ b/packages/api/src/lib/starter-prompts/favorite-store.ts
@@ -16,7 +16,7 @@ import {
   hasInternalDB,
   internalQuery,
 } from "@atlas/api/lib/db/internal";
-import { PG_UNIQUE_VIOLATION } from "@atlas/api/lib/db/pg-errors";
+import { asUniqueViolation } from "@atlas/api/lib/db/pg-errors";
 
 const log = createLogger("favorite-store");
 
@@ -216,8 +216,16 @@ export async function createFavorite(
     }
     return toRow(rows[0]);
   } catch (err) {
-    const code = (err as { code?: string }).code;
-    if (code === PG_UNIQUE_VIOLATION) {
+    // ⚠️ FLAT `code`, and this path writes through `internalQuery`, which
+    // wraps the driver error under `.cause` once the Effect Layer has booted
+    // — so this arm may be dead in production and a duplicate may surface as
+    // a 500 instead of the specific message below. Same hazard as
+    // `admin-prompts.ts` and `sub-processor-subscriptions.ts`; pre-existing,
+    // surfaced by the #5271 review panel, tracked in #5272. Noted on all four
+    // sites deliberately: a defect documented in half its instances is one
+    // that gets closed on the documented half.
+    const collision = asUniqueViolation(err);
+    if (collision !== undefined) {
       throw new DuplicateFavoriteError();
     }
     throw err instanceof Error ? err : new Error(String(err));

--- a/packages/api/src/lib/suggestions/approval-store.ts
+++ b/packages/api/src/lib/suggestions/approval-store.ts
@@ -25,7 +25,7 @@ import {
   type QuerySuggestionRow,
 } from "@atlas/api/lib/db/internal";
 import { toQuerySuggestion } from "@atlas/api/lib/learn/suggestion-helpers";
-import { PG_UNIQUE_VIOLATION } from "@atlas/api/lib/db/pg-errors";
+import { asUniqueViolation } from "@atlas/api/lib/db/pg-errors";
 
 const log = createLogger("approval-store");
 
@@ -312,8 +312,10 @@ export async function createApprovedSuggestion(input: {
     }
     return toQuerySuggestion(rows[0]);
   } catch (err) {
-    const code = (err as { code?: string }).code;
-    if (code === PG_UNIQUE_VIOLATION) {
+    // ⚠️ FLAT `code` on an `internalQuery` path — see the identical note in
+    // `starter-prompts/favorite-store.ts`. Tracked in #5272.
+    const collision = asUniqueViolation(err);
+    if (collision !== undefined) {
       throw new DuplicateSuggestionError();
     }
     throw err instanceof Error ? err : new Error(String(err));

--- a/packages/api/src/lib/suggestions/approval-store.ts
+++ b/packages/api/src/lib/suggestions/approval-store.ts
@@ -25,13 +25,12 @@ import {
   type QuerySuggestionRow,
 } from "@atlas/api/lib/db/internal";
 import { toQuerySuggestion } from "@atlas/api/lib/learn/suggestion-helpers";
+import { PG_UNIQUE_VIOLATION } from "@atlas/api/lib/db/pg-errors";
 
 const log = createLogger("approval-store");
 
 /** Upper bound on admin-authored prompt text. */
 export const SUGGESTION_TEXT_MAX_LENGTH = 2000;
-
-const PG_UNIQUE_VIOLATION = "23505";
 
 // ---------------------------------------------------------------------------
 // Typed errors


### PR DESCRIPTION
Three issues, in one PR at the author's request. #5266 is independent of the
other two.

⚠️ **Two of the three issues turned out to be wrong about their own mechanism,
and this PR corrects both rather than shipping on a false rationale.** Read the
"What the issues got wrong" section before the diff — it changes what the
change is for.

## #5266 — the datasource catalog seeder reported a blocked row as "preserved"

`seed-builtin-datasource-catalog.ts` inserted with an unqualified
`ON CONFLICT DO NOTHING`, which swallows a conflict on ANY constraint — so a
row whose slug was held under a foreign id was silently not written. The
reporting was the worse half: `preservedSlugs` was derived by **subtraction**
(every expected slug minus the inserted ones), so a blocked row landed in the
same bucket as one that genuinely already existed and the caller was told it is
fine. #5239's pre-fix knowledge seeder reported an ambiguous count; this one
asserted a specific, wrong, reassuring fact. Both docstrings called the
unqualified target intentional, so a reader had to disprove a comment to find
the bug.

Mirrors #5260's knowledge-side fix rather than inventing a second policy:
`ON CONFLICT (id) DO NOTHING`, per-row statements (a bulk INSERT rejects the
whole batch on the first violation, so per-row recovery is only expressible as
per-row statements), SQLSTATE classification, and `blockedSlugs` as its own
outcome threaded through the boot result and the Effect layer. `preservedSlugs`
is now a positive observation — the empty `RETURNING` set — so the three lists
partition the expected slugs.

`PG_UNIQUE_VIOLATION` is consolidated into `lib/db/pg-errors.ts`. Only the
constant is universal: `routing-id-conflict.ts` keeps its `.cause` chain walk,
because `@effect/sql` wraps the driver error and a flat read would classify
every real collision as an unhandled throw.

## #5270 + #5262 — the settings write path's audit row

One seam, `lib/audit/settings-write.ts`, closing three defects that shared one
call site. The route hands over the definition and the raw value and never
touches `metadata`, so there is no spelling of the call site that reintroduces
the plaintext.

1. **The value was recorded verbatim** — now redacted through `redactAuditValue`,
   with `metadata.value` typed `AuditedValue` so a raw assignment is a compile
   error. Defense in depth, not a live-breach fix — see below.
2. **The row was stamped `scope: "workspace"`** — this one WAS live. Platform-tier
   settings writes landed on `GET /admin/admin-actions`, which filters
   `org_id = $1 AND scope = 'workspace'`, returns `metadata` verbatim, has a CSV
   export, and needs only `adminAuth` while the write needed `admin:settings`.
3. **The audit row was fire-and-forget** — now `logAdminActionAwait`, with an
   explicit 500 saying the setting DID change and is unaudited.

## What the issues got wrong

**#5270's headline is false.** Both settings verbs 403 a `secret: true` key
*before* the write, and that guard is on `main` — there was never a window. Of
`redactAuditValue`'s three arms only the verbatim one has a production caller.
So the redaction is defense in depth for a future call site, not a plaintext
leak being closed. Severity drops accordingly; what survives is defect 2, whose
values are non-secret registry settings. Correction posted on #5270.

**#5262's mechanism is false in both halves, and the truth is a stronger
argument for the same fix.** There is no `log.warn` for `ATLAS_LOG_LEVEL` to
silence: past an open circuit breaker `internalExecute` increments a counter and
returns with NO log line at any level; before it opens the drop logs at `error`,
which only `fatal` silences — and `fatal` is in `ATLAS_LOG_LEVEL`'s own option
list, so even that trace is operator-revocable. #5262's instinct was not
baseless; it named the wrong line and the wrong branch. **#5262 is deliberately
NOT auto-closed** — its acceptance criteria were written against the falsified
premise. It ships here only in its re-scoped form.

## Review panel — the curve, and why it stopped at round 2

| Round | Findings | New surface | Defect-in-prior-fix |
|---|---|---|---|
| 1 | ~19 | ~19 | 0 |
| 2 (closing) | ~16 | ~6 | **~10** |

Round 2 ran the three code reviewers plus `comment-analyzer`, which only runs
on the round that turns out to be final. It earned its slot: **six more false
claims**, on a diff whose prose had already been wrong six times.

Stopped on the **ratio rule**, not the cap: defect-in-prior-fix exceeded
new-surface, so round 1's fixes were manufacturing work faster than they closed
surface. The raw count fell, which alone would not have stopped it.

Round 2's sharpest findings were both round 1 reproducing its own defect one
layer over:

- Round 1 corrected #5262's false mechanism **in the header and left three
  restatements of the retracted version behind** — one opening with "The
  residual #5262 is *actually* about", presenting itself as the correction while
  being the thing corrected. Two reviewers found it independently. The mechanism
  is now stated once and the restatements point at it.
- Round 1's **mismatch guard was itself a silent failure**: it detected a
  programmer bug and recorded it in one JSONB field nothing greps, and on the
  `reset_to_default` path — where there is no value — it computed the mismatch,
  found it true, and discarded it. Now warns unconditionally, both arms tested.

**This diff's prose has now been wrong nine times, every one caught by a
reviewer rather than by me.** Beyond the two above: "which `ATLAS_LOG_LEVEL`
does not silence" (false at `fatal`, which is in that setting's own dropdown —
so #5262's instinct was not baseless, it named the wrong line and branch); the
census recipe, twice (`= "23505"` returns 8 lines; its replacement returns 2,
because the comment quoting the recipe matches it); a "three DIFFERENT sizes"
comment about 1/1/7; a `platformTier` docstring advertising the very spelling
round 2 had rejected fifteen lines away; and the delta table's claim that
`=== undefined` re-exposes a global write on the org-scoped read API — **false**,
since `requireOrgContext` 400s on a falsy orgId, so the row is misfiled rather
than disclosed. Correct fix, wrong reason, now recorded as such.

Two comments OUTSIDE the diff were also corrected, because they contradict this
PR's header and the code behind them was read to write it: `internal.ts` claimed
a per-write debug line on a circuit-open drop (it is a `log.error`, suppressed
once the circuit opens) and `audit/admin.ts` claimed `internalExecute` returns a
promise (it returns `void`).

## Falsifiers — eleven, each measured RED, each hitting only its own test

| Mutation | Result |
|---|---|
| `preservedSlugs` back to subtraction | 2 RED |
| conflict target back to unqualified | 3 of 8 real-Postgres RED |
| `value: entry.value` instead of redacted | **compile error** |
| bypass `redactAuditValue` at runtime | 3 RED |
| drop `scope: tier` | 3 RED |
| awaiting sink → fire-and-forget | 11 of 12 RED |
| boot wrapper hardcodes `blockedSlugs: []` | 1 RED |
| boot wrapper hardcodes `preservedSlugs: []` | 1 RED |
| route passes `definition: undefined` | 2 RED |
| DELETE claims `action: "update"` | 1 RED |
| mismatch guard removed | 1 RED |
| fire-and-forget row re-added alongside | 1 RED |
| rollback via `deleteSetting` in the catch | 1 RED |
| `platformTier` back to `=== undefined` | 1 RED |
| route stops reading the IP headers | 1 RED |
| mismatch warn removed | 2 RED |
| `hasInternalDB` guard removed | 1 RED |

The `hasInternalDB` guard reddened all 12 tests in its file when added — unit
runs have no `DATABASE_URL` — which is the proof it does real work rather than
guarding a state nothing reaches.

The `-pg` file seeds a **real** squatting row rather than hand-writing both
sides, and pins the counterfactual: the unqualified target still swallows
exactly that collision, so the change is load-bearing rather than decorative.

## Deferred, each with a reason and an issue

- **#5272** — `internalQuery` goes through `Effect.runPromise(_sqlClient.unsafe(…))`
  once the Layer boots, wrapping the driver error under `.cause`. Four sites read
  a flat `code`, so their 409/duplicate arms may be dead in production.
  Pre-existing, needs a `-pg` harness, and a second classifier changing four
  sites' error handling is machinery with no round left to review it. All four
  carry a ⚠️ note pointing there, and all four now use the shared narrowing
  instead of an unguarded cast.
- **#5273** — neither built-in catalog seed Layer has any test, so `blockedSlugs`'
  entire production route is unobserved (replacing the forwarded fields with
  `...zeroCounts` costs nothing). Class-wide and pre-existing; building the
  repo's first Live-seed-layer harness in a closing round is the same
  machinery-with-no-round-left case.
- A type reviewer's proposal to restructure `SettingsAuditMetadata` into a
  three-arm union (closing the documented spread hole at the type level rather
  than by test) is a good idea and ~15 lines of new machinery. Not in a closing
  round.

## Verification

- 537/537 affected test files green (`test-isolated.ts --affected`, real Postgres)
- `lint`, `type`, `lint:type-aware` — 0 errors
- `check-mutation-tables.sh --affected` — clean, re-run after the last test edit

Closes #5266
Closes #5270
