### PR TITLE
fix(db): unique-violation classification was dead on every Effect path — five sites, measured (#5272)

### DIFF
--- a/packages/api/src/api/routes/admin-prompts.ts
+++ b/packages/api/src/api/routes/admin-prompts.ts
@@ -10,7 +10,7 @@ import { Effect } from "effect";
 import type { Context as HonoContext } from "hono";
 import { createRoute, z } from "@hono/zod-openapi";
 import { createLogger } from "@atlas/api/lib/logger";
-import { asUniqueViolation } from "@atlas/api/lib/db/pg-errors";
+import { asWrappedUniqueViolation } from "@atlas/api/lib/db/pg-errors";
 import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
 import { runEffect } from "@atlas/api/lib/effect/hono";
 import { RequestContext, AuthContext } from "@atlas/api/lib/effect/services";
@@ -32,22 +32,13 @@ const log = createLogger("admin-prompts");
  * violation into a typed result so create/rename routes can return a 409
  * instead of leaking a generic 500.
  *
- * ⚠️ **READS A FLAT TOP-LEVEL `code`, AND THIS ROUTE WRITES THROUGH
- * `internalQuery`, WHICH MAY NOT PRODUCE ONE.** Once the Layer has booted,
- * `internalQuery` goes through `Effect.runPromise(_sqlClient.unsafe(…))`
- * (`db/internal.ts:768-773`), which rejects with a `FiberFailure` wrapping
- * `SqlError` wrapping the pg `DatabaseError` — no top-level `code`. That is
- * the shape `integrations/install/routing-id-conflict.ts` walks the `.cause`
- * chain for. If it holds here, this 409 is dead in production and a duplicate
- * name 500s instead. The existing tests cannot see it: they set `err.code`
- * directly on a hand-built rejection, a fixture agreeing with the assumption.
- * Surfaced by the #5271 review panel and NOT fixed there — it is pre-existing,
- * needs a `-pg` harness to settle, and changing four call sites' error
- * classification (two routes, two stores) is machinery this PR has no round
- * left to review. Tracked in #5272.
+ * ⚠️ #5272 SETTLED: `internalQuery` rejects with a `FiberFailure` whose Cause
+ * is symbol-keyed, so the flat read this used to do missed EVERY collision and
+ * a duplicate surfaced as a 500. `asWrappedUniqueViolation` unwraps it. Do not
+ * "simplify" back to `asUniqueViolation` — that is the raw-`Pool` sibling.
  */
 function isUniqueViolation(err: unknown): boolean {
-  return asUniqueViolation(err) !== undefined;
+  return asWrappedUniqueViolation(err) !== undefined;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/api/src/api/routes/sub-processor-subscriptions.ts
+++ b/packages/api/src/api/routes/sub-processor-subscriptions.ts
@@ -24,7 +24,7 @@ import { AuthContext, RequestContext } from "@atlas/api/lib/effect/services";
 import { hasInternalDB } from "@atlas/api/lib/db/internal";
 import { isSafeExternalUrl } from "@atlas/api/lib/sandbox/validate";
 import { createLogger } from "@atlas/api/lib/logger";
-import { asUniqueViolation } from "@atlas/api/lib/db/pg-errors";
+import { asWrappedUniqueViolation } from "@atlas/api/lib/db/pg-errors";
 import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
 import { createSubscription } from "@atlas/api/lib/sub-processor-publisher";
 
@@ -149,14 +149,10 @@ router.openapi(createSubscriptionRoute, async (c) => {
           // packages/api/src/lib/suggestions/approval-store.ts (both of which
           // now import the shared constant from `db/pg-errors.ts`).
           //
-          // ⚠️ FLAT `code`, and this path writes through `internalQuery`,
-          // which wraps the driver error under `.cause` once the Layer has
-          // booted — so this `duplicate` arm may be dead in production and a
-          // duplicate URL may 500 instead. Same hazard as
-          // `admin-prompts.ts`'s `isUniqueViolation`; see the note there.
-          // Pre-existing, surfaced by the #5271 review panel, tracked in
-          // #5272.
-          if (asUniqueViolation(err) !== undefined) {
+          // ⚠️ #5272: this path writes through `internalQuery`, whose
+          // rejection is a `FiberFailure` with a symbol-keyed Cause — the flat
+          // read missed every collision and a duplicate URL 500'd.
+          if (asWrappedUniqueViolation(err) !== undefined) {
             return { kind: "duplicate" };
           }
           throw err instanceof Error ? err : new Error(String(err));

--- a/packages/api/src/lib/db/__tests__/internal-query-error-shape-pg.test.ts
+++ b/packages/api/src/lib/db/__tests__/internal-query-error-shape-pg.test.ts
@@ -1,0 +1,183 @@
+/**
+ * #5272 — WHAT SHAPE does `internalQuery` reject with once the Effect Layer
+ * has booted?
+ *
+ * Four call sites classify a Postgres `unique_violation` by reading a FLAT,
+ * top-level `code` off the caught error:
+ *
+ *   - `api/routes/admin-prompts.ts`            → 409 on a duplicate collection name
+ *   - `api/routes/sub-processor-subscriptions.ts` → 409 on a duplicate webhook URL
+ *   - `lib/starter-prompts/favorite-store.ts`  → `DuplicateFavoriteError`
+ *   - `lib/suggestions/approval-store.ts`      → duplicate-suggestion path
+ *
+ * All four write through `internalQuery`, which takes the `_sqlClient` branch
+ * whenever the Layer has booted — i.e. always, in production. If `@effect/sql`
+ * wraps the driver error under `.cause` with no top-level `code`, every one of
+ * those arms is DEAD in production and a routine duplicate surfaces as a 500.
+ *
+ * ⚠️ THIS CANNOT BE SETTLED WITH A MOCK, WHICH IS THE WHOLE POINT. Every
+ * existing test for those four sites hand-builds the rejection as
+ * `Object.assign(new Error(...), { code: "23505" })` — a fixture that agrees
+ * with the flat assumption by construction, and therefore passes whether the
+ * assumption holds or not. This file drives a REAL duplicate through a REAL
+ * `PgClient.layerFromPool` client against real Postgres and records what comes
+ * back.
+ *
+ * ⚠️ **THE ANSWER, so nobody re-runs the experiment.** A promise-awaited
+ * `internalQuery` rejects with:
+ *
+ *     FiberFailureImpl                      ← own props: message, name, stack
+ *       [Symbol(effect/Runtime/FiberFailure/Cause)] = { _tag: "Fail", error }
+ *           SqlError.cause = DatabaseError { code: "23505", constraint, … }
+ *
+ * No top-level `code`, and **no `.cause` on the FiberFailure** — the cause is
+ * symbol-keyed. Both the flat read and a naive `.cause` walk miss it, so every
+ * affected arm was surfacing a routine duplicate as a 500.
+ *
+ * Skipped cleanly when `TEST_DATABASE_URL` is unset.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { Cause, Effect, Exit, Layer, Runtime, Scope } from "effect";
+import { SqlClient } from "@effect/sql";
+import { PgClient } from "@effect/sql-pg";
+import { Pool } from "pg";
+import { internalQuery, _resetPool } from "@atlas/api/lib/db/internal";
+import { asUniqueViolation, asWrappedUniqueViolation } from "@atlas/api/lib/db/pg-errors";
+
+const TEST_DB_URL = process.env.TEST_DATABASE_URL;
+const describeIfPg = TEST_DB_URL ? describe : describe.skip;
+const PG_TIMEOUT_MS = 30_000;
+
+/** Every link in an error's `.cause` chain, outermost first. */
+function causeChain(err: unknown, max = 8): ReadonlyArray<Record<string, unknown>> {
+  const links: Record<string, unknown>[] = [];
+  let cur: unknown = err;
+  for (let i = 0; i < max; i++) {
+    if (typeof cur !== "object" || cur === null) break;
+    const o = cur as Record<string, unknown>;
+    links.push(o);
+    if (o.cause === cur) break;
+    cur = o.cause;
+  }
+  return links;
+}
+
+/** The first `code` found anywhere in the chain, with its depth. */
+function findCode(err: unknown): { depth: number; code: string } | undefined {
+  const links = causeChain(err);
+  for (let i = 0; i < links.length; i++) {
+    const c = links[i]!.code;
+    if (typeof c === "string") return { depth: i, code: c };
+  }
+  return undefined;
+}
+
+describeIfPg("internalQuery's rejection shape on the Effect path (#5272)", () => {
+  let pool: Pool;
+  let scope: Scope.CloseableScope;
+  const schemaName = `errshape_${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
+
+  beforeAll(async () => {
+    pool = new Pool({
+      connectionString: TEST_DB_URL,
+      options: `-c search_path="${schemaName}"`,
+      max: 3,
+    });
+    await pool.query(`CREATE SCHEMA IF NOT EXISTS "${schemaName}"`);
+    await pool.query(`
+      CREATE TABLE dup_probe (
+        id   TEXT PRIMARY KEY,
+        name TEXT NOT NULL UNIQUE
+      )
+    `);
+
+    // ⚠️ A REAL `@effect/sql` client over that pool — the same construction
+    // `initInternalDB` uses (`PgClient.layerFromPool`). Injecting a hand-rolled
+    // stand-in here would reintroduce the very agree-by-construction problem
+    // this file exists to remove.
+    scope = Effect.runSync(Scope.make());
+    const layer = PgClient.layerFromPool({
+      acquire: Effect.succeed(pool),
+      applicationName: "atlas-errshape-test",
+    });
+    const ctx = await Effect.runPromise(
+      Scope.extend(Layer.build(layer), scope) as Effect.Effect<never, never, never>,
+    );
+    const sqlClient = await Effect.runPromise(
+      Effect.provide(SqlClient.SqlClient, ctx as never) as Effect.Effect<
+        SqlClient.SqlClient,
+        never,
+        never
+      >,
+    );
+    _resetPool(pool as never, sqlClient);
+  }, PG_TIMEOUT_MS);
+
+  afterAll(async () => {
+    _resetPool(null, null);
+    if (scope) await Effect.runPromise(Scope.close(scope, Exit.void));
+    if (pool) {
+      await pool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+      await pool.end();
+    }
+  }, PG_TIMEOUT_MS);
+
+  /** Insert `name` twice; return whatever the second attempt rejects with. */
+  async function raiseDuplicate(name: string): Promise<unknown> {
+    await internalQuery(`INSERT INTO dup_probe (id, name) VALUES ($1, $2)`, [`${name}-1`, name]);
+    try {
+      await internalQuery(`INSERT INTO dup_probe (id, name) VALUES ($1, $2)`, [`${name}-2`, name]);
+    } catch (err) {
+      return err;
+    }
+    throw new Error("expected the duplicate INSERT to reject, but it succeeded");
+  }
+
+  it("⭐ the SQLSTATE is NOT on the rejection, and NOT on its .cause chain", async () => {
+    const raised = await raiseDuplicate("shape");
+
+    // This is the defect, measured. Both readings a caller would naturally
+    // reach for come back empty.
+    expect(findCode(raised)).toBeUndefined();
+    expect(causeChain(raised)).toHaveLength(1); // no `.cause` at all
+    expect(asUniqueViolation(raised)).toBeUndefined();
+  }, PG_TIMEOUT_MS);
+
+  it("⭐ it is reachable ONLY through the FiberFailure's symbol-keyed Cause", async () => {
+    // Where it actually lives. Asserted through Effect's public API rather
+    // than the raw symbol, which is also how the fix reads it.
+    const raised = await raiseDuplicate("symbol");
+    expect(Runtime.isFiberFailure(raised)).toBe(true);
+
+    const squashed = Cause.squash(
+      (raised as Record<symbol, Cause.Cause<unknown>>)[Runtime.FiberFailureCauseId],
+    );
+    // `SqlError` itself carries no code; its `.cause` is the pg DatabaseError.
+    expect(asUniqueViolation(squashed)).toBeUndefined();
+    expect(asUniqueViolation((squashed as { cause?: unknown }).cause)?.constraint).toBe(
+      "dup_probe_name_key",
+    );
+  }, PG_TIMEOUT_MS);
+
+  it("⭐ asWrappedUniqueViolation classifies it — the arm the four call sites now use", async () => {
+    const raised = await raiseDuplicate("classified");
+    const collision = asWrappedUniqueViolation(raised);
+    expect(collision).toBeDefined();
+    expect(collision?.constraint).toBe("dup_probe_name_key");
+    expect(String(collision?.detail)).toContain("already exists");
+  }, PG_TIMEOUT_MS);
+
+  it("does NOT classify a different SQLSTATE raised through the same transport", async () => {
+    // The guard on the guard: the unwrapping must not turn every Effect-wrapped
+    // failure into a benign collision. `42P01` = undefined_table.
+    let raised: unknown;
+    try {
+      await internalQuery(`INSERT INTO no_such_table (x) VALUES ($1)`, ["y"]);
+    } catch (err) {
+      raised = err;
+    }
+    expect(raised).toBeDefined();
+    expect(asWrappedUniqueViolation(raised)).toBeUndefined();
+  }, PG_TIMEOUT_MS);
+});

--- a/packages/api/src/lib/db/pg-errors.ts
+++ b/packages/api/src/lib/db/pg-errors.ts
@@ -31,14 +31,24 @@
  * flat read applied to the Effect path would classify every real collision as
  * an unhandled throw.
  *
- * ⚠️ FOUR of the six consumers are on exactly that Effect path today:
- * `admin-prompts.ts`, `sub-processor-subscriptions.ts`,
- * `starter-prompts/favorite-store.ts` and `suggestions/approval-store.ts` all
- * read this flat classification off an `internalQuery` result, where the shape
- * may be wrapped. Tracked in #5272; each site carries the same note. Do not
- * read "flat is right for the `pg` driver" as "flat is right at every call
- * site" — only the two seeders pass a raw `Pool`.
+ * ⚠️ **#5272 SETTLED — the four `internalQuery` consumers needed the second
+ * classifier, and the shape is worse than "wrapped under `.cause`".** Measured
+ * against real Postgres with a real `PgClient.layerFromPool` client
+ * (`__tests__/internal-query-error-shape-pg.test.ts`), a promise-awaited
+ * `internalQuery` rejects with:
+ *
+ *     FiberFailureImpl                      ← own props: message, name, stack
+ *       [Symbol(effect/Runtime/FiberFailure/Cause)] = { _tag: "Fail", error }
+ *           SqlError.cause = DatabaseError { code: "23505", constraint, … }
+ *
+ * There is no top-level `code` AND **no `.cause` on the FiberFailure** — the
+ * cause hangs off a symbol. So both the flat read and a naive `.cause` walk
+ * miss it, and every affected 409/duplicate arm surfaced a routine collision
+ * as a 500. {@link asWrappedUniqueViolation} unwraps that; the four sites use
+ * it now.
  */
+
+import { Cause, Runtime } from "effect";
 
 /** Postgres SQLSTATE for `unique_violation`. */
 export const PG_UNIQUE_VIOLATION = "23505";
@@ -83,3 +93,77 @@ export function asUniqueViolation(
  * hedge each seeder's warning carries.
  */
 export const PG_PLUGIN_CATALOG_SLUG_CONSTRAINT = "plugin_catalog_slug_key";
+
+/**
+ * Max `.cause` links to follow after unwrapping. The driver error is at most a
+ * couple of links deep (`SqlError.cause` → pg `DatabaseError`); the cap is a
+ * backstop against a cyclic chain, not a depth requirement.
+ */
+const MAX_CAUSE_DEPTH = 8;
+
+/**
+ * The diagnostic fields of a `23505` raised through an Effect-backed client, or
+ * `undefined` for anything else.
+ *
+ * ⚠️ **THE SIBLING OF {@link asUniqueViolation}, NOT A REPLACEMENT — the two
+ * model different transports and merging them breaks both.** A chain walk
+ * applied to the raw-`Pool` seeders would classify a wrapped violation from an
+ * unrelated layer as a benign collision; a flat read applied here classifies
+ * every real collision as an unhandled throw. Pick by how the caller obtained
+ * the error, not by taste:
+ *
+ * - `await pool.query(...)` / a raw `Pool` seam → {@link asUniqueViolation}
+ * - `await internalQuery(...)` / anything through `Effect.runPromise` → this
+ *
+ * Two unwrapping steps, and BOTH are load-bearing (#5272, measured):
+ *
+ * 1. **The `FiberFailure` symbol.** `Effect.runPromise` rejects with a
+ *    `FiberFailureImpl` whose only own properties are `message`, `name` and
+ *    `stack`; the `Cause` is stored under `Runtime.FiberFailureCauseId`.
+ *    `Cause.squash` reduces that to the underlying failure. Read through
+ *    Effect's own API rather than the raw symbol so a runtime change surfaces
+ *    as a type error rather than a silently-undefined lookup.
+ * 2. **The `.cause` chain.** `SqlError` then holds the pg `DatabaseError` under
+ *    an ordinary `.cause`.
+ *
+ * An error that is NOT a `FiberFailure` still gets the chain walk, because a
+ * caller inside an Effect program (catching in the error channel rather than
+ * after `runPromise`) sees the bare `SqlError` — same transport, one less
+ * wrapper.
+ */
+export function asWrappedUniqueViolation(
+  err: unknown,
+): { readonly constraint?: string; readonly detail?: string } | undefined {
+  let current: unknown = unwrapFiberFailure(err);
+
+  for (let depth = 0; depth < MAX_CAUSE_DEPTH; depth++) {
+    const flat = asUniqueViolation(current);
+    if (flat !== undefined) return flat;
+    if (typeof current !== "object" || current === null) return undefined;
+    const next: unknown = (current as { cause?: unknown }).cause;
+    if (next === current) return undefined; // self-referential guard
+    current = next;
+  }
+  return undefined;
+}
+
+/**
+ * Peel Effect's `FiberFailure` wrapper off a rejection, or return `err` as-is.
+ *
+ * `Effect.runPromise` rejects with a `FiberFailureImpl` whose only own
+ * properties are `message`, `name` and `stack` — the `Cause` hangs off
+ * `Runtime.FiberFailureCauseId`, so `.cause` is `undefined` and every ordinary
+ * chain walk stops at the wrapper. Measured in
+ * `__tests__/internal-query-error-shape-pg.test.ts` (#5272).
+ *
+ * Exported because TWO classifiers need this same first step and must not each
+ * grow their own copy: this one, and
+ * `integrations/install/routing-id-conflict.ts`, whose constraint-name walk was
+ * equally blind to the wrapper. A caller that catches INSIDE an Effect program
+ * sees the bare error and passes through untouched.
+ */
+export function unwrapFiberFailure(err: unknown): unknown {
+  return Runtime.isFiberFailure(err)
+    ? Cause.squash(err[Runtime.FiberFailureCauseId])
+    : err;
+}

--- a/packages/api/src/lib/integrations/install/__tests__/routing-id-conflict.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/routing-id-conflict.test.ts
@@ -10,6 +10,7 @@
  * relabelled with a misleading cross-workspace message.
  */
 
+import { Cause, Runtime } from "effect";
 import { describe, expect, it } from "bun:test";
 import {
   CHAT_ROUTING_ID_UNIQUE_INDEX,
@@ -79,6 +80,38 @@ describe("isRoutingIdUniqueViolation (#3167)", () => {
     const cyclic: { code: string; cause?: unknown } = { code: "08006" };
     cyclic.cause = cyclic;
     expect(isRoutingIdUniqueViolation(cyclic)).toBe(false);
+  });
+
+  it("⭐ matches through Effect's FiberFailure wrapper (#5272)", () => {
+    // The shape `persist-form-install.ts` actually catches: it awaits
+    // `internalQuery(...).catch(raiseWriteError)`, so `Effect.runPromise`
+    // rejects with a FiberFailure whose Cause is SYMBOL-keyed and whose
+    // `.cause` is undefined. The walk below used to stop at the wrapper and
+    // return false for every real concurrent-install race, making #3167's
+    // "already connected elsewhere" message unreachable on that path.
+    //
+    // Built with Effect's own constructors rather than a hand-rolled
+    // look-alike — a fixture that guesses the wrapper's shape would agree with
+    // whatever the code guesses too. The real shape is pinned against a live
+    // client in `db/__tests__/internal-query-error-shape-pg.test.ts`.
+    const sqlError = Object.assign(new Error("statement failed"), {
+      _tag: "SqlError",
+      cause: pgError("23505", CHAT_ROUTING_ID_UNIQUE_INDEX),
+    });
+    const fiberFailure = Runtime.makeFiberFailure(Cause.fail(sqlError));
+    // The premise: the wrapper really does hide it from a plain walk.
+    expect((fiberFailure as { cause?: unknown }).cause).toBeUndefined();
+    expect(isRoutingIdUniqueViolation(fiberFailure)).toBe(true);
+  });
+
+  it("still does NOT match a wrapped 23505 on a different index through the same wrapper", () => {
+    // The discriminating half — unwrapping must widen what the walk can SEE,
+    // not what it accepts.
+    const sqlError = Object.assign(new Error("statement failed"), {
+      _tag: "SqlError",
+      cause: pgError("23505", "workspace_plugins_singleton"),
+    });
+    expect(isRoutingIdUniqueViolation(Runtime.makeFiberFailure(Cause.fail(sqlError)))).toBe(false);
   });
 
   it("pins the index name the migration + schema mirror create", () => {

--- a/packages/api/src/lib/integrations/install/routing-id-conflict.ts
+++ b/packages/api/src/lib/integrations/install/routing-id-conflict.ts
@@ -29,7 +29,7 @@
  * {@link isRoutingIdUniqueViolation}.
  */
 
-import { PG_UNIQUE_VIOLATION } from "@atlas/api/lib/db/pg-errors";
+import { PG_UNIQUE_VIOLATION, unwrapFiberFailure } from "@atlas/api/lib/db/pg-errors";
 
 /**
  * Name of the partial unique index created by migration 0120 and mirrored
@@ -74,7 +74,18 @@ interface PgErrorLike {
  * wrapped it.
  */
 export function isRoutingIdUniqueViolation(err: unknown): boolean {
-  let current: unknown = err;
+  // ⚠️ #5272 — UNWRAP BEFORE WALKING. `persist-form-install.ts` catches with
+  // `.catch(raiseWriteError)` on a promise, so what arrives here is Effect's
+  // `FiberFailure`, whose Cause is symbol-keyed and whose `.cause` is
+  // `undefined` — the walk below stopped at the wrapper and this returned
+  // `false` for every real concurrent-install race. The chat handlers' #3167
+  // "already connected elsewhere" message was therefore unreachable on that
+  // path and the loser got a raw 500.
+  //
+  // Additive by construction: unwrapping can only ever let the walk see MORE
+  // links, never fewer, and the CHAT_ROUTING_ID_UNIQUE_INDEX check below still
+  // gates what counts — so this cannot start mislabelling an unrelated 23505.
+  let current: unknown = unwrapFiberFailure(err);
   for (let depth = 0; depth < MAX_CAUSE_DEPTH; depth++) {
     if (typeof current !== "object" || current === null) return false;
     const e = current as PgErrorLike;

--- a/packages/api/src/lib/starter-prompts/favorite-store.ts
+++ b/packages/api/src/lib/starter-prompts/favorite-store.ts
@@ -16,7 +16,7 @@ import {
   hasInternalDB,
   internalQuery,
 } from "@atlas/api/lib/db/internal";
-import { asUniqueViolation } from "@atlas/api/lib/db/pg-errors";
+import { asWrappedUniqueViolation } from "@atlas/api/lib/db/pg-errors";
 
 const log = createLogger("favorite-store");
 
@@ -216,15 +216,10 @@ export async function createFavorite(
     }
     return toRow(rows[0]);
   } catch (err) {
-    // ⚠️ FLAT `code`, and this path writes through `internalQuery`, which
-    // wraps the driver error under `.cause` once the Effect Layer has booted
-    // — so this arm may be dead in production and a duplicate may surface as
-    // a 500 instead of the specific message below. Same hazard as
-    // `admin-prompts.ts` and `sub-processor-subscriptions.ts`; pre-existing,
-    // surfaced by the #5271 review panel, tracked in #5272. Noted on all four
-    // sites deliberately: a defect documented in half its instances is one
-    // that gets closed on the documented half.
-    const collision = asUniqueViolation(err);
+    // ⚠️ #5272: `internalQuery` rejects with a `FiberFailure` whose Cause is
+    // symbol-keyed, so the flat read missed every collision and a duplicate
+    // pin surfaced as a 500 with a `createFavorite failed` error line.
+    const collision = asWrappedUniqueViolation(err);
     if (collision !== undefined) {
       throw new DuplicateFavoriteError();
     }

--- a/packages/api/src/lib/suggestions/approval-store.ts
+++ b/packages/api/src/lib/suggestions/approval-store.ts
@@ -25,7 +25,7 @@ import {
   type QuerySuggestionRow,
 } from "@atlas/api/lib/db/internal";
 import { toQuerySuggestion } from "@atlas/api/lib/learn/suggestion-helpers";
-import { asUniqueViolation } from "@atlas/api/lib/db/pg-errors";
+import { asWrappedUniqueViolation } from "@atlas/api/lib/db/pg-errors";
 
 const log = createLogger("approval-store");
 
@@ -312,9 +312,9 @@ export async function createApprovedSuggestion(input: {
     }
     return toQuerySuggestion(rows[0]);
   } catch (err) {
-    // ⚠️ FLAT `code` on an `internalQuery` path — see the identical note in
-    // `starter-prompts/favorite-store.ts`. Tracked in #5272.
-    const collision = asUniqueViolation(err);
+    // ⚠️ #5272 — same `FiberFailure` unwrap as
+    // `starter-prompts/favorite-store.ts`; see the note there.
+    const collision = asWrappedUniqueViolation(err);
     if (collision !== undefined) {
       throw new DuplicateSuggestionError();
     }


### PR DESCRIPTION
#5272 asked whether `internalQuery`'s rejection carries a flat SQLSTATE. **It does not**, and the real shape is worse than the issue guessed. Measured against real Postgres through a real `PgClient.layerFromPool` client:

```
FiberFailureImpl                      ← own props: message, name, stack
  [Symbol(effect/Runtime/FiberFailure/Cause)] = { _tag: "Fail", error: SqlError }
      SqlError.cause = DatabaseError { code: "23505", constraint, detail }
```

No top-level `code` **and no `.cause` on the wrapper** — the Cause is symbol-keyed. The flat read missed it; a plain chain walk missed it too. Every affected arm turned a routine duplicate into a 500.

## Five sites, not four

The issue named four. `persist-form-install.ts` awaits `internalQuery(...).catch(raiseWriteError)` — a **promise** catch — so `isRoutingIdUniqueViolation` was equally blind, and #3167's concurrent-install race guard could never fire on that path: the workspace losing the race got a raw 500 instead of "already connected elsewhere". Stopping at the issue's list would have missed it.

| Site | Was returning |
|---|---|
| `admin-prompts.ts` | 500 instead of 409 on a duplicate collection name |
| `sub-processor-subscriptions.ts` | 500 instead of 409 on a duplicate webhook URL |
| `starter-prompts/favorite-store.ts` | 500 instead of `DuplicateFavoriteError` |
| `suggestions/approval-store.ts` | 500 instead of the duplicate-suggestion path |
| `install/routing-id-conflict.ts` | 500 instead of #3167's actionable message |

## The fix

One shared `unwrapFiberFailure` in `pg-errors.ts` used by both classifiers, so the two don't each grow a copy of the same first step. `asWrappedUniqueViolation` unwraps then walks `.cause` — it is the **sibling** of `asUniqueViolation`, not a replacement: the raw-`Pool` seeders must keep the flat read, or a wrapped violation from an unrelated layer would classify as a benign collision.

`routing-id-conflict.ts` gets the unwrap in front of its existing walk. **Additive by construction** — unwrapping only lets the walk see more links, and the `CHAT_ROUTING_ID_UNIQUE_INDEX` check still gates what counts, so it cannot start mislabelling an unrelated `23505`.

## Why no existing test could see this

All five sites' tests hand-build the rejection as `Object.assign(new Error(...), { code: "23505" })` — flat *by construction*, so they passed whether or not production produces that shape. Fixtures agreeing with the assumption they exist to check. That is why this needed a `-pg` harness rather than an argument, and it's the same class as #5000 and #5266's `-pg` half.

`internal-query-error-shape-pg.test.ts` records the answer so nobody re-runs the experiment: the SQLSTATE is **not** on the rejection, **not** on its `.cause` chain, reachable **only** through the symbol-keyed Cause, and classified by the new helper — plus a `42P01` through the same transport that must still not classify.

## Falsifiers — three, each measured RED, each independently necessary

| Mutation | Result |
|---|---|
| drop the FiberFailure unwrap | 1 RED |
| drop the `.cause` walk after it | 1 RED |
| drop routing-id's unwrap | 1 RED |

## Verification

12/12 affected files green, **plus every registry-reached consumer run explicitly** — five chat handlers, both catalog seeders, both stores, both routes, `persist-form-install`. `--affected` under-reports here, as it did on #5239. `lint`, `type`, `lint:type-aware` at 0 errors.

Closes #5272