### PR TITLE
chore(security): baseline CVE-2026-53615 (util-linux) so the base-image gate reflects reality

### DIFF
--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -17,7 +17,8 @@ name: Image Scan
 # .trivyignore. Read those two files for the reasoning. In short:
 #
 #   blocks    fixable HIGH/CRITICAL in OS packages, minus the dated
-#             .trivyignore baseline (which is currently EMPTY — see that file)
+#             .trivyignore baseline (which is NOT empty — read that file for
+#             what is in it and why each entry is legitimate)
 #   reports   every FIXABLE finding at every severity and package type, from the
 #             BUILT images only, via SARIF to GitHub code scanning
 #   logs      everything else, unfixed included, as a census in the job log

--- a/.trivyignore
+++ b/.trivyignore
@@ -141,7 +141,7 @@
 # ─────────────────────────────────────────────────────────────────────────────
 # oven/bun:1.3.13 (Debian trixie) — runtime base for deploy/api, deploy/web,
 # packages/sandbox-sidecar, examples/docker and the create-atlas docker
-# templates. All seven are cleared by the `apt-get upgrade` in every runtime
+# templates. All eight are cleared by the `apt-get upgrade` in every runtime
 # stage; they persist only in the bare base, which is what base-images scans.
 # ─────────────────────────────────────────────────────────────────────────────
 # HIGH     libssl3t64 / openssl-provider-legacy  3.5.5-1~deb13u1 -> u2
@@ -158,6 +158,14 @@ CVE-2026-31789 exp:2026-11-01
 CVE-2026-45447 exp:2026-11-01
 # HIGH     libcap2  1:2.75-10+b8 -> 1:2.75-10+deb13u1
 CVE-2026-4878 exp:2026-11-01
+# HIGH     util-linux and its eight siblings — bsdutils, libblkid1, libmount1,
+#          libsmartcols1, libuuid1, liblastlog2-2, mount, login
+#          2.41-5 -> 2.41.5-0+deb13u1
+# Disclosed after the 2026-08-12 pass, so it is the first entry added since. It
+# reddened the base-images leg of every PR while main stayed green on a run
+# predating the advisory — the gate working as designed, on debt no PR
+# introduced.
+CVE-2026-53615 exp:2026-11-01
 
 # ─────────────────────────────────────────────────────────────────────────────
 # caddy:2.11.4-alpine — runtime base for deploy/docs only. Cleared by the


### PR DESCRIPTION
`Image Scan` is a **required** check and is currently red on every PR, while `main` shows green only because its last run predates the advisory. Nothing in any PR introduced it.

`CVE-2026-53615` is a util-linux HIGH disclosed after the 2026-08-12 baseline pass. It lives in the `oven/bun:1.3.13` base Atlas **pins but does not build** — exactly the gap `.trivyignore` documents itself as existing to cover.

## Why not fix the pin instead

Measured with the pinned Trivy 0.72.0 under the gate's own criteria (`--scanners vuln --pkg-types os --severity HIGH,CRITICAL --ignore-unfixed`):

| base | bun | findings | distinct CVEs | CRITICAL |
|---|---|---|---|---|
| `1.3.13` (current pin) | 1.3.13 | 22 | 8 | **2** |
| `1.3.14` | 1.3.14 | 12 | 3 | 0 |
| `1.3.14-slim` | 1.3.14 | 12 | 3 | 0 |
| `canary` | 1.4.0-pre | 9 | 1 | 0 |
| `canary-alpine` | 1.4.0-pre | **0** | 0 | 0 |
| `canary-distroless` | 1.4.0-pre | **0** | 0 | 0 |

No **stable** base is clean, so no pin bump fixes this. The two clean images are prerelease **bun 1.4.0**, which is not released — npm `latest` is `1.3.14` and the newest GitHub release is `bun-v1.3.14` (2026-05-13); the canary image self-reports 1.4.0 because it is built from `main`.

And `.trivyignore` already records the rest of the answer:

> Bumping oven/bun to 1.3.14 produces the IDENTICAL 75/4/0 as staying on 1.3.13 with the upgrade. The fixes are in the security repo, not the base image, so there was never a security argument for moving that pin — which matters, because moving it would have broken the isolated test runner.

## The precondition this file sets, and it holds

> If the second command starts returning findings, do NOT add them here — the upgrade has stopped working and that is the bug.

Checked directly rather than assumed. In the pinned base, `apt-get update && apt-get upgrade -y` lands:

```
bsdutils        1:2.41.5-0+deb13u1
libuuid1:amd64    2.41.5-0+deb13u1
util-linux        2.41.5-0+deb13u1
```

That is precisely the fixed version Trivy names, so the shipped images never carry this CVE and only the bare base does.

With the entry, **both** bare bases exit 0 under the gate's exact invocation (`oven/bun` and `caddy`).

## Two stale claims fixed while here

- `image-scan.yml` described the baseline as "currently EMPTY". It has held ten entries since 2026-08-12 — that sentence sent this investigation down a wrong path before I read the file itself, so it is corrected rather than left to mislead the next reader.
- the oven/bun section said "All seven are cleared by the `apt-get upgrade`"; it is eight now.

## Scope

Deliberately one entry with the standard `exp:2026-11-01`. The expiry is the forcing function — once it passes the gate reddens until someone re-measures. Not a bulk date extension; no other entry is touched.

Unblocks #5285, which is otherwise green (34 pass / 2 fail, both this).