### PR TITLE
fix(db): classify unique violations on the WRAPPED shape — four dead 409s, and a fifth site the fix exposed (#5272)

### DIFF
--- a/packages/api/src/api/routes/admin-prompts.ts
+++ b/packages/api/src/api/routes/admin-prompts.ts
@@ -10,7 +10,7 @@ import { Effect } from "effect";
 import type { Context as HonoContext } from "hono";
 import { createRoute, z } from "@hono/zod-openapi";
 import { createLogger } from "@atlas/api/lib/logger";
-import { asUniqueViolation } from "@atlas/api/lib/db/pg-errors";
+import { asWrappedUniqueViolation } from "@atlas/api/lib/db/pg-errors";
 import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
 import { runEffect } from "@atlas/api/lib/effect/hono";
 import { RequestContext, AuthContext } from "@atlas/api/lib/effect/services";
@@ -32,22 +32,17 @@ const log = createLogger("admin-prompts");
  * violation into a typed result so create/rename routes can return a 409
  * instead of leaking a generic 500.
  *
- * ⚠️ **READS A FLAT TOP-LEVEL `code`, AND THIS ROUTE WRITES THROUGH
- * `internalQuery`, WHICH MAY NOT PRODUCE ONE.** Once the Layer has booted,
- * `internalQuery` goes through `Effect.runPromise(_sqlClient.unsafe(…))`
- * (`db/internal.ts:768-773`), which rejects with a `FiberFailure` wrapping
- * `SqlError` wrapping the pg `DatabaseError` — no top-level `code`. That is
- * the shape `integrations/install/routing-id-conflict.ts` walks the `.cause`
- * chain for. If it holds here, this 409 is dead in production and a duplicate
- * name 500s instead. The existing tests cannot see it: they set `err.code`
- * directly on a hand-built rejection, a fixture agreeing with the assumption.
- * Surfaced by the #5271 review panel and NOT fixed there — it is pre-existing,
- * needs a `-pg` harness to settle, and changing four call sites' error
- * classification (two routes, two stores) is machinery this PR has no round
- * left to review. Tracked in #5272.
+ * ⚠️ **Classifies on the WRAPPED shape, and a flat read here was dead.** This
+ * route writes through `queryEffect`, so once the Layer has booted the
+ * rejection is a `FiberFailure` wrapping `SqlError` wrapping the pg
+ * `DatabaseError`, with no top-level `code` — measured against a real database
+ * in #5272, where a flat read returned "not a violation" and this 409 was
+ * unreachable in production. `normalizeError` passes the `FiberFailure` through
+ * untouched (it is already an `Error`), so the typed channel carries that exact
+ * shape.
  */
 function isUniqueViolation(err: unknown): boolean {
-  return asUniqueViolation(err) !== undefined;
+  return asWrappedUniqueViolation(err) !== undefined;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/api/src/api/routes/sub-processor-subscriptions.ts
+++ b/packages/api/src/api/routes/sub-processor-subscriptions.ts
@@ -24,7 +24,7 @@ import { AuthContext, RequestContext } from "@atlas/api/lib/effect/services";
 import { hasInternalDB } from "@atlas/api/lib/db/internal";
 import { isSafeExternalUrl } from "@atlas/api/lib/sandbox/validate";
 import { createLogger } from "@atlas/api/lib/logger";
-import { asUniqueViolation } from "@atlas/api/lib/db/pg-errors";
+import { asWrappedUniqueViolation } from "@atlas/api/lib/db/pg-errors";
 import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
 import { createSubscription } from "@atlas/api/lib/sub-processor-publisher";
 
@@ -149,14 +149,12 @@ router.openapi(createSubscriptionRoute, async (c) => {
           // packages/api/src/lib/suggestions/approval-store.ts (both of which
           // now import the shared constant from `db/pg-errors.ts`).
           //
-          // ⚠️ FLAT `code`, and this path writes through `internalQuery`,
-          // which wraps the driver error under `.cause` once the Layer has
-          // booted — so this `duplicate` arm may be dead in production and a
-          // duplicate URL may 500 instead. Same hazard as
-          // `admin-prompts.ts`'s `isUniqueViolation`; see the note there.
-          // Pre-existing, surfaced by the #5271 review panel, tracked in
-          // #5272.
-          if (asUniqueViolation(err) !== undefined) {
+          // ⚠️ The WRAPPED classifier, because this path writes through
+          // `internalQuery`: once the Layer has booted the rejection is a
+          // `FiberFailure` with no top-level `code`, so the flat read this
+          // used to do left the `duplicate` arm dead and a duplicate URL 500ed.
+          // Measured against a real database in #5272.
+          if (asWrappedUniqueViolation(err) !== undefined) {
             return { kind: "duplicate" };
           }
           throw err instanceof Error ? err : new Error(String(err));

--- a/packages/api/src/lib/db/__tests__/pg-errors-wrapped-pg.test.ts
+++ b/packages/api/src/lib/db/__tests__/pg-errors-wrapped-pg.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Real-Postgres coverage for unique-violation classification across the two
+ * error shapes a caller can be handed (#5272).
+ *
+ * **Why this suite has to exist.** Every unit test of this classification
+ * hand-builds its rejection — `Object.assign(new Error(), { code: "23505" })` —
+ * so the fixture agrees with the flat assumption by construction and cannot
+ * discriminate the two shapes. That is the #5000 / #5068 class: a test that
+ * passes for a reason unrelated to the thing it claims to prove. Four call
+ * sites classified on a flat top-level `code` while writing through
+ * `internalQuery`, and the whole suite was green while all four 409/duplicate
+ * arms were unreachable in production.
+ *
+ * Only a real database settles it, because the shape is produced by the
+ * `@effect/sql` layer wrapping a real driver error — not by anything a fixture
+ * can honestly imitate. The measured chain, which the assertions below pin:
+ *
+ *   `FiberFailureImpl` (own props: message/name/stack ONLY — no `code`, and
+ *   critically no `cause`) → `Cause` under a symbol → `Cause.squash` →
+ *   `SqlError` (no `code`) → `.cause` → pg `DatabaseError` (`code: "23505"`,
+ *   `constraint`, `detail`).
+ *
+ * The missing `cause` own-property on `FiberFailure` is the load-bearing fact:
+ * it is why a plain `.cause` walk — the fix #5272 originally proposed, and the
+ * one `routing-id-conflict.ts` shipped — reads `undefined` and stops at depth
+ * 0. `asserts the walk is not naive` below is that falsifier.
+ *
+ * Opt in locally with:
+ *   bun run db:up && export TEST_DATABASE_URL=postgresql://atlas:atlas@localhost:5432/atlas
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { Pool } from "pg";
+import { Effect } from "effect";
+import { PgClient } from "@effect/sql-pg";
+import { SqlClient } from "@effect/sql";
+import { internalQuery, _resetPool } from "@atlas/api/lib/db/internal";
+import {
+  asUniqueViolation,
+  asWrappedUniqueViolation,
+  pgErrorLinks,
+  PG_UNIQUE_VIOLATION,
+} from "@atlas/api/lib/db/pg-errors";
+import {
+  isRoutingIdUniqueViolation,
+  CHAT_ROUTING_ID_UNIQUE_INDEX,
+} from "@atlas/api/lib/integrations/install/routing-id-conflict";
+
+const TEST_DB_URL = process.env.TEST_DATABASE_URL;
+const describeIfPg = TEST_DB_URL ? describe : describe.skip;
+const PG_TEST_TIMEOUT_MS = 60_000;
+
+describeIfPg("unique-violation classification against real Postgres", () => {
+  // Entropy beyond the timestamp, matching the other `-pg` suites: this repo
+  // routinely runs concurrent `-pg` suites from several worktrees against one
+  // local Postgres, and `afterAll` DROPs the schema CASCADE.
+  const SCHEMA = `s5272_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
+  let pool: Pool;
+  /** The real rejection `internalQuery` produces once the Layer has booted. */
+  let wrapped: unknown;
+  /** The same collision through a raw `Pool` — the seeders' shape. */
+  let flat: unknown;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: TEST_DB_URL, max: 4 });
+    await pool.query(`CREATE SCHEMA ${SCHEMA}`);
+    await pool.query(`CREATE TABLE ${SCHEMA}.t (id int, name text)`);
+    // Named for the routing-id index deliberately, so that when the routing-id
+    // classifier is asserted below, the CONSTRAINT NAME cannot be the reason it
+    // fails — only the error's shape can be.
+    await pool.query(
+      `CREATE UNIQUE INDEX ${CHAT_ROUTING_ID_UNIQUE_INDEX} ON ${SCHEMA}.t (name)`,
+    );
+    await pool.query(`INSERT INTO ${SCHEMA}.t (id, name) VALUES (1, 'dup')`);
+
+    // Shape A — through `internalQuery` with a real SqlClient installed.
+    const layer = PgClient.layerFromPool({ acquire: Effect.succeed(pool) as never });
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const sql = yield* SqlClient.SqlClient;
+        _resetPool(null, sql);
+        const outcome = yield* Effect.tryPromise({
+          try: () => internalQuery(`INSERT INTO ${SCHEMA}.t (id, name) VALUES ($1, $2)`, [2, "dup"]),
+          catch: (e) => e,
+        }).pipe(Effect.either);
+        if (outcome._tag === "Right") throw new Error("expected a unique violation");
+        wrapped = outcome.left;
+      }).pipe(Effect.scoped, Effect.provide(layer)),
+    );
+
+    // Shape B — the raw driver error, which the two catalog seeders see.
+    try {
+      await pool.query(`INSERT INTO ${SCHEMA}.t (id, name) VALUES ($1, $2)`, [3, "dup"]);
+      throw new Error("expected a unique violation");
+    } catch (err) {
+      flat = err;
+    }
+  }, PG_TEST_TIMEOUT_MS);
+
+  afterAll(async () => {
+    _resetPool(null, null);
+    if (pool) {
+      await pool.query(`DROP SCHEMA IF EXISTS ${SCHEMA} CASCADE`);
+      await pool.end();
+    }
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("the wrapped rejection carries NO top-level code — the premise of #5272", () => {
+    expect((wrapped as Record<string, unknown>).code).toBeUndefined();
+    // The whole defect in one assertion: the flat classifier, which four call
+    // sites used, reports "not a violation" for a real unique violation.
+    expect(asUniqueViolation(wrapped)).toBeUndefined();
+  });
+
+  it("asserts the walk is not naive — FiberFailure exposes no `cause` own-property", () => {
+    // If this ever starts passing, a plain `.cause` walk would suffice and the
+    // unwrap step could be simplified. Until then it is why the unwrap exists,
+    // and it is the assertion that fails if someone "simplifies" it away.
+    expect(Object.getOwnPropertyNames(wrapped as object)).not.toContain("cause");
+    expect((wrapped as Record<string, unknown>).cause).toBeUndefined();
+  });
+
+  it("classifies the wrapped rejection, with the driver's diagnostics intact", () => {
+    const hit = asWrappedUniqueViolation(wrapped);
+    expect(hit).toBeDefined();
+    expect(hit?.constraint).toBe(CHAT_ROUTING_ID_UNIQUE_INDEX);
+    // `detail` is what a caller surfaces to explain WHICH value collided.
+    expect(hit?.detail).toContain("dup");
+  });
+
+  it("classifies the flat driver error too — one classifier covers both shapes", () => {
+    expect(asWrappedUniqueViolation(flat)).toBeDefined();
+    expect(asUniqueViolation(flat)).toBeDefined();
+  });
+
+  it("reaches the pg DatabaseError through the chain", () => {
+    const links = pgErrorLinks(wrapped);
+    const codes = links.map((l) => (l as Record<string, unknown> | null)?.code);
+    expect(codes).toContain(PG_UNIQUE_VIOLATION);
+    // Outermost link is the FiberFailure itself, which carries no code — so a
+    // classifier that only read `links[0]` would still be broken.
+    expect(codes[0]).toBeUndefined();
+  });
+
+  it("the routing-id classifier survives the wrapped shape (#3167 was dead here too)", () => {
+    expect(isRoutingIdUniqueViolation(wrapped)).toBe(true);
+    expect(isRoutingIdUniqueViolation(flat)).toBe(true);
+  });
+
+  it("stays tight: a 23505 on a DIFFERENT index is not a routing-id conflict", async () => {
+    await pool.query(`CREATE TABLE ${SCHEMA}.u (name text)`);
+    await pool.query(`CREATE UNIQUE INDEX some_other_index ON ${SCHEMA}.u (name)`);
+    await pool.query(`INSERT INTO ${SCHEMA}.u (name) VALUES ('x')`);
+    let other: unknown;
+    try {
+      await pool.query(`INSERT INTO ${SCHEMA}.u (name) VALUES ('x')`);
+    } catch (err) {
+      other = err;
+    }
+    // It IS a unique violation …
+    expect(asWrappedUniqueViolation(other)).toBeDefined();
+    // … but NOT the routing-id one. Relabelling it would turn an unrelated
+    // failure into "already connected elsewhere".
+    expect(isRoutingIdUniqueViolation(other)).toBe(false);
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("does not classify a non-violation error", () => {
+    expect(asWrappedUniqueViolation(new Error("connection reset"))).toBeUndefined();
+    expect(asWrappedUniqueViolation(null)).toBeUndefined();
+    expect(asWrappedUniqueViolation(undefined)).toBeUndefined();
+    expect(asWrappedUniqueViolation("23505")).toBeUndefined();
+  });
+});

--- a/packages/api/src/lib/db/__tests__/pg-errors-wrapped-pg.test.ts
+++ b/packages/api/src/lib/db/__tests__/pg-errors-wrapped-pg.test.ts
@@ -32,6 +32,8 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { Pool } from "pg";
 import { Effect } from "effect";
+import * as Cause from "effect/Cause";
+import * as Runtime from "effect/Runtime";
 import { PgClient } from "@effect/sql-pg";
 import { SqlClient } from "@effect/sql";
 import { internalQuery, _resetPool } from "@atlas/api/lib/db/internal";
@@ -118,6 +120,19 @@ describeIfPg("unique-violation classification against real Postgres", () => {
     // and it is the assertion that fails if someone "simplifies" it away.
     expect(Object.getOwnPropertyNames(wrapped as object)).not.toContain("cause");
     expect((wrapped as Record<string, unknown>).cause).toBeUndefined();
+  });
+
+  it("⭐ the SQLSTATE is reachable ONLY through the symbol-keyed Cause", () => {
+    // The positive half of the two assertions above: not merely "the naive
+    // reads miss it" but "here is where it actually lives". Without this a
+    // future refactor could satisfy the negatives by breaking the error
+    // entirely. (Adopted from #5276, which measured this independently.)
+    const cause = (wrapped as Record<symbol, unknown>)[Runtime.FiberFailureCauseId];
+    expect(cause).toBeDefined();
+    const squashed = Cause.squash(cause as Cause.Cause<unknown>) as Record<string, unknown>;
+    expect(squashed._tag).toBe("SqlError");
+    expect(squashed.code).toBeUndefined();
+    expect((squashed.cause as Record<string, unknown>)?.code).toBe(PG_UNIQUE_VIOLATION);
   });
 
   it("classifies the wrapped rejection, with the driver's diagnostics intact", () => {

--- a/packages/api/src/lib/db/__tests__/pg-errors.test.ts
+++ b/packages/api/src/lib/db/__tests__/pg-errors.test.ts
@@ -5,21 +5,46 @@
  * consumer's recovery works: *"Reads a TOP-LEVEL `code` only. An
  * `@effect/sql`-backed client wraps the driver error under `.cause`, so every
  * collision would arrive here unclassified."* That is the whole reason
- * `routing-id-conflict.ts` keeps a separate `.cause` walk instead of adopting
- * this helper.
+ * `asWrappedUniqueViolation` exists as a separate classifier rather than this
+ * one growing a chain walk.
  *
  * Prose is not a checked condition. This file makes it one — in particular the
  * wrapped case, which is the arm the header uses to justify NOT unifying the
- * two classifiers, and which #5272 is open against for the four call sites
- * (two routes, two stores) that read the flat shape on a wrapped path.
+ * two classifiers, and which #5272 settled for the four call sites (two routes,
+ * two stores) that read the flat shape on a wrapped path.
+ *
+ * ⚠️ The fixtures here build their rejections BY HAND, which is exactly the
+ * limitation #5272 was filed about: a hand-built error agrees with whatever
+ * shape its author assumed. The wrapped cases below therefore build a REAL
+ * `FiberFailure` through `Effect.runPromise` rather than imitating one — that
+ * is the wrapper whose missing `cause` own-property broke the naive walk, and
+ * it cannot be faked with an object literal. The innermost pg error is still
+ * hand-shaped; `pg-errors-wrapped-pg.test.ts` is what pins it against a real
+ * database.
  */
 
 import { describe, expect, it } from "bun:test";
+import { Effect } from "effect";
 import {
   asUniqueViolation,
+  asWrappedUniqueViolation,
+  pgErrorLinks,
   PG_UNIQUE_VIOLATION,
   PG_PLUGIN_CATALOG_SLUG_CONSTRAINT,
 } from "@atlas/api/lib/db/pg-errors";
+
+/**
+ * A genuine `FiberFailure` wrapping `inner` — the shape `Effect.runPromise`
+ * rejects with, produced rather than imitated.
+ */
+async function realFiberFailure(inner: unknown): Promise<unknown> {
+  try {
+    await Effect.runPromise(Effect.fail(inner));
+    throw new Error("expected the effect to fail");
+  } catch (err) {
+    return err;
+  }
+}
 
 describe("PG constants", () => {
   it("pins the SQLSTATE and the constraint name", () => {
@@ -58,10 +83,12 @@ describe("asUniqueViolation", () => {
   });
 
   it("⭐ returns undefined for a `.cause`-WRAPPED 23505 — the header's load-bearing claim", () => {
-    // This is why `routing-id-conflict.ts` walks the chain instead of calling
-    // this helper, and why #5272 exists. If this ever starts returning a
-    // value, the two classifiers have converged and that module's "do not
-    // simplify the two into one helper" argument needs re-reading.
+    // This is why `asWrappedUniqueViolation` exists, and it stays asserted
+    // because the flat classifier must KEEP failing here: the two seeders hold
+    // a raw `Pool` and rely on it not classifying a wrapped violation from an
+    // unrelated layer as a benign slug collision. If this ever starts returning
+    // a value, the two classifiers have converged and the module header's "do
+    // not simplify the two into one helper" argument needs re-reading.
     const wrapped = Object.assign(new Error("SqlError"), { cause: violation() });
     expect(asUniqueViolation(wrapped)).toBeUndefined();
   });
@@ -93,5 +120,73 @@ describe("asUniqueViolation", () => {
     // compares it against a constraint NAME and silently never match.
     const got = asUniqueViolation(violation({ constraint: 1234, detail: 5678 }));
     expect(got).toEqual({ constraint: undefined, detail: undefined });
+  });
+});
+
+describe("asWrappedUniqueViolation", () => {
+  const pgError = (extra: Record<string, unknown> = {}) =>
+    Object.assign(new Error("duplicate key value violates unique constraint"), {
+      code: "23505",
+      constraint: "prompt_collections_org_name_uniq",
+      detail: "Key (lower(name))=(x) already exists.",
+      ...extra,
+    });
+
+  /** `SqlError`-shaped: no `code` of its own, driver error under `.cause`. */
+  const sqlErrorLike = (cause: unknown) =>
+    Object.assign(new Error("Failed to execute statement"), { _tag: "SqlError", cause });
+
+  it("classifies the flat shape too — one classifier covers both", () => {
+    expect(asWrappedUniqueViolation(pgError())).toEqual({
+      constraint: "prompt_collections_org_name_uniq",
+      detail: "Key (lower(name))=(x) already exists.",
+    });
+  });
+
+  it("⭐ classifies a REAL FiberFailure → SqlError → pg error", async () => {
+    // The production shape. `asUniqueViolation` returning undefined here is the
+    // defect #5272 fixed, asserted alongside so the two cannot drift apart.
+    const wrapped = await realFiberFailure(sqlErrorLike(pgError()));
+    expect(asUniqueViolation(wrapped)).toBeUndefined();
+    expect(asWrappedUniqueViolation(wrapped)).toEqual({
+      constraint: "prompt_collections_org_name_uniq",
+      detail: "Key (lower(name))=(x) already exists.",
+    });
+  });
+
+  it("⭐ a real FiberFailure exposes no `cause` — why the unwrap exists", async () => {
+    const wrapped = (await realFiberFailure(sqlErrorLike(pgError()))) as object;
+    expect(Object.getOwnPropertyNames(wrapped)).not.toContain("cause");
+    expect((wrapped as { cause?: unknown }).cause).toBeUndefined();
+  });
+
+  it("does not classify a wrapped NON-violation", async () => {
+    const wrapped = await realFiberFailure(
+      sqlErrorLike(Object.assign(new Error("deadlock detected"), { code: "40P01" })),
+    );
+    expect(asWrappedUniqueViolation(wrapped)).toBeUndefined();
+  });
+
+  it("returns undefined for non-objects, matching the flat classifier", () => {
+    for (const notAnObject of ["23505", 23505, null, undefined, true]) {
+      expect(asWrappedUniqueViolation(notAnObject)).toBeUndefined();
+    }
+  });
+
+  it("terminates on a self-referential cause chain", () => {
+    // The cap is a backstop, but a self-link is the cheap case to get wrong and
+    // it hangs the process rather than failing a test.
+    const cyclic: Record<string, unknown> = { code: "XX000" };
+    cyclic.cause = cyclic;
+    expect(asWrappedUniqueViolation(cyclic)).toBeUndefined();
+  });
+
+  it("stops at the depth cap rather than walking forever", () => {
+    // 20 links, cap is 8 — the 23505 at the bottom must NOT be found, which is
+    // what proves the cap is enforced rather than merely declared.
+    let deep: unknown = pgError();
+    for (let i = 0; i < 20; i++) deep = { cause: deep };
+    expect(asWrappedUniqueViolation(deep)).toBeUndefined();
+    expect(pgErrorLinks(deep).length).toBe(8);
   });
 });

--- a/packages/api/src/lib/db/pg-errors.ts
+++ b/packages/api/src/lib/db/pg-errors.ts
@@ -22,23 +22,38 @@
  * matches seven test fixtures that build a rejection by hand.)
  *
  * ⚠️ **Only the CONSTANT is universal; the classification around it is not.**
- * `asUniqueViolation` below reads a FLAT `code`, which is right for the `pg`
+ * {@link asUniqueViolation} reads a FLAT `code`, which is right for the `pg`
  * driver and wrong for `@effect/sql` — that wrapper moves the driver error
- * under `.cause`, which is why `routing-id-conflict.ts` walks the chain
- * instead. It imports the constant and keeps its own walk. Do not "simplify"
- * the two into one helper: a chain walk applied to the seeders would classify
- * a wrapped violation from an unrelated layer as a benign collision, and a
- * flat read applied to the Effect path would classify every real collision as
- * an unhandled throw.
+ * down a chain, which is what {@link asWrappedUniqueViolation} traverses. Do
+ * not "simplify" the two into one helper: a chain walk applied to the seeders
+ * would classify a wrapped violation from an unrelated layer as a benign
+ * collision, and a flat read applied to the Effect path would classify every
+ * real collision as an unhandled throw.
  *
- * ⚠️ FOUR of the six consumers are on exactly that Effect path today:
- * `admin-prompts.ts`, `sub-processor-subscriptions.ts`,
- * `starter-prompts/favorite-store.ts` and `suggestions/approval-store.ts` all
- * read this flat classification off an `internalQuery` result, where the shape
- * may be wrapped. Tracked in #5272; each site carries the same note. Do not
- * read "flat is right for the `pg` driver" as "flat is right at every call
- * site" — only the two seeders pass a raw `Pool`.
+ * ⚠️ The TRAVERSAL, unlike the classification, is now shared —
+ * `routing-id-conflict.ts` used to keep its own `.cause` loop and that loop was
+ * dead on the very paths its docstring cited (#5272). It keeps its own
+ * constraint-name check, which is the part that is genuinely local to it, and
+ * takes {@link pgErrorLinks} for the part that is not.
+ *
+ * ⚠️ FOUR of the six consumers were on exactly that Effect path and were
+ * therefore DEAD — `admin-prompts.ts`, `sub-processor-subscriptions.ts`,
+ * `starter-prompts/favorite-store.ts` and `suggestions/approval-store.ts` each
+ * read the flat classification off an `internalQuery` result. #5272 settled it
+ * against a real database and they now call {@link asWrappedUniqueViolation}.
+ * Do not read "flat is right for the `pg` driver" as "flat is right at every
+ * call site" — only the two seeders pass a raw `Pool`.
  */
+
+// ⚠️ SUBPATH imports, not the `effect` barrel, and deliberately so. Importing
+// `{ Cause, Runtime }` from `"effect"` raises a runtime `SyntaxError: Export
+// named 'Cause' not found` when a suite that partially mocks the barrel links a
+// graph reaching this file — `admin-marketplace.test.ts` is one. It is not a
+// type error and this module's own tests did not see it, so the barrel form
+// looked correct right up to the point another suite red. Other modules here do
+// use the barrel; they are not reached from a partially-mocked graph.
+import * as Cause from "effect/Cause";
+import * as Runtime from "effect/Runtime";
 
 /** Postgres SQLSTATE for `unique_violation`. */
 export const PG_UNIQUE_VIOLATION = "23505";
@@ -67,6 +82,92 @@ export function asUniqueViolation(
   const constraint = "constraint" in err && typeof err.constraint === "string" ? err.constraint : undefined;
   const detail = "detail" in err && typeof err.detail === "string" ? err.detail : undefined;
   return { constraint, detail };
+}
+
+/**
+ * Max links to follow. Measured depth on the Effect path is 2
+ * (`SqlError` → pg `DatabaseError`); the cap is a backstop against a cyclic
+ * `cause` chain rather than a real depth requirement.
+ */
+const MAX_CAUSE_DEPTH = 8;
+
+/**
+ * One `FiberFailure` unwrapped to the error its `Cause` carries, or `err`
+ * unchanged when it is not one.
+ *
+ * ⚠️ **A `FiberFailure` exposes NO `cause` own-property, and that is why a
+ * plain `.cause` walk does not reach the driver error.** #5272 proposed exactly
+ * such a walk, and the settling experiment falsified it: the rejection from
+ * `Effect.runPromise` is a `FiberFailureImpl` whose only own property names are
+ * `message`, `name` and `stack`. The `Cause` hangs off the symbol below, so any
+ * walk that starts with `err.cause` reads `undefined` and stops at depth 0 —
+ * which is precisely how `routing-id-conflict.ts`'s walk was failing on the two
+ * `internalQuery`/`queryEffect` paths its own docstring claimed to cover.
+ */
+function unwrapFiberFailure(err: unknown): unknown {
+  if (typeof err !== "object" || err === null) return err;
+  if (!(Runtime.FiberFailureCauseId in err)) return err;
+  const cause = (err as Record<symbol, unknown>)[Runtime.FiberFailureCauseId];
+  if (cause === undefined || cause === null) return err;
+  return Cause.squash(cause as Cause.Cause<unknown>);
+}
+
+/**
+ * Every error link worth classifying, outermost first.
+ *
+ * Unwraps a `FiberFailure` at each step before following `.cause`, so one
+ * traversal covers both shapes a caller can be handed: the raw pg
+ * `DatabaseError` from a `Pool`, and the `FiberFailure` → `SqlError` → pg
+ * `DatabaseError` stack that `internalQuery` produces once the Effect Layer has
+ * booted.
+ *
+ * **The measured chain (#5272, real Postgres, Layer booted):**
+ * `FiberFailureImpl` (no `code`) → `Cause.squash` → `SqlError` (no `code`,
+ * `_tag` its only own key) → `.cause` → pg `DatabaseError` carrying
+ * `code: "23505"`, `constraint` and `detail`.
+ *
+ * Exported so a classifier for a DIFFERENT SQLSTATE reuses the traversal rather
+ * than re-deriving it — the six-spellings problem this module's header opens
+ * with, one level up from the constant.
+ */
+export function pgErrorLinks(err: unknown): readonly unknown[] {
+  const links: unknown[] = [];
+  let current = unwrapFiberFailure(err);
+  for (let depth = 0; depth < MAX_CAUSE_DEPTH; depth++) {
+    links.push(current);
+    if (typeof current !== "object" || current === null) break;
+    const next = (current as { readonly cause?: unknown }).cause;
+    if (next === undefined || next === null) break;
+    if (next === current) break; // self-referential guard
+    current = unwrapFiberFailure(next);
+  }
+  return links;
+}
+
+/**
+ * The diagnostic fields of a `23505` found anywhere in `err`'s chain, or
+ * `undefined`.
+ *
+ * The classifier for every caller that writes through `internalQuery` or
+ * `queryEffect`. {@link asUniqueViolation} is its flat counterpart and stays
+ * separate deliberately — this module's header carries that argument, and it is
+ * unchanged by #5272: a chain walk applied to the two seeders, which hold a raw
+ * `Pool`, would classify a wrapped violation from an unrelated layer as a
+ * benign slug collision.
+ *
+ * ⚠️ It reads the SQLSTATE only. A caller that must distinguish WHICH
+ * constraint was violated has to check `constraint` itself — see
+ * `integrations/install/routing-id-conflict.ts`, whose whole point is that a
+ * `23505` on any other index is a different failure.
+ */
+export function asWrappedUniqueViolation(
+  err: unknown,
+): { readonly constraint?: string; readonly detail?: string } | undefined {
+  for (const link of pgErrorLinks(err)) {
+    const flat = asUniqueViolation(link);
+    if (flat !== undefined) return flat;
+  }
+  return undefined;
 }
 
 /**

--- a/packages/api/src/lib/db/pg-errors.ts
+++ b/packages/api/src/lib/db/pg-errors.ts
@@ -103,13 +103,16 @@ const MAX_CAUSE_DEPTH = 8;
  * walk that starts with `err.cause` reads `undefined` and stops at depth 0 —
  * which is precisely how `routing-id-conflict.ts`'s walk was failing on the two
  * `internalQuery`/`queryEffect` paths its own docstring claimed to cover.
+ *
+ * Uses Effect's own `isFiberFailure` guard rather than testing for the symbol
+ * by hand, so a runtime change to how the wrapper is marked surfaces as a type
+ * error instead of a silently-undefined lookup that would make every collision
+ * unclassified again — which is the exact failure mode this function exists to
+ * end. (Adopted from the parallel fix in #5276, which reached this module
+ * independently.)
  */
 function unwrapFiberFailure(err: unknown): unknown {
-  if (typeof err !== "object" || err === null) return err;
-  if (!(Runtime.FiberFailureCauseId in err)) return err;
-  const cause = (err as Record<symbol, unknown>)[Runtime.FiberFailureCauseId];
-  if (cause === undefined || cause === null) return err;
-  return Cause.squash(cause as Cause.Cause<unknown>);
+  return Runtime.isFiberFailure(err) ? Cause.squash(err[Runtime.FiberFailureCauseId]) : err;
 }
 
 /**

--- a/packages/api/src/lib/integrations/install/routing-id-conflict.ts
+++ b/packages/api/src/lib/integrations/install/routing-id-conflict.ts
@@ -66,7 +66,13 @@ interface PgErrorLike {
  * loop was DEAD on exactly the two Effect paths the paragraph above cites.**
  * `Effect.runPromise` rejects with a `FiberFailure`, which exposes no `cause`
  * own-property — its `Cause` hangs off a symbol — so the loop read `undefined`
- * at depth 0 and returned `false` for every wrapped collision. Measured in
+ * at depth 0 and returned `false` for every wrapped collision.
+ *
+ * The concrete route in: `persist-form-install.ts` catches with
+ * `.catch(raiseWriteError)` on a promise, so what reaches here is the
+ * `FiberFailure` rather than the `SqlError` an in-program catch would see. That
+ * made #3167's "already connected elsewhere" message unreachable on that path
+ * and handed the losing installer a raw 500. Measured in
  * #5272 against a real database with the index deliberately named
  * {@link CHAT_ROUTING_ID_UNIQUE_INDEX}, so the constraint check could not be
  * what failed: it returned `false` on the real error and `true` on the

--- a/packages/api/src/lib/integrations/install/routing-id-conflict.ts
+++ b/packages/api/src/lib/integrations/install/routing-id-conflict.ts
@@ -29,7 +29,7 @@
  * {@link isRoutingIdUniqueViolation}.
  */
 
-import { PG_UNIQUE_VIOLATION } from "@atlas/api/lib/db/pg-errors";
+import { PG_UNIQUE_VIOLATION, pgErrorLinks } from "@atlas/api/lib/db/pg-errors";
 
 /**
  * Name of the partial unique index created by migration 0120 and mirrored
@@ -39,23 +39,14 @@ import { PG_UNIQUE_VIOLATION } from "@atlas/api/lib/db/pg-errors";
 export const CHAT_ROUTING_ID_UNIQUE_INDEX = "workspace_plugins_chat_routing_id_unique";
 
 /**
- * Max `.cause` links to follow. The pg error is at most a couple of links
- * deep (`SqlError.cause` → pg `DatabaseError`); the cap is a backstop against
- * a cyclic `cause` chain rather than a real depth requirement.
- */
-const MAX_CAUSE_DEPTH = 8;
-
-/**
  * Shape of the fields we read off an error link. `code` carries the SQLSTATE;
  * `constraint` carries the violated index/constraint name on a unique
- * violation; `cause` is the next link to inspect. All optional because the
- * value reaching a `catch` is `unknown` — a network/driver error won't have
- * them.
+ * violation. Both optional because the value reaching a `catch` is `unknown` —
+ * a network/driver error won't have them.
  */
 interface PgErrorLike {
   readonly code?: unknown;
   readonly constraint?: unknown;
-  readonly cause?: unknown;
 }
 
 /**
@@ -69,20 +60,27 @@ interface PgErrorLike {
  * install via `getInternalDB().connect()`), but the no-org direct-insert path
  * and the generic marketplace config UPDATE both go through `@effect/sql`
  * (`internalQuery` / `queryEffect` → `_sqlClient.unsafe`), which wraps the pg
- * error inside a `SqlError.cause` with NO top-level `code`. Inspecting each
- * link catches the 23505 regardless of how deeply the driver/Effect layer
- * wrapped it.
+ * error inside a `SqlError` with NO top-level `code`.
+ *
+ * ⚠️ **The walk this function used to do was its OWN `.cause` loop, and that
+ * loop was DEAD on exactly the two Effect paths the paragraph above cites.**
+ * `Effect.runPromise` rejects with a `FiberFailure`, which exposes no `cause`
+ * own-property — its `Cause` hangs off a symbol — so the loop read `undefined`
+ * at depth 0 and returned `false` for every wrapped collision. Measured in
+ * #5272 against a real database with the index deliberately named
+ * {@link CHAT_ROUTING_ID_UNIQUE_INDEX}, so the constraint check could not be
+ * what failed: it returned `false` on the real error and `true` on the
+ * hand-built fixture its tests use. {@link pgErrorLinks} unwraps the
+ * `FiberFailure` before following `.cause`, which is the part the local loop
+ * could not have gotten right by inspection.
  */
 export function isRoutingIdUniqueViolation(err: unknown): boolean {
-  let current: unknown = err;
-  for (let depth = 0; depth < MAX_CAUSE_DEPTH; depth++) {
-    if (typeof current !== "object" || current === null) return false;
-    const e = current as PgErrorLike;
+  for (const link of pgErrorLinks(err)) {
+    if (typeof link !== "object" || link === null) continue;
+    const e = link as PgErrorLike;
     if (e.code === PG_UNIQUE_VIOLATION && e.constraint === CHAT_ROUTING_ID_UNIQUE_INDEX) {
       return true;
     }
-    if (e.cause === current) return false; // self-referential guard
-    current = e.cause;
   }
   return false;
 }

--- a/packages/api/src/lib/starter-prompts/favorite-store.ts
+++ b/packages/api/src/lib/starter-prompts/favorite-store.ts
@@ -16,7 +16,7 @@ import {
   hasInternalDB,
   internalQuery,
 } from "@atlas/api/lib/db/internal";
-import { asUniqueViolation } from "@atlas/api/lib/db/pg-errors";
+import { asWrappedUniqueViolation } from "@atlas/api/lib/db/pg-errors";
 
 const log = createLogger("favorite-store");
 
@@ -216,15 +216,12 @@ export async function createFavorite(
     }
     return toRow(rows[0]);
   } catch (err) {
-    // ⚠️ FLAT `code`, and this path writes through `internalQuery`, which
-    // wraps the driver error under `.cause` once the Effect Layer has booted
-    // — so this arm may be dead in production and a duplicate may surface as
-    // a 500 instead of the specific message below. Same hazard as
-    // `admin-prompts.ts` and `sub-processor-subscriptions.ts`; pre-existing,
-    // surfaced by the #5271 review panel, tracked in #5272. Noted on all four
-    // sites deliberately: a defect documented in half its instances is one
-    // that gets closed on the documented half.
-    const collision = asUniqueViolation(err);
+    // ⚠️ The WRAPPED classifier, because this path writes through
+    // `internalQuery`: once the Effect Layer has booted the rejection carries
+    // no top-level `code`, so the flat read this used to do left the arm dead
+    // and a duplicate surfaced as a 500 rather than the message below.
+    // Measured against a real database in #5272.
+    const collision = asWrappedUniqueViolation(err);
     if (collision !== undefined) {
       throw new DuplicateFavoriteError();
     }

--- a/packages/api/src/lib/suggestions/approval-store.ts
+++ b/packages/api/src/lib/suggestions/approval-store.ts
@@ -25,7 +25,7 @@ import {
   type QuerySuggestionRow,
 } from "@atlas/api/lib/db/internal";
 import { toQuerySuggestion } from "@atlas/api/lib/learn/suggestion-helpers";
-import { asUniqueViolation } from "@atlas/api/lib/db/pg-errors";
+import { asWrappedUniqueViolation } from "@atlas/api/lib/db/pg-errors";
 
 const log = createLogger("approval-store");
 
@@ -312,9 +312,9 @@ export async function createApprovedSuggestion(input: {
     }
     return toQuerySuggestion(rows[0]);
   } catch (err) {
-    // ⚠️ FLAT `code` on an `internalQuery` path — see the identical note in
-    // `starter-prompts/favorite-store.ts`. Tracked in #5272.
-    const collision = asUniqueViolation(err);
+    // ⚠️ The WRAPPED classifier on an `internalQuery` path — see the identical
+    // note in `starter-prompts/favorite-store.ts` (#5272).
+    const collision = asWrappedUniqueViolation(err);
     if (collision !== undefined) {
       throw new DuplicateSuggestionError();
     }


### PR DESCRIPTION
Closes #5272.

## What was wrong

`internalQuery` takes the `_sqlClient` branch once the Effect Layer has booted — i.e. always, in production — and rejects with a `FiberFailure` carrying no top-level `code`. Four call sites classified `23505` on a flat read off that path, so every duplicate 500ed instead of returning its 409 / `duplicate` / typed error:

- `admin-prompts.ts` — duplicate collection name
- `sub-processor-subscriptions.ts` — duplicate webhook URL
- `starter-prompts/favorite-store.ts` — duplicate pin
- `suggestions/approval-store.ts` — duplicate suggestion text

## The settling experiment (AC-1)

Run against a real database rather than argued. The measured chain:

```
FiberFailureImpl  (own property names: message, name, stack — ONLY)
  → Cause, under Symbol(effect/Runtime/FiberFailure/Cause)
  → Cause.squash
  → SqlError  (no `code`; `_tag` its only own key)
  → .cause
  → pg DatabaseError  (code "23505", constraint, detail)
```

## ⚠️ The issue's proposed fix does not work

#5272 called for *"a second named classifier that walks `.cause`"*. **A `.cause` walk starting at the `FiberFailure` reads `undefined` and stops at depth 0**, because `FiberFailure` exposes no `cause` own-property — the `Cause` hangs off a symbol. The unwrap has to happen first, and no amount of inspection would have shown that; only running it did.

## ⚠️ It also falsifies a FIFTH site — the one the issue held up as correct

`routing-id-conflict.ts` shipped exactly that naive walk, and its docstring claimed it covered the `internalQuery` / `queryEffect` paths *"regardless of how deeply the driver/Effect layer wrapped it"*. It did not.

Measured with the test index deliberately named `workspace_plugins_chat_routing_id_unique`, so the constraint check could not be what failed:

| input | `isRoutingIdUniqueViolation` |
|---|---|
| real wrapped rejection | **`false`** ← #3167 dead here |
| hand-built fixture its tests use | `true` |

So #3167's concurrent-install conflict detection was dead on those paths too, and a losing concurrent installer got a raw 500 instead of "already connected elsewhere". It now takes the shared traversal and keeps its own constraint-name check — the part that is genuinely local to it.

This is inside AC-5's sweep (*"the other `internalQuery` callers that classify on SQLSTATE"*), but flagging it explicitly because the issue cited this module as the precedent to copy.

## The shape of the fix

- `pgErrorLinks(err)` — shared traversal: unwrap `FiberFailure`, then follow `.cause`, at each step. Exported so a classifier for a different SQLSTATE reuses it.
- `asWrappedUniqueViolation(err)` — the classifier for the Effect path.
- `asUniqueViolation(err)` — **unchanged and still flat.** The two catalog seeders hold a raw `Pool`, and the module header's "do not merge these into one helper" argument survives #5272 intact: a chain walk applied there would classify a wrapped violation from an unrelated layer as a benign slug collision. That is asserted, not just asserted-in-prose.

## Tests

**`pg-errors-wrapped-pg.test.ts` (new, `-pg`)** seeds a **real** conflicting row through the `internalQuery` seam (AC-2). This is the point: every existing fixture hand-builds `Object.assign(new Error(), { code: "23505" })`, which agrees with the flat assumption by construction and cannot discriminate the two shapes — the #5000 / #5068 class that hid this for four sites while the suite stayed green.

**Falsifiers measured** (restored from a backup, not `git checkout`):

| mutation | result |
|---|---|
| skip the `FiberFailure` unwrap (the naive walk) | **3 fail** |
| stop after the unwrap, don't follow `.cause` | **3 fail** |
| drop the constraint-name check in routing-id | **1 fail** (the tightness case) |

Both halves of the traversal are independently load-bearing.

**Unit tests** build a genuine `FiberFailure` via `Effect.runPromise` rather than imitating one (AC-4) — the missing `cause` own-property is the whole defect and cannot be faked with an object literal. Also covers the depth cap and a self-referential chain.

## ⚠️ One non-obvious landmine

`Cause` and `Runtime` are imported by **subpath**, not from the `effect` barrel. The barrel form type-checks, passes `lint:type-aware`, and passes this module's own tests — then reds `admin-marketplace.test.ts` with a runtime `SyntaxError: Export named 'Cause' not found` when a partially-mocked module graph links this file. Caught only because I ran suites outside the `--affected` set.

## Acceptance criteria

- [x] A `-pg` test establishes which shape `internalQuery` rejects with — recorded in the module docstring and the test header
- [x] Both routes classify on the wrapped shape, proven by seeding a REAL conflicting row
- [x] (n/a — it was wrapped, not flat)
- [x] Hand-built fixtures supplemented with real-`FiberFailure` cases
- [x] Swept the other `internalQuery` callers — `favorite-store.ts`, `approval-store.ts`, and `routing-id-conflict.ts`

## Gates

`bun run lint` · `bun run type` · `bun run lint:type-aware` all exit 0. Affected suite 12/12; `admin-marketplace`, `admin-prompts-audit`, `routing-id-conflict`, `sub-processor-subscriptions` run individually and green.

Not run: full `ci-local.sh`. Nothing here reshapes a source anchor in `scripts/mutations/`, so the cheap pre-flight is the documented gate — remote CI on this PR is the real one.

https://claude.ai/code/session_01Q3GX59hGfmkXvrD9cFCjaM
