### PR TITLE
fix(agents): /reset Step 3 verified nothing — `rev-parse --short` takes one revision

### DIFF
--- a/.claude/commands/reset.md
+++ b/.claude/commands/reset.md
@@ -49,9 +49,15 @@ Run these three. Report the result of each.
 
 ```bash
 git rev-parse --abbrev-ref HEAD               # expect: main
-git rev-parse --short HEAD origin/main        # expect: two equal SHAs
 git status --porcelain                        # expect: no output
+[ "$(git rev-parse HEAD)" = "$(git rev-parse origin/main)" ] \
+  && echo "in sync with origin/main" || echo "DIVERGED from origin/main"
 ```
+
+⚠️ `git rev-parse --short HEAD origin/main` does not work. `--short` takes one revision
+only, and two make it exit 128 with *"fatal: Needed a single revision"*. This runbook
+shipped that form and it failed on the first real run. Compare the two SHAs and report the
+verdict, as above — do not print two strings and leave the reader to match them by eye.
 
 Write **UNKNOWN** for any check you could not run. A skipped step is not a passed step.
 


### PR DESCRIPTION
Found on `/reset`'s first real run, by the step that exists to catch exactly this.

## The defect

Step 3 shipped:

```bash
git rev-parse --short HEAD origin/main        # expect: two equal SHAs
```

`--short` accepts **one** revision. Two make it exit 128 with *"fatal: Needed a single
revision"*. So the check errored on every invocation, and the SHA comparison never ran.

It failed loudly rather than silently, which is the good direction. But the shape is the
one #5346 was entirely about: **a step that reads as verification and verifies nothing.**

It reached `main` because the three commands were verified in parts — every bash block
parsed under `bash -n`, and **a parse is not a run.**

## The fix

```bash
[ "$(git rev-parse HEAD)" = "$(git rev-parse origin/main)" ] \
  && echo "in sync with origin/main" || echo "DIVERGED from origin/main"
```

Better than the original intent regardless: printing two SHAs asks the reader to match
them by eye, and that check degrades the moment anyone skims. This one states its verdict.

The failing form is recorded inline so nobody "simplifies" it back.

## Verification

Run, not parsed. Exits 0 and prints `in sync with origin/main` on a clean tree.
`check-agent-doc-paths.sh` green.