### PR TITLE
Two Layer/type-safety issues, and the two that were already done (#5305, #5303)

### DIFF
--- a/packages/api/src/api/routes/admin-migrate.ts
+++ b/packages/api/src/api/routes/admin-migrate.ts
@@ -8,6 +8,16 @@
  */
 
 import { createRoute, z } from "@hono/zod-openapi";
+// The one spelling of the refusal item's eight fields (#5303), shared with the
+// runtime screen in `lib/residency/migrate.ts`.
+//
+// ⚠️ A VALUE import, and NOT the hazard `VOCABULARY_REFUSAL_DETAIL_CAP` below is
+// about. That one is about resolution against a PUBLISHED package — this file is
+// copied into the `create-atlas` scaffold, which installs `@useatlas/types` from
+// npm. `@useatlas/schemas` never publishes; `prepare-templates.sh` (step 5e)
+// copies its SOURCE into every template behind a `tsconfig` path alias, so the
+// scaffold gets this file and this schema from the same commit.
+import { VocabularyRefusalDetailSchema } from "@useatlas/schemas";
 import { createLogger } from "@atlas/api/lib/logger";
 import { EPISODE_SOURCES, isEpisodeSource } from "@atlas/api/lib/brain/sources";
 import { getInternalDB, type InternalPoolClient } from "@atlas/api/lib/db/internal";
@@ -1019,20 +1029,17 @@ const ImportResultSchema = z.object({
     // member — extends to the array ITEM's fields too, which is a second level of
     // nesting it does not mention. `.nullable()` keeps a field present-and-null and
     // is therefore pinned; `.optional()` on either spelling is pinned by nothing.
-    // That is the whole reason all eight are required here.
+    // That is the whole reason all eight are required.
+    //
+    // ⚠️ REFERENCED, NOT RESTATED, since #5303. The eight fields used to be spelled
+    // out here, which made this the SECOND of three copies — and the third
+    // (`screenRefusalDetails` in `lib/residency/migrate.ts`, which decides what this
+    // region actually persists) was coupled to neither by anything but hand. They
+    // are now one `satisfies z.ZodType<VocabularyRefusalDetail>` definition in
+    // `@useatlas/schemas`, which is stronger than the measured pin above precisely
+    // where the pin is blind: it cannot be defeated by an optional member.
     refusalDetails: z
-      .array(
-        z.object({
-          slotPosition: z.string(),
-          fromNorm: z.string(),
-          toNorm: z.string(),
-          approvedBy: z.string().nullable(),
-          approvedAt: z.string(),
-          refusal: z.string(),
-          existingTarget: z.string().nullable(),
-          reason: z.string(),
-        }),
-      )
+      .array(VocabularyRefusalDetailSchema)
       // ⚠️ DOCUMENTATION, NOT ENFORCEMENT, and worth having for exactly that. Nothing
       // validates a RESPONSE against this schema at runtime, so the two `.slice()`
       // calls (here and in `residency/migrate.ts`) remain the enforcement. What

--- a/packages/api/src/api/routes/admin-migrate.ts
+++ b/packages/api/src/api/routes/admin-migrate.ts
@@ -1035,9 +1035,13 @@ const ImportResultSchema = z.object({
     // out here, which made this the SECOND of three copies — and the third
     // (`screenRefusalDetails` in `lib/residency/migrate.ts`, which decides what this
     // region actually persists) was coupled to neither by anything but hand. They
-    // are now one `satisfies z.ZodType<VocabularyRefusalDetail>` definition in
-    // `@useatlas/schemas`, which is stronger than the measured pin above precisely
-    // where the pin is blind: it cannot be defeated by an optional member.
+    // are now one definition in `@useatlas/schemas`.
+    //
+    // ⚠️ What closes the optional-member hole measured above is that definition's
+    // KEY-SET pin, not its `satisfies` — re-measured at review, an optional ninth
+    // field defeats the `satisfies` exactly as it defeats the pin below. Two
+    // different pins, two different reaches; the numbers are recorded beside the
+    // schema so this comment does not have to be trusted.
     refusalDetails: z
       .array(VocabularyRefusalDetailSchema)
       // ⚠️ DOCUMENTATION, NOT ENFORCEMENT, and worth having for exactly that. Nothing

--- a/packages/api/src/lib/effect/__tests__/builtin-catalog-seed-layers.test.ts
+++ b/packages/api/src/lib/effect/__tests__/builtin-catalog-seed-layers.test.ts
@@ -168,9 +168,12 @@ interface UpstreamGate {
 // `InternalDB` + `Migration` are rebuilt per call rather than shared. The reason
 // is legibility, NOT necessity — and the first version of this comment claimed
 // necessity, which is measurably false: hoisting the composed seed layer to module
-// scope and sharing it across every call leaves the suite at 29/29, because each
+// scope and sharing it across every call leaves the suite fully green, because each
 // `Effect.provide`/`runPromise` builds its own MemoMap and the `Layer.effect`
-// therefore re-runs anyway.
+// therefore re-runs anyway. (Measured at 29/29 when #5273 wrote this; the suite is
+// 41 tests since #5305 added the override driver. The pass COUNT is incidental to
+// the experiment, so it is no longer quoted here — a number that has to be revised
+// every time a test is added is a number that will eventually be wrong.)
 //
 // Per-call construction is kept because it makes each case's independence a
 // property of the code rather than of Effect's memo scoping — a reader should not

--- a/packages/api/src/lib/effect/__tests__/builtin-catalog-seed-layers.test.ts
+++ b/packages/api/src/lib/effect/__tests__/builtin-catalog-seed-layers.test.ts
@@ -1,11 +1,23 @@
 /**
- * The Live boot-seed Layers of `effect/layers.ts` (#5273).
+ * The Live boot Layers of `effect/layers.ts` that resolve their work through a
+ * dynamic import (#5273, #5305).
  *
  * `BuiltinDatasourceCatalogSeedLive`, `BuiltinKnowledgeCatalogSeedLive` — the two
  * #5273 names — plus `OpenApiDatasourceCatalogSeedLive`, which this PR's review
  * panel added after finding it had the very defect the other two were being pinned
  * against (see that describe block), and a lexical guard that makes a fourth
  * instance a test failure rather than a reviewer's lucky read.
+ *
+ * ⚠️ AND `ImplementationStatusOverrideLive` (#5305), which is why the file's own
+ * name now undersells it: that Layer is not a *seed*. It is here anyway because it
+ * is the same MECHANISM — an upstream `InternalDB` + `Migration` gate, a dynamic
+ * `await import(...)` inside `Effect.tryPromise`, a `catchAll` that scrubs — and
+ * the whole point of the harness below is that the mechanism is what is hard to
+ * test, not the individual Layer. It also has the richest outcome set of the four:
+ * its boot wrapper's `skipped` kind carries THREE `reason` values that fan out to
+ * THREE different outcomes, including `skipped-empty`, which none of the seed
+ * Layers has. `layers.test.ts:1490` used to punt those arms to "the wrapper's own
+ * tests"; they are driven here now, and that note says so.
  *
  * The first harness in the repo to drive a boot-seed Layer's DYNAMIC IMPORT — which
  * is items (2) and (3) below, not (1). `layers.test.ts` already builds Live boot
@@ -55,9 +67,11 @@ import { Effect, Layer } from "effect";
 import * as realDatasourceSeedModule from "@atlas/api/lib/db/seed-builtin-datasource-catalog";
 import * as realKnowledgeSeedModule from "@atlas/api/lib/db/seed-builtin-knowledge-catalog";
 import * as realOpenApiSeedModule from "@atlas/api/lib/openapi/catalog-seed";
+import * as realOverrideModule from "@atlas/api/lib/integrations/implementation-status-override";
 import type { BuiltinDatasourceCatalogSeedBootResult } from "@atlas/api/lib/db/seed-builtin-datasource-catalog";
 import type { BuiltinKnowledgeCatalogSeedBootResult } from "@atlas/api/lib/db/seed-builtin-knowledge-catalog";
 import type { OpenApiDatasourceCatalogSeedBootResult } from "@atlas/api/lib/openapi/catalog-seed";
+import type { ImplementationStatusOverrideBootResult } from "@atlas/api/lib/integrations/implementation-status-override";
 import { createInternalDBTestLayer } from "@atlas/api/lib/db/internal";
 import {
   BuiltinDatasourceCatalogSeed,
@@ -66,10 +80,14 @@ import {
   BuiltinKnowledgeCatalogSeedLive,
   OpenApiDatasourceCatalogSeed,
   OpenApiDatasourceCatalogSeedLive,
+  CatalogSeed,
+  ImplementationStatusOverride,
+  ImplementationStatusOverrideLive,
   Migration,
   type BuiltinDatasourceCatalogSeedShape,
   type BuiltinKnowledgeCatalogSeedShape,
   type OpenApiDatasourceCatalogSeedShape,
+  type ImplementationStatusOverrideShape,
 } from "../layers";
 
 // ── The dynamic-import interception ─────────────────────────────────
@@ -78,6 +96,7 @@ import {
 const realDatasourceExports = { ...realDatasourceSeedModule };
 const realKnowledgeExports = { ...realKnowledgeSeedModule };
 const realOpenApiExports = { ...realOpenApiSeedModule };
+const realOverrideExports = { ...realOverrideModule };
 
 const NOT_CONFIGURED =
   "boot stub not configured by this test — the Layer reached the dynamic import unexpectedly";
@@ -88,10 +107,13 @@ let knowledgeBoot: () => Promise<BuiltinKnowledgeCatalogSeedBootResult> = () =>
   Promise.reject(new Error(NOT_CONFIGURED));
 let openApiBoot: () => Promise<OpenApiDatasourceCatalogSeedBootResult> = () =>
   Promise.reject(new Error(NOT_CONFIGURED));
+let overrideBoot: () => Promise<ImplementationStatusOverrideBootResult> = () =>
+  Promise.reject(new Error(NOT_CONFIGURED));
 
 const datasourceBootCalls = mock(() => {});
 const knowledgeBootCalls = mock(() => {});
 const openApiBootCalls = mock(() => {});
+const overrideBootCalls = mock(() => {});
 
 void mock.module("@atlas/api/lib/db/seed-builtin-datasource-catalog", () => ({
   ...realDatasourceExports,
@@ -117,13 +139,23 @@ void mock.module("@atlas/api/lib/openapi/catalog-seed", () => ({
   },
 }));
 
+void mock.module("@atlas/api/lib/integrations/implementation-status-override", () => ({
+  ...realOverrideExports,
+  runImplementationStatusOverrideBoot: () => {
+    overrideBootCalls();
+    return overrideBoot();
+  },
+}));
+
 afterEach(() => {
   datasourceBootCalls.mockClear();
   knowledgeBootCalls.mockClear();
   openApiBootCalls.mockClear();
+  overrideBootCalls.mockClear();
   datasourceBoot = () => Promise.reject(new Error(NOT_CONFIGURED));
   knowledgeBoot = () => Promise.reject(new Error(NOT_CONFIGURED));
   openApiBoot = () => Promise.reject(new Error(NOT_CONFIGURED));
+  overrideBoot = () => Promise.reject(new Error(NOT_CONFIGURED));
 });
 
 // ── Layer drivers ───────────────────────────────────────────────────
@@ -200,6 +232,57 @@ function runOpenApiSeed(
             Layer.merge(
               createInternalDBTestLayer({ available: gate.available ?? true }),
               Layer.succeed(Migration, { migrated: gate.migrated ?? true }),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+/**
+ * `ImplementationStatusOverrideLive` needs two Tags the three seed Layers do not:
+ * `CatalogSeed` and `BuiltinDatasourceCatalogSeed`. Both are supplied as
+ * `Layer.succeed` stubs, exactly as `layers.test.ts` does — the Live impl yields
+ * them for ORDERING (the override must be the final word on
+ * `implementation_status`, after the catalog seeder's re-asserting `EXCLUDED`
+ * upsert) and never reads their values.
+ *
+ * ⚠️ `BuiltinDatasourceCatalogSeedLive` is deliberately NOT used here even though
+ * this file builds it three describes up. Providing the Live seed Layer would put
+ * the override's arms behind the seed's dynamic import — a failure in one would
+ * surface as a failure in the other, and `datasourceBoot` would have to be
+ * configured in every override test for reasons that have nothing to do with the
+ * override.
+ */
+const overrideSeedStubs = Layer.merge(
+  Layer.succeed(CatalogSeed, {
+    insertedCount: 0,
+    updatedCount: 0,
+    preservedCount: 0,
+    orphanSlugs: [],
+    outcome: "seeded" as const,
+  }),
+  Layer.succeed(BuiltinDatasourceCatalogSeed, {
+    insertedSlugs: [],
+    preservedSlugs: [],
+    blockedSlugs: [],
+    outcome: "seeded" as const,
+  }),
+);
+
+function runOverride(gate: UpstreamGate = {}): Promise<ImplementationStatusOverrideShape> {
+  return Effect.runPromise(
+    Effect.gen(function* () {
+      return yield* ImplementationStatusOverride;
+    }).pipe(
+      Effect.provide(
+        ImplementationStatusOverrideLive.pipe(
+          Layer.provide(
+            Layer.mergeAll(
+              createInternalDBTestLayer({ available: gate.available ?? true }),
+              Layer.succeed(Migration, { migrated: gate.migrated ?? true }),
+              overrideSeedStubs,
             ),
           ),
         ),
@@ -576,6 +659,196 @@ describe("OpenApiDatasourceCatalogSeedLive", () => {
     expect(shape.outcome).toBe("error");
     expect(shape.error).toBe(CREDENTIAL_SCRUBBED);
     expect(shape.error).not.toContain("hunter2");
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════════
+// ImplementationStatusOverrideLive — not a seed, and the richest outcome
+// set of the four (#5305)
+// ══════════════════════════════════════════════════════════════════════
+
+describe("ImplementationStatusOverrideLive", () => {
+  // `layers.test.ts` covers the two upstream-gate arms and then says, in as many
+  // words, that the gates-PASS arms are "covered by the wrapper's own tests". They
+  // are not: the wrapper's tests pin what the WRAPPER returns, and every arm below
+  // is the Layer's own translation of that return into a Tag value. The two are
+  // different functions, and the mapping between them is where a `reason` can be
+  // silently re-pointed at the wrong `outcome`.
+  //
+  // The gate arms are re-driven here rather than left to `layers.test.ts` for one
+  // reason the seed describes share: `not.toHaveBeenCalled()` on the boot stub is
+  // the only thing that distinguishes "skipped before the import" from "skipped
+  // after it", and both land on the same `outcome`. `layers.test.ts` has no stub
+  // to assert against, so it cannot make that distinction at all.
+
+  test("skips on `!db.available` alone, without reaching the import", async () => {
+    const shape = await runOverride({ available: false, migrated: true });
+    expect(shape.outcome).toBe("skipped-gate");
+    expect(shape.updatedCount).toBe(0);
+    expect(shape.unmatchedSlugs).toEqual([]);
+    expect(shape.error).toBeUndefined();
+    expect(overrideBootCalls).not.toHaveBeenCalled();
+  });
+
+  test("skips on `!migration.migrated` alone, without reaching the import", async () => {
+    const shape = await runOverride({ available: true, migrated: false });
+    expect(shape.outcome).toBe("skipped-gate");
+    expect(shape.updatedCount).toBe(0);
+    expect(overrideBootCalls).not.toHaveBeenCalled();
+  });
+
+  test("skips when both upstream halves are unsatisfied", async () => {
+    const shape = await runOverride({ available: false, migrated: false });
+    expect(shape.outcome).toBe("skipped-gate");
+    expect(overrideBootCalls).not.toHaveBeenCalled();
+  });
+
+  // ── the three `reason` values, which fan out to THREE outcomes ─────
+  //
+  // ⚠️ THE ARM THIS ISSUE EXISTS FOR. One wrapper `kind` — `"skipped"` — maps to
+  // three different `outcome`s depending on `reason`, and the mapping is neither
+  // identity nor uniform: two reasons are skips and the middle one is an ERROR.
+  // Nothing outside this Layer performs that mapping, so nothing outside this
+  // describe can observe it being wrong. A `switch` whose three arms were
+  // permuted would leave every other test in the repo green.
+
+  test("⭐ `no-internal-db` lands on `skipped-gate` — but DID run", async () => {
+    // Unreachable in production (the `!db.available` gate above catches it first)
+    // and mapped anyway, so that a future refactor decoupling the gate from the
+    // wrapper degrades to the honest outcome instead of mislabelling.
+    overrideBoot = () => Promise.resolve({ kind: "skipped", reason: "no-internal-db" });
+    const shape = await runOverride();
+    expect(shape.outcome).toBe("skipped-gate");
+    expect(shape.updatedCount).toBe(0);
+    expect(shape.error).toBeUndefined();
+    // The call count is the ONLY thing separating this from the gate cases above.
+    expect(overrideBootCalls).toHaveBeenCalledTimes(1);
+  });
+
+  test("⭐ `no-config` lands on `error` — a SKIP the Layer promotes", async () => {
+    // The asymmetric arm. The Config Tag should have loaded long before the
+    // post-seed boot phase, so a `no-config` here is a real fault rather than a
+    // configuration choice — and reporting it as a skip would hide it from the
+    // health surface `outcome` exists to feed.
+    overrideBoot = () => Promise.resolve({ kind: "skipped", reason: "no-config" });
+    const shape = await runOverride();
+    expect(shape.outcome).toBe("error");
+    // The exact sentence, not just "some error": this is the one producing arm
+    // whose message is a LITERAL rather than a scrubbed wrapper string, so
+    // asserting only `toBeDefined()` would pass on a message copied from the arm
+    // next door.
+    expect(shape.error).toBe(
+      "Implementation-status override: no resolved config at post-seed boot phase",
+    );
+    expect(shape.updatedCount).toBe(0);
+    expect(shape.unmatchedSlugs).toEqual([]);
+  });
+
+  test("⭐ `empty-override` lands on `skipped-empty` — the third skip kind", async () => {
+    // The SaaS norm (`deploy/api/atlas.config.ts` declares every row's status
+    // directly and leaves the override empty) and the explicit "operator declared
+    // nothing" path on self-host. No seed Layer has an outcome like it, which is
+    // why the harness's other three describes cannot have covered it by accident.
+    //
+    // ⚠️ Asserted as its own value and NOT as "not skipped-gate": collapsing
+    // `skipped-empty` into `skipped-gate` is the plausible mutation here, and it
+    // would tell an operator the upstream DB gate was unsatisfied when in fact
+    // their config was read successfully and was empty.
+    overrideBoot = () => Promise.resolve({ kind: "skipped", reason: "empty-override" });
+    const shape = await runOverride();
+    expect(shape.outcome).toBe("skipped-empty");
+    expect(shape.updatedCount).toBe(0);
+    expect(shape.unmatchedSlugs).toEqual([]);
+    expect(shape.error).toBeUndefined();
+    expect(overrideBootCalls).toHaveBeenCalledTimes(1);
+  });
+
+  // ── the `applied` arm ─────────────────────────────────────────────
+
+  test("⭐ forwards `updatedCount` and `unmatchedSlugs` at distinct, non-zero sizes", async () => {
+    // The override's sibling of #5273's headline mutation: fill the `case
+    // "applied"` arm with `...zeroCounts` and the Layer reports a successful
+    // override that changed nothing. `updatedCount: 3` against a 2-element
+    // `unmatchedSlugs` means neither field can be sourced from the other, and
+    // both are non-empty so the zeroCounts spread cannot satisfy either.
+    //
+    // `noopSlugs` is on the wrapper result and deliberately NOT on the shape —
+    // it is supplied here so the fixture is a real `kind: "applied"` value rather
+    // than a partial one, and its absence downstream is the Layer's choice.
+    overrideBoot = () =>
+      Promise.resolve({
+        kind: "applied",
+        updatedCount: 3,
+        unmatchedSlugs: ["discord", "intercom"],
+        noopSlugs: ["slack"],
+      });
+
+    const shape = await runOverride();
+
+    expect(shape.outcome).toBe("applied");
+    expect(shape.updatedCount).toBe(3);
+    expect(shape.unmatchedSlugs).toEqual(["discord", "intercom"]);
+    expect(shape.error).toBeUndefined();
+  });
+
+  test("`applied` with nothing unmatched is still `applied`", async () => {
+    // The clean path, kept because the case above is satisfied by a Layer that
+    // hardcoded a non-empty list just as surely as the reverse.
+    overrideBoot = () =>
+      Promise.resolve({ kind: "applied", updatedCount: 1, unmatchedSlugs: [], noopSlugs: [] });
+
+    const shape = await runOverride();
+
+    expect(shape.outcome).toBe("applied");
+    expect(shape.updatedCount).toBe(1);
+    expect(shape.unmatchedSlugs).toEqual([]);
+  });
+
+  // ── the `error` arm and the `catchAll` ────────────────────────────
+
+  test("⭐ SCRUBS the boot wrapper's error message", async () => {
+    // Same pin as its three siblings, for the same reason: `error` is DOCUMENTED
+    // as scrubbed on the shape, and this Layer has FOUR producers of that one
+    // field (`no-config`, `error`, `catchAll`, and the literal above). #5239 is
+    // what one field with two guarantees costs.
+    overrideBoot = () => Promise.resolve({ kind: "error", message: CREDENTIAL_LEAK_MESSAGE });
+
+    const shape = await runOverride();
+
+    expect(shape.outcome).toBe("error");
+    expect(shape.error).toBe(CREDENTIAL_SCRUBBED);
+    expect(shape.error).not.toContain("hunter2");
+    // `0` / `[]` here mean UNKNOWN, not "none" — a throw mid-pass abandons
+    // whatever the override had already applied. Pinned so the meaning does not
+    // drift into a claim that nothing changed.
+    expect(shape.updatedCount).toBe(0);
+    expect(shape.unmatchedSlugs).toEqual([]);
+  });
+
+  test("⭐ catchAll SCRUBS a rejection from the dynamic-import seam", async () => {
+    overrideBoot = () => Promise.reject(new Error(CREDENTIAL_LEAK_MESSAGE));
+
+    const shape = await runOverride();
+
+    expect(shape.outcome).toBe("error");
+    expect(shape.error).toBe(CREDENTIAL_SCRUBBED);
+    expect(shape.error).not.toContain("hunter2");
+    expect(shape.updatedCount).toBe(0);
+  });
+
+  test("catchAll normalizes a non-Error rejection", async () => {
+    overrideBoot = () => Promise.reject("import map resolution failed");
+    const shape = await runOverride();
+    expect(shape.outcome).toBe("error");
+    expect(shape.error).toBe("import map resolution failed");
+  });
+
+  test("never fails the Layer — every arm succeeds", async () => {
+    // The Layer's error channel is `never`, and the stakes are higher here than
+    // on the seeds: this Layer runs LAST in the catalog chain, so an escaping
+    // error takes the boot down after the seeds have already written.
+    overrideBoot = () => Promise.reject(new Error("total failure"));
+    await expect(runOverride()).resolves.toMatchObject({ outcome: "error" });
   });
 });
 

--- a/packages/api/src/lib/effect/__tests__/layers.test.ts
+++ b/packages/api/src/lib/effect/__tests__/layers.test.ts
@@ -1487,10 +1487,17 @@ describe("ImplementationStatusOverrideLive", () => {
     expect(result.updatedCount).toBe(0);
   });
 
-  // Note: gates-pass paths (`skipped-empty` / `applied` / `error`) are
-  // covered by `runImplementationStatusOverrideBoot (discriminated
-  // outcomes)` in `lib/integrations/__tests__/implementation-status-override.test.ts`.
-  // The wrapper covers the boot-time side of the contract; this Layer
-  // test covers only the upstream-gate branch that can't be reached
-  // from the wrapper alone.
+  // Note: the gates-PASS paths (`skipped-empty` / `applied` / `error`, and
+  // all three `reason` values behind the wrapper's single `skipped` kind)
+  // are driven against the LIVE Layer in
+  // `lib/effect/__tests__/builtin-catalog-seed-layers.test.ts` (#5305).
+  //
+  // ⚠️ This note used to punt them to `runImplementationStatusOverrideBoot
+  // (discriminated outcomes)` in
+  // `lib/integrations/__tests__/implementation-status-override.test.ts`, which
+  // was not the same claim: those tests pin what the WRAPPER returns, and every
+  // gates-pass arm is the Layer's own TRANSLATION of that return into a Tag
+  // value. `no-config` → `outcome: "error"` is the clearest case — the wrapper
+  // calls it a skip and the Layer promotes it, so no wrapper test can see the
+  // promotion. Nothing built the Live Layer past its gate until #5305.
 });

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -890,6 +890,12 @@ export type BuiltinDatasourceCatalogSeedOutcome =
   | "seeded"
   | "error";
 
+/**
+ * ⚠️ Flat record, deliberately, not a union discriminated on `outcome` — so
+ * `{ outcome: "error", insertedSlugs: ["x"] }` is type-legal here. The decision
+ * and the measurement behind it live once, beside
+ * {@link ImplementationStatusOverrideShape} (#5305).
+ */
 export interface BuiltinDatasourceCatalogSeedShape {
   /** Slugs whose row was newly inserted this boot. */
   readonly insertedSlugs: ReadonlyArray<string>;
@@ -1287,13 +1293,60 @@ export type ImplementationStatusOverrideOutcome =
   | "applied"
   | "error";
 
+/**
+ * ⚠️ A FLAT RECORD, NOT A UNION DISCRIMINATED ON `outcome` — decided at #5305
+ * rather than drifted into, and recorded here because the decision is invisible
+ * from the type itself. Applies equally to the three seed shapes above, whose
+ * docstrings call them "discriminated outcome" and which are the same shape.
+ *
+ * The proposal was that making these unions would turn #5273's headline mutation
+ * — the `case "seeded"` / `case "applied"` arm filled with `...zeroCounts`
+ * instead of the forwarded fields — into a compile error, demoting the Layer
+ * tests from the only guard on the payload to a backstop.
+ *
+ * ⚠️ MEASURED, AND THAT PREMISE IS FALSE. Under a union whose `applied` variant
+ * declares `updatedCount: number` and `unmatchedSlugs: ReadonlyArray<string>`,
+ * `{ ...zeroCounts, outcome: "applied" }` still type-checks: `zeroCounts` carries
+ * BOTH fields at exactly those types, and `0` / `[]` are ordinary inhabitants of
+ * them. The mutation is a wrong VALUE, not a wrong shape, and no arrangement of
+ * variants makes a type system reject it. Pinning it needs a test, which is what
+ * `builtin-catalog-seed-layers.test.ts` now is (M3/M6 there, both measured red).
+ *
+ * What the union WOULD buy, measured in the same experiment, is narrower and
+ * real: `{ ...zeroCounts, outcome: "error" }` — an error outcome carrying no
+ * message at all — is a compile error under a union (`error` required on that
+ * variant) and legal today, because `error?: string` is optional on every arm.
+ *
+ * Not taken, on two grounds:
+ *
+ *   - the gain is bounded and already covered. Every producing arm of `error` is
+ *     now asserted to carry a SCRUBBED message, so an arm that produced none
+ *     fails those tests for the same reason it would fail the compiler;
+ *   - the cost lands on the readers rather than the producers. Nothing in
+ *     production reads these Tag payloads yet — they exist for a future `/health`
+ *     consumer — and that consumer's whole job is to report `updatedCount` and
+ *     the slug lists UNIFORMLY across outcomes. A union makes every such read a
+ *     narrow first, for fields whose value on the non-applied arms ("0 / [], and
+ *     on `error` that means UNKNOWN rather than none") is exactly what it wants
+ *     to print.
+ *
+ * Revisit if a real consumer appears that branches on `outcome` anyway — at that
+ * point the narrowing is being written regardless and the union is free.
+ */
 export interface ImplementationStatusOverrideShape {
   /** UPDATEs issued this boot. */
   readonly updatedCount: number;
   /** Slugs in the override that didn't match a catalog row. */
   readonly unmatchedSlugs: ReadonlyArray<string>;
   readonly outcome: ImplementationStatusOverrideOutcome;
-  /** Scrubbed error message when `outcome === "error"`. */
+  /**
+   * Scrubbed error message when `outcome === "error"`.
+   *
+   * FOUR producers on this Layer — the `no-config` literal, the wrapper's
+   * `error` kind, the `catchAll`, and nothing on the two skip arms. #5239 is
+   * what one field with two different guarantees costs, so every producing arm
+   * is pinned scrubbed in `builtin-catalog-seed-layers.test.ts`.
+   */
   readonly error?: string;
 }
 

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -1412,7 +1412,11 @@ export const ImplementationStatusOverrideLive: Layer.Layer<
         const result = await runImplementationStatusOverrideBoot();
         switch (result.kind) {
           case "skipped":
-            // Three skip reasons, two outcomes:
+            // Three skip reasons, THREE outcomes — and this line read "two
+            // outcomes" until #5305, while the switch below it has always
+            // fanned out to three. The Layer tests assert the three in as many
+            // words, so the stale count was the one thing a reader would trust
+            // over the code:
             //   - `no-internal-db` should be unreachable here (the Layer's
             //     `!db.available` gate above already caught it), but if a
             //     future refactor decouples the gate from the wrapper this

--- a/packages/api/src/lib/residency/migrate.ts
+++ b/packages/api/src/lib/residency/migrate.ts
@@ -16,6 +16,21 @@
  * by the migration write-lock middleware (see readonly.ts).
  */
 
+// The one spelling of the refusal item's eight fields (#5303) — the same schema
+// `admin-migrate.ts` publishes in `ImportResultSchema`. `lib/**` must not import
+// from `api/routes/**`, so `@useatlas/schemas` is the only legal shared home.
+//
+// ⚠️ A VALUE import, and safe here for a reason that is NOT the one that would
+// make it safe from `@useatlas/types`. The hazard the cap constant's docstring
+// describes is resolution against a PUBLISHED package: this file is copied into
+// the `create-atlas` scaffold, which installs `@useatlas/types` from npm and
+// therefore cannot see a symbol added in the same commit. `@useatlas/schemas`
+// never publishes at all — instead `create-atlas/scripts/prepare-templates.sh`
+// (step 5e) copies its SOURCE into every template and aliases it through
+// `tsconfig` paths, so the scaffold gets this file and this schema from the same
+// commit. That copy is what makes the import safe, not the absence of a
+// registry entry — and `check-template-drift.sh` is what keeps it true.
+import { VocabularyRefusalDetailSchema } from "@useatlas/schemas";
 import { createLogger } from "@atlas/api/lib/logger";
 import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
 import { hasInternalDB, internalQuery, getInternalDB } from "@atlas/api/lib/db/internal";
@@ -318,26 +333,6 @@ export interface ScreenedRefusalDetails {
   readonly malformed: number;
 }
 
-/** `unknown` → `string`, as a predicate so the narrowing survives destructuring. */
-const isStr = (v: unknown): v is string => typeof v === "string";
-/**
- * `unknown` → `string | null`.
- *
- * `null` is a VALUE on both nullable fields — an auto-approved edge, and a refusal
- * arm with no conflicting edge — so `undefined` is malformed while `null` is not.
- *
- * Spelled `v === null || isStr(v)`. The strict `===` is what excludes `undefined`;
- * the LOOSE `v == null || isStr(v)` would admit it and invent "auto-approved" for an
- * entry that simply did not say.
- *
- * ⚠️ A bare `v != null` also kills a test, but for the OPPOSITE reason and an earlier
- * version of this comment had it backwards: `!=` is false for `undefined` too, so it
- * admits nothing extra — it goes red because it REJECTS `null`, which must pass
- * (`migrate.test.ts`'s "null included" case). Two different mistakes, two different
- * failures; naming the wrong one would send the next reader looking in the wrong place.
- */
-const isStrOrNull = (v: unknown): v is string | null => v === null || isStr(v);
-
 /**
  * Screen `refusalDetails` out of a target region's JSON (#5112).
  *
@@ -361,6 +356,34 @@ const isStrOrNull = (v: unknown): v is string | null => v === null || isStr(v);
  * can only carry as many refusals as the fixture exports edges, so the cap and the
  * "every arm of the screen" cases are unreachable from there — and a cap test whose
  * input cannot exceed the cap tests nothing.
+ *
+ * ⚠️ DERIVED FROM THE SCHEMA SINCE #5303, not from a hand-maintained field list.
+ * This function used to be the THIRD independent spelling of the eight fields — a
+ * destructure, two predicate lists, and a re-built literal — coupled to
+ * `VocabularyRefusalDetail` by nothing but care. It is now a per-entry
+ * `safeParse` against `VocabularyRefusalDetailSchema`, which is the same eight
+ * fields the route's `ImportResultSchema` publishes.
+ *
+ * Every clause of the old screen has an exact counterpart, and that is what makes
+ * the swap behaviour-preserving rather than merely shorter:
+ *
+ *   - `entry === null || typeof entry !== "object" || Array.isArray(entry)` →
+ *     Zod's object type check, which rejects `null`, primitives AND arrays;
+ *   - the six `isStr` checks → `z.string()`;
+ *   - the two `isStrOrNull` checks → `.nullable()`, which accepts `null` and
+ *     rejects `undefined`. This is the distinction the old comment was written
+ *     about, and it survives verbatim: a MISSING `approvedBy` is malformed
+ *     because reading it as `null` would invent "auto-approved" for an entry that
+ *     never said so;
+ *   - the field-by-field re-build → Zod object parsing, which STRIPS undeclared
+ *     keys by default. `safeParse().data` is a fresh object, so a foreign
+ *     region's arbitrary extra keys still never reach this region's `jsonb`
+ *     column.
+ *
+ * What it buys: a ninth field added to `VocabularyRefusalDetail` is a compile
+ * error at the schema's `satisfies` (so it cannot be forgotten), and once added
+ * there it is screened HERE with no edit at all — which is precisely the coupling
+ * the two deleted predicate lists could not provide.
  */
 export function screenRefusalDetails(raw: unknown): ScreenedRefusalDetails {
   if (raw === undefined || raw === null) return { details: [], malformed: 0 };
@@ -368,70 +391,25 @@ export function screenRefusalDetails(raw: unknown): ScreenedRefusalDetails {
 
   const details: VocabularyRefusalDetail[] = [];
   let malformed = 0;
-  // Bounded HERE as well as at the producer. The producer's cap is a promise
-  // about a well-behaved region; this one is a property of what this region will
-  // store, and the two are different guarantees — a target that ignores the cap
-  // is exactly the target whose payload should not size a row in this database.
+  // Bounded HERE as well as at the producer, and BEFORE the loop. The producer's
+  // cap is a promise about a well-behaved region; this one is a property of what
+  // this region will store, and the two are different guarantees — a target that
+  // ignores the cap is exactly the target whose payload should not size a row in
+  // this database. Slicing first is also what keeps `malformed` a statement about
+  // what this region LOOKED AT: garbage past the cap is never examined, so it is
+  // never counted.
   for (const entry of raw.slice(0, VOCABULARY_REFUSAL_DETAIL_CAP)) {
-    // `Array.isArray` is BELT-AND-BRACES, and saying so is the point: removing it
-    // kills zero tests (measured), because an array has none of the required
-    // string fields and the destructured checks below reject it anyway. Kept
-    // because "an entry is an object, not an array" is a claim worth making
-    // structurally rather than relying on a downstream check to imply it — but a
-    // comment claiming this arm is separately falsifiable would be false.
-    if (entry === null || typeof entry !== "object" || Array.isArray(entry)) {
+    // ⚠️ PER ENTRY, never `z.array(...).safeParse(raw)`. A whole-array parse fails
+    // the entire array on one bad element, which would turn a single unreadable
+    // payload into zero recovered refusals — the opposite of this function's
+    // polarity. A bad entry is DROPPED and counted; the good ones beside it
+    // survive.
+    const parsed = VocabularyRefusalDetailSchema.safeParse(entry);
+    if (!parsed.success) {
       malformed++;
       continue;
     }
-    // ⚠️ DESTRUCTURED AND NARROWED BY PREDICATE, not key-listed and cast. The first
-    // version tested `["slotPosition", …].some(k => typeof e[k] !== "string")` and
-    // then built the result with eight `as string` casts — sound at the time, and
-    // structurally fragile: the key list and the constructed literal were coupled by
-    // hand, so a NINTH required field on `VocabularyRefusalDetail` would compile the
-    // moment someone added `newField: e.newField as string` and would admit an entry
-    // that never had it. Here the literal names bare locals, so a new field cannot
-    // reach it unnarrowed — the compiler asks for the check.
-    const {
-      slotPosition,
-      fromNorm,
-      toNorm,
-      approvedBy,
-      approvedAt,
-      refusal,
-      existingTarget,
-      reason,
-    } = entry as Record<string, unknown>;
-    if (
-      !isStr(slotPosition) ||
-      !isStr(fromNorm) ||
-      !isStr(toNorm) ||
-      !isStr(approvedAt) ||
-      !isStr(refusal) ||
-      !isStr(reason) ||
-      !isStrOrNull(approvedBy) ||
-      !isStrOrNull(existingTarget)
-    ) {
-      malformed++;
-      continue;
-    }
-    // ⚠️ FIELD BY FIELD, so undeclared keys are STRIPPED rather than persisted.
-    // `push(entry as VocabularyRefusalDetail)` would be shorter and would put a
-    // foreign region's arbitrary extra keys — unbounded size, unvalidated content —
-    // into this region's `jsonb` column under a name that claims a shape. That is
-    // the whole thesis of this function, and it is the one property every fixture
-    // in the tests used to agree with by construction (they all carried exactly
-    // these eight keys), so there is now a case that adds extras and asserts they
-    // are gone.
-    details.push({
-      slotPosition,
-      fromNorm,
-      toNorm,
-      approvedBy,
-      approvedAt,
-      refusal,
-      existingTarget,
-      reason,
-    });
+    details.push(parsed.data);
   }
   // Anything past the cap is not malformed — it is bounded. Counting it as
   // malformed would report a target bug for behaviour this build defines.

--- a/packages/api/src/lib/residency/migrate.ts
+++ b/packages/api/src/lib/residency/migrate.ts
@@ -381,9 +381,14 @@ export interface ScreenedRefusalDetails {
  *     column.
  *
  * What it buys: a ninth field added to `VocabularyRefusalDetail` is a compile
- * error at the schema's `satisfies` (so it cannot be forgotten), and once added
- * there it is screened HERE with no edit at all — which is precisely the coupling
- * the two deleted predicate lists could not provide.
+ * error over in `@useatlas/schemas` (so it cannot be forgotten), and once added
+ * to the schema it is screened HERE with no edit at all — which is precisely the
+ * coupling the two deleted predicate lists could not provide.
+ *
+ * ⚠️ It is the KEY-SET pin that makes that true, not the `satisfies` — an earlier
+ * version of this sentence credited the `satisfies`, and measurement says an
+ * OPTIONAL ninth field passes it silently and is then stripped here. Both pins
+ * live beside the schema; the reasoning and the numbers are there.
  */
 export function screenRefusalDetails(raw: unknown): ScreenedRefusalDetails {
   if (raw === undefined || raw === null) return { details: [], malformed: 0 };

--- a/packages/schemas/src/residency.ts
+++ b/packages/schemas/src/residency.ts
@@ -31,6 +31,7 @@ import {
   type RegionRoutingMap,
   type RegionRoutingMapEntry,
   type RegionStatus,
+  type VocabularyRefusalDetail,
   type WorkspaceRegion,
 } from "@useatlas/types";
 import { IsoTimestampSchema } from "./common";
@@ -132,6 +133,73 @@ export const RegionMigrationSchema = z.discriminatedUnion("status", [
 ]) satisfies z.ZodType<RegionMigration>;
 
 export { MigrationStatusEnum };
+
+// ---------------------------------------------------------------------------
+// Vocabulary refusal payloads (#5112, #5303)
+// ---------------------------------------------------------------------------
+
+/**
+ * One refused vocabulary edge, as the destination region reports it.
+ *
+ * ⚠️ THE ONE SPELLING OF THESE EIGHT FIELDS. Before #5303 there were three, and
+ * nothing tied them together:
+ *
+ *   1. the TypeScript type — `VocabularyRefusalDetail` in `@useatlas/types`;
+ *   2. a Zod object literal restated inline in `ImportResultSchema`
+ *      (`api/routes/admin-migrate.ts`);
+ *   3. a hand-written runtime screen — `screenRefusalDetails` in
+ *      `lib/residency/migrate.ts`, eight fields checked by two predicate lists.
+ *
+ * (1) and (2) were held together by `_SchemaMatchesWireType`, whose reach #5112
+ * MEASURED: a required item field or a dropped `.nullable()` on either side is
+ * red, but an OPTIONAL item field on one side only is silent. (3) was held
+ * together by nothing at all — it was coupled to the type by hand, and its own
+ * docstring said so.
+ *
+ * ⚠️ `satisfies z.ZodType<VocabularyRefusalDetail>` HERE is strictly stronger
+ * than that inference pin, because it cannot be defeated by an optional member:
+ * a ninth field added to the type is a compile error on this line, whichever way
+ * it is declared. That is the property the acceptance criterion asks for, and it
+ * lives at the definition rather than at one of the consumers.
+ *
+ * ⚠️ THIS PACKAGE IS THE ONLY LEGAL SHARED HOME for it. `lib/**` must not import
+ * from `api/routes/**` (CLAUDE.md), so the screen cannot reach the route's
+ * literal; and `@useatlas/types` cannot hold it either — a Zod schema is a
+ * RUNTIME value, and `packages/api/src` is copied into the `create-atlas`
+ * scaffold template, which installs the PUBLISHED `@useatlas/types` and so cannot
+ * see a symbol added in the same commit (`VOCABULARY_REFUSAL_DETAIL_CAP`'s
+ * docstring carries the CI failure that proved it).
+ *
+ * `@useatlas/schemas` escapes that trap by never publishing at all: the scaffold
+ * gets it from `prepare-templates.sh` step 5e, which copies this package's SOURCE
+ * into every template behind a `tsconfig` path alias. Same commit, same schema.
+ *
+ * The array-level cap is deliberately NOT here. It is a property of a particular
+ * transfer, applied by the two `.slice()` calls and documented on the route's
+ * `.max()`; baking it into the item schema would put a bound on a single edge.
+ */
+export const VocabularyRefusalDetailSchema = z.object({
+  /** The slot position the edge was approved at, verbatim from the source row. */
+  slotPosition: z.string(),
+  fromNorm: z.string(),
+  toNorm: z.string(),
+  /**
+   * `null` is an auto-approved edge, not an unknown one — so `.nullable()` and
+   * NOT `.optional()`. A missing key and a key whose value says "auto-approved"
+   * read identically in a log aggregator, and only one of them is true. The
+   * screen depends on this exact distinction: `null` passes, absent is malformed.
+   */
+  approvedBy: z.string().nullable(),
+  /** The SOURCE region's approval timestamp, carried verbatim (never re-stamped). */
+  approvedAt: z.string(),
+  /** Which of the four rules refused it — `already-aliased`, `would-cycle`, … */
+  refusal: z.string(),
+  /** What the DESTINATION holds for `fromNorm` instead, or `null` for the arms
+   * that have no conflicting edge. `.nullable()` for `approvedBy`'s reason. */
+  existingTarget: z.string().nullable(),
+  /** The refusal's human-readable reason, as the destination phrased it. */
+  reason: z.string(),
+}) satisfies z.ZodType<VocabularyRefusalDetail>;
 
 // ---------------------------------------------------------------------------
 // Composite response shapes

--- a/packages/schemas/src/residency.ts
+++ b/packages/schemas/src/residency.ts
@@ -156,11 +156,32 @@ export { MigrationStatusEnum };
  * together by nothing at all — it was coupled to the type by hand, and its own
  * docstring said so.
  *
- * ⚠️ `satisfies z.ZodType<VocabularyRefusalDetail>` HERE is strictly stronger
- * than that inference pin, because it cannot be defeated by an optional member:
- * a ninth field added to the type is a compile error on this line, whichever way
- * it is declared. That is the property the acceptance criterion asks for, and it
- * lives at the definition rather than at one of the consumers.
+ * ⚠️ THE `satisfies` ALONE IS NOT ENOUGH, and the first version of this docstring
+ * said it was — in precisely the way this whole consolidation exists to prevent.
+ * Measured with `tsgo`, not reasoned about:
+ *
+ *   - ninth field REQUIRED on the type, schema untouched  → RED (TS1360)
+ *   - ninth field OPTIONAL on the type, schema untouched  → **GREEN**
+ *   - ninth field on the SCHEMA only, either way          → **GREEN**
+ *
+ * `refusalKind?: string` is the normal, backward-compatible way to add a field
+ * here — older regions will not send it — and under the `satisfies` alone it
+ * compiles everywhere, after which the screen STRIPS it from every inbound
+ * payload. Once the source region's grace period closes, that stripped field is
+ * gone from the last surviving copy of a human review decision. A silent drop,
+ * with three docstrings telling the next maintainer the compiler had it covered.
+ *
+ * So the key-set pin below carries the property the acceptance criterion actually
+ * asks for. Re-measured with both pins in place — all four RED:
+ *
+ *   - ninth REQUIRED on the type    → 5 errors (satisfies, screen, route, key pin)
+ *   - ninth OPTIONAL on the type    → 1 error  — THE KEY PIN ALONE
+ *   - ninth REQUIRED on the schema  → 3 errors
+ *   - ninth OPTIONAL on the schema  → 1 error  — THE KEY PIN ALONE
+ *
+ * The `satisfies` stays, and is not redundant: key equality cannot see a field's
+ * TYPE changing or a dropped `.nullable()`, which is exactly what it does see.
+ * Two pins, two reaches, neither one sufficient.
  *
  * ⚠️ THIS PACKAGE IS THE ONLY LEGAL SHARED HOME for it. `lib/**` must not import
  * from `api/routes/**` (CLAUDE.md), so the screen cannot reach the route's
@@ -200,6 +221,32 @@ export const VocabularyRefusalDetailSchema = z.object({
   /** The refusal's human-readable reason, as the destination phrased it. */
   reason: z.string(),
 }) satisfies z.ZodType<VocabularyRefusalDetail>;
+
+/**
+ * Compile-time pin: the schema and the wire type declare the SAME KEYS.
+ *
+ * This is the half `satisfies` cannot do (see the measurements above). `keyof`
+ * enumerates optional members too, so `refusalKind?: string` added to either
+ * spelling alone lands in one of the two `Exclude`s and fails this line.
+ *
+ * ⚠️ The two directions are SEPARATE nested conditions, not a union. While the
+ * spellings agree both `Exclude`s are `never`, and a union of nevers trips
+ * `no-duplicate-type-constituents` + `no-redundant-type-constituents` in
+ * `lint:type-aware` — a CI-blocking gate. Nesting keeps the pin lint-clean and
+ * keeps each direction separately falsifiable. Same idiom, and same reason, as
+ * `_SchemaMatchesWireType` in `admin-migrate.ts`.
+ */
+type _RefusalDetailKeysMatch = [
+  Exclude<keyof z.infer<typeof VocabularyRefusalDetailSchema>, keyof VocabularyRefusalDetail>,
+] extends [never]
+  ? [
+      Exclude<keyof VocabularyRefusalDetail, keyof z.infer<typeof VocabularyRefusalDetailSchema>>,
+    ] extends [never]
+    ? true
+    : never
+  : never;
+const _refusalDetailKeysMatch: _RefusalDetailKeysMatch = true;
+void _refusalDetailKeysMatch;
 
 // ---------------------------------------------------------------------------
 // Composite response shapes


### PR DESCRIPTION
Batch of the four issues in the request. **Two of them were already on `main`** — see below — so the diff is #5305 and #5303.

## ⚠️ #5299 and #5306 were already implemented; the issues were just never closed

Commit `888a0d7db` ("Three harness fixes, then the review of them") landed both, with gates, adversarial fixtures and CI wiring. Verified on this branch rather than taken on trust:

| Issue | State on `main` | Verified by |
|---|---|---|
| #5299 doc-path guard | `scripts/check-agent-doc-paths.sh` exists, wired into `ci-local.sh:257` and the `drift` job | gate green (1989 path / 1092 command / 5 count candidates checked); `check-agent-doc-paths.test.sh` **30 passed, 0 failed** |
| #5306 brand-token bypasses | `layout.tsx` body carries no color utility, both fonts load, `sql-block.tsx` is `oneDark` over `--code-bg`, `scripts/check-web-brand-tokens.sh` is the gate | gate green; `check-web-brand-tokens.test.sh` **24 passed, 0 failed** |

Nothing to do for either. **They should be closed**, not re-implemented — I have not closed them here since that is a call for the maintainer.

## #5305 — `ImplementationStatusOverrideLive` has no Layer test

`layers.test.ts` covered the two upstream-gate arms and punted the rest to "the wrapper's own tests". That was not the same claim: the wrapper's tests pin what the *wrapper* returns, and every gates-pass arm is the Layer's own **translation** of that return into a Tag value. `no-config` is the clearest case — the wrapper calls it a skip and the Layer promotes it to `outcome: "error"`, so no wrapper test can see the promotion.

Adds a fourth driver to #5273's harness (29 → 41 tests). The file is no longer only about seed Layers and its header says so.

Six mutations measured RED:

| Mutation | Result |
|---|---|
| `empty-override` → `skipped-gate` | 40 pass **1 fail** |
| `no-config` demoted from `error` to a plain skip | 40 pass **1 fail** |
| `applied` arm filled with `...zeroCounts` | 39 pass **2 fail** |
| `error` arm unscrubbed | 39 pass **2 fail** |
| `catchAll` unscrubbed | 40 pass **1 fail** |
| `applied` `updatedCount` hardcoded to `0` | 39 pass **2 fail** |

> ⚠️ The first mutation run reported the `catchAll` one **green**, and it was the *harness* lying. `error: errorMessage(err),` occurs five times in `layers.ts` — once per Layer with a `catchAll` — and a non-global `s///` mutated the first, belonging to a Layer this suite does not cover. The mutations are now line-targeted, and the runner refuses to print a verdict for a pattern that did not match.

### The union-vs-flat decision (4th acceptance criterion)

**The shapes stay flat**, recorded beside them in `layers.ts` rather than in this PR. The issue's stated premise for changing them is **false — measured, not reasoned**: under a discriminated union whose `applied`/`seeded` variant declares the forwarded fields, `{ ...zeroCounts, outcome: "applied" }` still type-checks, because `zeroCounts` carries both fields at exactly those types. The headline mutation is a wrong *value*, not a wrong *shape*; no arrangement of variants rejects it, so it needs a test — which is what this PR adds.

What the union *would* buy, from the same experiment, is narrower and real: `{ ...zeroCounts, outcome: "error" }` — an error outcome with no message — is a compile error under a union and legal today. Not taken, because every producing arm of `error` is now pinned scrubbed, and the cost lands on the future `/health` consumer whose job is to report counts uniformly across outcomes. Revisit when a consumer appears that branches on `outcome` anyway.

## #5303 — one spelling of `VocabularyRefusalDetail`

Three spellings → one `VocabularyRefusalDetailSchema` in `@useatlas/schemas`, declared `satisfies z.ZodType<VocabularyRefusalDetail>` (strictly stronger than the `_SchemaMatchesWireType` inference pin, because it cannot be defeated by an optional member). The route references it; `screenRefusalDetails` becomes a per-entry `safeParse`, deleting both predicate lists and the re-built literal.

Contract preserved clause for clause — object check rejects `null`/primitives/arrays, `z.string()` for the six `isStr`, `.nullable()` for `isStrOrNull` (so `null` passes and **missing** is malformed), object parsing strips undeclared keys, cap still applied **before** the loop. **The whole `screenRefusalDetails` describe in `migrate.test.ts` passes unchanged — not one case edited.**

Measured:

| Mutation | Result |
|---|---|
| ninth required field on the type, screen untouched | **14 compile errors**, in three places at once: schema `satisfies` (TS1360), screen push site (TS2741), `_SchemaMatchesWireType` (TS2322) |
| cap removed from the screen | 59 pass **2 fail** |
| `.nullable()` weakened to `.optional()` | 60 pass **1 fail** |
| `z.object` → `z.looseObject` | 60 pass **1 fail** |
| screen bypassed entirely | 56 pass **5 fail** |

> ⚠️ The ninth-field measurement was **vacuous on its first run** and reported zero errors. `@useatlas/types` resolves through `exports` to `./dist/*.d.ts`, so editing `packages/types/src` changes nothing a consumer sees until the package is rebuilt. Re-measured with a rebuild in the loop; the number above is that run.

`@useatlas/schemas` stays `private: true`. It is the only legal shared home — `lib/**` must not import from `api/routes/**`, and a Zod schema is a runtime value that `@useatlas/types` cannot carry for the scaffold-template reason `VOCABULARY_REFUSAL_DETAIL_CAP` documents. It escapes that trap by never publishing: `prepare-templates.sh` step 5e copies its source into every template behind a tsconfig alias.

## Verification

- `tsgo --noEmit` clean · `bun run lint` exit 0 · `bun run lint:type-aware` exit 0
- `test-isolated.ts --affected` — **133 files, 133 passed**
- `packages/schemas` — 501 pass
- Gates run green: `check-agent-doc-paths`, `check-web-brand-tokens`, `check-openapi-drift` (spec byte-identical), `check-template-drift`, `check-schema-drift`, `check-published-symbols`, `check-unpublished-versions`, `check-test-discipline`, `check-gate-fixtures-wired`

Two `packages/web` files fail **on my local machine only** — `signup/success/page.test.tsx` and `use-success-starter-prompts.test.tsx`. Confirmed not from this branch by stashing these changes and reproducing both on the clean tree; and **remote CI's `test-others` job passes**, so they are a local-environment artifact rather than a repo-wide break. Noted here only so the local/CI discrepancy is on the record.

**Remote CI: all checks green** (`ci`, `drift`, `lint`, `lint-type-aware`, `type`, `build`, `api-tests` 1-4, `mutation-tables` 1-4, `test-others`, `test-e2e-integration`, CodeQL, Deploy Validation, both Scaffold jobs).

Closes #5305
Closes #5303
