### PR TITLE
chore(agents): restore /reset, /sitrep and /tidy, re-derived against the bar

### DIFF
--- a/.claude/commands/reset.md
+++ b/.claude/commands/reset.md
@@ -1,0 +1,65 @@
+---
+description: "Return to a clean main baseline. Stops if the tree holds uncommitted or unpushed work. Prunes [gone] marks, installs, and reports the end state it verified. Run after a merge."
+---
+
+# Reset
+
+Return to `main` at `origin`. Install dependencies from the lockfile.
+
+Run this after a merge.
+
+## Step 1 — Check before you act
+
+Run these three commands. Read all three results before you continue.
+
+```bash
+git rev-parse --show-toplevel                 # which checkout is this?
+git status --porcelain                        # uncommitted work
+git log --oneline @{u}..HEAD 2>/dev/null      # unpushed commits
+```
+
+Stop and report if any row below is true. Do not continue.
+
+| Condition | What to do |
+|---|---|
+| `git status --porcelain` prints files | `git checkout` moves that work onto `main`. Name the files. Offer `git stash -u` or a commit. Let the operator choose. Never stash without asking — nobody looks for a stash they did not make. |
+| `git log @{u}..HEAD` prints commits | The branch holds work that `origin` does not have. Name the commits and the branch, so the operator can find them again by name. |
+| `@{u}` gives an error | The branch has no upstream. This is the worse case, not the safer one: every commit on it is unpushed. Compare against `main` instead — `git log --oneline main..HEAD`. |
+| The toplevel is not the primary checkout | You are in a worktree. The primary checkout already holds `main`. |
+
+## Step 2 — Reset
+
+```bash
+git checkout main
+git fetch --prune origin
+git pull --ff-only
+bun install
+```
+
+Two flags are deliberate. Keep them.
+
+- **`--ff-only`** — `main` must fast-forward. Stop and report if it does not. A plain
+  `git pull` hides the divergence inside a merge commit.
+- **`--prune`** — this is what marks a deleted remote branch as `[gone]`. `/tidy` reads
+  that mark. Without the prune, the `/tidy` branch sweep matches nothing and reports clean.
+
+## Step 3 — Report what you verified
+
+Run these three. Report the result of each.
+
+```bash
+git rev-parse --abbrev-ref HEAD               # expect: main
+git rev-parse --short HEAD origin/main        # expect: two equal SHAs
+git status --porcelain                        # expect: no output
+```
+
+Write **UNKNOWN** for any check you could not run. A skipped step is not a passed step.
+
+`bun install` exits 0 and still prints peer-dependency conflicts. Quote any warning it
+prints. Say so if it changed `bun.lock`.
+
+## Out of scope
+
+- Branch and worktree deletion — `/tidy`, which needs the prune above.
+- Dev servers — `/dev`.
+- Remote branches. This command never pushes and never deletes on `origin`.

--- a/.claude/commands/sitrep.md
+++ b/.claude/commands/sitrep.md
@@ -1,0 +1,145 @@
+---
+description: "Read-only orientation: commits, issues, milestones, CI, deploy state, package drift, release distance. Marks anything it could not read as UNKNOWN. Run at session start or when switching context."
+---
+
+# Sitrep
+
+Read-only orientation. Where the project stands right now.
+
+**This command writes nothing.** No issues, no labels, no edits, no commits, no pushes.
+
+Run it at the start of a session, when you switch context, or before you pick up work.
+
+## The rule that makes it worth running
+
+A sitrep that always produces a confident picture is a measurement that cannot fail.
+
+So: read every field from a command, or print it as **UNKNOWN** with the reason. Never
+fill a gap by inference. You will act on this report. Once a guessed field is in the
+table, it looks exactly like a read one.
+
+Two habits follow from that.
+
+- **Derive lists. Do not hard-code them.** Every list below comes from disk or from the API
+  at read time. The previous version of this command carried a four-row package table
+  while five packages publish.
+- **Never truncate a finding.** Print failing CI lines in full.
+
+## Step 1 — Gather
+
+Set the window first, so no `YYYY-MM-DD` placeholder reaches a command:
+
+```bash
+SINCE=$(date -d '3 days ago' +%F)      # macOS: SINCE=$(date -v-3d +%F)
+```
+
+Run the rest in parallel. Pass `-R AtlasDevHQ/atlas` to every `gh` call — this box runs
+several clones and worktrees, and repo inference has picked the wrong one
+(`docs/agents/issue-tracker.md`).
+
+**1. Commits and open PRs**
+```bash
+git log --oneline --since="$SINCE" --format='%h %s (%cr)'
+gh pr list -R AtlasDevHQ/atlas --state open --json number,title,isDraft,headRefName
+```
+
+**2. Issues — open, and closed inside the window**
+```bash
+gh issue list -R AtlasDevHQ/atlas --state open --limit 100 --json number,title,labels,milestone
+gh issue list -R AtlasDevHQ/atlas --state closed --limit 100 \
+  --search "closed:>=$SINCE" --json number,title,labels
+```
+
+**3. Milestones**
+```bash
+gh api repos/AtlasDevHQ/atlas/milestones?state=open \
+  --jq '.[] | "\(.title): \(.open_issues) open / \(.closed_issues) closed"'
+```
+
+**4. CI on `main`**
+```bash
+gh run list -R AtlasDevHQ/atlas --branch main --limit 5 \
+  --json name,status,conclusion,createdAt,databaseId
+gh run view <databaseId> -R AtlasDevHQ/atlas --log-failed 2>&1 | tail -60   # if any failed
+```
+
+**5. Deploy state and release distance**
+```bash
+gh api repos/AtlasDevHQ/atlas/commits/main/statuses \
+  --jq '[.[] | {context, state}] | unique_by(.context) | .[] | "\(.context): \(.state)"'
+git fetch origin prod --quiet 2>/dev/null
+git rev-parse --short origin/prod 2>/dev/null       || echo "prod: UNKNOWN"
+git rev-list --count origin/prod..origin/main 2>/dev/null || echo "distance: UNKNOWN"
+```
+
+This command does not say which service tracks `main` and which tracks `prod`. `/deploy`
+says that. Read it there.
+
+Always report the `prod`-to-`main` count, even when nothing is wrong. CLAUDE.md makes it
+the precondition for a hotfix: a non-zero count means a tag cut from `main` also ships an
+unreleased arc.
+
+**6. Published packages, with drift**
+```bash
+for p in $(grep -L '"private": *true' packages/*/package.json); do
+  name=$(jq -r .name "$p"); local=$(jq -r .version "$p")
+  pub=$(npm view "$name" version 2>/dev/null || echo UNKNOWN)
+  [ "$local" = "$pub" ] && flag="" || flag="  <- DRIFT"
+  printf '%-28s local %-10s npm %-10s%s\n' "$name" "$local" "$pub" "$flag"
+done
+```
+
+Drift is the column that matters, not the version. A local version ahead of npm means a
+publish is pending. Bumping consuming refs before that publish lands breaks Deploy
+Validation scaffolds on `npm install` (CLAUDE.md).
+
+**7. The record**
+
+Read the `## Next` section of `.claude/research/ROADMAP.md`, and every ⚠️ in it. That file
+is the record. An open warning there outranks anything you infer from issue counts.
+
+## Step 2 — Report
+
+```markdown
+## Atlas Sitrep — <date>
+
+### Health          <- always first; a red row here outranks everything below
+| System | State |
+|---|---|
+| CI (main) | green / FAILING: <job> + the failure lines in full / UNKNOWN |
+| Deploy statuses | <context: state, one per row> / UNKNOWN |
+| `prod` to `main` | N commits behind (`prod` @ <sha>) / UNKNOWN |
+
+### Activity (since <SINCE>)
+Commits: N · Issues closed: N · Open PRs: N (M draft)
+Themes: <from the feat/fix/refactor/docs/chore prefixes>
+
+### Open work (N total)
+| Type | Count | Areas |
+|---|---|---|
+<one row per type label present; areas from the `area: *` labels>
+
+Blocked: <issues carrying `blocked`, by number> / none
+
+### Milestones
+<title: open/closed, one per line> / none open
+
+### Packages
+<the derived table from step 6, with the drift column>
+
+### From the record
+<the `## Next` heading, then each ⚠️ in one line>
+
+### Could not determine
+<every UNKNOWN above, with its reason. Omit this section only when it is empty.>
+```
+
+## What this command no longer produces
+
+The previous version ended with **What Matters Now**: two or three sentences of strategy,
+in the same table style as the readings. It is gone. **Could not determine** takes its
+place.
+
+Ask for a recommendation as a separate question. Then the answer arrives labelled as a
+judgement, not as a reading. Here, only the CI row and `Blocked` say what to do next, and
+this command reads both.

--- a/.claude/commands/tidy.md
+++ b/.claude/commands/tidy.md
@@ -1,0 +1,203 @@
+---
+description: "Reconcile merged work against issues, labels, ROADMAP and stale branches. Applies only fact-determined fixes; proposes every judgement call with its evidence. Run after a burst of merged PRs."
+---
+
+# Tidy
+
+Reconcile recent merged work against GitHub issues, labels, the ROADMAP, and local
+branches.
+
+Run it after a burst of PRs land.
+
+**Companion:** `/triage` moves *inbound* issues through the state machine. `/tidy`
+reconciles work that is *already tracked*. Run `/triage` first when external issues wait.
+
+## Two lanes
+
+The previous version did everything itself. It judged which issues had shipped and closed
+them. It wrote the ROADMAP entry for the work. It approved its own edits. All of that
+happened in the session that had just done the work. `docs/agents/practices.md` names the
+shape: **the actor that builds a check may not be its only judge.**
+
+So this command has two lanes. The test is **does a printable fact decide the action**,
+not is the action risky.
+
+| Lane | Test | Behaviour |
+|---|---|---|
+| **APPLY** | A fact decides it. The remote branch is gone. The issue is closed. A merged PR carries a closing keyword for an issue that is closed. | Act. Report what you did. |
+| **PROPOSE** | A person decides it. *Which* area label. *Whether* this shipped. *What* the ROADMAP entry says. *Whether* this needs an issue. | Print the proposal and the evidence. Stop. |
+
+Do not apply a PROPOSE item because it looks obvious. "Obvious to the session that wrote
+the code" is the failure this split exists to stop.
+
+⚠️ **Never truncate the report.** No `head`, no `cut`, no "and 12 more".
+
+## Step 1 — Gather
+
+```bash
+SINCE=$(date -d '2 days ago' +%F)      # macOS: SINCE=$(date -v-2d +%F)
+
+git log --oneline --since="$SINCE" --format='%h %s'
+gh pr list -R AtlasDevHQ/atlas --state merged --limit 30 --json number,title,body,mergedAt
+gh pr list -R AtlasDevHQ/atlas --state open --json number,title,headRefName
+gh issue list -R AtlasDevHQ/atlas --state open --limit 100 --json number,title,labels,milestone
+gh issue list -R AtlasDevHQ/atlas --state closed --limit 100 --search "closed:>=$SINCE" \
+  --json number,title,labels
+```
+
+Pass `-R AtlasDevHQ/atlas` to every `gh` call. Prefer REST over GraphQL: GraphQL returns
+503 often enough here that a sweep must verify by re-listing (`docs/agents/issue-tracker.md`).
+
+Read only the `## Next` section of `.claude/research/ROADMAP.md`. The archive is cold
+storage; reading it costs context and reconciles nothing.
+
+## Step 2 — APPLY
+
+### 2a. Stale waiting-labels on closed issues
+
+`needs-triage` and `needs-info` assert a live obligation. They are wrong on a closed issue.
+`ready-for-agent`, `ready-for-human` and `wontfix` record routing and verdict, so **keep**
+them. `docs/agents/triage-labels.md` is the convention. Trust it over this paragraph.
+
+```bash
+for L in needs-triage needs-info; do
+  gh api --paginate "repos/AtlasDevHQ/atlas/issues?state=closed&labels=$L&per_page=100" \
+    --jq '.[] | select(.pull_request == null) | .number'
+done
+gh api -X DELETE "repos/AtlasDevHQ/atlas/issues/<N>/labels/<label>"
+```
+
+Re-list after the deletes. Report the **second** count as the result. A 503 on a DELETE
+prints no error you will notice, so a first count reports removals that did not happen.
+
+### 2b. Stale branches and orphan worktrees
+
+This needs the prune from `/reset`. Run `git fetch --prune origin` first if you skipped it.
+Without the prune nothing is ever marked `[gone]`, and this sweep reports clean after
+reading nothing.
+
+```bash
+git branch -vv | grep ': gone\]'
+```
+
+Git writes the mark as `[origin/<branch>: gone]`. A literal `[gone]` pattern matches
+nothing, and reads as "no stale branches" rather than as a broken grep.
+
+Take each candidate through these three checks in order.
+
+1. **Open PR on it — skip.**
+   `gh pr list -R AtlasDevHQ/atlas --state open --head <branch>`
+2. **Merged PR on it — safe, delete.**
+   `gh pr list -R AtlasDevHQ/atlas --state merged --head <branch> --json number,mergedAt`
+3. **No PR at all — look for unmerged work.**
+   `git cherry main <branch>`. Any line that starts `+` has no patch-equivalent on `main`.
+   Report those. Do not delete.
+
+⚠️ **Do not use `git log main..<branch>` for check 3.** It is the obvious choice and it is
+wrong here. This repo squash-merges, so a merged branch keeps its original SHAs and
+`main..<branch>` never empties. The guard would report unmerged work on every branch and
+delete nothing, while it reads as careful. Measured on
+`fix/5233-bridge-window-object-cmp-trace`: merged as PR #5315, landed on `main` under a new
+SHA, and `main..<branch>` still listed its commit. `git cherry` compares patch-ids and got
+that one right, but a multi-commit branch squashed into one has no patch-equivalent either.
+**Check 2 is the signal. `git cherry` only covers branches GitHub never saw.**
+
+Then remove any owning worktree and delete the branch:
+
+```bash
+git branch -vv | grep ': gone\]' | sed 's/^[+* ]//' | awk '{print $1}' | while read branch; do
+  worktree=$(git worktree list | grep "\[$branch\]" | awk '{print $1}')
+  if [ -n "$worktree" ] && [ "$worktree" != "$(git rev-parse --show-toplevel)" ]; then
+    if ! git worktree remove "$worktree" 2>/dev/null; then
+      lock_pid=$(git worktree list --porcelain | awk -v p="$worktree" '$2==p {f=1} f && /^locked/ {print; exit}' | grep -oE 'pid [0-9]+' | awk '{print $2}')
+      if [ -n "$lock_pid" ] && ! ps -p "$lock_pid" > /dev/null 2>&1; then
+        git worktree remove -f -f "$worktree"          # only with a confirmed-dead PID
+      else
+        echo "  $worktree locked by a live PID — skipping"; continue
+      fi
+    fi
+  fi
+  git branch -D "$branch"
+done
+```
+
+**Never delete a remote branch here.** That reaches other machines and other people, and
+GitHub already deletes merged branches for you.
+
+### 2c. ROADMAP checkboxes
+
+Change `- [ ]` to `- [x]` only when a merged PR body carries a closing keyword for issue N
+**and** N is closed. Anything weaker belongs in 3c.
+
+⚠️ A `#N` anywhere in a PR body parses as a real edge, and a closing keyword ignores
+negation — *"does not fix #N"* still closes it (`docs/agents/issue-tracker.md`). So confirm
+against the closed state of N. Do not trust the keyword alone.
+
+## Step 3 — PROPOSE
+
+Print each item with its evidence. Apply nothing in this step.
+
+### 3a. Missing labels
+
+Two axes are required: exactly one of `bug` / `feature` / `refactor` / `chore` / `docs`,
+plus one or more `area: *`. `docs/agents/issue-tracker.md` holds the list.
+
+Detecting a missing axis is mechanical. Choosing the value is a reading of the issue, so
+propose it:
+
+`#N "<title>" — missing an area label. Suggest `area: api` (body names packages/api/src/lib/brain).`
+
+### 3b. Issues that look shipped
+
+Give the number, the PR you believe closed it, and the acceptance criteria you believe are
+met. Never close an issue from this command.
+
+Never close an issue that has open sub-issues. Propose a status comment instead.
+
+### 3c. ROADMAP entries
+
+Propose the text. Do not write it.
+
+Match the shape of the entries around it. Read them first. Today that shape is:
+
+- `**Shipped YYYY-MM-DD — <hook>** ([#N](url); PR [#M](url)) — what changed, and why.`
+- `⭐` marks a transferable finding. `⚠️` marks a hazard or a breaking change. Each one ends
+  in the general form of the claim.
+- Detail lives in the issue, the PR body, and `.claude/research/architecture-wins.md` for
+  refactors that deepen a module. Link to it. Do not copy it.
+- When a milestone closes, collapse its section to one `- [x]` line. Move the detail
+  verbatim to `ROADMAP-archive.md`, so `ROADMAP.md` stays cheap to edit.
+
+Not every closed `architecture` issue earns an `architecture-wins.md` entry. That file
+tracks a contract that had copies and now has one home. A guard refinement, or a feature
+that touches many files, stops at the ROADMAP.
+
+### 3d. Untracked work
+
+Merged PRs that reference no issue. Propose an issue only for significant work. Typos and
+one-line fixes are noise. Search first, so you do not propose a duplicate.
+
+## Step 4 — Report
+
+```markdown
+### Applied
+- Waiting-labels removed: N (verified by re-list: N)
+- Branches deleted: <names> · Worktrees removed: <paths> · Skipped: <name — reason>
+- ROADMAP checkboxes ticked: N
+
+### Proposed — needs your call
+<one block per item: what, the evidence, the command that applies it>
+
+### Could not check
+<anything that errored, and what is therefore unverified>
+```
+
+Commit a changed `.claude/research/ROADMAP.md` as `docs: tidy — …`. **Do not push unless
+asked.** A push reaches other people, and this command often runs unattended.
+
+## What is not a rule here
+
+Everything in Step 3 is a note, in the sense `docs/agents/practices.md` defines. It informs
+judgement and gates nothing. No gate can tell a good ROADMAP entry from a plausible one.
+APPLY is the only lane whose correctness is checkable, and that is why it is the only lane
+that acts.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,10 +131,12 @@ Env vars: see `.env.example`. Key ones — `ATLAS_PROVIDER`, `ATLAS_MODEL`, `ATL
 
 **The workflow layer was deleted on 2026-08-17** — 26 of 34 commands, all 5 review agents
 and `docs/agents/`, ~6,250 lines. It was not wrong; it was satisfied nominally, three
-escalations deep, while the defect moved up a level each time. What remains in
-`.claude/commands/` is eight **operational** runbooks (`release`, `publish`, `deploy`,
+escalations deep, while the defect moved up a level each time. What remained in
+`.claude/commands/` was eight **operational** runbooks (`release`, `publish`, `deploy`,
 `ci`, `verify-mcp-cli`, `verify-prod-signup`, `dev`, `deps-update`) — sequences against
-external systems that fail loudly, which no finding implicated.
+external systems that fail loudly, which no finding implicated. `/reset`, `/sitrep` and
+`/tidy` were restored on 2026-08-19 under the same test, bringing the directory to
+eleven operational runbooks; `docs/agents/practices.md` records the grounds.
 The replacement is one page: **[docs/agents/practices.md](docs/agents/practices.md)** — the
 bar a practice must clear (a gate, or a measurement that can fail, or it is a note in
 ROADMAP), and the one structural rule (the actor that builds a check may not be its only

--- a/docs/agents/practices.md
+++ b/docs/agents/practices.md
@@ -1,7 +1,7 @@
 # Agent practices
 
 Rebuilt 2026-08-17 by deleting ~6,250 lines of workflow layer — 7,893 removed, then 1,639
-restored as the eight operational runbooks (see "What survived", below). This file is short
+restored as the runbooks listed under "What survived", below. This file is short
 on purpose, and the reason it is short is the finding that caused the rebuild.
 
 ## Why the old layer was deleted
@@ -59,7 +59,7 @@ Applied:
 
 ## What survived the deletion, and on what grounds
 
-**Eight operational runbooks** in `.claude/commands/`: `release`, `publish`, `deploy`,
+**The eight that survived**, in `.claude/commands/`: `release`, `publish`, `deploy`,
 `ci`, `verify-mcp-cli`, `verify-prod-signup`, `dev`, `deps-update`. They are step
 sequences against external systems — npm tags in groups of ≤3, the prod fast-forward, the
 staging soak — where the cost of re-deriving is real and the failure mode is a broken
@@ -74,6 +74,32 @@ workflow loop, where a rule's only enforcement was an author's willingness to fo
 That is the line, and it is worth stating as a general test: **delete the practice whose
 enforcement was your own diligence; keep the sequence whose enforcement is an external
 system that will fail loudly.**
+
+## What was restored on 2026-08-19
+
+`/reset`, `/sitrep` and `/tidy` came back. `.claude/commands/` now holds **eleven
+operational runbooks**.
+
+They were re-derived, not restored. Two of the three failed the test above as written.
+
+| | Verdict | What changed |
+|---|---|---|
+| `/reset` | Passed | It is git and bun, and a wrong step fails at once. It now refuses on uncommitted or unpushed work instead of carrying it onto `main`, and reports the end state it verified. |
+| `/sitrep` | Passed on inputs, failed on output | Every field is read from `gh`, `git` or `npm`. But it closed with strategy rendered in the same tables as the readings, and hard-coded four packages while five publish. It now derives every list and marks what it could not read UNKNOWN. |
+| `/tidy` | Failed | It closed issues on its own judgement, wrote the ROADMAP entry for work it had just done, and approved its own edits. That is the structural rule above, broken inside one command. |
+
+`/tidy` is restored in two lanes. **APPLY** acts only where a printable fact decides the
+action. **PROPOSE** prints the proposal with its evidence and stops. The test is *does a
+fact decide it*, not *is it risky*.
+
+Two limits, stated because this page's own failure mode is claiming more than it holds:
+
+- **The lanes are a note, not a gate.** Nothing stops a session from applying a PROPOSE
+  item. The bar predicts that, and it is still the honest place to put the split.
+- **One dead rule was dropped rather than carried across.** The old `/tidy` capped ROADMAP
+  bullets at *"≤ 2 sentences / ~240 chars"*. `ROADMAP.md` abandoned that long ago, so the
+  command and the file disagreed for months. A rule the artifact contradicts is worse than
+  no rule. *"Match the entries around it"* replaces it.
 
 ## What is deliberately not here
 


### PR DESCRIPTION
Restores three of the 26 commands the 2026-08-17 burn (#5298) deleted. They are
**re-derived, not restored** — two of the three failed `docs/agents/practices.md`'s own
test as written.

## Against which test

The test is the one `practices.md` states: *is the enforcement an external system that
fails loudly, or was it your own diligence?*

| Command | Verdict | What changed |
|---|---|---|
| `/reset` | Passed | It is git and bun, and a wrong step fails on the spot. It now refuses on uncommitted or unpushed work instead of carrying it onto `main`, uses `--ff-only` so a diverged `main` surfaces rather than hiding in a merge commit, and reports the end state it verified. |
| `/sitrep` | Passed on inputs, failed on output | Every field is read from `gh`, `git` or `npm`. But it closed with strategy rendered in the same tables as the readings, and hard-coded a four-row package table while five packages publish. It now derives every list and marks anything unread **UNKNOWN**. |
| `/tidy` | Failed | It judged which issues had shipped and closed them, wrote the ROADMAP entry for work it had just done, and approved its own edits — in the session that did the work. The structural rule, broken inside one command. |

`/tidy` is restored in two lanes. **APPLY** acts only where a printable fact decides the
action. **PROPOSE** prints the proposal with its evidence and stops. The test is *does a
fact decide it*, not *is it risky*.

## Two findings from building it, both measured

**A guard that could not pass.** The first draft blocked branch deletion on
`git log main..<branch>`. This repo squash-merges, so a merged branch keeps its original
SHAs and that range never empties. Measured on `fix/5233-bridge-window-object-cmp-trace`:
merged as PR #5315, landed on `main` under a new SHA, still listed as unmerged. The guard
would have reported unmerged work on every branch and deleted nothing, while reading as
careful — the mirror of the defect the burn was about. The merged-PR query is the signal
now; `git cherry` only covers branches GitHub never saw.

**A rule its own artifact contradicted.** The old `/tidy` capped ROADMAP bullets at
*"<= 2 sentences / ~240 chars"*. `ROADMAP.md` abandoned that long ago, so the command and
the file had disagreed for months. Dropped rather than carried across.

## The gate did its job

`count_commands` goes 8 to 11, so `check-agent-doc-paths.sh` failed on both *"eight
operational runbooks"* claims in `practices.md` until they were fixed. The two historical
sentences are reworded to read as history; the live count sits in the new section.
CLAUDE.md's line moves to past tense and records the restoration.

## Known gap, deliberately not fixed here

A **bolded** count slips past the count regex — `eight **operational** runbooks` does not
match `<number>\s+operational runbooks`, verified directly. CLAUDE.md carried exactly that
form. The prose is fixed; the gate is not. Hardening a CI-blocking check plus its
adversarial suite is a separate change, and the actor that found the hole should not be its
only judge. Fix is ~10 lines plus one fixture.

## Verification

- `scripts/check-agent-doc-paths.sh` — green
- `scripts/__tests__/check-agent-doc-paths.test.sh` — 30 passed, 0 failed
- Every bash block in the three commands parses under `bash -n`
- Every derivation executed rather than assumed (package drift, `prod`→`main` count, the `gh` search form, the `[gone]` branch check)
- `/sitrep` run end to end against the live repo
- Markdown only; no TypeScript or source touched