### PR TITLE
docs(www): de-link retired commands in two blog posts

### DIFF
--- a/apps/www/src/app/blog/out-of-the-runtime/page.tsx
+++ b/apps/www/src/app/blog/out-of-the-runtime/page.tsx
@@ -120,14 +120,9 @@ export default function OutOfTheRuntime() {
           Atlas began as a commit in February, co-authored with the agent from
           line one. I didn&apos;t arrive empty-handed. I brought over a handful
           of commands from the previous project I&apos;d just walked away from:{" "}
-          <a
-            href="https://github.com/AtlasDevHQ/atlas/blob/main/.claude/commands/next.md"
-            className="link-accent"
-          >
-            one to decide what to work on next
-          </a>
-          , one to research the codebase, one to check its health. Three small
-          text files. That was the whole system.
+          one to decide what to work on next*, one to research the codebase,
+          one to check its health. Three small text files. That was the whole
+          system.
         </P>
         <P>
           Everything between those commands was manual, and I was the part that
@@ -225,47 +220,29 @@ export default function OutOfTheRuntime() {
           :
         </P>
         <DefList>
-          <DefItem
-            term={
-              <a
-                href="https://github.com/AtlasDevHQ/atlas/blob/main/.claude/commands/ship-issue.md"
-                className="link-accent font-mono"
-              >
-                ship-issue
-              </a>
-            }
-          >
+          <DefItem term={<span className="font-mono">ship-issue*</span>}>
             One issue, nothing to merged. Picks the craft loop, runs the panel,
             passes CI, opens the PR, services every comment until it lands.
           </DefItem>
-          <DefItem
-            term={
-              <a
-                href="https://github.com/AtlasDevHQ/atlas/blob/main/.claude/commands/ship-batch.md"
-                className="link-accent font-mono"
-              >
-                ship-batch
-              </a>
-            }
-          >
+          <DefItem term={<span className="font-mono">ship-batch*</span>}>
             A handful at once. The top few ready issues, each dispatched to its
             own isolated worktree agent, then collected when they finish.
           </DefItem>
-          <DefItem
-            term={
-              <a
-                href="https://github.com/AtlasDevHQ/atlas/blob/main/.claude/commands/ship-milestone.md"
-                className="link-accent font-mono"
-              >
-                ship-milestone
-              </a>
-            }
-          >
+          <DefItem term={<span className="font-mono">ship-milestone*</span>}>
             The whole thing, on a heartbeat. It grinds an entire milestone to
             merged, waking itself each time a PR lands to dispatch the next
             unblocked issue. This is the one behind the good mornings.
           </DefItem>
         </DefList>
+        <P>
+          <em>
+            * Retired since this was written. These commands were deleted in
+            August 2026, along with most of the workflow layer around them —
+            what they describe is how the loop ran at the time, not how it runs
+            today. The replacement is much smaller, and deliberately so; a
+            future post will cover what changed and why.
+          </em>
+        </P>
         <P>
           The dispatcher I used to be is a command now. So is the reviewer, and
           the scheduler, and the person who used to sit refreshing a PR for six

--- a/apps/www/src/app/blog/the-price-of-ci/page.tsx
+++ b/apps/www/src/app/blog/the-price-of-ci/page.tsx
@@ -79,50 +79,30 @@ export default function ThePriceOfCi() {
           eating something like a tenth of my weekly token budget, and the
           reason took a minute to track down. <InlineCode>/ci</InlineCode>{" "}
           sits as a mandatory gate inside nearly every other command that
-          ships code here —{" "}
-          <a
-            href="https://github.com/AtlasDevHQ/atlas/blob/main/.claude/commands/pr.md"
-            className="link-accent font-mono"
-          >
-            /pr
-          </a>
-          ,{" "}
+          ships code here — <InlineCode>/pr</InlineCode>*,{" "}
           <a
             href="https://github.com/AtlasDevHQ/atlas/blob/main/.claude/commands/release.md"
             className="link-accent font-mono"
           >
             /release
           </a>
-          ,{" "}
-          <a
-            href="https://github.com/AtlasDevHQ/atlas/blob/main/.claude/commands/next.md"
-            className="link-accent font-mono"
-          >
-            /next
-          </a>
-          , and{" "}
-          <a
-            href="https://github.com/AtlasDevHQ/atlas/blob/main/.claude/commands/ship-issue.md"
-            className="link-accent font-mono"
-          >
-            /ship-issue
-          </a>
-          . Which means{" "}
-          <a
-            href="https://github.com/AtlasDevHQ/atlas/blob/main/.claude/commands/ship-batch.md"
-            className="link-accent font-mono"
-          >
-            /ship-batch
-          </a>{" "}
-          and{" "}
-          <a
-            href="https://github.com/AtlasDevHQ/atlas/blob/main/.claude/commands/ship-milestone.md"
-            className="link-accent font-mono"
-          >
-            /ship-milestone
-          </a>{" "}
-          run it once per issue, all night, unattended, while I sleep.
+          , <InlineCode>/next</InlineCode>*, and{" "}
+          <InlineCode>/ship-issue</InlineCode>*. Which means{" "}
+          <InlineCode>/ship-batch</InlineCode>* and{" "}
+          <InlineCode>/ship-milestone</InlineCode>* run it once per issue, all
+          night, unattended, while I sleep.
         </Lead>
+        <P>
+          <em>
+            * Retired since this was written. The workflow layer these commands
+            belonged to was deleted in August 2026 and replaced by something a
+            great deal smaller — the shipping process described here is the one
+            that ran at the time. <InlineCode>/ci</InlineCode> and{" "}
+            <InlineCode>/release</InlineCode> are still here and still do what
+            this post says they do. A future post will cover what replaced the
+            rest, and why.
+          </em>
+        </P>
         <P>
           Each of those invocations ran 16 separate gates: lint, the type
           checker, the full test suite, a dozen drift and security scripts.
@@ -309,7 +289,7 @@ RESULT: FAIL — 1 of 27 gates failed: test
         <H2>Where it stops</H2>
         <P>
           By the end of the same day, the same move went into{" "}
-          <InlineCode>/ship-issue</InlineCode>&apos;s external-review step —
+          <InlineCode>/ship-issue</InlineCode>*&apos;s external-review step —
           the part that used to sweep three GitHub endpoints by hand and poll
           them every 30 to 60 seconds, up to ten minutes, three rounds deep. A
           second wrapper,{" "}


### PR DESCRIPTION
Nine links across `the-price-of-ci` and `out-of-the-runtime` pointed at `.claude/commands/{pr,next,ship-issue,ship-batch,ship-milestone}.md` on `main`. #5298 deleted those files, so every one **404s from a public, indexed page**.

## What changed

De-linked to plain mono text rather than repointed at a git SHA. A permalink to a deleted file preserves the *artifact* but not the *claim* — these posts describe a shipping process that no longer runs, so pointing a reader at a frozen copy would be answering a question they didn't ask.

Each retired name now carries a `*`, with one short italic note per post: the workflow layer was replaced in August 2026, the post describes the loop **as it ran at the time**, and a future post will cover what replaced it.

## What deliberately did not change

- **`/ci` and `/release` survive the burn**, so their links are intact and their prose is still accurate. 21 `/ci` references across the blog needed no change — the post's whole argument about `/ci` still holds.
- `scripts/pr-review-status.sh` and the `.claude/commands` **directory** link both still resolve.
- The **"30 custom commands"** stat in `out-of-the-runtime`. It was true on 2026-06-26, the post is dated, and the note covers the drift. Editing a historical stat in a dated post rewrites the record rather than annotating it.

## Verification

- Repo-wide scan for `.claude/commands/*.md` references (excluding `.git`/`node_modules`) returns **only `ci.md` and `release.md`**, both of which exist
- `bun run type` clean in `apps/www`
- `bun run lint` — zero errors touching these files

⚠️ `apps/www` deploys **direct-from-main to prod**, so merging this publishes it.