### PR TITLE
sec(deps): baseline CVE-2026-53612/53613/53614 (util-linux) — the same batch as 53615

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -166,6 +166,21 @@ CVE-2026-4878 exp:2026-11-01
 # predating the advisory — the gate working as designed, on debt no PR
 # introduced.
 CVE-2026-53615 exp:2026-11-01
+# HIGH     util-linux and the same eight siblings — three more from the SAME
+#          advisory batch and the SAME package update: 2.41-5 -> 2.41.5-0+deb13u1.
+#          53612 TOCTOU applying post-mount ownership/mode changes; 53613 TOCTOU
+#          via ancestor directory swap; 53614 SUID mount(8) nosuid/noexec bypass
+#          via LIBMOUNT_FORCE_MOUNT2.
+# Disclosed 2026-08-20 between main's 18:33 UTC scan (green) and the next PR's
+# 20:52 UTC scan (red) — the same shape as 53615 one entry up, four CVEs later.
+# ⚠️ Read that repetition as a signal, not a coincidence: this is the SECOND
+# time in eight days that one util-linux advisory batch has reddened every PR in
+# the repo, and the fixed version is identical to the one already listed above.
+# The baseline is doing its job, but a gate that goes red on the same package
+# twice is telling you the bare base is the wrong thing to hold the debt.
+CVE-2026-53612 exp:2026-11-01
+CVE-2026-53613 exp:2026-11-01
+CVE-2026-53614 exp:2026-11-01
 
 # ─────────────────────────────────────────────────────────────────────────────
 # caddy:2.11.4-alpine — runtime base for deploy/docs only. Cleared by the


### PR DESCRIPTION
One file, `.trivyignore`. Three lines plus the comment explaining them.

## What happened

Three util-linux CVEs were disclosed on **2026-08-20 between 18:33 and 20:52 UTC** — after `main`'s last base-image scan (green) and before the next PR's (red). They redden `Base image (oven-bun-1.3.13)`, and therefore the **required** `Image Scan` context, on **every open PR**. No PR introduced them.

| CVE | Title |
|---|---|
| CVE-2026-53612 | TOCTOU in `mount` applying post-mount ownership/mode changes |
| CVE-2026-53613 | TOCTOU in `mount` via ancestor directory swap |
| CVE-2026-53614 | SUID `mount(8)` allows nosuid/noexec bypass via `LIBMOUNT_FORCE_MOUNT2` |

Installed `2.41-5`, fixed in **`2.41.5-0+deb13u1`** — the **identical fixed version** as `CVE-2026-53615`, which is already in the file. Same advisory batch, same package, same nine binaries (`util-linux`, `bsdutils`, `libblkid1`, `libmount1`, `libsmartcols1`, `libuuid1`, `liblastlog2-2`, `mount`, `login`).

## Why a baseline entry is the right instrument here

`.trivyignore` documents this exact case one entry up, for 53615:

> Disclosed after the 2026-08-12 pass … It reddened the base-images leg of every PR while main stayed green on a run predating the advisory — **the gate working as designed, on debt no PR introduced.**

The premise those entries rest on is unchanged: **every runtime stage in the tree runs `apt-get upgrade`**, so these are already patched out of the BUILT images that reach Railway and customers. They persist only in the bare base, which the base-images tier scans for pin regressions and discovery.

**Nothing is hidden.** `scripts/scan-image.sh` runs Trivy twice; the report pass uses `--ignorefile /dev/null`, so all three still reach GitHub code scanning. Only the gate pass applies this file.

`exp:2026-11-01` matches the surrounding block so the whole util-linux group expires together and is re-measured in one pass.

## The thing worth a decision, not another entry

⚠️ **This is the second time in eight days that a single util-linux advisory batch has reddened every PR in the repo, with an identical fixed version both times.** The baseline is doing its job. But a gate that goes red on the same package twice in eight days is evidence that **holding this debt against the bare base is the wrong shape** — the built images have been clean throughout. That is a design question about which surface the gate should block on, and it deserves its own issue rather than a third batch of entries. Flagged in the file at the point someone will next read it.

## What was NOT done

- **No `--admin` merge.** The gate is working correctly on a true finding; CLAUDE.md reserves `--admin` for a broken gate.
- **Not folded into [#5359](https://github.com/AtlasDevHQ/atlas/pull/5359)**, the docs PR this unblocks. A security-gate change should be reviewable on its own.
- **The built-image re-measure was not re-run.** `.trivyignore` warns that if `deploy/api` starts returning findings, the `apt-get upgrade` has stopped working and baselining would be a lie. That premise is inherited from the 2026-08-12 measurement and the 53615 entry, not re-verified here — it needs a Docker build. Called out because it is the one assumption this change rests on.