### PR TITLE
sec(settings): #5263 → #5262 → #5264, all on the auditSettingsWrite seam

### DIFF
--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -76975,6 +76975,15 @@
                     "valueMasked": {
                       "type": "boolean",
                       "description": "True when `value` is a withheld-placeholder rather than the stored characters. Without it the placeholder is indistinguishable from a setting whose literal value is that string."
+                    },
+                    "maskReason": {
+                      "type": "string",
+                      "enum": [
+                        "secret",
+                        "unknown_definition",
+                        "definition_mismatch"
+                      ],
+                      "description": "Why `value` was withheld, present exactly when `valueMasked` is true. `secret` is a credential; the other two are defects — `unknown_definition` means the key has no registry entry, `definition_mismatch` means the caller resolved another key's entry."
                     }
                   },
                   "required": [

--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -76969,13 +76969,19 @@
                       "type": "string"
                     },
                     "value": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "The stored value, withheld for a `secret: true` definition — see `valueMasked` (#5263)."
+                    },
+                    "valueMasked": {
+                      "type": "boolean",
+                      "description": "True when `value` is a withheld-placeholder rather than the stored characters. Without it the placeholder is indistinguishable from a setting whose literal value is that string."
                     }
                   },
                   "required": [
                     "success",
                     "key",
-                    "value"
+                    "value",
+                    "valueMasked"
                   ]
                 }
               }

--- a/packages/api/src/__mocks__/api-test-mocks.ts
+++ b/packages/api/src/__mocks__/api-test-mocks.ts
@@ -441,6 +441,10 @@ export interface ApiTestMocks {
    * test, which then observed actor `platform-admin-1`/org `"org-1"` instead of
    * the default it never chose, and passed anyway.
    *
+   * The queue itself was deleted at source, so the 422 test's comment records the
+   * reproduction and this function's own falsifier is the starred test in
+   * `admin-settings.test.ts`'s audit-failure describe.
+   *
    * The isolated runner does not cover this: `bun test` resets module mocks per
    * FILE, not per test.
    */

--- a/packages/api/src/__mocks__/api-test-mocks.ts
+++ b/packages/api/src/__mocks__/api-test-mocks.ts
@@ -428,6 +428,23 @@ export interface ApiTestMockOverrides {
 }
 
 export interface ApiTestMocks {
+  /**
+   * Drain per-test overrides and restore defaults. Call from `beforeEach`.
+   *
+   * ⚠️ **`mockClear()` IS NOT ENOUGH, and the difference is a measured bug.** It
+   * clears recorded CALLS and leaves the `mockImplementationOnce` QUEUE intact, so
+   * a test that queues a session and then takes a path where `authenticateRequest`
+   * is never called parks that session for whichever test runs next. Measured in
+   * `admin-settings.test.ts`: a request rejected by the router's `validationHook`
+   * 422s BEFORE the handler, and `adminAuthAndContext` authenticates inside the
+   * handler — so the queued platform-admin session survived into the following
+   * test, which then observed actor `platform-admin-1`/org `"org-1"` instead of
+   * the default it never chose, and passed anyway.
+   *
+   * The isolated runner does not cover this: `bun test` resets module mocks per
+   * FILE, not per test.
+   */
+  resetPerTest: () => void;
   /** The authenticateRequest mock — override per test via .mockImplementation(), .mockImplementationOnce(), or .mockResolvedValue(). */
   mockAuthenticateRequest: Mock<(req: Request) => Promise<unknown>>;
   /** The checkRateLimit mock. */
@@ -508,19 +525,25 @@ export function createApiTestMocks(
       ? { twoFactorEnabled: true }
       : undefined;
 
+  /**
+   * The default session, hoisted so {@link ApiTestMocks.resetPerTest} can put it
+   * back. `mockReset()` alone would leave the mock with NO implementation, which
+   * fails every test rather than restoring the default.
+   */
+  const defaultAuthImpl = (): Promise<unknown> =>
+    Promise.resolve({
+      authenticated: true,
+      mode: authUser.mode,
+      user: {
+        ...authUser,
+        ...(defaultClaims !== undefined
+          ? { claims: { ...defaultClaims, ...(authUser.claims ?? {}) } }
+          : {}),
+      },
+    });
+
   const mockAuthenticateRequest: Mock<(req: Request) => Promise<unknown>> =
-    mock(() =>
-      Promise.resolve({
-        authenticated: true,
-        mode: authUser.mode,
-        user: {
-          ...authUser,
-          ...(defaultClaims !== undefined
-            ? { claims: { ...defaultClaims, ...(authUser.claims ?? {}) } }
-            : {}),
-        },
-      }),
-    );
+    mock(defaultAuthImpl);
 
   const mockCheckRateLimit: Mock<AnyFn> = mock(() => ({ allowed: true }));
 
@@ -1152,6 +1175,14 @@ export function createApiTestMocks(
     setOrgAdmin,
     setPlatformAdmin,
     setMember,
+    resetPerTest: () => {
+      // `mockReset` drains the once-queue AND removes the implementation, so the
+      // default has to be reinstalled rather than merely cleared.
+      mockAuthenticateRequest.mockReset();
+      mockAuthenticateRequest.mockImplementation(defaultAuthImpl);
+      mockCheckRateLimit.mockReset();
+      mockCheckRateLimit.mockImplementation(() => ({ allowed: true }));
+    },
     cleanup,
   };
 }

--- a/packages/api/src/api/__tests__/admin-settings.test.ts
+++ b/packages/api/src/api/__tests__/admin-settings.test.ts
@@ -251,8 +251,10 @@ void mock.module("@atlas/api/lib/settings", () => ({
   // echo, and a body built inline could only ever be asserted on the verbatim
   // arm. The redaction ITSELF is pinned in `lib/__tests__/settings.test.ts`
   // against real registry definitions; what this mock exists to catch is the
-  // route going back to `{ success: true, key, value }`, which no type can
-  // see (`AuditedValue` is assignable to the schema's `z.string()`).
+  // route going back to `{ success: true, key, value }`, which the schema as
+  // written does not see (`AuditedValue` is assignable to `z.string()`; a
+  // branded schema WOULD catch it and stops the OpenAPI spec generating —
+  // measured, see `settingUpdateResponseBody`'s docstring).
   settingUpdateResponseBody: mock((_def: unknown, key: string, value: string) =>
     settingUpdateResponseBodyImpl(key, value),
   ),
@@ -354,7 +356,7 @@ describe("admin settings routes", () => {
     // `lib/__tests__/settings.test.ts` against real registry entries, because
     // the `def.secret` 403 makes it unreachable from here. What is only
     // observable here is whether the route still ROUTES through the builder —
-    // the cheaper edit, and the one no type catches.
+    // the cheaper edit, and the one the shipped schema does not catch.
     it("⭐ the 200 body is the builder's output, not an inlined literal", async () => {
       settingUpdateResponseBodyImpl = () => ({
         success: true,

--- a/packages/api/src/api/__tests__/admin-settings.test.ts
+++ b/packages/api/src/api/__tests__/admin-settings.test.ts
@@ -18,6 +18,16 @@ import { createApiTestMocks } from "@atlas/api/testing/api-test-mocks";
 // dereference resolves against the mock (a stub without that path would
 // TypeError inside the handler).
 import { ADMIN_ACTIONS as REAL_ADMIN_ACTIONS } from "@atlas/api/lib/audit/actions";
+// ⚠️ TYPE-ONLY, so importing from a module this file MOCKS is safe — type imports
+// are erased and never reach the runtime registry. These are what let the mock
+// factory's `satisfies` check the stubs against the real exports.
+import type {
+  AuditedValue,
+  RedactedAuditValue,
+  SettingDefinition,
+  SettingUpdateResponse,
+  SettingWithValue,
+} from "@atlas/api/lib/settings";
 
 // --- Unified mocks ---
 
@@ -73,7 +83,7 @@ void mock.module("@atlas/api/lib/config", () => ({
 }));
 
 // Settings registry data used by mocks
-const settingsRegistryData = [
+const settingsRegistryData: SettingDefinition[] = [
   {
     key: "ATLAS_ROW_LIMIT",
     section: "Query Limits",
@@ -156,7 +166,7 @@ const settingsRegistryData = [
   },
 ];
 
-const mockGetSettingsForAdmin = mock(() => [
+const mockGetSettingsForAdmin = mock((): SettingWithValue[] => [
   {
     ...settingsRegistryData[0],
     currentValue: "1000",
@@ -203,11 +213,14 @@ const mockIsSaasModeForGuard = mock(saasGuardDefaultImpl);
  * "the route returns an object literal that happens to match" are the same
  * observation, because the pass-through is the identity on a non-secret key.
  */
-type SettingUpdateBody = { success: true; key: string; value: string; valueMasked: boolean };
+// ⚠️ The REAL response type, not a hand-rolled twin. A local shape would drift
+// from `SettingUpdateResponse` silently — and this file's whole premise is that
+// the route's contract is observed.
+type SettingUpdateBody = SettingUpdateResponse;
 const echoResponseBodyImpl = (key: string, value: string): SettingUpdateBody => ({
   success: true,
   key,
-  value,
+  value: value as AuditedValue,
   valueMasked: false,
 });
 let settingUpdateResponseBodyImpl: (key: string, value: string) => SettingUpdateBody =
@@ -228,8 +241,10 @@ let settingUpdateResponseBodyImpl: (key: string, value: string) => SettingUpdate
  * type-legal"); it was applied to one of the handler's two call sites.
  */
 const mockSettingUpdateResponseBody: Mock<
-  (def: unknown, key: string, value: string) => SettingUpdateBody
-> = mock((_def: unknown, key: string, value: string) => settingUpdateResponseBodyImpl(key, value));
+  (def: SettingDefinition | undefined, key: string, value: string) => SettingUpdateResponse
+> = mock((_def: SettingDefinition | undefined, key: string, value: string) =>
+  settingUpdateResponseBodyImpl(key, value),
+);
 
 void mock.module("@atlas/api/lib/settings", () => ({
   getSettingsForAdmin: mockGetSettingsForAdmin,
@@ -263,11 +278,22 @@ void mock.module("@atlas/api/lib/settings", () => ({
   // the omission surfaces as `undefined is not a function` several files from
   // the cause. `securitySensitiveAuditLine` and `settingsCacheEverLoaded`
   // were already missing; added for the same reason.
-  redactAuditValue: mock((_def: unknown, value: string | undefined) => ({
-    value,
-    masked: false,
-    maskReason: undefined,
-  })),
+  redactAuditValue: mock(
+    (_key: string, _def: unknown, value: string | undefined): RedactedAuditValue => ({
+      value: value as AuditedValue | undefined,
+      masked: false,
+    }),
+  ),
+  redactPresentAuditValue: mock(
+    (
+      _key: string,
+      _def: unknown,
+      value: string,
+    ): RedactedAuditValue & { readonly value: AuditedValue } => ({
+      value: value as AuditedValue,
+      masked: false,
+    }),
+  ),
   // #5263 — the route's 200 body is this builder's output rather than an
   // object literal, so that the withheld arm is measurable at all: the
   // `def.secret` 403 above means no request can carry a secret value to the
@@ -281,7 +307,12 @@ void mock.module("@atlas/api/lib/settings", () => ({
   settingUpdateResponseBody: mockSettingUpdateResponseBody,
   securitySensitiveAuditLine: mock(() => null),
   settingsCacheEverLoaded: mock(() => true),
-}));
+  // ⚠️ `satisfies` IS THE RATCHET. `mock.module` factories are untyped, so a stub
+  // whose shape drifts from the real export — a changed arity, a `{}` where the
+  // signature says `| null` — is reported by nothing until it throws several files
+  // from the cause. Four sibling suites shipped exactly that. This makes the next
+  // signature change a compile error here instead.
+}) satisfies Partial<typeof import("@atlas/api/lib/settings")>);
 
 // --- Import the app AFTER mocks ---
 
@@ -316,6 +347,11 @@ describe("admin settings routes", () => {
     // whichever test runs next, failing far from the cause.
     mockAuditSettingsWrite.mockReset();
     mockAuditSettingsWrite.mockImplementation(async () => {});
+    // ⚠️ Drains per-test session overrides. `mockAuthenticateRequest` is driven
+    // with `mockImplementationOnce` throughout this file, and a request that
+    // short-circuits before the handler leaves its queued session unconsumed —
+    // see the 422 test for the measured instance.
+    mocks.resetPerTest();
     mockIsSaasModeForGuard.mockClear();
     mockIsSaasModeForGuard.mockImplementation(saasGuardDefaultImpl);
     // ⚠️ Restored here, not in the one test that swaps it: a leaked sentinel
@@ -389,8 +425,11 @@ describe("admin settings routes", () => {
       settingUpdateResponseBodyImpl = () => ({
         success: true,
         key: "BUILDER-KEY",
-        value: "BUILDER-VALUE",
+        // The brand is minted only inside `redactPresentAuditValue`; a sentinel
+        // needs the cast, and the cast is confined to this one test literal.
+        value: "BUILDER-VALUE" as AuditedValue,
         valueMasked: true,
+        maskReason: "secret",
       });
       const res = await request("/api/v1/admin/settings/ATLAS_ROW_LIMIT", {
         method: "PUT",
@@ -405,6 +444,7 @@ describe("admin settings routes", () => {
         key: "BUILDER-KEY",
         value: "BUILDER-VALUE",
         valueMasked: true,
+        maskReason: "secret",
       });
     });
 
@@ -1517,7 +1557,21 @@ describe("admin settings routes", () => {
     });
 
     it("unknown tier value is schema-rejected (422), no inference", async () => {
-      asPlatformAdminWithOrg();
+      // ⚠️ NO `asPlatformAdminWithOrg()` HERE, and its absence is the point.
+      // `z.enum(["platform"])` rejects this in the router's shared
+      // `validationHook`, BEFORE the handler — and `adminAuthAndContext`
+      // authenticates inside the handler, so `authenticateRequest` is never
+      // called. A session queued with `mockImplementationOnce` is therefore left
+      // UNCONSUMED and leaks into the next test; nothing resets this mock between
+      // tests at all.
+      //
+      // Measured: with the queue here, the "PUT passes the full entry" test below
+      // received actor `platform-admin-1` / orgId `"org-1"` instead of the
+      // `admin-1` default it never chose, and passed anyway because
+      // `platformTier: expect.any(Boolean)` accepts either. The session was
+      // pointless for a request that 422s at validation, so deleting it removes
+      // the leak at source, and `createApiTestMocks` now exposes `resetPerTest()`
+      // for the general case.
       const res = await request("/api/v1/admin/settings/ATLAS_AGENT_AUTH_ENABLED?tier=workspace", {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
@@ -1559,6 +1613,12 @@ describe("admin settings routes", () => {
         body: JSON.stringify({ value: "500" }),
       });
       expect(res.status).toBe(200);
+      // ⚠️ THE ACTOR AND ORG, which nothing here asserted. This describe's whole
+      // premise is "every argument is observed", and it was observing a session
+      // leaked from another test — see the 422 test above. Asserting the default
+      // session makes that leak fail loudly instead of silently changing what
+      // this test measures.
+      expect(mockSetSetting).toHaveBeenCalledWith("ATLAS_ROW_LIMIT", "500", "admin-1", undefined);
       expect(mockAuditSettingsWrite).toHaveBeenCalledWith({
         key: "ATLAS_ROW_LIMIT",
         // The REAL definition for THIS key — not `undefined`, and not another
@@ -1611,7 +1671,7 @@ describe("admin settings routes", () => {
       // claimed. Pinning the gate here means that if it is ever relaxed — to
       // let platform admins rotate a key from the UI, say — this test is what
       // says the redaction has just become load-bearing.
-      // Uses the registry fixture's real `secret: true` entry rather than a
+      // Uses the file's shared registry fixture rather than a
       // hand-built definition — a fixture written for this test could agree
       // with it by construction.
       const res = await request("/api/v1/admin/settings/ANTHROPIC_API_KEY", {
@@ -1747,7 +1807,55 @@ describe("admin settings routes", () => {
       expect(mockSetSetting).not.toHaveBeenCalled();
     });
 
+    it("⭐ resetPerTest drains a queued SESSION override, not just recorded calls", async () => {
+      // ⚠️ THE FALSIFIER FOR `mocks.resetPerTest()`, which otherwise has none —
+      // the auth leak was fixed at its source (the 422 test no longer queues a
+      // pointless session), so nothing would notice the reset being removed.
+      // Written order-independently: queue, drain, then observe, all in one test,
+      // rather than relying on two tests running adjacently.
+      mocks.mockAuthenticateRequest.mockImplementationOnce(() =>
+        Promise.resolve({
+          authenticated: true,
+          mode: "simple-key",
+          user: { id: "leaked-actor", role: "platform_admin", activeOrganizationId: "org-leak" },
+        }),
+      );
+      mocks.resetPerTest();
+      const res = await request("/api/v1/admin/settings/ATLAS_ROW_LIMIT", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ value: "500" }),
+      });
+      expect(res.status).toBe(200);
+      // The DEFAULT actor, not the queued one. `mockClear` would leave the queue
+      // intact and this would read `leaked-actor`.
+      expect(mockSetSetting).toHaveBeenCalledWith("ATLAS_ROW_LIMIT", "500", "admin-1", undefined);
+    });
+
+    it("⭐ a queued audit rejection does NOT leak past a request that 403s before the seam", async () => {
+      // ⚠️ THE FALSIFIER FOR THE `mockReset` IN `beforeEach`, which had none —
+      // every existing `auditDown()` test consumes its own queued rejection, so
+      // `mockReset` vs `mockClear` was behaviourally identical under this suite
+      // and reverting the fix could not go red.
+      //
+      // This queues a rejection and then sends a request that 403s on
+      // `def.secret` BEFORE reaching the seam, so the queue is left unconsumed.
+      // The next test then decides whether `beforeEach` drained it: with
+      // `mockClear` the parked rejection lands on the following request and
+      // 500s it, far from the cause.
+      auditDown();
+      const res = await request("/api/v1/admin/settings/ANTHROPIC_API_KEY", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ value: "x" }),
+      });
+      expect(res.status).toBe(403);
+      expect(mockAuditSettingsWrite).not.toHaveBeenCalled();
+    });
+
     it("stays 200 when the audit row commits — the arm that must NOT fail", async () => {
+      // ⚠️ ALSO the assertion half of the leak test above: it runs immediately
+      // after, so a rejection that survived `beforeEach` fails HERE with a 500.
       // The other half of the claim: a route that 500'd unconditionally would
       // pass all three tests above.
       const res = await request("/api/v1/admin/settings/ATLAS_ROW_LIMIT", {

--- a/packages/api/src/api/__tests__/admin-settings.test.ts
+++ b/packages/api/src/api/__tests__/admin-settings.test.ts
@@ -213,6 +213,24 @@ const echoResponseBodyImpl = (key: string, value: string): SettingUpdateBody => 
 let settingUpdateResponseBodyImpl: (key: string, value: string) => SettingUpdateBody =
   echoResponseBodyImpl;
 
+/**
+ * ⚠️ HOISTED TO A NAMED `Mock`, unlike the first draft's inline factory, because
+ * the ARGUMENT contract is the half that matters and an inline stand-in gives
+ * nothing to assert on. `_def` was discarded and unobservable, so
+ * `settingUpdateResponseBody(undefined, key, value)` at the route — one word —
+ * type-checks, keeps every test green, and makes every PUT 200 return
+ * `value: "[withheld:secret-setting]", valueMasked: true`. That is the exact
+ * "redact everything" failure the control below was written to prevent, which it
+ * could not see while measuring its own echo stub.
+ *
+ * The neighbouring `#5270` describe already makes this argument for
+ * `auditSettingsWrite` ("`definition: def → definition: undefined` is
+ * type-legal"); it was applied to one of the handler's two call sites.
+ */
+const mockSettingUpdateResponseBody: Mock<
+  (def: unknown, key: string, value: string) => SettingUpdateBody
+> = mock((_def: unknown, key: string, value: string) => settingUpdateResponseBodyImpl(key, value));
+
 void mock.module("@atlas/api/lib/settings", () => ({
   getSettingsForAdmin: mockGetSettingsForAdmin,
   getSettingsRegistry: mockGetSettingsRegistry,
@@ -233,7 +251,12 @@ void mock.module("@atlas/api/lib/settings", () => ({
   HOT_RELOADED_KEYS: new Set<string>(),
   isHotReloadedKey: mock(() => false),
   SECURITY_SENSITIVE_KEYS: new Set<string>(),
-  securitySensitiveAuditFields: mock(() => undefined),
+  // `null`, not `undefined` — the real signature is `SecuritySensitiveAudit |
+  // null`, and `auditSettingsWrite` tests `!== null`. A stub returning
+  // `undefined` would pass that guard and then throw on a property read. Not
+  // reachable here (the seam itself is mocked), but `mock.module` factories are
+  // untyped, so nothing would report it when it becomes reachable.
+  securitySensitiveAuditFields: mock(() => null),
   // #5270 — newly load-bearing: `lib/audit/settings-write.ts` resolves
   // `redactAuditValue` from this module. A partial mock replaces the WHOLE
   // module, so the moment anything in admin.ts's import graph reaches it,
@@ -255,10 +278,8 @@ void mock.module("@atlas/api/lib/settings", () => ({
   // written does not see (`AuditedValue` is assignable to `z.string()`; a
   // branded schema WOULD catch it and stops the OpenAPI spec generating —
   // measured, see `settingUpdateResponseBody`'s docstring).
-  settingUpdateResponseBody: mock((_def: unknown, key: string, value: string) =>
-    settingUpdateResponseBodyImpl(key, value),
-  ),
-  securitySensitiveAuditLine: mock(() => undefined),
+  settingUpdateResponseBody: mockSettingUpdateResponseBody,
+  securitySensitiveAuditLine: mock(() => null),
   settingsCacheEverLoaded: mock(() => true),
 }));
 
@@ -288,13 +309,20 @@ describe("admin settings routes", () => {
     mockSetSetting.mockClear();
     mockDeleteSetting.mockClear();
     mockLogAdminAction.mockClear();
-    mockAuditSettingsWrite.mockClear();
+    // ⚠️ `mockReset`, not `mockClear`: the audit-failure tests queue a one-shot
+    // rejection with `mockImplementationOnce`, and `mockClear` drops recorded
+    // CALLS while leaving the queue intact. Today every such test consumes its
+    // own, but a future one that 403s before the seam would park a rejection for
+    // whichever test runs next, failing far from the cause.
+    mockAuditSettingsWrite.mockReset();
+    mockAuditSettingsWrite.mockImplementation(async () => {});
     mockIsSaasModeForGuard.mockClear();
     mockIsSaasModeForGuard.mockImplementation(saasGuardDefaultImpl);
     // ⚠️ Restored here, not in the one test that swaps it: a leaked sentinel
     // body would make every other PUT assertion in this file read
     // "BUILDER-VALUE" and fail somewhere far from the cause.
     settingUpdateResponseBodyImpl = echoResponseBodyImpl;
+    mockSettingUpdateResponseBody.mockClear();
   });
 
   // ─── GET /settings ──────────────────────────────────────────────
@@ -396,6 +424,30 @@ describe("admin settings routes", () => {
         value: "500",
         valueMasked: false,
       });
+    });
+
+    it("⭐ hands the builder the DEFINITION it resolved, not undefined", async () => {
+      // ⚠️ THE ARGUMENT, which no other test in this file could see. Passing
+      // `undefined` here routes `redactAuditValue` to its fail-closed arm, so
+      // every PUT 200 would return the withheld placeholder with
+      // `valueMasked: true` — "redact everything", the failure mode the control
+      // above exists to catch and cannot, because it measures the echo stub
+      // rather than the real builder.
+      const res = await request("/api/v1/admin/settings/ATLAS_ROW_LIMIT", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ value: "500" }),
+      });
+      expect(res.status).toBe(200);
+      expect(mockSettingUpdateResponseBody).toHaveBeenCalledTimes(1);
+      expect(mockSettingUpdateResponseBody).toHaveBeenCalledWith(
+        // The registry entry for this key — not a different key's, and not
+        // `undefined`. `objectContaining` rather than the whole literal so a
+        // registry edit elsewhere does not break this on an unrelated field.
+        expect.objectContaining({ key: "ATLAS_ROW_LIMIT" }),
+        "ATLAS_ROW_LIMIT",
+        "500",
+      );
     });
 
     it("rejects unknown setting keys", async () => {

--- a/packages/api/src/api/__tests__/admin-settings.test.ts
+++ b/packages/api/src/api/__tests__/admin-settings.test.ts
@@ -334,17 +334,18 @@ void mock.module("@atlas/api/lib/settings", () => ({
 // a difference in either direction.
 type Equal<X, Y> =
   (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2 ? true : false;
-type Simplify<T> = { readonly [K in keyof T]: T[K] };
+/** Normalises mutability so `Equal` compares shapes, not `readonly` modifiers. */
+type AllReadonly<T> = { readonly [K in keyof T]: T[K] };
 type SchemaMatchesResponseType = Equal<
   // Both sides normalised: `z.infer` yields mutable properties while
   // `SettingUpdateResponse` is `readonly` throughout, and `Equal` is strict about
-  // that. `Simplify` also flattens the intersection so the comparison is between
+  // that. `AllReadonly` also flattens the intersection so the comparison is between
   // two plain property bags rather than an object and an `A & B`.
-  Simplify<z.infer<typeof settingUpdateResponseSchema>>,
-  Simplify<
-    Readonly<Omit<SettingUpdateResponse, "success" | "value">> & {
-      readonly success: boolean;
-      readonly value: string;
+  AllReadonly<z.infer<typeof settingUpdateResponseSchema>>,
+  AllReadonly<
+    Omit<SettingUpdateResponse, "success" | "value"> & {
+      success: boolean;
+      value: string;
     }
   >
 >;

--- a/packages/api/src/api/__tests__/admin-settings.test.ts
+++ b/packages/api/src/api/__tests__/admin-settings.test.ts
@@ -192,6 +192,27 @@ const saasGuardDefaultImpl = () =>
   (mockConfigOverride as { deployMode?: string } | null)?.deployMode === "saas";
 const mockIsSaasModeForGuard = mock(saasGuardDefaultImpl);
 
+/**
+ * #5263 — swappable stand-in for `settingUpdateResponseBody`.
+ *
+ * ⚠️ It is a MUTABLE binding rather than a fixed mock because `mock.module` is
+ * module-scoped and the two claims need opposite behaviour: the default echoes
+ * the value so every existing PUT assertion keeps its meaning, while one test
+ * swaps in a body sharing no field with the request and asserts the response
+ * carries it. Without that swap "the route returns the builder's output" and
+ * "the route returns an object literal that happens to match" are the same
+ * observation, because the pass-through is the identity on a non-secret key.
+ */
+type SettingUpdateBody = { success: true; key: string; value: string; valueMasked: boolean };
+const echoResponseBodyImpl = (key: string, value: string): SettingUpdateBody => ({
+  success: true,
+  key,
+  value,
+  valueMasked: false,
+});
+let settingUpdateResponseBodyImpl: (key: string, value: string) => SettingUpdateBody =
+  echoResponseBodyImpl;
+
 void mock.module("@atlas/api/lib/settings", () => ({
   getSettingsForAdmin: mockGetSettingsForAdmin,
   getSettingsRegistry: mockGetSettingsRegistry,
@@ -224,6 +245,17 @@ void mock.module("@atlas/api/lib/settings", () => ({
     masked: false,
     maskReason: undefined,
   })),
+  // #5263 — the route's 200 body is this builder's output rather than an
+  // object literal, so that the withheld arm is measurable at all: the
+  // `def.secret` 403 above means no request can carry a secret value to the
+  // echo, and a body built inline could only ever be asserted on the verbatim
+  // arm. The redaction ITSELF is pinned in `lib/__tests__/settings.test.ts`
+  // against real registry definitions; what this mock exists to catch is the
+  // route going back to `{ success: true, key, value }`, which no type can
+  // see (`AuditedValue` is assignable to the schema's `z.string()`).
+  settingUpdateResponseBody: mock((_def: unknown, key: string, value: string) =>
+    settingUpdateResponseBodyImpl(key, value),
+  ),
   securitySensitiveAuditLine: mock(() => undefined),
   settingsCacheEverLoaded: mock(() => true),
 }));
@@ -257,6 +289,10 @@ describe("admin settings routes", () => {
     mockAuditSettingsWrite.mockClear();
     mockIsSaasModeForGuard.mockClear();
     mockIsSaasModeForGuard.mockImplementation(saasGuardDefaultImpl);
+    // ⚠️ Restored here, not in the one test that swaps it: a leaked sentinel
+    // body would make every other PUT assertion in this file read
+    // "BUILDER-VALUE" and fail somewhere far from the cause.
+    settingUpdateResponseBodyImpl = echoResponseBodyImpl;
   });
 
   // ─── GET /settings ──────────────────────────────────────────────
@@ -311,6 +347,53 @@ describe("admin settings routes", () => {
       expect(data.key).toBe("ATLAS_ROW_LIMIT");
       expect(data.value).toBe("500");
       expect(mockSetSetting).toHaveBeenCalledTimes(1);
+    });
+
+    // ⚠️ #5263 — THE SEAM, not the policy. The policy (what a `secret: true`
+    // definition does to the echoed value) is measured in
+    // `lib/__tests__/settings.test.ts` against real registry entries, because
+    // the `def.secret` 403 makes it unreachable from here. What is only
+    // observable here is whether the route still ROUTES through the builder —
+    // the cheaper edit, and the one no type catches.
+    it("⭐ the 200 body is the builder's output, not an inlined literal", async () => {
+      settingUpdateResponseBodyImpl = () => ({
+        success: true,
+        key: "BUILDER-KEY",
+        value: "BUILDER-VALUE",
+        valueMasked: true,
+      });
+      const res = await request("/api/v1/admin/settings/ATLAS_ROW_LIMIT", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ value: "500" }),
+      });
+      expect(res.status).toBe(200);
+      // Every field differs from what an inlined `{ success: true, key, value }`
+      // would produce, so this cannot pass by coincidence.
+      expect(await res.json()).toEqual({
+        success: true,
+        key: "BUILDER-KEY",
+        value: "BUILDER-VALUE",
+        valueMasked: true,
+      });
+    });
+
+    it("reports valueMasked on the ordinary non-secret write", async () => {
+      // The control for the assertion above: with the real builder shape the
+      // response says the characters were NOT withheld, so a client can tell
+      // the placeholder from a literal. A route hardcoding `valueMasked: true`
+      // would pass the seam test and lie on every normal write.
+      const res = await request("/api/v1/admin/settings/ATLAS_ROW_LIMIT", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ value: "500" }),
+      });
+      expect(await res.json()).toEqual({
+        success: true,
+        key: "ATLAS_ROW_LIMIT",
+        value: "500",
+        valueMasked: false,
+      });
     });
 
     it("rejects unknown setting keys", async () => {

--- a/packages/api/src/api/__tests__/admin-settings.test.ts
+++ b/packages/api/src/api/__tests__/admin-settings.test.ts
@@ -18,6 +18,8 @@ import { createApiTestMocks } from "@atlas/api/testing/api-test-mocks";
 // dereference resolves against the mock (a stub without that path would
 // TypeError inside the handler).
 import { ADMIN_ACTIONS as REAL_ADMIN_ACTIONS } from "@atlas/api/lib/audit/actions";
+import { z } from "@hono/zod-openapi";
+import { settingUpdateResponseSchema } from "../routes/admin";
 // ⚠️ TYPE-ONLY, so importing from a module this file MOCKS is safe — type imports
 // are erased and never reach the runtime registry. These are what let the mock
 // factory's `satisfies` check the stubs against the real exports.
@@ -313,6 +315,41 @@ void mock.module("@atlas/api/lib/settings", () => ({
   // from the cause. Four sibling suites shipped exactly that. This makes the next
   // signature change a compile error here instead.
 }) satisfies Partial<typeof import("@atlas/api/lib/settings")>);
+
+/**
+ * ⚠️ COMPILE-TIME TIE between the three representations of the settings `PUT` 200
+ * body: the TS type, the zod schema that generates the published spec, and this
+ * file's fake. Adding a field to one and not the others is now a type error here.
+ *
+ * The `value` divergence is the one DELIBERATE difference — branded `AuditedValue`
+ * in TS so only the redaction can mint one, plain `z.string()` in the schema
+ * because `z.custom` cannot be rendered by the OpenAPI extractor (measured: it
+ * fails with `UnknownZodTypeError`). Written as a type rather than a paragraph, so
+ * a fourth divergence cannot be introduced silently.
+ */
+// ⚠️ MUTUAL, not one-directional, and the first draft was the latter. Written as
+// `A extends B`, adding an OPTIONAL field to `SettingUpdateResponse` slipped
+// through — measured: 0 type errors — because an optional property never blocks
+// assignability. `Equal` is the standard invariant-position trick and it fails on
+// a difference in either direction.
+type Equal<X, Y> =
+  (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2 ? true : false;
+type Simplify<T> = { readonly [K in keyof T]: T[K] };
+type SchemaMatchesResponseType = Equal<
+  // Both sides normalised: `z.infer` yields mutable properties while
+  // `SettingUpdateResponse` is `readonly` throughout, and `Equal` is strict about
+  // that. `Simplify` also flattens the intersection so the comparison is between
+  // two plain property bags rather than an object and an `A & B`.
+  Simplify<z.infer<typeof settingUpdateResponseSchema>>,
+  Simplify<
+    Readonly<Omit<SettingUpdateResponse, "success" | "value">> & {
+      readonly success: boolean;
+      readonly value: string;
+    }
+  >
+>;
+const _schemaMatchesResponseType: SchemaMatchesResponseType = true;
+void _schemaMatchesResponseType;
 
 // --- Import the app AFTER mocks ---
 

--- a/packages/api/src/api/__tests__/cors.test.ts
+++ b/packages/api/src/api/__tests__/cors.test.ts
@@ -87,7 +87,11 @@ void mock.module("@atlas/api/lib/settings", () => ({
   isHotReloadedKey: () => false,
   HOT_RELOADED_KEYS: new Set<string>(),
   SECURITY_SENSITIVE_KEYS: new Set<string>(),
-  securitySensitiveAuditFields: () => ({}),
+  // `null`, matching `SecuritySensitiveAudit | null`. A truthy `{}` passes
+  // `auditSettingsWrite`'s `!== null` guard and then reads properties off an
+  // empty object — unreachable from this suite, and reported by nothing, because
+  // `mock.module` factories are untyped.
+  securitySensitiveAuditFields: () => null,
   getSettingLive: async () => undefined,
   setSetting: async () => {},
   deleteSetting: async () => {},

--- a/packages/api/src/api/routes/admin.ts
+++ b/packages/api/src/api/routes/admin.ts
@@ -1547,6 +1547,7 @@ const updateSettingRoute = createRoute({
             // against what you sent.
             value: z.string().openapi({ description: "The stored value, withheld for a `secret: true` definition — see `valueMasked` (#5263)." }),
             valueMasked: z.boolean().openapi({ description: "True when `value` is a withheld-placeholder rather than the stored characters. Without it the placeholder is indistinguishable from a setting whose literal value is that string." }),
+            maskReason: z.enum(["secret", "unknown_definition", "definition_mismatch"]).optional().openapi({ description: "Why `value` was withheld, present exactly when `valueMasked` is true. `secret` is a credential; the other two are defects — `unknown_definition` means the key has no registry entry, `definition_mismatch` means the caller resolved another key's entry." }),
           }),
         },
       },
@@ -3704,8 +3705,20 @@ function settingsAuditFailureBody(
   // the thing that was just lost. This log.error is the closest surviving
   // record of an unaudited configuration change, and without the actor it
   // takes a join on `requestId` against the earlier info line to answer "who".
+  // ⚠️ THE ERROR OBJECT, not `err.message`. The message below promises the log
+  // has the cause, and `.message` is a string — `scrubErrSerializer` takes its
+  // string branch and emits one scrubbed sentence, dropping `type`, `stack` and
+  // the whitelisted `code`/`constraint`. Every failure this broad catch is
+  // documented to cover is diagnosed by exactly those fields: a pg `22001`
+  // value-too-long on a fat `metadata`, a `resolveEntry` TypeError, a serializer
+  // throw. The operator quoted the requestId, found this line, and learned
+  // nothing the response had not already told them.
+  //
+  // Safe: `scrubErrSerializer` scrubs `message` AND `stack` for connection-string
+  // userinfo and is fail-open, and the response body is unchanged — so this adds
+  // no disclosure while making the promise above true.
   log.error(
-    { err: err instanceof Error ? err.message : String(err), requestId, key, actorId },
+    { err: err instanceof Error ? err : new Error(String(err)), requestId, key, actorId },
     "Settings write succeeded but its admin_action_log row could not be committed",
   );
   return {
@@ -3716,7 +3729,7 @@ function settingsAuditFailureBody(
     // earlier draft told the operator to "check the internal database's health",
     // which for any of those sends them to look at a healthy database and close
     // the alert. The requestId is the handle; the log line has the cause.
-    message: `"${key}" was ${verb}, and the change is already in effect — but the admin action-log entry recording it could not be written, so this change is currently unaudited. Re-apply the setting to produce a logged entry. If the internal database is healthy, quote requestId ${requestId}: an audit write that fails against a healthy database is a defect, not a transient.`,
+    message: `"${key}" was ${verb}, and the change is already in effect — but the admin action-log entry recording it could not be written, so this change is currently unaudited. Repeat the same request to produce a logged entry. If the internal database is healthy, quote requestId ${requestId}: an audit write that fails against a healthy database is a defect, not a transient.`,
     requestId,
   };
 }
@@ -3915,18 +3928,13 @@ admin.openapi(updateSettingRoute, async (c) => runHandler(c, "save setting", asy
   // true` to get a dedicated write surface, and a secret key acquiring the same
   // treatment reads as routine.
   //
-  // ⚠️ Same policy AND the same fail-closed discard as the seam's, which is what
-  // makes the echo and the row agree about what was stored. An earlier draft of
-  // this comment claimed they "cannot disagree" because both reach
-  // `redactAuditValue(def, value)`; they did not — the seam discards a definition
-  // belonging to another key and the builder did not, so what actually held them
-  // together was `SETTINGS_MAP` being keyed by `def.key`, in a third file and
-  // stated nowhere. `settingUpdateResponseBody` now carries the discard too.
-  //
-  // Two calls rather than one value threaded out of `auditSettingsWrite`: the
-  // audit runs AFTER `setSetting` and may reject, in which case the 500 above
-  // returns and this line is never reached — so threading it would buy nothing
-  // and give the audit a second job.
+  // ⚠️ The echo and the audit row agree because they are the SAME decision:
+  // `redactPresentAuditValue(key, def, value)`, which owns the secret,
+  // unknown-definition and wrong-key arms and reports which one it took. Two
+  // calls rather than one value threaded out of `auditSettingsWrite`, because the
+  // audit runs AFTER `setSetting` and may reject — the 500 above then returns and
+  // this line is never reached, so threading it would buy nothing and give the
+  // audit a second job.
   return c.json(settingUpdateResponseBody(def, key, value), 200);
 }));
 

--- a/packages/api/src/api/routes/admin.ts
+++ b/packages/api/src/api/routes/admin.ts
@@ -3710,7 +3710,13 @@ function settingsAuditFailureBody(
   );
   return {
     error: "audit_not_committed",
-    message: `"${key}" was ${verb}, and the change is already in effect — but the admin action-log entry recording it could not be written, so this change is currently unaudited. Check the internal database's health, then re-apply the setting to produce a logged entry.`,
+    // ⚠️ It does NOT name the internal database as the cause. The catch above it
+    // is deliberately broad, so it also covers a serializer throw, a non-
+    // serialisable metadata field, and an actor-assertion failure — and an
+    // earlier draft told the operator to "check the internal database's health",
+    // which for any of those sends them to look at a healthy database and close
+    // the alert. The requestId is the handle; the log line has the cause.
+    message: `"${key}" was ${verb}, and the change is already in effect — but the admin action-log entry recording it could not be written, so this change is currently unaudited. Re-apply the setting to produce a logged entry. If the internal database is healthy, quote requestId ${requestId}: an audit write that fails against a healthy database is a defect, not a transient.`,
     requestId,
   };
 }
@@ -3804,7 +3810,12 @@ admin.openapi(updateSettingRoute, async (c) => runHandler(c, "save setting", asy
     return c.json({ error: "invalid_request", message: "Missing 'value' in request body." }, 400);
   }
 
-  const value = String(body.value as string | number | boolean);
+  // `String` accepts `unknown`, so the `as string | number | boolean` this
+  // replaced bought nothing and asserted something false — an object body
+  // reaches here and stringifies to "[object Object]". Narrowing the INPUT is
+  // the real fix and is a behaviour change (a new 400), so it is filed rather
+  // than smuggled in here; see the PR body.
+  const value = String(body.value);
 
   // Type-specific validation
   if (def.type === "number") {
@@ -3904,13 +3915,18 @@ admin.openapi(updateSettingRoute, async (c) => runHandler(c, "save setting", asy
   // true` to get a dedicated write surface, and a secret key acquiring the same
   // treatment reads as routine.
   //
-  // ⚠️ Same policy, same arguments as the seam's — both reach
-  // `redactAuditValue(def, value)` with the `def` this route resolved — so the
-  // echo and the row cannot disagree about what was stored. Two calls rather
-  // than one value threaded out of `auditSettingsWrite`: the audit runs AFTER
-  // `setSetting` and may reject, in which case the 500 above returns and this
-  // line is never reached, so threading it would buy nothing and give the audit
-  // a second job.
+  // ⚠️ Same policy AND the same fail-closed discard as the seam's, which is what
+  // makes the echo and the row agree about what was stored. An earlier draft of
+  // this comment claimed they "cannot disagree" because both reach
+  // `redactAuditValue(def, value)`; they did not — the seam discards a definition
+  // belonging to another key and the builder did not, so what actually held them
+  // together was `SETTINGS_MAP` being keyed by `def.key`, in a third file and
+  // stated nowhere. `settingUpdateResponseBody` now carries the discard too.
+  //
+  // Two calls rather than one value threaded out of `auditSettingsWrite`: the
+  // audit runs AFTER `setSetting` and may reject, in which case the 500 above
+  // returns and this line is never reached — so threading it would buy nothing
+  // and give the audit a second job.
   return c.json(settingUpdateResponseBody(def, key, value), 200);
 }));
 

--- a/packages/api/src/api/routes/admin.ts
+++ b/packages/api/src/api/routes/admin.ts
@@ -40,6 +40,7 @@ import {
   setSetting,
   deleteSetting,
   isSaasModeForGuard,
+  settingUpdateResponseBody,
 } from "@atlas/api/lib/settings";
 import { SaasImmutableSettingError } from "@atlas/api/lib/settings-errors";
 import { detectAuthMode } from "@atlas/api/lib/auth/detect";
@@ -1535,7 +1536,20 @@ const updateSettingRoute = createRoute({
   responses: {
     200: {
       description: "Setting saved",
-      content: { "application/json": { schema: z.object({ success: z.boolean(), key: z.string(), value: z.string() }) } },
+      content: {
+        "application/json": {
+          schema: z.object({
+            success: z.boolean(),
+            key: z.string(),
+            // #5263 — the value as the audit row records it, not as the request
+            // sent it. Identical for every key reachable today (a `secret: true`
+            // key is 403'd above), so read `valueMasked` rather than comparing
+            // against what you sent.
+            value: z.string().openapi({ description: "The stored value, withheld for a `secret: true` definition — see `valueMasked` (#5263)." }),
+            valueMasked: z.boolean().openapi({ description: "True when `value` is a withheld-placeholder rather than the stored characters. Without it the placeholder is indistinguishable from a setting whose literal value is that string." }),
+          }),
+        },
+      },
     },
     400: { description: "Invalid request", content: { "application/json": { schema: ErrorSchema } } },
     401: { description: "Authentication required", content: { "application/json": { schema: AuthErrorSchema } } },
@@ -3877,7 +3891,27 @@ admin.openapi(updateSettingRoute, async (c) => runHandler(c, "save setting", asy
     return c.json(settingsAuditFailureBody(err, key, requestId, "updated", authResult.user?.id), 500);
   }
 
-  return c.json({ success: true, key, value }, 200);
+  // #5263 — the response is the THIRD sink for this value, and it was the last
+  // one still echoing the request verbatim. `auditSettingsWrite` already routes
+  // `metadata.value` through `redactAuditValue`; the 200 body did not, so the
+  // `secret: true` plaintext had one surviving exit.
+  //
+  // ⚠️ NOT a live leak, and the honest claim is narrow — the `def.secret` 403
+  // above returns before any of this, so no request can reach here with a
+  // secret key today. That guard STAYS and remains the primary control; this is
+  // what is left if someone relaxes it, and relaxing it is a normal-looking
+  // change: the sandbox keys already carry `saasVisible: false, saasWritable:
+  // true` to get a dedicated write surface, and a secret key acquiring the same
+  // treatment reads as routine.
+  //
+  // ⚠️ Same policy, same arguments as the seam's — both reach
+  // `redactAuditValue(def, value)` with the `def` this route resolved — so the
+  // echo and the row cannot disagree about what was stored. Two calls rather
+  // than one value threaded out of `auditSettingsWrite`: the audit runs AFTER
+  // `setSetting` and may reject, in which case the 500 above returns and this
+  // line is never reached, so threading it would buy nothing and give the audit
+  // a second job.
+  return c.json(settingUpdateResponseBody(def, key, value), 200);
 }));
 
 admin.openapi(deleteSettingRoute, async (c) => runHandler(c, "delete setting", async () => {

--- a/packages/api/src/api/routes/admin.ts
+++ b/packages/api/src/api/routes/admin.ts
@@ -3842,7 +3842,8 @@ admin.openapi(updateSettingRoute, async (c) => runHandler(c, "save setting", asy
   // nothing (`String` accepts `unknown`) and asserted something false. An object
   // body passed the null/undefined check above, stringified to
   // `"[object Object]"`, and was PERSISTED: `def.type` validation catches it for
-  // `number`, `boolean` and `select`, but a `type: "string"` setting accepted it,
+  // `number`, `boolean` and any `select` that declares `options` (all of today's
+  // do), but a `type: "string"` setting accepted it,
   // wrote it, audited it and echoed it back as though it were the admin's value.
   //
   // Rejecting it here is also what makes the coercion below honest — every

--- a/packages/api/src/api/routes/admin.ts
+++ b/packages/api/src/api/routes/admin.ts
@@ -1519,6 +1519,30 @@ const getSettingsRoute = createRoute({
   },
 });
 
+/**
+ * The settings `PUT` 200 body, hoisted so `admin-settings.test.ts` can assert it
+ * against {@link SettingUpdateResponse} at compile time.
+ *
+ * ⚠️ **THREE REPRESENTATIONS OF ONE BODY, and nothing used to tie them.** The TS
+ * type in `lib/settings.ts`, this schema (which generates the published spec), and
+ * the test's fake. `c.json`'s argument is a function RETURN VALUE rather than a
+ * fresh object literal, so excess-property checking does not apply — a field added
+ * to the builder ships in the body and is absent from the spec. The type assertion
+ * in the test makes "added a field to one side, forgot the other" a compile error,
+ * with the one deliberate divergence (`value` is branded in TS, `z.string()` here)
+ * written down as a type rather than a paragraph.
+ */
+export const settingUpdateResponseSchema = z.object({
+  success: z.boolean(),
+  key: z.string(),
+  // #5263 — the value as the audit row records it, not as the request sent it.
+  // Identical for every key reachable today (a `secret: true` key is 403'd), so
+  // read `valueMasked` rather than comparing against what you sent.
+  value: z.string().openapi({ description: "The stored value, withheld for a `secret: true` definition — see `valueMasked` (#5263)." }),
+  valueMasked: z.boolean().openapi({ description: "True when `value` is a withheld-placeholder rather than the stored characters. Without it the placeholder is indistinguishable from a setting whose literal value is that string." }),
+  maskReason: z.enum(["secret", "unknown_definition", "definition_mismatch"]).optional().openapi({ description: "Why `value` was withheld, present exactly when `valueMasked` is true. `secret` is a credential; the other two are defects — `unknown_definition` means the key has no registry entry, `definition_mismatch` means the caller resolved another key's entry." }),
+});
+
 const updateSettingRoute = createRoute({
   method: "put",
   path: "/settings/{key}",
@@ -1538,17 +1562,7 @@ const updateSettingRoute = createRoute({
       description: "Setting saved",
       content: {
         "application/json": {
-          schema: z.object({
-            success: z.boolean(),
-            key: z.string(),
-            // #5263 — the value as the audit row records it, not as the request
-            // sent it. Identical for every key reachable today (a `secret: true`
-            // key is 403'd above), so read `valueMasked` rather than comparing
-            // against what you sent.
-            value: z.string().openapi({ description: "The stored value, withheld for a `secret: true` definition — see `valueMasked` (#5263)." }),
-            valueMasked: z.boolean().openapi({ description: "True when `value` is a withheld-placeholder rather than the stored characters. Without it the placeholder is indistinguishable from a setting whose literal value is that string." }),
-            maskReason: z.enum(["secret", "unknown_definition", "definition_mismatch"]).optional().openapi({ description: "Why `value` was withheld, present exactly when `valueMasked` is true. `secret` is a credential; the other two are defects — `unknown_definition` means the key has no registry entry, `definition_mismatch` means the caller resolved another key's entry." }),
-          }),
+          schema: settingUpdateResponseSchema,
         },
       },
     },
@@ -3823,11 +3837,30 @@ admin.openapi(updateSettingRoute, async (c) => runHandler(c, "save setting", asy
     return c.json({ error: "invalid_request", message: "Missing 'value' in request body." }, 400);
   }
 
-  // `String` accepts `unknown`, so the `as string | number | boolean` this
-  // replaced bought nothing and asserted something false — an object body
-  // reaches here and stringifies to "[object Object]". Narrowing the INPUT is
-  // the real fix and is a behaviour change (a new 400), so it is filed rather
-  // than smuggled in here; see the PR body.
+  // ⚠️ NARROW THE INPUT, don't coerce whatever arrived. This was
+  // `String(body.value as string | number | boolean)` — a cast that bought
+  // nothing (`String` accepts `unknown`) and asserted something false. An object
+  // body passed the null/undefined check above, stringified to
+  // `"[object Object]"`, and was PERSISTED: `def.type` validation catches it for
+  // `number`, `boolean` and `select`, but a `type: "string"` setting accepted it,
+  // wrote it, audited it and echoed it back as though it were the admin's value.
+  //
+  // Rejecting it here is also what makes the coercion below honest — every
+  // remaining input has a faithful string form.
+  if (
+    typeof body.value !== "string"
+    && typeof body.value !== "number"
+    && typeof body.value !== "boolean"
+  ) {
+    return c.json(
+      {
+        error: "invalid_request",
+        message: `"${key}" must be a string, number or boolean — received ${Array.isArray(body.value) ? "an array" : typeof body.value}.`,
+        requestId,
+      },
+      400,
+    );
+  }
   const value = String(body.value);
 
   // Type-specific validation

--- a/packages/api/src/lib/__tests__/settings-audit-log.test.ts
+++ b/packages/api/src/lib/__tests__/settings-audit-log.test.ts
@@ -3,17 +3,17 @@
  *
  * `settings.test.ts` pins the payload builder. This file pins the one line that
  * consumes it, and it exists because review measured that the builder's tests
- * cannot see that line at all: with 150 pure-function assertions green,
- * `log.warn({ ...line, value }, …)` — issue #5180 verbatim, plaintext straight
- * back into the log stream — passed the entire suite. So did dropping the
- * definition (withholding every value, which silently destroys the "do not
- * withhold everything" control), and so did deleting the audit outright.
+ * cannot see that line at all: `log.warn({ ...line, value }, …)` — issue #5180
+ * verbatim, plaintext straight back into the log stream — passed that whole
+ * suite green. So did dropping the definition (withholding every value, which
+ * silently destroys the "do not withhold everything" control), and so did
+ * deleting the audit outright.
  *
  * A SEPARATE FILE, deliberately. `settings.test.ts` avoids `mock.module` on
  * purpose — it injects the pool via `_resetPool(mockPool)` — and a module mock
- * applies to a whole file, so installing a logger mock there would put all 150
- * of its tests behind a fake logger. The isolated runner gives each file its
- * own module registry, which is what makes this split free.
+ * applies to a whole file, so installing a logger mock there would put every
+ * test in it behind a fake logger. The isolated runner gives each file its own
+ * module registry, which is what makes this split free.
  *
  * Most assertions compare the EMITTED object against
  * `securitySensitiveAuditLine`'s own output rather than a hand-written literal.
@@ -203,9 +203,8 @@ describe("auditSecuritySensitiveChange — what reaches the log stream (#5180)",
 
   it("records the message, and the message does not carry the value", async () => {
     // A template literal is a leak channel no type can close: `${line.value}`
-    // and `${rawValue}` are both just strings there. Nothing else in this file
-    // looks at the message at all, so without this the emitter could append
-    // the secret to the text and stay green.
+    // and `${rawValue}` are both just strings there, so the message needs an
+    // assertion of its own rather than riding on the payload's.
     await setSetting(SOURCES, "warehouse_key,extractor", "user_1");
     const [, msg] = auditCall();
     expect(msg).toBe(`Security-sensitive setting changed at runtime: ${SOURCES}`);
@@ -305,8 +304,8 @@ describe("auditSecuritySensitiveChange — what reaches the log stream (#5180)",
   // `secret` on it for the duration of one test makes redacted and raw differ
   // on a fully reachable input, and the leak becomes an ordinary assertion —
   // which also catches the two edits the brand cannot see: inlining `log.warn`
-  // back into the caller, and fabricating a `{ key, secret: false }` definition
-  // at the call site.
+  // back into the caller, and handing the call site a `{ ...def, secret: false }`
+  // definition that lies about the key it belongs to.
   //
   // Scoped and restored. Never at top level, and the isolated runner gives this
   // file its own module registry, so the flip cannot reach another file.

--- a/packages/api/src/lib/__tests__/settings.test.ts
+++ b/packages/api/src/lib/__tests__/settings.test.ts
@@ -21,6 +21,7 @@ import {
   securitySensitiveAuditFields,
   securitySensitiveAuditLine,
   redactAuditValue,
+  redactPresentAuditValue,
   settingUpdateResponseBody,
   settingsCacheEverLoaded,
   SECURITY_SENSITIVE_KEYS,
@@ -1555,7 +1556,7 @@ describe("audit value redaction (#5180)", () => {
   const SECRET_LENGTHS = ["sk-ant-api03-SUPERSECRET-payload", "abcdefghi", "hunter22", "   ", "x"];
 
   it.each(SECRET_LENGTHS)("withholds a secret's value entirely — %p", (written) => {
-    const { value, masked, maskReason } = redactAuditValue(SECRET_DEF, written);
+    const { value, masked, maskReason } = redactAuditValue("ANTHROPIC_API_KEY", SECRET_DEF, written);
     expect(masked).toBe(true);
     expect(maskReason).toBe("secret");
     expect(value).toBe(audited("[withheld:secret-setting]"));
@@ -1569,11 +1570,11 @@ describe("audit value redaction (#5180)", () => {
   // input. `maskSecret` reveals eight characters of two of these five values,
   // so it goes red here.
   it("produces one identical placeholder for every secret, whatever its length", () => {
-    const outputs = new Set(SECRET_LENGTHS.map((w) => redactAuditValue(SECRET_DEF, w).value));
+    const outputs = new Set(SECRET_LENGTHS.map((w) => redactAuditValue("ANTHROPIC_API_KEY", SECRET_DEF, w).value));
     expect(outputs.size).toBe(1);
     expect([...outputs][0]).toBe(audited("[withheld:secret-setting]"));
     // And the distinctive one, named directly rather than derived.
-    expect(redactAuditValue(SECRET_DEF, "sk-ant-api03-SUPERSECRET-payload").value).not.toContain(
+    expect(redactAuditValue("ANTHROPIC_API_KEY", SECRET_DEF, "sk-ant-api03-SUPERSECRET-payload").value).not.toContain(
       "SUPERSECRET",
     );
   });
@@ -1582,12 +1583,12 @@ describe("audit value redaction (#5180)", () => {
   // what tells an incident responder WHICH WAY a control moved, and an audit
   // line that redacts a rate limit has thrown away its own subject.
   it("leaves a non-secret definition's value verbatim", () => {
-    expect(redactAuditValue(PLAIN_DEF, "0")).toEqual({
+    expect(redactAuditValue(RPM, PLAIN_DEF, "0")).toEqual({
       value: audited("0"),
       masked: false,
       maskReason: undefined,
     });
-    expect(redactAuditValue(getSettingDefinition(SOURCES), "warehouse_key,extractor")).toEqual({
+    expect(redactAuditValue(SOURCES, getSettingDefinition(SOURCES), "warehouse_key,extractor")).toEqual({
       value: audited("warehouse_key,extractor"),
       masked: false,
       maskReason: undefined,
@@ -1600,7 +1601,7 @@ describe("audit value redaction (#5180)", () => {
     // no registry entry is drift — reported as a plain masked write it would be
     // indistinguishable from the healthy case, and the backstop would fire
     // silently.
-    expect(redactAuditValue(undefined, "mystery-value-here")).toEqual({
+    expect(redactAuditValue("ATLAS_SOMETHING_RENAMED", undefined, "mystery-value-here")).toEqual({
       value: audited("[withheld:secret-setting]"),
       masked: true,
       maskReason: "unknown_definition",
@@ -1610,12 +1611,12 @@ describe("audit value redaction (#5180)", () => {
   it("a clear carries no value and is not reported as masked", () => {
     // `masked: true` here would be a lie in the audit's own metadata — nothing
     // was withheld, there was nothing to withhold.
-    expect(redactAuditValue(SECRET_DEF, undefined)).toEqual({
+    expect(redactAuditValue("ANTHROPIC_API_KEY", SECRET_DEF, undefined)).toEqual({
       value: undefined,
       masked: false,
       maskReason: undefined,
     });
-    expect(redactAuditValue(PLAIN_DEF, undefined)).toEqual({
+    expect(redactAuditValue(RPM, PLAIN_DEF, undefined)).toEqual({
       value: undefined,
       masked: false,
       maskReason: undefined,
@@ -1629,12 +1630,12 @@ describe("audit value redaction (#5180)", () => {
   // set/clear distinction it was protecting lives in `action`, which is where
   // it always was.
   it("withholds an empty write to a secret key like any other value", () => {
-    expect(redactAuditValue(SECRET_DEF, "")).toEqual({
+    expect(redactAuditValue("ANTHROPIC_API_KEY", SECRET_DEF, "")).toEqual({
       value: audited("[withheld:secret-setting]"),
       masked: true,
       maskReason: "secret",
     });
-    expect(redactAuditValue(PLAIN_DEF, "")).toEqual({
+    expect(redactAuditValue(RPM, PLAIN_DEF, "")).toEqual({
       value: audited(""),
       masked: false,
       maskReason: undefined,
@@ -1703,6 +1704,36 @@ describe("settingUpdateResponseBody — the PUT echo (#5263)", () => {
     expect(body.value).toBe(audited("[withheld:secret-setting]"));
     expect(body.valueMasked).toBe(true);
     expect(JSON.stringify(body)).not.toContain("SUPERSECRET");
+  });
+
+  it("⭐ reports definition_mismatch, not unknown_definition — the arms are distinguishable", () => {
+    // ⚠️ THE REASON, not just the withholding, and driven through all THREE sinks
+    // that share the decision. `unknown_definition` reads as registry drift and
+    // sends an operator to grep `SETTINGS_REGISTRY`; for a definition belonging to
+    // another key the entry is right there and the bug is at the call site.
+    // Reported as drift, that alert is closed as a false positive.
+    //
+    // Before centralisation each sink recomputed this after discarding the
+    // evidence, and the response sink could not report it at all.
+    const body = settingUpdateResponseBody(PLAIN_DEF, "ATLAS_MODEL", "0");
+    expect(body.maskReason).toBe("definition_mismatch");
+
+    const decided = redactPresentAuditValue("ATLAS_MODEL", PLAIN_DEF, "0");
+    expect(decided.maskReason).toBe("definition_mismatch");
+
+    // …and the genuinely-absent case still says drift, so the two are not merged.
+    expect(redactPresentAuditValue("ATLAS_NOPE", undefined, "0").maskReason).toBe(
+      "unknown_definition",
+    );
+  });
+
+  it("a mismatched AND secret definition reports the caller bug, not the secrecy", () => {
+    // Order is observable and was preserved from the three hand-written copies:
+    // the caller bug is the actionable fact, and another key's secrecy is not
+    // evidence about this one.
+    expect(
+      redactPresentAuditValue("ATLAS_MODEL", SECRET_DEF, "x").maskReason,
+    ).toBe("definition_mismatch");
   });
 
   it("⭐ withholds when the definition belongs to a DIFFERENT key", () => {

--- a/packages/api/src/lib/__tests__/settings.test.ts
+++ b/packages/api/src/lib/__tests__/settings.test.ts
@@ -1894,7 +1894,7 @@ describe("securitySensitiveAuditLine (#5180)", () => {
   // masked value parses as nothing. The flags are the reason this line exists;
   // losing them to protect the value would be a worse audit than the leak.
   //
-  // `"0"` is the fixture that can see it: withheld it becomes `[redacted]`,
+  // `"0"` is the fixture that can see it: withheld it becomes `[withheld:secret-setting]`,
   // which `Number` reads as NaN → "the reader kept its default" →
   // disablesControl false. Raw, it is the documented disabled sentinel → true.
   // ANY other secret redacts to that same unparseable placeholder, so masked
@@ -1953,7 +1953,7 @@ describe("securitySensitiveAuditLine (#5180)", () => {
   // "not secret", so the row would demand the value verbatim while
   // `redactAuditValue` correctly fails closed — going red with a message that
   // accuses the redaction of a bug that is actually a rename. The assertion
-  // below names the real cause; `:1327` owns the claim itself.
+  // below names the real cause; the `"every sensitive key exists in the settings registry"` test owns the claim itself.
   it.each([...SECURITY_SENSITIVE_KEYS])(
     "%s redacts exactly as its own registry definition dictates",
     (key) => {

--- a/packages/api/src/lib/__tests__/settings.test.ts
+++ b/packages/api/src/lib/__tests__/settings.test.ts
@@ -1566,8 +1566,8 @@ describe("audit value redaction (#5180)", () => {
   // but it stripped lowercase letters before comparing, so for `"abcdefghi"`
   // and `"x"` it iterated ZERO times and asserted nothing at all. The property
   // worth pinning is stronger and uniform: the output does not depend on the
-  // input. `maskSecret` produces five DIFFERENT strings for these five values,
-  // two of them revealing eight characters, so it goes red here.
+  // input. `maskSecret` reveals eight characters of two of these five values,
+  // so it goes red here.
   it("produces one identical placeholder for every secret, whatever its length", () => {
     const outputs = new Set(SECRET_LENGTHS.map((w) => redactAuditValue(SECRET_DEF, w).value));
     expect(outputs.size).toBe(1);

--- a/packages/api/src/lib/__tests__/settings.test.ts
+++ b/packages/api/src/lib/__tests__/settings.test.ts
@@ -1705,6 +1705,36 @@ describe("settingUpdateResponseBody — the PUT echo (#5263)", () => {
     expect(JSON.stringify(body)).not.toContain("SUPERSECRET");
   });
 
+  it("⭐ withholds when the definition belongs to a DIFFERENT key", () => {
+    // The discard `auditSettingsWrite` has and this builder did not. Without it
+    // the two sinks apply different fail-closed rules: the row would withhold
+    // the characters and record `maskReason: "definition_mismatch"` while this
+    // body echoed the plaintext — the third sink leaking exactly what #5263
+    // closed, in the one input class the seam was hardened against.
+    //
+    // Unreachable through today's route (`SETTINGS_MAP` is keyed by `def.key`,
+    // so `mismatched` is always false there) and reachable the day
+    // `getSettingDefinition` gains alias or rename resolution.
+    //
+    // ⚠️ A NON-SECRET definition, and that is the whole reason this test can
+    // fail. The first draft passed `SECRET_DEF`, which reaches the withheld
+    // placeholder through its OWN `secret: true` arm whether or not the discard
+    // exists — measured: deleting the discard left the suite green. With a
+    // non-secret definition for another key, the discard is the only thing
+    // standing between this value and the verbatim arm.
+    const body = settingUpdateResponseBody(PLAIN_DEF, "ATLAS_MODEL", "0");
+    expect(body.value).toBe(audited("[withheld:secret-setting]"));
+    expect(body.valueMasked).toBe(true);
+  });
+
+  it("a definition whose key MATCHES is still used — the discard is not a blanket withhold", () => {
+    // The discriminating half. A builder that discarded every definition would
+    // pass the test above and withhold every value in the product.
+    expect(
+      settingUpdateResponseBody(PLAIN_DEF, "ATLAS_TRIAL_IP_RATE_LIMIT_RPM", "0").value,
+    ).toBe(audited("0"));
+  });
+
   it("echoes the key it was given, not the definition's", () => {
     // A body naming the definition's key would misreport which setting the
     // caller just wrote whenever the two disagree — the same wrong-definition

--- a/packages/api/src/lib/__tests__/settings.test.ts
+++ b/packages/api/src/lib/__tests__/settings.test.ts
@@ -1761,9 +1761,15 @@ describe("settingUpdateResponseBody — the PUT echo (#5263)", () => {
   it("a definition whose key MATCHES is still used — the discard is not a blanket withhold", () => {
     // The discriminating half. A builder that discarded every definition would
     // pass the test above and withhold every value in the product.
-    expect(
-      settingUpdateResponseBody(PLAIN_DEF, "ATLAS_TRIAL_IP_RATE_LIMIT_RPM", "0").value,
-    ).toBe(audited("0"));
+    //
+    // ⚠️ A DIFFERENT key from the verbatim-arm test above, deliberately. Driving
+    // the same inputs would restate that assertion and add no falsifier.
+    const ALIAS_SOURCES = "ATLAS_BRAIN_ALIAS_AUTO_APPROVE_SOURCES";
+    const def = getSettingDefinition(ALIAS_SOURCES);
+    expect(def).toBeDefined();
+    expect(settingUpdateResponseBody(def, ALIAS_SOURCES, "warehouse_key").value).toBe(
+      audited("warehouse_key"),
+    );
   });
 
   it("echoes the key it was given, not the definition's", () => {
@@ -1829,6 +1835,9 @@ describe("securitySensitiveAuditLine (#5180)", () => {
         maskReason: undefined,
         disablesControl: false,
         widensAuthority: false,
+        // A clear carries the caveat: the flags judge a WRITTEN value and a clear
+        // has none, so `false`/`false` must not read as "nothing weakened".
+        judgement: "reverted_value_not_evaluated",
         actorId: undefined,
         orgId: undefined,
         event: "security_setting.changed",
@@ -1855,6 +1864,7 @@ describe("securitySensitiveAuditLine (#5180)", () => {
       maskReason: undefined,
       disablesControl: false,
       widensAuthority: false,
+      judgement: "reverted_value_not_evaluated",
       actorId: "user_1",
       orgId: "org_1",
       event: "security_setting.changed",

--- a/packages/api/src/lib/__tests__/settings.test.ts
+++ b/packages/api/src/lib/__tests__/settings.test.ts
@@ -21,6 +21,7 @@ import {
   securitySensitiveAuditFields,
   securitySensitiveAuditLine,
   redactAuditValue,
+  settingUpdateResponseBody,
   settingsCacheEverLoaded,
   SECURITY_SENSITIVE_KEYS,
   type SecuritySensitiveKey,
@@ -1638,6 +1639,77 @@ describe("audit value redaction (#5180)", () => {
       masked: false,
       maskReason: undefined,
     });
+  });
+});
+
+describe("settingUpdateResponseBody — the PUT echo (#5263)", () => {
+  // The third sink for a written value, and the last one that played the
+  // request back verbatim. Driven here rather than through the route because
+  // the route 403s a `secret: true` key before a body exists: an assertion
+  // written against `PUT /admin/settings/{key}` can only ever reach the
+  // verbatim arm, which passes identically with this fix and without it.
+  const SECRET_DEF = getSettingDefinition("ANTHROPIC_API_KEY");
+  const PLAIN_DEF = getSettingDefinition("ATLAS_TRIAL_IP_RATE_LIMIT_RPM");
+  const SECRET_VALUE = "sk-ant-api03-SUPERSECRET-payload";
+
+  it("the two fixtures differ on the only axis under test", () => {
+    // ⚠️ `toBeDefined` on the plain one FIRST: `expect(PLAIN_DEF?.secret)
+    // .not.toBe(true)` passes when `PLAIN_DEF` is `undefined`, which would
+    // route the "verbatim" case through the fail-closed arm and make the
+    // control below assert the placeholder while reading as a pass.
+    expect(SECRET_DEF?.secret).toBe(true);
+    expect(PLAIN_DEF).toBeDefined();
+    expect(PLAIN_DEF?.secret).not.toBe(true);
+  });
+
+  it("⭐ withholds a `secret: true` value from the response body", () => {
+    const body = settingUpdateResponseBody(SECRET_DEF, "ANTHROPIC_API_KEY", SECRET_VALUE);
+    expect(body.value).toBe(audited("[withheld:secret-setting]"));
+    expect(body.valueMasked).toBe(true);
+    // ⚠️ THE WHOLE SERIALIZED BODY, not just `value`. A future field carrying
+    // the plaintext — `previousValue`, a diff, an echo of the request — would
+    // satisfy the assertion above and still be the disclosure.
+    expect(JSON.stringify(body)).not.toContain("SUPERSECRET");
+  });
+
+  // ⚠️ THE CONTROL. "Redact everything" passes the test above and destroys the
+  // response's only useful content: an admin UI that cannot read back what it
+  // just stored has no way to show the write took effect.
+  it("records a non-secret value verbatim, and says it was not masked", () => {
+    expect(settingUpdateResponseBody(PLAIN_DEF, "ATLAS_TRIAL_IP_RATE_LIMIT_RPM", "0")).toEqual({
+      success: true,
+      key: "ATLAS_TRIAL_IP_RATE_LIMIT_RPM",
+      value: audited("0"),
+      valueMasked: false,
+    });
+  });
+
+  // ⚠️ The two flags must not agree by accident. `valueMasked` is the ONLY
+  // thing separating the placeholder from a setting whose literal value is
+  // that string, so a builder hardcoding it either way passes one of the two
+  // tests above and lies on the other.
+  it("`valueMasked` tracks the arm taken, on both arms", () => {
+    expect(settingUpdateResponseBody(SECRET_DEF, "ANTHROPIC_API_KEY", "x").valueMasked).toBe(true);
+    expect(
+      settingUpdateResponseBody(PLAIN_DEF, "ATLAS_TRIAL_IP_RATE_LIMIT_RPM", "x").valueMasked,
+    ).toBe(false);
+  });
+
+  it("fails closed on a key with no registry entry", () => {
+    // The route 400s an unknown key before the write, so this is a backstop
+    // against a rename rather than a live path — which is exactly why it must
+    // not be the permissive one.
+    const body = settingUpdateResponseBody(undefined, "ATLAS_SOMETHING_RENAMED", SECRET_VALUE);
+    expect(body.value).toBe(audited("[withheld:secret-setting]"));
+    expect(body.valueMasked).toBe(true);
+    expect(JSON.stringify(body)).not.toContain("SUPERSECRET");
+  });
+
+  it("echoes the key it was given, not the definition's", () => {
+    // A body naming the definition's key would misreport which setting the
+    // caller just wrote whenever the two disagree — the same wrong-definition
+    // input class `auditSettingsWrite` guards, arriving at the response.
+    expect(settingUpdateResponseBody(PLAIN_DEF, "ATLAS_MODEL", "x").key).toBe("ATLAS_MODEL");
   });
 });
 

--- a/packages/api/src/lib/audit/__tests__/settings-write.test.ts
+++ b/packages/api/src/lib/audit/__tests__/settings-write.test.ts
@@ -15,9 +15,10 @@
  * needs redacted and raw to DIFFER on it. This is the trap #5180 documented:
  * for a key whose value is not secret, the redacted and raw strings are
  * identical, so an assertion comparing them passes under a fix and under its
- * removal alike. Every claim-1 test below therefore drives a real
- * `secret: true` definition (`RESEND_API_KEY`) with a value that is visibly
- * not the placeholder.
+ * removal alike. The WITHHOLDING tests therefore drive `RESEND_API_KEY`'s real
+ * `secret: true` entry with a value visibly unlike the placeholder; their
+ * controls drive `ATLAS_MODEL`'s non-secret entry, and the empty-secret case
+ * drives `""` on purpose.
  */
 
 import { describe, expect, it, mock, beforeEach, afterEach } from "bun:test";
@@ -100,11 +101,12 @@ const SECRET_DEF = getSettingDefinition("RESEND_API_KEY");
 const PLAIN_DEF = getSettingDefinition("ATLAS_MODEL");
 
 /**
- * One key from EACH security-sensitive family (#5262). They weaken in opposite
- * directions — a LOW abuse threshold disables a control, a WIDE alias source
- * list grants authority, and each family's other flag is structurally always
- * `false` — so a single fixture would leave one rule unexercised and could not
- * tell a per-key rule table from one rule applied to everything.
+ * One key per RULE (#5262): the abuse threshold, plus both alias knobs, which
+ * have separate rules. The two families weaken in opposite directions — a LOW
+ * abuse threshold disables a control, a WIDE alias source list grants authority,
+ * and each family's other flag is structurally always `false` — so a single
+ * fixture would leave rules unexercised and could not tell a per-key rule table
+ * from one rule applied to everything.
  */
 const RPM_KEY = "ATLAS_TRIAL_IP_RATE_LIMIT_RPM";
 const SOURCES_KEY = "ATLAS_BRAIN_ALIAS_AUTO_APPROVE_SOURCES";
@@ -566,6 +568,20 @@ describe("auditSettingsWrite", () => {
         disablesControl: true,
         widensAuthority: false,
       });
+      // ⚠️ THE KEY SET TOO, because `toEqual` IGNORES keys whose value is
+      // `undefined` — so dropping the `!== undefined` guard on the `action`
+      // spread gives every update row `action: undefined` and the assertion
+      // above stays green. Production-inert (`JSON.stringify` drops it) but the
+      // test's NAME claims exactness, and a test that claims more than it checks
+      // is the thing this PR is about.
+      expect(Object.keys(meta()).sort()).toEqual([
+        "disablesControl",
+        "key",
+        "tier",
+        "value",
+        "valueMasked",
+        "widensAuthority",
+      ]);
     });
 
     it("⭐ records widensAuthority on an alias source list naming a class beyond warehouse_key", async () => {
@@ -690,12 +706,21 @@ describe("auditSettingsWrite", () => {
         platformTier: true,
         ipAddress: null,
       });
-      expect(meta().judgement).toBe("reverted_value_not_evaluated");
-      // ⚠️ The flags are deliberately still there and still false — both sinks
-      // share `securitySensitiveAuditFields`, so changing them would move the
-      // pino line's #3797/#5161 semantics too. The marker is additive.
-      expect(meta().disablesControl).toBe(false);
-      expect(meta().widensAuthority).toBe(false);
+      // ⚠️ THE WHOLE ARM, not field-by-field. This is the shape this PR ADDED and
+      // it is the widest one the seam produces, so it earns the exact-shape check
+      // its update sibling has. It also pins that a clear carries NO `value` —
+      // asserted elsewhere only for a secret key, not for a sensitive one — and
+      // that the flags are deliberately still present and still `false`, because
+      // both sinks share `securitySensitiveAuditFields` and changing them would
+      // move the pino line's #3797/#5161 semantics. The marker is additive.
+      expect(meta()).toEqual({
+        key: RPM_KEY,
+        tier: "platform",
+        action: "reset_to_default",
+        disablesControl: false,
+        widensAuthority: false,
+        judgement: "reverted_value_not_evaluated",
+      });
     });
 
     it("⭐ does NOT mark an update, nor a clear of a non-sensitive key", async () => {
@@ -723,27 +748,35 @@ describe("auditSettingsWrite", () => {
       expect("judgement" in meta()).toBe(false);
     });
 
-    // ⚠️ NO RUNTIME TEST FOR THE THIRD-FLAG DRIFT, and the reason is worth
-    // recording rather than leaving as a gap someone re-derives.
-    //
-    // The defect was #5262's own asymmetry one field over: the first draft
-    // copied the two flags into the metadata BY NAME, so a flag added to
-    // `SecuritySensitiveAudit` would reach the pino line by inheritance
-    // (`SecuritySensitiveAuditLine extends` it) and miss the durable row with no
-    // compile error. Observing that at runtime needs
-    // `securitySensitiveAuditFields` to return a field the real rules do not —
-    // which needs `mock.module` on `@atlas/api/lib/settings`, and that replaces
-    // all 22 exports including the `getSettingDefinition` every fixture in this
-    // file depends on. A monkeypatch is not available either: this module
-    // imports the function directly, and ESM bindings cannot be reassigned from
-    // outside.
-    //
-    // So the guard is structural instead of asserted: `SettingsAuditMetadata` is
-    // `… & Partial<SecuritySensitiveAudit>` rather than two re-declared fields,
-    // and the builder spreads `ruleFlags` whole. The type tracks the interface by
-    // derivation; the value tracks it by the spread. What is NOT closed — and a
-    // reader should not assume otherwise — is the spelling revert: going back to
-    // named fields compiles, and only re-reading the seam catches it.
+    it("⭐ the row carries EVERY field the rule engine returns", async () => {
+      // ⚠️ A DORMANT TRIPWIRE. Deriving the expected key set from the real
+      // function's own output makes the assertion track the interface the same
+      // way the builder's spread does — no mocking needed.
+      //
+      // It goes RED when a REQUIRED flag joins `SecuritySensitiveAudit` and the
+      // builder has stopped spreading `ruleFlags` whole. That is #5262's own
+      // asymmetry, which this PR reproduced once, one field over.
+      //
+      // ⚠️ Two cases survive, and the precondition is worth naming because it is
+      // load-bearing: this reads the flags THIS key's rule returns, so a flag
+      // added optionally, or one only the alias rules populate, never enters the
+      // key set. It works today because `SecuritySensitiveRule` returns
+      // `SecuritySensitiveAudit` with required properties, forcing every rule to
+      // carry a new flag. The other survivor is the spelling revert with no new
+      // flag — the key sets agree then, and only re-reading the seam catches it.
+      const { securitySensitiveAuditFields } = await import("@atlas/api/lib/settings");
+      const fields = securitySensitiveAuditFields(RPM_KEY, "set", "0");
+      expect(fields).not.toBeNull();
+      await auditSettingsWrite({
+        key: RPM_KEY,
+        definition: RPM_DEF,
+        value: "0",
+        action: "update",
+        platformTier: true,
+        ipAddress: null,
+      });
+      for (const k of Object.keys(fields ?? {})) expect(meta()).toHaveProperty(k);
+    });
 
     it("maps `reset_to_default` to `clear`, which flags nothing on either family", async () => {
       // A clear reverts to a platform override that may itself be wide, so the

--- a/packages/api/src/lib/audit/__tests__/settings-write.test.ts
+++ b/packages/api/src/lib/audit/__tests__/settings-write.test.ts
@@ -119,7 +119,14 @@ const THRESHOLD_DEF = getSettingDefinition(THRESHOLD_KEY);
 const SECRET_VALUE = "resend_fake_51H8xQ2eZvKYlo2C_not_a_placeholder";
 const WITHHELD = "[withheld:secret-setting]";
 
-const lastAwaited = (): AwaitedEntry => awaited[awaited.length - 1]!;
+const lastAwaited = (): AwaitedEntry => {
+  const last = awaited[awaited.length - 1];
+  // Diagnostic rather than a `TypeError` several frames away: reaching here with
+  // an empty array means the test exercised the no-DB arm (or 404'd) and every
+  // `meta()` assertion below it is about a row that was never recorded.
+  if (!last) throw new Error("no audit row was awaited — did this test reach the no-internal-DB arm?");
+  return last;
+};
 const meta = (): Record<string, unknown> => lastAwaited().metadata ?? {};
 
 let savedDbUrl: string | undefined;
@@ -411,6 +418,14 @@ describe("auditSettingsWrite", () => {
       // ⚠️ Different lengths (1 vs 0), so the two sinks cannot be swapped
       // without a count disagreeing.
       expect(fireAndForget).toHaveLength(0);
+      // ⚠️ THE LEVEL, not just the message. The COMMITTED line's whole argument
+      // for being `info` rather than `debug` is that an operator greps it to
+      // tell a committed row from an emitted-then-lost one — and the only other
+      // assertion on it filters by message across every level, so a demotion to
+      // `debug` (off in production) went unnoticed.
+      expect(
+        logged.filter((c) => c.level === "info" && c.message.includes("COMMITTED")),
+      ).toHaveLength(1);
     });
 
     it("⭐ says NOT PERSISTED rather than COMMITTED when there is no internal DB", async () => {
@@ -442,6 +457,32 @@ describe("auditSettingsWrite", () => {
       expect(logged.filter((c) => c.message.includes("COMMITTED"))).toHaveLength(0);
     });
 
+    it("⭐ the no-DB warn carries the judgement AND its caveat, not the flags alone", async () => {
+      // The arm a fix-vs-finding pass caught one branch over from the fix: this
+      // path spread the rule flags without `judgement`, so on a sensitive CLEAR
+      // it emitted `disablesControl: false` — the exoneration the marker exists
+      // to prevent — on the one path that has no durable row to correct it.
+      //
+      // ⚠️ A CLEAR of a SENSITIVE key, both at once. An update would carry no
+      // marker by design, and a non-sensitive key would carry no flags, so
+      // either alone passes whether or not the caveat travels.
+      delete process.env.DATABASE_URL;
+      await auditSettingsWrite({
+        key: RPM_KEY,
+        definition: RPM_DEF,
+        action: "reset_to_default",
+        platformTier: true,
+        ipAddress: null,
+      });
+      expect(awaited).toHaveLength(0);
+      const warns = logged.filter((c) => c.level === "warn");
+      expect(warns).toHaveLength(1);
+      expect(warns[0]?.payload).toMatchObject({
+        disablesControl: false,
+        judgement: "reverted_value_not_evaluated",
+      });
+    });
+
     it("⭐ propagates a rejection instead of swallowing it", async () => {
       // The whole point of the await: when the row cannot be committed the
       // caller has to find out. `logAdminAction` drops it instead — and past
@@ -460,6 +501,11 @@ describe("auditSettingsWrite", () => {
           ipAddress: null,
         }),
       ).rejects.toThrow(/circuit breaker open/);
+      // ⚠️ AND NOTHING CLAIMED THE ROW LANDED. The line is `info` and sits after
+      // the await for exactly this input; moving it above the await would make
+      // the stream confidently name a row that was rolled back, and asserting
+      // only the rejection cannot see that.
+      expect(logged.filter((c) => c.message.includes("COMMITTED"))).toHaveLength(0);
     });
   });
 
@@ -497,6 +543,29 @@ describe("auditSettingsWrite", () => {
       // ignored: the abuse family has no notion of widening, so a rule table
       // wired to one shared rule would light both here.
       expect(meta().widensAuthority).toBe(false);
+    });
+
+    it("the fully-populated sensitive arm has EXACTLY these fields", async () => {
+      // The metadata is four conditional spreads; every other test here reads
+      // one field, so a stray or clobbered field on this path is invisible. One
+      // `toEqual` pins the whole union cheaply — and would have caught the
+      // `judgement` marker leaking onto the update path.
+      await auditSettingsWrite({
+        key: RPM_KEY,
+        definition: RPM_DEF,
+        value: "0",
+        action: "update",
+        platformTier: true,
+        ipAddress: null,
+      });
+      expect(meta()).toEqual({
+        key: RPM_KEY,
+        tier: "platform",
+        value: "0",
+        valueMasked: false,
+        disablesControl: true,
+        widensAuthority: false,
+      });
     });
 
     it("⭐ records widensAuthority on an alias source list naming a class beyond warehouse_key", async () => {
@@ -607,6 +676,74 @@ describe("auditSettingsWrite", () => {
       // Likewise: the source list only widens under `set`.
       expect(meta().widensAuthority).toBe(true);
     });
+
+    it("⭐ marks a sensitive CLEAR as un-judged, so `false` cannot read as an exoneration", async () => {
+      // The rules judge the WRITTEN value and a clear has none, so they return
+      // false/false on every key — accurate about the rule, and read by an
+      // operator as "this write weakened nothing". It can be the opposite:
+      // clearing a "10" override on the RPM key while the env var holds "0"
+      // turns the per-IP limiter OFF, and the row said disablesControl: false.
+      await auditSettingsWrite({
+        key: RPM_KEY,
+        definition: RPM_DEF,
+        action: "reset_to_default",
+        platformTier: true,
+        ipAddress: null,
+      });
+      expect(meta().judgement).toBe("reverted_value_not_evaluated");
+      // ⚠️ The flags are deliberately still there and still false — both sinks
+      // share `securitySensitiveAuditFields`, so changing them would move the
+      // pino line's #3797/#5161 semantics too. The marker is additive.
+      expect(meta().disablesControl).toBe(false);
+      expect(meta().widensAuthority).toBe(false);
+    });
+
+    it("⭐ does NOT mark an update, nor a clear of a non-sensitive key", async () => {
+      // The discriminating half, on both axes. A marker on every row is a marker
+      // on nothing: the incident query
+      //   WHERE disablesControl = 'true' OR judgement = 'reverted_value_not_evaluated'
+      // would return every settings write in the table.
+      await auditSettingsWrite({
+        key: RPM_KEY,
+        definition: RPM_DEF,
+        value: "0",
+        action: "update",
+        platformTier: true,
+        ipAddress: null,
+      });
+      expect("judgement" in meta()).toBe(false);
+
+      await auditSettingsWrite({
+        key: "ATLAS_MODEL",
+        definition: PLAIN_DEF,
+        action: "reset_to_default",
+        platformTier: true,
+        ipAddress: null,
+      });
+      expect("judgement" in meta()).toBe(false);
+    });
+
+    // ⚠️ NO RUNTIME TEST FOR THE THIRD-FLAG DRIFT, and the reason is worth
+    // recording rather than leaving as a gap someone re-derives.
+    //
+    // The defect was #5262's own asymmetry one field over: the first draft
+    // copied the two flags into the metadata BY NAME, so a flag added to
+    // `SecuritySensitiveAudit` would reach the pino line by inheritance
+    // (`SecuritySensitiveAuditLine extends` it) and miss the durable row with no
+    // compile error. Observing that at runtime needs
+    // `securitySensitiveAuditFields` to return a field the real rules do not —
+    // which needs `mock.module` on `@atlas/api/lib/settings`, and that replaces
+    // all 22 exports including the `getSettingDefinition` every fixture in this
+    // file depends on. A monkeypatch is not available either: this module
+    // imports the function directly, and ESM bindings cannot be reassigned from
+    // outside.
+    //
+    // So the guard is structural instead of asserted: `SettingsAuditMetadata` is
+    // `… & Partial<SecuritySensitiveAudit>` rather than two re-declared fields,
+    // and the builder spreads `ruleFlags` whole. The type tracks the interface by
+    // derivation; the value tracks it by the spread. What is NOT closed — and a
+    // reader should not assume otherwise — is the spelling revert: going back to
+    // named fields compiles, and only re-reading the seam catches it.
 
     it("maps `reset_to_default` to `clear`, which flags nothing on either family", async () => {
       // A clear reverts to a platform override that may itself be wide, so the

--- a/packages/api/src/lib/audit/__tests__/settings-write.test.ts
+++ b/packages/api/src/lib/audit/__tests__/settings-write.test.ts
@@ -99,6 +99,20 @@ const SECRET_DEF = getSettingDefinition("RESEND_API_KEY");
 /** A real non-secret entry, so the verbatim arm is exercised against the registry too. */
 const PLAIN_DEF = getSettingDefinition("ATLAS_MODEL");
 
+/**
+ * One key from EACH security-sensitive family (#5262). They weaken in opposite
+ * directions — a LOW abuse threshold disables a control, a WIDE alias source
+ * list grants authority, and each family's other flag is structurally always
+ * `false` — so a single fixture would leave one rule unexercised and could not
+ * tell a per-key rule table from one rule applied to everything.
+ */
+const RPM_KEY = "ATLAS_TRIAL_IP_RATE_LIMIT_RPM";
+const SOURCES_KEY = "ATLAS_BRAIN_ALIAS_AUTO_APPROVE_SOURCES";
+const THRESHOLD_KEY = "ATLAS_BRAIN_ALIAS_AUTO_APPROVE_THRESHOLD";
+const RPM_DEF = getSettingDefinition(RPM_KEY);
+const SOURCES_DEF = getSettingDefinition(SOURCES_KEY);
+const THRESHOLD_DEF = getSettingDefinition(THRESHOLD_KEY);
+
 // ⚠️ Deliberately NOT a real provider prefix. `re_live_…` is Resend's live-key
 // shape and GitHub push protection scans for it — a fabricated value that trips
 // a secret scanner costs a CI round for nothing.
@@ -446,6 +460,193 @@ describe("auditSettingsWrite", () => {
           ipAddress: null,
         }),
       ).rejects.toThrow(/circuit breaker open/);
+    });
+  });
+
+  describe("4 — the judgement (#5262)", () => {
+    it("the family fixtures are real registry entries and are actually sensitive", async () => {
+      // Without this the whole block could be asserting that a MISSPELLED key
+      // records no flags — which is what "absence is meaningful" looks like
+      // from the outside, so every test below would pass for the wrong reason.
+      const { SECURITY_SENSITIVE_KEYS } = await import("@atlas/api/lib/settings");
+      for (const key of [RPM_KEY, SOURCES_KEY, THRESHOLD_KEY]) {
+        expect(SECURITY_SENSITIVE_KEYS.has(key)).toBe(true);
+      }
+      expect(RPM_DEF).toBeDefined();
+      expect(SOURCES_DEF).toBeDefined();
+      expect(THRESHOLD_DEF).toBeDefined();
+      // And the control key must be OUTSIDE the set, or the absence tests below
+      // would be asserting absence against a key that has a rule.
+      expect(SECURITY_SENSITIVE_KEYS.has("ATLAS_MODEL")).toBe(false);
+    });
+
+    it("⭐ records disablesControl on an abuse threshold written to its disabled sentinel", async () => {
+      // The durable row now carries the ANALYSIS, not just the fact. Before
+      // this, `admin_action_log` could say "someone set this to 0" and only the
+      // suppressible pino line said "that disabled an abuse control".
+      await auditSettingsWrite({
+        key: RPM_KEY,
+        definition: RPM_DEF,
+        value: "0",
+        action: "update",
+        platformTier: true,
+        ipAddress: null,
+      });
+      expect(meta().disablesControl).toBe(true);
+      // ⚠️ The OTHER flag asserted too, and asserted `false` rather than
+      // ignored: the abuse family has no notion of widening, so a rule table
+      // wired to one shared rule would light both here.
+      expect(meta().widensAuthority).toBe(false);
+    });
+
+    it("⭐ records widensAuthority on an alias source list naming a class beyond warehouse_key", async () => {
+      // The opposite direction, and the reason the rules are per-key: reusing
+      // the numeric rule here would flag the SAFEST possible alias write (an
+      // empty list — everything queues for review) as a disable.
+      await auditSettingsWrite({
+        key: SOURCES_KEY,
+        definition: SOURCES_DEF,
+        value: "warehouse_key,extractor",
+        action: "update",
+        platformTier: false,
+        ipAddress: null,
+      });
+      expect(meta().widensAuthority).toBe(true);
+      expect(meta().disablesControl).toBe(false);
+    });
+
+    it("records widensAuthority when the alias confidence bar drops below the shipped 1", async () => {
+      await auditSettingsWrite({
+        key: THRESHOLD_KEY,
+        definition: THRESHOLD_DEF,
+        value: "0.5",
+        action: "update",
+        platformTier: false,
+        ipAddress: null,
+      });
+      expect(meta().widensAuthority).toBe(true);
+      expect(meta().disablesControl).toBe(false);
+    });
+
+    // ⚠️ THE DISCRIMINATING HALF, per family. A seam that hardcoded either flag
+    // to `true` would pass all three tests above and make the field useless in
+    // the other direction — every settings write would read as a weakening.
+    it("records both flags FALSE on a harmless write to a sensitive key", async () => {
+      await auditSettingsWrite({
+        key: RPM_KEY,
+        definition: RPM_DEF,
+        value: "5",
+        action: "update",
+        platformTier: true,
+        ipAddress: null,
+      });
+      expect(meta().disablesControl).toBe(false);
+      expect(meta().widensAuthority).toBe(false);
+
+      await auditSettingsWrite({
+        key: SOURCES_KEY,
+        definition: SOURCES_DEF,
+        value: "warehouse_key",
+        action: "update",
+        platformTier: false,
+        ipAddress: null,
+      });
+      expect(meta().disablesControl).toBe(false);
+      expect(meta().widensAuthority).toBe(false);
+    });
+
+    // ⚠️ ABSENCE, NOT `false` — the control #5262 names explicitly. A row that
+    // always carried `disablesControl: false` cannot be filtered on:
+    // `WHERE metadata->>'disablesControl' = 'false'` would match every settings
+    // write in the table. Absence must mean "no rule applies"; `false` must
+    // mean "a rule ran and said no". `in`, not `toBeUndefined()` — a present
+    // key with an `undefined` value satisfies the latter and still serializes
+    // into the row.
+    it("⭐ records NEITHER flag for a key outside the sensitive set", async () => {
+      await auditSettingsWrite({
+        key: "ATLAS_MODEL",
+        definition: PLAIN_DEF,
+        value: "claude-opus-5",
+        action: "update",
+        platformTier: true,
+        ipAddress: null,
+      });
+      expect("disablesControl" in meta()).toBe(false);
+      expect("widensAuthority" in meta()).toBe(false);
+      // And nothing snuck in through the serialized row either.
+      expect(JSON.stringify(lastAwaited())).not.toContain("disablesControl");
+    });
+
+    // ⚠️ THE ACTION MAPPING, DRIVEN FROM EACH FAMILY on the `update` side —
+    // which is the only side where a swap is visible. Measured: with
+    // `value: undefined` on the reset path, both families return false/false
+    // whichever action they are handed, so a clear-path assertion cannot fail
+    // under `{ update: "clear", reset_to_default: "set" }`. #5262's body
+    // predicts the blind axis is the FAMILY; it is the VERB.
+    it("⭐ maps `update` to the rule engine's `set`, on both families", async () => {
+      await auditSettingsWrite({
+        key: RPM_KEY,
+        definition: RPM_DEF,
+        value: "0",
+        action: "update",
+        platformTier: true,
+        ipAddress: null,
+      });
+      // `"0"` only disables under `set`; under `clear` the abuse rule
+      // short-circuits and reports nothing weakened.
+      expect(meta().disablesControl).toBe(true);
+
+      await auditSettingsWrite({
+        key: SOURCES_KEY,
+        definition: SOURCES_DEF,
+        value: "warehouse_key,extractor",
+        action: "update",
+        platformTier: false,
+        ipAddress: null,
+      });
+      // Likewise: the source list only widens under `set`.
+      expect(meta().widensAuthority).toBe(true);
+    });
+
+    it("maps `reset_to_default` to `clear`, which flags nothing on either family", async () => {
+      // A clear reverts to a platform override that may itself be wide, so the
+      // written value does not determine the outcome — both flags are `false`,
+      // and PRESENT, because a rule did run.
+      for (const [key, definition] of [
+        [RPM_KEY, RPM_DEF],
+        [SOURCES_KEY, SOURCES_DEF],
+      ] as const) {
+        await auditSettingsWrite({
+          key,
+          definition,
+          action: "reset_to_default",
+          platformTier: false,
+          ipAddress: null,
+        });
+        expect(meta().disablesControl).toBe(false);
+        expect(meta().widensAuthority).toBe(false);
+        expect(meta().action).toBe("reset_to_default");
+      }
+    });
+
+    it("⭐ records the judgement even when the VALUE is withheld", async () => {
+      // The two decisions are independent, and this is the shape that proves
+      // the flags are computed from `key` rather than from `definition`: a
+      // definition belonging to another key withholds the characters, while the
+      // rule — which reads the key and the real written value — still reports
+      // what the write did. Withholding the analysis alongside the value would
+      // reintroduce #5262 through the back door.
+      await auditSettingsWrite({
+        key: RPM_KEY,
+        definition: PLAIN_DEF, // ATLAS_MODEL's entry — wrong key
+        value: "0",
+        action: "update",
+        platformTier: true,
+        ipAddress: null,
+      });
+      expect(meta().value).toBe(WITHHELD);
+      expect(meta().maskReason).toBe("definition_mismatch");
+      expect(meta().disablesControl).toBe(true);
     });
   });
 

--- a/packages/api/src/lib/audit/__tests__/settings-write.test.ts
+++ b/packages/api/src/lib/audit/__tests__/settings-write.test.ts
@@ -169,6 +169,18 @@ describe("auditSettingsWrite", () => {
     // passes-for-the-wrong-reason class this block exists to prevent.
     expect(PLAIN_DEF).toBeDefined();
     expect(PLAIN_DEF?.secret).toBeFalsy();
+    // ⚠️ The rule fixtures are guarded HERE, not inside the describe that uses
+    // them. `describe("3 — the await")` also drives `RPM_DEF`, and would have
+    // passed with it `undefined` (the flags derive from `entry.key`, not the
+    // definition) — so a guard living in describe 4 covered the file only by
+    // accident of ordering.
+    for (const [k, def] of [
+      [RPM_KEY, RPM_DEF],
+      [SOURCES_KEY, SOURCES_DEF],
+      [THRESHOLD_KEY, THRESHOLD_DEF],
+    ] as const) {
+      expect(def, `no registry definition for ${k}`).toBeDefined();
+    }
   });
 
   describe("1 — the value", () => {
@@ -520,9 +532,6 @@ describe("auditSettingsWrite", () => {
       for (const key of [RPM_KEY, SOURCES_KEY, THRESHOLD_KEY]) {
         expect(SECURITY_SENSITIVE_KEYS.has(key)).toBe(true);
       }
-      expect(RPM_DEF).toBeDefined();
-      expect(SOURCES_DEF).toBeDefined();
-      expect(THRESHOLD_DEF).toBeDefined();
       // And the control key must be OUTSIDE the set, or the absence tests below
       // would be asserting absence against a key that has a rule.
       expect(SECURITY_SENSITIVE_KEYS.has("ATLAS_MODEL")).toBe(false);
@@ -664,10 +673,9 @@ describe("auditSettingsWrite", () => {
 
     // ⚠️ THE ACTION MAPPING, DRIVEN FROM EACH FAMILY on the `update` side —
     // which is the only side where a swap is visible. Measured: with
-    // `value: undefined` on the reset path, both families return false/false
+    // `value: undefined` on the reset path, all three rules return false/false
     // whichever action they are handed, so a clear-path assertion cannot fail
-    // under `{ update: "clear", reset_to_default: "set" }`. #5262's body
-    // predicts the blind axis is the FAMILY; it is the VERB.
+    // under a swapped mapping. The blind axis is the VERB, not the family.
     it("⭐ maps `update` to the rule engine's `set`, on both families", async () => {
       await auditSettingsWrite({
         key: RPM_KEY,

--- a/packages/api/src/lib/audit/settings-write.ts
+++ b/packages/api/src/lib/audit/settings-write.ts
@@ -5,7 +5,9 @@
  * ⚠️ **NOT "the one seam for settings writes" — three other writers exist and
  * none of them routes through here.** `platform-demo.ts` files its own
  * `settings.update` with the fire-and-forget `logAdminAction` (it does pass
- * `scope: "platform"`, so only defect 3 below applies to it);
+ * `scope: "platform"`, so defect 2 below does not apply to it — but it puts
+ * its written values straight into `metadata` with no redaction, which is
+ * structurally defect 1, safe only because those keys are not `secret: true`);
  * `onboarding.ts` writes `ATLAS_DEMO_INDUSTRY` and `admin-sandbox.ts` clears
  * `ATLAS_SANDBOX_BACKEND`; neither files an audit row. They are outside
  * this PR, and naming them here is the point — the next reader must not take
@@ -18,14 +20,17 @@
  *
  * 1. **The value was recorded verbatim — but a `secret: true` value cannot
  *    reach it.** `metadata: { key, value, tier }` carried the raw string, and
- *    #5270 claimed that put the seven `secret: true` credentials in a DB row.
+ *    #5270 claimed that put the registry's `secret: true` credentials in a DB
+ *    row.
  *    It does not: both verbs in `api/routes/admin.ts` 403 a `secret: true`
  *    key *before* the write — grep the guard by its copy, `"Secret settings
  *    cannot be modified from the UI."`, which appears once per verb — and
  *    that guard is on `main` already, so there was no window. So
  *    `redactAuditValue`'s `secret` arm and its `undefined`-definition
  *    fail-closed arm are BOTH route-unreachable today, and every production
- *    entry takes the verbatim arm.
+ *    entry THAT CARRIES A VALUE takes the verbatim arm. (Not every entry: the
+ *    union below forces `value?: undefined` on `reset_to_default`, so a DELETE
+ *    row takes the no-value arm instead.)
  *
  *    ⚠️ Cited by MESSAGE rather than by line, deliberately. The first draft of
  *    this block pinned `admin.ts:3720`/`:3876` and both were stale within the
@@ -55,20 +60,25 @@
  *
  * 3. **The audit row was fire-and-forget — and the drop is SILENT, which is
  *    a stronger reason than the one #5262 gave.** #5262 argued a raised
- *    `ATLAS_LOG_LEVEL` silences the drop's `log.warn`. There is no such warn.
- *    Once the internal-DB circuit breaker is open, `internalExecute`
- *    (`db/internal.ts:874-879`) increments `_droppedCount` and returns with
- *    NO log line at any level — the only trace is an anonymous count on a
- *    later recovery line, naming no key, actor or value. Before the breaker
- *    opens, the drop logs at `error` (`:889-898`), which names no key — and
- *    which only `fatal` silences, a level that is itself in
+ *    `ATLAS_LOG_LEVEL` silences the drop's `log.warn`. There IS such a warn on
+ *    the synchronous-throw drop in `logAdminAction` (`audit/admin.ts`), but not
+ *    on the drop that matters. Once the internal-DB circuit breaker is open,
+ *    `internalExecute`'s `_circuitOpen` early return increments `_droppedCount`
+ *    and returns with NO log line at any level — the only trace is an anonymous
+ *    count on a later recovery line, naming no key, actor or value. Before the
+ *    breaker opens, its `if (!_circuitOpen)` branch logs at `error`, which names
+ *    no key — and which only `fatal` silences, a level that is itself in
  *    `ATLAS_LOG_LEVEL`'s own option list, so even that trace is
- *    operator-revocable — so #5262's instinct was not baseless; it named the
- *    wrong line and the wrong branch. Either way the settings change is
- *    unrecorded and unattributable, so
- *    `logAdminActionAwait` is the
- *    right instrument — for the reason its own docstring gives about the
- *    audit-retention surface, not for the reason #5262 gave.
+ *    operator-revocable. #5262's instinct was not baseless; it named the wrong
+ *    line and the wrong branch. Either way the settings change is unrecorded and
+ *    unattributable, so `logAdminActionAwait` is the right instrument — for the
+ *    reason its own docstring gives about the audit-retention surface, not for
+ *    the reason #5262 gave.
+ *
+ *    ⚠️ Both `db/internal.ts` sites cited by SYMBOL, not line. The first draft
+ *    pinned `:874-879` and `:889-898`, which were accurate and in a file this
+ *    change does not touch — so they drift independently, which is exactly what
+ *    the paragraph below says makes a citation worse than none.
  *
  * ⚠️ **AND THE RULE FLAGS LAND HERE TOO (#5262, the surviving finding).** The
  * row carries `disablesControl` / `widensAuthority` for a
@@ -85,16 +95,24 @@
  *
  * ⚠️ **WHY THE WHOLE ENTRY IS BUILT HERE rather than at the route.** The
  * redaction is not something a call site can be trusted to remember: #5180
- * measured that re-inlining `log.warn({ ...line, value })` passed the whole
- * suite, because redacted equals raw on every currently-reachable input. The
- * brand is the guard — and a brand only bites where something is EXPECTED to
- * carry it. `AdminActionEntry`'s `metadata` is `Record<string, unknown>`, so a
- * route that builds its own object gets no help at all. Hence: the route hands
+ * measured that re-inlining `log.warn({ ...line, value })` passed the suite AS
+ * IT THEN STOOD, because redacted equalled raw on every input that suite
+ * reached. (Not "on every reachable input" — the registry-flip block in
+ * `settings-audit-log.test.ts` later made them differ on a fully reachable one.
+ * That distinction is #5264 item 3, and this paragraph was carrying the same
+ * stale premise one file over.) The brand is a guard for the seam-preserving
+ * edit — and a brand only bites where something is EXPECTED to carry it.
+ * `AdminActionEntry`'s `metadata` is `Record<string, unknown>`, so a route that
+ * builds its own object gets no help at all. Hence: the route hands
  * over the definition and the raw value, and never touches `metadata`.
  *
+ * A definition belonging to a DIFFERENT key IS closed, by the `mismatched`
+ * check below — added after review caught that its #5180 sibling had one and
+ * this module did not.
+ *
  * ⚠️ **WHAT THIS DOES NOT CLOSE**, stated because the fence invites the wrong
- * confidence. The spread case below was measured by compiling both spellings;
- * the other two are stated from the type system's rules:
+ * confidence. The spread case was measured by compiling both spellings; the
+ * other is stated from the type system's rules:
  *
  * - **A caller that goes back to `logAdminAction` with a hand-built metadata
  *   object** bypasses everything here, and no type can see it.
@@ -105,9 +123,6 @@
  *   spread form is caught only by `settings-write.test.ts`'s whole-entry
  *   `JSON.stringify` negative assertion, which is why that assertion is on
  *   the serialized entry rather than on `metadata.value`.
- * - **A definition belonging to a DIFFERENT key** — closed below by the
- *   `mismatched` check, which this module was missing until review caught
- *   that its #5180 sibling has one and it did not.
  */
 
 import { createLogger } from "@atlas/api/lib/logger";
@@ -119,6 +134,7 @@ import {
   securitySensitiveAuditFields,
   type AuditedValue,
   type AuditMaskReason,
+  type SecuritySensitiveAudit,
   type SettingAuditAction,
   type SettingDefinition,
 } from "@atlas/api/lib/settings";
@@ -136,7 +152,8 @@ export type SettingsWriteAction = "update" | "reset_to_default";
 /**
  * The verb vocabularies of the two audit channels, joined here (#5262).
  *
- * ⚠️ **A TOTAL `Record`, NOT a ternary, and that is the only defence there is.**
+ * ⚠️ **A TOTAL `Record`, NOT a ternary — which closes a MISSING verb, not a
+ * swapped one.**
  * `SettingsWriteAction` is this module's HTTP-verb vocabulary;
  * {@link SettingAuditAction} is the rule engine's. The mapping is one line and
  * is exactly the adjacent pair that goes wrong silently — nothing about
@@ -167,36 +184,81 @@ const AUDIT_ACTION: Record<SettingsWriteAction, SettingAuditAction> = {
 };
 
 /**
- * The metadata shape that reaches `admin_action_log.metadata`.
+ * The row's own verb discriminator, total for the same reason
+ * {@link AUDIT_ACTION} is.
+ *
+ * `undefined` for `update` because absence already means `update` in every row
+ * written before the field existed — labelling it would split one verb across
+ * two spellings and break those rows' readers.
+ */
+const METADATA_ACTION: Record<SettingsWriteAction, SettingsAuditMetadataBase["action"]> = {
+  update: undefined,
+  reset_to_default: "reset_to_default",
+};
+
+/**
+ * Everything in the row's metadata except the rule flags, which are derived from
+ * {@link SecuritySensitiveAudit} by {@link SettingsAuditMetadata} below.
  *
  * ⚠️ `value` is {@link AuditedValue}, not `string`. That is the compile-time
  * half of defect (1) above: the only way to obtain one is
  * {@link redactAuditValue}, so `value: rawValue` here is a type error on the
  * day it is harmless and on the day it is a breach.
  */
-type SettingsAuditMetadata = {
+type SettingsAuditMetadataBase = {
   readonly key: string;
   readonly tier: "workspace" | "platform";
   readonly action?: "reset_to_default";
+  /**
+   * Present only on a clear of a security-sensitive key: the two flags below
+   * describe what the RULE answered, and for a clear that is structurally
+   * `false`/`false` on every key — the rules judge the WRITTEN value, and a
+   * clear has none. What the setting reverts to (the env var, the default, or a
+   * platform override that may itself be wide) is not evaluated.
+   *
+   * ⚠️ **It exists because `false` would otherwise read as an exoneration.**
+   * Clearing a `"10"` override on `ATLAS_TRIAL_IP_RATE_LIMIT_RPM` when the env
+   * var holds `"0"` turns the per-IP limiter OFF, and the row said
+   * `disablesControl: false`. So the incident query is
+   * `WHERE metadata->>'disablesControl' = 'true' OR metadata->>'judgement' =
+   * 'reverted_value_not_evaluated'`, and the second disjunct is the difference
+   * between "no weakening" and "nobody checked".
+   */
+  readonly judgement?: "reverted_value_not_evaluated";
   readonly value?: AuditedValue;
   /** Present whenever a value is; `true` means the characters were withheld. */
   readonly valueMasked?: boolean;
   /** Present only when `valueMasked` is true. */
   readonly maskReason?: AuditMaskReason;
-  /**
-   * An abuse control was turned OFF by this write (#5262). Always absent for a
-   * key outside {@link SECURITY_SENSITIVE_KEYS}, and always `false` for the
-   * alias keys — whose disabled position queues everything for review, i.e. the
-   * SAFE end. See `securitySensitiveAuditFields` for why the rules are per-key.
-   */
-  readonly disablesControl?: boolean;
-  /**
-   * More proposals now auto-approve with nobody in front of them (#5262).
-   * Always absent for a non-sensitive key, always `false` for the abuse
-   * thresholds, which have no such notion.
-   */
-  readonly widensAuthority?: boolean;
 };
+
+/**
+ * The metadata shape that reaches `admin_action_log.metadata` (#5262).
+ *
+ * ⚠️ **`Partial<SecuritySensitiveAudit>` RATHER THAN THE TWO FLAGS RESTATED, and
+ * the restatement was the bug.** The first draft declared `disablesControl?:
+ * boolean` and `widensAuthority?: boolean` here and copied them across
+ * field-by-field. Add a third flag to `SecuritySensitiveAudit` and the pino line
+ * would get it for free — `SecuritySensitiveAuditLine extends
+ * SecuritySensitiveAudit` — while this row silently would not, with no compile
+ * error anywhere. That is the exact pino-has-it / durable-row-lacks-it asymmetry
+ * #5262 was filed to remove, reproduced one field over by its own fix.
+ *
+ * Deriving from the interface makes it one fact. The builder spreads `ruleFlags`
+ * whole rather than naming fields, so a third flag flows into the row the day it
+ * is added.
+ *
+ * FLAT, not nested under a `security` key, deliberately: #5262's acceptance
+ * criterion writes the incident query as `metadata->>'disablesControl'`, and
+ * nesting would move every reader to `metadata->'security'->>'disablesControl'`
+ * for no gain the spread does not already give.
+ *
+ * ⚠️ The flags are all-or-nothing in practice — `securitySensitiveAuditFields`
+ * returns both or `null` — which `Partial` cannot express. The spread is what
+ * keeps the pair atomic; a hand-built `{ disablesControl: true }` would type-check
+ * and mean nothing, so do not build one.
+ */
+type SettingsAuditMetadata = SettingsAuditMetadataBase & Partial<SecuritySensitiveAudit>;
 
 interface SettingsAuditCommon {
   readonly key: string;
@@ -332,16 +394,55 @@ export async function auditSettingsWrite(entry: SettingsAuditWrite): Promise<voi
     entry.value,
   );
 
+  /**
+   * ⚠️ **THE FLAGS AND THEIR CAVEAT, BOUND TOGETHER, because separating them
+   * once was enough.** The first draft spread `ruleFlags` into the metadata and
+   * added `judgement` beside it, then spread `ruleFlags` ALONE into the no-DB
+   * warn below — so on a sensitive clear that branch emitted the `false`/`false`
+   * pair with no caveat, which is the exoneration this marker exists to prevent,
+   * on the one path that has no second record. A review pass caught it one
+   * branch over from the fix.
+   *
+   * One binding rather than two spreads and a rule in prose: every sink that
+   * reports the judgement now reports its limits with it, and a third sink
+   * cannot take the flags without the caveat because there is nothing else to
+   * take.
+   */
+  const ruleFields =
+    ruleFlags === null
+      ? {}
+      : {
+          ...ruleFlags,
+          ...(entry.action === "reset_to_default"
+            ? { judgement: "reverted_value_not_evaluated" as const }
+            : {}),
+        };
+
   const metadata: SettingsAuditMetadata = {
     key: entry.key,
     tier,
-    ...(entry.action === "reset_to_default" ? { action: "reset_to_default" as const } : {}),
-    ...(ruleFlags !== null
-      ? {
-          disablesControl: ruleFlags.disablesControl,
-          widensAuthority: ruleFlags.widensAuthority,
-        }
+    // ⚠️ A TOTAL `Record`, for the reason `AUDIT_ACTION`'s docstring gives about
+    // itself. This line was a ternary with a silent `{}` default, two statements
+    // below a comment arguing that a ternary is what lets a third verb fall
+    // through — and this is the field where the fall-through actually costs
+    // something: `ADMIN_ACTIONS.settings` has ONE member, so `metadata.action`
+    // is the only thing separating the two verbs in `admin_action_log`. A third
+    // verb would have filed rows indistinguishable from an `update`.
+    //
+    // `update` maps to `undefined` rather than a label because absence already
+    // means `update` in every row written before this field existed; giving it a
+    // label would split one verb across two spellings.
+    ...(METADATA_ACTION[entry.action] !== undefined
+      ? { action: METADATA_ACTION[entry.action] }
       : {}),
+    // ⚠️ SPREAD WHOLE, never field-by-field — see {@link SettingsAuditMetadata}.
+    // Naming the fields here is what let the first draft reproduce #5262's own
+    // asymmetry: a third flag added to `SecuritySensitiveAudit` reaches the pino
+    // line by inheritance and would have missed the durable row silently.
+    //
+    // `ruleFields`, not `ruleFlags` — the judgement travels with its caveat; see
+    // that binding above for the branch that proved they must not be separable.
+    ...ruleFields,
     ...(redacted.value !== undefined
       ? {
           value: redacted.value,
@@ -366,8 +467,13 @@ export async function auditSettingsWrite(entry: SettingsAuditWrite): Promise<voi
   // rely on when the failure is a log line confidently naming a row that does
   // not exist.
   if (!hasInternalDB()) {
+    // ⚠️ The flags ride along, because on THIS branch the pino line is the only
+    // trail — so it should carry the most, not the least. The first draft
+    // computed `ruleFlags` above and dropped them here, which is the same
+    // computed-then-discarded defect this module fixes forty lines up for
+    // `mismatched`, reappearing on the one path that has no second record.
     log.warn(
-      { key: entry.key, tier, action: entry.action },
+      { key: entry.key, tier, action: entry.action, ...ruleFields },
       "Settings write audit row NOT persisted — no internal database configured. The pino line is the only trail for this configuration change.",
     );
     return;
@@ -393,5 +499,18 @@ export async function auditSettingsWrite(entry: SettingsAuditWrite): Promise<voi
   // duplicates fields the pre-commit line already has; at `info` it is the
   // difference an operator greps for between a committed row and an
   // emitted-then-lost one.
-  log.info({ key: entry.key, tier, action: entry.action }, "Settings write audit row COMMITTED");
+  //
+  // ⚠️ AND OUTSIDE THE CALLER'S FAILURE DOMAIN. Both routes wrap this whole
+  // function in a try whose catch returns a 500 reading "the setting changed but
+  // was not recorded". A throw from THIS line — a pino serializer fault, a
+  // transport error — would therefore convert a row that DID commit into a 500
+  // whose every word is false, which is the lying-disclosure shape the 500 copy
+  // was written to avoid. The row is already durable by here; nothing about it
+  // depends on the line being emitted.
+  try {
+    log.info({ key: entry.key, tier, action: entry.action }, "Settings write audit row COMMITTED");
+  } catch {
+    // intentionally ignored: the row is committed. Reporting a logging fault to
+    // the caller would make it tell the admin the audit was lost when it was not.
+  }
 }

--- a/packages/api/src/lib/audit/settings-write.ts
+++ b/packages/api/src/lib/audit/settings-write.ts
@@ -9,14 +9,13 @@
  * its written values straight into `metadata` with no redaction, which is
  * structurally defect 1, safe only because those keys are not `secret: true`);
  * `onboarding.ts` writes `ATLAS_DEMO_INDUSTRY` and `admin-sandbox.ts` clears
- * `ATLAS_SANDBOX_BACKEND`; neither files an audit row. They are outside
- * this PR, and naming them here is the point — the next reader must not take
- * "the seam" to mean coverage nobody built.
+ * `ATLAS_SANDBOX_BACKEND`. None of the three files an audit row today, so "the
+ * seam" must not be read as coverage nobody built.
  *
- * ⚠️ **THREE DEFECTS SHARED ONE CALL SITE. ONE WAS LIVE; TWO WERE NOT WHAT
- * THE ISSUES SAID THEY WERE.** Both stated mechanisms were checked and both
- * were wrong — recorded here rather than quietly corrected, because a fix
- * resting on a false rationale is one verification away from being deleted:
+ * ⚠️ **THREE DEFECTS SHARED ONE CALL SITE. ONE WAS LIVE; TWO WERE NOT WHAT THE
+ * ISSUES SAID THEY WERE.** Both stated mechanisms were checked and both were
+ * wrong, recorded because a fix resting on a false rationale gets deleted at the
+ * first verification:
  *
  * 1. **The value was recorded verbatim — but a `secret: true` value cannot
  *    reach it.** `metadata: { key, value, tier }` carried the raw string, and
@@ -26,18 +25,14 @@
  *    key *before* the write — grep the guard by its copy, `"Secret settings
  *    cannot be modified from the UI."`, which appears once per verb — and
  *    that guard is on `main` already, so there was no window. So
- *    `redactAuditValue`'s `secret` arm and its `undefined`-definition
- *    fail-closed arm are BOTH route-unreachable today, and every production
- *    entry THAT CARRIES A VALUE takes the verbatim arm. (Not every entry: the
- *    union below forces `value?: undefined` on `reset_to_default`, so a DELETE
- *    row takes the no-value arm instead.)
+ *    all THREE of the decision's withholding arms — `secret`,
+ *    `unknown_definition` and `definition_mismatch` — are route-unreachable
+ *    today, and every production entry THAT CARRIES A VALUE takes the verbatim
+ *    arm. (Not every entry: the union below forces `value?: undefined` on
+ *    `reset_to_default`, so a DELETE row takes the no-value arm instead.)
  *
- *    ⚠️ Cited by MESSAGE rather than by line, deliberately. The first draft of
- *    this block pinned `admin.ts:3720`/`:3876` and both were stale within the
- *    same round — the line numbers moved when this PR's own helper was added
- *    forty lines above them. A citation that rots is worse than none, because
- *    the next reader checks it, finds unrelated code, and stops trusting the
- *    paragraph that was right.
+ *    ⚠️ Cited by MESSAGE, not line: line pins here went stale within one round,
+ *    and a citation that rots is worse than none.
  *
  *    The redaction is kept as defense in depth, and the honest claim is
  *    narrow: the 403 is the primary control, this is what remains if someone
@@ -74,11 +69,6 @@
  *    unattributable, so `logAdminActionAwait` is the right instrument — for the
  *    reason its own docstring gives about the audit-retention surface, not for
  *    the reason #5262 gave.
- *
- *    ⚠️ Both `db/internal.ts` sites cited by SYMBOL, not line. The first draft
- *    pinned `:874-879` and `:889-898`, which were accurate and in a file this
- *    change does not touch — so they drift independently, which is exactly what
- *    the paragraph below says makes a citation worse than none.
  *
  * ⚠️ **AND THE RULE FLAGS LAND HERE TOO (#5262, the surviving finding).** The
  * row carries `disablesControl` / `widensAuthority` for a
@@ -171,14 +161,16 @@ export type SettingsWriteAction = "update" | "reset_to_default";
  * is ill-typed and the rules answer confidently either way, so the swap is a
  * test's job.
  *
- * ⚠️ **A SWAP IS ONLY VISIBLE FROM THE `update` SIDE**, which is where the tests
- * drive it. Measured against the shipped rules: on `reset_to_default` there is no
+ * ⚠️ **A SWAPPED `rule` IS ONLY VISIBLE FROM THE `update` SIDE**, which is where
+ * the tests drive it. (A swap of the whole ROWS is caught on the clear path
+ * instead, by `metadataAction` — the exact-shape assertion there pins
+ * `action: "reset_to_default"` alongside `judgement`.) Measured against the shipped rules: on `reset_to_default` there is no
  * value, and with `value: undefined` all three rules return `false`/`false`
  * whichever action they are handed — the abuse rule short-circuits on
  * `action !== "set"` *and* on the missing value, the alias source rule's
  * `(value ?? "")` splits to nothing, and the alias threshold rule has its own
- * `value === undefined` guard. So a clear-path-only suite would pass with the two
- * exchanged. Driven from `update`, `ATLAS_TRIAL_IP_RATE_LIMIT_RPM="0"` and
+ * `value === undefined` guard. So a clear-path-only suite would pass with the two `rule`
+ * values exchanged. Driven from `update`, `ATLAS_TRIAL_IP_RATE_LIMIT_RPM="0"` and
  * `ATLAS_BRAIN_ALIAS_AUTO_APPROVE_SOURCES="warehouse_key,extractor"` both go
  * `true → false` under a swap. The axis that hides a swap is the VERB, not the
  * family — recorded because the wrong axis sends the next reader to add a second
@@ -270,8 +262,8 @@ type SettingsAuditMetadataBase = {
 /**
  * The metadata shape that reaches `admin_action_log.metadata` (#5262).
  *
- * ⚠️ **`Partial<SecuritySensitiveAudit>` RATHER THAN THE TWO FLAGS RESTATED, and
- * the restatement was the bug.** The first draft declared `disablesControl?:
+ * ⚠️ **DERIVED FROM {@link RuleFields} RATHER THAN THE FLAGS RESTATED, and the
+ * restatement was the bug.** The first draft declared `disablesControl?:
  * boolean` and `widensAuthority?: boolean` here and copied them across
  * field-by-field. Add a third flag to `SecuritySensitiveAudit` and the pino line
  * would get it for free — `SecuritySensitiveAuditLine extends
@@ -288,22 +280,22 @@ type SettingsAuditMetadataBase = {
  * nesting would move every reader to `metadata->'security'->>'disablesControl'`
  * for no gain the spread does not already give.
  *
- * ⚠️ **`Partial<RuleFields>`, and what that does and does not forbid is worth
- * being exact about.** It replaced `Partial<SecuritySensitiveAudit>` plus a
- * `judgement` declared separately on the base — which meant `judgement` was
- * representable with no flags at all, a row claiming "nobody checked" while
- * claiming no rule applied. Deriving from {@link RuleFields} removes that: the
- * caveat now exists only alongside the flags it qualifies, and a third flag added
- * to {@link SecuritySensitiveAudit} flows in the day it is added.
+ * ⚠️ **`Partial<RuleFields>` FORBIDS NOTHING STRUCTURALLY, and an earlier draft of
+ * this paragraph claimed it forbade a bare `judgement`.** Measured: `Partial` is
+ * homomorphic over `keyof (SecuritySensitiveAudit & { judgement?: … })`, so all
+ * three properties are optional and both
+ * `{ key, tier, judgement: "reverted_value_not_evaluated" }` (nobody checked, and
+ * no rule applied) and `{ key, tier, disablesControl: true }` (half a pair) compile
+ * clean.
  *
- * What it does NOT forbid is one flag without the other. A discriminated union
- * (`RuleFields | all-absent`) would, and was tried: it does not check a
- * spread-built literal — the conditional spreads widen every property to optional,
- * so the compiler cannot prove which arm the object is, and the assignment fails
- * outright. Building both arms as whole literals inside the branch would fix that
- * and is not worth the churn, because the VALUE side is already atomic: the only
- * producer is the `ruleFields` binding, typed `RuleFields | undefined` and spread
- * whole, so no code path can emit a half pair. Do not hand-build one.
+ * What deriving from {@link RuleFields} actually buys is narrower and still worth
+ * having: the caveat is DECLARED next to the flags it qualifies rather than on the
+ * base type, and a third flag added to {@link SecuritySensitiveAudit} flows in the
+ * day it is added.
+ *
+ * The atomicity is on the VALUE side, not the type side: the only producer is the
+ * `ruleFields` binding, typed `RuleFields | undefined` and spread whole, so no code
+ * path can emit a half pair. Do not hand-build one.
  */
 type SettingsAuditMetadata = SettingsAuditMetadataBase & Partial<RuleFields>;
 
@@ -448,29 +440,17 @@ export async function auditSettingsWrite(entry: SettingsAuditWrite): Promise<voi
     entry.value,
   );
 
-  /**
-   * ⚠️ **THE FLAGS AND THEIR CAVEAT, BOUND TOGETHER, because separating them
-   * once was enough.** The first draft spread `ruleFlags` into the metadata and
-   * added `judgement` beside it, then spread `ruleFlags` ALONE into the no-DB
-   * warn below — so on a sensitive clear that branch emitted the `false`/`false`
-   * pair with no caveat, which is the exoneration this marker exists to prevent,
-   * on the one path that has no second record. A review pass caught it one
-   * branch over from the fix.
-   *
-   * One binding rather than two spreads and a rule in prose: every sink that
-   * reports the judgement now reports its limits with it, and a third sink
-   * cannot take the flags without the caveat because there is nothing else to
-   * take.
-   */
+  // The flags travel WITH their caveat: every sink that reports the judgement
+  // reports its limits, and no sink can take one without the other because there
+  // is nothing else to take.
   // ⚠️ ANNOTATED `RuleFields | undefined`, and a nested ternary rather than a
   // conditional spread, because excess-property checking does not reach spread-in
   // properties. Misspelling the field as `judgment` inside a `...(cond ? {…} : {})`
   // lands the typo in the JSONB and makes the documented query return nothing
   // while the row still reads `disablesControl: false`.
   //
-  // ⚠️ **AND `| undefined` RATHER THAN `| Record<never, never>`, which is not a
-  // style choice — it is the difference between the check working and not.**
-  // Measured, both spellings, with the typo applied:
+  // ⚠️ **AND `| undefined`, NOT `| Record<never, never>`.** Measured, both
+  // spellings, with the typo applied:
   //
   //   `RuleFields | Record<never, never>`  ->  0 errors. EPC is skipped entirely
   //                                            when ANY union member is an empty
@@ -478,10 +458,6 @@ export async function auditSettingsWrite(entry: SettingsAuditWrite): Promise<voi
   //                                            lets `const x: {} = { a: 1 }` pass.
   //   `RuleFields | undefined`             ->  TS2561, with a "did you mean
   //                                            'judgement'?" hint.
-  //
-  // The first spelling shipped for one round with a comment claiming it checked
-  // the name. It did not, and only a review pass asking for the measurement
-  // caught it — so the annotation is load-bearing and so is which annotation.
   //
   // `RuleFields` also states the pair-plus-caveat as one type, so the atomicity is
   // declared rather than left as a fact about an inferred union.
@@ -495,13 +471,12 @@ export async function auditSettingsWrite(entry: SettingsAuditWrite): Promise<voi
   const metadata: SettingsAuditMetadata = {
     key: entry.key,
     tier,
-    // ⚠️ A TOTAL `Record`, for the reason `AUDIT_ACTION`'s docstring gives about
-    // itself. This line was a ternary with a silent `{}` default, two statements
-    // below a comment arguing that a ternary is what lets a third verb fall
-    // through — and this is the field where the fall-through actually costs
-    // something: `ADMIN_ACTIONS.settings` has ONE member, so `metadata.action`
-    // is the only thing separating the two verbs in `admin_action_log`. A third
-    // verb would have filed rows indistinguishable from an `update`.
+    // ⚠️ From the total table, for the reason {@link VERBS} gives. This was a
+    // ternary with a silent `{}` default, and this is the field where a
+    // fall-through actually costs something: `ADMIN_ACTIONS.settings` has ONE
+    // member, so `metadata.action` is the only thing separating the two verbs in
+    // `admin_action_log`. A third verb would have filed rows indistinguishable
+    // from an `update`.
     // See {@link VERBS} for why `update` maps to absence.
     ...(verb.metadataAction !== null ? { action: verb.metadataAction } : {}),
     // ⚠️ SPREAD WHOLE, never field-by-field — see {@link SettingsAuditMetadata}.

--- a/packages/api/src/lib/audit/settings-write.ts
+++ b/packages/api/src/lib/audit/settings-write.ts
@@ -215,13 +215,35 @@ const VERBS: Record<
  *
  * The pair is all-or-nothing because `securitySensitiveAuditFields` returns both
  * or `null`; `judgement` is present on a clear of a SECURITY-SENSITIVE key. A
- * clear of any other key produces no `RuleFields` at all — asserted in
- * `settings-write.test.ts`, and the sibling declaration on
- * {@link SettingsAuditMetadataBase} says the same. Naming the shape
- * is what lets the builder write the field as a checked literal instead of an
- * unchecked spread — see the binding for the measured typo hole.
+ * clear of any other key produces no `RuleFields` at all. Naming the shape is what
+ * lets the builder write the field as a checked literal instead of an unchecked
+ * spread — see the binding for the measured typo hole.
  */
 type RuleFields = SecuritySensitiveAudit & {
+  /**
+   * Present only on a clear: the two rule flags describe what the RULE answered,
+   * and for a clear that is structurally `false`/`false` on every key — the rules
+   * judge the WRITTEN value, and a clear has none. What the setting reverts to
+   * (the env var, the default, or a platform override that may itself be wide) is
+   * not evaluated.
+   *
+   * ⚠️ **It exists because `false` would otherwise read as an exoneration.**
+   * Clearing a `"10"` override on `ATLAS_TRIAL_IP_RATE_LIMIT_RPM` when the env var
+   * holds `"0"` turns the per-IP limiter OFF, and the row said
+   * `disablesControl: false`. So the incident query is
+   *
+   * ```sql
+   * WHERE metadata->>'disablesControl' = 'true'
+   *    OR metadata->>'widensAuthority' = 'true'
+   *    OR metadata->>'judgement'       = 'reverted_value_not_evaluated'
+   * ```
+   *
+   * and the last disjunct is the difference between "no weakening" and "nobody
+   * checked". ⚠️ The `widensAuthority` disjunct is not optional: it is the ONLY
+   * flag the alias family ever sets — `disablesControl` is structurally `false` on
+   * both alias keys by design — so a query without it never surfaces an
+   * alias-family WIDENING. It still surfaces alias clears, via the last disjunct.
+   */
   readonly judgement?: "reverted_value_not_evaluated";
 };
 
@@ -238,31 +260,6 @@ type SettingsAuditMetadataBase = {
   readonly key: string;
   readonly tier: "workspace" | "platform";
   readonly action?: "reset_to_default";
-  /**
-   * Present only on a clear of a security-sensitive key: the two rule flags on
-   * {@link SettingsAuditMetadata} describe what the RULE answered, and for a clear that is structurally
-   * `false`/`false` on every key — the rules judge the WRITTEN value, and a
-   * clear has none. What the setting reverts to (the env var, the default, or a
-   * platform override that may itself be wide) is not evaluated.
-   *
-   * ⚠️ **It exists because `false` would otherwise read as an exoneration.**
-   * Clearing a `"10"` override on `ATLAS_TRIAL_IP_RATE_LIMIT_RPM` when the env
-   * var holds `"0"` turns the per-IP limiter OFF, and the row said
-   * `disablesControl: false`. So the incident query is
-   *
-   * ```sql
-   * WHERE metadata->>'disablesControl' = 'true'
-   *    OR metadata->>'widensAuthority' = 'true'
-   *    OR metadata->>'judgement'       = 'reverted_value_not_evaluated'
-   * ```
-   *
-   * and the last disjunct is the difference between "no weakening" and "nobody
-   * checked". ⚠️ The `widensAuthority` disjunct is not optional: it is the ONLY
-   * flag the alias family ever sets — `disablesControl` is structurally `false`
-   * on both alias keys by design — so a query without it never surfaces an
-   * alias-family WIDENING. It still surfaces alias clears, via the last disjunct.
-   */
-  readonly judgement?: "reverted_value_not_evaluated";
   readonly value?: AuditedValue;
   /** Present whenever a value is; `true` means the characters were withheld. */
   readonly valueMasked?: boolean;
@@ -291,12 +288,24 @@ type SettingsAuditMetadataBase = {
  * nesting would move every reader to `metadata->'security'->>'disablesControl'`
  * for no gain the spread does not already give.
  *
- * ⚠️ The flags are all-or-nothing in practice — `securitySensitiveAuditFields`
- * returns both or `null` — which `Partial` cannot express. The spread is what
- * keeps the pair atomic; a hand-built `{ disablesControl: true }` would type-check
- * and mean nothing, so do not build one.
+ * ⚠️ **`Partial<RuleFields>`, and what that does and does not forbid is worth
+ * being exact about.** It replaced `Partial<SecuritySensitiveAudit>` plus a
+ * `judgement` declared separately on the base — which meant `judgement` was
+ * representable with no flags at all, a row claiming "nobody checked" while
+ * claiming no rule applied. Deriving from {@link RuleFields} removes that: the
+ * caveat now exists only alongside the flags it qualifies, and a third flag added
+ * to {@link SecuritySensitiveAudit} flows in the day it is added.
+ *
+ * What it does NOT forbid is one flag without the other. A discriminated union
+ * (`RuleFields | all-absent`) would, and was tried: it does not check a
+ * spread-built literal — the conditional spreads widen every property to optional,
+ * so the compiler cannot prove which arm the object is, and the assignment fails
+ * outright. Building both arms as whole literals inside the branch would fix that
+ * and is not worth the churn, because the VALUE side is already atomic: the only
+ * producer is the `ruleFields` binding, typed `RuleFields | undefined` and spread
+ * whole, so no code path can emit a half pair. Do not hand-build one.
  */
-type SettingsAuditMetadata = SettingsAuditMetadataBase & Partial<SecuritySensitiveAudit>;
+type SettingsAuditMetadata = SettingsAuditMetadataBase & Partial<RuleFields>;
 
 interface SettingsAuditCommon {
   readonly key: string;

--- a/packages/api/src/lib/audit/settings-write.ts
+++ b/packages/api/src/lib/audit/settings-write.ts
@@ -130,6 +130,7 @@ import { logAdminActionAwait } from "@atlas/api/lib/audit/admin";
 import { hasInternalDB } from "@atlas/api/lib/db/internal";
 import { ADMIN_ACTIONS } from "@atlas/api/lib/audit/actions";
 import {
+  definitionMismatchesKey,
   redactAuditValue,
   securitySensitiveAuditFields,
   type AuditedValue,
@@ -150,50 +151,78 @@ const log = createLogger("audit.settings-write");
 export type SettingsWriteAction = "update" | "reset_to_default";
 
 /**
- * The verb vocabularies of the two audit channels, joined here (#5262).
+ * Everything that depends on WHICH VERB produced the row, in one table (#5262).
  *
- * ⚠️ **A TOTAL `Record`, NOT a ternary — which closes a MISSING verb, not a
- * swapped one.**
- * `SettingsWriteAction` is this module's HTTP-verb vocabulary;
- * {@link SettingAuditAction} is the rule engine's. The mapping is one line and
- * is exactly the adjacent pair that goes wrong silently — nothing about
- * `update → clear` is ill-typed, and the rules answer confidently either way.
- * A `Record` keyed by the closed union makes adding a third verb a compile
- * error instead of a fall-through, the same device
- * `SECURITY_SENSITIVE_RULES` uses in `settings.ts`.
+ * ⚠️ **THREE DISPATCHES BECAME ONE, and the third is why.** This module had two
+ * total `Record`s — the rule-engine vocabulary and the row's discriminator — and
+ * then grew an inline `entry.action === "reset_to_default"` ternary for
+ * `judgement`, in the same commit that praised the `Record`s for making a missing
+ * verb a compile error. Adding a third valueless verb would have reddened both
+ * tables and forced a line, while the ternary answered `false` silently: the row
+ * would carry `disablesControl: false, widensAuthority: false` with no caveat on
+ * a write whose value the rules never saw — exactly the false exoneration
+ * `judgement` exists to prevent, reachable by the one edit the tables are
+ * designed for.
  *
- * ⚠️ A SWAP IS ONLY VISIBLE FROM THE `update` SIDE, which is where the tests
- * drive it. Measured against the shipped rules: on `reset_to_default` there is
- * no value, and with `value: undefined` both families return
- * `false`/`false` whichever action they are handed — the abuse rule short-
- * circuits on `action !== "set"` *and* on the missing value, and the alias
- * source rule's `(value ?? "")` splits to nothing. So a reset-path assertion
- * cannot fail on a swapped mapping, and a suite pinning only the clear path
- * would pass with the two exchanged.
+ * `null` rather than `undefined` throughout, so "deliberately absent" is an
+ * answer a third verb has to give rather than the default of forgetting.
  *
- * (#5262's body predicts the swap is "invisible on one of the two families".
- * It is not: driven from `update`, `ATLAS_TRIAL_IP_RATE_LIMIT_RPM="0"` and
+ * ⚠️ It closes a MISSING verb, not a SWAPPED one. Nothing about `update → clear`
+ * is ill-typed and the rules answer confidently either way, so the swap is a
+ * test's job.
+ *
+ * ⚠️ **A SWAP IS ONLY VISIBLE FROM THE `update` SIDE**, which is where the tests
+ * drive it. Measured against the shipped rules: on `reset_to_default` there is no
+ * value, and with `value: undefined` all three rules return `false`/`false`
+ * whichever action they are handed — the abuse rule short-circuits on
+ * `action !== "set"` *and* on the missing value, the alias source rule's
+ * `(value ?? "")` splits to nothing, and the alias threshold rule has its own
+ * `value === undefined` guard. So a clear-path-only suite would pass with the two
+ * exchanged. Driven from `update`, `ATLAS_TRIAL_IP_RATE_LIMIT_RPM="0"` and
  * `ATLAS_BRAIN_ALIAS_AUTO_APPROVE_SOURCES="warehouse_key,extractor"` both go
- * `true → false` under a swap. The axis that hides it is the verb, not the
- * family — recorded because the wrong axis would send the next reader to add a
- * second family instead of a second verb.)
+ * `true → false` under a swap. The axis that hides a swap is the VERB, not the
+ * family — recorded because the wrong axis sends the next reader to add a second
+ * family instead of a second verb.
  */
-const AUDIT_ACTION: Record<SettingsWriteAction, SettingAuditAction> = {
-  update: "set",
-  reset_to_default: "clear",
+const VERBS: Record<
+  SettingsWriteAction,
+  {
+    /** How the rule engine names this verb ({@link SettingAuditAction}). */
+    readonly rule: SettingAuditAction;
+    /**
+     * The row's `metadata.action`. `null` for `update` because absence already
+     * means `update` in every row written before the field existed; labelling it
+     * would split one verb across two spellings and break those rows' readers.
+     */
+    readonly metadataAction: "reset_to_default" | null;
+    /**
+     * The caveat the row carries for a security-sensitive key. `null` where the
+     * rules judged the written value, so no caveat is owed.
+     */
+    readonly judgement: "reverted_value_not_evaluated" | null;
+  }
+> = {
+  update: { rule: "set", metadataAction: null, judgement: null },
+  reset_to_default: {
+    rule: "clear",
+    metadataAction: "reset_to_default",
+    judgement: "reverted_value_not_evaluated",
+  },
 };
 
 /**
- * The row's own verb discriminator, total for the same reason
- * {@link AUDIT_ACTION} is.
+ * The rule flags plus the caveat that qualifies them, as one type.
  *
- * `undefined` for `update` because absence already means `update` in every row
- * written before the field existed — labelling it would split one verb across
- * two spellings and break those rows' readers.
+ * The pair is all-or-nothing because `securitySensitiveAuditFields` returns both
+ * or `null`; `judgement` is present on a clear of a SECURITY-SENSITIVE key. A
+ * clear of any other key produces no `RuleFields` at all — asserted in
+ * `settings-write.test.ts`, and the sibling declaration on
+ * {@link SettingsAuditMetadataBase} says the same. Naming the shape
+ * is what lets the builder write the field as a checked literal instead of an
+ * unchecked spread — see the binding for the measured typo hole.
  */
-const METADATA_ACTION: Record<SettingsWriteAction, SettingsAuditMetadataBase["action"]> = {
-  update: undefined,
-  reset_to_default: "reset_to_default",
+type RuleFields = SecuritySensitiveAudit & {
+  readonly judgement?: "reverted_value_not_evaluated";
 };
 
 /**
@@ -210,8 +239,8 @@ type SettingsAuditMetadataBase = {
   readonly tier: "workspace" | "platform";
   readonly action?: "reset_to_default";
   /**
-   * Present only on a clear of a security-sensitive key: the two flags below
-   * describe what the RULE answered, and for a clear that is structurally
+   * Present only on a clear of a security-sensitive key: the two rule flags on
+   * {@link SettingsAuditMetadata} describe what the RULE answered, and for a clear that is structurally
    * `false`/`false` on every key — the rules judge the WRITTEN value, and a
    * clear has none. What the setting reverts to (the env var, the default, or a
    * platform override that may itself be wide) is not evaluated.
@@ -220,9 +249,18 @@ type SettingsAuditMetadataBase = {
    * Clearing a `"10"` override on `ATLAS_TRIAL_IP_RATE_LIMIT_RPM` when the env
    * var holds `"0"` turns the per-IP limiter OFF, and the row said
    * `disablesControl: false`. So the incident query is
-   * `WHERE metadata->>'disablesControl' = 'true' OR metadata->>'judgement' =
-   * 'reverted_value_not_evaluated'`, and the second disjunct is the difference
-   * between "no weakening" and "nobody checked".
+   *
+   * ```sql
+   * WHERE metadata->>'disablesControl' = 'true'
+   *    OR metadata->>'widensAuthority' = 'true'
+   *    OR metadata->>'judgement'       = 'reverted_value_not_evaluated'
+   * ```
+   *
+   * and the last disjunct is the difference between "no weakening" and "nobody
+   * checked". ⚠️ The `widensAuthority` disjunct is not optional: it is the ONLY
+   * flag the alias family ever sets — `disablesControl` is structurally `false`
+   * on both alias keys by design — so a query without it never surfaces an
+   * alias-family WIDENING. It still surfaces alias clears, via the last disjunct.
    */
   readonly judgement?: "reverted_value_not_evaluated";
   readonly value?: AuditedValue;
@@ -335,8 +373,15 @@ export async function auditSettingsWrite(entry: SettingsAuditWrite): Promise<voi
   // "the call site passed the wrong entry" send an operator to different
   // places — the distinction `AuditMaskReason` exists to draw, and which this
   // module advertised in its type while being unable to produce it.
-  const mismatched = entry.definition !== undefined && entry.definition.key !== entry.key;
-  const redacted = redactAuditValue(mismatched ? undefined : entry.definition, entry.value);
+  const verb = VERBS[entry.action];
+  const redacted = redactAuditValue(entry.key, entry.definition, entry.value);
+  // ⚠️ THE SHARED PREDICATE, not `redacted.maskReason`. Reading the reason off the
+  // redaction looks tidier and is wrong on the clear path: with no value the
+  // decision never consults the definition, so it reports nothing — while the
+  // caller bug is just as real. Deriving it that way silently dropped the warn on
+  // a DELETE, and the test for that arm caught it. `definitionMismatchesKey` is
+  // the one rule; the row's `maskReason` and this warn are its two consumers.
+  const mismatched = definitionMismatchesKey(entry.key, entry.definition);
   const tier = entry.platformTier ? "platform" : "workspace";
 
   // ⚠️ EMITTED UNCONDITIONALLY, AND NOT VIA `maskReason`. The first draft of
@@ -390,7 +435,7 @@ export async function auditSettingsWrite(entry: SettingsAuditWrite): Promise<voi
   // applies" and `false` has to mean "a rule ran and said no".
   const ruleFlags = securitySensitiveAuditFields(
     entry.key,
-    AUDIT_ACTION[entry.action],
+    verb.rule,
     entry.value,
   );
 
@@ -408,15 +453,35 @@ export async function auditSettingsWrite(entry: SettingsAuditWrite): Promise<voi
    * cannot take the flags without the caveat because there is nothing else to
    * take.
    */
-  const ruleFields =
+  // ⚠️ ANNOTATED `RuleFields | undefined`, and a nested ternary rather than a
+  // conditional spread, because excess-property checking does not reach spread-in
+  // properties. Misspelling the field as `judgment` inside a `...(cond ? {…} : {})`
+  // lands the typo in the JSONB and makes the documented query return nothing
+  // while the row still reads `disablesControl: false`.
+  //
+  // ⚠️ **AND `| undefined` RATHER THAN `| Record<never, never>`, which is not a
+  // style choice — it is the difference between the check working and not.**
+  // Measured, both spellings, with the typo applied:
+  //
+  //   `RuleFields | Record<never, never>`  ->  0 errors. EPC is skipped entirely
+  //                                            when ANY union member is an empty
+  //                                            object type, the same rule that
+  //                                            lets `const x: {} = { a: 1 }` pass.
+  //   `RuleFields | undefined`             ->  TS2561, with a "did you mean
+  //                                            'judgement'?" hint.
+  //
+  // The first spelling shipped for one round with a comment claiming it checked
+  // the name. It did not, and only a review pass asking for the measurement
+  // caught it — so the annotation is load-bearing and so is which annotation.
+  //
+  // `RuleFields` also states the pair-plus-caveat as one type, so the atomicity is
+  // declared rather than left as a fact about an inferred union.
+  const ruleFields: RuleFields | undefined =
     ruleFlags === null
-      ? {}
-      : {
-          ...ruleFlags,
-          ...(entry.action === "reset_to_default"
-            ? { judgement: "reverted_value_not_evaluated" as const }
-            : {}),
-        };
+      ? undefined
+      : verb.judgement !== null
+        ? { ...ruleFlags, judgement: verb.judgement }
+        : ruleFlags;
 
   const metadata: SettingsAuditMetadata = {
     key: entry.key,
@@ -428,13 +493,8 @@ export async function auditSettingsWrite(entry: SettingsAuditWrite): Promise<voi
     // something: `ADMIN_ACTIONS.settings` has ONE member, so `metadata.action`
     // is the only thing separating the two verbs in `admin_action_log`. A third
     // verb would have filed rows indistinguishable from an `update`.
-    //
-    // `update` maps to `undefined` rather than a label because absence already
-    // means `update` in every row written before this field existed; giving it a
-    // label would split one verb across two spellings.
-    ...(METADATA_ACTION[entry.action] !== undefined
-      ? { action: METADATA_ACTION[entry.action] }
-      : {}),
+    // See {@link VERBS} for why `update` maps to absence.
+    ...(verb.metadataAction !== null ? { action: verb.metadataAction } : {}),
     // ⚠️ SPREAD WHOLE, never field-by-field — see {@link SettingsAuditMetadata}.
     // Naming the fields here is what let the first draft reproduce #5262's own
     // asymmetry: a third flag added to `SecuritySensitiveAudit` reaches the pino
@@ -442,18 +502,16 @@ export async function auditSettingsWrite(entry: SettingsAuditWrite): Promise<voi
     //
     // `ruleFields`, not `ruleFlags` — the judgement travels with its caveat; see
     // that binding above for the branch that proved they must not be separable.
-    ...ruleFields,
+    ...(ruleFields ?? {}),
     ...(redacted.value !== undefined
       ? {
           value: redacted.value,
           valueMasked: redacted.masked,
-          // `mismatched` needs no disjunct here: it forces the
-          // `undefined`-definition arm, which always sets a `maskReason` when
-          // a value exists — so `redacted.maskReason !== undefined` is
-          // already true whenever this spread is reached.
-          ...(redacted.maskReason !== undefined
-            ? { maskReason: mismatched ? ("definition_mismatch" as const) : redacted.maskReason }
-            : {}),
+          // No fixup: the decision already reported the right reason, so this is
+          // a pass-through. It used to overwrite `maskReason` with a locally
+          // recomputed `definition_mismatch`, which is how the two sinks came to
+          // hold two implementations of one rule.
+          ...(redacted.masked ? { maskReason: redacted.maskReason } : {}),
         }
       : {}),
   };
@@ -473,7 +531,7 @@ export async function auditSettingsWrite(entry: SettingsAuditWrite): Promise<voi
     // computed-then-discarded defect this module fixes forty lines up for
     // `mismatched`, reappearing on the one path that has no second record.
     log.warn(
-      { key: entry.key, tier, action: entry.action, ...ruleFields },
+      { key: entry.key, tier, action: entry.action, ...(ruleFields ?? {}) },
       "Settings write audit row NOT persisted — no internal database configured. The pino line is the only trail for this configuration change.",
     );
     return;
@@ -500,17 +558,10 @@ export async function auditSettingsWrite(entry: SettingsAuditWrite): Promise<voi
   // difference an operator greps for between a committed row and an
   // emitted-then-lost one.
   //
-  // ⚠️ AND OUTSIDE THE CALLER'S FAILURE DOMAIN. Both routes wrap this whole
-  // function in a try whose catch returns a 500 reading "the setting changed but
-  // was not recorded". A throw from THIS line — a pino serializer fault, a
-  // transport error — would therefore convert a row that DID commit into a 500
-  // whose every word is false, which is the lying-disclosure shape the 500 copy
-  // was written to avoid. The row is already durable by here; nothing about it
-  // depends on the line being emitted.
-  try {
-    log.info({ key: entry.key, tier, action: entry.action }, "Settings write audit row COMMITTED");
-  } catch {
-    // intentionally ignored: the row is committed. Reporting a logging fault to
-    // the caller would make it tell the admin the audit was lost when it was not.
-  }
+  // ⚠️ NOT wrapped in a try/catch. Swallowing a fault here would make this line's
+  // ABSENCE ambiguous between "the row was lost" and "the logger faulted", and the
+  // absence is the whole signal. If a synchronous throw is ever observed, the fix
+  // is a `console.error` fallback that keeps the COMMITTED fact recorded — not a
+  // silent catch.
+  log.info({ key: entry.key, tier, action: entry.action }, "Settings write audit row COMMITTED");
 }

--- a/packages/api/src/lib/audit/settings-write.ts
+++ b/packages/api/src/lib/audit/settings-write.ts
@@ -70,6 +70,19 @@
  *    right instrument — for the reason its own docstring gives about the
  *    audit-retention surface, not for the reason #5262 gave.
  *
+ * ⚠️ **AND THE RULE FLAGS LAND HERE TOO (#5262, the surviving finding).** The
+ * row carries `disablesControl` / `widensAuthority` for a
+ * `SECURITY_SENSITIVE_KEYS` member, so the durable channel holds the JUDGEMENT
+ * and not only the fact. Before that the split was backwards — the pino
+ * `security_setting.changed` line had the analysis and `admin_action_log` had
+ * the value — which meant reading *"that disabled an abuse control"* out of the
+ * retained table required reimplementing the rules against it. Folded in at this
+ * seam precisely because it already holds `key`, `definition`, `value` and
+ * `action`: no new sink, and no second classification of "which writes are
+ * weakening" to drift from the first. The two callers of
+ * `securitySensitiveAuditFields` are both in `lib/` (the pino builder in
+ * `settings.ts` and this one); the route layer has none.
+ *
  * ⚠️ **WHY THE WHOLE ENTRY IS BUILT HERE rather than at the route.** The
  * redaction is not something a call site can be trusted to remember: #5180
  * measured that re-inlining `log.warn({ ...line, value })` passed the whole
@@ -103,8 +116,10 @@ import { hasInternalDB } from "@atlas/api/lib/db/internal";
 import { ADMIN_ACTIONS } from "@atlas/api/lib/audit/actions";
 import {
   redactAuditValue,
+  securitySensitiveAuditFields,
   type AuditedValue,
   type AuditMaskReason,
+  type SettingAuditAction,
   type SettingDefinition,
 } from "@atlas/api/lib/settings";
 
@@ -117,6 +132,39 @@ const log = createLogger("audit.settings-write");
  * exactly as secret as the override was.
  */
 export type SettingsWriteAction = "update" | "reset_to_default";
+
+/**
+ * The verb vocabularies of the two audit channels, joined here (#5262).
+ *
+ * ⚠️ **A TOTAL `Record`, NOT a ternary, and that is the only defence there is.**
+ * `SettingsWriteAction` is this module's HTTP-verb vocabulary;
+ * {@link SettingAuditAction} is the rule engine's. The mapping is one line and
+ * is exactly the adjacent pair that goes wrong silently — nothing about
+ * `update → clear` is ill-typed, and the rules answer confidently either way.
+ * A `Record` keyed by the closed union makes adding a third verb a compile
+ * error instead of a fall-through, the same device
+ * `SECURITY_SENSITIVE_RULES` uses in `settings.ts`.
+ *
+ * ⚠️ A SWAP IS ONLY VISIBLE FROM THE `update` SIDE, which is where the tests
+ * drive it. Measured against the shipped rules: on `reset_to_default` there is
+ * no value, and with `value: undefined` both families return
+ * `false`/`false` whichever action they are handed — the abuse rule short-
+ * circuits on `action !== "set"` *and* on the missing value, and the alias
+ * source rule's `(value ?? "")` splits to nothing. So a reset-path assertion
+ * cannot fail on a swapped mapping, and a suite pinning only the clear path
+ * would pass with the two exchanged.
+ *
+ * (#5262's body predicts the swap is "invisible on one of the two families".
+ * It is not: driven from `update`, `ATLAS_TRIAL_IP_RATE_LIMIT_RPM="0"` and
+ * `ATLAS_BRAIN_ALIAS_AUTO_APPROVE_SOURCES="warehouse_key,extractor"` both go
+ * `true → false` under a swap. The axis that hides it is the verb, not the
+ * family — recorded because the wrong axis would send the next reader to add a
+ * second family instead of a second verb.)
+ */
+const AUDIT_ACTION: Record<SettingsWriteAction, SettingAuditAction> = {
+  update: "set",
+  reset_to_default: "clear",
+};
 
 /**
  * The metadata shape that reaches `admin_action_log.metadata`.
@@ -135,6 +183,19 @@ type SettingsAuditMetadata = {
   readonly valueMasked?: boolean;
   /** Present only when `valueMasked` is true. */
   readonly maskReason?: AuditMaskReason;
+  /**
+   * An abuse control was turned OFF by this write (#5262). Always absent for a
+   * key outside {@link SECURITY_SENSITIVE_KEYS}, and always `false` for the
+   * alias keys — whose disabled position queues everything for review, i.e. the
+   * SAFE end. See `securitySensitiveAuditFields` for why the rules are per-key.
+   */
+  readonly disablesControl?: boolean;
+  /**
+   * More proposals now auto-approve with nobody in front of them (#5262).
+   * Always absent for a non-sensitive key, always `false` for the abuse
+   * thresholds, which have no such notion.
+   */
+  readonly widensAuthority?: boolean;
 };
 
 interface SettingsAuditCommon {
@@ -241,10 +302,46 @@ export async function auditSettingsWrite(entry: SettingsAuditWrite): Promise<voi
     );
   }
 
+  // ⚠️ **THE JUDGEMENT, IN THE DURABLE CHANNEL (#5262).** Before this the split
+  // was backwards: the pino `security_setting.changed` line carried
+  // `disablesControl`/`widensAuthority` while `admin_action_log` carried the
+  // value — so the SUPPRESSIBLE channel held the analysis and the RETAINED one
+  // held only the fact. An incident query could see *"someone set
+  // ATLAS_TRIAL_IP_RATE_LIMIT_RPM to 0"* and not *"that disabled an abuse
+  // control"*, and the only way to learn the second was to reimplement
+  // `securitySensitiveAuditFields` against the row — a second classification of
+  // "which writes are weakening", which is a second thing that drifts from the
+  // first.
+  //
+  // ⚠️ Computed from `entry.key`, NOT from `entry.definition` — so the mismatch
+  // above does not touch it, and that is correct rather than an oversight. The
+  // rules key off the setting's NAME and the written value; a definition
+  // belonging to another key is evidence about neither. The value's characters
+  // may be withheld from the row while the judgement derived from them is
+  // recorded in full, which is the whole point: the analysis is the part worth
+  // retaining.
+  //
+  // ⚠️ `null` for a non-sensitive key, and the flags are then ABSENT rather than
+  // `false`. A row that always carries `disablesControl: false` cannot be
+  // filtered on — `WHERE metadata->>'disablesControl' = 'false'` would match
+  // every settings write in the table — so absence has to mean "no rule
+  // applies" and `false` has to mean "a rule ran and said no".
+  const ruleFlags = securitySensitiveAuditFields(
+    entry.key,
+    AUDIT_ACTION[entry.action],
+    entry.value,
+  );
+
   const metadata: SettingsAuditMetadata = {
     key: entry.key,
     tier,
     ...(entry.action === "reset_to_default" ? { action: "reset_to_default" as const } : {}),
+    ...(ruleFlags !== null
+      ? {
+          disablesControl: ruleFlags.disablesControl,
+          widensAuthority: ruleFlags.widensAuthority,
+        }
+      : {}),
     ...(redacted.value !== undefined
       ? {
           value: redacted.value,

--- a/packages/api/src/lib/brain/ingest/__tests__/outlook-connector.test.ts
+++ b/packages/api/src/lib/brain/ingest/__tests__/outlook-connector.test.ts
@@ -44,7 +44,11 @@ void mock.module("@atlas/api/lib/settings", () => ({
   refreshSettingsTick: async () => {},
   isHotReloadedKey: () => false,
   isSaasModeForGuard: () => false,
-  securitySensitiveAuditFields: () => ({}),
+  // `null`, matching `SecuritySensitiveAudit | null`. A truthy `{}` passes
+  // `auditSettingsWrite`'s `!== null` guard and then reads properties off an
+  // empty object — unreachable from this suite, and reported by nothing, because
+  // `mock.module` factories are untyped.
+  securitySensitiveAuditFields: () => null,
   _resetSettingsCache: () => {},
   HOT_RELOADED_KEYS: new Set<string>(),
   SECURITY_SENSITIVE_KEYS: new Set<string>(),

--- a/packages/api/src/lib/brain/ingest/__tests__/slack-connector.test.ts
+++ b/packages/api/src/lib/brain/ingest/__tests__/slack-connector.test.ts
@@ -42,7 +42,11 @@ void mock.module("@atlas/api/lib/settings", () => ({
   refreshSettingsTick: async () => {},
   isHotReloadedKey: () => false,
   isSaasModeForGuard: () => false,
-  securitySensitiveAuditFields: () => ({}),
+  // `null`, matching `SecuritySensitiveAudit | null`. A truthy `{}` passes
+  // `auditSettingsWrite`'s `!== null` guard and then reads properties off an
+  // empty object — unreachable from this suite, and reported by nothing, because
+  // `mock.module` factories are untyped.
+  securitySensitiveAuditFields: () => null,
   _resetSettingsCache: () => {},
   HOT_RELOADED_KEYS: new Set<string>(),
   SECURITY_SENSITIVE_KEYS: new Set<string>(),

--- a/packages/api/src/lib/brain/ingest/__tests__/zoom-connector.test.ts
+++ b/packages/api/src/lib/brain/ingest/__tests__/zoom-connector.test.ts
@@ -46,7 +46,11 @@ void mock.module("@atlas/api/lib/settings", () => ({
   refreshSettingsTick: async () => {},
   isHotReloadedKey: () => false,
   isSaasModeForGuard: () => false,
-  securitySensitiveAuditFields: () => ({}),
+  // `null`, matching `SecuritySensitiveAudit | null`. A truthy `{}` passes
+  // `auditSettingsWrite`'s `!== null` guard and then reads properties off an
+  // empty object — unreachable from this suite, and reported by nothing, because
+  // `mock.module` factories are untyped.
+  securitySensitiveAuditFields: () => null,
   _resetSettingsCache: () => {},
   HOT_RELOADED_KEYS: new Set<string>(),
   SECURITY_SENSITIVE_KEYS: new Set<string>(),

--- a/packages/api/src/lib/settings.ts
+++ b/packages/api/src/lib/settings.ts
@@ -3227,6 +3227,46 @@ export interface RedactedAuditValue {
  * `[withheld:secret-setting]`, so `undefined` singled the empty one out and
  * disclosed it exactly. Uniformity is the property; `action` carries set-vs-
  * clear, which is the distinction that was worth keeping.
+ *
+ * ⚠️ **THREE SINKS NOW, AND THE `Audit` IN THE NAME IS THE NARROWER WORD.**
+ * #5263 asked whether the sink-generic name had become a liability once a
+ * second sink adopted it — the #5180 review called it "a latent invitation".
+ * The answer taken, deliberately, is that the trade GENERALISES and the name
+ * stays:
+ *
+ * - the pino `security_setting.changed` line ({@link securitySensitiveAuditLine})
+ * - the `admin_action_log.metadata` row (`lib/audit/settings-write.ts`)
+ * - the settings `PUT` 200 body (`api/routes/admin.ts`, #5263)
+ *
+ * Renaming it to say which sink it serves was the alternative, and it is not
+ * available: it serves three, and one of them is not an audit. The trade being
+ * inherited is *withhold every character rather than reveal some* — see
+ * {@link REDACTED_AUDIT_VALUE} for why that is not {@link maskSecret} — and it
+ * holds at the response too, for a reason worth stating rather than assuming.
+ * The `PUT` caller already holds the value it just sent, so withholding it in
+ * the echo costs that caller nothing; what the echo owes is *what is now
+ * stored*, and `valueMasked` says the characters were withheld rather than
+ * leaving the placeholder indistinguishable from a literal.
+ *
+ * What does NOT generalise is any reading of the brand as a clearance —
+ * {@link AuditedValue}'s last paragraph is the standing warning, and a fourth
+ * sink with a different audience owes the same paragraph this one does.
+ */
+export function redactAuditValue(
+  def: SettingDefinition | undefined,
+  value: string,
+): RedactedAuditValue & { readonly value: AuditedValue };
+export function redactAuditValue(
+  def: SettingDefinition | undefined,
+  value: string | undefined,
+): RedactedAuditValue;
+/**
+ * ⚠️ The overload above is the only reason a caller holding a `string` can put
+ * the result straight into a non-optional field. `value: undefined` is the sole
+ * input producing `value: undefined` — read the arms below — so a present input
+ * yields a present {@link AuditedValue}, and saying so in the signature is what
+ * keeps the `PUT` response from needing a `?? rawValue` fallback to satisfy its
+ * schema. That fallback is the whole defect written as a type workaround.
  */
 export function redactAuditValue(
   def: SettingDefinition | undefined,
@@ -3246,6 +3286,51 @@ export function redactAuditValue(
     return { value: audited(REDACTED_AUDIT_VALUE), masked: true, maskReason: "secret" };
   }
   return { value: audited(value), masked: false, maskReason: undefined };
+}
+
+/** The 200 body `PUT /admin/settings/{key}` returns (#5263). */
+export interface SettingUpdateResponse {
+  readonly success: true;
+  readonly key: string;
+  /**
+   * What is now stored, as {@link redactAuditValue} permits it to be echoed —
+   * NOT the request's value played back. Read it with `valueMasked`.
+   */
+  readonly value: AuditedValue;
+  /** True when `value` is the withheld placeholder rather than the characters. */
+  readonly valueMasked: boolean;
+}
+
+/**
+ * Build the settings `PUT` 200 body, withholding a `secret: true` value (#5263).
+ *
+ * ⚠️ **A BUILDER RATHER THAN THREE LINES AT THE ROUTE, for the one reason that
+ * survives: it is the only way to MEASURE the secret arm.** The route 403s a
+ * `secret: true` key before any response body exists, so no request can carry a
+ * secret value to the echo — an assertion written against the route can only
+ * ever exercise the verbatim arm, which passes identically with the fix and
+ * without it. That is #5180's accidental-equality trap arriving one sink later.
+ * Pulled out here, the secret arm takes a real registry definition
+ * (`RESEND_API_KEY`) in a unit test and the plaintext's absence is a measured
+ * fact instead of an argument.
+ *
+ * ⚠️ It does NOT close the route inlining `{ success: true, key, value }` again.
+ * Nothing can: the 200 schema's `value` is `z.string()` and {@link AuditedValue}
+ * is assignable to `string`, so — measured by compiling the raw spelling against
+ * the schema — the echo type-checks clean either way. Branding the schema was
+ * the alternative and costs the OpenAPI generator a type it cannot render. So
+ * that spelling is closed by a test in `admin-settings.test.ts` asserting the
+ * response IS this builder's output, which is the same split
+ * {@link AuditedValue} documents: a type for the seam-preserving edit, a test
+ * for the seam-removing one.
+ */
+export function settingUpdateResponseBody(
+  def: SettingDefinition | undefined,
+  key: string,
+  value: string,
+): SettingUpdateResponse {
+  const audited = redactAuditValue(def, value);
+  return { success: true, key, value: audited.value, valueMasked: audited.masked };
 }
 
 /** The full structured payload {@link auditSecuritySensitiveChange} logs. */

--- a/packages/api/src/lib/settings.ts
+++ b/packages/api/src/lib/settings.ts
@@ -2537,6 +2537,17 @@ export async function setSetting(key: string, value: string, userId?: string, or
   // side effect produces, so the ordering is free. No handler throws today —
   // the only one catches internally — which makes this cheap insurance rather
   // than a live fix.
+  //
+  // ⚠️ **THIS ORDERING ARGUMENT COVERS THE PINO LINE ONLY, and it was written when
+  // that was the only audit.** Since #5262 the DURABLE `admin_action_log` row is
+  // filed by the CALLER, after `setSetting` returns — so a throw from
+  // `applySettingSideEffect` below, or from the caller's own `log.info`, escapes
+  // the route's `SaasImmutableSettingError`-only catch, reaches `runHandler`, and
+  // returns the GENERIC 500. That 500 implies the write did not land while the
+  // setting is live and no row was filed, which is the opposite of what
+  // `settingsAuditFailureBody` was written to say. Insurance-only today for the
+  // same reason as above; the point is that the reasoning here no longer reaches
+  // the row that matters most.
   auditSecuritySensitiveChange(key, "set", value, userId, effectiveOrgId);
 
   // Apply runtime side effects for hot-reloadable settings
@@ -2885,11 +2896,9 @@ function isSaasImmutableKey(key: string): key is SaasImmutableKey {
  */
 /**
  * What a settings write did: persisted a value, or removed the override and
- * reverted to the next tier. One definition rather than a copy at every consumer
- * — the audit rule, the flag decision, the payload, the builder input, the
- * emitter and `settings-write.ts`'s verb mapping all have to agree, and a third
- * action would otherwise drift. (The count that stood here said "five"; #5262's
- * `AUDIT_ACTION` made it six, which is why it is no longer a number.)
+ * reverted to the next tier. One definition rather than a copy at every consumer,
+ * all of which have to agree — a count stood here and #5262 invalidated it, which
+ * is why there is no longer a count or a list.
  */
 export type SettingAuditAction = "set" | "clear";
 
@@ -3487,6 +3496,18 @@ export interface SecuritySensitiveAuditLine extends SecuritySensitiveAudit {
   readonly maskReason: AuditMaskReason | undefined;
   readonly actorId: string | undefined;
   readonly orgId: string | undefined;
+  /**
+   * Why the two rule flags cannot be read as an exoneration, when they cannot.
+   *
+   * ⚠️ **THE SAME CAVEAT THE DURABLE ROW CARRIES, for symmetry that is the whole
+   * point of #5262.** On a `clear` every rule short-circuits and returns
+   * `false`/`false` — accurate about what the rule answered, and read by an
+   * operator as "this write weakened nothing", which the rules explicitly decline
+   * to establish for a clear. The value is derivable from `action` here, so this
+   * is discoverability rather than new information; it exists so a reader of
+   * either channel does not have to know that.
+   */
+  readonly judgement?: "reverted_value_not_evaluated";
   readonly event: "security_setting.changed";
 }
 
@@ -3555,7 +3576,8 @@ export interface SecuritySensitiveAuditInput {
  * Neither closes it alone: removing the seam removes the type, and the test only
  * became possible once it stopped assuming the registry was fixed — flipping a
  * definition to `secret: true` for one test makes raw and redacted differ on a
- * fully reachable input.
+ * input that is reachable once a `secret: true` key joins
+ * {@link SECURITY_SENSITIVE_KEYS}, which this module explicitly permits.
  */
 export function securitySensitiveAuditLine(
   input: SecuritySensitiveAuditInput,
@@ -3582,6 +3604,9 @@ export function securitySensitiveAuditLine(
     value: redacted.value,
     valueMasked: redacted.masked,
     maskReason: redacted.maskReason,
+    // Mirrors `auditSettingsWrite`'s row: a clear cannot be exonerated by flags
+    // that only judge a written value.
+    ...(action === "clear" ? { judgement: "reverted_value_not_evaluated" as const } : {}),
     disablesControl: fields.disablesControl,
     widensAuthority: fields.widensAuthority,
     actorId,

--- a/packages/api/src/lib/settings.ts
+++ b/packages/api/src/lib/settings.ts
@@ -3196,13 +3196,32 @@ declare const auditedValueBrand: unique symbol;
  */
 export type AuditedValue = string & { readonly [auditedValueBrand]: true };
 
-/** {@link redactAuditValue}'s decision: what to log, and why. */
-export interface RedactedAuditValue {
-  readonly value: AuditedValue | undefined;
-  readonly masked: boolean;
-  /** `undefined` exactly when `masked` is false. */
-  readonly maskReason: AuditMaskReason | undefined;
-}
+/**
+ * {@link redactAuditValue}'s decision: what to log, and why.
+ *
+ * ⚠️ **A UNION, so the correlation between the three fields is a compiler fact.**
+ * It was an interface with `masked: boolean` and a docstring reading
+ * "`maskReason` is `undefined` exactly when `masked` is false" — a biconditional
+ * enforced by nothing, which `settings-write.ts` then spent a comment deriving a
+ * consequence of. Worse, the prose was already violated: on a clear with a
+ * mismatched definition, {@link securitySensitiveAuditLine} produced
+ * `masked: false` WITH a `maskReason`, because it rebuilt the reason after the
+ * decision had discarded it.
+ *
+ * As a union, `masked: true` implies both a present `maskReason` and a present
+ * value, and `if (redacted.masked)` narrows all three at once.
+ */
+export type RedactedAuditValue =
+  | {
+      readonly value: AuditedValue | undefined;
+      readonly masked: false;
+      readonly maskReason?: undefined;
+    }
+  | {
+      readonly value: AuditedValue;
+      readonly masked: true;
+      readonly maskReason: AuditMaskReason;
+    };
 
 /**
  * The written value as an audit line may record it (#5180), plus whether — and
@@ -3280,7 +3299,34 @@ export interface RedactedAuditValue {
  * With the arms behind this annotated return type, that edit is `TS2322` here,
  * on the day it is written. Nothing about the decision moved; only who checks it.
  */
-function redactPresentAuditValue(
+/**
+ * Does this definition belong to this key?
+ *
+ * ⚠️ **ONE PREDICATE, TWO QUESTIONS, and conflating them caused a regression.**
+ * The wrong-key condition is asked for two different purposes:
+ *
+ * - *what reason to record for a withheld value* — {@link redactPresentAuditValue}
+ * - *whether the CALLER has a bug* — `auditSettingsWrite`'s unconditional warn
+ *
+ * An attempt to serve the second by reading the first's `maskReason` broke the
+ * clear path: with no value there is nothing to redact, so the decision never
+ * consults the definition and reports no reason — while the caller bug is just as
+ * real and just as worth warning about. A definition mismatch on a DELETE was
+ * silently dropped, which is the defect `auditSettingsWrite`'s own warn exists to
+ * prevent, and an existing test caught it.
+ *
+ * So the predicate is shared and the two uses stay separate. That is still one
+ * source of truth — what it is not is one call site.
+ */
+export function definitionMismatchesKey(
+  key: string,
+  def: SettingDefinition | undefined,
+): boolean {
+  return def !== undefined && def.key !== key;
+}
+
+export function redactPresentAuditValue(
+  key: string,
   def: SettingDefinition | undefined,
   value: string,
 ): RedactedAuditValue & { readonly value: AuditedValue } {
@@ -3293,37 +3339,49 @@ function redactPresentAuditValue(
   if (def === undefined) {
     return { value: audited(REDACTED_AUDIT_VALUE), masked: true, maskReason: "unknown_definition" };
   }
+  // ⚠️ BEFORE the `secret` arm, and the order is observable: a definition that is
+  // both mismatched and secret reports `definition_mismatch`, because the caller
+  // bug is the actionable fact and the secrecy of someone else's key is not
+  // evidence about this one. That is the order the three call sites produced by
+  // hand, preserved here so centralising is behaviour-neutral.
+  if (definitionMismatchesKey(key, def)) {
+    return {
+      value: audited(REDACTED_AUDIT_VALUE),
+      masked: true,
+      maskReason: "definition_mismatch",
+    };
+  }
   if (def.secret === true) {
     return { value: audited(REDACTED_AUDIT_VALUE), masked: true, maskReason: "secret" };
   }
   return { value: audited(value), masked: false, maskReason: undefined };
 }
 
-export function redactAuditValue(
-  def: SettingDefinition | undefined,
-  value: string,
-): RedactedAuditValue & { readonly value: AuditedValue };
-export function redactAuditValue(
-  def: SettingDefinition | undefined,
-  value: string | undefined,
-): RedactedAuditValue;
 /**
- * ⚠️ The overload above is the only reason a caller holding a `string` can put
- * the result straight into a non-optional field. `value: undefined` is the sole
- * input producing `value: undefined` — the one arm below — so a present input
- * yields a present {@link AuditedValue}, and saying so in the signature is what
- * keeps the `PUT` response from needing a `?? rawValue` fallback to satisfy its
- * schema. That fallback is the whole defect written as a type workaround.
+ * The written value as an audit line may record it, plus whether — and why — it
+ * was withheld. Takes the KEY as well as the definition, so the decision owns
+ * every reason it can report.
  *
- * The promise is CHECKED rather than asserted: every present-value arm lives in
- * {@link redactPresentAuditValue} behind an annotated return type.
+ * ⚠️ **NO OVERLOADS, deliberately, and a round of review was spent learning
+ * why.** This had a narrow `(def, value: string)` overload promising a present
+ * {@link AuditedValue}. TypeScript checks an overload against the IMPLEMENTATION
+ * signature bivariantly, so the promise was never verified against any arm — and
+ * the wrapper's own body was the natural home for the edit that breaks it
+ * (`value === "" ⇒ undefined`, which this file's history shows was shipped once).
+ * Measured: adding that arm to the wrapper produced ZERO type errors.
+ *
+ * A caller holding a `string` calls {@link redactPresentAuditValue} directly and
+ * gets a checked non-optional value. This function is the wide entry for callers
+ * whose value may be absent. Nothing asserts a return the compiler has not
+ * checked.
  */
 export function redactAuditValue(
+  key: string,
   def: SettingDefinition | undefined,
   value: string | undefined,
 ): RedactedAuditValue {
   if (value === undefined) return { value: undefined, masked: false, maskReason: undefined };
-  return redactPresentAuditValue(def, value);
+  return redactPresentAuditValue(key, def, value);
 }
 
 /** The 200 body `PUT /admin/settings/{key}` returns (#5263). */
@@ -3337,6 +3395,17 @@ export interface SettingUpdateResponse {
   readonly value: AuditedValue;
   /** True when `value` is the withheld placeholder rather than the characters. */
   readonly valueMasked: boolean;
+  /**
+   * Why it was withheld, when it was. Present exactly when `valueMasked` is true.
+   *
+   * ⚠️ **THE HUMAN-FACING SINK IS THE ONE THAT MOST NEEDS IT, and it shipped
+   * without it.** The placeholder is `[withheld:secret-setting]`, so an admin who
+   * just set a NON-secret key whose definition failed the key check was told
+   * their setting was withheld as a *secret* — a wrong message, not merely a
+   * generic one. The other two sinks carry a `maskReason`; this one had no field
+   * to put it in.
+   */
+  readonly maskReason?: AuditMaskReason;
 }
 
 /**
@@ -3377,23 +3446,21 @@ export function settingUpdateResponseBody(
   key: string,
   value: string,
 ): SettingUpdateResponse {
-  // ⚠️ THE SAME DISCARD `auditSettingsWrite` APPLIES, and it is here because the
-  // first draft of this function did not have it while claiming the two sinks
-  // "cannot disagree". They could. The seam withholds on a definition belonging
-  // to another key; this builder had no such check, so the invariant actually
-  // holding the two together was unstated and in a third place — `SETTINGS_MAP`
-  // is keyed by `def.key`, making `mismatched` always false at today's route.
-  //
-  // That invariant moves in a normal-looking change: `getSettingDefinition`
-  // gaining alias or rename resolution, so `ATLAS_OLD_NAME` returns the new
-  // entry. At that moment the audit row would withhold the characters and record
-  // `maskReason: "definition_mismatch"` while this body echoed the plaintext —
-  // the third sink leaking exactly what #5263 closed, in the one input class the
-  // seam was hardened against. Applying the discard makes the two agree by
-  // construction instead of by a coincidence documented nowhere.
-  const mismatched = def !== undefined && def.key !== key;
-  const audited = redactAuditValue(mismatched ? undefined : def, value);
-  return { success: true, key, value: audited.value, valueMasked: audited.masked };
+  // ⚠️ NO LOCAL MISMATCH CHECK — the decision owns it. This function briefly had
+  // a hand-copied `def.key !== key` guard, which made it the THIRD copy of one
+  // rule and the only copy that could not report the reason it found, because
+  // `SettingUpdateResponse` had no field for it. Both are fixed at the source:
+  // `redactPresentAuditValue` returns `definition_mismatch` itself, so the echo
+  // and the audit row now agree because they are the SAME decision rather than
+  // two implementations of it.
+  const audited = redactPresentAuditValue(key, def, value);
+  return {
+    success: true,
+    key,
+    value: audited.value,
+    valueMasked: audited.masked,
+    ...(audited.masked ? { maskReason: audited.maskReason } : {}),
+  };
 }
 
 /** The full structured payload {@link auditSecuritySensitiveChange} logs. */
@@ -3496,27 +3563,25 @@ export function securitySensitiveAuditLine(
   const { key, action, value, actorId, orgId } = input;
   const fields = securitySensitiveAuditFields(key, action, value);
   if (!fields) return null;
-  // A definition belonging to some OTHER key tells us nothing about this one,
-  // so it is discarded rather than trusted, and `redactAuditValue` fails closed
-  // on the `undefined`.
+  // ⚠️ The wrong-key check lives in the decision now, not here. This site used to
+  // discard the definition and then REBUILD the reason below — which is how the
+  // union's `masked: false` + present `maskReason` state became reachable on a
+  // clear. One call, one reason, no fixup.
   //
-  // ⚠️ This closes "someone else's definition". It structurally CANNOT close
-  // "this key's definition, lying about `secret`": the compiling spelling is
-  // `{ ...def, secret: false }`, which passes the check and reaches the verbatim
-  // arm. Two tests cover it from opposite ends — `definitionWithSecret` in
-  // `settings.test.ts` builds that spread and drives the builder with it, and
-  // the registry-flip block in `settings-audit-log.test.ts` mutates the shipped
-  // definition so redacted and raw differ on a reachable input.
-  const mismatched = input.definition !== undefined && input.definition.key !== key;
-  const redacted = redactAuditValue(mismatched ? undefined : input.definition, value);
+  // It structurally CANNOT close "this key's definition, lying about `secret`":
+  // the compiling spelling is `{ ...def, secret: false }`, which passes the key
+  // check and reaches the verbatim arm. Two tests cover that from opposite ends —
+  // `definitionWithSecret` in `settings.test.ts` builds the spread and drives the
+  // builder with it, and the registry-flip block in `settings-audit-log.test.ts`
+  // mutates the shipped definition so redacted and raw differ on a reachable
+  // input.
+  const redacted = redactAuditValue(key, input.definition, value);
   return {
     key,
     action,
     value: redacted.value,
     valueMasked: redacted.masked,
-    // A mismatch is a caller bug, not registry drift; reporting it as drift
-    // sends the operator to grep a registry where the key is present and fine.
-    maskReason: mismatched ? "definition_mismatch" : redacted.maskReason,
+    maskReason: redacted.maskReason,
     disablesControl: fields.disablesControl,
     widensAuthority: fields.widensAuthority,
     actorId,

--- a/packages/api/src/lib/settings.ts
+++ b/packages/api/src/lib/settings.ts
@@ -2891,8 +2891,13 @@ function isSaasImmutableKey(key: string): key is SaasImmutableKey {
  *   Membership is the audit half of #5161; `saasVisible: false` on the defs is
  *   the access half.
  *
- * Adding a family means adding a rule in {@link SECURITY_SENSITIVE_RULES}; the
- * table below IS the key set, so there is no way to join one without the other.
+ * Adding a family means adding a rule in {@link SECURITY_SENSITIVE_RULES}. The
+ * `as const` literal IS the key set and the rules are a `Record` over it, so a key
+ * without a rule — or a rule without a key — is a compile error.
+ *
+ * ⚠️ This block documents {@link SECURITY_SENSITIVE_KEYS_LITERAL}, which is
+ * declared further down the file; it sits here for reading order, not because it
+ * attaches to the declaration below it.
  */
 /**
  * What a settings write did: persisted a value, or removed the override and
@@ -3233,12 +3238,82 @@ export type RedactedAuditValue =
     };
 
 /**
- * The written value as an audit line may record it (#5180), plus whether — and
- * why — it was withheld.
+ * Does this definition belong to this key?
  *
- * Takes the DEFINITION rather than the key on purpose: the decision genuinely
- * depends on `def.secret`, and passing `undefined` explicitly is what makes the
- * fail-closed contract legible — and testable — at the call site.
+ * ⚠️ **ONE PREDICATE, TWO QUESTIONS, and conflating them caused a regression.**
+ * The wrong-key condition is asked for two different purposes:
+ *
+ * - *what reason to record for a withheld value* — {@link redactPresentAuditValue}
+ * - *whether the CALLER has a bug* — `auditSettingsWrite`'s unconditional warn
+ *
+ * An attempt to serve the second by reading the first's `maskReason` broke the
+ * clear path: with no value there is nothing to redact, so the decision never
+ * consults the definition and reports no reason — while the caller bug is just as
+ * real and just as worth warning about. A definition mismatch on a DELETE was
+ * silently dropped, which is the defect `auditSettingsWrite`'s own warn exists to
+ * prevent, and an existing test caught it.
+ *
+ * So the predicate is shared and the two uses stay separate. That is still one
+ * source of truth — what it is not is one call site.
+ */
+export function definitionMismatchesKey(
+  key: string,
+  def: SettingDefinition | undefined,
+): boolean {
+  return def !== undefined && def.key !== key;
+}
+
+/**
+ * The present-value arms, annotated so the non-optional `value` is CHECKED rather
+ * than asserted.
+ *
+ * ⚠️ **An overload is an unchecked claim, and this one had already been broken
+ * once.** TypeScript compares an overload signature to the IMPLEMENTATION
+ * signature bivariantly, so a wide `RedactedAuditValue` implementation satisfies
+ * a narrow `… & { value: AuditedValue }` overload without any arm being
+ * verified. The docstring below records that an earlier draft returned
+ * `undefined` for `""` — re-adding that arm reads as tidying, would have
+ * type-checked clean, and would have shipped a 200 body missing a field the
+ * published spec marks `required`.
+ *
+ * With the arms behind this annotated return type, that edit is `TS2322` here,
+ * on the day it is written. Nothing about the decision moved; only who checks it.
+ */
+export function redactPresentAuditValue(
+  key: string,
+  def: SettingDefinition | undefined,
+  value: string,
+): RedactedAuditValue & { readonly value: AuditedValue } {
+  // The sole minting site for {@link AuditedValue}. Every `as` below is a
+  // string that has just been through the decision above it — that is what the
+  // brand asserts, and keeping the casts in one function is what keeps the
+  // assertion true.
+  const audited = (v: string): AuditedValue => v as AuditedValue;
+
+  if (def === undefined) {
+    return { value: audited(REDACTED_AUDIT_VALUE), masked: true, maskReason: "unknown_definition" };
+  }
+  // ⚠️ BEFORE the `secret` arm, and the order is observable: a definition that is
+  // both mismatched and secret reports `definition_mismatch`, because the caller
+  // bug is the actionable fact and the secrecy of someone else's key is not
+  // evidence about this one.
+  if (definitionMismatchesKey(key, def)) {
+    return {
+      value: audited(REDACTED_AUDIT_VALUE),
+      masked: true,
+      maskReason: "definition_mismatch",
+    };
+  }
+  if (def.secret === true) {
+    return { value: audited(REDACTED_AUDIT_VALUE), masked: true, maskReason: "secret" };
+  }
+  return { value: audited(value), masked: false, maskReason: undefined };
+}
+
+/**
+ * The written value as an audit line may record it (#5180), plus whether — and
+ * why — it was withheld. Takes the KEY as well as the definition, so the decision
+ * owns every reason it can report.
  *
  * ⚠️ It takes the WHOLE `SettingDefinition`, and an earlier draft narrowing it
  * to `Pick<…, "key" | "secret">` was measured to be a net loss. The narrowing
@@ -3291,85 +3366,7 @@ export type RedactedAuditValue =
  * What does NOT generalise is any reading of the brand as a clearance —
  * {@link AuditedValue}'s last paragraph is the standing warning, and a fourth
  * sink with a different audience owes the same paragraph this one does.
- */
-/**
- * The present-value arms, split out so the compiler CHECKS what the narrow
- * overload below merely asserts.
  *
- * ⚠️ **An overload is an unchecked claim, and this one had already been broken
- * once.** TypeScript compares an overload signature to the IMPLEMENTATION
- * signature bivariantly, so a wide `RedactedAuditValue` implementation satisfies
- * a narrow `… & { value: AuditedValue }` overload without any arm being
- * verified. The docstring below records that an earlier draft returned
- * `undefined` for `""` — re-adding that arm reads as tidying, would have
- * type-checked clean, and would have shipped a 200 body missing a field the
- * published spec marks `required`.
- *
- * With the arms behind this annotated return type, that edit is `TS2322` here,
- * on the day it is written. Nothing about the decision moved; only who checks it.
- */
-/**
- * Does this definition belong to this key?
- *
- * ⚠️ **ONE PREDICATE, TWO QUESTIONS, and conflating them caused a regression.**
- * The wrong-key condition is asked for two different purposes:
- *
- * - *what reason to record for a withheld value* — {@link redactPresentAuditValue}
- * - *whether the CALLER has a bug* — `auditSettingsWrite`'s unconditional warn
- *
- * An attempt to serve the second by reading the first's `maskReason` broke the
- * clear path: with no value there is nothing to redact, so the decision never
- * consults the definition and reports no reason — while the caller bug is just as
- * real and just as worth warning about. A definition mismatch on a DELETE was
- * silently dropped, which is the defect `auditSettingsWrite`'s own warn exists to
- * prevent, and an existing test caught it.
- *
- * So the predicate is shared and the two uses stay separate. That is still one
- * source of truth — what it is not is one call site.
- */
-export function definitionMismatchesKey(
-  key: string,
-  def: SettingDefinition | undefined,
-): boolean {
-  return def !== undefined && def.key !== key;
-}
-
-export function redactPresentAuditValue(
-  key: string,
-  def: SettingDefinition | undefined,
-  value: string,
-): RedactedAuditValue & { readonly value: AuditedValue } {
-  // The sole minting site for {@link AuditedValue}. Every `as` below is a
-  // string that has just been through the decision above it — that is what the
-  // brand asserts, and keeping the casts in one function is what keeps the
-  // assertion true.
-  const audited = (v: string): AuditedValue => v as AuditedValue;
-
-  if (def === undefined) {
-    return { value: audited(REDACTED_AUDIT_VALUE), masked: true, maskReason: "unknown_definition" };
-  }
-  // ⚠️ BEFORE the `secret` arm, and the order is observable: a definition that is
-  // both mismatched and secret reports `definition_mismatch`, because the caller
-  // bug is the actionable fact and the secrecy of someone else's key is not
-  // evidence about this one. That is the order the three call sites produced by
-  // hand, preserved here so centralising is behaviour-neutral.
-  if (definitionMismatchesKey(key, def)) {
-    return {
-      value: audited(REDACTED_AUDIT_VALUE),
-      masked: true,
-      maskReason: "definition_mismatch",
-    };
-  }
-  if (def.secret === true) {
-    return { value: audited(REDACTED_AUDIT_VALUE), masked: true, maskReason: "secret" };
-  }
-  return { value: audited(value), masked: false, maskReason: undefined };
-}
-
-/**
- * The written value as an audit line may record it, plus whether — and why — it
- * was withheld. Takes the KEY as well as the definition, so the decision owns
- * every reason it can report.
  *
  * ⚠️ **NO OVERLOADS, deliberately, and a round of review was spent learning
  * why.** This had a narrow `(def, value: string)` overload promising a present

--- a/packages/api/src/lib/settings.ts
+++ b/packages/api/src/lib/settings.ts
@@ -2885,9 +2885,11 @@ function isSaasImmutableKey(key: string): key is SaasImmutableKey {
  */
 /**
  * What a settings write did: persisted a value, or removed the override and
- * reverted to the next tier. One definition rather than five inline copies —
- * the audit rule, the flag decision, the payload, the builder input and the
- * emitter all have to agree, and a third action would otherwise drift.
+ * reverted to the next tier. One definition rather than a copy at every consumer
+ * — the audit rule, the flag decision, the payload, the builder input, the
+ * emitter and `settings-write.ts`'s verb mapping all have to agree, and a third
+ * action would otherwise drift. (The count that stood here said "five"; #5262's
+ * `AUDIT_ACTION` made it six, which is why it is no longer a number.)
  */
 export type SettingAuditAction = "set" | "clear";
 
@@ -2999,8 +3001,8 @@ const aliasThresholdRule: SecuritySensitiveRule = (action, value) => {
  * Every sensitive key, paired with the rule that reads it.
  *
  * ⚠️ THE TABLE IS THE SET — that is the whole point of the shape, and it is the
- * same `as const`-plus-closed-union device `SAAS_IMMUTABLE_KEYS` uses forty
- * uses above it for the same reason. A hand-maintained `Set` with a `switch`
+ * same `as const`-plus-closed-union device `SAAS_IMMUTABLE_KEYS` uses for the
+ * same reason. A hand-maintained `Set` with a `switch`
  * beside it lets a fifth key be added with no rule, where it falls through to
  * whatever arm is last — and review measured that against the NUMERIC rule of
  * the day: a boolean key landing on {@link abuseThresholdRule} reported
@@ -3142,7 +3144,8 @@ declare const auditedValueBrand: unique symbol;
  * A string that has been through {@link redactAuditValue} — the ONLY thing an
  * audit line may carry in its `value` field.
  *
- * ⚠️ **The brand is the guard, and it is here because the suite it was measured
+ * ⚠️ **The brand closes the seam-PRESERVING edit; the registry-flip test closes
+ * the seam-REMOVING one. It is here because the suite it was measured
  * against could not be.** Round 1 ran `log.warn({ ...line, value }, …)` at the
  * emitter — issue #5180 verbatim, plaintext back in the log stream — against a
  * suite that took the registry's contents as fixed, and it passed every test.
@@ -3261,6 +3264,41 @@ export interface RedactedAuditValue {
  * {@link AuditedValue}'s last paragraph is the standing warning, and a fourth
  * sink with a different audience owes the same paragraph this one does.
  */
+/**
+ * The present-value arms, split out so the compiler CHECKS what the narrow
+ * overload below merely asserts.
+ *
+ * ⚠️ **An overload is an unchecked claim, and this one had already been broken
+ * once.** TypeScript compares an overload signature to the IMPLEMENTATION
+ * signature bivariantly, so a wide `RedactedAuditValue` implementation satisfies
+ * a narrow `… & { value: AuditedValue }` overload without any arm being
+ * verified. The docstring below records that an earlier draft returned
+ * `undefined` for `""` — re-adding that arm reads as tidying, would have
+ * type-checked clean, and would have shipped a 200 body missing a field the
+ * published spec marks `required`.
+ *
+ * With the arms behind this annotated return type, that edit is `TS2322` here,
+ * on the day it is written. Nothing about the decision moved; only who checks it.
+ */
+function redactPresentAuditValue(
+  def: SettingDefinition | undefined,
+  value: string,
+): RedactedAuditValue & { readonly value: AuditedValue } {
+  // The sole minting site for {@link AuditedValue}. Every `as` below is a
+  // string that has just been through the decision above it — that is what the
+  // brand asserts, and keeping the casts in one function is what keeps the
+  // assertion true.
+  const audited = (v: string): AuditedValue => v as AuditedValue;
+
+  if (def === undefined) {
+    return { value: audited(REDACTED_AUDIT_VALUE), masked: true, maskReason: "unknown_definition" };
+  }
+  if (def.secret === true) {
+    return { value: audited(REDACTED_AUDIT_VALUE), masked: true, maskReason: "secret" };
+  }
+  return { value: audited(value), masked: false, maskReason: undefined };
+}
+
 export function redactAuditValue(
   def: SettingDefinition | undefined,
   value: string,
@@ -3272,29 +3310,20 @@ export function redactAuditValue(
 /**
  * ⚠️ The overload above is the only reason a caller holding a `string` can put
  * the result straight into a non-optional field. `value: undefined` is the sole
- * input producing `value: undefined` — read the arms below — so a present input
+ * input producing `value: undefined` — the one arm below — so a present input
  * yields a present {@link AuditedValue}, and saying so in the signature is what
  * keeps the `PUT` response from needing a `?? rawValue` fallback to satisfy its
  * schema. That fallback is the whole defect written as a type workaround.
+ *
+ * The promise is CHECKED rather than asserted: every present-value arm lives in
+ * {@link redactPresentAuditValue} behind an annotated return type.
  */
 export function redactAuditValue(
   def: SettingDefinition | undefined,
   value: string | undefined,
 ): RedactedAuditValue {
-  // The sole minting site for {@link AuditedValue}. Every `as` below is a
-  // string that has just been through the decision above it — that is what the
-  // brand asserts, and keeping the casts in one function is what keeps the
-  // assertion true.
-  const audited = (v: string): AuditedValue => v as AuditedValue;
-
   if (value === undefined) return { value: undefined, masked: false, maskReason: undefined };
-  if (def === undefined) {
-    return { value: audited(REDACTED_AUDIT_VALUE), masked: true, maskReason: "unknown_definition" };
-  }
-  if (def.secret === true) {
-    return { value: audited(REDACTED_AUDIT_VALUE), masked: true, maskReason: "secret" };
-  }
-  return { value: audited(value), masked: false, maskReason: undefined };
+  return redactPresentAuditValue(def, value);
 }
 
 /** The 200 body `PUT /admin/settings/{key}` returns (#5263). */
@@ -3348,7 +3377,22 @@ export function settingUpdateResponseBody(
   key: string,
   value: string,
 ): SettingUpdateResponse {
-  const audited = redactAuditValue(def, value);
+  // ⚠️ THE SAME DISCARD `auditSettingsWrite` APPLIES, and it is here because the
+  // first draft of this function did not have it while claiming the two sinks
+  // "cannot disagree". They could. The seam withholds on a definition belonging
+  // to another key; this builder had no such check, so the invariant actually
+  // holding the two together was unstated and in a third place — `SETTINGS_MAP`
+  // is keyed by `def.key`, making `mismatched` always false at today's route.
+  //
+  // That invariant moves in a normal-looking change: `getSettingDefinition`
+  // gaining alias or rename resolution, so `ATLAS_OLD_NAME` returns the new
+  // entry. At that moment the audit row would withhold the characters and record
+  // `maskReason: "definition_mismatch"` while this body echoed the plaintext —
+  // the third sink leaking exactly what #5263 closed, in the one input class the
+  // seam was hardened against. Applying the discard makes the two agree by
+  // construction instead of by a coincidence documented nowhere.
+  const mismatched = def !== undefined && def.key !== key;
+  const audited = redactAuditValue(mismatched ? undefined : def, value);
   return { success: true, key, value: audited.value, valueMasked: audited.masked };
 }
 
@@ -3441,13 +3485,10 @@ export interface SecuritySensitiveAuditInput {
  *   infers `log.warn`'s first parameter from the literal, leaving no target
  *   type to check against.
  *
- * Neither closes it alone. The second draft of this comment credited the test
- * alone (it could not see the leak: `value` is a declared field, so the edit
- * overwrites rather than adds, and raw equals redacted for every key shipping
- * today). The third credited the type alone, and missed that removing the seam
- * removes the type. The test only became possible once it stopped assuming the
- * registry was fixed: flipping a definition to `secret: true` for one test
- * makes raw and redacted differ on a fully reachable input.
+ * Neither closes it alone: removing the seam removes the type, and the test only
+ * became possible once it stopped assuming the registry was fixed — flipping a
+ * definition to `secret: true` for one test makes raw and redacted differ on a
+ * fully reachable input.
  */
 export function securitySensitiveAuditLine(
   input: SecuritySensitiveAuditInput,
@@ -3492,7 +3533,8 @@ export function securitySensitiveAuditLine(
  *
  * ⚠️ It emits through {@link emitSecuritySensitiveAudit} rather than calling
  * `log.warn` directly, and the indirection is load-bearing: `log.warn` takes
- * an untyped object, so `log.warn({ ...line, value }, …)` — #5180 verbatim —
+ * a first parameter it infers from the literal, so `log.warn({ ...line, value },
+ * …)` — #5180 verbatim —
  * has no target type to be checked against and compiles. Routed through a
  * parameter typed {@link SecuritySensitiveAuditLine}, the same edit fails to
  * type-check, because `value` there is an {@link AuditedValue}.

--- a/packages/api/src/lib/settings.ts
+++ b/packages/api/src/lib/settings.ts
@@ -3142,18 +3142,27 @@ declare const auditedValueBrand: unique symbol;
  * A string that has been through {@link redactAuditValue} — the ONLY thing an
  * audit line may carry in its `value` field.
  *
- * ⚠️ **The brand is the guard, and it is here because nothing else could be.**
- * Review measured that `log.warn({ ...line, value }, …)` at the emitter —
- * issue #5180 verbatim, plaintext back in the log stream — passed all 154
- * tests. Not because the tests were weak: no sensitive key is `secret: true`
- * today, so the redacted value and the raw value are *identical on every
- * reachable input*, and the edit is a behavioural no-op until the day it is a
- * breach. An assertion cannot see a difference that does not yet exist.
+ * ⚠️ **The brand is the guard, and it is here because the suite it was measured
+ * against could not be.** Round 1 ran `log.warn({ ...line, value }, …)` at the
+ * emitter — issue #5180 verbatim, plaintext back in the log stream — against a
+ * suite that took the registry's contents as fixed, and it passed every test.
+ * Not because the tests were weak: no shipped sensitive key is `secret: true`,
+ * so redacted and raw were identical on every input that suite reached, and the
+ * edit was a behavioural no-op until the day it is a breach.
  *
- * So the check is a type rather than a test: {@link emitSecuritySensitiveAudit}
- * takes a {@link SecuritySensitiveAuditLine}, whose `value` is branded, and a
- * raw `string` is not assignable to it. That one-keystroke edit is now a
- * compile error, on the day it is harmless and on the day it is not.
+ * ⚠️ That measurement is a fact about a suite, not a law about assertions, and
+ * an earlier draft of this paragraph stated it as the latter — "an assertion
+ * cannot see a difference that does not yet exist" — in the same docstring as
+ * the section describing the assertion that sees it. A later round stopped assuming
+ * the registry was fixed: flipping a definition to `secret: true` for one test
+ * makes the difference reachable, and the leak becomes ordinary. See
+ * "WHAT THE BRAND DOES NOT CLOSE" below for the split.
+ *
+ * The type is still the right instrument for the seam-PRESERVING edit:
+ * {@link emitSecuritySensitiveAudit} takes a {@link SecuritySensitiveAuditLine},
+ * whose `value` is branded, and a raw `string` is not assignable to it. That
+ * one-keystroke edit is a compile error on the day it is harmless and on the day
+ * it is not — and unlike a test, it does not need anyone to run the suite.
  *
  * This is the repo's own rule applied to itself — brand the OUTPUT, not just
  * the parameter — and the escalation the review loop asks for once a principle
@@ -3163,10 +3172,10 @@ declare const auditedValueBrand: unique symbol;
  * ⚠️ **WHAT THE BRAND DOES NOT CLOSE**, stated because a brand invites exactly
  * the wrong confidence, and both survivors were measured rather than guessed:
  *
- * - **A leak that never mentions the seam.** `log.warn` types its first
- *   parameter as `<T extends object>`, inferring `T` from the literal, so
- *   `log.warn({ ...line, value: raw }, …)` type-checks clean. The brand bites
- *   only where something is *expected* to carry it — hence
+ * - **A leak that never mentions the seam.** pino infers the first parameter's
+ *   type from the literal you hand it, so there is no target type to check
+ *   against and `log.warn({ ...line, value: raw }, …)` type-checks clean. The
+ *   brand bites only where something is *expected* to carry it — hence
  *   {@link warnAuditLine}. Inline `log.warn` back and the fence is gone.
  * - **A dishonest `definition`.** The brand fences the OUTPUT of the decision;
  *   the INPUT is an ordinary structural value, so `{ …, secret: false }` at the
@@ -3311,16 +3320,26 @@ export interface SettingUpdateResponse {
  * ever exercise the verbatim arm, which passes identically with the fix and
  * without it. That is #5180's accidental-equality trap arriving one sink later.
  * Pulled out here, the secret arm takes a real registry definition
- * (`RESEND_API_KEY`) in a unit test and the plaintext's absence is a measured
+ * (`ANTHROPIC_API_KEY`) in a unit test and the plaintext's absence is a measured
  * fact instead of an argument.
  *
- * ⚠️ It does NOT close the route inlining `{ success: true, key, value }` again.
- * Nothing can: the 200 schema's `value` is `z.string()` and {@link AuditedValue}
- * is assignable to `string`, so — measured by compiling the raw spelling against
- * the schema — the echo type-checks clean either way. Branding the schema was
- * the alternative and costs the OpenAPI generator a type it cannot render. So
- * that spelling is closed by a test in `admin-settings.test.ts` asserting the
- * response IS this builder's output, which is the same split
+ * ⚠️ It does NOT close the route inlining `{ success: true, key, value }` again,
+ * and that is a TRADE rather than an impossibility — an earlier draft of this
+ * paragraph said "nothing can", which the experiment below falsified. Both arms
+ * were measured:
+ *
+ * - As shipped, the 200 schema's `value` is `z.string()` and
+ *   {@link AuditedValue} is assignable to `string`, so the raw echo type-checks
+ *   clean. `c.json` IS checked against the response schema; it just has nothing
+ *   to object to in that direction.
+ * - Branding the schema (`z.custom<AuditedValue>()`) DOES make the raw echo
+ *   `TS2322` — and then `scripts/extract-openapi.ts` dies with
+ *   `UnknownZodTypeError: Unknown zod object type`, even with `.openapi()`
+ *   attached, so the spec and the api-reference docs stop generating.
+ *
+ * A compile-time guard on one unreachable arm is not worth the published spec,
+ * so the seam-removing spelling is closed by a test in `admin-settings.test.ts`
+ * asserting the response IS this builder's output. That is the same split
  * {@link AuditedValue} documents: a type for the seam-preserving edit, a test
  * for the seam-removing one.
  */
@@ -3418,8 +3437,9 @@ export interface SecuritySensitiveAuditInput {
  * - {@link AuditedValue} plus {@link warnAuditLine} close every spelling that
  *   still routes through {@link emitSecuritySensitiveAudit}.
  * - The registry-flip test in `settings-audit-log.test.ts` closes the spelling
- *   that inlines `log.warn` back here — which no type can see, because
- *   `log.warn`'s first parameter is untyped.
+ *   that inlines `log.warn` back here — which no type can see, because pino
+ *   infers `log.warn`'s first parameter from the literal, leaving no target
+ *   type to check against.
  *
  * Neither closes it alone. The second draft of this comment credited the test
  * alone (it could not see the leak: `value` is a declared field, so the edit
@@ -3440,10 +3460,12 @@ export function securitySensitiveAuditLine(
   // on the `undefined`.
   //
   // ⚠️ This closes "someone else's definition". It structurally CANNOT close
-  // "this key's definition, lying about `secret`" — a fabricated
-  // `{ key, secret: false }` passes the check and reaches the verbatim arm. The
-  // registry-flip test in `settings-audit-log.test.ts` is what covers that, by
-  // making redacted and raw differ on a reachable input.
+  // "this key's definition, lying about `secret`": the compiling spelling is
+  // `{ ...def, secret: false }`, which passes the check and reaches the verbatim
+  // arm. Two tests cover it from opposite ends — `definitionWithSecret` in
+  // `settings.test.ts` builds that spread and drives the builder with it, and
+  // the registry-flip block in `settings-audit-log.test.ts` mutates the shipped
+  // definition so redacted and raw differ on a reachable input.
   const mismatched = input.definition !== undefined && input.definition.key !== key;
   const redacted = redactAuditValue(mismatched ? undefined : input.definition, value);
   return {
@@ -3498,13 +3520,13 @@ function auditSecuritySensitiveChange(
  * `log.warn`, narrowed to this one payload shape.
  *
  * ⚠️ **The narrowing is what gives {@link AuditedValue} teeth, and calling
- * `log.warn` directly does not.** Pino types its log functions as
- * `<T extends object>(obj: T, …)`, so `T` is INFERRED from whatever literal you
- * hand it: there is no target type, no excess-property check, and no branded-
- * field check. Measured — `log.warn({ ...line, value: raw }, …)` type-checks
- * clean, while the same object assigned into a `SecuritySensitiveAuditLine`
- * position is `TS2322`. A brand only bites where something is expected to have
- * it. This alias creates that expectation.
+ * `log.warn` directly does not.** pino infers the first parameter's type from
+ * whatever literal you hand it, so there is no target type to check against: no
+ * excess-property check, and no branded-field check. Measured —
+ * `log.warn({ ...line, value: raw }, …)` type-checks clean, while the same
+ * object assigned into a `SecuritySensitiveAuditLine` position is `TS2322`. A
+ * brand only bites where something is expected to have it. This alias creates
+ * that expectation.
  */
 const warnAuditLine: (line: SecuritySensitiveAuditLine, msg: string) => void = (line, msg) => {
   log.warn(line, msg);


### PR DESCRIPTION
Three residue items from the #5180 / #5271 settings-audit work, fixed in the stated order, one commit per item — plus three commits of review fallout.

Closes #5290
Closes #5263
Closes #5262
Closes #5264

---

## Review outcome, stated up front

The panel ran **two rounds and stopped on the defect-in-prior-fix ratio**, not on the 3-round cap.

| Round | Findings | New surface | Defect-in-prior-fix |
|---:|---:|---:|---:|
| 1 | ~41 | ~41 | 0 |
| 2 | ~19 | ~5 | **~14** |

The total fell, but roughly three quarters of round 2 was cleanup after round 1's own fixes. Per the stop rule that means another round would add work faster than it removed it, so round 2 was the last. **Every confirmed must-fix from both rounds is fixed** — the stop ended the rounds, not the work.

**Nothing is deferred.** An earlier revision pushed ~10 items into follow-up issues (#5293, #5294, #5295); that was wrong under the repo's fix-inline rule, and all three are now closed as done by `9e1ba965c`, `f3d5c51b9` and `152178a77`.

**One item is deliberately declined**, and it is a decision rather than a leftover: a `try/catch` around `securitySensitiveAuditFields`. All three rule arms are total over `string | undefined` (verified by reading), so it would be an unfalsifiable guard against an unverified state — which is exactly what this PR *removed* from the `COMMITTED` log line. Adding it would contradict that.

## Where #5263's defect actually lives now

#5263's body predates #5271 and points at the wrong file. Re-located against `main` first, and the premise had **half-moved**:

| Sink | On `main` |
|---|---|
| `admin_action_log.metadata.value` | **Already redacted** — #5271 moved this write into `lib/audit/settings-write.ts`, which calls `redactAuditValue` |
| the 200 response body | **Still echoed the request verbatim** |

So only the response half was outstanding. The issue's "Key files" are stale exactly as #5290 predicted.

Not a live leak either way: both verbs 403 a `secret: true` key before the write. **That guard stays** and remains the primary control — this is defence-in-depth for the day someone relaxes it, which is a normal-looking change (the sandbox keys already carry `saasVisible: false, saasWritable: true`).

**#5263's fourth criterion** — is `redactAuditValue`'s sink-generic name a liability? **Keep it, document that the trade generalises.** Renaming it to name its sink is unavailable: it serves three now, and one is not an audit. The inherited trade is *withhold every character rather than reveal some*, and it holds at the response because the PUT caller already holds the value it sent; what the echo owes is *what is now stored*.

## #5262, against the rewritten body

The split was backwards: pino carried the judgement, `admin_action_log` carried the value — the suppressible channel held the analysis and the retained one held only the fact. Folded in at `auditSettingsWrite`. `securitySensitiveAuditFields` still has exactly two callers, both in `lib/`; **zero in the route layer**, per the criterion.

### An issue-body claim measured false

#5262 predicts a swapped action mapping is *"invisible on one of the two families"*. Measured: it is visible on **both** from the `update` side. The axis that hides a swapped `rule` is the **verb** — on a clear there is no value, so all three rules return `false`/`false` whichever action they receive. The tests drive each family from `update` accordingly.

### A false exoneration this PR created, then closed

Round 2 found that moving the judgement into the durable row made a **clear** record `disablesControl: false` — accurate about the rule, and read as "nothing weakened". Clearing a `"10"` override on `ATLAS_TRIAL_IP_RATE_LIMIT_RPM` while the env var holds `"0"` turns the per-IP limiter **off**. Before this PR nobody queried `admin_action_log` for a judgement it did not carry; after it, they would — and get a wrong answer from the system of record.

Closed with an additive `judgement: "reverted_value_not_evaluated"` marker. The behaviour delta moves no existing field on any input class, so no reader that works today reads differently tomorrow. The reviewer's preferred fix (judge the clear on its reverted value) was **declined**: it remaps `reset_to_default → "set"`, deleting the mapping criterion 3 exists to pin.

## #5264, widened to this PR's own diff

Run last and over the resulting diff. All four named items plus item 5; items 1 and 4 resolved by **deletion**. Both unverifiable historical test counts dropped.

**The sibling grep found instances the issue did not name** — a third `{ key, secret: false }` in another file, and a third mis-description of pino's parameter.

## Six of my own comments turned out false

This is the part worth a reviewer's attention. In order:

1. **"the echo and the row cannot disagree"** — they could. The seam discarded a wrong-key definition; my builder did not. Fixed by making the claim *true*, not by rewording.
2. **"nothing can close this"** — branding the schema *does* make the raw echo `TS2322`; it just breaks `extract-openapi.ts` with `UnknownZodTypeError`. A trade, not an impossibility.
3. **A miscounted sibling grep** — I claimed a third instance; there were four, and the survivor disagreed with the three I fixed.
4. **"`judgement` present exactly on the clear path"** — it needs a *sensitive* key, as this PR's own test asserts.
5. **`RuleFields | Record<never, never>` "checks the name"** — 0 errors. Excess-property checking is skipped when any union member is an empty object type. `| undefined` gives `TS2561`.
6. **"`Partial<RuleFields>` removes the bare-`judgement` state"** — it does not; `Partial` is homomorphic, so both meaningless states still compile. Probed both directly.

Each is now corrected against a measurement rather than reworded.

## Falsifiers — measured, not reasoned about

Every must-fix's falsifier was built and run in the round that wrote it.

| Mutation | Result |
|---|---|
| builder echoes the raw value | 3 RED |
| route inlines the response literal | 1 RED |
| route passes `undefined` as the definition | 1 RED |
| builder loses the mismatch discard | 1 RED |
| both rule flags hardcoded `false` | 5 RED |
| action mapping swapped (`update` side) | 5 RED |
| flags always present via `?? false` | 1 RED |
| `judgement` marker removed | 1 RED |
| marker emitted on updates too | 2 RED |
| `METADATA_ACTION` loses the reset label | 2 RED |
| no-DB warn spreads `ruleFlags` alone | 1 RED |
| `COMMITTED` demoted `info`→`debug` | 1 RED |
| `COMMITTED` moved before the await | 1 RED |
| centralised mismatch arm removed | 4 RED |
| mismatch reported as drift | 3 RED |
| response drops `maskReason` | 1 RED |
| `VERBS` full swap / `update`-half swap | 6 RED each |
| `VERBS` reset-half swap | **GREEN — the documented claim holding** |
| `resetPerTest` → `mockClear` | 1 RED |
| `satisfies` removed + a lying stub | 1 type error |
| schema↔type field added to either side | 1 error each |
| secret arm returns absence for a present input | `TS2322` (0 without the helper) |

**Three came back green and had to be strengthened**, which is the reason for running them rather than reasoning:

- the mismatch-discard test used a `secret: true` fixture, so it reached the placeholder either way — **accidental equality**, in a fix for an unrelated finding, in the round where a reviewer named that as the class to hunt
- `resetPerTest` shipped with **no falsifier** — the same unfalsifiable-guard sin this PR deleted a `try/catch` for, two commits earlier
- the schema↔type tie was **one-directional**: `A extends B` let an optional field added to the TS type pass with 0 errors

## The controls

Each fix has a way to be "right" by being uselessly broad, and only the control catches it:

- a non-secret key still echoes its value with `valueMasked: false` — so "redact everything" fails, and `valueMasked` is asserted on **both** arms
- a key outside the sensitive set records **neither** flag, checked with `in` rather than `toBeUndefined()`. A row always carrying `disablesControl: false` cannot be filtered on
- a harmless write to a *sensitive* key records both flags `false` and **present** — so hardcoding `true` fails
- `definition_mismatch` and `unknown_definition` stay distinguishable, driven through all three sinks

## One honest gap

The third-flag drift has a **dormant tripwire**, not a today-RED test: it derives its expected key set from the rule engine's own output, so it fires when a *required* flag joins `SecuritySensitiveAudit` and the builder has stopped spreading whole. Two cases survive and are named in the test — a flag added *optionally* or returned only by the alias rules, and the spelling revert with no new flag. Only re-reading the seam catches those.

## Gates

`lint`, `type`, `lint:type-aware`, `check-openapi-drift` — all exit 0.

Eight suites green isolated: `settings` 165 · `settings-write` 32 · `admin-settings` 96 · `settings-audit-log` 10 · `cors` 6 · slack/zoom/outlook connectors 10 / 21 / 18.

`mutation-tables`: no spec targets any file in this diff (verified by intersecting `git diff --name-only` against every spec's target list), so the branch cannot have made a table stale. Remote CI runs the gate regardless.
