### PR TITLE
chore(api): bundle 3 — an unobserved seed Layer and a refusal that outlives its log (#5273, #5112)

### DIFF
--- a/apps/docs/content/docs/platform-ops/data-residency.mdx
+++ b/apps/docs/content/docs/platform-ops/data-residency.mdx
@@ -229,7 +229,7 @@ curl http://localhost:3001/api/v1/admin/residency/migration \
 | Scheduled tasks (definitions) | Moves in the bundle; the next run time is recomputed in the target so its scheduler re-plans. Run history stays behind. Connection-group / plugin references resolve again once the datasource or plugin is re-installed in the target |
 | Durable agent session memory | Moves in the bundle (keyed to migrated conversations) |
 | Company brain (episodes, reviewed facts, provenance graph, audience membership) | Moves in the bundle. Each fact travels with its provenance, its visibility grant, its review status, and its full validity history — including retracted and superseded claims, so "what we believed on Monday" still answers correctly in the target. Audience membership moves with it, so `audience:`-scoped facts stay visible to the right people |
-| Company brain vocabulary (approved term aliases) | Moves in the bundle. The approved aliases — the decisions a reviewer made about which two spellings name the same thing — travel with the brain, because they are what every migrated claim's identity is built from. An alias already approved in the target region wins: an arriving edge for a term that is already aliased there is skipped rather than applied over the top. The derived lookup they compose into is rebuilt in the target rather than copied |
+| Company brain vocabulary (approved term aliases) | Moves in the bundle. The approved aliases — the decisions a reviewer made about which two spellings name the same thing — travel with the brain, because they are what every migrated claim's identity is built from. An alias already approved in the target region wins: an arriving edge that would contradict one already there — taking a second parent for the same term, or closing a loop between two spellings — is **refused**, not merged over the top. A refusal is a reviewer's decision that this region will not hold, so it is recorded rather than dropped quietly: the count appears in the CLI's import summary and in the migration's audit events, and the refused edges themselves are stored on the migration record, which survives the 7-day cleanup — up to a bound, and only when the target region's build returns them. Compare the stored payload count against the refusal count before relying on it. **Act on a non-zero count before the grace period expires** — see the recovery note below. The derived lookup the aliases compose into is rebuilt in the target rather than copied |
 | Company brain enrollment (which warehouse dimensions Atlas may hold claims about) | Moves in the bundle. The pairs a person deliberately enrolled travel with the brain, because they are what bounds anything it produces from your warehouse in the first place. An enrollment already made in the target region wins — an arriving one for a pair already enrolled there is skipped rather than re-attributed to whoever enrolled it in the source region. Losing them would leave the target's producer reaching nothing at all, which looks identical to a working system, so they are carried rather than re-created by hand |
 | Company brain entity store (the names Atlas resolves your warehouse rows by) | Moves in the bundle. Each entry pairs one warehouse row's primary key with the human-readable name a person picked for it, and the identifiers in those entries are already written onto the facts that travel beside them — so leaving the store behind would land facts whose comparison values nothing in the target could explain. An entry already in the target region wins, including when the arriving snapshot is newer, because a stale name arriving from an older export would silently re-file every fact about that entity under it |
 | In-flight agent run checkpoints | Stays — resume leases are region-local and cannot be resumed cross-region; an interrupted turn is simply re-asked in the target |
@@ -358,6 +358,44 @@ When `executeRegionMigration` fails after Phase 3 succeeded, the row will be `st
 4. **Audit the recovery.** File an `admin_action_log` row referencing the migration ID, the chosen direction, and the operator who performed it. The forensic trail must show that the 409 guard fired and was resolved deliberately, not papered over. The `/migrate/:id/retry` endpoint already records the rejected attempt with `status = 'failure'`; the recovery action is the matching follow-up.
 
 > The `region_updated` column is the single source of truth for "destination has taken ownership." It is set inside the same migration executor process that performs the cutover, immediately after `organization.region` is updated, before Phase 4 starts. If you ever need to manually flip `region_updated`, treat it as a destructive operation — the guard exists exactly because the wrong value here corrupts customer data.
+
+### Recovering refused vocabulary aliases (7-day window)
+
+A migration can complete successfully and still drop reviewer decisions. The target region **refuses** an arriving alias edge that would contradict a decision already made there — taking a second parent for the same term, or closing a loop between two spellings — because a cyclic vocabulary has no answer for "what is the canonical spelling of this", and destination-wins is what keeps the target consistent at every step. That is the right trade, and it is not free: each refusal is one reviewer's approved decision the destination will never hold.
+
+**Where the count appears.** Any of:
+
+- the CLI's import summary — the `Refused` column on the `Alias edges` row, plus an itemised block listing each dropped edge;
+- the migration's own audit events (`region_migration_completed` and `region_migration_cleanup_scheduled`, the latter naming the same 7-day timer);
+- the source region's `region_migrations` row.
+
+**The window.** The source region keeps its own `brain_vocabulary_edge` rows for the whole grace period, then deletes them. That copy needs no cooperation from anyone and is the one to use:
+
+```sql
+-- Everything the source still holds, before the cleanup runs.
+SELECT slot_position, from_norm, to_norm, approved_by, approved_at
+  FROM brain_vocabulary_edge
+ WHERE workspace_id = '<workspaceId>'
+ ORDER BY slot_position, from_norm;
+```
+
+After the cleanup has run, the surviving record is on the migration row — which is platform-classified, so the sweep never touches it:
+
+```sql
+SELECT vocabulary_edges_refused,
+       jsonb_array_length(COALESCE(vocabulary_refusals, '[]'::jsonb)) AS payloads_recorded,
+       vocabulary_refusals
+  FROM region_migrations
+ WHERE id = '<migrationId>';
+```
+
+`payloads_recorded` short of `vocabulary_edges_refused` means part of the set has no payload here — the target's build predated the payload contract, the response's bound truncated the list, or an entry was unreadable. For the remainder, the target region's own log carries the refusal lines for this workspace.
+
+**What to do with them.** Re-approve the ones the target should hold, in the target region, through the normal alias review path — approving re-derives the affected claims' identity under the target's vocabulary. A refusal is not a bug to be fixed by forcing the edge in: the two regions genuinely disagreed, and a human has to decide which spelling wins.
+
+<Callout type="warn" title="Do not wait out the grace period">
+  `vocabulary_edges_refused > 0` is the one migration outcome with a deadline attached. The migration reports success, the workspace serves normally, and nothing degrades — so the only signal is the count, and the source rows it refers to are deleted on schedule.
+</Callout>
 
 ## Limitations
 

--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -59106,12 +59106,62 @@
                         },
                         "refused": {
                           "type": "number"
+                        },
+                        "refusalDetails": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "slotPosition": {
+                                "type": "string"
+                              },
+                              "fromNorm": {
+                                "type": "string"
+                              },
+                              "toNorm": {
+                                "type": "string"
+                              },
+                              "approvedBy": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "approvedAt": {
+                                "type": "string"
+                              },
+                              "refusal": {
+                                "type": "string"
+                              },
+                              "existingTarget": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "reason": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "slotPosition",
+                              "fromNorm",
+                              "toNorm",
+                              "approvedBy",
+                              "approvedAt",
+                              "refusal",
+                              "existingTarget",
+                              "reason"
+                            ]
+                          },
+                          "maxItems": 50
                         }
                       },
                       "required": [
                         "imported",
                         "skipped",
-                        "refused"
+                        "refused",
+                        "refusalDetails"
                       ]
                     },
                     "brainSlackChannelExclusions": {

--- a/packages/api/scripts/mutations/bundle-identity.md
+++ b/packages/api/scripts/mutations/bundle-identity.md
@@ -65,7 +65,7 @@ Every number is the count of tests that FAIL in that suite under that mutation, 
 | the exporter feeds identity values through a cast instead of `textOrNull` | 0 | 0 | 2 | 0 | 0 | 0 |
 | the importer writes `predicate_cardinality` again (from the legacy field) | 9 | 0 | 0 | 0 | 1 | 0 |
 
-Suite sizes: **roundtrip-pg** 15 tests (`src/lib/residency/__tests__/migrate-roundtrip-pg.test.ts`) · **admin-migrate** 114 tests (`src/api/__tests__/admin-migrate.test.ts`) · **export** 24 tests (`src/lib/residency/__tests__/export.test.ts`) · **object-cmp** 64 tests (`src/lib/brain/__tests__/object-cmp.test.ts`) · **v3 pin** 6 tests (`src/lib/residency/__tests__/bundle-identity-v3.test.ts`) · **logging** 9 tests (`src/lib/residency/__tests__/migrate-identity-logging.test.ts`).
+Suite sizes: **roundtrip-pg** 18 tests (`src/lib/residency/__tests__/migrate-roundtrip-pg.test.ts`) · **admin-migrate** 114 tests (`src/api/__tests__/admin-migrate.test.ts`) · **export** 24 tests (`src/lib/residency/__tests__/export.test.ts`) · **object-cmp** 64 tests (`src/lib/brain/__tests__/object-cmp.test.ts`) · **v3 pin** 6 tests (`src/lib/residency/__tests__/bundle-identity-v3.test.ts`) · **logging** 9 tests (`src/lib/residency/__tests__/migrate-identity-logging.test.ts`).
 
 ## Notes
 

--- a/packages/api/src/api/__tests__/admin-migrate.test.ts
+++ b/packages/api/src/api/__tests__/admin-migrate.test.ts
@@ -14,7 +14,56 @@ import type {
   ImportResult,
 } from "@useatlas/types";
 import type { InternalPoolClient } from "@atlas/api/lib/db/internal";
-import { importBundle, validateBundle } from "../routes/admin-migrate";
+import { importBundle as importBundleWithCorrelationId, validateBundle } from "../routes/admin-migrate";
+
+/**
+ * `importBundle` with #5112's correlation token defaulted.
+ *
+ * The token is REQUIRED on the real signature, deliberately: it is stamped on
+ * every vocabulary-refusal line so two attempts at the same bundle stop emitting
+ * byte-identical line sets, and a parameter a production caller can omit is one a
+ * production caller will omit. That argument is about PRODUCTION callers — the
+ * compile error still fires for every one of them — so the tests in this file,
+ * none of which is about the token, opt in through one named shim rather than
+ * threading a constant through forty call sites. The token's own behaviour is pinned
+ * in `lib/brain/__tests__/vocabulary-merge-pg.test.ts` (group 8, which passes it
+ * explicitly and compares two attempts' whole payloads) and in
+ * `api/routes/__tests__/admin-migrate-import-errors.test.ts` (which pins the join key
+ * from the per-refusal line to the post-COMMIT confirmation, end to end).
+ *
+ * ⚠️ An earlier version of this sentence named `migrate-refusal-durability.test.ts`,
+ * which does not exist, and credited `migrate-roundtrip-pg.test.ts` with token
+ * assertions it does not make — it uses the same shim. A pointer to coverage is a
+ * claim like any other; both halves were wrong.
+ */
+type ImportBundleArgs = Parameters<typeof importBundleWithCorrelationId>;
+const importBundle = (
+  client: ImportBundleArgs[0],
+  bundle: ImportBundleArgs[1],
+  orgId: ImportBundleArgs[2],
+  correlationId: ImportBundleArgs[3] = "req-admin-migrate-test",
+) => importBundleWithCorrelationId(client, bundle, orgId, correlationId);
+
+/**
+ * ⚠️ `importBundle`'s 4th parameter is REQUIRED, pinned here because the shim above
+ * hides it — and nothing pinned it until the comment sweep went looking.
+ *
+ * The docstring on `importBundle` argues the token must be required because "a
+ * parameter a caller can omit is one a caller will omit". Relaxing it to
+ * `correlationId?: string` leaves this shim and `migrate-roundtrip-pg.test.ts`'s
+ * compiling — `ImportBundleArgs[3]` merely becomes `string | undefined` and the default
+ * still fills it — so the argument was documentation with no guard.
+ *
+ * An optional 4th argument makes `length` the union `3 | 4`, which fails `extends 4`.
+ * (`vocabulary-merge-pg.test.ts` carries the twin pin for `mergeApprovedEdges`; two
+ * functions took this parameter, and each needs its own.)
+ */
+const _importBundleTokenIsRequired: Parameters<
+  typeof importBundleWithCorrelationId
+>["length"] extends 4
+  ? true
+  : never = true;
+void _importBundleTokenIsRequired;
 import { warehouseRowId } from "@atlas/api/lib/brain/warehouse-producer";
 
 // ---------------------------------------------------------------------------
@@ -263,7 +312,7 @@ describe("bundle round-trip shape", () => {
       brainEdges: { imported: 4, skipped: 0 },
       factAudienceMembers: { imported: 2, skipped: 5 },
       // Three counters here alone (#5036).
-      brainVocabularyEdges: { imported: 1, skipped: 4, refused: 6 },
+      brainVocabularyEdges: { imported: 1, skipped: 4, refused: 6, refusalDetails: [] },
       brainSlackChannelExclusions: { imported: 2, skipped: 1, refused: 0 },
       brainEnrollments: { imported: 3, skipped: 1, namingDropped: 2, namingApplied: 4 },
       brainEntities: { imported: 6, skipped: 2 },
@@ -292,8 +341,14 @@ describe("bundle round-trip shape", () => {
     // fourth counter slips past both. The reconciliation behaviour that would
     // need revisiting is pinned in `migrate.test.ts`; this file pins shape, and
     // `bun run type` is what enforces it.
+    //
+    // `refusalDetails` joins the set at #5112, and it is a PAYLOAD rather than a
+    // counter — the only one in the whole type. It earns its place here on the
+    // same grounds: required, so dropping it stops the literal above
+    // type-checking, and named, so renaming it goes red.
     expect(Object.keys(result.brainVocabularyEdges).toSorted()).toEqual([
       "imported",
+      "refusalDetails",
       "refused",
       "skipped",
     ]);

--- a/packages/api/src/api/routes/__tests__/admin-migrate-import-errors.test.ts
+++ b/packages/api/src/api/routes/__tests__/admin-migrate-import-errors.test.ts
@@ -64,20 +64,48 @@ let statements: string[] = [];
 let rollbackFailure: Error | null = null;
 /** When set, `BEGIN` throws this — a socket that was dead before anything ran. */
 let beginFailure: Error | null = null;
+/**
+ * When set, `COMMIT` throws this (#5112).
+ *
+ * The one failure that lets the whole import RUN and then keeps it from taking
+ * effect — which is the input class the post-`COMMIT` refusal confirmation exists
+ * to distinguish. Every other injection in this file fails before the vocabulary
+ * merge, so none of them can tell "the confirmation is after COMMIT" from "the
+ * confirmation is after the merge".
+ */
+let commitFailure: Error | null = null;
 /** What `release()` was called WITH. `undefined` = pooled; an Error = destroyed. */
 let releasedWith: unknown[] = [];
 /** Saved so the suite leaves the environment as it found it. */
 let priorInternalSecret: string | undefined;
+
+/**
+ * Rows the fake client answers for statements matching a substring (#5112).
+ *
+ * The default `{ rows: [] }` is right for the error cases above — nothing is ever
+ * "already present" and the importer takes every INSERT path. It is NOT enough to
+ * reach a vocabulary REFUSAL, which is a decision made from rows: the merge's
+ * advisory-lock PROBE refuses to proceed unless it reads a count, and
+ * `admitAliasEdge` refuses `already-aliased` only when it finds an existing edge.
+ * So the refusal cases script exactly those two reads and nothing else.
+ */
+let rowResponders: Array<{ pattern: string; rows: Record<string, unknown>[] }> = [];
 
 const FAKE_CLIENT = {
   query: async (sql: string) => {
     statements.push(typeof sql === "string" ? sql : String(sql));
     if (sql === "BEGIN" && beginFailure !== null) throw beginFailure;
     if (sql === "ROLLBACK" && rollbackFailure !== null) throw rollbackFailure;
-    // BEGIN and COMMIT always succeed: a failure there is a different test, and
-    // one here would mask the arm under test.
+    if (sql === "COMMIT" && commitFailure !== null) throw commitFailure;
+    // Otherwise BEGIN/ROLLBACK/COMMIT succeed: a failure there is a different
+    // test, and an unrequested one here would mask the arm under test.
     if (sql === "BEGIN" || sql === "ROLLBACK" || sql === "COMMIT") return { rows: [], rowCount: 0 };
     if (queryFailure !== null) throw queryFailure;
+    for (const responder of rowResponders) {
+      if (sql.includes(responder.pattern)) {
+        return { rows: responder.rows, rowCount: responder.rows.length };
+      }
+    }
     return { rows: [], rowCount: 0 };
   },
   release: (err?: unknown) => {
@@ -162,6 +190,14 @@ const {
   RegionImportVocabularyTargetError,
   IMPORT_FAILED_MESSAGE,
 } = await import("../admin-migrate");
+// ⚠️ DYNAMIC, and it has to be. A STATIC import of `lib/brain/vocabulary` is hoisted
+// above every `mock.module` call in this file, and that module calls `createLogger()`
+// at MODULE SCOPE — so it binds the REAL logger and `mergeApprovedEdges`' per-refusal
+// warn stops reaching `logged`. Measured: importing the cap statically made the
+// per-refusal line invisible while every assertion still passed, because the
+// post-COMMIT confirmation QUOTES the phrase `WILL DROP` and the lookup matched that
+// instead. Same trap `cleanup.test.ts` documents from the other side.
+const { VOCABULARY_REFUSAL_DETAIL_CAP } = await import("@atlas/api/lib/brain/vocabulary");
 
 /**
  * A bundle `validateBundle` accepts that makes the importer ISSUE A STATEMENT.
@@ -208,11 +244,21 @@ interface ErrorBody {
 interface Handler {
   readonly name: string;
   readonly post: (body: unknown) => Promise<Response>;
+  /**
+   * The correlation token this handler must use, where it has a request-scoped one.
+   *
+   * The admin route reads `c.get("requestId")`, which the mocked `requireOrgContext`
+   * sets to a known value — so it is assertable. The internal route has no
+   * middleware and mints its own `crypto.randomUUID()`, so there is nothing to
+   * compare against and this stays `undefined`.
+   */
+  readonly expectedToken?: string;
 }
 
 const HANDLERS: Handler[] = [
   {
     name: "admin",
+    expectedToken: "test-req",
     post: async (body: unknown) =>
       adminMigrate.request("/import", {
         method: "POST",
@@ -239,8 +285,10 @@ describe("the import's error responses — both handlers", () => {
     queryFailure = null;
     rollbackFailure = null;
     beginFailure = null;
+    commitFailure = null;
     releasedWith = [];
     statements = [];
+    rowResponders = [];
     logged.length = 0;
     priorInternalSecret = process.env.ATLAS_INTERNAL_SECRET;
     process.env.ATLAS_INTERNAL_SECRET = INTERNAL_SECRET;
@@ -594,6 +642,215 @@ describe("the import's error responses — both handlers", () => {
       // anything the caller did not already send.
       expect(refused.message).toContain("0f8c4a2e-4444-4000-8000-000000000003");
       expect(failed.message).not.toContain("0f8c4a2e-4444-4000-8000-000000000003");
+    });
+  });
+
+
+  // ── #5112 — the post-COMMIT "DID DROP" confirmation, both handlers ──
+  //
+  // `mergeApprovedEdges` emits one FUTURE-TENSE warn per refusal, and that tense
+  // is correct: the merge is section 9 of ~13 inside the transaction, so the
+  // closure rebuild, the brain's identity refusal or any driver error can still
+  // roll the whole import back — and then no edge was dropped because none was
+  // applied. The cost of being correct there is that nothing ever said the drop
+  // HAPPENED, so an operator following the recovery path could not tell a
+  // committed loss from a rolled-back attempt whose retry succeeded.
+  //
+  // Asserted over BOTH handlers, for this file's founding reason: the two
+  // post-COMMIT blocks are copies, so the realistic defect is a line added to one.
+
+  /**
+   * Make the merge REFUSE one arriving edge.
+   *
+   * Two scripted reads and no more. The advisory-lock probe must answer a count
+   * or the merge refuses to run at all (it cannot verify it holds the lock), and
+   * `admitAliasEdge`'s first SELECT must find an existing edge onto a DIFFERENT
+   * target — same target is a `duplicate`, which is the benign half and no
+   * refusal at all.
+   */
+  function scriptOneRefusal(): void {
+    rowResponders = [
+      { pattern: "pg_locks", rows: [{ n: 1 }] },
+      { pattern: "SELECT to_norm FROM brain_vocabulary_edge", rows: [{ to_norm: "cost" }] },
+    ];
+  }
+
+  /**
+   * A bundle `validateBundle` accepts that carries `count` alias edges.
+   *
+   * Distinct `fromNorm`s, because `validateBundle` refuses an empty norm and a
+   * self-edge and the merge would otherwise count duplicates rather than refusals.
+   */
+  function bundleWithEdges(count: number): ExportBundle {
+    return {
+      ...minimalBundle(),
+      brainVocabularyEdges: Array.from({ length: count }, (_, i) => ({
+        slotPosition: "predicate",
+        fromNorm: `price ${i}`,
+        toNorm: "priced at",
+        approvedBy: "source-admin",
+        approvedAt: "2026-06-01T00:00:00.000Z",
+      })),
+    };
+  }
+
+  const bundleWithOneEdge = (): ExportBundle => bundleWithEdges(1);
+
+  const CONFIRMATION = "Vocabulary merge DID DROP";
+  /**
+   * The per-refusal, future-tense line from `mergeApprovedEdges`.
+   *
+   * ⚠️ NOT `"WILL DROP"`, which is what this started as and which matched the
+   * CONFIRMATION — that message quotes the phrase ("Every preceding 'WILL DROP' line
+   * carrying this correlationId is now a fact"), so the lookup found the confirmation,
+   * the join-key assertion compared the confirmation to itself, and both passed while
+   * the per-refusal line was absent entirely. A lexical matcher cannot tell a
+   * quotation from the thing it quotes; this one matches wording only the real line
+   * has.
+   */
+  const WILL_DROP = "WILL DROP an arriving alias edge";
+
+  describe.each(HANDLERS)("$name handler — refusal confirmation", ({ post, expectedToken }) => {
+    it("⭐ warns DID DROP after COMMIT, carrying the payloads and the requestId", async () => {
+      scriptOneRefusal();
+
+      const res = await post(bundleWithOneEdge());
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        brainVocabularyEdges: { refused: number; refusalDetails: unknown[] };
+      };
+
+      // Premise guard: the test is vacuous unless an edge really was refused. The
+      // first cut of the scripting above returned no rows and every assertion
+      // below passed against `refused: 0`.
+      expect(body.brainVocabularyEdges.refused).toBe(1);
+      expect(body.brainVocabularyEdges.refusalDetails).toHaveLength(1);
+
+      // `COMMIT` ran at all. ⚠️ THIS IS A PRESENCE CHECK, NOT A POSITION CHECK, and
+      // an earlier version of this comment claimed otherwise — `statements` and
+      // `logged` are unrelated arrays with no interleaving, so moving the
+      // confirmation one line ABOVE the `COMMIT` passes this outright. The position
+      // is guarded by the `commitFailure` case at the end of this block, which is
+      // the only injection that lets the merge run and then keeps the transaction
+      // from taking effect.
+      expect(statements).toContain("COMMIT");
+
+      const confirmation = logged.find((l) => l.message.includes(CONFIRMATION));
+      expect(confirmation).toBeDefined();
+      // `warn`, not `info`: dropping a human's approved decision is not routine.
+      // The level travels with the payload here for that reason.
+      expect(confirmation?.level).toBe("warn");
+      expect(confirmation?.payload).toMatchObject({
+        refused: 1,
+        detailsCarried: 1,
+        // Asserted, because it was in the payload and pinned by nothing — and the
+        // whole reason it is there is to make a `detailsCarried` short of `refused`
+        // legible rather than looking like an inconsistency.
+        detailCap: VOCABULARY_REFUSAL_DETAIL_CAP,
+      });
+      // The token is asserted as a JOIN KEY below rather than as a literal, because
+      // the two handlers mint it differently and both are correct: the admin route
+      // reads `c.get("requestId")`, while the internal route has no middleware and
+      // mints its own `crypto.randomUUID()`. What must hold in both is that it is a
+      // real value and that the same one appears on the WILL-DROP line.
+      const token = (confirmation?.payload as { correlationId: unknown }).correlationId;
+      expect(typeof token).toBe("string");
+      expect(token).not.toBe("");
+      // The payloads are REPEATED rather than referenced: the per-refusal warns
+      // and this line can be separated by minutes of unrelated traffic, and a
+      // confirmation saying "the lines above are real" is unreadable once they
+      // are not above it.
+      expect(
+        (confirmation?.payload as { refusalDetails: Array<{ existingTarget: string }> })
+          .refusalDetails[0].existingTarget,
+      ).toBe("cost");
+
+      // ⚠️ THE JOIN KEY. The same token appears on the per-refusal WILL-DROP line,
+      // which is what converts that line's future tense into a fact. Without this
+      // the confirmation is a second, unrelated line about the same event.
+      const willDrop = logged.find((l) => l.message.includes(WILL_DROP));
+      expect(willDrop).toBeDefined();
+      expect((willDrop?.payload as { correlationId: unknown }).correlationId).toBe(token);
+
+      // ⚠️ AND, where the handler has one, the token IS the request's own id. Asserted
+      // per-handler rather than globally because the two mint differently and both are
+      // correct — but "a non-empty string that joins to WILL DROP" is satisfied by a
+      // freshly-minted UUID that correlates to NOTHING else in the request, which
+      // would silently break the join to the 500 body's `requestId` and to every
+      // other line the request emits.
+      if (expectedToken !== undefined) expect(token).toBe(expectedToken);
+    });
+
+    it("⭐ CAPS the payloads it carries, and reports both numbers", async () => {
+      // `detailsCarried === refused` in the case above, which is the accidental
+      // equality that makes `detailsCarried: refused` an invisible mutation — and the
+      // route's own comment says naming both numbers is the point precisely BECAUSE
+      // they can differ. Here they must: one more edge than the cap.
+      const over = VOCABULARY_REFUSAL_DETAIL_CAP + 1;
+      scriptOneRefusal();
+
+      const res = await post(bundleWithEdges(over));
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        brainVocabularyEdges: { refused: number; refusalDetails: unknown[] };
+      };
+
+      // Every edge refused (the scripted read answers `already-aliased` for all of
+      // them), and the response carries only the cap's worth.
+      expect(body.brainVocabularyEdges.refused).toBe(over);
+      expect(body.brainVocabularyEdges.refusalDetails).toHaveLength(
+        VOCABULARY_REFUSAL_DETAIL_CAP,
+      );
+
+      const confirmation = logged.find((l) => l.message.includes(CONFIRMATION));
+      expect(confirmation?.payload).toMatchObject({
+        refused: over,
+        detailsCarried: VOCABULARY_REFUSAL_DETAIL_CAP,
+        detailCap: VOCABULARY_REFUSAL_DETAIL_CAP,
+      });
+      // The two numbers DIFFER, which is the property this case exists for.
+      expect(over).not.toBe(VOCABULARY_REFUSAL_DETAIL_CAP);
+    });
+
+    it("⭐ says NOTHING when no edge was refused", async () => {
+      // The other input class at the same guard. A confirmation that fired on
+      // every import carrying a vocabulary would train an operator to skip the
+      // line, which is the alarm fatigue the source-side disclosure already
+      // guards against — and deleting `if (refused === 0) return` is the mutation
+      // this catches.
+      rowResponders = [{ pattern: "pg_locks", rows: [{ n: 1 }] }];
+
+      const res = await post(bundleWithOneEdge());
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { brainVocabularyEdges: { refused: number } };
+      // Premise guard the other way: the edge was APPLIED, so there was a
+      // vocabulary section and it produced no refusal.
+      expect(body.brainVocabularyEdges.refused).toBe(0);
+
+      expect(logged.filter((l) => l.message.includes(CONFIRMATION))).toEqual([]);
+      expect(logged.filter((l) => l.message.includes(WILL_DROP))).toEqual([]);
+    });
+
+    it("⭐ says nothing when the COMMIT itself failed — a rollback dropped nothing", async () => {
+      // The load-bearing negative, and the ONLY injection in this file that can
+      // make it: the whole import runs, the refusal is computed, the WILL-DROP line
+      // is emitted — and then `COMMIT` throws, so no edge was dropped because none
+      // was applied. A confirmation here would send an operator to re-author
+      // decisions that are still in the source region.
+      //
+      // A failure earlier in the transaction could not test this: the merge would
+      // never run, so a confirmation placed right after the merge — the defect —
+      // would stay silent for the wrong reason and the test would pass.
+      scriptOneRefusal();
+      commitFailure = new Error("connection terminated during COMMIT");
+
+      const res = await post(bundleWithOneEdge());
+      expect(res.status).toBe(500);
+
+      // The merge DID run and DID decide — that is what makes the silence below a
+      // property of the confirmation's position rather than of the merge's.
+      expect(logged.some((l) => l.message.includes(WILL_DROP))).toBe(true);
+      expect(logged.filter((l) => l.message.includes(CONFIRMATION))).toEqual([]);
     });
   });
 

--- a/packages/api/src/api/routes/admin-migrate.ts
+++ b/packages/api/src/api/routes/admin-migrate.ts
@@ -26,6 +26,12 @@ import { SLACK_CHANNEL_ID_PATTERN } from "@atlas/api/lib/brain/ingest/slack/conf
 import {
   VOCABULARY_LOCK_NAMESPACE,
   VOCABULARY_LOCK_SQL,
+  // ⚠️ The refusal-payload cap lives HERE, not in `@useatlas/types` beside the type
+  // it bounds. A VALUE import from the published package resolves at runtime against
+  // the version the scaffold template pins, and this file is copied into that
+  // template — see the constant's own docstring for the CI failure that proved it.
+  // Type imports from `@useatlas/types` are erased and therefore free.
+  VOCABULARY_REFUSAL_DETAIL_CAP,
   loadClaimVocabulary,
   mergeApprovedEdges,
 } from "@atlas/api/lib/brain/vocabulary";
@@ -991,6 +997,50 @@ const ImportResultSchema = z.object({
     imported: z.number(),
     skipped: z.number(),
     refused: z.number(),
+    // The refused edges themselves (#5112). The ONE section that returns
+    // payloads rather than counts, because it is the one section whose dropped
+    // outcome is not re-derivable: the source region schedules the delete of its
+    // own `brain_vocabulary_edge` rows, so once the grace period closes this
+    // array is the last copy of N human review decisions.
+    //
+    // Capped by the producer at `VOCABULARY_REFUSAL_DETAIL_CAP`, so
+    // `refusalDetails.length < refused` means truncated. No `truncated` flag: a
+    // flag and a derivable comparison can disagree.
+    //
+    // ⚠️ EVERY ITEM FIELD REQUIRED, including the two nullable ones — and the reach
+    // of the pin below is MEASURED, not assumed. Three experiments, run against
+    // `tsgo --noEmit`:
+    //
+    //   - drop a required item field from this side only  → RED (pinned)
+    //   - drop `.nullable()` from this side only          → RED (pinned)
+    //   - add an OPTIONAL item field to this side only    → GREEN (NOT pinned)
+    //
+    // So the hole the pin's own comment names one level up — an optional NESTED
+    // member — extends to the array ITEM's fields too, which is a second level of
+    // nesting it does not mention. `.nullable()` keeps a field present-and-null and
+    // is therefore pinned; `.optional()` on either spelling is pinned by nothing.
+    // That is the whole reason all eight are required here.
+    refusalDetails: z
+      .array(
+        z.object({
+          slotPosition: z.string(),
+          fromNorm: z.string(),
+          toNorm: z.string(),
+          approvedBy: z.string().nullable(),
+          approvedAt: z.string(),
+          refusal: z.string(),
+          existingTarget: z.string().nullable(),
+          reason: z.string(),
+        }),
+      )
+      // ⚠️ DOCUMENTATION, NOT ENFORCEMENT, and worth having for exactly that. Nothing
+      // validates a RESPONSE against this schema at runtime, so the two `.slice()`
+      // calls (here and in `residency/migrate.ts`) remain the enforcement. What
+      // `.max()` buys is the bound appearing in the published OpenAPI spec, where a
+      // consumer can see it — otherwise the contract says `array` and the cap is
+      // folklore. `z.infer` is unchanged, so the `_SchemaMatchesWireType` pin below
+      // is unaffected.
+      .max(VOCABULARY_REFUSAL_DETAIL_CAP),
   }),
   // Three counters for `brainVocabularyEdges`' reason, one arm over. `skipped`
   // is an exclusion this region already holds — an idempotent re-import.
@@ -1695,10 +1745,21 @@ function importedIdentity(fact: ExportedBrainFact, source: IdentitySource): Impo
   };
 }
 
+/**
+ * Import one export bundle into `orgId`, inside the caller's transaction.
+ *
+ * `correlationId` is the caller's per-attempt token (`requestId` on both routes).
+ * REQUIRED rather than optional: it is stamped on every vocabulary refusal line
+ * so two attempts at the same bundle stop emitting byte-identical line sets
+ * (#5112), and a parameter a caller can omit is one a caller will omit. It is
+ * carried, never persisted — the durable half is the source region's
+ * `region_migrations.vocabulary_refusals`.
+ */
 export async function importBundle(
   client: InternalPoolClient,
   bundle: ExportBundle,
   orgId: string,
+  correlationId: string,
 ): Promise<ImportResult> {
   const result: ImportResult = {
     conversations: { imported: 0, skipped: 0 },
@@ -1713,7 +1774,7 @@ export async function importBundle(
     brainFacts: { imported: 0, skipped: 0 },
     brainEdges: { imported: 0, skipped: 0 },
     factAudienceMembers: { imported: 0, skipped: 0 },
-    brainVocabularyEdges: { imported: 0, skipped: 0, refused: 0 },
+    brainVocabularyEdges: { imported: 0, skipped: 0, refused: 0, refusalDetails: [] },
     brainSlackChannelExclusions: { imported: 0, skipped: 0, refused: 0 },
     brainEnrollments: { imported: 0, skipped: 0, namingDropped: 0, namingApplied: 0 },
     brainEntities: { imported: 0, skipped: 0 },
@@ -2147,6 +2208,9 @@ export async function importBundle(
       approvedBy: edge.approvedBy ?? null,
       approvedAt: edge.approvedAt,
     })),
+    // The caller's per-attempt token, stamped on every refusal line so a retry's
+    // line set is distinguishable from the first attempt's (#5112).
+    correlationId,
   );
 
   // Three counters, and the split is the point of the slice. `skipped` is the
@@ -2164,6 +2228,42 @@ export async function importBundle(
   result.brainVocabularyEdges.imported = vocabularyMerge.applied;
   result.brainVocabularyEdges.skipped = vocabularyMerge.duplicate;
   result.brainVocabularyEdges.refused = vocabularyMerge.refusals.length;
+
+  // ⚠️ THE PAYLOADS, NOT JUST THE COUNT — this line is #5112 (#5036 read
+  // `refusals.length` here and threw the array away).
+  //
+  // The refused edge is a human review decision the SOURCE region approved and
+  // this region declined. The source is the party that cuts over and schedules
+  // the cleanup that DELETEs its own `brain_vocabulary_edge` rows after the grace
+  // period, so without this the party owning the irreversible act got a number
+  // while the record that would let anyone undo it lived only in THIS region's
+  // log retention. `residency/migrate.ts` reads these off the response and writes
+  // them to the source's `region_migrations` row, which cleanup never deletes.
+  //
+  // Capped: a hand-built or corrupted bundle can conflict with itself on every
+  // edge, and this array becomes an HTTP response body AND a `jsonb` column. The
+  // count above is always the true total, so a shorter array is the truncation
+  // signal — see `VOCABULARY_REFUSAL_DETAIL_CAP`.
+  //
+  // Field-by-field rather than spread: `VocabularyMergeRefusal` nests the edge
+  // and carries `existingTarget` on only one arm, and the wire type is FLAT with
+  // `existingTarget` always present. Spreading would put a nested `edge` object
+  // on the wire and make the field absent on three of the four refusal kinds —
+  // and "absent" and "there is no conflicting edge" read identically to the
+  // operator this payload exists for, which is the same distinction the
+  // target-side warn already makes with an explicit `null`.
+  result.brainVocabularyEdges.refusalDetails = vocabularyMerge.refusals
+    .slice(0, VOCABULARY_REFUSAL_DETAIL_CAP)
+    .map((refusal) => ({
+      slotPosition: refusal.edge.position,
+      fromNorm: refusal.edge.fromNorm,
+      toNorm: refusal.edge.toNorm,
+      approvedBy: refusal.edge.approvedBy ?? null,
+      approvedAt: refusal.edge.approvedAt,
+      refusal: refusal.refusal,
+      existingTarget: refusal.refusal === "already-aliased" ? refusal.existingTarget : null,
+      reason: refusal.message,
+    }));
 
   // --- 9b. The Slack ingest-scope narrowings (#5203) ---
   // Written BEFORE the episodes below, and that ordering is load-bearing: the
@@ -2863,6 +2963,123 @@ export async function importBundle(
   return result;
 }
 
+/**
+ * The post-`COMMIT` confirmation that turns "WILL DROP" into "DID DROP" (#5112).
+ *
+ * `mergeApprovedEdges` emits one `log.warn` per refusal in the FUTURE TENSE, and
+ * that tense is correct: the merge is section 9 of ~13 inside the caller's
+ * transaction, so the closure rebuild, the brain's identity refusal or any driver
+ * error can still roll the whole import back — and then no edge was dropped
+ * because none was applied. The cost of being correct there is that nothing ever
+ * said the drop HAPPENED. An operator following the recovery path could not tell
+ * a committed loss from a rolled-back attempt whose retry succeeded.
+ *
+ * ⚠️ CALLED AFTER `COMMIT`, NEVER INSIDE THE `try` BEFORE IT, and the position is
+ * the whole content of the line. Moved one statement earlier it makes exactly the
+ * over-report the future tense exists to avoid.
+ *
+ * `correlationId` is the same token the per-refusal lines carry, so the two line
+ * sets join on one grep. The payloads are repeated rather than referenced: the
+ * warns and this line can be separated by minutes of unrelated traffic, and a
+ * confirmation that says only "the 3 lines above are real" is unreadable once
+ * they are not above it.
+ *
+ * Silent when nothing was refused — a `refused: 0` confirmation would fire on
+ * every import that carries a vocabulary and train an operator to skip the line.
+ *
+ * ## Why THIS side logs the payloads and the source side logs only counts
+ *
+ * A deliberate asymmetry, recorded because the two halves look inconsistent and a
+ * later reader will otherwise "fix" one to match the other. In the TARGET region
+ * the log IS the recovery path — this is the only process that ever holds the
+ * refused edges, so a count here would discard the thing worth keeping. In the
+ * SOURCE region (`residency/migrate.ts`) the payloads go to a DATABASE COLUMN and
+ * the log carries counts, because that module's whole argument is that a log line
+ * does not outlive the data it describes.
+ *
+ * The cost is real and accepted: these lines put customer-derived lexical norms and
+ * approver user ids into this region's log stream, which is a retention surface. It
+ * is the same data the region already holds in `brain_vocabulary_edge`, it is
+ * bounded by the cap, and it fires only when a human decision was actually dropped.
+ */
+function logVocabularyRefusalsCommitted(
+  correlationId: string,
+  orgId: string,
+  result: ImportResult,
+): void {
+  const { refused, refusalDetails } = result.brainVocabularyEdges;
+  if (refused === 0) return;
+  logRefusalConfirmation(correlationId, orgId, refused, refusalDetails);
+}
+
+/**
+ * The confirmation's body, wrapped so it CANNOT fail the request (panel round 1).
+ *
+ * Both handlers call `logVocabularyRefusalsCommitted` inside the `try`, after
+ * `COMMIT` — the position the confirmation's whole meaning depends on. The residual
+ * that round 1 caught: a throw in that window (a pino transport EPIPE on a closed
+ * stdout, a full transport buffer) lands in the catch, where `ROLLBACK`-after-COMMIT
+ * succeeds, so `uncertain` is false and the handler answers **500 `import_failed`**
+ * — whose message says the import did not take effect — for a transaction that
+ * committed, refusals included. `transferBundleToTarget` then maps that 500 to
+ * "Target region import failed", aborts the migration, and discards the very
+ * refusal evidence it was about to persist.
+ *
+ * So the disclosure is made unable to invalidate the thing it discloses. Additive
+ * rather than a restructure: hoisting the post-`COMMIT` statements out of the `try`
+ * would need a new response code for "committed but reporting failed", which is new
+ * machinery for a strictly worse outcome — the data DID land, and a 200 that lost
+ * one log line is the honest answer.
+ *
+ * The catch logs at `error` and re-narrows, so the failure is never silent: what is
+ * lost is the confirmation, and that loss is itself announced.
+ */
+function logRefusalConfirmation(
+  correlationId: string,
+  orgId: string,
+  refused: number,
+  refusalDetails: ImportResult["brainVocabularyEdges"]["refusalDetails"],
+): void {
+  try {
+    emitRefusalConfirmation(correlationId, orgId, refused, refusalDetails);
+  } catch (err) {
+    log.error(
+      { err: err instanceof Error ? err.message : String(err), correlationId, orgId, refused },
+      "Import COMMITTED and its refusal confirmation could not be emitted — the data landed and " +
+        "the refusals ARE dropped; the per-refusal WILL DROP lines carrying this correlationId " +
+        "are the surviving record",
+    );
+  }
+}
+
+function emitRefusalConfirmation(
+  correlationId: string,
+  orgId: string,
+  refused: number,
+  refusalDetails: ImportResult["brainVocabularyEdges"]["refusalDetails"],
+): void {
+  log.warn(
+    {
+      correlationId,
+      orgId,
+      refused,
+      // Both numbers, always. `refused` is the truth and `refusalDetails` is
+      // capped, so a reader who sees only the array reads a smaller loss than
+      // happened. Naming the cap in the payload is what makes the difference
+      // legible rather than looking like an inconsistency.
+      detailsCarried: refusalDetails.length,
+      detailCap: VOCABULARY_REFUSAL_DETAIL_CAP,
+      refusalDetails,
+    },
+    "Vocabulary merge DID DROP arriving alias edges — the import COMMITTED, so this many " +
+      "approved human review decisions are permanently not applied in this region. Every " +
+      "preceding 'WILL DROP' line carrying this correlationId is now a fact. The source " +
+      "region's own brain_vocabulary_edge rows are the recovery path and its cleanup deletes " +
+      "them once the grace period expires; the same payloads are recorded on the source's " +
+      "region_migrations row, which cleanup never touches.",
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Router
 // ---------------------------------------------------------------------------
@@ -2911,9 +3128,10 @@ adminMigrate.openapi(importRoute, async (c) => {
   try {
     await client.query("BEGIN");
     begun = true;
-    const result = await importBundle(client, bundle, orgId);
+    const result = await importBundle(client, bundle, orgId, requestId);
     await client.query("COMMIT");
 
+    logVocabularyRefusalsCommitted(requestId, orgId, result);
     log.info({ requestId, orgId, result }, "Migration import complete");
     return c.json(result, 200);
   } catch (err) {
@@ -3091,9 +3309,10 @@ internalMigrate.post("/import", async (c) => {
   try {
     await client.query("BEGIN");
     begun = true;
-    const result = await importBundle(client, bundle, orgId);
+    const result = await importBundle(client, bundle, orgId, requestId);
     await client.query("COMMIT");
 
+    logVocabularyRefusalsCommitted(requestId, orgId, result);
     log.info({ requestId, orgId, result }, "Internal cross-region import complete");
     return c.json(result, 200);
   } catch (err) {

--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -618,6 +618,10 @@ describe("migrateAuthTables", () => {
             // text (#5240) — again a data-only UPDATE on `plugin_catalog`, so
             // the same grounds as 0196–0202.
             { name: "0203_brain_catalog_config_help_company_atlas.sql" },
+            // 0204 adds two nullable columns to `region_migrations` (#5112) —
+            // an Atlas-owned table Better Auth has no stake in, so the same
+            // grounds as 0196–0203.
+            { name: "0204_region_migrations_vocabulary_refusals.sql" },
           ],
         };
       }

--- a/packages/api/src/lib/brain/__tests__/vocabulary-merge-pg.test.ts
+++ b/packages/api/src/lib/brain/__tests__/vocabulary-merge-pg.test.ts
@@ -35,6 +35,10 @@
  *      merge and must still account three ways.
  *   7. **The transaction** — the merge refuses to run outside one, and takes no
  *      lock when there is nothing to merge.
+ *   8. **The correlation token** (#5112) — every refusal line carries it, and two
+ *      attempts at the SAME bundle in the SAME workspace stop emitting
+ *      byte-identical payloads. That equality was the defect, so the assertion
+ *      compares the whole serialized payload rather than the token alone.
  *
  * ## Why the logger is mocked here
  *
@@ -108,7 +112,53 @@ const PG_TEST_TIMEOUT_MS = 60_000;
 // DYNAMIC, after the mock above is installed.
 const { runMigrations } = await import("@atlas/api/lib/db/migrate");
 const { MANAGED_AUTH_MIGRATIONS, _resetPool } = await import("@atlas/api/lib/db/internal");
-const { approveAliasEdge, mergeApprovedEdges } = await import("@atlas/api/lib/brain/vocabulary");
+const { approveAliasEdge, mergeApprovedEdges: mergeApprovedEdgesWithCorrelationId } = await import(
+  "@atlas/api/lib/brain/vocabulary"
+);
+
+/**
+ * The default correlation token for this file's cases (#5112).
+ *
+ * Distinct per attempt in production — a `requestId` — and every existing case
+ * here makes exactly one attempt, so one constant is faithful. The two cases that
+ * exist to exercise the token (group 8, at the end of this file) pass their own.
+ */
+const DEFAULT_CORRELATION_ID = "req-vocabulary-merge-pg";
+
+type MergeArgs = Parameters<typeof mergeApprovedEdgesWithCorrelationId>;
+/**
+ * `mergeApprovedEdges` with the token defaulted. REQUIRED on the real signature so a
+ * production caller cannot omit it; defaulted through one named shim here so the cases
+ * that are not about the token do not each restate it.
+ */
+const mergeApprovedEdges = (
+  tx: MergeArgs[0],
+  workspaceId: MergeArgs[1],
+  edges: MergeArgs[2],
+  correlationId: MergeArgs[3] = DEFAULT_CORRELATION_ID,
+) => mergeApprovedEdgesWithCorrelationId(tx, workspaceId, edges, correlationId);
+
+/**
+ * ⚠️ The 4th parameter is REQUIRED, pinned here because the shim above hides it.
+ *
+ * `mergeApprovedEdges`' docstring argues at length that the token must be required
+ * because "a parameter a caller can omit is one a caller will omit" — and nothing
+ * enforced that: relaxing THIS signature to `correlationId?: string` leaves the shim
+ * above compiling (`MergeArgs[3]` merely becomes `string | undefined`, and the default
+ * still fills it), so the argument was documentation with no guard.
+ *
+ * The two `importBundle` shims — `api/__tests__/admin-migrate.test.ts` and
+ * `residency/__tests__/migrate-roundtrip-pg.test.ts` — hide the same parameter on the
+ * OTHER function; its arity is pinned in the first of those.
+ *
+ * An optional 4th argument makes `length` the union `3 | 4`, which fails `extends 4`.
+ */
+const _correlationIdIsRequired: Parameters<
+  typeof mergeApprovedEdgesWithCorrelationId
+>["length"] extends 4
+  ? true
+  : never = true;
+void _correlationIdIsRequired;
 type ArrivingAliasEdge = import("@atlas/api/lib/brain/vocabulary").ArrivingAliasEdge;
 type SlotPosition = import("@atlas/api/lib/brain/identity").SlotPosition;
 
@@ -843,6 +893,75 @@ describeIfPg("merging two vocabularies (#5036)", () => {
       const merge = await mergeApprovedEdges(pool, ws, []);
       expect(merge).toEqual({ applied: 0, duplicate: 0, refusals: [], positionsRecomputed: [] });
       expect(warns).toEqual([]);
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+
+  // ── 8. #5112 — the correlation token ───────────────────────────────
+
+  it(
+    "⭐ stamps the correlation token on EVERY refusal line",
+    async () => {
+      // Before it, this payload was derived entirely from the arriving edge and this
+      // region's rows, so nothing in a refusal line said which ATTEMPT produced it.
+      const ws = freshWorkspace();
+      const merge = await inTx((tx) =>
+        mergeApprovedEdges(
+          tx,
+          ws,
+          // TWO refusals, so "every line" is a real claim: an implementation that
+          // stamped only the first would satisfy a single-refusal fixture.
+          [arriving("", "price"), arriving("price", "price")],
+          "req-attempt-alpha",
+        ),
+      );
+
+      expect(merge.refusals).toHaveLength(2);
+      expect(warns).toHaveLength(2);
+      expect(warns.map((w) => w.payload.correlationId)).toEqual([
+        "req-attempt-alpha",
+        "req-attempt-alpha",
+      ]);
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "⭐ makes two attempts at the SAME bundle distinguishable",
+    async () => {
+      // The defect, stated exactly: two attempts at one bundle emitted BYTE-IDENTICAL
+      // line sets. A retry after a rollback produced a second copy of the first
+      // attempt's lines, and the future tense the lines are written in ("WILL DROP …
+      // when this transaction commits") makes each line individually honest while
+      // leaving the aggregate unreadable — an operator grepping the norm cannot tell
+      // three attempts at one edge from one attempt at three.
+      //
+      // ⚠️ THE SAME WORKSPACE AND THE SAME EDGE, twice. A fixture that varied the
+      // workspace or the norms would produce different lines for a reason that has
+      // nothing to do with the token, which is what makes this the falsifiable form.
+      const ws = freshWorkspace();
+      const bundle = [arriving("", "price")];
+
+      await inTx((tx) => mergeApprovedEdges(tx, ws, bundle, "req-attempt-one"));
+      const first = warns.map((w) => JSON.stringify(w.payload));
+      warns.length = 0;
+
+      await inTx((tx) => mergeApprovedEdges(tx, ws, bundle, "req-attempt-two"));
+      const second = warns.map((w) => JSON.stringify(w.payload));
+
+      expect(first).toHaveLength(1);
+      expect(second).toHaveLength(1);
+      // ⚠️ The WHOLE payload compared, not just the token: without the token the two
+      // serializations are equal, and that equality IS the bug. Asserting only that
+      // the tokens differ would pass an implementation that stamped the token
+      // somewhere the line never carries.
+      expect(second[0]).not.toBe(first[0]);
+      // …and the difference is the token and nothing else, which is what makes the
+      // two lines comparable rather than merely unequal.
+      expect(JSON.parse(second[0]) as Record<string, unknown>).toEqual({
+        ...(JSON.parse(first[0]) as Record<string, unknown>),
+        correlationId: "req-attempt-two",
+      });
     },
     PG_TEST_TIMEOUT_MS,
   );

--- a/packages/api/src/lib/brain/vocabulary.ts
+++ b/packages/api/src/lib/brain/vocabulary.ts
@@ -627,6 +627,52 @@ export interface ArrivingAliasEdge extends AliasEdgeInput {
 }
 
 /**
+ * The maximum number of refusal payloads that travel back to the source region
+ * on one import response, and the maximum this region will store (#5112).
+ *
+ * A bound is required rather than prudent. The payloads become an HTTP response
+ * body between regions AND a `jsonb` column on the source's `region_migrations`
+ * row, and a hand-built or corrupted bundle can conflict with itself on every
+ * edge — so an unbounded array is a bundle-sized response and a bundle-sized row.
+ * `refused` is always the true total, so `refusalDetails.length < refused` is what
+ * says the list was truncated; there is no separate flag, because a flag and a
+ * derivable comparison can disagree and only one of them can be right.
+ *
+ * 50 is chosen against the population, not as a round number: a refusal is rare
+ * by construction (two regions holding CONTRADICTORY curated decisions at the
+ * same norm), so a real migration produces single digits. A response carrying 50
+ * is already telling the operator the two vocabularies disagree structurally
+ * rather than incidentally, and the fifty-first payload adds nothing.
+ *
+ * ## ⚠️ Why this lives HERE and not in `@useatlas/types` beside the type it bounds
+ *
+ * It did, for one CI run, and `Deploy Validation`'s scaffold build is what caught
+ * it: *"Export VOCABULARY_REFUSAL_DETAIL_CAP doesn't exist in target module
+ * .../node_modules/@useatlas/types/dist/index.js"*.
+ *
+ * `create-atlas/scripts/prepare-templates.sh` copies `packages/api/src` into the
+ * scaffold template, which installs the PUBLISHED `@useatlas/types` — pinned
+ * `^0.7.0`, so it cannot even reach the workspace's 0.10.x. A **type** import from
+ * that package is erased at build time and therefore free; a **value** import is
+ * a runtime resolution against a version that predates the symbol. The monorepo
+ * hides this completely, because `Standalone Example Build` compiles against the
+ * local workspace build and passed on the same commit.
+ *
+ * So the rule is narrower than "don't add exports to the published package":
+ * `packages/api/src` has ~376 legitimate value imports from `@useatlas/*`, and
+ * they work because those symbols exist in the pinned version. A NEW runtime
+ * symbol that `packages/api` consumes is unusable until it is published AND the
+ * template's caret range is bumped to reach it — two coordinated steps for what is
+ * an implementation detail of the producer. The wire contract is "bounded, and a
+ * short list means truncated"; the specific number is nobody's business but ours,
+ * and publishing it would invite a consumer to depend on a value we may change.
+ *
+ * The check is already mechanical and already required — `Deploy Validation` — so
+ * this comment is the missing half: the diagnosis, at the place someone would
+ * consider moving the constant back.
+ */
+export const VOCABULARY_REFUSAL_DETAIL_CAP = 50;
+
 /**
  * One arriving edge the merge would not write, and everything needed to
  * re-author it by hand.
@@ -636,6 +682,11 @@ export interface ArrivingAliasEdge extends AliasEdgeInput {
  * whole edge, not a norm pair. An operator reading one of these has to be able
  * to reconstruct the source row without the bundle, which by then may be
  * deleted (`stays` cleanup, #4458).
+ *
+ * Since #5112 the log is no longer the ONLY path: `admin-migrate.ts` maps these
+ * onto `ImportResult`'s `refusalDetails` and the source region persists them on
+ * its own `region_migrations` row, which the cleanup never deletes. The payload
+ * still has to be the whole edge for the same reason.
  */
 export type VocabularyMergeRefusal =
   | {
@@ -740,11 +791,27 @@ export interface VocabularyMergeResult {
  * re-derivable from it; a per-row version would be a third representation to
  * keep consistent, and an imported row would carry a FOREIGN version that means
  * nothing in this region.
+ *
+ * ## `correlationId` is REQUIRED, and that is the whole point of it (#5112)
+ *
+ * One opaque per-attempt token, stamped on every refusal line. Before it, two
+ * attempts at the same bundle emitted BYTE-IDENTICAL line sets: the payload is
+ * derived entirely from the arriving edge and this region's rows, so a retry
+ * after a rollback produced a second copy of the first attempt's lines with
+ * nothing to tell them apart — and the future tense the lines are written in
+ * ("WILL DROP ... when this transaction commits") makes each line individually
+ * honest while leaving the aggregate unreadable. An operator grepping the norm
+ * cannot tell three attempts at one edge from one attempt at three.
+ *
+ * REQUIRED rather than optional so a caller cannot omit it, which is the same
+ * defect one argument over. The route passes its `requestId`; a caller with no
+ * request of its own owes a token it minted, not `""`.
  */
 export async function mergeApprovedEdges(
   tx: VocabularyExecutor,
   workspaceId: string,
   edges: readonly ArrivingAliasEdge[],
+  correlationId: string,
 ): Promise<VocabularyMergeResult> {
   // No edges, no lock. Not an optimization — the lock is only meaningful around
   // a write, and taking it here would make every import of a bundle that
@@ -869,6 +936,15 @@ export async function mergeApprovedEdges(
     log.warn(
       {
         workspaceId,
+        // ⚠️ ONE TOKEN PER ATTEMPT, and it is what makes this line set countable
+        // (#5112). See the `correlationId` section of this function's docstring:
+        // every other field here is derived from the arriving edge or from this
+        // region's rows, so without it a retry emits a byte-identical set and an
+        // operator cannot tell N attempts at one edge from one attempt at N. It
+        // is also the join key to the post-COMMIT "DID DROP" confirmation the
+        // route emits, which is what converts this line's future tense into a
+        // fact.
+        correlationId,
         position: refusal.edge.position,
         fromNorm: refusal.edge.fromNorm,
         toNorm: refusal.edge.toNorm,

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -379,7 +379,14 @@ describe("runMigrations", () => {
     //   guarded rewrite of one string INSIDE the JSONB array — the array is
     //   rebuilt element-wise with `jsonb_agg … WITH ORDINALITY` so every other
     //   field, flag and position survives byte-identical) = 204.
-    expect(count).toBe(204);
+    //   Plus 0204 (region_migrations_vocabulary_refusals — #5112: the refused
+    //   alias edges, durable on the SOURCE region's own migration row. Two
+    //   columns, both nullable, on a table classified `platform` in
+    //   bundle-scope.ts — which is what makes them outlive the grace-period
+    //   delete of the `brain_vocabulary_edge` rows they describe. NULL means
+    //   UNKNOWN, not zero: a row written before this migration, or a source
+    //   build that never asked the target) = 205.
+    expect(count).toBe(205);
 
     // Advisory lock acquired before anything else
     expect(queries[0]).toContain("pg_advisory_lock");
@@ -612,6 +619,7 @@ describe("runMigrations", () => {
         "0201_brain_catalog_rows_company_atlas.sql",
         "0202_brain_coverage_snapshot.sql",
         "0203_brain_catalog_config_help_company_atlas.sql",
+        "0204_region_migrations_vocabulary_refusals.sql",
       ],
     });
 

--- a/packages/api/src/lib/db/migrations/0204_region_migrations_vocabulary_refusals.sql
+++ b/packages/api/src/lib/db/migrations/0204_region_migrations_vocabulary_refusals.sql
@@ -1,0 +1,47 @@
+-- 0204_region_migrations_vocabulary_refusals.sql
+-- #5112 — a refused alias edge, durable at the SOURCE region.
+--
+-- #5036 made a region import refuse an arriving alias edge that would close a
+-- cycle or take a second parent, and log every refusal with enough of the source
+-- row to re-author it by hand. That log line lives in the TARGET region's
+-- process. Meanwhile the SOURCE region is the one that cuts over and schedules
+-- the cleanup which DELETEs its own `brain_vocabulary_edge` rows after
+-- CLEANUP_GRACE_PERIOD_DAYS (7). So the party that owns the irreversible act
+-- held a COUNT, and the record that would let anyone undo it lived in another
+-- region's log retention — outliving the data it describes by only as long as
+-- that retention happens to be.
+--
+-- These two columns are that record, on the source's own migration row.
+--
+-- ## Why `region_migrations` is the right home
+--
+-- It is classified `platform` in `lib/residency/bundle-scope.ts` — "the
+-- migration bookkeeping itself — must survive the migration it describes" — so
+-- `runSourceCleanupSweep` never touches it. The refusal payloads therefore
+-- outlive the very deletion that makes them the last copy, which is the whole
+-- requirement. `cleanup.ts` also already re-reads this row under `FOR UPDATE` at
+-- the moment of deletion, so the count is readable at the instant it becomes
+-- irreversible without adding a query.
+--
+-- ## Two columns rather than one
+--
+-- `vocabulary_edges_refused` is the COUNT, and it is what the audit events, the
+-- API and the CLI surface. `vocabulary_refusals` is the recovery PAYLOAD, capped
+-- at VOCABULARY_REFUSAL_DETAIL_CAP entries by the writer.
+--
+-- They are not redundant, and the count is not derivable from the array's
+-- length: the array is capped and an older target answers with a count and no
+-- payloads at all, so `jsonb_array_length(vocabulary_refusals) <
+-- vocabulary_edges_refused` is exactly the "some of this is unrecoverable"
+-- signal. Collapsing them would make a truncated record indistinguishable from a
+-- complete one.
+--
+-- Both NULL is the state of every row written before this migration, and of
+-- every migration that never reached the transfer phase. NULL means UNKNOWN, not
+-- zero: a source build that did not ask, or a migration that failed before the
+-- target answered. `0` means the target answered and refused nothing.
+ALTER TABLE region_migrations
+  ADD COLUMN IF NOT EXISTS vocabulary_edges_refused INTEGER;
+
+ALTER TABLE region_migrations
+  ADD COLUMN IF NOT EXISTS vocabulary_refusals JSONB;

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -1725,6 +1725,31 @@ export const regionMigrations = pgTable(
     // due query filters on it. Stamped in the same transaction as the
     // deletes, so a partial failure rolls back to "still due".
     sourceCleanedAt: timestamp("source_cleaned_at", { withTimezone: true }),
+    // #5112 — the refused alias edges, durable on the SOURCE region's own row.
+    // `region_migrations` is classified `platform` in bundle-scope.ts, so the
+    // cleanup sweep never deletes it; that is what makes these two columns
+    // outlive the grace-period delete of `brain_vocabulary_edge` they describe.
+    //
+    // NULL on both = UNKNOWN, not zero: a row written before this migration, a
+    // source build that did not ask, or a migration that failed before the
+    // target answered. `0` = the target answered and refused nothing.
+    //
+    // The count is NOT derivable from the array length — the array is capped at
+    // VOCABULARY_REFUSAL_DETAIL_CAP and an older target answers with a count and
+    // no payloads, so a shorter array beside a larger count is exactly the "part
+    // of this is unrecoverable" signal.
+    //
+    // ⚠️ `jsonb` is deliberately BARE — no `.$type<VocabularyRefusalDetail[]>()`.
+    // Drizzle then infers `unknown`, which forces any future reader to narrow, and
+    // that is the correct posture: these rows are read back from a database whose
+    // contents may have been written by an older build, by a region running a
+    // different payload contract, or by hand. `$type` would claim a validation the
+    // read path does not perform, contradicting the screening policy
+    // `residency/migrate.ts` applies on the way IN. There is no TypeScript reader
+    // today (every access is raw `internalQuery`; this table is a drift mirror), so
+    // the annotation would buy nothing and assert something false.
+    vocabularyEdgesRefused: integer("vocabulary_edges_refused"),
+    vocabularyRefusals: jsonb("vocabulary_refusals"),
   },
   (t) => [
     index("idx_region_migrations_workspace").on(t.workspaceId),

--- a/packages/api/src/lib/effect/__tests__/builtin-catalog-seed-layers.test.ts
+++ b/packages/api/src/lib/effect/__tests__/builtin-catalog-seed-layers.test.ts
@@ -1,0 +1,668 @@
+/**
+ * The Live boot-seed Layers of `effect/layers.ts` (#5273).
+ *
+ * `BuiltinDatasourceCatalogSeedLive`, `BuiltinKnowledgeCatalogSeedLive` — the two
+ * #5273 names — plus `OpenApiDatasourceCatalogSeedLive`, which this PR's review
+ * panel added after finding it had the very defect the other two were being pinned
+ * against (see that describe block), and a lexical guard that makes a fourth
+ * instance a test failure rather than a reviewer's lucky read.
+ *
+ * The first harness in the repo to drive a boot-seed Layer's DYNAMIC IMPORT — which
+ * is items (2) and (3) below, not (1). `layers.test.ts` already builds Live boot
+ * Layers behind a stubbed `InternalDB` + `Migration` (`runOverride`,
+ * `makeConnectionsHydrateLive`), so that part is precedented. What it does with these
+ * three Tags is supply exactly one of them, `BuiltinDatasourceCatalogSeed`, as a
+ * `Layer.succeed(...)` stub — which exercises the wiring around it and nothing inside
+ * it. The knowledge and OpenAPI Tags appear there not at all. The consequence was
+ * measured: the `case "seeded"` arm is the ONLY route by which `blockedSlugs` (the
+ * field #5266/#5239 exist to produce) reaches the Tag at all — nothing serves the
+ * shape over HTTP today, as the field's own docstring says, so the Layer's value is
+ * the only place a consumer could ever read it. Replacing the three forwarded fields
+ * with `...zeroCounts` was green across the whole suite.
+ *
+ * ## Why this needs a new pattern
+ *
+ * Each Layer resolves its boot wrapper through a dynamic `await import(...)` inside
+ * `Effect.tryPromise`, and each gates on `InternalDB` + `Migration` upstream. So a
+ * test needs three things at once:
+ *
+ *   1. `InternalDB` and `Migration` stubbed as Layers — `db.available` and
+ *      `migration.migrated` drive the `skipped-gate` arm before any import
+ *      happens.
+ *   2. The dynamic import intercepted, so the three boot-result kinds — plus a
+ *      rejection, which is the `catchAll` seam and not a kind — can be driven
+ *      directly instead of through a real Postgres.
+ *   3. The interception to leave the rest of the seed module intact — `mock.module`
+ *      replaces the WHOLE module and the catalog row tables ship from the same
+ *      file, so any export left out becomes `undefined` for every consumer in this
+ *      process, the Live Layer included.
+ *
+ * (3) is why each `mock.module` factory spreads a SNAPSHOT of the real module
+ * rather than listing exports by hand: `import * as` evaluates before the
+ * `mock.module` call (import declarations are hoisted), so `{ ...realModule }`
+ * captures the genuine values and the mock overrides exactly one function. A
+ * hand-written export list would silently drop the next `BUILTIN_*_CATALOG_ROW`
+ * someone adds.
+ *
+ * The override is `() => datasourceBoot()`, not `datasourceBoot` — one level of
+ * indirection so a test can swap the implementation after the factory has
+ * already run and been cached.
+ */
+import { describe, test, expect, afterEach, mock } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { Effect, Layer } from "effect";
+import * as realDatasourceSeedModule from "@atlas/api/lib/db/seed-builtin-datasource-catalog";
+import * as realKnowledgeSeedModule from "@atlas/api/lib/db/seed-builtin-knowledge-catalog";
+import * as realOpenApiSeedModule from "@atlas/api/lib/openapi/catalog-seed";
+import type { BuiltinDatasourceCatalogSeedBootResult } from "@atlas/api/lib/db/seed-builtin-datasource-catalog";
+import type { BuiltinKnowledgeCatalogSeedBootResult } from "@atlas/api/lib/db/seed-builtin-knowledge-catalog";
+import type { OpenApiDatasourceCatalogSeedBootResult } from "@atlas/api/lib/openapi/catalog-seed";
+import { createInternalDBTestLayer } from "@atlas/api/lib/db/internal";
+import {
+  BuiltinDatasourceCatalogSeed,
+  BuiltinDatasourceCatalogSeedLive,
+  BuiltinKnowledgeCatalogSeed,
+  BuiltinKnowledgeCatalogSeedLive,
+  OpenApiDatasourceCatalogSeed,
+  OpenApiDatasourceCatalogSeedLive,
+  Migration,
+  type BuiltinDatasourceCatalogSeedShape,
+  type BuiltinKnowledgeCatalogSeedShape,
+  type OpenApiDatasourceCatalogSeedShape,
+} from "../layers";
+
+// ── The dynamic-import interception ─────────────────────────────────
+
+/** Snapshots taken before `mock.module` replaces any of the three modules. */
+const realDatasourceExports = { ...realDatasourceSeedModule };
+const realKnowledgeExports = { ...realKnowledgeSeedModule };
+const realOpenApiExports = { ...realOpenApiSeedModule };
+
+const NOT_CONFIGURED =
+  "boot stub not configured by this test — the Layer reached the dynamic import unexpectedly";
+
+let datasourceBoot: () => Promise<BuiltinDatasourceCatalogSeedBootResult> = () =>
+  Promise.reject(new Error(NOT_CONFIGURED));
+let knowledgeBoot: () => Promise<BuiltinKnowledgeCatalogSeedBootResult> = () =>
+  Promise.reject(new Error(NOT_CONFIGURED));
+let openApiBoot: () => Promise<OpenApiDatasourceCatalogSeedBootResult> = () =>
+  Promise.reject(new Error(NOT_CONFIGURED));
+
+const datasourceBootCalls = mock(() => {});
+const knowledgeBootCalls = mock(() => {});
+const openApiBootCalls = mock(() => {});
+
+void mock.module("@atlas/api/lib/db/seed-builtin-datasource-catalog", () => ({
+  ...realDatasourceExports,
+  runBuiltinDatasourceCatalogSeedBoot: () => {
+    datasourceBootCalls();
+    return datasourceBoot();
+  },
+}));
+
+void mock.module("@atlas/api/lib/db/seed-builtin-knowledge-catalog", () => ({
+  ...realKnowledgeExports,
+  runBuiltinKnowledgeCatalogSeedBoot: () => {
+    knowledgeBootCalls();
+    return knowledgeBoot();
+  },
+}));
+
+void mock.module("@atlas/api/lib/openapi/catalog-seed", () => ({
+  ...realOpenApiExports,
+  runOpenApiDatasourceCatalogSeedBoot: () => {
+    openApiBootCalls();
+    return openApiBoot();
+  },
+}));
+
+afterEach(() => {
+  datasourceBootCalls.mockClear();
+  knowledgeBootCalls.mockClear();
+  openApiBootCalls.mockClear();
+  datasourceBoot = () => Promise.reject(new Error(NOT_CONFIGURED));
+  knowledgeBoot = () => Promise.reject(new Error(NOT_CONFIGURED));
+  openApiBoot = () => Promise.reject(new Error(NOT_CONFIGURED));
+});
+
+// ── Layer drivers ───────────────────────────────────────────────────
+
+interface UpstreamGate {
+  readonly available?: boolean;
+  readonly migrated?: boolean;
+}
+
+// `InternalDB` + `Migration` are rebuilt per call rather than shared. The reason
+// is legibility, NOT necessity — and the first version of this comment claimed
+// necessity, which is measurably false: hoisting the composed seed layer to module
+// scope and sharing it across every call leaves the suite at 29/29, because each
+// `Effect.provide`/`runPromise` builds its own MemoMap and the `Layer.effect`
+// therefore re-runs anyway.
+//
+// Per-call construction is kept because it makes each case's independence a
+// property of the code rather than of Effect's memo scoping — a reader should not
+// have to know where the MemoMap boundary is to know that the stub set two lines
+// up is the stub that runs.
+
+function runDatasourceSeed(
+  gate: UpstreamGate = {},
+): Promise<BuiltinDatasourceCatalogSeedShape> {
+  return Effect.runPromise(
+    Effect.gen(function* () {
+      return yield* BuiltinDatasourceCatalogSeed;
+    }).pipe(
+      Effect.provide(
+        BuiltinDatasourceCatalogSeedLive.pipe(
+          Layer.provide(
+            Layer.merge(
+              createInternalDBTestLayer({ available: gate.available ?? true }),
+              Layer.succeed(Migration, { migrated: gate.migrated ?? true }),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+function runKnowledgeSeed(
+  gate: UpstreamGate = {},
+): Promise<BuiltinKnowledgeCatalogSeedShape> {
+  return Effect.runPromise(
+    Effect.gen(function* () {
+      return yield* BuiltinKnowledgeCatalogSeed;
+    }).pipe(
+      Effect.provide(
+        BuiltinKnowledgeCatalogSeedLive.pipe(
+          Layer.provide(
+            Layer.merge(
+              createInternalDBTestLayer({ available: gate.available ?? true }),
+              Layer.succeed(Migration, { migrated: gate.migrated ?? true }),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+function runOpenApiSeed(
+  gate: UpstreamGate = {},
+): Promise<OpenApiDatasourceCatalogSeedShape> {
+  return Effect.runPromise(
+    Effect.gen(function* () {
+      return yield* OpenApiDatasourceCatalogSeed;
+    }).pipe(
+      Effect.provide(
+        OpenApiDatasourceCatalogSeedLive.pipe(
+          Layer.provide(
+            Layer.merge(
+              createInternalDBTestLayer({ available: gate.available ?? true }),
+              Layer.succeed(Migration, { migrated: gate.migrated ?? true }),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+/**
+ * A pg connect failure whose message carries the DB password, which is the
+ * hazard `errorMessage` exists for. The password is a distinct token so a test
+ * can assert its ABSENCE rather than only asserting the scrubbed shape's
+ * presence.
+ */
+const CREDENTIAL_LEAK_MESSAGE =
+  "connect ECONNREFUSED postgres://seeduser:hunter2@db.internal:5432/atlas";
+const CREDENTIAL_SCRUBBED =
+  "connect ECONNREFUSED postgres://***@db.internal:5432/atlas";
+
+// ══════════════════════════════════════════════════════════════════════
+// BuiltinDatasourceCatalogSeedLive
+// ══════════════════════════════════════════════════════════════════════
+
+describe("BuiltinDatasourceCatalogSeedLive", () => {
+  // ── the `skipped-gate` arm, both halves of its `||` ────────────────
+  //
+  // The guard is `!db.available || !migration.migrated`. Each disjunct gets its
+  // own case: an `&&` typo, or a guard that reads only one Tag, produces the
+  // right answer for the both-false input and the wrong one for exactly one of
+  // the singles. A both-false-only test cannot see that.
+
+  test("skips on `!db.available` alone, without reaching the import", async () => {
+    const shape = await runDatasourceSeed({ available: false, migrated: true });
+    expect(shape.outcome).toBe("skipped-gate");
+    expect(datasourceBootCalls).not.toHaveBeenCalled();
+  });
+
+  test("skips on `!migration.migrated` alone, without reaching the import", async () => {
+    const shape = await runDatasourceSeed({ available: true, migrated: false });
+    expect(shape.outcome).toBe("skipped-gate");
+    expect(datasourceBootCalls).not.toHaveBeenCalled();
+  });
+
+  test("skips when both upstream halves are unsatisfied", async () => {
+    const shape = await runDatasourceSeed({ available: false, migrated: false });
+    expect(shape.outcome).toBe("skipped-gate");
+    expect(shape.insertedSlugs).toEqual([]);
+    expect(shape.preservedSlugs).toEqual([]);
+    expect(shape.blockedSlugs).toEqual([]);
+    expect(shape.error).toBeUndefined();
+    expect(datasourceBootCalls).not.toHaveBeenCalled();
+  });
+
+  test("a boot-wrapper `kind: 'skipped'` also lands on `skipped-gate` — but DID run", async () => {
+    // Same `outcome` as the upstream gate above, reached down a different path.
+    // The call count is the only thing that tells the two apart, which is why
+    // the gate cases assert `not.toHaveBeenCalled()`.
+    datasourceBoot = () =>
+      Promise.resolve({ kind: "skipped", reason: "no-internal-db" });
+    const shape = await runDatasourceSeed();
+    expect(shape.outcome).toBe("skipped-gate");
+    expect(shape.blockedSlugs).toEqual([]);
+    expect(datasourceBootCalls).toHaveBeenCalledTimes(1);
+  });
+
+  // ── the `seeded` arm — the mutation this issue exists for ──────────
+
+  test("⭐ forwards inserted / preserved / blocked slugs at THREE distinct lengths", async () => {
+    // ⚠️ THE HEADLINE MUTATION (#5273): replace the three forwarded fields in
+    // the `case "seeded"` arm with `...zeroCounts`. That was green across the
+    // entire suite before this test existed, because no test ever built the
+    // Live Layer.
+    //
+    // Three DIFFERENT lengths — 3 inserted, 2 preserved, 1 blocked — and three
+    // DISJOINT slug sets. The disjointness is what defeats a permutation, since the
+    // assertions below compare CONTENTS with `toEqual`; the distinct lengths are
+    // belt-and-braces, and the first version of this comment credited them with the
+    // work the content comparison is actually doing. Kept anyway, because they cost
+    // nothing and they are the property a future weaker assertion (a `toHaveLength`
+    // added in a hurry) would need. (`seed-builtin-datasource-catalog.test.ts` one
+    // Layer down had to settle for content-only assertions because its fixture gave
+    // blocked and preserved the same size; here the fixture is synthetic, so the
+    // sizes are free.)
+    datasourceBoot = () =>
+      Promise.resolve({
+        kind: "seeded",
+        insertedSlugs: ["postgres", "mysql", "bigquery"],
+        preservedSlugs: ["snowflake", "duckdb"],
+        blockedSlugs: ["clickhouse"],
+      });
+
+    const shape = await runDatasourceSeed();
+
+    expect(shape.outcome).toBe("seeded");
+    expect(shape.insertedSlugs).toEqual(["postgres", "mysql", "bigquery"]);
+    expect(shape.preservedSlugs).toEqual(["snowflake", "duckdb"]);
+    expect(shape.blockedSlugs).toEqual(["clickhouse"]);
+    expect(shape.error).toBeUndefined();
+  });
+
+  test("a seed that blocked EVERY row still reports `seeded` with the blocked list", async () => {
+    // The state the shape's doc comment warns about: `outcome: "seeded"` with
+    // nothing inserted. A consumer reading `outcome` alone is told the catalog
+    // is fine; `blockedSlugs` is the only field that says otherwise, so it has
+    // to survive the arm even when the other two are genuinely empty.
+    datasourceBoot = () =>
+      Promise.resolve({
+        kind: "seeded",
+        insertedSlugs: [],
+        preservedSlugs: [],
+        blockedSlugs: ["postgres", "mysql"],
+      });
+
+    const shape = await runDatasourceSeed();
+
+    expect(shape.outcome).toBe("seeded");
+    expect(shape.blockedSlugs).toEqual(["postgres", "mysql"]);
+    expect(shape.insertedSlugs).toEqual([]);
+    expect(shape.preservedSlugs).toEqual([]);
+  });
+
+  // ── the `error` arm ───────────────────────────────────────────────
+
+  test("⭐ SCRUBS the boot wrapper's error message", async () => {
+    // `error` is DOCUMENTED as scrubbed. #5239 fixed the asymmetry one Layer
+    // over (one arm raw, its sibling scrubbed) and nothing pinned it here or on
+    // the knowledge side, so dropping `errorMessage(...)` from either producing
+    // arm was a green change that puts the DB password in a health payload.
+    datasourceBoot = () =>
+      Promise.resolve({ kind: "error", message: CREDENTIAL_LEAK_MESSAGE });
+
+    const shape = await runDatasourceSeed();
+
+    expect(shape.outcome).toBe("error");
+    expect(shape.error).toBe(CREDENTIAL_SCRUBBED);
+    expect(shape.error).not.toContain("hunter2");
+    // `[]` here means UNKNOWN, not "none" — the arm cannot know what the
+    // abandoned pass had accumulated. Pinned so the meaning does not drift.
+    expect(shape.insertedSlugs).toEqual([]);
+    expect(shape.preservedSlugs).toEqual([]);
+    expect(shape.blockedSlugs).toEqual([]);
+  });
+
+  // ── the `catchAll` arm ────────────────────────────────────────────
+
+  test("⭐ catchAll SCRUBS a rejection from the dynamic-import seam", async () => {
+    // In production this arm is reached when the dynamic `import(...)` itself
+    // rejects — the boot wrapper catches its own SQL errors and returns
+    // `kind: "error"` instead. The arm cannot distinguish an import rejection
+    // from a wrapper rejection: both simply reject the `Effect.tryPromise`
+    // `try` promise, and this test drives it with the latter.
+    datasourceBoot = () => Promise.reject(new Error(CREDENTIAL_LEAK_MESSAGE));
+
+    const shape = await runDatasourceSeed();
+
+    expect(shape.outcome).toBe("error");
+    expect(shape.error).toBe(CREDENTIAL_SCRUBBED);
+    expect(shape.error).not.toContain("hunter2");
+    expect(shape.blockedSlugs).toEqual([]);
+  });
+
+  test("catchAll normalizes a non-Error rejection", async () => {
+    // `catch: (err) => err instanceof Error ? err : new Error(String(err))`.
+    // Without the normalizer `errorMessage` still stringifies, so the
+    // observable claim is that the value survives rather than becoming
+    // `[object Object]` or an empty string.
+    datasourceBoot = () => Promise.reject("import map resolution failed");
+
+    const shape = await runDatasourceSeed();
+
+    expect(shape.outcome).toBe("error");
+    expect(shape.error).toBe("import map resolution failed");
+  });
+
+  test("never fails the Layer — every arm succeeds", async () => {
+    // The Layer's error channel is `never`: a seed failure must degrade the
+    // health payload, not take the boot down. `Effect.runPromise` above would
+    // reject if any arm escaped, so this asserts it on the harshest input.
+    datasourceBoot = () => Promise.reject(new Error("total failure"));
+    await expect(runDatasourceSeed()).resolves.toMatchObject({
+      outcome: "error",
+    });
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════════
+// BuiltinKnowledgeCatalogSeedLive
+// ══════════════════════════════════════════════════════════════════════
+
+describe("BuiltinKnowledgeCatalogSeedLive", () => {
+  test("skips on `!db.available` alone, without reaching the import", async () => {
+    const shape = await runKnowledgeSeed({ available: false, migrated: true });
+    expect(shape.outcome).toBe("skipped-gate");
+    expect(shape.inserted).toBe(false);
+    expect(knowledgeBootCalls).not.toHaveBeenCalled();
+  });
+
+  test("skips on `!migration.migrated` alone, without reaching the import", async () => {
+    const shape = await runKnowledgeSeed({ available: true, migrated: false });
+    expect(shape.outcome).toBe("skipped-gate");
+    expect(shape.inserted).toBe(false);
+    expect(knowledgeBootCalls).not.toHaveBeenCalled();
+  });
+
+  test("skips when both upstream halves are unsatisfied", async () => {
+    const shape = await runKnowledgeSeed({ available: false, migrated: false });
+    expect(shape.outcome).toBe("skipped-gate");
+    expect(shape.inserted).toBe(false);
+    expect(shape.blockedSlugs).toEqual([]);
+    expect(shape.error).toBeUndefined();
+    expect(knowledgeBootCalls).not.toHaveBeenCalled();
+  });
+
+  test("a boot-wrapper `kind: 'skipped'` also lands on `skipped-gate` — but DID run", async () => {
+    knowledgeBoot = () =>
+      Promise.resolve({ kind: "skipped", reason: "no-internal-db" });
+    const shape = await runKnowledgeSeed();
+    expect(shape.outcome).toBe("skipped-gate");
+    expect(shape.inserted).toBe(false);
+    expect(knowledgeBootCalls).toHaveBeenCalledTimes(1);
+  });
+
+  test("⭐ forwards a NON-EMPTY blockedSlugs alongside `inserted: true`", async () => {
+    // The knowledge sibling of the headline mutation: `blockedSlugs: []` or
+    // `inserted: false` hardcoded in the `case "seeded"` arm. Two blocked slugs
+    // rather than one, and asserted on CONTENTS, so a hardcoded single-element
+    // list cannot pass either.
+    //
+    // `inserted: true` WITH blocked rows is the real combination #5239 named:
+    // twelve rows landed, two did not, and the boolean alone reads as success.
+    knowledgeBoot = () =>
+      Promise.resolve({
+        kind: "seeded",
+        inserted: true,
+        blockedSlugs: ["gitbook", "zendesk"],
+      });
+
+    const shape = await runKnowledgeSeed();
+
+    expect(shape.outcome).toBe("seeded");
+    expect(shape.inserted).toBe(true);
+    expect(shape.blockedSlugs).toEqual(["gitbook", "zendesk"]);
+    expect(shape.error).toBeUndefined();
+  });
+
+  test("⭐ `inserted: false` with blocked rows is distinct from a clean re-boot", async () => {
+    // `inserted: false` has two meanings — "every row already existed" and
+    // "nothing could be inserted" — and `blockedSlugs` is the discriminator.
+    // Both cases run through the same arm, so both are asserted here: a Layer
+    // that forwarded `inserted` but hardcoded `blockedSlugs: []` would pass the
+    // second and fail the first.
+    knowledgeBoot = () =>
+      Promise.resolve({
+        kind: "seeded",
+        inserted: false,
+        blockedSlugs: ["okf-upload"],
+      });
+    const blocked = await runKnowledgeSeed();
+    expect(blocked.outcome).toBe("seeded");
+    expect(blocked.inserted).toBe(false);
+    expect(blocked.blockedSlugs).toEqual(["okf-upload"]);
+
+    knowledgeBoot = () =>
+      Promise.resolve({ kind: "seeded", inserted: false, blockedSlugs: [] });
+    const reboot = await runKnowledgeSeed();
+    expect(reboot.outcome).toBe("seeded");
+    expect(reboot.inserted).toBe(false);
+    expect(reboot.blockedSlugs).toEqual([]);
+  });
+
+  test("⭐ SCRUBS the boot wrapper's error message", async () => {
+    knowledgeBoot = () =>
+      Promise.resolve({ kind: "error", message: CREDENTIAL_LEAK_MESSAGE });
+
+    const shape = await runKnowledgeSeed();
+
+    expect(shape.outcome).toBe("error");
+    expect(shape.error).toBe(CREDENTIAL_SCRUBBED);
+    expect(shape.error).not.toContain("hunter2");
+    expect(shape.inserted).toBe(false);
+    expect(shape.blockedSlugs).toEqual([]);
+  });
+
+  test("⭐ catchAll SCRUBS a rejection from the dynamic-import seam", async () => {
+    knowledgeBoot = () => Promise.reject(new Error(CREDENTIAL_LEAK_MESSAGE));
+
+    const shape = await runKnowledgeSeed();
+
+    expect(shape.outcome).toBe("error");
+    expect(shape.error).toBe(CREDENTIAL_SCRUBBED);
+    expect(shape.error).not.toContain("hunter2");
+    expect(shape.inserted).toBe(false);
+    expect(shape.blockedSlugs).toEqual([]);
+  });
+
+  test("catchAll normalizes a non-Error rejection", async () => {
+    knowledgeBoot = () => Promise.reject("import map resolution failed");
+    const shape = await runKnowledgeSeed();
+    expect(shape.outcome).toBe("error");
+    expect(shape.error).toBe("import map resolution failed");
+  });
+
+  test("never fails the Layer — every arm succeeds", async () => {
+    knowledgeBoot = () => Promise.reject(new Error("total failure"));
+    await expect(runKnowledgeSeed()).resolves.toMatchObject({
+      outcome: "error",
+    });
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════════
+// OpenApiDatasourceCatalogSeedLive — the third sibling, and the one that
+// was actually broken
+// ══════════════════════════════════════════════════════════════════════
+
+describe("OpenApiDatasourceCatalogSeedLive", () => {
+  // This Layer was NOT in #5273's scope. It arrived because the review panel read
+  // the enclosing FILE rather than the changed lines, and found `case "error":`
+  // filling the shape straight from the wrapper's message while the shape's own doc
+  // says "Scrubbed error message" and the `catchAll` arm below scrubbed. That is the
+  // #5239 asymmetry — one field, two producers, two guarantees — for the THIRD time.
+  //
+  // Two consequences, both here: the arm is covered like its siblings, and the
+  // lexical guard below makes a fourth instance a test failure rather than a
+  // reviewer's lucky read.
+
+  test("skips on `!db.available` alone, without reaching the import", async () => {
+    const shape = await runOpenApiSeed({ available: false, migrated: true });
+    expect(shape.outcome).toBe("skipped-gate");
+    expect(shape.inserted).toBe(false);
+    expect(openApiBootCalls).not.toHaveBeenCalled();
+  });
+
+  test("skips on `!migration.migrated` alone, without reaching the import", async () => {
+    const shape = await runOpenApiSeed({ available: true, migrated: false });
+    expect(shape.outcome).toBe("skipped-gate");
+    expect(openApiBootCalls).not.toHaveBeenCalled();
+  });
+
+  test("a boot-wrapper `kind: 'skipped'` also lands on `skipped-gate` — but DID run", async () => {
+    openApiBoot = () => Promise.resolve({ kind: "skipped", reason: "no-internal-db" });
+    const shape = await runOpenApiSeed();
+    expect(shape.outcome).toBe("skipped-gate");
+    expect(shape.inserted).toBe(false);
+    expect(openApiBootCalls).toHaveBeenCalledTimes(1);
+  });
+
+  test("forwards `inserted` on the seeded arm, both ways", async () => {
+    // Both values, because `inserted: false` is what a hardcoded forward produces
+    // and a happy-path-only test would pin exactly that.
+    openApiBoot = () => Promise.resolve({ kind: "seeded", inserted: true });
+    expect(await runOpenApiSeed()).toMatchObject({ outcome: "seeded", inserted: true });
+
+    openApiBoot = () => Promise.resolve({ kind: "seeded", inserted: false });
+    expect(await runOpenApiSeed()).toMatchObject({ outcome: "seeded", inserted: false });
+  });
+
+  test("⭐ SCRUBS the boot wrapper's error message — the arm that was RAW", async () => {
+    openApiBoot = () => Promise.resolve({ kind: "error", message: CREDENTIAL_LEAK_MESSAGE });
+
+    const shape = await runOpenApiSeed();
+
+    expect(shape.outcome).toBe("error");
+    expect(shape.error).toBe(CREDENTIAL_SCRUBBED);
+    expect(shape.error).not.toContain("hunter2");
+    expect(shape.inserted).toBe(false);
+  });
+
+  test("⭐ catchAll SCRUBS a rejection from the dynamic-import seam", async () => {
+    openApiBoot = () => Promise.reject(new Error(CREDENTIAL_LEAK_MESSAGE));
+
+    const shape = await runOpenApiSeed();
+
+    expect(shape.outcome).toBe("error");
+    expect(shape.error).toBe(CREDENTIAL_SCRUBBED);
+    expect(shape.error).not.toContain("hunter2");
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════════
+// The lexical guard — three hand-fixes is where prose stops being enough
+// ══════════════════════════════════════════════════════════════════════
+
+describe("no seed Layer fills its `error` field from a raw wrapper message", () => {
+  /**
+   * ⚠️ A LEXICAL GUARD, added because one defect was fixed by hand THREE times:
+   * #5239 on the knowledge Layer, #5273 on the knowledge + datasource Layers, and
+   * this PR's review on the OpenAPI sibling. Each fix was correct about its
+   * instance and blind to the next, which says the instrument is wrong rather than
+   * the reviewers.
+   *
+   * The rule, stated as narrowly as it is true: in `layers.ts`, a shape field
+   * documented as a scrubbed error message must not be filled straight from a boot
+   * wrapper's `result.message`. Wrap it in `errorMessage` from
+   * `lib/audit/error-scrub` — a `pg` connect failure carries
+   * `scheme://user:pass@host` in `message`.
+   *
+   * ⚠️ NARROWED TO THE BOOT-WRAPPER SEAM ON PURPOSE, and the first draft was not.
+   * It also matched an `error` field filled from a narrowed local, which fires on
+   * `MigrationLive` — whose `MigrationShape.error` is DELIBERATELY raw, because it
+   * feeds a boot-failure log line that exists to name the actual Drizzle/pg error
+   * (#1988). That is a legitimate producer, and a guard that flags it would be
+   * turned off within a week. The negative control below is what caught it; it is
+   * not ceremony.
+   *
+   * The defeated wording lives only in the matcher and is described rather than quoted
+   * in the prose above. ⚠️ Note that for THIS guard that is discipline, not necessity:
+   * the scan is scoped to `../layers.ts`, so nothing in this file can trip it. The
+   * hazard is live for a guard that greps its own tree, and the habit is kept so the
+   * next person who widens the scan does not have to rediscover it.
+   */
+  const FORBIDDEN_RAW_PRODUCERS = [
+    // A shape's `error` filled directly from a boot wrapper's message, unscrubbed.
+    "error: result.message",
+  ];
+
+  const layersSource = (): string =>
+    readFileSync(fileURLToPath(new URL("../layers.ts", import.meta.url)), "utf8");
+
+  test("⭐ layers.ts has no `error: result.message` producer", () => {
+    const offenders = FORBIDDEN_RAW_PRODUCERS.filter((p) => layersSource().includes(p));
+    expect(
+      offenders,
+      "layers.ts fills a documented-as-scrubbed `error` field straight from a boot " +
+        "wrapper's message. Wrap it: `errorMessage(new Error(result.message))`. One field " +
+        "with two producers must not have two guarantees (#5239, #5273).",
+    ).toEqual([]);
+  });
+
+  test("the matcher still matches the shape it was written for", () => {
+    // A POSITIVE control on the MATCHER, not on the file. A guard whose pattern has
+    // drifted from the shape it was written for reads green over a live instance,
+    // which this repo has measured.
+    //
+    // ⚠️ A PLAIN LITERAL, and the first version assembled it at runtime "so the guard
+    // cannot find this string in its own source" — which was a false justification for
+    // a real habit. This guard scans `../layers.ts` and nothing else, so it cannot read
+    // the file it lives in and a literal here is unreachable by it. The self-trip
+    // hazard is real for a guard that greps its own tree (its `WILL DROP` sibling in
+    // `admin-migrate-import-errors.test.ts` genuinely hit it), and inheriting the
+    // caution was reasonable; writing down a mechanism that does no work was not.
+    const planted = "error: result.message,";
+    expect(FORBIDDEN_RAW_PRODUCERS.some((p) => planted.includes(p))).toBe(true);
+  });
+
+  test("the guard does NOT fire on legitimate code or on prose about it", () => {
+    // The NEGATIVE control. Both the matcher and its positive case are written by
+    // the same hand, so a matcher broad enough to hit everything passes its own
+    // planted case by construction. These four lines are all real: two are
+    // legitimate producers in `layers.ts` today, one is `MigrationLive`'s
+    // deliberately-raw arm (which the first draft of this matcher flagged), and one
+    // is the field docstring that STATES the guarantee.
+    const legitimate = [
+      "              error: errorMessage(new Error(result.message)),",
+      "          error: errorMessage(err),",
+      "        return Effect.succeed({ migrated: false, error: err.message } satisfies MigrationShape);",
+      "  /** Scrubbed error message when `outcome === \"error\"`. */",
+    ];
+    for (const line of legitimate) {
+      expect(
+        FORBIDDEN_RAW_PRODUCERS.some((p) => line.includes(p)),
+        `the guard fired on legitimate code or prose: ${line.trim()}`,
+      ).toBe(false);
+    }
+  });
+});

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -1232,10 +1232,28 @@ export const OpenApiDatasourceCatalogSeedLive: Layer.Layer<
               outcome: "seeded",
             } satisfies OpenApiDatasourceCatalogSeedShape;
           case "error":
+            // ⚠️ SCRUBBED — and this arm was the THIRD instance of one defect.
+            //
+            // `OpenApiDatasourceCatalogSeedShape.error` is DOCUMENTED as "Scrubbed
+            // error message" and the `catchAll` arm below has always
+            // scrubbed, so this producer made the field mean two different things
+            // depending on which path filled it. #5239 fixed exactly that asymmetry
+            // on the knowledge Layer; #5273's tests pinned it on the knowledge and
+            // datasource Layers; this sibling still had it, found only because that
+            // review read the enclosing FILE rather than the changed lines.
+            //
+            // A `pg` connect failure carries `scheme://user:pass@host` in
+            // `message`, and one field with two producers must not have two
+            // guarantees. The lexical guard in
+            // `effect/__tests__/builtin-catalog-seed-layers.test.ts` fails on this
+            // exact SPELLING — the one that has now occurred three times. A
+            // differently-named local (`error: r.message`) still slips past it, so
+            // the guard narrows the odds rather than closing the class; three
+            // hand-fixes is simply where prose stopped being enough on its own.
             return {
               inserted: false,
               outcome: "error",
-              error: result.message,
+              error: errorMessage(new Error(result.message)),
             } satisfies OpenApiDatasourceCatalogSeedShape;
         }
       },

--- a/packages/api/src/lib/residency/__tests__/cleanup-refusal-audit.test.ts
+++ b/packages/api/src/lib/residency/__tests__/cleanup-refusal-audit.test.ts
@@ -1,0 +1,303 @@
+/**
+ * What the source cleanup SAYS about refused alias edges (#5112).
+ *
+ * The sweep is the irreversible act: after it, the source's own
+ * `brain_vocabulary_edge` rows are gone and the payloads on `region_migrations`
+ * are the last copy of N approved human review decisions. #5036's disclosure fired
+ * in phase 2, up to seven days earlier, in a different process's log stream — so
+ * nothing spoke at the moment the loss became permanent.
+ *
+ * ## Why this is a separate file from `cleanup.test.ts`
+ *
+ * `cleanup.test.ts` imports `../cleanup` STATICALLY. Import declarations are
+ * hoisted above every `mock.module` call in the file, and `cleanup.ts` calls
+ * `createLogger()` at MODULE SCOPE — so by the time the logger mock lands, the real
+ * logger is already bound. Its DB and misrouting mocks work anyway because their
+ * exports are only reached at call time; the logger's is not.
+ *
+ * The fix is a DYNAMIC import after the mocks, which is what this file does. It is
+ * a separate file rather than a conversion of that one because the isolated runner
+ * gives each file its own process, so the two mock sets cannot interfere — and
+ * rewriting a 600-line suite's import to chase a log assertion is a worse trade
+ * than a focused file that states its own premise.
+ */
+
+import { describe, it, expect, beforeEach, mock } from "bun:test";
+import { buildInternalDbMockDefaults } from "@atlas/api/testing/api-test-mocks";
+
+// ── Mocks (before the dynamic import below) ─────────────────────────
+
+interface ClientResponder {
+  pattern: string;
+  rows?: Record<string, unknown>[];
+  rowCount?: number;
+}
+let clientResponders: ClientResponder[] = [];
+const clientQueries: Array<{ sql: string; params: unknown[] }> = [];
+
+function clientQuery(
+  sql: string,
+  params?: unknown[],
+): Promise<{ rows: Record<string, unknown>[]; rowCount: number }> {
+  clientQueries.push({ sql, params: params ?? [] });
+  for (const responder of clientResponders) {
+    if (!sql.includes(responder.pattern)) continue;
+    return Promise.resolve({
+      rows: responder.rows ?? [],
+      rowCount: responder.rowCount ?? responder.rows?.length ?? 0,
+    });
+  }
+  return Promise.resolve({ rows: [], rowCount: 0 });
+}
+
+// ⚠️ THE COMPLETE SURFACE via `buildInternalDbMockDefaults`, not a hand-written
+// subset. `mock.module` replaces the WHOLE module, so any export left out becomes
+// `undefined` — and `cleanup.ts` reaches `migrate.ts`, `bundle-scope.ts` and
+// `misrouting.ts`, so a transitive `import { x }` of an unmocked name is a load-time
+// failure in a file with nothing to do with this one. The first draft here listed
+// eight keys against ~90 exports and worked only by luck; its sibling in the same
+// commit (`admin-migrate-import-errors.test.ts`) already used the helper.
+void mock.module("@atlas/api/lib/db/internal", () => ({
+  ...buildInternalDbMockDefaults({ internalQuery: async () => [] }),
+  getInternalDB: () => ({
+    query: clientQuery,
+    connect: async () => ({ query: clientQuery, release: () => {} }),
+    end: async () => {},
+    on: () => {},
+  }),
+}));
+
+/**
+ * `info` and `warn` in SEPARATE sinks.
+ *
+ * Which channel carried the line is part of what these tests claim: the `info` is
+ * the routine deletion audit that fires for every cleanup, while the `warn` says
+ * an irreversible thing just happened to a human's approved decision. One merged
+ * sink would pass a mutation that swapped them, which is this repo's recorded
+ * "helper that merges what the test asserts" shape.
+ */
+const infos: Array<{ payload: Record<string, unknown>; message: string }> = [];
+const warns: Array<{ payload: Record<string, unknown>; message: string }> = [];
+
+// Every value export of `lib/logger`, matching the two sibling suites rather than
+// being the one file that supplies a single key.
+void mock.module("@atlas/api/lib/logger", () => {
+  const record =
+    (sink: Array<{ payload: Record<string, unknown>; message: string }>) =>
+    (payload: unknown, message?: unknown) =>
+      sink.push({
+        payload: (payload ?? {}) as Record<string, unknown>,
+        message: typeof message === "string" ? message : String(payload),
+      });
+  const logger = {
+    info: record(infos),
+    warn: record(warns),
+    error: () => {},
+    debug: () => {},
+    level: "info",
+    child: () => logger,
+  };
+  return {
+    createLogger: () => logger,
+    getLogger: () => logger,
+    setLogLevel: () => true,
+    getRequestContext: () => undefined,
+    withRequestContext: <T,>(_ctx: unknown, fn: () => T): T => fn(),
+    redactPaths: [] as string[],
+    scrubErrSerializer: (err: unknown) => err,
+    scrubLogFormatter: (obj: unknown) => obj,
+    hashShareToken: (token: string) => token,
+    ACTOR_KINDS: ["human", "agent", "mcp", "scheduler", "api_key"] as const,
+  };
+});
+
+void mock.module("@atlas/api/lib/residency/misrouting", () => ({
+  getApiRegion: () => null,
+  getMisroutedCount: () => 0,
+  _resetMisroutedCount: () => {},
+  _resetRegionCache: () => {},
+  isStrictRoutingEnabled: () => false,
+  detectMisrouting: async () => ({ misrouted: false }),
+}));
+
+// ── DYNAMIC, after the mocks — see the file docstring ───────────────
+
+const { cleanupMigrationSourceData } = await import("../cleanup");
+
+beforeEach(() => {
+  clientResponders = [];
+  clientQueries.length = 0;
+  infos.length = 0;
+  warns.length = 0;
+});
+
+/**
+ * An eligible, past-grace migration whose workspace has moved away.
+ *
+ * `vocabulary_edges_refused` is passed through verbatim — `undefined` answers the
+ * column as ABSENT, which is what a row written before migration 0204 looks like.
+ */
+function eligible(
+  vocabularyEdgesRefused: number | null | undefined,
+  /**
+   * How many payloads the row actually holds — `COALESCE(jsonb_array_length(...), 0)`
+   * in the real query, so `0` covers both "column NULL" and "empty array".
+   *
+   * Defaults to matching `refused`, i.e. the complete-recovery case, so a caller that
+   * does not care about the split gets the state where the recovery instruction is
+   * unconditionally true.
+   */
+  vocabularyRefusalsRecorded: number = vocabularyEdgesRefused ?? 0,
+): void {
+  clientResponders.push(
+    {
+      pattern: "FROM region_migrations WHERE id",
+      rows: [
+        {
+          status: "completed",
+          source_cleaned_at: null,
+          vocabulary_edges_refused: vocabularyEdgesRefused,
+          vocabulary_refusals_recorded: vocabularyRefusalsRecorded,
+        },
+      ],
+    },
+    { pattern: "FROM organization", rows: [{ region: "eu-west" }] },
+  );
+}
+
+const run = () =>
+  cleanupMigrationSourceData({ id: "mig-1", workspaceId: "org-1", sourceRegion: "us-east" });
+
+const REFUSAL_WARN = "DELETED the brain_vocabulary_edge rows";
+
+function auditEvent(): Record<string, unknown> | undefined {
+  return infos.find((i) => i.payload.event === "region_migration_source_cleaned")?.payload;
+}
+
+describe("source cleanup — refused alias edges (#5112)", () => {
+  it("⭐ reads the count on the SAME `FOR UPDATE` row lock, not a second query", async () => {
+    // The existing eligibility re-check already holds the lock that pins the
+    // verdict to the deletes, so the count is read UNDER it. A second query would
+    // be an extra round-trip per migration for a field the first one can carry —
+    // and, worse, would read outside the lock.
+    eligible(2);
+    await run();
+
+    const lockReads = clientQueries.filter((q) => q.sql.includes("FROM region_migrations WHERE id"));
+    expect(lockReads).toHaveLength(1);
+    expect(lockReads[0].sql).toContain("vocabulary_edges_refused");
+    expect(lockReads[0].sql).toContain("FOR UPDATE");
+  });
+
+  it("⭐ carries the count on the deletion audit event AND warns separately", async () => {
+    eligible(2);
+    const result = await run();
+    // Positive control: the deletes actually ran, so the event describes a real
+    // deletion rather than a skip.
+    expect(result.outcome).toBe("cleaned");
+
+    const audit = auditEvent();
+    expect(audit).toBeDefined();
+    expect(audit).toMatchObject({ migrationId: "mig-1", vocabularyEdgesRefused: 2 });
+
+    const warn = warns.find((w) => w.message.includes(REFUSAL_WARN));
+    expect(warn).toBeDefined();
+    expect(warn?.payload).toMatchObject({
+      migrationId: "mig-1",
+      vocabularyEdgesRefused: 2,
+      vocabularyRefusalsRecorded: 2,
+    });
+    // Points at where the payloads still are — the only actionable part of the
+    // line, and the reason it is not just a count.
+    expect(warn?.message).toContain("vocabulary_refusals");
+    expect(warn?.message).toContain("all on this migration");
+  });
+
+  it("⭐ does NOT promise payloads when NONE were recorded", async () => {
+    // The state review round 1 caught: the column is NULL for a target that predated
+    // the payload contract, and the first version of this warn told the operator to
+    // re-author from it unconditionally — at the exact instant the originals stopped
+    // existing. A recovery instruction pointing at an empty column is worse than none.
+    eligible(3, 0);
+    await run();
+
+    const warn = warns.find((w) => w.message.includes(REFUSAL_WARN));
+    expect(warn).toBeDefined();
+    expect(warn?.payload).toMatchObject({
+      vocabularyEdgesRefused: 3,
+      vocabularyRefusalsRecorded: 0,
+    });
+    expect(warn?.message).toContain("NO recovery payload was recorded");
+    expect(warn?.message).toContain("target region's own log is the only surviving copy");
+    // ⚠️ And it must NOT say the payloads are here. This is the assertion that goes
+    // red if the three-way branch collapses back to one message.
+    expect(warn?.message).not.toContain("all on this migration");
+  });
+
+  it("⭐ reports a PARTIAL recording as partial", async () => {
+    // The cap bit, or entries were screened out. Two numbers, deliberately unequal —
+    // with `recorded === refused` this case is indistinguishable from the complete
+    // one, which is the accidental equality the default argument above would give it.
+    eligible(9, 4);
+    await run();
+
+    const warn = warns.find((w) => w.message.includes(REFUSAL_WARN));
+    expect(warn?.payload).toMatchObject({
+      vocabularyEdgesRefused: 9,
+      vocabularyRefusalsRecorded: 4,
+    });
+    expect(warn?.message).toContain("Only 4 of the 9 recovery payloads");
+    expect(warn?.message).toContain("the remainder exist only");
+    expect(warn?.message).not.toContain("NO recovery payload was recorded");
+  });
+
+  it("⭐ does NOT warn on zero, but still reports the zero on the audit event", async () => {
+    // `0` is a positive claim — the target answered and refused nothing — and it
+    // belongs in the audit trail. What it must not do is fire the warn: a
+    // disclosure that fires for every migration that lost nothing is alarm fatigue,
+    // and dropping `&& > 0` from the guard is the mutation this catches.
+    eligible(0);
+    await run();
+
+    expect(auditEvent()?.vocabularyEdgesRefused).toBe(0);
+    expect(warns.filter((w) => w.message.includes(REFUSAL_WARN))).toEqual([]);
+  });
+
+  it("⭐ reports NULL — not 0 — for a row written before migration 0204", async () => {
+    // UNKNOWN and "nothing was refused" are different sentences, and only one of
+    // them this column can make for a pre-0204 row. Coercing to `0` would have the
+    // audit trail assert that an old migration lost nothing, which it cannot know.
+    eligible(undefined);
+    await run();
+
+    const audit = auditEvent();
+    expect(audit).toBeDefined();
+    // Present-and-null, not absent: a missing key and "we do not know" read
+    // identically in a log aggregator, and only one of them is true.
+    expect(audit).toHaveProperty("vocabularyEdgesRefused");
+    expect(audit?.vocabularyEdgesRefused).toBeNull();
+    // Unknown is not a reason to shout — there may be nothing to shout about.
+    expect(warns.filter((w) => w.message.includes(REFUSAL_WARN))).toEqual([]);
+  });
+
+  it("says nothing about refusals when the cleanup was SKIPPED by the cutover guard", async () => {
+    // The workspace is homed in the source region again, so nothing was deleted —
+    // and a warn claiming the edges are gone would be false. The count is real and
+    // non-zero here, so this is the input class where the guard on the DELETE path
+    // is the only thing keeping the line honest.
+    clientResponders.push(
+      {
+        pattern: "FROM region_migrations WHERE id",
+        rows: [{ status: "completed", source_cleaned_at: null, vocabulary_edges_refused: 3 }],
+      },
+      { pattern: "FROM organization", rows: [{ region: "us-east" }] },
+    );
+
+    const result = await run();
+
+    expect(result.outcome).toBe("workspace_active_in_source");
+    expect(warns.filter((w) => w.message.includes(REFUSAL_WARN))).toEqual([]);
+    // And the deletion audit event never fired at all — the skip has its own.
+    expect(auditEvent()).toBeUndefined();
+  });
+});

--- a/packages/api/src/lib/residency/__tests__/cleanup.test.ts
+++ b/packages/api/src/lib/residency/__tests__/cleanup.test.ts
@@ -100,6 +100,15 @@ void mock.module("@atlas/api/lib/db/internal", () => ({
   getPendingAmendmentCount: async () => 0,
 }));
 
+// ⚠️ This file's `import { … } from "../cleanup"` is STATIC and therefore hoisted
+// above every `mock.module` call here — and `cleanup.ts` calls `createLogger()` at
+// MODULE SCOPE, so it binds the real logger before this mock lands. The DB and
+// misrouting mocks work anyway because their exports are only reached at call time.
+// Capturing log output from this file is therefore not possible without converting
+// the import to a dynamic one; #5112's log assertions live in
+// `cleanup-refusal-audit.test.ts`, which imports dynamically for exactly that
+// reason. Do not "fix" this by asserting on logs here — it will silently pass
+// against a real logger writing to stdout.
 void mock.module("@atlas/api/lib/logger", () => ({
   createLogger: () => ({
     info: () => {},
@@ -180,6 +189,10 @@ function setEligible(overrides?: {
         {
           status: overrides?.status ?? "completed",
           source_cleaned_at: overrides?.source_cleaned_at ?? null,
+          // #5112's `vocabulary_edges_refused` is deliberately ABSENT here, which
+          // is what a row written before migration 0204 looks like — so every case
+          // in this file keeps exercising the unknown path. The column's own
+          // behaviour lives in `cleanup-refusal-audit.test.ts`.
         },
       ],
     },

--- a/packages/api/src/lib/residency/__tests__/migrate-identity-logging.test.ts
+++ b/packages/api/src/lib/residency/__tests__/migrate-identity-logging.test.ts
@@ -84,14 +84,25 @@ void mock.module("@atlas/api/lib/logger", () => {
 type ImportBundle = typeof import("@atlas/api/api/routes/admin-migrate")["importBundle"];
 type UnkeyableError =
   typeof import("@atlas/api/api/routes/admin-migrate")["RegionImportUnkeyableError"];
-let importBundle: ImportBundle;
+let importBundleWithCorrelationId: ImportBundle;
+/**
+ * `importBundle` with #5112's correlation token defaulted — same shim, and same
+ * reasoning, as `api/__tests__/admin-migrate.test.ts`. Every case in this file is
+ * about the identity-loss warn, not about the token.
+ */
+const importBundle = (
+  client: Parameters<ImportBundle>[0],
+  bundle: Parameters<ImportBundle>[1],
+  orgId: Parameters<ImportBundle>[2],
+  correlationId: Parameters<ImportBundle>[3] = "req-migrate-identity-logging",
+) => importBundleWithCorrelationId(client, bundle, orgId, correlationId);
 // Loaded through the same dynamic import as `importBundle`, not a static one:
 // this file mocks the logger module, so a static import would bind the real one
 // before the mock is installed.
 let RegionImportUnkeyableError: UnkeyableError;
 
 beforeAll(async () => {
-  ({ importBundle, RegionImportUnkeyableError } = await import(
+  ({ importBundle: importBundleWithCorrelationId, RegionImportUnkeyableError } = await import(
     "@atlas/api/api/routes/admin-migrate"
   ));
 });

--- a/packages/api/src/lib/residency/__tests__/migrate-roundtrip-pg.test.ts
+++ b/packages/api/src/lib/residency/__tests__/migrate-roundtrip-pg.test.ts
@@ -32,12 +32,26 @@ import { warehouseRowId } from "@atlas/api/lib/brain/warehouse-producer";
 import {
   RegionImportUnkeyableError,
   RegionImportVocabularyTargetError,
-  importBundle,
+  importBundle as importBundleWithCorrelationId,
   validateBundle,
 } from "../../../api/routes/admin-migrate";
 import { PROVISIONAL_PREDICATE } from "@atlas/api/lib/brain/candidates";
 import { buildCleanupStatements, runSourceCleanupSweep } from "../cleanup";
+import { recordVocabularyRefusals } from "../migrate";
 import type { ImportResult } from "@useatlas/types";
+
+/**
+ * `importBundle` with #5112's correlation token defaulted — see the same shim in
+ * `api/__tests__/admin-migrate.test.ts` for why the real parameter is required and
+ * why these suites take it through one named wrapper.
+ */
+type ImportBundleArgs = Parameters<typeof importBundleWithCorrelationId>;
+const importBundle = (
+  client: ImportBundleArgs[0],
+  bundle: ImportBundleArgs[1],
+  orgId: ImportBundleArgs[2],
+  correlationId: ImportBundleArgs[3] = "req-migrate-roundtrip-pg",
+) => importBundleWithCorrelationId(client, bundle, orgId, correlationId);
 
 const TEST_DB_URL = process.env.TEST_DATABASE_URL;
 const describeIfPg = TEST_DB_URL ? describe : describe.skip;
@@ -535,7 +549,15 @@ describeIfPg("region-migration bundle round-trip (real Postgres, #4460)", () => 
       expect(result.brainFacts).toEqual({ imported: 3, skipped: 0 });
       expect(result.brainEdges).toEqual({ imported: 2, skipped: 0 });
       expect(result.factAudienceMembers).toEqual({ imported: 1, skipped: 0 });
-      expect(result.brainVocabularyEdges).toEqual({ imported: 2, skipped: 0, refused: 0 });
+      expect(result.brainVocabularyEdges).toEqual({
+        imported: 2,
+        skipped: 0,
+        refused: 0,
+        // `[]` here MEANS none, because `refused` is 0 (#5112). It is the same
+        // literal a broken forward produces, which is why the refusal cases in
+        // this file assert contents rather than length.
+        refusalDetails: [],
+      });
       // Both exclusions IMPORTED — including the one that hit an existing
       // membership row. A `DO NOTHING` conflict arm would have dropped
       // C0LEGAL's exclusion (over-disclosure, the unrecoverable direction) and
@@ -1064,7 +1086,7 @@ describeIfPg("region-migration bundle round-trip (real Postgres, #4460)", () => 
         // decision, which is what an operator reads the counter to find out.
         // A merge that counted every conflict as a refusal would report two
         // dropped approvals on the most routine path there is.
-        brainVocabularyEdges: { imported: 0, skipped: 2, refused: 0 },
+        brainVocabularyEdges: { imported: 0, skipped: 2, refused: 0, refusalDetails: [] },
         // #5203: both exclusions are already here from the first import, so
         // the re-import skips them — `skipped`, not `refused`, on the
         // vocabulary edges' reasoning above: the channels ARE excluded,
@@ -1289,7 +1311,15 @@ describeIfPg("region-migration bundle round-trip (real Postgres, #4460)", () => 
         );
         await client.query("COMMIT");
         expect(result.brainFacts).toEqual({ imported: 1, skipped: 0 });
-        expect(result.brainVocabularyEdges).toEqual({ imported: 2, skipped: 0, refused: 0 });
+        expect(result.brainVocabularyEdges).toEqual({
+        imported: 2,
+        skipped: 0,
+        refused: 0,
+        // `[]` here MEANS none, because `refused` is 0 (#5112). It is the same
+        // literal a broken forward produces, which is why the refusal cases in
+        // this file assert contents rather than length.
+        refusalDetails: [],
+      });
       } finally {
         client.release();
       }
@@ -1453,7 +1483,34 @@ describeIfPg("region-migration bundle round-trip (real Postgres, #4460)", () => 
         );
         await client.query("COMMIT");
         // The import COMMITS — one refusal, and the fact still lands.
-        expect(result.brainVocabularyEdges).toEqual({ imported: 0, skipped: 0, refused: 1 });
+        //
+        // ⚠️ THE PAYLOAD, NOT JUST THE COUNT (#5112). `refused: 1` beside
+        // `refusalDetails: []` was the whole defect: the source region gets the
+        // count and schedules the delete of its own copy, so an empty payload here
+        // means the only record of this human decision is a log line in this
+        // region. Asserted field-by-field rather than by length, because
+        // `refusalDetails` mapped from the wrong arm of `VocabularyMergeRefusal`
+        // would still be length 1.
+        expect(result.brainVocabularyEdges).toEqual({
+          imported: 0,
+          skipped: 0,
+          refused: 1,
+          refusalDetails: [
+            {
+              slotPosition: "predicate",
+              fromNorm: "price",
+              toNorm: "priced at",
+              approvedBy: "source-admin",
+              approvedAt: "2026-06-01T00:00:00Z",
+              refusal: "already-aliased",
+              // What THIS region holds instead — the field that makes the payload
+              // re-authorable rather than merely descriptive, and the one an
+              // `undefined`-instead-of-`null` bug would blank.
+              existingTarget: "cost",
+              reason: expect.stringContaining("cost") as unknown as string,
+            },
+          ],
+        });
         expect(result.brainFacts).toEqual({ imported: 1, skipped: 0 });
       } finally {
         client.release();
@@ -1601,7 +1658,12 @@ describeIfPg("region-migration bundle round-trip (real Postgres, #4460)", () => 
 
         await holder.query("COMMIT");
         const result = await blocked;
-        expect(result.brainVocabularyEdges).toEqual({ imported: 1, skipped: 0, refused: 0 });
+        expect(result.brainVocabularyEdges).toEqual({
+          imported: 1,
+          skipped: 0,
+          refused: 0,
+          refusalDetails: [],
+        });
         await importer.query("COMMIT");
       } catch (err) {
         // intentionally ignored: the assertion failure below is the real
@@ -1790,7 +1852,30 @@ describeIfPg("region-migration bundle round-trip (real Postgres, #4460)", () => 
 
       // One applied, one refused, nothing duplicated — three distinct values, so
       // a merge that mixed two counters up cannot satisfy this.
-      expect(result.brainVocabularyEdges).toEqual({ imported: 1, skipped: 0, refused: 1 });
+      //
+      // ⚠️ The payload names the CYCLE arm (#5112), which is the arm with NO
+      // `existingTarget`: the refusal is a statement about the closure, not about a
+      // conflicting edge at `c`. `null` rather than absent, so a JSONB query and a
+      // log aggregator both read "there is no conflicting edge" instead of "the
+      // field is missing" — the same reason the target-side warn writes it
+      // explicitly.
+      expect(result.brainVocabularyEdges).toEqual({
+        imported: 1,
+        skipped: 0,
+        refused: 1,
+        refusalDetails: [
+          {
+            slotPosition: "predicate",
+            fromNorm: "c",
+            toNorm: "a",
+            approvedBy: "source-admin",
+            approvedAt: "2026-06-01T00:00:00Z",
+            refusal: "would-cycle",
+            existingTarget: null,
+            reason: expect.any(String) as unknown as string,
+          },
+        ],
+      });
 
       // The target keeps its own two decisions, GAINS the non-cycling arrival,
       // and never receives `c → a`.
@@ -2771,6 +2856,275 @@ describeIfPg("region import: a fact whose key cannot be supplied (#5047)", () =>
         [KEEP_ORG],
       );
       expect(rows[0]!.invalidated_at.toISOString()).toBe(original);
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// The refusal record OUTLIVES the source cleanup (#5112)
+// ---------------------------------------------------------------------------
+
+/**
+ * #5112's falsifier, stated by the issue: *a migration with a refusal leaves a
+ * record still readable AFTER the source cleanup has run.*
+ *
+ * That is a claim about two tables with opposite fates in the same transaction.
+ * `runSourceCleanupSweep` DELETEs `brain_vocabulary_edge` — the source's own
+ * approved decisions, the copy #5036 named as the recovery path — while
+ * `region_migrations` is classified `platform` in `bundle-scope.ts` and is never
+ * touched. Everything about this issue rests on that asymmetry holding against a
+ * real Postgres and a real sweep, so a mocked sweep would test the wrong thing.
+ *
+ * Its own `describeIfPg` block with its own schema, deliberately: the sweep test
+ * above asserts an exact `{ due, cleaned, skipped, blocked }` tuple, so adding a
+ * migration row to its fixture would break it for a reason unrelated to what it
+ * measures.
+ */
+describeIfPg("a refused alias edge's record outlives the source cleanup (#5112)", () => {
+  let pool: Pool;
+  const schemaName = `refusal_durability_${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
+  const ORG = "org-refusal-durability";
+  const MIGRATION_ID = "mig-refusal-durability-1";
+
+  /** The payload as the target region returns it, and as the source persists it. */
+  const REFUSAL = {
+    slotPosition: "predicate",
+    fromNorm: "price",
+    toNorm: "priced at",
+    approvedBy: "source-admin",
+    approvedAt: "2026-06-01T00:00:00.000Z",
+    refusal: "already-aliased",
+    existingTarget: "cost",
+    reason: '"price" is already aliased to "cost" in this region',
+  };
+
+  const ORIGINAL_DATABASE_URL = process.env.DATABASE_URL;
+
+  beforeAll(async () => {
+    // `search_path` pinned at connection STARTUP, not via an unawaited `SET` —
+    // `runSourceCleanupSweep` opens its own client off the pool it is handed, and
+    // an un-awaited SET races the first statement on it.
+    pool = new Pool({
+      connectionString: TEST_DB_URL,
+      options: `-c search_path="${schemaName}"`,
+    });
+    const admin = new Pool({ connectionString: TEST_DB_URL });
+    await admin.query(`CREATE SCHEMA IF NOT EXISTS "${schemaName}"`);
+    await admin.end();
+    await runMigrations(pool, { skip: MANAGED_AUTH_MIGRATIONS });
+
+    // The sweep reads through the MODULE-level internal pool, not the one this
+    // block holds — so it has to be pointed at this schema or it cleans nothing
+    // and the test passes for the wrong reason.
+    process.env.DATABASE_URL = TEST_DB_URL;
+    _resetPool(pool as unknown as InternalPool, null);
+  }, PG_TEST_TIMEOUT_MS);
+
+  afterAll(async () => {
+    if (!pool) return;
+    _resetPool(null, null);
+    if (ORIGINAL_DATABASE_URL === undefined) delete process.env.DATABASE_URL;
+    else process.env.DATABASE_URL = ORIGINAL_DATABASE_URL;
+    await pool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+    await pool.end();
+  });
+
+  it(
+    "⭐ the sweep DELETES brain_vocabulary_edge and the refusal payload is still readable",
+    async () => {
+      // ── The source region, after a completed migration ──────────────
+      //
+      // Its own approved decision — the row the operator would re-author FROM,
+      // and the row the sweep is about to destroy. TWO of them, at different
+      // norms, so "the edges are gone" is a count going 2 → 0 rather than 1 → 0:
+      // a sweep that deleted one row and left another would still satisfy a
+      // `not.toBe(1)` style assertion.
+      await pool.query(
+        `INSERT INTO brain_vocabulary_edge
+           (workspace_id, slot_position, from_norm, to_norm, approved_by, approved_at)
+         VALUES ($1, 'predicate', 'price', 'cost', 'target-admin', now()),
+                ($1, 'predicate', 'margin', 'cost', 'target-admin', now())`,
+        [ORG],
+      );
+      // Minimal Better-Auth `organization` mirror for the cutover guard — that
+      // table is in `MANAGED_AUTH_MIGRATIONS`, so `runMigrations` skips it and the
+      // sweep test above builds the same two columns by hand.
+      await pool.query(
+        `CREATE TABLE IF NOT EXISTS organization (id text PRIMARY KEY, region text)`,
+      );
+      // Homed in the TARGET region. The cutover guard refuses to delete while it
+      // still points HERE, so getting this wrong would make the sweep skip and the
+      // test would prove nothing — which is what the `edgesAfter` assertion catches.
+      await pool.query(`INSERT INTO organization (id, region) VALUES ($1, 'eu-test')`, [ORG]);
+      // Past the grace period, so the sweep is actually due.
+      await pool.query(
+        `INSERT INTO region_migrations
+           (id, workspace_id, source_region, target_region, status, completed_at,
+            region_updated, vocabulary_edges_refused, vocabulary_refusals)
+         VALUES ($1, $2, 'us-test', 'eu-test', 'completed', now() - interval '8 days',
+                 TRUE, 1, $3::jsonb)`,
+        [MIGRATION_ID, ORG, JSON.stringify([REFUSAL])],
+      );
+
+      // ⚠️ THE BEFORE HALF, and it is not ceremony. Without it a sweep that
+      // deleted nothing at all would pass every assertion below — the payload
+      // would still be readable because nothing had happened.
+      const edgesBefore = await pool.query<{ n: number }>(
+        `SELECT count(*)::int AS n FROM brain_vocabulary_edge WHERE workspace_id = $1`,
+        [ORG],
+      );
+      expect(edgesBefore.rows[0].n).toBe(2);
+
+      const savedRegion = process.env.ATLAS_API_REGION;
+      process.env.ATLAS_API_REGION = "us-test";
+      let sweep: Awaited<ReturnType<typeof runSourceCleanupSweep>>;
+      try {
+        sweep = await runSourceCleanupSweep();
+      } finally {
+        if (savedRegion === undefined) delete process.env.ATLAS_API_REGION;
+        else process.env.ATLAS_API_REGION = savedRegion;
+      }
+
+      // The irreversible act really ran.
+      expect(sweep.cleaned).toBeGreaterThanOrEqual(1);
+      const edgesAfter = await pool.query<{ n: number }>(
+        `SELECT count(*)::int AS n FROM brain_vocabulary_edge WHERE workspace_id = $1`,
+        [ORG],
+      );
+      expect(edgesAfter.rows[0].n).toBe(0);
+
+      // ⭐ AND THE RECORD SURVIVED IT. This is the whole issue: the last copy of
+      // a human's approved decision is now this row, and the sweep that destroyed
+      // the original never touched it.
+      const row = await pool.query<{
+        source_cleaned_at: Date | null;
+        vocabulary_edges_refused: number | null;
+        vocabulary_refusals: unknown;
+      }>(
+        `SELECT source_cleaned_at, vocabulary_edges_refused, vocabulary_refusals
+           FROM region_migrations WHERE id = $1`,
+        [MIGRATION_ID],
+      );
+      expect(row.rows).toHaveLength(1);
+      // The stamp proves we are reading the row AFTER the cleanup, not before it.
+      expect(row.rows[0].source_cleaned_at).not.toBeNull();
+      expect(row.rows[0].vocabulary_edges_refused).toBe(1);
+      // Field-by-field. A `toBeDefined()` or a length check would pass a cleanup
+      // that had blanked the column's contents while leaving the row.
+      expect(row.rows[0].vocabulary_refusals).toEqual([REFUSAL]);
+      // Named explicitly, because it is the field that makes the payload
+      // RE-AUTHORABLE rather than merely descriptive — the operator needs to know
+      // what this region holds at `price` instead.
+      expect((row.rows[0].vocabulary_refusals as Array<{ existingTarget: string }>)[0].existingTarget).toBe("cost");
+
+      // Belt and braces on the classification itself, since that is WHY the row
+      // survives. A future `platform` → `exported` reclassification of
+      // `region_migrations` would put a DELETE for it in the statement set, and
+      // this test's premise would silently invert.
+      expect(buildCleanupStatements().map((s) => s.table)).not.toContain("region_migrations");
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "⭐ the WRITER's own statement runs against the real schema",
+    async () => {
+      // ⚠️ THE GAP BETWEEN THE TWO HALVES OF THIS FEATURE'S COVERAGE, and the one this
+      // file exists to close for everything else. `migrate.test.ts` finds the write by
+      // grepping `capturedQueries` for a substring and inspects `params` — the SQL
+      // string is never executed. The case above seeds the row with its OWN `INSERT`.
+      // Both are hand-written statements about the same two columns, so neither
+      // confronts the writer's SQL with the migrated table.
+      //
+      // Measured: renaming the column in `recordVocabularyRefusals` to
+      // `vocabulary_refusals_json` left every other test green, because the substring
+      // the mock suite greps for (`vocabulary_edges_refused`) is on the same statement.
+      // In production that throws, and since `refused > 0` aborts, it fails EVERY
+      // migration carrying a refusal.
+      const WRITER_MIGRATION = "mig-refusal-writer-1";
+      const payload = [
+        { ...REFUSAL, fromNorm: "writer-a" },
+        { ...REFUSAL, fromNorm: "writer-b", approvedBy: null, existingTarget: null },
+      ];
+
+      // The row starts WITHOUT the two columns populated, so anything read back was
+      // put there by the function under test.
+      await pool.query(
+        `INSERT INTO region_migrations
+           (id, workspace_id, source_region, target_region, status, completed_at, region_updated)
+         VALUES ($1, $2, 'us-test', 'eu-test', 'completed', now(), TRUE)`,
+        [WRITER_MIGRATION, `${ORG}-writer`],
+      );
+
+      await recordVocabularyRefusals(WRITER_MIGRATION, {
+        refused: 5,
+        details: payload,
+        malformedDetails: 1,
+      });
+
+      const row = await pool.query<{
+        vocabulary_edges_refused: number | null;
+        vocabulary_refusals: unknown;
+      }>(
+        `SELECT vocabulary_edges_refused, vocabulary_refusals
+           FROM region_migrations WHERE id = $1`,
+        [WRITER_MIGRATION],
+      );
+      expect(row.rows).toHaveLength(1);
+      // 5 refused with 2 payloads — DISTINCT numbers, so a writer that stored the
+      // array's length in the count column (or vice versa) fails.
+      expect(row.rows[0].vocabulary_edges_refused).toBe(5);
+      // Round-tripped through real `jsonb`. This pins the `JSON.stringify` — without
+      // it `pg` sends a JS array as a Postgres array literal and the statement raises
+      // (measured: 1 fail).
+      //
+      // ⚠️ It does NOT pin the `::jsonb` cast, and an earlier version of this comment
+      // claimed it did. Measured: deleting the cast leaves all 18 tests green, because
+      // Postgres implicitly casts the text parameter on assignment to a `jsonb`
+      // column. The cast is belt-and-braces — kept because it states the intent at the
+      // call site and costs nothing — but nothing here falsifies it.
+      expect(row.rows[0].vocabulary_refusals).toEqual(payload);
+      // And the nullable fields survived as `null`, not as absent or "null".
+      const stored = row.rows[0].vocabulary_refusals as Array<Record<string, unknown>>;
+      expect(stored[1].approvedBy).toBeNull();
+      expect(stored[1].existingTarget).toBeNull();
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "⭐ records NULL rather than an empty array when there is nothing to recover",
+    async () => {
+      // The other arm of the writer's one conditional, against the real column — so
+      // "migrations with recoverable payloads" really is `IS NOT NULL` and does not
+      // also have to know that `'[]'::jsonb` means the same thing.
+      const EMPTY_MIGRATION = "mig-refusal-writer-2";
+      await pool.query(
+        `INSERT INTO region_migrations
+           (id, workspace_id, source_region, target_region, status, completed_at, region_updated)
+         VALUES ($1, $2, 'us-test', 'eu-test', 'completed', now(), TRUE)`,
+        [EMPTY_MIGRATION, `${ORG}-writer-empty`],
+      );
+
+      await recordVocabularyRefusals(EMPTY_MIGRATION, {
+        refused: 0,
+        details: [],
+        malformedDetails: 0,
+      });
+
+      const row = await pool.query<{
+        vocabulary_edges_refused: number | null;
+        vocabulary_refusals: unknown;
+      }>(
+        `SELECT vocabulary_edges_refused, vocabulary_refusals
+           FROM region_migrations WHERE id = $1`,
+        [EMPTY_MIGRATION],
+      );
+      // `0`, not NULL — the target answered and refused nothing, which is a claim.
+      expect(row.rows[0].vocabulary_edges_refused).toBe(0);
+      // NULL, not `[]`.
+      expect(row.rows[0].vocabulary_refusals).toBeNull();
     },
     PG_TEST_TIMEOUT_MS,
   );

--- a/packages/api/src/lib/residency/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/residency/__tests__/migrate.test.ts
@@ -6,6 +6,11 @@
  */
 
 import { describe, it, expect, beforeEach, mock, afterEach, afterAll } from "bun:test";
+// A plain const, so a static import cannot bind ahead of the `mock.module` calls
+// below the way a logger or DB import would. From `lib/brain/vocabulary`, not
+// `@useatlas/types` — see the constant's docstring for why a VALUE export in the
+// published package broke every scaffold build.
+import { VOCABULARY_REFUSAL_DETAIL_CAP } from "@atlas/api/lib/brain/vocabulary";
 
 // ── Mocks ────────────────────────────────────────────────────────────
 
@@ -82,18 +87,50 @@ void mock.module("@atlas/api/lib/db/internal", () => ({
  */
 const capturedWarns: Array<{ payload: Record<string, unknown>; message: string }> = [];
 
+/**
+ * Captured `log.info` payloads — `logMigrationEvent`'s channel (#5112).
+ *
+ * A SECOND array rather than one sink with the level in the payload, for
+ * `capturedWarns`' reason exactly: the refusal disclosure is a `warn` and the
+ * audit events are `info`, and a merged sink would pass a mutation that swapped
+ * them. Two arrays make "which channel said this" part of what the assertions
+ * can see.
+ */
+const capturedInfos: Array<{ payload: Record<string, unknown>; message: string }> = [];
+/**
+ * Captured `log.error` payloads — its own sink, for `capturedWarns`' reason.
+ *
+ * Needed since #5297's review: the fix that stopped driver text reaching the durable
+ * `error_message` has TWO halves, and the second is that the raw text still goes
+ * somewhere. A sink that merged levels would let "log it at debug" pass.
+ */
+const capturedErrors: Array<{ payload: Record<string, unknown>; message: string }> = [];
+
 void mock.module("@atlas/api/lib/logger", () => ({
   createLogger: () => ({
-    info: () => {},
+    info: (payload: unknown, message?: unknown) =>
+      capturedInfos.push({
+        payload: (payload ?? {}) as Record<string, unknown>,
+        message: typeof message === "string" ? message : String(payload),
+      }),
     warn: (payload: unknown, message?: unknown) =>
       capturedWarns.push({
         payload: (payload ?? {}) as Record<string, unknown>,
         message: typeof message === "string" ? message : String(payload),
       }),
-    error: () => {},
+    error: (payload: unknown, message?: unknown) =>
+      capturedErrors.push({
+        payload: (payload ?? {}) as Record<string, unknown>,
+        message: typeof message === "string" ? message : String(payload),
+      }),
     debug: () => {},
   }),
 }));
+
+/** Find one `logMigrationEvent` emission by its `event` name. */
+function migrationEvent(event: string): Record<string, unknown> | undefined {
+  return capturedInfos.find((i) => i.payload.event === event)?.payload;
+}
 
 const mockFlushCache = mock(async () => {});
 const mockFlushCacheByOrg = mock(async (_orgId: string) => 0);
@@ -142,6 +179,14 @@ interface SectionAck {
   skipped: number;
   /** #5036's third vocabulary counter. Absent from every other section. */
   refused?: number;
+  /**
+   * #5112's refusal payloads. `unknown` deliberately, and not
+   * `VocabularyRefusalDetail[]`: half the cases here answer with something a
+   * well-behaved region would never send, which is the input the screening exists
+   * for. A typed field would make those cases uncompilable and quietly narrow the
+   * suite to the happy path.
+   */
+  refusalDetails?: unknown;
 }
 
 function acknowledgeAll(options?: RequestInit): Record<string, SectionAck> {
@@ -193,6 +238,7 @@ const {
   getCleanupDueMigrations,
   resetMigrationForRetry,
   cancelMigration,
+  screenRefusalDetails,
 } = await import("../migrate");
 
 // ── Helpers ─────────────────────────────────────────────────────────
@@ -211,6 +257,8 @@ function resetMocks() {
   mockFetchError = null;
   reshapeAck = null;
   capturedWarns.length = 0;
+  capturedInfos.length = 0;
+  capturedErrors.length = 0;
   capturedFetchCalls = [];
   mockConfig = { ...DEFAULT_MOCK_CONFIG };
   process.env.ATLAS_INTERNAL_SECRET = "test-secret";
@@ -481,6 +529,395 @@ describe("executeRegionMigration", () => {
     expect(disclosure?.message).toContain("grace period");
   });
 
+  // ── #5112 — the refusal record, durable at the SOURCE ───────────────
+  //
+  // #5036 gave the source a COUNT and left the recovery payload in the TARGET
+  // region's log. This region schedules the cleanup that DELETEs its own
+  // `brain_vocabulary_edge` rows after the grace period, so the party owning the
+  // irreversible act held the number and another region's log retention held the
+  // record. These cases pin the four places that changed: the durable write, the
+  // two audit events, and the executor's own result.
+
+  /**
+   * One refusal payload as a well-behaved target sends it.
+   *
+   * `existingTarget` non-null, so the field is live: an implementation that wrote
+   * `null` for every arm would satisfy a fixture whose value was already null,
+   * which is this repo's recorded accidental-equality shape.
+   */
+  const refusalDetail = (fromNorm: string) => ({
+    slotPosition: "predicate",
+    fromNorm,
+    toNorm: "priced at",
+    approvedBy: "source-admin",
+    approvedAt: "2026-06-01T00:00:00Z",
+    refusal: "already-aliased",
+    existingTarget: "cost",
+    reason: `"${fromNorm}" is already aliased to "cost"`,
+  });
+
+  /**
+   * Answer with a mixed vocabulary section: 2 imported, 1 refused out of 3
+   * exported, plus `refusalDetails`.
+   *
+   * The three numbers stay DISTINCT for the reason the #5036 case above records —
+   * with `expected`, `imported` and `refused` all equal, an implementation that
+   * reported any one of them satisfies assertions about all of them.
+   */
+  /**
+   * The exported vocabulary count the last `ackWithRefusals` actually saw.
+   *
+   * ⚠️ A PREMISE GUARD, and its absence was a real hole. The #5036 case above
+   * captures the same number and asserts `toBe(3)` specifically so a fixture that
+   * stopped exporting alias edges cannot make a test vacuous — `reshapeAck`'s
+   * `if (ack.brainVocabularyEdges)` would go false, the write would record `0`/`null`,
+   * and every `refused: 0` case here would still pass while proving nothing.
+   * `expectVocabularyExported()` is what closes that.
+   */
+  let vocabularyExportedCount = -1;
+
+  function ackWithRefusals(details: unknown, refused = 1): void {
+    vocabularyExportedCount = -1;
+    mockQueryResults["SELECT id, workspace_id"] = [
+      { id: "mig-1", workspace_id: "org-1", source_region: "us-east", target_region: "eu-west", status: "pending" },
+    ];
+    mockQueryResults["UPDATE region_migrations"] = [];
+    reshapeAck = (ack) => {
+      const vocabulary = ack.brainVocabularyEdges;
+      vocabularyExportedCount = vocabulary?.imported ?? 0;
+      if (vocabulary) {
+        ack.brainVocabularyEdges = {
+          imported: 3 - refused,
+          skipped: 0,
+          refused,
+          refusalDetails: details,
+        };
+      }
+      return ack;
+    };
+  }
+
+  /**
+   * Assert the fixture really exported three alias edges.
+   *
+   * Exactly 3, not merely non-zero: `imported: 3 - refused` and every "distinct
+   * numbers" claim in this group depend on the section carrying three rows, so a
+   * fixture change that collapsed it to one would silently restore the accidental
+   * equality the numbers are chosen to avoid.
+   */
+  function expectVocabularyExported(): void {
+    expect(vocabularyExportedCount).toBe(3);
+  }
+
+  /** The `UPDATE region_migrations SET vocabulary_edges_refused = …` write. */
+  function refusalRecordWrite(): { sql: string; params: unknown[] } | undefined {
+    return capturedQueries.find((q) => q.sql.includes("vocabulary_edges_refused"));
+  }
+
+  it("⭐ RECORDS the refused count AND payloads on the source's own migration row", async () => {
+    ackWithRefusals([refusalDetail("price")]);
+
+    const result = await executeRegionMigration("mig-1");
+    expect(result.success).toBe(true);
+    expectVocabularyExported();
+
+    const write = refusalRecordWrite();
+    expect(write).toBeDefined();
+    // `region_migrations`, not some other table — the platform-classified row is
+    // the entire reason this survives the cleanup.
+    expect(write?.sql).toContain("UPDATE region_migrations");
+    expect(write?.params[0]).toBe("mig-1");
+    // 1, which is neither the section total (3) nor the imported count (2).
+    expect(write?.params[1]).toBe(1);
+    // The payload goes in as JSON text bound to a `::jsonb` parameter. Parsed and
+    // compared field-by-field: a length assertion would pass an implementation
+    // that wrote the wrong arm of `VocabularyMergeRefusal`.
+    expect(JSON.parse(String(write?.params[2]))).toEqual([refusalDetail("price")]);
+  });
+
+  it("⭐ KEEPS the refusal record when the migration fails AFTER the write", async () => {
+    // The other half of the "PERSISTED BEFORE CUTOVER, not in Phase 4" decision, and
+    // the half nothing tested. The comment's stated reason for the position is that
+    // "the record exists even for a migration that never completes" — so a mutation
+    // moving the write down past the cutover would satisfy every other case here
+    // (the abort case only checks that cutover did NOT happen) while re-opening the
+    // documented window: the target has committed a partial import, and the source
+    // holds no record of it.
+    ackWithRefusals([refusalDetail("price")]);
+    // The cutover's `UPDATE organization ... RETURNING id` answering no rows is how
+    // this file already makes Phase 3 throw.
+    mockPoolQueryResult = { rows: [] };
+
+    const result = await executeRegionMigration("mig-1");
+    expectVocabularyExported();
+
+    // Failed — after the record was written.
+    expect(result.success).toBe(false);
+    const write = refusalRecordWrite();
+    expect(write).toBeDefined();
+    expect(write?.params[1]).toBe(1);
+    // The PAYLOAD too, not just the count: a write that landed the count and lost the
+    // array would satisfy a presence check and leave nothing to re-author from.
+    expect(JSON.parse(String(write?.params[2]))).toEqual([refusalDetail("price")]);
+  });
+
+  it("⭐ ABORTS BEFORE CUTOVER when the refusal record cannot be written", async () => {
+    // The polarity that makes this feature worth having. Continuing past a failed
+    // write would cut over and schedule the destructive cleanup while the only
+    // durable record of a dropped human decision is a log line in another region —
+    // the exact state #5112 removes, re-entered through the error path.
+    ackWithRefusals([refusalDetail("price")]);
+    // A driver message carrying the three kinds of infrastructure detail that must
+    // never reach a workspace admin: an internal host and port, a row fragment, and an
+    // internal column spelling. `errorMessage`'s scrub covers NONE of them — it
+    // rewrites credential URIs only — so the guard has to be that the throw site does
+    // not interpolate driver text at all.
+    const DRIVER_LEAK =
+      "connect ECONNREFUSED 10.0.3.7:5432 - DETAIL: Key (workspace_id)=(org-1) already exists, " +
+      'column "vocabulary_refusals_internal" does not exist';
+    mockInternalQueryRejectPattern = {
+      pattern: "vocabulary_edges_refused",
+      error: new Error(DRIVER_LEAK),
+    };
+
+    const result = await executeRegionMigration("mig-1");
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("refused alias edge");
+      expect(result.error).toContain("BEFORE cutover");
+      // ⭐ `result.error` IS `region_migrations.error_message`, which
+      // `admin-residency.ts` returns verbatim to a workspace admin. The whole string
+      // and each distinctive fragment, both directions — asserting only the whole
+      // string passes a message that appended the detail, and asserting only the
+      // fragments passes one that echoed a DIFFERENT driver error.
+      expect(result.error).not.toContain(DRIVER_LEAK);
+      for (const fragment of [
+        "ECONNREFUSED",
+        "10.0.3.7",
+        "Key (workspace_id)=",
+        "vocabulary_refusals_internal",
+      ]) {
+        expect(result.error, `the durable error message leaked ${fragment}`).not.toContain(fragment);
+      }
+      // And it says where the detail went, so the operator is not left guessing.
+      expect(result.error).toContain("recorded server-side");
+    }
+    // ⚠️ THE OTHER HALF: the raw text is not discarded, it is logged. Without this the
+    // fix could be "drop the message entirely", which trades a leak for a blind spot.
+    // `capturedErrors` is its own sink, so the LEVEL is part of the claim.
+    expect(
+      capturedErrors.some((e) => String(e.payload.err).includes("ECONNREFUSED")),
+      "the driver error was neither returned nor logged — it was swallowed",
+    ).toBe(true);
+    // ⚠️ THE LOAD-BEARING HALF: nothing was cut over, so nothing will be deleted.
+    // Without this, an implementation that threw AFTER the cutover would satisfy
+    // every assertion above while having scheduled the delete anyway.
+    const cutover = capturedQueries.find(
+      (q) => q.sql.includes("UPDATE organization") || q.sql.includes("region_updated = TRUE"),
+    );
+    expect(cutover).toBeUndefined();
+  });
+
+  it("⭐ SCRUBS a credential URI out of the durable error message", async () => {
+    // The half `errorMessage` genuinely covers, and it was unfalsified until this case:
+    // removing `errorMessage(err)` from the durable field left all 60 tests green,
+    // because no fixture drove a credential-bearing error down that path. The scrub was
+    // decoration.
+    //
+    // `error_message` is returned VERBATIM to a workspace admin by
+    // `admin-residency.ts`'s `failed` arm, and `error-scrub.ts`'s own header names this
+    // exact hazard: "pg / better-auth error text sometimes echoes the connection
+    // string, so the DB password lands in the audit row verbatim".
+    ackWithRefusals(undefined, 0);
+    mockPoolQueryError = new Error(
+      "connection terminated: postgres://atlas:hunter2@db.internal:5432/atlas",
+    );
+
+    const result = await executeRegionMigration("mig-1");
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      // The PASSWORD is gone and the scrubbed form is present — both, because asserting
+      // only the absence passes a message that dropped the whole string, and asserting
+      // only the presence passes one that appended the raw copy beside it.
+      expect(result.error).not.toContain("hunter2");
+      expect(result.error).toContain("postgres://***@db.internal:5432/atlas");
+    }
+    // And the raw text still reaches an operator, which is the same two-halves split the
+    // abort case above pins.
+    expect(capturedErrors.some((e) => String(e.payload.err).includes("hunter2"))).toBe(true);
+  });
+
+  it("does NOT abort when the record write fails and nothing was refused", async () => {
+    // The other input class at the same guard. A migration that is going to lose
+    // nothing must not fail on the bookkeeping FOR the loss — the two branches of
+    // `evidence.refused > 0` are what make that a decision rather than an
+    // accident, and a single-input test cannot tell them apart.
+    ackWithRefusals(undefined, 0);
+    mockInternalQueryRejectPattern = {
+      pattern: "vocabulary_edges_refused",
+      error: new Error("column does not exist"),
+    };
+
+    const result = await executeRegionMigration("mig-1");
+
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.vocabularyEdgesRefused).toBe(0);
+    const cutover = capturedQueries.find(
+      (q) => q.sql.includes("UPDATE organization") || q.sql.includes("region_updated = TRUE"),
+    );
+    expect(cutover).toBeDefined();
+    // ⚠️ AND THE CATCH SAID SO. Continuing is right; continuing SILENTLY is a
+    // swallowed error, and the `log.warn` on that arm is the only signal it emits.
+    // Without this, deleting the warn leaves a catch that says nothing and the test
+    // stays green — which is the exact shape CLAUDE.md's error-handling rule forbids.
+    expect(
+      capturedWarns.some((w) =>
+        w.message.includes("Could not record the vocabulary-refusal bookkeeping"),
+      ),
+      "the record-write catch continued without emitting anything",
+    ).toBe(true);
+  });
+
+  it("records `null` rather than an empty array when there is nothing to recover", async () => {
+    // So "migrations with recoverable payloads" is `IS NOT NULL` and does not have
+    // to also know that `'[]'::jsonb` means the same thing.
+    ackWithRefusals(undefined, 0);
+
+    const result = await executeRegionMigration("mig-1");
+    expect(result.success).toBe(true);
+
+    const write = refusalRecordWrite();
+    // `0`, not null — the target ANSWERED and refused nothing. NULL on the column
+    // is reserved for "this build never asked", which is what a pre-0204 row is.
+    expect(write?.params[1]).toBe(0);
+    expect(write?.params[2]).toBeNull();
+  });
+
+  it("⭐ routes the count through BOTH migration audit events", async () => {
+    // The disclosure was a bare `log.warn` sitting beside an audit channel built
+    // for exactly this. `cleanup_scheduled` fires for the 7-day timer the
+    // disclosure names, so the deadline and what expires with it are now one
+    // record; `completed` carries it so the question "did this migration lose any
+    // curated decisions" is answerable from the terminal event alone.
+    ackWithRefusals([refusalDetail("price")]);
+
+    const result = await executeRegionMigration("mig-1");
+    expect(result.success).toBe(true);
+
+    expectVocabularyExported();
+
+    const scheduled = migrationEvent("region_migration_cleanup_scheduled");
+    expect(scheduled).toBeDefined();
+    expect(scheduled).toMatchObject({
+      vocabularyEdgesRefused: 1,
+      vocabularyRefusalDetailsRecorded: 1,
+      gracePeriodDays: expect.any(Number) as unknown as number,
+    });
+
+    const completed = migrationEvent("region_migration_completed");
+    expect(completed).toBeDefined();
+    expect(completed).toMatchObject({ vocabularyEdgesRefused: 1 });
+  });
+
+  it("⭐ surfaces the count on MigrationResult, distinct from imported and total", async () => {
+    // AC-4's server half: the operator who pressed the button gets the number
+    // without grepping a log stream. `1` is neither the section total (3) nor the
+    // imported count (2), so an implementation returning either fails.
+    ackWithRefusals([refusalDetail("price")]);
+
+    const result = await executeRegionMigration("mig-1");
+
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.vocabularyEdgesRefused).toBe(1);
+  });
+
+  it("carries the count on the success arm even when nothing was refused", async () => {
+    // `0` is a claim, and it is the claim the CLI renders. An implementation that
+    // only populated the field on the non-zero path would leave it `undefined`
+    // here and the CLI would print nothing at all.
+    ackWithRefusals(undefined, 0);
+    const result = await executeRegionMigration("mig-1");
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.vocabularyEdgesRefused).toBe(0);
+  });
+
+  it("keeps the count when a target predating #5112 sends NO payloads", async () => {
+    // The cross-version case. A target between #5036 and #5112 answers with
+    // `refused` and no `refusalDetails` at all — which must not abort, because
+    // #5036's remedy (this region still holds its own rows for the grace period)
+    // is intact. `refused` still has to survive.
+    ackWithRefusals(undefined, 1);
+
+    const result = await executeRegionMigration("mig-1");
+
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.vocabularyEdgesRefused).toBe(1);
+    const write = refusalRecordWrite();
+    expect(write?.params[1]).toBe(1);
+    expect(write?.params[2]).toBeNull();
+    // And the disclosure says the payload count is SHORT of the refusal count,
+    // which is the operator's signal that part of this has no record here.
+    const disclosure = capturedWarns.find((w) => w.message.includes("REFUSED curated alias edges"));
+    expect(disclosure?.payload).toMatchObject({ refused: 1, detailsRecorded: 0, malformedDetails: 0 });
+  });
+
+  it("⭐ SCREENS malformed refusal entries on the way to the durable row", async () => {
+    // The integration half of the screening: what survives is what gets written and
+    // what the disclosure counts. Every ARM of the screen, and the cap, are covered
+    // by `screenRefusalDetails`' own describe below — the reconciliation here bounds
+    // `refused` to the three edges the fixture exports, so those cases are simply
+    // not expressible from this side.
+    //
+    // ⚠️ TWO distinct numbers do the work here — 1 kept, 2 dropped — so a screen that
+    // kept everything (3/0) or nothing (0/3) fails. The `refused: 3` is NOT a third
+    // independent number: with three edges exported it is simultaneously the section
+    // total and the refusal count, so `params[1] === 3` cannot tell "reported the
+    // refusal count" from "reported the section total". The siblings are what separate
+    // those — the case above has refused 1 against a total of 3, and the payload cases
+    // have 1 refused against 0 details. An earlier version of this comment claimed
+    // three distinct numbers and was wrong about which ones were load-bearing.
+    ackWithRefusals(
+      [
+        refusalDetail("price"),
+        "not an object",
+        { ...refusalDetail("margin"), fromNorm: undefined },
+      ],
+      3,
+    );
+
+    const result = await executeRegionMigration("mig-1");
+
+    // Screening DROPS; it does not abort. The count still reconciles and this
+    // region still holds its own rows, so failing a cutover over an unreadable
+    // log-grade field would make the improvement a new way to fail.
+    expect(result.success).toBe(true);
+
+    const write = refusalRecordWrite();
+    expect(write?.params[1]).toBe(3);
+    expect(JSON.parse(String(write?.params[2]))).toEqual([refusalDetail("price")]);
+
+    const disclosure = capturedWarns.find((w) => w.message.includes("REFUSED curated alias edges"));
+    expect(disclosure?.payload).toMatchObject({
+      refused: 3,
+      detailsRecorded: 1,
+      malformedDetails: 2,
+    });
+  });
+
+  it("counts a non-array `refusalDetails` as malformed rather than throwing", async () => {
+    ackWithRefusals({ nope: true }, 1);
+
+    const result = await executeRegionMigration("mig-1");
+
+    expect(result.success).toBe(true);
+    const write = refusalRecordWrite();
+    expect(write?.params[2]).toBeNull();
+    const disclosure = capturedWarns.find((w) => w.message.includes("REFUSED curated alias edges"));
+    expect(disclosure?.payload).toMatchObject({ detailsRecorded: 0, malformedDetails: 1 });
+  });
+
   it("ABORTS on a NEGATIVE counter, which would otherwise mask an over-import (#5036)", async () => {
     // The fail-OPEN direction, and the one an arithmetic guard cannot see on its
     // own. `acknowledged` is `as`-cast from another region's JSON and only its
@@ -735,6 +1172,167 @@ describe("executeRegionMigration", () => {
     expect(failedUpdate).toBeDefined();
     expect(failedUpdate!.params).toContain(false);
     expect(failedUpdate!.params).not.toContain(true);
+  });
+});
+
+describe("screenRefusalDetails (#5112)", () => {
+  /**
+   * One well-formed entry. `existingTarget` is a STRING here, so the field is
+   * live: an implementation that hardcoded `null` would satisfy a fixture whose
+   * value was already null.
+   */
+  const good = (fromNorm: string) => ({
+    slotPosition: "predicate",
+    fromNorm,
+    toNorm: "priced at",
+    approvedBy: "source-admin",
+    approvedAt: "2026-06-01T00:00:00Z",
+    refusal: "already-aliased",
+    existingTarget: "cost",
+    reason: `"${fromNorm}" is already aliased to "cost"`,
+  });
+
+  it("passes a well-formed entry through unchanged", () => {
+    const { details, malformed } = screenRefusalDetails([good("price")]);
+    // Field-by-field, not by length: a screen that dropped `existingTarget` or
+    // `reason` on the way through would still return one entry.
+    expect(details).toEqual([good("price")]);
+    expect(malformed).toBe(0);
+  });
+
+  it("⭐ STRIPS keys the type does not declare", () => {
+    // The property that makes this a SCREEN rather than a cast, and the one every
+    // other fixture in this file agreed with by construction — they all carry exactly
+    // the eight declared keys, so `push(entry as VocabularyRefusalDetail)` satisfies
+    // them all. That mutation puts a foreign region's arbitrary extra keys — unbounded
+    // size, unvalidated content — into this region's `jsonb` column under a name that
+    // claims a shape, which is the whole thesis of the function.
+    //
+    // `toEqual` fails on EXTRA properties (unlike `toMatchObject`), which is what makes
+    // this assertion able to go red.
+    const raw = {
+      ...good("price"),
+      attacker: "<script>alert(1)</script>",
+      nested: { deep: [1, 2, 3] },
+    };
+    const { details, malformed } = screenRefusalDetails([raw]);
+    expect(details).toEqual([good("price")]);
+    expect(malformed).toBe(0);
+    // Named explicitly, because the `toEqual` above is the kind of assertion whose
+    // strictness a future reader might soften without realising what it was for.
+    expect(Object.keys(details[0])).not.toContain("attacker");
+  });
+
+  it("treats `undefined` and `null` as NOTHING TO SCREEN, not as malformed", () => {
+    // A target predating #5112 omits the key entirely. That is a build, not a bug,
+    // and reporting it as malformed would tell an operator a region is broken.
+    expect(screenRefusalDetails(undefined)).toEqual({ details: [], malformed: 0 });
+    expect(screenRefusalDetails(null)).toEqual({ details: [], malformed: 0 });
+  });
+
+  it("counts a non-array as ONE malformed thing", () => {
+    // Not an array at all — an object, a string, a number. One malformed
+    // "collection", because there are no entries to count individually.
+    for (const raw of [{ nope: true }, "refusals", 7, true]) {
+      expect(screenRefusalDetails(raw)).toEqual({ details: [], malformed: 1 });
+    }
+  });
+
+  it("⭐ drops each malformed ENTRY KIND and keeps the good ones beside them", () => {
+    // ⚠️ Four bad entries, each a different SHAPE, with a good entry either side so
+    // a screen that bailed on the first bad one cannot pass. FOUR bad, TWO good —
+    // distinct counts, so neither "kept everything" nor "kept nothing" satisfies
+    // this.
+    //
+    // ⚠️ These four are not four independently falsifiable ARMS, and the comment
+    // that first said they were was wrong. Measured: deleting `Array.isArray(entry)`
+    // from the screen kills nothing, because an array carries none of the required
+    // string fields and the field check rejects it regardless. The array and `null`
+    // cases are here as SHAPES a foreign region might really send, not as proof that
+    // each clause is load-bearing — only `null` and the missing-string case are.
+    const { details, malformed } = screenRefusalDetails([
+      good("price"),
+      // Not an object at all.
+      "not an object",
+      // An array — `typeof "object"`, but with no fields. Rejected by the field
+      // check even without the explicit `Array.isArray` clause.
+      [good("margin")],
+      // `null` — also `typeof "object"`, and the one that THROWS without the
+      // explicit null check rather than merely failing it.
+      null,
+      // A required string missing.
+      { ...good("margin"), toNorm: undefined },
+      good("cost"),
+    ]);
+
+    expect(details).toEqual([good("price"), good("cost")]);
+    expect(malformed).toBe(4);
+  });
+
+  it("⭐ requires `approvedBy` and `existingTarget` to be PRESENT, null included", () => {
+    // `null` is a VALUE on both — an auto-approved edge, and a refusal arm with no
+    // conflicting edge. So `null` passes and MISSING is malformed: reading a missing
+    // key as `null` would invent "auto-approved" for an entry that never said, and
+    // invent "there is no conflicting edge" for one that simply omitted it.
+    //
+    // Two assertions in one test because they are one rule, and the pair is what
+    // makes it falsifiable: a screen that accepted `undefined` passes the first
+    // half's `null` case on its own.
+    const nulls = { ...good("price"), approvedBy: null, existingTarget: null };
+    expect(screenRefusalDetails([nulls])).toEqual({ details: [nulls], malformed: 0 });
+
+    const { approvedBy: _a, ...missingApprovedBy } = good("price");
+    const { existingTarget: _e, ...missingExistingTarget } = good("margin");
+    expect(screenRefusalDetails([missingApprovedBy, missingExistingTarget])).toEqual({
+      details: [],
+      malformed: 2,
+    });
+  });
+
+  it("rejects a non-string, non-null value on the nullable fields", () => {
+    // `0` and `false` are the ones a truthiness check lets through.
+    const { details, malformed } = screenRefusalDetails([
+      { ...good("price"), approvedBy: 0 },
+      { ...good("margin"), existingTarget: false },
+    ]);
+    expect(details).toEqual([]);
+    expect(malformed).toBe(2);
+  });
+
+  it("⭐ CAPS what it returns, and the excess is BOUNDED rather than malformed", () => {
+    // The producer's cap is a promise about a well-behaved region; this one is a
+    // property of what this region will store in its own `jsonb` column, and a
+    // target that ignores the cap is exactly the target whose payload should not
+    // size a row here.
+    //
+    // Counting the excess malformed would report a target bug for behaviour this
+    // build defines — so `malformed` must be 0 even though entries were discarded.
+    const over = VOCABULARY_REFUSAL_DETAIL_CAP + 7;
+    const { details, malformed } = screenRefusalDetails(
+      Array.from({ length: over }, (_, i) => good(`norm-${i}`)),
+    );
+    expect(details).toHaveLength(VOCABULARY_REFUSAL_DETAIL_CAP);
+    expect(malformed).toBe(0);
+    // The FIRST cap entries, not an arbitrary slice — the arriving order is the
+    // source's export order (`slot_position, from_norm ASC`), so a truncated list
+    // that started in the middle would be harder to reconcile against the source.
+    expect(details[0]).toEqual(good("norm-0"));
+    expect(details[VOCABULARY_REFUSAL_DETAIL_CAP - 1]).toEqual(
+      good(`norm-${VOCABULARY_REFUSAL_DETAIL_CAP - 1}`),
+    );
+  });
+
+  it("counts malformed entries only within the cap it examines", () => {
+    // A pathological target sending cap+N entries where the bad ones are past the
+    // cap. Nothing beyond the cap is read, so nothing beyond it can be reported —
+    // which keeps `malformed` a statement about what this region looked at.
+    const raw: unknown[] = Array.from({ length: VOCABULARY_REFUSAL_DETAIL_CAP }, (_, i) =>
+      good(`norm-${i}`),
+    );
+    raw.push("garbage", "more garbage");
+    const { details, malformed } = screenRefusalDetails(raw);
+    expect(details).toHaveLength(VOCABULARY_REFUSAL_DETAIL_CAP);
+    expect(malformed).toBe(0);
   });
 });
 

--- a/packages/api/src/lib/residency/cleanup.ts
+++ b/packages/api/src/lib/residency/cleanup.ts
@@ -473,8 +473,27 @@ export async function cleanupMigrationSourceData(migration: {
 
     // Re-check eligibility under a row lock — the loser of a concurrent
     // sweep (multi-instance deploy) sees the winner's stamp and skips.
+    // BOTH #5112 columns ride the SAME `FOR UPDATE` read — no extra query, and
+    // read under the lock that pins the verdict to the deletes. This sweep is the
+    // irreversible act: after it, the source's own `brain_vocabulary_edge` rows are
+    // gone and the payloads on this row are the last copy of those approved
+    // decisions. The audit event below is where that becomes visible at the moment
+    // it becomes true, rather than only in a phase-2 warn emitted seven days
+    // earlier.
+    //
+    // ⚠️ `vocabulary_refusals` is read as a LENGTH, not as the array. The warn
+    // below tells an operator to go and re-author from that column, and round 1 of
+    // this PR's review caught it making that promise unconditionally — while the
+    // column is NULL for a target that predated #5112 (count answered, no payloads)
+    // and shorter than the count whenever the cap bit or an entry was screened out.
+    // A recovery instruction pointing at an empty column, emitted at the instant
+    // the originals become unrecoverable, is worse than no instruction.
     const rows = await client.query(
-      `SELECT status, source_cleaned_at FROM region_migrations WHERE id = $1 FOR UPDATE`,
+      `SELECT status,
+              source_cleaned_at,
+              vocabulary_edges_refused,
+              COALESCE(jsonb_array_length(vocabulary_refusals), 0) AS vocabulary_refusals_recorded
+         FROM region_migrations WHERE id = $1 FOR UPDATE`,
       [migrationId],
     );
     const row = rows.rows[0];
@@ -482,6 +501,17 @@ export async function cleanupMigrationSourceData(migration: {
       await client.query("ROLLBACK");
       return { outcome: "already_resolved" };
     }
+    // NULL means UNKNOWN, not zero — a row written before migration 0204, or a
+    // migration whose source build never asked the target. Kept as `null` rather
+    // than coerced to `0`, because `0` is a positive claim that nothing was
+    // refused and this column cannot make it for those rows.
+    const vocabularyEdgesRefused: number | null =
+      typeof row.vocabulary_edges_refused === "number" ? row.vocabulary_edges_refused : null;
+    // `0` here IS a claim — `COALESCE(..., 0)` folds "column NULL" and "empty
+    // array" together deliberately, because both mean the same thing to the
+    // operator: no payload is recoverable from this row.
+    const vocabularyRefusalsRecorded: number =
+      typeof row.vocabulary_refusals_recorded === "number" ? row.vocabulary_refusals_recorded : 0;
 
     // Cutover guard: never delete a workspace that is homed HERE. After a
     // normal cutover the source DB's organization row points at the target
@@ -561,11 +591,48 @@ export async function cleanupMigrationSourceData(migration: {
       sourceRegion,
       deletedRows,
       deletedByTable,
+      // #5112 — the counts travel with the deletion audit, because THIS is the
+      // event that made the loss permanent. `null` = unknown (pre-0204 row).
+      vocabularyEdgesRefused,
+      vocabularyRefusalsRecorded,
     });
     log.info(
-      { migrationId, workspaceId, sourceRegion, deletedRows },
+      { migrationId, workspaceId, sourceRegion, deletedRows, vocabularyEdgesRefused },
       "Source-region data cleanup completed",
     );
+    // ⚠️ A SEPARATE `warn`, not a clause on the `info` above, and only when the
+    // number is non-zero (#5112). The line above is routine — it fires for every
+    // migration — and an operator who greps for it is looking at row counts. This
+    // one says an irreversible thing just happened to a human's approved decisions
+    // and points at where they can still be found, which from this instant on is
+    // the only remaining copy.
+    if (vocabularyEdgesRefused !== null && vocabularyEdgesRefused > 0) {
+      // ⚠️ THREE MESSAGES, because there are three states and only one of them can
+      // honestly say "re-author them from this row". Round 1 of this PR's review
+      // caught a single unconditional message that promised the payloads whether or
+      // not any had been recorded — the worst possible moment to be wrong, since it
+      // fires exactly when the originals stop existing.
+      const recovery =
+        vocabularyRefusalsRecorded === 0
+          ? "NO recovery payload was recorded for this migration (the target region's build " +
+            "predated the payload contract, or every entry it sent was unreadable), so the " +
+            "target region's own log is the only surviving copy — search it for this " +
+            "workspace's refusal lines."
+          : vocabularyRefusalsRecorded < vocabularyEdgesRefused
+            ? `Only ${vocabularyRefusalsRecorded} of the ${vocabularyEdgesRefused} recovery ` +
+              "payloads are on this migration's region_migrations.vocabulary_refusals " +
+              "(platform-classified, so this sweep never touches it); the remainder exist only " +
+              "in the target region's log."
+            : "The recovery payloads are all on this migration's " +
+              "region_migrations.vocabulary_refusals (platform-classified, so this sweep never " +
+              "touches it); re-author them there.";
+      log.warn(
+        { migrationId, workspaceId, sourceRegion, vocabularyEdgesRefused, vocabularyRefusalsRecorded },
+        "Source cleanup DELETED the brain_vocabulary_edge rows behind refused alias edges — that " +
+          "many approved human review decisions were never applied in the target region and " +
+          `their source rows are now gone. ${recovery}`,
+      );
+    }
     return { outcome: "cleaned", deletedRows };
   } catch (err) {
     try {

--- a/packages/api/src/lib/residency/migrate.ts
+++ b/packages/api/src/lib/residency/migrate.ts
@@ -17,11 +17,25 @@
  */
 
 import { createLogger } from "@atlas/api/lib/logger";
+import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
 import { hasInternalDB, internalQuery, getInternalDB } from "@atlas/api/lib/db/internal";
 import { getConfig } from "@atlas/api/lib/config";
 import { UnsafeRegionMigrationResetError } from "@atlas/api/lib/effect/errors";
 import { exportWorkspaceBundle } from "./export";
-import type { MigrationStatus, MigrationPhase, ExportBundle, ExportManifest, ImportResult } from "@useatlas/types";
+import type {
+  MigrationStatus,
+  MigrationPhase,
+  ExportBundle,
+  ExportManifest,
+  ImportResult,
+  VocabularyRefusalDetail,
+} from "@useatlas/types";
+// ⚠️ From `lib/brain/vocabulary`, NOT from `@useatlas/types` beside the type it
+// bounds. A VALUE import from the published package resolves at runtime against
+// the version the scaffold template pins, and `packages/api/src` is copied into
+// that template — the constant's docstring carries the CI failure that proved it.
+// The `import type` above is erased and therefore free.
+import { VOCABULARY_REFUSAL_DETAIL_CAP } from "@atlas/api/lib/brain/vocabulary";
 
 /** Days to wait before cleaning up source region data after migration. */
 const CLEANUP_GRACE_PERIOD_DAYS = 7;
@@ -243,7 +257,24 @@ async function updateMigrationStatus(
 
 /** Discriminated result from migration execution. */
 export type MigrationResult =
-  | { readonly success: true; readonly migrationId: string }
+  | {
+      readonly success: true;
+      readonly migrationId: string;
+      /**
+       * Curated alias edges the TARGET region refused (#5112).
+       *
+       * On the success arm only, and that is not an oversight: this is the arm
+       * on which the source's `brain_vocabulary_edge` rows are now scheduled for
+       * deletion, so it is the only arm where the number is a call to act. A
+       * failed migration deleted nothing.
+       *
+       * `> 0` means that many of a human's approved review decisions are NOT
+       * applied in the destination and the source's copies expire with the grace
+       * period. The payloads are on `region_migrations.vocabulary_refusals`,
+       * which the cleanup sweep never touches.
+       */
+      readonly vocabularyEdgesRefused: number;
+    }
   | { readonly success: false; readonly migrationId: string; readonly error: string };
 
 /** Failure reason codes for structured HTTP status mapping. */
@@ -259,17 +290,173 @@ export type OperationResult =
 // ---------------------------------------------------------------------------
 
 /**
+ * One target-region response's worth of refusal evidence, brought back to the
+ * source (#5112).
+ *
+ * `refused` is the count the reconciliation loop already validated as a
+ * non-negative integer. `details` is what the source can still act on, screened
+ * entry-by-entry from foreign JSON.
+ *
+ * `details.length < refused` is the load-bearing comparison, and every cause reads
+ * the same to the operator — "part of this loss has no payload here". The causes: the
+ * list was capped (by the target, or by this region's own `slice` when the target
+ * ignored the bound), the target predates #5112 and sent none, or an entry was
+ * malformed and screened out. `malformedDetails` separates the last, because that one
+ * is a bug in a region rather than a documented bound.
+ */
+export interface VocabularyRefusalEvidence {
+  readonly refused: number;
+  readonly details: readonly VocabularyRefusalDetail[];
+  /** Entries the target sent that this build could not read. */
+  readonly malformedDetails: number;
+}
+
+/** What {@link screenRefusalDetails} kept, and how many entries it could not read. */
+export interface ScreenedRefusalDetails {
+  readonly details: readonly VocabularyRefusalDetail[];
+  /** Entries the target sent that this build could not read. */
+  readonly malformed: number;
+}
+
+/** `unknown` → `string`, as a predicate so the narrowing survives destructuring. */
+const isStr = (v: unknown): v is string => typeof v === "string";
+/**
+ * `unknown` → `string | null`.
+ *
+ * `null` is a VALUE on both nullable fields — an auto-approved edge, and a refusal
+ * arm with no conflicting edge — so `undefined` is malformed while `null` is not.
+ *
+ * Spelled `v === null || isStr(v)`. The strict `===` is what excludes `undefined`;
+ * the LOOSE `v == null || isStr(v)` would admit it and invent "auto-approved" for an
+ * entry that simply did not say.
+ *
+ * ⚠️ A bare `v != null` also kills a test, but for the OPPOSITE reason and an earlier
+ * version of this comment had it backwards: `!=` is false for `undefined` too, so it
+ * admits nothing extra — it goes red because it REJECTS `null`, which must pass
+ * (`migrate.test.ts`'s "null included" case). Two different mistakes, two different
+ * failures; naming the wrong one would send the next reader looking in the wrong place.
+ */
+const isStrOrNull = (v: unknown): v is string | null => v === null || isStr(v);
+
+/**
+ * Screen `refusalDetails` out of a target region's JSON (#5112).
+ *
+ * ⚠️ EVERY FIELD IS FOREIGN INPUT and this value is about to be written into this
+ * region's own database as `jsonb`, so it is screened rather than cast. The counters
+ * one block down get the same treatment for the same reason, and the argument there
+ * applies with more force here: a counter that is wrong is a number that misleads,
+ * while an unscreened array is another region's arbitrary JSON persisted under a name
+ * that claims a shape.
+ *
+ * Screening DROPS a bad entry rather than failing the migration. That is the opposite
+ * polarity to the counter check, and deliberately so: an unusable COUNTER breaks
+ * reconciliation, which is the guard that decides whether it is safe to delete the
+ * source's data. A malformed refusal PAYLOAD does not — the count still reconciles,
+ * the source's own `brain_vocabulary_edge` rows are still present for the whole grace
+ * period, and aborting a cutover over an unreadable log-grade field would make this
+ * improvement a new way for migrations to fail. The count of what was dropped is
+ * returned so the caller can say so out loud.
+ *
+ * EXPORTED for its own tests. The integration path through `executeRegionMigration`
+ * can only carry as many refusals as the fixture exports edges, so the cap and the
+ * "every arm of the screen" cases are unreachable from there — and a cap test whose
+ * input cannot exceed the cap tests nothing.
+ */
+export function screenRefusalDetails(raw: unknown): ScreenedRefusalDetails {
+  if (raw === undefined || raw === null) return { details: [], malformed: 0 };
+  if (!Array.isArray(raw)) return { details: [], malformed: 1 };
+
+  const details: VocabularyRefusalDetail[] = [];
+  let malformed = 0;
+  // Bounded HERE as well as at the producer. The producer's cap is a promise
+  // about a well-behaved region; this one is a property of what this region will
+  // store, and the two are different guarantees — a target that ignores the cap
+  // is exactly the target whose payload should not size a row in this database.
+  for (const entry of raw.slice(0, VOCABULARY_REFUSAL_DETAIL_CAP)) {
+    // `Array.isArray` is BELT-AND-BRACES, and saying so is the point: removing it
+    // kills zero tests (measured), because an array has none of the required
+    // string fields and the destructured checks below reject it anyway. Kept
+    // because "an entry is an object, not an array" is a claim worth making
+    // structurally rather than relying on a downstream check to imply it — but a
+    // comment claiming this arm is separately falsifiable would be false.
+    if (entry === null || typeof entry !== "object" || Array.isArray(entry)) {
+      malformed++;
+      continue;
+    }
+    // ⚠️ DESTRUCTURED AND NARROWED BY PREDICATE, not key-listed and cast. The first
+    // version tested `["slotPosition", …].some(k => typeof e[k] !== "string")` and
+    // then built the result with eight `as string` casts — sound at the time, and
+    // structurally fragile: the key list and the constructed literal were coupled by
+    // hand, so a NINTH required field on `VocabularyRefusalDetail` would compile the
+    // moment someone added `newField: e.newField as string` and would admit an entry
+    // that never had it. Here the literal names bare locals, so a new field cannot
+    // reach it unnarrowed — the compiler asks for the check.
+    const {
+      slotPosition,
+      fromNorm,
+      toNorm,
+      approvedBy,
+      approvedAt,
+      refusal,
+      existingTarget,
+      reason,
+    } = entry as Record<string, unknown>;
+    if (
+      !isStr(slotPosition) ||
+      !isStr(fromNorm) ||
+      !isStr(toNorm) ||
+      !isStr(approvedAt) ||
+      !isStr(refusal) ||
+      !isStr(reason) ||
+      !isStrOrNull(approvedBy) ||
+      !isStrOrNull(existingTarget)
+    ) {
+      malformed++;
+      continue;
+    }
+    // ⚠️ FIELD BY FIELD, so undeclared keys are STRIPPED rather than persisted.
+    // `push(entry as VocabularyRefusalDetail)` would be shorter and would put a
+    // foreign region's arbitrary extra keys — unbounded size, unvalidated content —
+    // into this region's `jsonb` column under a name that claims a shape. That is
+    // the whole thesis of this function, and it is the one property every fixture
+    // in the tests used to agree with by construction (they all carried exactly
+    // these eight keys), so there is now a case that adds extras and asserts they
+    // are gone.
+    details.push({
+      slotPosition,
+      fromNorm,
+      toNorm,
+      approvedBy,
+      approvedAt,
+      refusal,
+      existingTarget,
+      reason,
+    });
+  }
+  // Anything past the cap is not malformed — it is bounded. Counting it as
+  // malformed would report a target bug for behaviour this build defines.
+  return { details, malformed };
+}
+
+/**
  * Send an export bundle to the target region's internal import endpoint.
  *
  * Uses ATLAS_INTERNAL_SECRET for service-to-service auth. The target endpoint
  * is derived from the region's apiUrl in the residency config.
+ *
+ * On success it returns the target's vocabulary-refusal evidence (#5112) — the
+ * count AND the payloads — because this is the only point at which the source
+ * ever sees them, and the source is the region that schedules the delete.
  */
 async function transferBundleToTarget(
   bundle: ExportBundle,
   targetApiUrl: string,
   orgId: string,
   migrationId: string,
-): Promise<{ ok: true } | { ok: false; error: string }> {
+): Promise<
+  | { ok: true; vocabularyRefusals: VocabularyRefusalEvidence }
+  | { ok: false; error: string }
+> {
   const secret = process.env.ATLAS_INTERNAL_SECRET;
   if (!secret) {
     return { ok: false, error: "ATLAS_INTERNAL_SECRET is not configured — cannot authenticate cross-region transfer" };
@@ -326,10 +513,15 @@ async function transferBundleToTarget(
   // `refused` is #5036's third vocabulary counter. Every field is optional here
   // regardless of what the local `ImportResult` requires, because this is
   // another region's JSON and possibly another region's BUILD.
+  //
+  // `refusalDetails` is #5112's payload, and it is typed `unknown` rather than
+  // `VocabularyRefusalDetail[]` on purpose: a declared array type here would let
+  // the rest of this function index into another region's JSON as though the
+  // shape were proven. `screenRefusalDetails` is where it becomes a type.
   let acknowledged: Partial<
     Record<
       (typeof RECONCILED_SECTIONS)[number],
-      { imported?: number; skipped?: number; refused?: number }
+      { imported?: number; skipped?: number; refused?: number; refusalDetails?: unknown }
     >
   >;
   try {
@@ -364,6 +556,18 @@ async function transferBundleToTarget(
     : never = true;
   void _refusalSectionsReviewed;
 
+  // #5112. Accumulated inside the loop so it uses the counter the loop has
+  // already validated as a non-negative integer, rather than re-reading the raw
+  // JSON and re-deciding whether to trust it.
+  //
+  // ⚠️ THIS INITIALIZER IS LOAD-BEARING, not a placeholder. A bundle that carried
+  // zero alias edges never reaches the capture block — the loop `continue`s on
+  // `expected === 0` — so `refused: 0` here is what gets recorded, and it is what
+  // makes a later NULL on the column mean "this build never asked" rather than "we
+  // forgot". Zero is the honest value in that case: a source that exported no edges
+  // cannot have had one refused.
+  let vocabularyRefusals: VocabularyRefusalEvidence = { refused: 0, details: [], malformedDetails: 0 };
+
   for (const section of RECONCILED_SECTIONS) {
     // Ground truth from the payload where the section IS a top-level array;
     // the manifest is a self-report written in a different literal, so a
@@ -392,7 +596,31 @@ async function transferBundleToTarget(
           "data has been deleted. This is an exporter bug — the section needs a manifest count.",
       };
     }
-    if (expected === 0) continue; // nothing exported ⇒ nothing to reconcile
+    if (expected === 0) {
+      // ⚠️ NOT SILENT ANY MORE. Nothing exported means nothing to reconcile, and
+      // that is still true — a source that sent zero rows cannot lose any. But
+      // `continue` also skipped the counter validation and, since #5112, the refusal
+      // capture, so a target answering `{imported: 0, skipped: 0, refused: 7}` for a
+      // section the bundle carried NOTHING of was discarded without a word. This
+      // block's own comment calls that shape "either a target bug or a section that
+      // grew a refusal without anyone revisiting … Both are worth a human's
+      // attention" — and this was the one path where the attention was switched off.
+      //
+      // Still a `continue`, not a return: the arithmetic is unaffected and failing a
+      // cutover over a counter about rows that do not exist would be the
+      // over-reaction this whole block is careful to avoid elsewhere.
+      const idle = acknowledged[section];
+      const claimed = (idle?.imported ?? 0) + (idle?.skipped ?? 0) + (idle?.refused ?? 0);
+      if (claimed !== 0) {
+        log.warn(
+          { migrationId, section, imported: idle?.imported, skipped: idle?.skipped, refused: idle?.refused },
+          "Target region reported non-zero counters for a section the bundle carried NOTHING of " +
+            "— not reconciled (there is nothing to reconcile) and not fatal, but it means the " +
+            "target is counting rows this bundle did not send. Check both builds.",
+        );
+      }
+      continue;
+    }
     const got = acknowledged[section];
 
     // ⚠️ `refused` IS ACCOUNTING, NOT LOSS — but ONLY for the one section that
@@ -497,9 +725,64 @@ async function transferBundleToTarget(
     // Pre-#5036 the same input failed the import outright and nothing was ever
     // scheduled for deletion. Refusing gracefully is the right call; doing it
     // without telling the side that owns the delete timer is not.
+    // ⚠️ THE PAYLOADS ARE READ HERE, BEFORE THE DISCLOSURE BELOW AND BEFORE
+    // CUTOVER (#5112). `refused > 0` is not the condition: a target that refuses
+    // nothing still tells us `0`, and recording that `0` is what makes a later
+    // NULL on the column mean "this build never asked" rather than "we forgot".
+    if (section === "brainVocabularyEdges") {
+      const screened = screenRefusalDetails(got?.refusalDetails);
+      vocabularyRefusals = {
+        refused,
+        details: screened.details,
+        malformedDetails: screened.malformed,
+      };
+      // ⚠️ TWO WARNS THAT DO NOT DEPEND ON `refused > 0`, because both describe a
+      // TARGET BUG rather than a loss, and a target bug is worth saying out loud
+      // whether or not anything was refused. Round 1 of this PR's review found both
+      // numbers computed and then discarded unless the disclosure below fired — so
+      // a target answering `refused: 0` with a garbage `refusalDetails` produced a
+      // count in hand and not one byte of signal.
+      if (screened.malformed > 0) {
+        log.warn(
+          { migrationId, section, refused, malformedDetails: screened.malformed },
+          "Target region sent refusal payloads this build could not read — they were DROPPED " +
+            "rather than stored, which is the right polarity (the count still reconciles and the " +
+            "source keeps its own rows) but it is a bug in the target region: its payload does " +
+            "not match the contract it answered on.",
+        );
+      }
+      // The inverse of the load-bearing `details.length < refused` comparison. More
+      // payloads than the target's own count contradicts itself, and this module
+      // already refuses an unusable COUNTER on the reasoning that a count which
+      // cannot be trusted is not a count — the same argument applies to a payload
+      // set that disagrees with the count beside it. Not fatal: the count is the
+      // reconciled value and the extra payloads are merely stored.
+      if (screened.details.length > refused) {
+        log.warn(
+          { migrationId, section, refused, detailsRecorded: screened.details.length },
+          "Target region sent MORE refusal payloads than its own refused counter — target bug. " +
+            "The counter is what reconciles and what the audit trail records; the surplus " +
+            "payloads are stored as-is.",
+        );
+      }
+    }
+
     if (refusalIsAccounting && refused > 0) {
       log.warn(
-        { migrationId, section, refused },
+        {
+          migrationId,
+          section,
+          refused,
+          // #5112 — the three numbers that say how much of this loss has a
+          // payload on THIS side. `detailsRecorded < refused` is the operator's
+          // signal that the source's own rows are the only copy for some of it,
+          // and `malformedDetails > 0` separates "the target sent something this
+          // build cannot read" from the documented cap.
+          detailsRecorded:
+            section === "brainVocabularyEdges" ? vocabularyRefusals.details.length : undefined,
+          malformedDetails:
+            section === "brainVocabularyEdges" ? vocabularyRefusals.malformedDetails : undefined,
+        },
         // ⚠️ CONDITIONAL TENSE, and it points at THIS region's own data.
         //
         // Two corrections, both caught by asking whether this fix reproduces the
@@ -508,9 +791,11 @@ async function transferBundleToTarget(
         // source copy is deleted" as fact is the same over-report the target-side
         // warn was just rewritten to avoid, one module over and in the same
         // commit. Second, and worse: it used to say "retrieve them from the
-        // TARGET's logs", which makes another region's log retention the
-        // recovery path — the very artifact this disclosure exists because it is
-        // NOT sufficient.
+        // TARGET's logs", making another region's log retention the recovery
+        // PATH — the artifact this disclosure exists because it is NOT
+        // sufficient. The target log is still NAMED, because it is where the
+        // per-edge detail lives; what changed is that this region's own rows are
+        // named first and called the copy that needs no cooperation.
         //
         // The source does not need them. It still HOLDS its own
         // `brain_vocabulary_edge` rows, in its own database, for the whole grace
@@ -520,13 +805,122 @@ async function transferBundleToTarget(
           "review decisions will NOT be applied in the destination. If this migration completes, " +
           "THIS region's own brain_vocabulary_edge rows are deleted once the cleanup grace " +
           "period expires: export or re-author them from this region's database before then. " +
-          "Which specific edges were refused is logged in the target region against this " +
-          "workspace; the full set is still here until cleanup runs.",
+          "Which specific edges were refused is logged in the target region. The full set is also " +
+          "still in THIS region's own brain_vocabulary_edge until cleanup runs, and that is the " +
+          "copy that needs no cooperation from anyone." +
+          // ⚠️ SECTION-SCOPED, because `detailsRecorded` is only populated for the
+          // vocabulary section — this warn is shared with `brainSlackChannelExclusions`,
+          // whose `refused` is structurally zero today but which would otherwise be told
+          // to read a field that is not on its line. A recovery instruction naming an
+          // absent field is the same defect as one naming an empty column.
+          (section === "brainVocabularyEdges"
+            ? " Whatever payloads the target returned are recorded on THIS migration's " +
+              "region_migrations row (vocabulary_refusals), which is platform-classified and " +
+              "outlives the cleanup — but read `detailsRecorded` on this line first: it is how " +
+              "many actually landed here, and a target predating the payload contract reports a " +
+              "count with none."
+            : ""),
       );
     }
   }
 
-  return { ok: true };
+  return { ok: true, vocabularyRefusals };
+}
+
+/**
+ * Record the target's refusal evidence on the SOURCE's own migration row (#5112).
+ *
+ * This is the durability step the whole issue is about. Everything else in this
+ * flow is a log line or a counter; `region_migrations` is `platform`-classified in
+ * `bundle-scope.ts`, so `runSourceCleanupSweep` never deletes it — which makes
+ * these two columns the one artifact that outlives the grace-period delete of the
+ * `brain_vocabulary_edge` rows they describe.
+ *
+ * ## Failing here ABORTS the migration when there is something to lose
+ *
+ * The polarity is chosen against the irreversible act, exactly as
+ * `transferBundleToTarget`'s counter check is. Continuing past a failed write with
+ * `refused > 0` would cut over and schedule the destructive cleanup while the only
+ * durable record of N approved human decisions is a log line in another region —
+ * the precise state this issue exists to remove, re-entered through the error
+ * path. Throwing here happens BEFORE cutover, so nothing is deleted and the
+ * workspace is still served from this region.
+ *
+ * With `refused === 0` a failed write costs a `0` nobody will act on, so it warns
+ * and carries on: a migration that is going to lose nothing should not fail on the
+ * bookkeeping for the loss.
+ *
+ * ## Exported for its own real-Postgres test, and that is not a convenience.
+ *
+ * Both existing halves of this feature's coverage are hand-written statements ABOUT
+ * these two columns: the mock suite greps `capturedQueries` for a substring and
+ * inspects `params` without ever executing the SQL, and the pg falsifier seeds the
+ * row with its own `INSERT`. So a typo'd column name, a missing `::jsonb` cast, or a
+ * dropped `JSON.stringify` was invisible to both — measured: renaming the column in
+ * this statement to `vocabulary_refusals_json` left every test green, while in
+ * production it makes `recordVocabularyRefusals` throw and (because `refused > 0`
+ * aborts) fails EVERY migration that carries a refusal.
+ *
+ * `migrate-roundtrip-pg.test.ts` now drives this function against the migrated
+ * schema, which is the only thing that confronts the statement with the real table.
+ */
+export async function recordVocabularyRefusals(
+  migrationId: string,
+  evidence: VocabularyRefusalEvidence,
+): Promise<void> {
+  try {
+    await internalQuery(
+      `UPDATE region_migrations
+          SET vocabulary_edges_refused = $2,
+              vocabulary_refusals = $3::jsonb
+        WHERE id = $1`,
+      [
+        migrationId,
+        evidence.refused,
+        // `null` rather than `'[]'` when there is nothing to record, so a query
+        // for "migrations with recoverable payloads" is `IS NOT NULL` and does not
+        // have to know that an empty array means the same thing.
+        evidence.details.length === 0 ? null : JSON.stringify(evidence.details),
+      ],
+    );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (evidence.refused > 0) {
+      // ⚠️ THE DRIVER TEXT GOES TO THE LOG, NEVER INTO THE THROWN MESSAGE — and the
+      // first version of this did interpolate it, which was the leak this whole
+      // scrubbing discussion is about, committed by the fix for it.
+      //
+      // Whatever is thrown here is caught by `executeRegionMigration`, written to
+      // `region_migrations.error_message`, and served VERBATIM to a workspace admin by
+      // `admin-residency.ts`'s `failed` arm. `errorMessage`'s scrub is credential-URI
+      // only — it rewrites `scheme://user:pass@host` and leaves
+      // `connect ECONNREFUSED 10.0.3.7:5432`, a pg `DETAIL: Key (…)=(…)` row fragment,
+      // and internal column spellings untouched. So scrubbing downstream is not
+      // sufficient for a pg error, and the only reliable answer is not to put driver
+      // text on a customer-served field in the first place.
+      //
+      // Nothing is lost operationally: the raw message is right here at `error` level
+      // with the `migrationId` as the join key, which is the same split the import
+      // routes' 500s already use (generic body, `requestId` as the handle).
+      log.error(
+        { err: message, migrationId, refused: evidence.refused },
+        "Failed to record refused alias edges on the migration row — aborting before cutover",
+      );
+      throw new Error(
+        `Failed to record ${evidence.refused} refused alias edge(s) on the migration row. ` +
+          `Migration ${migrationId} aborted BEFORE cutover; no source data has been deleted and the ` +
+          `workspace is still served from this region. Continuing would schedule the source cleanup ` +
+          `with no durable record of the refused decisions — the target region's log would be the ` +
+          `only copy, and it outlives the data by only as long as that region's log retention. ` +
+          `The underlying database error is recorded server-side against this migration id.`,
+      );
+    }
+    log.warn(
+      { err: message, migrationId },
+      "Could not record the vocabulary-refusal bookkeeping on the migration row — nothing was " +
+        "refused, so no recovery payload was lost; continuing",
+    );
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -626,7 +1020,18 @@ export async function executeRegionMigration(
       throw new Error(transferResult.error);
     }
 
-    log.info({ migrationId }, "Phase 2 complete: data transferred to target region");
+    // ⚠️ PERSISTED BEFORE CUTOVER, not in Phase 4 beside the cleanup schedule
+    // (#5112). The refusals are a fact about the TARGET's response and are known
+    // the instant Phase 2 returns; deferring the write to Phase 4 would leave a
+    // window where the target has committed a partial import — refusals included
+    // — and the source holds no record of it, which is exactly the window a
+    // cutover failure lands in. Writing here means the record exists even for a
+    // migration that never completes, and `recordVocabularyRefusals` throwing
+    // aborts while nothing has been deleted.
+    await recordVocabularyRefusals(migrationId, transferResult.vocabularyRefusals);
+    const vocabularyEdgesRefused = transferResult.vocabularyRefusals.refused;
+
+    log.info({ migrationId, vocabularyEdgesRefused }, "Phase 2 complete: data transferred to target region");
 
     // ── Phase 3: Cutover ─────────────────────────────────────────────
     log.info({ migrationId, step: MIGRATION_STEPS.cutting_over }, "Phase 3: Updating region assignment");
@@ -682,6 +1087,14 @@ export async function executeRegionMigration(
       sourceRegion,
       cleanupAfter: cleanupAfter.toISOString(),
       gracePeriodDays: CLEANUP_GRACE_PERIOD_DAYS,
+      // ⚠️ THIS IS THE EVENT THE COUNT BELONGS ON (#5112). It fires for the exact
+      // 7-day timer the refusal disclosure names, so the audit channel now carries
+      // the deadline and what expires with it in one record — instead of a bare
+      // `log.warn` in phase 2 sitting beside an audit event built for this. A
+      // non-zero value here means the delete this event schedules is what makes
+      // the source's copies unrecoverable.
+      vocabularyEdgesRefused,
+      vocabularyRefusalDetailsRecorded: transferResult.vocabularyRefusals.details.length,
     });
 
     log.info(
@@ -697,18 +1110,52 @@ export async function executeRegionMigration(
       workspaceId,
       sourceRegion,
       targetRegion,
+      // #5112 — on the completion event too, not only on the cleanup one. The two
+      // answer different questions and an operator reads them at different times:
+      // "did this migration lose any curated decisions" is a property of the
+      // migration, and it must be answerable from the terminal event without
+      // correlating back to the scheduling event that preceded it.
+      vocabularyEdgesRefused,
     });
 
-    log.info({ migrationId, workspaceId, sourceRegion, targetRegion, completedAt }, "Migration completed successfully");
+    log.info({ migrationId, workspaceId, sourceRegion, targetRegion, completedAt, vocabularyEdgesRefused }, "Migration completed successfully");
 
-    return { success: true, migrationId };
+    return { success: true, migrationId, vocabularyEdgesRefused };
   } catch (err) {
     const rawMessage = err instanceof Error ? err.message : String(err);
 
+    // ⚠️ SCRUBBED FOR THE DURABLE FIELD, RAW FOR THE LOG (#5112 panel round 1).
+    //
+    // `failureMessage` below is not just a log string: it is written to
+    // `region_migrations.error_message` and returned VERBATIM to a workspace admin
+    // by `admin-residency.ts`'s `failed` arm. So every message that can reach this
+    // catch is customer-readable.
+    //
+    // ⚠️ AND THE SCRUB IS NOT SUFFICIENT ON ITS OWN — stated exactly, because an
+    // earlier version of this comment claimed it closed a hazard it does not.
+    // `errorMessage` rewrites `scheme://user:pass@host` and NOTHING ELSE, so
+    // `connect ECONNREFUSED 10.0.3.7:5432`, a pg `DETAIL: Key (…)=(…)` row fragment
+    // and internal column spellings all survive it. It is a floor, not a filter.
+    //
+    // What actually keeps driver text off this field is the throw sites not putting it
+    // there: `recordVocabularyRefusals` (#5112) logs the DB error at `error` and throws
+    // a message with none of it. `transferBundleToTarget`'s `Network error connecting
+    // to target region: ${msg}` still interpolates a `fetch` error carrying the
+    // internal region host — PRE-EXISTING, unchanged here, and filed as a follow-up
+    // rather than fixed inline, because every message that can reach this catch needs
+    // the same audit and that is a wider change than this PR.
+    //
+    // `error-scrub.ts` lists "concatenated into a thrown `new Error(...)`" as a
+    // carve-out, and that carve-out is about keeping a THROWN error inspectable.
+    // It does not contemplate a throw whose message is persisted and then served,
+    // which is what this line does — so the raw text goes to `log.error` (where the
+    // operator can still see it) and the scrubbed text goes everywhere durable.
+    const safeMessage = errorMessage(err);
+
     // If the region was already updated, retry is dangerous — data exists in both regions
-    const errorMessage = regionUpdated
-      ? `${rawMessage} (WARNING: region was already updated to "${targetRegion}" — do NOT retry without investigation)`
-      : rawMessage;
+    const failureMessage = regionUpdated
+      ? `${safeMessage} (WARNING: region was already updated to "${targetRegion}" — do NOT retry without investigation)`
+      : safeMessage;
 
     log.error({ err: rawMessage, migrationId, workspaceId, regionUpdated }, "Migration failed");
 
@@ -716,7 +1163,7 @@ export async function executeRegionMigration(
       workspaceId,
       sourceRegion,
       targetRegion,
-      error: errorMessage,
+      error: failureMessage,
       regionUpdated,
     });
 
@@ -727,7 +1174,7 @@ export async function executeRegionMigration(
     // `region_updated` will mirror what the executor actually observed.
     try {
       await updateMigrationStatus(migrationId, "failed", {
-        errorMessage,
+        errorMessage: failureMessage,
         completedAt: new Date().toISOString(),
         regionUpdated,
       });
@@ -738,7 +1185,7 @@ export async function executeRegionMigration(
       );
     }
 
-    return { success: false, migrationId, error: errorMessage };
+    return { success: false, migrationId, error: failureMessage };
   }
 }
 

--- a/packages/cli/src/commands/__tests__/migrate-import-refusals.test.ts
+++ b/packages/cli/src/commands/__tests__/migrate-import-refusals.test.ts
@@ -1,0 +1,173 @@
+/**
+ * The CLI's refusal disclosure (#5112).
+ *
+ * `renderRefusalNotice` is the ONLY operator-facing surface for a dropped human
+ * review decision. Before review round 1 it was an inline block in
+ * `handleMigrateImport` with no test file anywhere under `packages/cli`, and three
+ * of its branches were free mutations:
+ *
+ *   - deleting the "target did not return the refused edges" arm collapsed two
+ *     different states — "nothing was refused" and "N were refused and we cannot
+ *     show you which" — into the same silence;
+ *   - deleting the "N more were refused but not listed" line made the CLI report a
+ *     smaller loss than happened;
+ *   - `refused ?? 0` turned "this build cannot report the counter" into the positive
+ *     claim "it refused nothing", and silenced the whole block.
+ *
+ * Every case here drives the real function with a captured sink, so a deleted branch
+ * is a missing line rather than an unobserved one.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { renderRefusalNotice } from "../migrate-import";
+
+/** One well-formed payload as a current target sends it. */
+const detail = (fromNorm: string) => ({
+  slotPosition: "predicate",
+  fromNorm,
+  toNorm: "priced at",
+  approvedBy: "source-admin",
+  approvedAt: "2026-06-01T00:00:00.000Z",
+  refusal: "already-aliased",
+  existingTarget: "cost",
+  reason: `"${fromNorm}" is already aliased to "cost"`,
+});
+
+/** Render into an array instead of stdout, and join for substring assertions. */
+function render(vocabulary: Parameters<typeof renderRefusalNotice>[0]): {
+  lines: string[];
+  text: string;
+} {
+  const lines: string[] = [];
+  renderRefusalNotice(vocabulary, (line) => lines.push(line));
+  // ANSI colour survives `pc.yellow`, so assertions match on substrings rather than
+  // whole lines — the codes are not what any of these tests are about.
+  return { lines, text: lines.join("\n") };
+}
+
+describe("renderRefusalNotice", () => {
+  it("says nothing at all when the section is absent", () => {
+    // A pre-#5022 target has no vocabulary section. Silence is right: there is no
+    // counter, no payload, and nothing an operator could act on.
+    expect(render(undefined).lines).toEqual([]);
+  });
+
+  it("says nothing when the target refused nothing", () => {
+    // `0` is a positive claim and it needs no prose. A disclosure that fired here
+    // would print on every import carrying a vocabulary and train an operator to
+    // skip the block.
+    expect(render({ imported: 4, skipped: 1, refused: 0 }).lines).toEqual([]);
+  });
+
+  it("⭐ WARNS when the target cannot report the counter — not silence, and not zero", () => {
+    // The `?? 0` defect. A target between #5022 and #5036 omits `refused` entirely,
+    // having folded contradictory decisions into `skipped` — so this is the one state
+    // where the operator has to be told to go and compare by hand, and the old code
+    // printed nothing at all.
+    const { text } = render({ imported: 4, skipped: 2 });
+    expect(text).toContain("does not report refused alias edges");
+    expect(text).toContain("counted under Skipped");
+    expect(text).toContain("brain_vocabulary_edge");
+    // ⚠️ And it must NOT claim a number. Reporting `0 curated alias edge(s) were
+    // REFUSED` here is the misleading render this branch exists to replace.
+    expect(text).not.toContain("were REFUSED");
+  });
+
+  it("⭐ distinguishes a count with NO payloads from nothing to recover", () => {
+    // A target between #5036 and #5112: it counted the refusals and carries none of
+    // them. Deleting this branch makes it render as an empty list under a non-zero
+    // count, which reads as "nothing to recover" — the opposite of the truth.
+    const { text } = render({ imported: 2, skipped: 0, refused: 3 });
+    expect(text).toContain("3 curated alias edge(s) were REFUSED");
+    expect(text).toContain("did not return the refused edges");
+    expect(text).toContain("its build predates them");
+    // No per-edge lines, because there are none to print.
+    expect(text).not.toContain("approved by");
+  });
+
+  it("⭐ enumerates the payloads, and names `existingTarget` when there is one", () => {
+    const { text } = render({
+      imported: 0,
+      skipped: 0,
+      refused: 2,
+      refusalDetails: [detail("price"), { ...detail("margin"), existingTarget: null }],
+    });
+    expect(text).toContain('[predicate] "price" → "priced at" — already-aliased');
+    // Present on the first, absent on the second — the two arms of the field, so a
+    // render that always printed it or never did fails one of them.
+    expect(text).toContain('(destination holds "cost")');
+    expect(text).toContain('"margin" → "priced at" — already-aliased');
+    expect(text.split("\n").filter((l) => l.includes("destination holds"))).toHaveLength(1);
+    expect(text).toContain("approved by source-admin at 2026-06-01T00:00:00.000Z");
+    // Both listed, so no truncation note.
+    expect(text).not.toContain("more were refused");
+  });
+
+  it("⭐ `null` approvedBy is auto-approval; ABSENT is not", () => {
+    // The distinction `?? "auto-approval"` destroyed. `null` is a real value — an
+    // edge approved by the system — while a missing key means the target did not say,
+    // and inventing an attribution for it is exactly the misread the server-side
+    // screen treats as malformed.
+    const autoApproved = render({
+      refused: 1,
+      refusalDetails: [{ ...detail("price"), approvedBy: null }],
+    }).text;
+    expect(autoApproved).toContain("approved by auto-approval at");
+
+    const notReported = render({
+      refused: 1,
+      refusalDetails: [{ ...detail("price"), approvedBy: undefined }],
+    }).text;
+    expect(notReported).toContain("(approver not reported)");
+    expect(notReported).not.toContain("auto-approval");
+  });
+
+  it("⭐ reports the SHORTFALL when fewer payloads arrive than were refused", () => {
+    // Deleting this line makes the CLI report a smaller loss than happened, which is
+    // the failure the response's own `detailsCarried`/`refused` pair exists to
+    // prevent one layer up.
+    const { text } = render({
+      refused: 7,
+      refusalDetails: [detail("price"), detail("margin")],
+    });
+    expect(text).toContain("7 curated alias edge(s) were REFUSED");
+    expect(text).toContain("5 more were refused but not listed here");
+  });
+
+  it("counts unreadable entries instead of printing `undefined`", () => {
+    // A malformed payload from a buggy target or a proxy. `[undefined] "undefined" →
+    // "undefined"` is what the undefended render produced.
+    const { text } = render({
+      refused: 3,
+      refusalDetails: [detail("price"), { reason: "no norms at all" }, "not an object" as never],
+    });
+    expect(text).toContain('"price" → "priced at"');
+    expect(text).toContain("2 refusal record(s) were unreadable");
+    expect(text).not.toContain("undefined");
+  });
+
+  it("fills the missing non-key fields with named placeholders", () => {
+    // `fromNorm`/`toNorm` are the load-bearing pair — without them there is nothing
+    // to re-author, which is why their absence makes an entry unreadable. The rest
+    // degrade rather than disqualify: an entry that still names the two norms is
+    // worth printing even if the target dropped the position or the reason.
+    const { text } = render({
+      refused: 1,
+      refusalDetails: [{ fromNorm: "price", toNorm: "priced at" }],
+    });
+    expect(text).toContain('[unknown position] "price" → "priced at" — unreported reason');
+    expect(text).toContain("(approver not reported) at (time not reported)");
+    expect(text).not.toContain("unreadable");
+  });
+
+  it("always closes with the remedy", () => {
+    // Every path that printed a loss must say what to do about it. Asserted on both
+    // shapes, because the two arms build their prose separately.
+    for (const vocabulary of [
+      { refused: 1, refusalDetails: [detail("price")] },
+      { refused: 1 },
+    ]) {
+      expect(render(vocabulary).text).toContain("Re-author them here");
+    }
+  });
+});

--- a/packages/cli/src/commands/migrate-import.ts
+++ b/packages/cli/src/commands/migrate-import.ts
@@ -8,6 +8,123 @@ import * as fs from "fs";
 import pc from "picocolors";
 import { getFlag } from "../../lib/cli-utils";
 
+/**
+ * The vocabulary section as a FOREIGN response may actually contain it (#5112).
+ *
+ * Every member optional, and `refusalDetails` a `Partial<...>` array — because this
+ * value comes from an unchecked `as` cast of another server's `resp.json()`, and
+ * this file already reasons about cross-version targets and proxies everywhere else.
+ * Declaring the payload fully-shaped here while `residency/migrate.ts` screens the
+ * identical value entry-by-entry ("every field is foreign input") would be one
+ * payload with two opposite policies, which is what review round 1 found.
+ */
+interface CrossVersionVocabularySection {
+  imported?: number;
+  skipped?: number;
+  refused?: number;
+  refusalDetails?: Array<Partial<import("@useatlas/types").VocabularyRefusalDetail>>;
+}
+
+/**
+ * Print the refusal disclosure for one import response.
+ *
+ * Extracted from the handler and given an injectable sink so its branches are
+ * reachable from a test. They are the ONLY operator-facing surface for a dropped
+ * human review decision, and before this they had no test at all: deleting the
+ * "target did not return the refused edges" branch collapsed two different states
+ * into silence, and deleting the "N more not listed" line made the CLI report a
+ * smaller loss than happened. Both were green.
+ */
+export function renderRefusalNotice(
+  vocabulary: CrossVersionVocabularySection | undefined,
+  write: (line: string) => void = console.log,
+): void {
+  if (!vocabulary) return;
+
+  // ⚠️ THREE STATES, not two. `refused` ABSENT is a target between #5022 and #5036:
+  // it folded contradictory decisions into `skipped` and cannot tell us. Rendering
+  // that as `0` — which `?? 0` did — is the most misleading value available, because
+  // it is a positive claim that nothing was refused AND it silences the whole block
+  // below. This is the same absent-vs-zero distinction the table's `-` filler makes
+  // for sections that have no refusal outcome at all.
+  if (typeof vocabulary.refused !== "number") {
+    write(
+      pc.yellow(
+        "  ! This target build does not report refused alias edges. A dropped review decision",
+      ),
+    );
+    write(
+      "    would be counted under Skipped — compare the source region's brain_vocabulary_edge",
+    );
+    write("    rows before its cleanup grace period expires.");
+    return;
+  }
+
+  const refused = vocabulary.refused;
+  if (refused <= 0) return;
+
+  const details = vocabulary.refusalDetails ?? [];
+  write("");
+  write(
+    pc.yellow(
+      `  ! ${refused} curated alias edge(s) were REFUSED — approved review decisions the ` +
+        "destination did not apply.",
+    ),
+  );
+
+  if (details.length === 0) {
+    // A count with no payloads, which is NOT "nothing to recover" — the difference
+    // is a build. A target between #5036 and #5112 reports the count and carries no
+    // details at all.
+    write("    The target did not return the refused edges (its build predates them). Retrieve them");
+    write("    from the SOURCE region's brain_vocabulary_edge rows before its cleanup grace period");
+    write("    expires.");
+  } else {
+    // ⚠️ RENDERED DEFENSIVELY, field by field. `d.approvedBy ?? "auto-approval"` was
+    // the defect: `null` means auto-approved and ABSENT means the target did not say,
+    // and `??` collapses them — inventing an attribution, which is verbatim the
+    // misread `residency/migrate.ts` refuses by treating `undefined` as malformed.
+    let unreadable = 0;
+    for (const d of details) {
+      if (typeof d.fromNorm !== "string" || typeof d.toNorm !== "string") {
+        unreadable++;
+        continue;
+      }
+      const held =
+        d.existingTarget === null || d.existingTarget === undefined
+          ? ""
+          : ` (destination holds "${d.existingTarget}")`;
+      const position = typeof d.slotPosition === "string" ? d.slotPosition : "unknown position";
+      const reason = typeof d.refusal === "string" ? d.refusal : "unreported reason";
+      write(`    - [${position}] "${d.fromNorm}" → "${d.toNorm}" — ${reason}${held}`);
+      const approver =
+        d.approvedBy === null
+          ? "auto-approval"
+          : typeof d.approvedBy === "string"
+            ? d.approvedBy
+            : "(approver not reported)";
+      const when = typeof d.approvedAt === "string" ? d.approvedAt : "(time not reported)";
+      write(`      approved by ${approver} at ${when}`);
+    }
+    if (unreadable > 0) {
+      write(
+        pc.yellow(
+          `    ! ${unreadable} refusal record(s) were unreadable — a bug in the target region; ` +
+            "check its logs.",
+        ),
+      );
+    }
+    // Both numbers whenever they differ. Printing only the list would report a
+    // smaller loss than happened. Two causes read alike from here — the response's
+    // cap, or a target that truncated for its own reason — so the wording names the
+    // consequence rather than guessing the cause.
+    if (details.length < refused) {
+      write(`    ... ${refused - details.length} more were refused but not listed here.`);
+    }
+  }
+  write("    Re-author them here, or export them from the source region's vocabulary.");
+}
+
 export async function handleMigrateImport(
   args: string[],
 ): Promise<void> {
@@ -177,9 +294,20 @@ export async function handleMigrateImport(
     // omits the v2 sections entirely, so they are optional HERE even though
     // the current ImportResult wire type requires them — the cast must not
     // claim more than the runtime guards below check.
+    //
+    // `brainVocabularyEdges` joins the optional set at #5112. It was absent from
+    // BOTH halves before then, so this table never printed a vocabulary counter at
+    // all — including `refused`, the one counter in the whole response that means
+    // a human's approved decision was dropped. Its nested `refusalDetails` is
+    // #5112's payload and a target between #5036 and #5112 omits it, which is why
+    // the render below treats an empty list beside a non-zero count as a distinct
+    // case rather than as "nothing to recover".
     type CrossVersionImportResult =
       Pick<import("@useatlas/types").ImportResult, "conversations" | "semanticEntities" | "learnedPatterns" | "settings"> &
-      Partial<Pick<import("@useatlas/types").ImportResult, "dashboards" | "knowledgeDocuments" | "scheduledTasks" | "agentSessionMemory" | "brainEpisodes" | "brainFacts" | "brainEdges" | "factAudienceMembers">>;
+      Partial<Pick<import("@useatlas/types").ImportResult, "dashboards" | "knowledgeDocuments" | "scheduledTasks" | "agentSessionMemory" | "brainEpisodes" | "brainFacts" | "brainEdges" | "factAudienceMembers">> &
+      {
+        brainVocabularyEdges?: CrossVersionVocabularySection;
+      };
     let result: CrossVersionImportResult;
     try {
       result =
@@ -209,70 +337,79 @@ export async function handleMigrateImport(
       process.exit(1);
     }
 
-    console.log(`${pc.green("\u2713")} Import complete!\n`);
+    // THREE columns since #5112. The third exists for one section today, and the
+    // two possible fillers for the rest are NOT interchangeable:
+    //
+    //   - `-` means the section HAS NO refusal outcome. There is nothing it could
+    //     report there, in any build.
+    //   - `0` would be a positive claim that it refused nothing — a different
+    //     sentence, and one those sections cannot make.
+    //
+    // Same distinction the target-side refusal warn makes by writing an explicit
+    // `null` for `existingTarget` rather than omitting the key: a blank and a zero
+    // read identically to someone skimming, and only one of them is true here.
+    const NO_REFUSAL_OUTCOME = "-";
+    /** The section CAN refuse, but this target's build does not report the counter. */
+    const REFUSAL_NOT_REPORTED = "?";
+    const row = (
+      label: string,
+      counts: { imported?: number; skipped?: number },
+      // Three cell kinds, and they are three different sentences: a NUMBER is what
+      // the target reported, `-` means the section has no refusal outcome in any
+      // build, and `?` means this section HAS one but the target's build cannot
+      // report it. Collapsing any pair loses a distinction an operator acts on.
+      refused: number | typeof NO_REFUSAL_OUTCOME | typeof REFUSAL_NOT_REPORTED,
+    ): void => {
+      console.log(
+        `  ${label.padEnd(17)} ${String(counts.imported ?? 0).padStart(8)}  ${String(counts.skipped ?? 0).padStart(7)}  ${String(refused).padStart(7)}`,
+      );
+    };
+
+    console.log(`${pc.green("✓")} Import complete!\n`);
     console.log(
-      "  Entity            Imported  Skipped",
+      "  Entity            Imported  Skipped  Refused",
     );
     console.log(
-      "  \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500  \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500  \u2500\u2500\u2500\u2500\u2500\u2500\u2500",
+      "  ────────────────  ────────  ───────  ───────",
     );
-    console.log(
-      `  Conversations     ${String(result.conversations.imported).padStart(8)}  ${String(result.conversations.skipped).padStart(7)}`,
-    );
-    console.log(
-      `  Semantic entities ${String(result.semanticEntities.imported).padStart(8)}  ${String(result.semanticEntities.skipped).padStart(7)}`,
-    );
-    console.log(
-      `  Learned patterns  ${String(result.learnedPatterns.imported).padStart(8)}  ${String(result.learnedPatterns.skipped).padStart(7)}`,
-    );
-    console.log(
-      `  Settings          ${String(result.settings.imported).padStart(8)}  ${String(result.settings.skipped).padStart(7)}`,
-    );
+    row("Conversations", result.conversations, NO_REFUSAL_OUTCOME);
+    row("Semantic entities", result.semanticEntities, NO_REFUSAL_OUTCOME);
+    row("Learned patterns", result.learnedPatterns, NO_REFUSAL_OUTCOME);
+    row("Settings", result.settings, NO_REFUSAL_OUTCOME);
     // v2 sections (#4460) — absent from an older server's response.
-    if (result.dashboards) {
-      console.log(
-        `  Dashboards        ${String(result.dashboards.imported).padStart(8)}  ${String(result.dashboards.skipped).padStart(7)}`,
-      );
-    }
-    if (result.knowledgeDocuments) {
-      console.log(
-        `  Knowledge docs    ${String(result.knowledgeDocuments.imported).padStart(8)}  ${String(result.knowledgeDocuments.skipped).padStart(7)}`,
-      );
-    }
-    if (result.scheduledTasks) {
-      console.log(
-        `  Scheduled tasks   ${String(result.scheduledTasks.imported).padStart(8)}  ${String(result.scheduledTasks.skipped).padStart(7)}`,
-      );
-    }
-    if (result.agentSessionMemory) {
-      console.log(
-        `  Session memory    ${String(result.agentSessionMemory.imported).padStart(8)}  ${String(result.agentSessionMemory.skipped).padStart(7)}`,
-      );
-    }
+    if (result.dashboards) row("Dashboards", result.dashboards, NO_REFUSAL_OUTCOME);
+    if (result.knowledgeDocuments) row("Knowledge docs", result.knowledgeDocuments, NO_REFUSAL_OUTCOME);
+    if (result.scheduledTasks) row("Scheduled tasks", result.scheduledTasks, NO_REFUSAL_OUTCOME);
+    if (result.agentSessionMemory) row("Session memory", result.agentSessionMemory, NO_REFUSAL_OUTCOME);
     // Company brain (#4767). Reported per-section so a migration that moved
     // ZERO brain rows can't print a summary identical to one that moved
     // everything — the operator-visible half of "silent loss is worse than
     // loud failure".
-    if (result.brainEpisodes) {
-      console.log(
-        `  Brain episodes    ${String(result.brainEpisodes.imported).padStart(8)}  ${String(result.brainEpisodes.skipped).padStart(7)}`,
+    if (result.brainEpisodes) row("Brain episodes", result.brainEpisodes, NO_REFUSAL_OUTCOME);
+    if (result.brainFacts) row("Brain facts", result.brainFacts, NO_REFUSAL_OUTCOME);
+    if (result.brainEdges) row("Brain edges", result.brainEdges, NO_REFUSAL_OUTCOME);
+    if (result.factAudienceMembers) row("Fact audiences", result.factAudienceMembers, NO_REFUSAL_OUTCOME);
+    // The curated identity vocabulary (#5036, #5112). Absent from this table
+    // ENTIRELY until #5112 — so the one counter in the whole response that reports
+    // a dropped human decision was the one counter the operator who pressed the
+    // button never saw.
+    const vocabulary = result.brainVocabularyEdges;
+    // `?` for a target that cannot report the counter at all — distinct from `0`
+    // ("refused nothing") and from `-` ("has no refusal outcome"). Three states,
+    // three cells; `?? 0` collapsed the first into the second.
+    if (vocabulary) {
+      row(
+        "Alias edges",
+        vocabulary,
+        typeof vocabulary.refused === "number" ? vocabulary.refused : REFUSAL_NOT_REPORTED,
       );
     }
-    if (result.brainFacts) {
-      console.log(
-        `  Brain facts       ${String(result.brainFacts.imported).padStart(8)}  ${String(result.brainFacts.skipped).padStart(7)}`,
-      );
-    }
-    if (result.brainEdges) {
-      console.log(
-        `  Brain edges       ${String(result.brainEdges.imported).padStart(8)}  ${String(result.brainEdges.skipped).padStart(7)}`,
-      );
-    }
-    if (result.factAudienceMembers) {
-      console.log(
-        `  Fact audiences    ${String(result.factAudienceMembers.imported).padStart(8)}  ${String(result.factAudienceMembers.skipped).padStart(7)}`,
-      );
-    }
+
+    // ⚠️ NOT A TABLE CELL. A number in a column is something to skim past. This is
+    // the only outcome in the response that says a human's approved review decision
+    // was discarded and the destination will never hold it, so it gets prose and the
+    // payloads. Extracted so its branches are testable — see `renderRefusalNotice`.
+    renderRefusalNotice(vocabulary);
   } catch (err) {
     const detail = err instanceof Error ? err.message : String(err);
     if (

--- a/packages/types/src/__tests__/migration.test.ts
+++ b/packages/types/src/__tests__/migration.test.ts
@@ -252,7 +252,7 @@ describe("migration types", () => {
       brainEdges: { imported: 5, skipped: 0 },
       factAudienceMembers: { imported: 3, skipped: 1 },
       // The one section with a THIRD counter (#5036).
-      brainVocabularyEdges: { imported: 2, skipped: 1, refused: 4 },
+      brainVocabularyEdges: { imported: 2, skipped: 1, refused: 4, refusalDetails: [] },
       brainSlackChannelExclusions: { imported: 3, skipped: 2, refused: 0 },
       brainEnrollments: { imported: 4, skipped: 1, namingDropped: 2, namingApplied: 5 },
       // Distinct numbers from every neighbour, so a mis-wired section cannot be
@@ -273,8 +273,12 @@ describe("migration types", () => {
     // someone edits it and this fires — but an OPTIONAL one changes nothing
     // here. `bun run type` is the real enforcement of the shape; this is the
     // runtime half, and it catches a rename or a removal.
+    // `refusalDetails` joins the set at #5112 — the only PAYLOAD in a type otherwise
+    // made of counters, and required for `refused`'s reason. Named, so a rename goes
+    // red here as well as at the Zod pin one package over.
     expect(Object.keys(result.brainVocabularyEdges).toSorted()).toEqual([
       "imported",
+      "refusalDetails",
       "refused",
       "skipped",
     ]);

--- a/packages/types/src/migration.ts
+++ b/packages/types/src/migration.ts
@@ -796,6 +796,63 @@ export interface ExportBundle {
 // Import result
 // ---------------------------------------------------------------------------
 
+/**
+ * One refused alias edge, carried back to the SOURCE region (#5112).
+ *
+ * ## Why this is on the wire at all
+ *
+ * The refused edge is a HUMAN's approved decision the destination is dropping,
+ * and #5036 made the target region's `log.warn` the entire recovery path. But
+ * the SOURCE region is the one that cuts over and schedules the cleanup which
+ * DELETEs its own `brain_vocabulary_edge` rows after the grace period — so the
+ * party owning the irreversible act held only a COUNT, while the record that
+ * would let anyone undo it lived in another region's log retention, outliving
+ * the data by only as long as that retention.
+ *
+ * These fields are exactly the target-side warn's payload, so one shape carries
+ * the recovery information whether it is read out of a log line or out of the
+ * source's `region_migrations.vocabulary_refusals` column.
+ *
+ * ⚠️ **FOREIGN INPUT on the source side.** This is another region's JSON and
+ * possibly another region's BUILD: a target predating #5112 omits the field
+ * entirely, and nothing about the transport guarantees the shape. `migrate.ts`
+ * screens every entry before it writes one into its own database.
+ *
+ * ⚠️ **BOUNDED, and the bound is deliberately NOT exported from this package.**
+ * The producer caps the array; `refused` is always the true total, so a
+ * `refusalDetails` shorter than `refused` is what says the list was truncated.
+ * The number itself lives with the producer
+ * (`VOCABULARY_REFUSAL_DETAIL_CAP` in `packages/api/src/lib/brain/vocabulary.ts`)
+ * because a value export here is a RUNTIME symbol, and `packages/api/src` is
+ * copied into the scaffold template — which installs the published version of
+ * this package and cannot see a symbol added in the same commit. That constant's
+ * docstring carries the full diagnosis. Consumers should read the comparison, not
+ * the constant, which we reserve the right to change.
+ */
+export interface VocabularyRefusalDetail {
+  /** The slot position the edge was approved at, verbatim from the source row. */
+  slotPosition: string;
+  fromNorm: string;
+  toNorm: string;
+  /** `null` is an auto-approved edge, not an unknown one. */
+  approvedBy: string | null;
+  /** The SOURCE region's approval timestamp, carried verbatim (never re-stamped). */
+  approvedAt: string;
+  /** Which of the four rules refused it — `already-aliased`, `would-cycle`, … */
+  refusal: string;
+  /**
+   * What the DESTINATION holds for `fromNorm` instead, or `null` for the arms
+   * that have no conflicting edge.
+   *
+   * `null` rather than absent, on the target-side warn's reasoning: a missing key
+   * and a key whose value is "there is no conflicting edge" read identically in
+   * a log aggregator or a JSONB query, and only one of them is true.
+   */
+  existingTarget: string | null;
+  /** The refusal's human-readable reason, as the destination phrased it. */
+  reason: string;
+}
+
 /** Summary returned by the import endpoint. */
 export interface ImportResult {
   conversations: { imported: number; skipped: number };
@@ -845,7 +902,38 @@ export interface ImportResult {
    * region's response model that with their own cross-version type, as
    * `migrate.ts` and `cli/migrate-import.ts` already do for whole sections.
    */
-  brainVocabularyEdges: { imported: number; skipped: number; refused: number };
+  brainVocabularyEdges: {
+    imported: number;
+    skipped: number;
+    refused: number;
+    /**
+     * The refused edges themselves, capped by the producer (#5112).
+     *
+     * The cap is NOT a `{@link}` to a symbol in this package, deliberately — see
+     * {@link VocabularyRefusalDetail}. Read the bound as the comparison
+     * `refusalDetails.length < refused`, which is what says the list was
+     * truncated, rather than as a number this package publishes.
+     *
+     * THE ONLY SECTION THAT RETURNS PAYLOADS RATHER THAN COUNTS, and the reason
+     * is the same asymmetry that earned `refused` its own counter one field up:
+     * every other outcome in this type is re-derivable. A skipped conversation
+     * is still in both regions; a refused alias edge is a human review decision
+     * the destination declined, and the only copy that survives a cutover is the
+     * SOURCE's — for as long as the grace period lasts.
+     *
+     * REQUIRED, on `refused`'s reasoning: this type describes what THIS region
+     * answers, and an optional field is one a producer can quietly stop
+     * populating without the `_SchemaMatchesWireType` pin in `admin-migrate.ts`
+     * noticing (it cannot see an optional NESTED member). A target predating
+     * #5112 omits it, and `migrate.ts` models a foreign region's response with
+     * its own cross-version type, exactly as it already does for `refused`.
+     *
+     * `[]` means NONE when `refused === 0`. When `refused > 0` it means the
+     * target answered without payloads — an older build — which is not the same
+     * as "nothing to recover", and the source's disclosure says so.
+     */
+    refusalDetails: VocabularyRefusalDetail[];
+  };
   brainSlackChannelExclusions: { imported: number; skipped: number; refused: number };
   /**
    * The warehouse producer's enrolled reach (#5196, ADR-0039).


### PR DESCRIPTION
Bundle 3 (#5297) — two api-side items that share a theme rather than a file: each takes something whose only record today is a log line or a stub, and makes it observable. **One commit per member**, in the order the bundle states, each holding its member's final state so either can be dropped without orphaning the other's fixes.

Closes #5273
Closes #5112
Closes #5297

---

## Review panel: ONE round, and the curve is why

`/review-panel` round 1 returned **28 findings, every one NEW SURFACE** — the three code reviewers between them found 11 HIGH and 17 MEDIUM/LOW, and **zero** were defects in a previous round's fix (there was no previous round). Under `/ship-issue`'s split that is a reason to continue, not to stop; the loop closed after one round because round 1's fixes were then audited by `fix-vs-finding` (two `REPRODUCED`, both fixed in the same round) and by `comment-analyzer` (eight more, fixed), and nothing outstanding remained.

`rounds: 1 (code reviewers 7m / 7m / 12m parallel; fix-vs-finding 3m / 3m; comment sweep 12m)` — agent-reported durations, not wall clock.

Two findings were **production defects the widened scope caught**, and both are worth reading before the rest:

**1. A third seed Layer had the very defect the new tests were pinning.** Reviewing #5273's harness by reading the enclosing *file* rather than the changed lines turned up `OpenApiDatasourceCatalogSeedLive` returning its boot wrapper's message **raw**, while the shape's own doc says "Scrubbed error message" and the `catchAll` arm below scrubs. That is the #5239 asymmetry — one field, two producers, two guarantees — for the **third** time. Fixed, covered like its siblings, and mechanised: a lexical guard now fails on that spelling, with a positive control on the matcher and a negative control of legitimate prose. The negative control earned its keep immediately — the first draft also matched `MigrationLive`, whose `error` is *deliberately* raw because it feeds a boot-failure line that exists to name the actual Drizzle/pg error (#1988).

**2. A raw pg message reached a workspace admin.** `recordVocabularyRefusals` interpolated the caught DB error into its thrown message, which becomes `region_migrations.error_message` and is returned verbatim by `admin-residency.ts`. The first fix scrubbed at the persistence site — and `fix-vs-finding` answered **REPRODUCED**, correctly: `errorMessage` rewrites `scheme://user:pass@host` and nothing else, so `connect ECONNREFUSED 10.0.3.7:5432`, a pg `DETAIL: Key (…)=(…)` fragment and internal column spellings all survive it. The scrub is a floor, not a filter, and my comment claimed it closed a hazard it does not. The throw site now carries no driver text at all: raw to `log.error` with the `migrationId` as the join key, generic on the customer-served field.

### Nine claims of mine were measured FALSE and corrected rather than shipped

Every one an experiment I ran instead of arguing:

| claim | measured |
|---|---|
| "a shared upstream Layer would answer every test with the first test's stub" | FALSE — sharing leaves the suite at 29/29; each `Effect.provide` builds its own MemoMap |
| three distinct fixture lengths defeat a permutation | the `toEqual` content comparison does; lengths are belt-and-braces |
| the new pg test pins the `::jsonb` cast | FALSE — deleting the cast leaves all 18 green (Postgres implicitly casts) |
| `expect(statements).toContain("COMMIT")` asserts POSITION | presence only; the `commitFailure` case is the position guard |
| coverage lives in `migrate-refusal-durability.test.ts` | that file does not exist |
| `v != null` "admits `undefined`" | it rejects `null` — true measurement, wrong reason |
| the guard "makes a fourth instance impossible" | it fails on one spelling; `error: r.message` still passes |
| the guard's runtime-assembled literal prevents a self-trip | it scans one *other* file and cannot read its own |
| the count "appears on the migration's status" (docs) | no API surface carries it — that is #5304 |

The panel also found three **structural** comment defects I introduced: a docstring severed from its declaration by the new constant, a function's docstring left sitting on the return-type interface, and a sentence whose colon opened a list a rewrite had deleted.

### Deferred, with reasons

New machinery, so a follow-up by default rather than entering a diff with no round left to review it:

- **#5303** — `VocabularyRefusalDetail` is spelled three times (type, inline Zod, hand-written screen). Move the schema to `@useatlas/schemas` and derive the screen from it via per-entry `safeParse`.
- **#5304** — the record exists and the human cannot reach it: the correlation token does not cross the region boundary, no API/web surface carries the count, `malformedDetails` never outlives the process that computed it, and `transferBundleToTarget`'s pre-existing `Network error … ${msg}` still interpolates the internal region host.
- **#5305** — `ImplementationStatusOverrideLive` has no Layer test and a richer outcome set than the three that now do; also whether the seed shapes should become unions discriminated on `outcome` (which would make #5273's headline mutation a compile error).

---

## 1. #5273 — the boot-seed Layers had no tests

`BuiltinDatasourceCatalogSeedLive` and `BuiltinKnowledgeCatalogSeedLive` were only ever supplied as `Layer.succeed(...)` stubs, so the `case "seeded"` arm — the only route by which `blockedSlugs` reaches the Tag at all — was unobserved.

New file: `builtin-catalog-seed-layers.test.ts`, **29 tests**. The pattern the issue said did not exist here yet is items 2 and 3 (item 1 is precedented by `layers.test.ts`'s `runOverride`):

1. `InternalDB` + `Migration` stubbed as Layers, built per call.
2. The dynamic `await import(...)` inside `Effect.tryPromise` intercepted with `mock.module`.
3. Each factory spreads a **snapshot of the real module** (`import * as` evaluates before the `mock.module` call, since import declarations are hoisted) and overrides one function through `() => boot()`, so a test can swap the implementation after the factory is cached. A hand-written export list would satisfy mock-all-exports today and drop the next `BUILTIN_*_CATALOG_ROW` someone adds — there are fifteen on the knowledge side.

Nine mutations measured, all RED, including the one the issue names (`case "seeded"`'s three fields → `...zeroCounts`: **27 pass / 2 FAIL**, green across the whole suite before this file existed) and both halves of the `||` gate, which is why each disjunct gets its own case.

## 2. #5112 — a refused alias edge, durable at the source

The refusal **payload** existed only in `mergeApprovedEdges`' `log.warn`, in the **target** region. The **source** schedules the cleanup that DELETEs its own `brain_vocabulary_edge` rows after 7 days, and read `refusals.length` while throwing the array away. Not "add a log line" — making a record outlive a grace period.

1. **`refusalDetails` on the wire** — the whole edge, flat, `existingTarget` always present. REQUIRED, because the `_SchemaMatchesWireType` pin cannot see an optional nested member (**measured**: a required item field → RED, a dropped `.nullable()` → RED, an *optional* item field on one side → GREEN, one level deeper than the pin's comment claimed). Bounded, with `refusalDetails.length < refused` as the truncation signal.
2. **Migration 0204** on `region_migrations`, which `bundle-scope.ts` classifies `platform` — that is what makes the record outlive the delete it describes. Two columns, because the count is not derivable from a capped array. NULL means UNKNOWN, never zero.
3. **Written before cutover**, so the record survives a migration that never completes.
4. **A failed write ABORTS when `refused > 0`**, before cutover, so nothing is deleted.
5. **Both audit events** carry the count, plus `MigrationResult` on the success arm only.
6. **The CLI prints it** — it printed no vocabulary counter at all, so the one counter reporting a dropped human decision was the one the operator never saw. Three cell kinds (`N` / `-` no refusal outcome / `?` target cannot report), and the itemised block is extracted as `renderRefusalNotice` with an injectable sink, because `packages/cli` had no test file and six of its branches were free mutations.
7. **A correlation token and a post-COMMIT confirmation**, turning #5036's future-tense "WILL DROP" into "DID DROP".

**The cap does not live in `@useatlas/types`,** and `Deploy Validation` is what taught me why: `prepare-templates.sh` copies `packages/api/src` into the scaffold template, which installs the *published* package (pinned `^0.7.0`, unable to reach the workspace's 0.10.x). A **type** import is erased and free; a **value** import resolves at runtime against a version predating the symbol. `Standalone Example Build` passed on the same commit because it compiles against the local build, which is exactly what hides it.

### The named falsifier, and the hole beside it

*A migration with a refusal leaves a record still readable AFTER the source cleanup has run.* A new `describeIfPg` block: real Postgres, real `runSourceCleanupSweep`, `brain_vocabulary_edge` **2 → 0** while `vocabulary_refusals` stays readable with `source_cleaned_at` stamped. RED when `region_migrations` is added to the delete set.

The panel found the gap next to it: **both halves of the writer's coverage were hand-written statements *about* the two columns** — the mock suite greps `capturedQueries` and never executes the SQL, the falsifier seeds the row with its own INSERT — so renaming the column left every test green while failing every migration carrying a refusal in production. `recordVocabularyRefusals` is now exported and driven against the migrated schema.

**27 mutations measured across both members. Every one RED but one:** `Array.isArray(entry)` in the screen kills nothing, because an array carries none of the required string fields and the destructured checks reject it anyway. Kept as belt-and-braces with the measurement written beside it — the full table is in each commit message.

---

## Notes for review

- **Migration-count tests updated in both places** `db/__tests__/migrate.test.ts` names (its count, and `auth/__tests__/migrate.test.ts`'s applied list). `check-schema-drift.sh` and `check-migration-rename-discipline.sh` pass; 0204 is expand-only.
- **OpenAPI regenerated**; the bound now appears as `maxItems: 50` in the published contract.
- **`packages/types` is published.** `ImportResult.brainVocabularyEdges` gains a required `refusalDetails` and `VocabularyRefusalDetail` is a new type export. Additive for readers of a response; version bumps belong to `/publish`.
- **Two arity pins added** — `mergeApprovedEdges` and `importBundle` both took the new required token, three test files shim it with a default, and *neither* function's requiredness was pinned. The comment sweep found the second while checking a claim about the first. Both measured RED when relaxed to optional.
- **`cleanup.test.ts` cannot assert on logs and now says so** — its static import is hoisted above every `mock.module`, and `cleanup.ts` calls `createLogger()` at module scope. #5112's cleanup-side log assertions live in the new `cleanup-refusal-audit.test.ts`, which imports dynamically for that reason.
- **A self-satisfying assertion, caught and fixed:** a lookup for `"WILL DROP"` matched the post-COMMIT confirmation, which *quotes* the phrase — so the join-key assertion compared the confirmation to itself and passed while the per-refusal line was absent entirely. Root cause was my own static import of the cap hoisting `vocabulary.ts` above the logger mock. Same trap, twice, in one PR.
- **Local `--affected` reported 13 red, of which 10 were parallel `-pg` contention** on one scratch Postgres; re-run serially, all 10 green. The three real ones were the two migration counts and an `ImportResult` key set.
