### PR TITLE
[qwen-loop/issue] AtlasDevHQ/atlas#5362: .trivyignore 'NEW entry' rule states the test the entries meet

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -131,12 +131,24 @@
 #
 # ── If a NEW entry is ever needed ─────────────────────────────────────────────
 #
-# Prefer fixing the image. A baseline entry is correct only when the distro has
-# published no fixed package (Trivy already filters those with --ignore-unfixed,
-# so this is rarer than it looks) or when the fix is unreachable from the pinned
-# repo snapshot. Always give it an `exp:` date — the expiry is the forcing
-# function; once passed, Trivy stops honouring it and the gate goes red until it
-# is fixed or consciously re-dated. Do not bulk-extend dates — re-scan first.
+# Prefer fixing the image. A baseline entry is correct only when the finding is
+# cleared from the *built* image by a runner-stage upgrade — i.e. it exists only
+# in the bare base, which is the surface the base-images gate actually scans.
+# Every entry above meets that test, and the bar is checkable with the two-
+# surface re-measure under "How to re-measure".
+#
+# "The distro has published no fixed package" is NOT a valid bar here: scripts/
+# scan-image.sh runs the gate pass with --ignore-unfixed, so a finding that
+# reaches the gate is fixable by construction — that branch can never hold for
+# anything the gate reports. "Unreachable from the pinned repo snapshot" is
+# similarly rare: every util-linux binary in the entries above, for example,
+# upgrades from Debian-Security:13/stable-security, a repo the pinned base
+# already has configured.
+#
+# Always give an entry an `exp:` date — the expiry is the forcing function;
+# once passed, Trivy stops honouring it and the gate goes red until the entry
+# is fixed or consciously re-dated. Do not bulk-extend dates — re-scan first,
+# against BOTH surfaces, the way "How to re-measure" describes.
 
 # ─────────────────────────────────────────────────────────────────────────────
 # oven/bun:1.3.13 (Debian trixie) — runtime base for deploy/api, deploy/web,


### PR DESCRIPTION
Fixes #5362

The 'If a NEW entry is ever needed' rule in `.trivyignore` stated a two-condition bar — 'no fixed package published' or 'unreachable from the pinned repo snapshot' — that every existing entry violates by construction:

- `scripts/scan-image.sh` runs the gate pass with `--ignore-unfixed`, so a finding that reaches the gate is fixable by definition. The first condition can never hold for anything the gate reports.
- The entries *do* clear from the built image via the runner-stage upgrade, which is the gap the baseline exists to capture. That is the test the entries actually rest on.

## What this PR changes

Docs only — no entries added or removed. Replaces the rule paragraph with the test the entries already meet, per the issue's acceptance criteria:

1. **States the real test.** A baseline entry is correct only when the finding is cleared from the *built* image by a runner-stage upgrade — i.e. it exists only in the bare base.
2. **Calls out that `--ignore-unfixed` makes 'no fixed package published' unreachable** for anything the gate reports, so that is not the bar.
3. **Keeps 'Prefer fixing the image' as the first instruction** and the `exp:` requirement.
4. **Points at 'How to re-measure' for the verification step** rather than restating it — one copy, one place to keep true (the file's own convention).

Not blocked by #5361 — the rule is wrong today regardless of which surface the gate ends up blocking on.