### PR TITLE
fix(web): the warehouse denominator is the semantic layer, not the enrolled subset

### DIFF
--- a/packages/web/src/ui/components/admin/__tests__/coverage-statement.test.ts
+++ b/packages/web/src/ui/components/admin/__tests__/coverage-statement.test.ts
@@ -114,6 +114,45 @@ describe("composeStatement — one claim, two placements (ADR-0041)", () => {
 });
 
 describe("composeStatement — no invented dates, no invented denominators", () => {
+  test("the warehouse denominator is the semantic layer, not the enrolled subset", () => {
+    // Found by hand on prod at v0.2.13, which is what #5216's verification is
+    // for. `coverage-warehouse.ts` walks every (entity, dimension) pair the
+    // semantic layer defines and sets `inPerimeter` PER UNIT, so enrollment
+    // selects the numerator out of that universe — it does not describe the
+    // universe. Calling the denominator "enrolled" asserted that a human had
+    // enrolled all 281 while 277 rows underneath read "visible to Atlas, not in
+    // scope": the headline and the list contradicted each other, on a page whose
+    // whole premise is that every part is separately true.
+    const base = build();
+    const warehouse = {
+      state: "enumerated" as const,
+      asOf: "2026-08-20T02:00:00.000Z",
+      ratio: {
+        surveyed: 4,
+        enumerated: 277,
+        enumerable: 281,
+        inPerimeterWithoutEvidence: 0,
+        unit: "semantic-layer-enrollment" as const,
+      },
+      freshness: { current: 0, stale: 0, unverified: 4 },
+      units: [],
+      unitsWithheld: 281,
+      unitsTruncated: false,
+      mapEdges: [],
+      unavailable: null,
+    };
+    const statement = composeStatement(
+      build({ availability: { ...base.availability, warehouse } }),
+    );
+    const sentence = statement.availability[3];
+    expect(sentence).toContain("4 of 281 entity–dimension pairs");
+    expect(sentence).toContain("your semantic layer defines");
+    // The load-bearing negative: no phrasing may claim the DENOMINATOR was
+    // enrolled. `enrolled` describing a unit is fine; describing the 281 is not.
+    expect(sentence).not.toMatch(/of \d+ enrolled/);
+    expect(sentence).not.toContain("pairs a human enrolled");
+  });
+
   test("a class with no attempt on record gets no date at all", () => {
     const [, transcript] = composeStatement(build()).availability;
     expect(transcript).not.toMatch(/\d{4}/);

--- a/packages/web/src/ui/components/admin/brain-coverage/vocabulary.ts
+++ b/packages/web/src/ui/components/admin/brain-coverage/vocabulary.ts
@@ -101,8 +101,15 @@ export const CLASS_COPY: Record<BrainCoverageSourceClass, ClassCopy> = {
   email: { title: "Mail", units: "mailboxes", unit: "mailbox" },
   warehouse: {
     title: "Warehouse",
-    units: "enrolled entity–dimension pairs",
-    unit: "enrolled entity–dimension pair",
+    // ⚠️ NOT "enrolled entity–dimension pairs". The denominator is every pair the
+    // SEMANTIC LAYER defines (`coverage-warehouse.ts` walks entities × dimensions
+    // and sets `inPerimeter = enrolled.has(unitId)` per unit), so enrollment is a
+    // property of individual units inside it, never a description of the whole.
+    // Measured on prod at v0.2.13: "4 of 281 enrolled entity–dimension pairs"
+    // over a list where 277 read "visible to Atlas, not in scope" — the headline
+    // asserted a human had enrolled all 281 while the rows below said otherwise.
+    units: "entity–dimension pairs",
+    unit: "entity–dimension pair",
   },
   human: { title: "People", units: "people", unit: "person" },
 };
@@ -119,7 +126,12 @@ export const UNIT_CAPTION: Record<BrainCoverageUnitOrigin, string> = {
   "chat-channel-roster": "of the channels Atlas's chat credentials can see",
   "granted-recording-scopes": "of the recordings Atlas's granted scopes can see",
   "mailbox-list": "of the mailboxes Atlas's mail credentials can see",
-  "semantic-layer-enrollment": "of the entity–dimension pairs a human enrolled",
+  // Named for its SOURCE, not for a filter applied to it: the universe is what
+  // the admin's own semantic layer describes, and enrollment (ADR-0039) is what
+  // selects the surveyed subset FROM it — the two are a numerator/denominator
+  // pair, so naming the denominator after the numerator's rule made the ratio
+  // read as "4 of 281, all of which were enrolled".
+  "semantic-layer-enrollment": "of the entity–dimension pairs your semantic layer defines",
 };
 
 /**


### PR DESCRIPTION
Found by hand on prod at v0.2.13 — which is exactly what #5216's verification exists to do, and the first claim it checked did not hold.

## The contradiction

The warehouse card read **"4 of 281 enrolled entity–dimension pairs"** over a list where **277 rows said "visible to Atlas, not in scope"**. Both cannot be true: if a human had enrolled all 281, none of them would be out of scope.

## The data was right; the words were wrong

`coverage-warehouse.ts:410` walks every `(entity, dimension)` pair the semantic layer defines and sets `inPerimeter = enrolled.has(unitId)` **per unit**. So 281 is the universe the admin's own semantic layer describes, and enrollment (ADR-0039) selects the *numerator* out of it. The copy named the denominator after the numerator's own filter.

That is not a styling nit. ADR-0041 puts the caption on the honesty side of the line — *"Every denominator is credential-relative … the honest phrasing is 'of what Atlas's credentials can see'"* — so a caption that misdescribes its own universe is a false statement on a page built to have none, and it was on the flagship claim.

## The fix

- `CLASS_COPY.warehouse` → `"entity–dimension pairs"` (was `"enrolled entity–dimension pairs"`)
- `UNIT_CAPTION["semantic-layer-enrollment"]` → `"of the entity–dimension pairs your semantic layer defines"` (was `"of the entity–dimension pairs a human enrolled"`)

Both sites carry a comment recording the measurement, so the next person to reach for "enrolled" here sees why it was removed.

## Acceptance criteria
- [x] The headline no longer describes the denominator as enrolled; `enrolled` describing a single unit stays correct and stays available
- [x] Pinned by a test whose load-bearing half is the **negative** — `not.toMatch(/of \d+ enrolled/)` and `not.toContain("pairs a human enrolled")` — since a positive-only assertion would pass again the moment someone reworded it back
- [x] No wire-shape change: `semantic-layer-enrollment` stays the unit slug, because the enum names the SOURCE of the universe and that is still accurate

## Verification
`tsgo` clean · `bun run lint` exit 0 · 47 web tests pass

## Not in this PR
The other #5216 checks still to walk on the redeployed page: chat 2-of-7 against the real Slack channel list, the `unverified since` date against the last successful cycle, `12 awaiting / 10 published` against the Facts queue, and whether "never enumerated" holds for transcripts and mail.
